### PR TITLE
feat: carry dependency attribution into evidence and observe

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -397,6 +397,8 @@
   :evidence/show-workflow "  Workflow:  {value}"
   :evidence/show-status "  Status:    {value}"
   :evidence/show-created "  Created:   {value}"
+  :evidence/show-failure-attribution "  Failure:   {value}"
+  :evidence/show-dependency-issues "  Dependencies: {value}"
   :evidence/show-artifacts "  Artifacts: {count}"
   :evidence/show-artifact-entry "    • {type} — {id}"
   :evidence/show-phases "  Phases:    {count}"

--- a/bases/cli/src/ai/miniforge/cli/main/commands/evidence.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/evidence.clj
@@ -60,17 +60,90 @@
   {:header   :evidence/show-header
    :fields   [[:bundle/workflow-id :evidence/show-workflow {:default "—"}]
               [:bundle/status      :evidence/show-status   {:default "unknown"}]
-              [:bundle/created-at  :evidence/show-created  {:default "—"}]]
+              [:bundle/created-at  :evidence/show-created  {:default "—"}]
+              [:bundle/failure-attribution :evidence/show-failure-attribution {:default "—"}]
+              [:bundle/dependency-issues :evidence/show-dependency-issues {:default 0}]]
    :sections [{:key :bundle/artifacts :header :evidence/show-artifacts
                :entry :evidence/show-artifact-entry :max 10
                :entry-fn (fn [a] {:type (get a :artifact/type "unknown")
                                    :id   (get a :artifact/id "")})}
               {:key :bundle/phases :header :evidence/show-phases}]})
 
+(def ^:private phase-evidence-keys
+  [:evidence/plan
+   :evidence/design
+   :evidence/implement
+   :evidence/verify
+   :evidence/review
+   :evidence/release
+   :evidence/observe])
+
+(defn- active-dependency?
+  [dependency]
+  (contains? #{:degraded :unavailable :misconfigured :operator-action-required}
+             (:dependency/status dependency)))
+
+(defn- label
+  [value]
+  (cond
+    (keyword? value) (name value)
+    (string? value) value
+    (nil? value) "unknown"
+    :else (str value)))
+
+(defn- dependency-issue-count
+  [dependency-health]
+  (->> dependency-health
+       vals
+       (filter active-dependency?)
+       count))
+
+(defn- failure-attribution-summary
+  [failure-attribution]
+  (when (seq failure-attribution)
+    (let [source (or (:failure/source failure-attribution)
+                     (:dependency/source failure-attribution)
+                     :unknown)
+          vendor (or (:failure/vendor failure-attribution)
+                     (:dependency/vendor failure-attribution)
+                     (:dependency/id failure-attribution))
+          failure-class (or (:dependency/class failure-attribution)
+                            (:failure/class failure-attribution)
+                            :unknown)]
+      (str (label source) " / " (label vendor) " / " (label failure-class)))))
+
+(defn- canonical-phase-names
+  [bundle]
+  (->> phase-evidence-keys
+       (filter #(contains? bundle %))
+       (mapv (comp keyword name))))
+
+(defn- normalize-bundle-detail
+  [bundle]
+  (let [dependency-health (or (:evidence/dependency-health bundle) {})
+        artifacts (or (:bundle/artifacts bundle) [])
+        phases (or (:bundle/phases bundle)
+                   (canonical-phase-names bundle))
+        status (or (:bundle/status bundle)
+                   (if (true? (get-in bundle [:evidence/outcome :outcome/success]))
+                     "completed"
+                     "failed"))]
+    {:bundle/workflow-id (or (:bundle/workflow-id bundle)
+                             (:evidence-bundle/workflow-id bundle))
+     :bundle/status status
+     :bundle/created-at (or (:bundle/created-at bundle)
+                            (:evidence-bundle/created-at bundle))
+     :bundle/artifacts artifacts
+     :bundle/phases phases
+     :bundle/dependency-issues (dependency-issue-count dependency-health)
+     :bundle/failure-attribution (failure-attribution-summary
+                                  (:evidence/failure-attribution bundle))}))
+
 (defn- display-bundle-detail
   "Render the detail view for a single evidence bundle."
   [id bundle]
-  (display/render-detail (assoc bundle-detail-spec :header-params {:id id}) bundle))
+  (display/render-detail (assoc bundle-detail-spec :header-params {:id id})
+                         (normalize-bundle-detail bundle)))
 
 (defn- load-bundle-for-show
   "Load a bundle from the component interface or the filesystem."

--- a/bases/cli/test/ai/miniforge/cli/main/commands/evidence_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/evidence_test.clj
@@ -52,6 +52,22 @@
            :bundle/phases [:plan :implement]}
           overrides)))
 
+(defn make-canonical-bundle
+  [overrides]
+  (merge {:evidence-bundle/id "bundle-2"
+          :evidence-bundle/workflow-id "wf-2"
+          :evidence-bundle/created-at "2026-04-30T10:00:00Z"
+          :evidence/plan {:phase/name :plan}
+          :evidence/implement {:phase/name :implement}
+          :evidence/outcome {:outcome/success false}
+          :evidence/dependency-health {:anthropic {:dependency/id :anthropic
+                                                   :dependency/status :degraded}}
+          :evidence/failure-attribution {:failure/source :external-provider
+                                         :failure/vendor :anthropic
+                                         :dependency/id :anthropic
+                                         :dependency/class :rate-limit}}
+         overrides))
+
 ;------------------------------------------------------------------------------ Layer 1: Tests
 
 (deftest evidence-list-cmd-no-component-empty-dir-test
@@ -95,6 +111,19 @@
                     app-config/home-dir (constantly *tmp-dir*)]
         (let [output (with-out-str (sut/evidence-show-cmd {:id "test-bundle"}))]
           (is (.contains output "wf-1")))))))
+
+(deftest evidence-show-cmd-with-canonical-bundle-test
+  (testing "show command normalizes canonical evidence bundle fields"
+    (let [evidence-path (str *tmp-dir* "/evidence")]
+      (fs/create-dirs evidence-path)
+      (spit (str evidence-path "/canonical-bundle.edn") (pr-str (make-canonical-bundle {})))
+      (with-redefs [shared/try-resolve-fn (constantly nil)
+                    app-config/home-dir (constantly *tmp-dir*)]
+        (let [output (with-out-str (sut/evidence-show-cmd {:id "canonical-bundle"}))]
+          (is (.contains output "wf-2"))
+          (is (.contains output "failed"))
+          (is (.contains output "external-provider / anthropic / rate-limit"))
+          (is (.contains output "Dependencies: 1")))))))
 
 (deftest evidence-export-cmd-missing-id-test
   (testing "export command exits with error when no id provided"

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -22,7 +22,6 @@
   (:require
    [ai.miniforge.content-hash.interface :as content-hash]
    [ai.miniforge.evidence-bundle.schema :as schema]
-   [ai.miniforge.event-stream.interface.stream :as event-stream]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -201,6 +200,15 @@
 ;------------------------------------------------------------------------------ Layer 3.5
 ;; Supervision Decision Evidence (N6)
 
+(defn- collect-event-stream-events
+  [event-stream query]
+  (try
+    (when event-stream
+      (let [get-events-fn (requiring-resolve 'ai.miniforge.event-stream.core/get-events)]
+        (vec (get-events-fn event-stream query))))
+    (catch Exception _e
+      [])))
+
 (defn collect-supervision-decisions
   "Collect supervision decision events from the event stream.
 
@@ -215,10 +223,9 @@
   [event-stream workflow-id]
   (try
     (when event-stream
-      (let [get-events-fn (requiring-resolve 'ai.miniforge.event-stream.core/get-events)
-            events (get-events-fn event-stream
-                                  {:workflow-id workflow-id
-                                   :event-type :supervision/tool-use-evaluated})]
+      (let [events (collect-event-stream-events event-stream
+                                                {:workflow-id workflow-id
+                                                 :event-type :supervision/tool-use-evaluated})]
         (mapv (fn [event]
                 (cond-> {:supervision/tool-name (get event :tool/name "unknown")
                          :supervision/decision (get event :supervision/decision "allow")
@@ -253,13 +260,12 @@
   [event-stream workflow-id]
   (try
     (when event-stream
-      (let [get-events-fn (requiring-resolve 'ai.miniforge.event-stream.core/get-events)
-            requested (get-events-fn event-stream
-                                     {:workflow-id workflow-id
-                                      :event-type :control-action/requested})
-            executed (get-events-fn event-stream
-                                    {:workflow-id workflow-id
-                                     :event-type :control-action/executed})
+      (let [requested (collect-event-stream-events event-stream
+                                                   {:workflow-id workflow-id
+                                                    :event-type :control-action/requested})
+            executed (collect-event-stream-events event-stream
+                                                  {:workflow-id workflow-id
+                                                   :event-type :control-action/executed})
             executed-by-id (into {} (map (fn [e] [(:action/id e) e]) executed))]
         (mapv (fn [req-event]
                 (let [action-id (:action/id req-event)
@@ -372,14 +378,15 @@
 
 (defn- dependency-health-from-events
   [stream workflow-id]
-  (let [events (event-stream/get-events stream {:workflow-id workflow-id})]
-    (->> events
-         (filter #(contains? dependency-event-types (:event/type %)))
-         (reduce (fn [projection event]
-                   (if-let [entry (canonical-dependency-entry (:dependency/id event) event)]
-                     (assoc projection (:dependency/id entry) entry)
-                     projection))
-                 {}))))
+  (->> dependency-event-types
+       (mapcat #(collect-event-stream-events stream
+                                             {:workflow-id workflow-id
+                                              :event-type %}))
+       (reduce (fn [projection event]
+                 (if-let [entry (canonical-dependency-entry (:dependency/id event) event)]
+                   (assoc projection (:dependency/id entry) entry)
+                   projection))
+               {})))
 
 (defn- collect-dependency-health
   [workflow-state stream workflow-id opts]

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -22,6 +22,7 @@
   (:require
    [ai.miniforge.content-hash.interface :as content-hash]
    [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.event-stream.interface.stream :as event-stream]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -335,6 +336,86 @@
       (contains? output :evidence/image-digest)
       (assoc :evidence/image-digest (:evidence/image-digest output)))))
 
+(def ^:private dependency-event-types
+  #{:dependency/health-updated
+    :dependency/recovered})
+
+(def ^:private dependency-health-keys
+  [:dependency/id
+   :dependency/source
+   :dependency/kind
+   :dependency/status
+   :dependency/failure-count
+   :dependency/window-size
+   :dependency/incident-counts
+   :dependency/vendor
+   :dependency/class
+   :dependency/retryability
+   :failure/class
+   :dependency/last-observed-at
+   :dependency/last-recovered-at])
+
+(defn- canonical-dependency-entry
+  [dependency-id dependency]
+  (let [entity (select-keys dependency dependency-health-keys)
+        canonical-id (or dependency-id (:dependency/id entity))]
+    (when canonical-id
+      (assoc entity :dependency/id canonical-id))))
+
+(defn- canonical-dependency-health
+  [dependency-health]
+  (into {}
+        (keep (fn [[dependency-id dependency]]
+                (when-let [entry (canonical-dependency-entry dependency-id dependency)]
+                  [(:dependency/id entry) entry])))
+        dependency-health))
+
+(defn- dependency-health-from-events
+  [stream workflow-id]
+  (let [events (event-stream/get-events stream {:workflow-id workflow-id})]
+    (->> events
+         (filter #(contains? dependency-event-types (:event/type %)))
+         (reduce (fn [projection event]
+                   (if-let [entry (canonical-dependency-entry (:dependency/id event) event)]
+                     (assoc projection (:dependency/id entry) entry)
+                     projection))
+                 {}))))
+
+(defn- collect-dependency-health
+  [workflow-state stream workflow-id opts]
+  (let [projection (or (:dependency-health opts)
+                       (:dependency-health workflow-state)
+                       (when stream
+                         (dependency-health-from-events stream workflow-id)))]
+    (canonical-dependency-health projection)))
+
+(def ^:private failure-attribution-keys
+  [:failure/source
+   :failure/vendor
+   :failure/class
+   :failure/message
+   :dependency/class
+   :dependency/retryability
+   :dependency/id
+   :dependency/source
+   :dependency/kind
+   :dependency/vendor
+   :dependency/status])
+
+(defn- failure-attribution
+  [failure]
+  (let [attribution (select-keys failure failure-attribution-keys)]
+    (when (seq attribution)
+      attribution)))
+
+(defn- collect-failure-attribution
+  [workflow-state opts]
+  (or (:failure-attribution opts)
+      (some-> (:workflow/error workflow-state) failure-attribution)
+      (some->> (:workflow/errors workflow-state)
+               (keep failure-attribution)
+               first)))
+
 ;------------------------------------------------------------------------------ Layer 5
 ;; Complete Bundle Assembly
 
@@ -354,6 +435,8 @@
         rules-applied (collect-rules-applied workflow-state)
         supervision-decisions (collect-supervision-decisions event-stream workflow-id)
         control-actions (collect-control-actions event-stream workflow-id)
+        dependency-health (collect-dependency-health workflow-state event-stream workflow-id opts)
+        failure-attribution (collect-failure-attribution workflow-state opts)
 
         ;; N11 §9.1: extract execution evidence from workflow result
         execution-evidence (collect-execution-evidence workflow-state)
@@ -392,6 +475,10 @@
                  (assoc :evidence/supervision-decisions supervision-decisions)
                  (seq control-actions)
                  (assoc :evidence/control-actions control-actions)
+                 (seq dependency-health)
+                 (assoc :evidence/dependency-health dependency-health)
+                 failure-attribution
+                 (assoc :evidence/failure-attribution failure-attribution)
                  (seq rules-applied)
                  (assoc :evidence/rules-applied rules-applied)
                  semantic-validation

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
@@ -20,6 +20,7 @@
   "Implementation functions for EvidenceBundle protocol.
    Pure functions organized in layers."
   (:require
+   [ai.miniforge.evidence-bundle.collector :as collector]
    [ai.miniforge.evidence-bundle.schema :as schema]
    [ai.miniforge.logging.interface :as log]))
 
@@ -58,71 +59,32 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Bundle Creation
 
-(defn- extract-execution-evidence
-  "Extract N11 §9.1 evidence fields from the workflow result's :execution/output.
-   Returns a map of evidence keys to merge into the bundle, or empty map."
+(defn extract-execution-evidence
+  "Compatibility wrapper for execution evidence extraction.
+   Delegates to the canonical collector implementation."
   [workflow-state]
-  (let [output (get workflow-state :execution/output {})]
-    (cond-> {}
-      (contains? output :evidence/execution-mode)
-      (assoc :evidence/execution-mode (:evidence/execution-mode output))
-
-      (contains? output :evidence/runtime-class)
-      (assoc :evidence/runtime-class (:evidence/runtime-class output))
-
-      (contains? output :evidence/task-started-at)
-      (assoc :evidence/task-started-at (:evidence/task-started-at output))
-
-      (contains? output :evidence/task-finished-at)
-      (assoc :evidence/task-finished-at (:evidence/task-finished-at output))
-
-      (contains? output :evidence/image-digest)
-      (assoc :evidence/image-digest (:evidence/image-digest output)))))
+  (collector/collect-execution-evidence workflow-state))
 
 (defn create-bundle-impl
   "Create evidence bundle from workflow state.
    Merges N11 §9.1 execution evidence fields from :execution/output.
    Returns [bundle updated-bundles-atom-value]"
-  [bundles _artifact-store logger workflow-id opts]
+  [bundles artifact-store logger workflow-id opts]
   (let [workflow-state (:workflow-state opts)
-        ;; Extract intent and outcome from workflow state if not provided
-        workflow-spec (:workflow/spec workflow-state)
-        intent (or (:intent opts)
-                  (when workflow-spec
-                    (let [extract-fn (requiring-resolve 'ai.miniforge.evidence-bundle.collector/extract-intent)]
-                      (extract-fn workflow-spec))))
-        outcome (or (:outcome opts)
-                   (let [build-fn (requiring-resolve 'ai.miniforge.evidence-bundle.collector/build-outcome-evidence)]
-                     (build-fn workflow-state)))
-        policy-checks (or (:policy-checks opts)
-                         (let [collect-fn (requiring-resolve 'ai.miniforge.evidence-bundle.collector/collect-policy-checks)]
-                           (collect-fn workflow-state)))
-        tool-invocations (let [collect-fn (requiring-resolve
-                                           'ai.miniforge.evidence-bundle.collector/collect-tool-invocations)]
-                           (collect-fn workflow-state))
-        semantic-validation (get opts :semantic-validation {})
-        collect-all-fn (requiring-resolve 'ai.miniforge.evidence-bundle.collector/collect-all-phases)
-        phase-evidence (collect-all-fn workflow-state)
-
-        ;; N11 §9.1: extract execution evidence from workflow result
-        execution-evidence (extract-execution-evidence workflow-state)
-
         bundle-id (random-uuid)
-        bundle (merge
-                (schema/create-evidence-bundle-template)
-                {:evidence-bundle/id bundle-id
-                 :evidence-bundle/workflow-id workflow-id
-                 :evidence-bundle/created-at (java.time.Instant/now)
-                 :evidence/intent intent
-                 :evidence/semantic-validation semantic-validation
-                 :evidence/policy-checks policy-checks
-                 :evidence/outcome outcome}
-                phase-evidence
-                execution-evidence)
-        bundle (cond-> bundle
-                 (seq tool-invocations)
-                 (assoc :evidence/tool-invocations tool-invocations))
+        assembled (collector/assemble-evidence-bundle workflow-id workflow-state artifact-store opts)
+        bundle (cond-> (assoc assembled :evidence-bundle/id bundle-id)
+                 (:intent opts)
+                 (assoc :evidence/intent (:intent opts))
 
+                 (contains? opts :semantic-validation)
+                 (assoc :evidence/semantic-validation (:semantic-validation opts))
+
+                 (:policy-checks opts)
+                 (assoc :evidence/policy-checks (:policy-checks opts))
+
+                 (:outcome opts)
+                 (assoc :evidence/outcome (:outcome opts)))
         new-bundles (assoc @bundles bundle-id bundle)]
 
     (log/info logger :evidence-bundle :bundle/created

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -259,6 +259,10 @@
    (optional-key :evidence/task-finished-at) inst?
    (optional-key :evidence/image-digest) string?
 
+   ;; Dependency Attribution
+   (optional-key :evidence/dependency-health) map?
+   (optional-key :evidence/failure-attribution) map?
+
    ;; Outcome
    :evidence/outcome map?
 
@@ -379,4 +383,5 @@
    :evidence/policy-checks []
    :evidence/outcome {}
    :evidence/tool-invocations []
-   :evidence/pack-promotions []})
+   :evidence/pack-promotions []
+   :evidence/dependency-health {}})

--- a/components/observer/src/ai/miniforge/observer/core.clj
+++ b/components/observer/src/ai/miniforge/observer/core.clj
@@ -42,6 +42,49 @@
 (declare generate-recommendations-report)
 
 ;; ============================================================================
+;; Failure Attribution Helpers
+;; ============================================================================
+
+(def ^:private failure-attribution-keys
+  [:failure/source
+   :failure/vendor
+   :failure/class
+   :failure/message
+   :dependency/id
+   :dependency/source
+   :dependency/kind
+   :dependency/vendor
+   :dependency/status
+   :dependency/class
+   :dependency/retryability])
+
+(defn- failure-attribution
+  [failure]
+  (let [attribution (select-keys failure failure-attribution-keys)]
+    (when (seq attribution)
+      attribution)))
+
+(defn- collect-failure-attribution
+  [workflow-state]
+  (or (some-> (:workflow/error workflow-state) failure-attribution)
+      (some->> (:workflow/errors workflow-state)
+               (keep failure-attribution)
+               first)))
+
+(defn- collect-dependency-health
+  [workflow-state]
+  (when-let [projection (:dependency-health workflow-state)]
+    (not-empty projection)))
+
+(defn- label
+  [value]
+  (cond
+    (keyword? value) (name value)
+    (string? value) value
+    (nil? value) "unknown"
+    :else (str value)))
+
+;; ============================================================================
 ;; Simple Observer Implementation
 ;; ============================================================================
 
@@ -57,6 +100,8 @@
           status (get workflow-state :workflow/status :unknown)
           history (get workflow-state :workflow/history [])
           errors (get workflow-state :workflow/errors [])
+          dependency-health (collect-dependency-health workflow-state)
+          failure-attribution (collect-failure-attribution workflow-state)
 
           workflow-metrics (proto/workflow-metrics
                             {:workflow-id workflow-id
@@ -65,6 +110,8 @@
                              :timestamp (java.util.Date.)
                              :history history
                              :errors errors
+                             :dependency-health dependency-health
+                             :failure-attribution failure-attribution
                              :phases (get-in @state [:phase-metrics workflow-id] [])})]
 
       (swap! state assoc-in [:metrics workflow-id] workflow-metrics)
@@ -341,6 +388,7 @@
   (let [limit (get opts :limit 100)
         metrics (proto/get-all-metrics observer {:limit limit})
         failed (filter phase/failed? metrics)
+        attributed-failures (keep :failure-attribution failed)
 
         ;; Analyze which phases fail most often
         failed-phases (reduce
@@ -353,6 +401,24 @@
                             failed-phases)))
                        {}
                        failed)
+        dependency-failures (->> attributed-failures
+                                 (keep (fn [failure]
+                                         (when-let [dependency-id (or (:dependency/id failure)
+                                                                      (:failure/vendor failure))]
+                                           [dependency-id (select-keys failure
+                                                                       [:failure/source
+                                                                        :failure/vendor
+                                                                        :failure/class
+                                                                        :dependency/class
+                                                                        :dependency/retryability])])))
+                                 (reduce (fn [acc [dependency-id failure]]
+                                           (update acc dependency-id
+                                                   (fn [existing]
+                                                     (-> (merge existing failure)
+                                                         (update :count (fnil inc 0))))))
+                                         {})
+                                 (sort-by (comp - :count val))
+                                 vec)
 
         total-workflows (count metrics)
         failure-rate (if (pos? total-workflows)
@@ -364,15 +430,20 @@
       :data {:total-workflows total-workflows
              :failed-workflows (count failed)
              :failure-rate failure-rate
-             :failed-phases (sort-by val > failed-phases)}
+             :failed-phases (sort-by val > failed-phases)
+             :dependency-failures dependency-failures}
       :summary (format "Failure rate: %.1f%% (%d/%d workflows failed)"
                        (* 100.0 failure-rate)
                        (count failed)
                        total-workflows)
       :recommendations
-      (when (seq failed-phases)
-        [(str "Most problematic phases: "
-              (str/join ", " (map first (take 3 (sort-by val > failed-phases)))))])})))
+      (cond-> []
+        (seq failed-phases)
+        (conj (str "Most problematic phases: "
+                   (str/join ", " (map first (take 3 (sort-by val > failed-phases))))))
+        (seq dependency-failures)
+        (conj (str "Dependency-attributed failures: "
+                   (str/join ", " (map (comp label first) (take 3 dependency-failures))))))})))
 
 (defn analyze-trends
   "Analyze metrics trends over time."
@@ -430,7 +501,7 @@
 (defn generate-summary-report
   "Generate a summary performance report."
   [observer opts]
-  (let [format (get opts :format :markdown)
+  (let [output-format (get opts :format :markdown)
         limit (get opts :limit 100)
 
         duration-analysis (proto/analyze-metrics observer :duration-stats {:limit limit})
@@ -444,7 +515,7 @@
                      :failures failure-analysis
                      :generated-at (java.util.Date.)}]
 
-    (case format
+    (case output-format
       :edn report-data
 
       :markdown
@@ -458,6 +529,18 @@
            (:summary token-analysis) "\n\n"
            "## Failure Analysis\n"
            (:summary failure-analysis) "\n"
+           (when-let [dependency-failures (seq (get-in failure-analysis [:data :dependency-failures]))]
+             (str "\n**Dependency-attributed failures:**\n"
+                  (str/join "\n"
+                            (map (fn [[dependency-id failure]]
+                                   (format "- %s (%s, count=%d)"
+                                           (label dependency-id)
+                                           (or (some-> (:dependency/class failure) label)
+                                               (some-> (:failure/class failure) label)
+                                               "unknown")
+                                           (:count failure)))
+                                 dependency-failures))
+                  "\n"))
            (when-let [recs (:recommendations failure-analysis)]
              (str "\n**Recommendations:**\n"
                   (str/join "\n" (map #(str "- " %) recs)) "\n")))
@@ -467,7 +550,7 @@
 (defn generate-detailed-report
   "Generate a detailed metrics breakdown report."
   [observer opts]
-  (let [format (get opts :format :edn)
+  (let [output-format (get opts :format :edn)
         limit (get opts :limit 50)
 
         all-metrics (proto/get-all-metrics observer {:limit limit})
@@ -478,7 +561,7 @@
                      :total-workflows (count all-metrics)
                      :generated-at (java.util.Date.)}]
 
-    (case format
+    (case output-format
       :edn report-data
       :markdown (str "# Detailed Workflow Metrics\n\n"
                      "**Generated:** " (:generated-at report-data) "\n"
@@ -497,7 +580,7 @@
 (defn generate-recommendations-report
   "Generate recommendations for workflow improvements."
   [observer opts]
-  (let [format (get opts :format :markdown)
+  (let [output-format (get opts :format :markdown)
         limit (get opts :limit 100)
 
         failure-analysis (proto/analyze-metrics observer :failure-patterns {:limit limit})
@@ -540,7 +623,7 @@
                      :trends-analysis trends-analysis
                      :generated-at (java.util.Date.)}]
 
-    (case format
+    (case output-format
       :edn report-data
       :markdown (str "# Workflow Improvement Recommendations\n\n"
                      "**Generated:** " (:generated-at report-data) "\n\n"
@@ -551,5 +634,17 @@
                      "\n\n"
                      "## Supporting Analysis\n\n"
                      "### Failures\n" (:summary failure-analysis) "\n\n"
+                     (when-let [dependency-failures (seq (get-in failure-analysis [:data :dependency-failures]))]
+                       (str "### Dependency Attribution\n"
+                            (str/join "\n"
+                                      (map (fn [[dependency-id failure]]
+                                             (format "- %s: %s (%d)"
+                                                     (label dependency-id)
+                                                     (or (some-> (:dependency/class failure) label)
+                                                         (some-> (:failure/class failure) label)
+                                                         "unknown")
+                                                     (:count failure)))
+                                           dependency-failures))
+                            "\n\n"))
                      "### Trends\n" (:summary trends-analysis) "\n")
       report-data)))

--- a/components/observer/src/ai/miniforge/observer/protocol.clj
+++ b/components/observer/src/ai/miniforge/observer/protocol.clj
@@ -130,15 +130,20 @@
    Optional fields:
    - :phases - Vector of phase metrics
    - :history - Workflow transition history
-   - :errors - Error information if failed"
-  [{:keys [workflow-id metrics status timestamp phases history errors]}]
+   - :errors - Error information if failed
+   - :dependency-health - Canonical dependency-health projection
+   - :failure-attribution - Canonical failure attribution for failed workflows"
+  [{:keys [workflow-id metrics status timestamp phases history errors
+           dependency-health failure-attribution]}]
   {:workflow-id workflow-id
    :metrics (or metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0})
    :status (or status :unknown)
    :timestamp (or timestamp (java.util.Date.))
    :phases (or phases [])
    :history (or history [])
-   :errors errors})
+   :errors errors
+   :dependency-health dependency-health
+   :failure-attribution failure-attribution})
 
 (defn phase-metrics
   "Create a phase metrics record.

--- a/components/observer/test/ai/miniforge/observer/interface_test.clj
+++ b/components/observer/test/ai/miniforge/observer/interface_test.clj
@@ -29,7 +29,7 @@
 
 (defn sample-workflow-state
   "Create a sample workflow state for testing."
-  [workflow-id status & {:keys [tokens cost duration]
+  [workflow-id status & {:keys [tokens cost duration dependency-health failure-attribution]
                          :or {tokens 1000 cost 0.10 duration 5000}}]
   {:workflow/id workflow-id
    :workflow/status status
@@ -39,6 +39,8 @@
    :workflow/history [{:from-phase :start
                       :to-phase :implement
                       :timestamp (java.util.Date.)}]
+   :dependency-health dependency-health
+   :workflow/error failure-attribution
    :workflow/errors (when (= status :failed)
                      [{:phase :test :error "Test failed"}])})
 
@@ -99,7 +101,27 @@
 
       (let [metrics (observer/get-workflow-metrics obs workflow-id)]
         (is (= :failed (:status metrics)) "Status should be :failed")
-        (is (seq (:errors metrics)) "Errors should be present")))))
+        (is (seq (:errors metrics)) "Errors should be present"))))
+
+  (testing "Collecting dependency attribution on failed workflow"
+    (let [obs (observer/create-observer)
+          workflow-id (random-uuid)
+          dependency-health {:anthropic {:dependency/id :anthropic
+                                         :dependency/status :degraded}}
+          failure-attribution {:failure/source :external-provider
+                               :failure/vendor :anthropic
+                               :failure/class :failure.class/external
+                               :dependency/id :anthropic
+                               :dependency/class :rate-limit
+                               :dependency/retryability :retryable}
+          workflow-state (sample-workflow-state workflow-id
+                                                :failed
+                                                :dependency-health dependency-health
+                                                :failure-attribution failure-attribution)]
+      (observer/collect-workflow-metrics obs workflow-id workflow-state)
+      (let [metrics (observer/get-workflow-metrics obs workflow-id)]
+        (is (= dependency-health (:dependency-health metrics)))
+        (is (= failure-attribution (:failure-attribution metrics)))))))
 
 (deftest collect-phase-metrics-test
   (testing "Collecting phase metrics"
@@ -281,7 +303,27 @@
         (let [data (:data analysis)]
           (is (= 10 (:total-workflows data)) "Should analyze 10 workflows")
           (is (= 3 (:failed-workflows data)) "Should have 3 failures")
-          (is (= 0.3 (:failure-rate data)) "Failure rate should be 30%"))))))
+          (is (= 0.3 (:failure-rate data)) "Failure rate should be 30%")))))
+
+  (testing "Analyzing dependency-attributed failures"
+    (let [obs (observer/create-observer)]
+      (dotimes [_ 2]
+        (observer/collect-workflow-metrics
+         obs
+         (random-uuid)
+         (sample-workflow-state
+          (random-uuid)
+          :failed
+          :failure-attribution {:failure/source :external-provider
+                                :failure/vendor :anthropic
+                                :failure/class :failure.class/external
+                                :dependency/id :anthropic
+                                :dependency/class :rate-limit
+                                :dependency/retryability :retryable})))
+      (let [analysis (observer/analyze-metrics obs :failure-patterns {})
+            dependency-failures (get-in analysis [:data :dependency-failures])]
+        (is (= :anthropic (ffirst dependency-failures)))
+        (is (= 2 (get-in (first dependency-failures) [1 :count])))))))
 
 (deftest analyze-trends-test
   (testing "Analyzing metrics trends"
@@ -311,11 +353,24 @@
         (observer/collect-workflow-metrics obs (random-uuid)
                                           (sample-workflow-state (random-uuid) :completed)))
 
+      (observer/collect-workflow-metrics
+       obs
+       (random-uuid)
+       (sample-workflow-state
+        (random-uuid)
+        :failed
+        :failure-attribution {:failure/source :external-provider
+                              :failure/vendor :anthropic
+                              :failure/class :failure.class/external
+                              :dependency/id :anthropic
+                              :dependency/class :rate-limit
+                              :dependency/retryability :retryable}))
       (let [report (observer/generate-report obs :summary {:format :markdown})]
         (is (string? report) "Report should be a string")
         (is (.contains report "Workflow Performance Summary") "Should have title")
         (is (.contains report "Duration Statistics") "Should have duration section")
-        (is (.contains report "Cost Statistics") "Should have cost section"))))
+        (is (.contains report "Cost Statistics") "Should have cost section")
+        (is (.contains report "Dependency-attributed failures") "Should include dependency attribution"))))
 
   (testing "Generating summary report in EDN"
     (let [obs (observer/create-observer)]

--- a/docs/pull-requests/2026-05-01-feat-dependency-evidence-and-observe.md
+++ b/docs/pull-requests/2026-05-01-feat-dependency-evidence-and-observe.md
@@ -1,0 +1,62 @@
+# feat/dependency-evidence-observe
+
+## Summary
+
+This PR carries canonical dependency attribution into the last reporting surfaces
+that still treated failures as undifferentiated workflow errors:
+
+- evidence bundles now persist dependency-health and failure-attribution
+- observer metrics and reports now preserve dependency-attributed failures
+- `mf evidence show` now displays dependency blame from canonical evidence data
+
+## Why
+
+Dogfooding exposed the product gap directly: when Claude or Codex or another
+external platform fails, Miniforge needs enough retained evidence to say that
+the run was blocked by a dependency, not by Miniforge itself.
+
+The earlier stack slices already established the canonical attribution model,
+classification, health projection, events, degradation signals, and live UX.
+This slice closes the historical/reporting path so offline evidence and observer
+reports tell the same story.
+
+## What Changed
+
+### Evidence Bundle
+
+- extended the evidence bundle schema with optional:
+  - `:evidence/dependency-health`
+  - `:evidence/failure-attribution`
+- updated bundle assembly to collect canonical dependency attribution from:
+  - explicit `opts`
+  - workflow-state
+  - dependency-health events when available
+
+### Observer
+
+- extended workflow metrics records with:
+  - `:dependency-health`
+  - `:failure-attribution`
+- updated failure-pattern analysis to summarize dependency-attributed failures
+- updated markdown summary/recommendation reports to surface dependency blame
+
+### CLI Evidence Display
+
+- normalized canonical evidence bundles for `evidence show`
+- added dependency issue count and failure attribution summary to the detail view
+
+## Validation
+
+- `clj-kondo --lint` on touched files
+- `bb pre-commit`
+
+## Follow-On
+
+Once this lands, the dependency-health stack is complete enough to go back to
+dogfooding with:
+
+- canonical dependency attribution
+- rolling dependency health projection
+- degradation signals
+- live workflow UX
+- persisted evidence and observer reporting

--- a/projects/miniforge/test/ai/miniforge/evidence_bundle/interface_test.clj
+++ b/projects/miniforge/test/ai/miniforge/evidence_bundle/interface_test.clj
@@ -30,9 +30,24 @@
   []
   (artifact/create-transit-store {:dir nil}))
 
+(defn dependency-health-entry
+  [overrides]
+  (merge {:dependency/id :anthropic
+          :dependency/source :external-provider
+          :dependency/kind :provider
+          :dependency/status :degraded
+          :dependency/failure-count 2
+          :dependency/window-size 5
+          :dependency/incident-counts {:rate-limit 2}
+          :dependency/vendor :anthropic
+          :dependency/class :rate-limit
+          :dependency/retryability :retryable}
+         overrides))
+
 (defn create-test-workflow-state
   "Create a test workflow state."
-  [workflow-id status & {:keys [tool-invocations] :or {tool-invocations []}}]
+  [workflow-id status & {:keys [tool-invocations dependency-health failure-attribution]
+                         :or {tool-invocations []}}]
   {:workflow/id workflow-id
    :workflow/status status
    :workflow/spec {:intent/type :import
@@ -53,6 +68,8 @@
                                 :artifacts []}}
    :workflow/gate-results []
    :workflow/tool-invocations tool-invocations
+   :dependency-health dependency-health
+   :workflow/error failure-attribution
    :workflow/pr-info {:number 123
                       :url "https://github.com/test/repo/pull/123"
                       :status :merged
@@ -129,7 +146,30 @@
       (is (not (nil? bundle)))
       (is (false? (get-in bundle [:evidence/outcome :outcome/success])))
       (is (= "Test error" (get-in bundle [:evidence/outcome :outcome/error-message])))
-      (is (= :verify (get-in bundle [:evidence/outcome :outcome/error-phase]))))))
+      (is (= :verify (get-in bundle [:evidence/outcome :outcome/error-phase])))))
+
+  (testing "Carries dependency attribution and dependency health into evidence"
+    (let [store (create-test-artifact-store)
+          manager (evidence/create-evidence-manager {:artifact-store store})
+          workflow-id (random-uuid)
+          dependency-health {:anthropic (dependency-health-entry {})}
+          failure-attribution {:failure/source :external-provider
+                               :failure/vendor :anthropic
+                               :failure/class :failure.class/external
+                               :dependency/id :anthropic
+                               :dependency/source :external-provider
+                               :dependency/kind :provider
+                               :dependency/vendor :anthropic
+                               :dependency/class :rate-limit
+                               :dependency/retryability :retryable
+                               :failure/message "Claude API rate limited"}
+          state (create-test-workflow-state workflow-id
+                                            :failed
+                                            :dependency-health dependency-health
+                                            :failure-attribution failure-attribution)
+          bundle (evidence/create-bundle manager workflow-id {:workflow-state state})]
+      (is (= dependency-health (:evidence/dependency-health bundle)))
+      (is (= failure-attribution (:evidence/failure-attribution bundle))))))
 
 ;------------------------------------------------------------------------------ Layer 3: Bundle Retrieval
 

--- a/projects/miniforge/test/ai/miniforge/observer/interface_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/observer/interface_integration_test.clj
@@ -23,7 +23,7 @@
    [ai.miniforge.workflow.interface.protocols.workflow-observer :as wf-proto]))
 
 (defn sample-workflow-state
-  [workflow-id status & {:keys [tokens cost duration]
+  [workflow-id status & {:keys [tokens cost duration dependency-health failure-attribution]
                          :or {tokens 1000 cost 0.10 duration 5000}}]
   {:workflow/id workflow-id
    :workflow/status status
@@ -33,6 +33,8 @@
    :workflow/history [{:from-phase :start
                        :to-phase :implement
                        :timestamp (java.util.Date.)}]
+   :dependency-health dependency-health
+   :workflow/error failure-attribution
    :workflow/errors (when (= status :failed)
                      [{:phase :test :error "Test failed"}])})
 
@@ -64,10 +66,23 @@
     (let [obs (observer/create-observer)
           workflow-id (random-uuid)]
       (wf-proto/on-phase-error obs workflow-id :test {:message "Test failed" :type :assertion-error})
-      (wf-proto/on-workflow-complete obs workflow-id (sample-workflow-state workflow-id :failed))
+      (wf-proto/on-workflow-complete
+       obs
+       workflow-id
+       (sample-workflow-state workflow-id
+                              :failed
+                              :dependency-health {:anthropic {:dependency/id :anthropic
+                                                              :dependency/status :degraded}}
+                              :failure-attribution {:failure/source :external-provider
+                                                    :failure/vendor :anthropic
+                                                    :failure/class :failure.class/external
+                                                    :dependency/id :anthropic
+                                                    :dependency/class :rate-limit
+                                                    :dependency/retryability :retryable}))
       (let [metrics (observer/get-workflow-metrics obs workflow-id)]
         (is (= :failed (:status metrics)))
-        (is (seq (:phases metrics))))))
+        (is (seq (:phases metrics)))
+        (is (= :anthropic (get-in metrics [:failure-attribution :dependency/id]))))))
 
   (testing "observer handles rollback"
     (let [obs (observer/create-observer)


### PR DESCRIPTION
# feat/dependency-evidence-observe

## Summary

This PR carries canonical dependency attribution into the last reporting surfaces
that still treated failures as undifferentiated workflow errors:

- evidence bundles now persist dependency-health and failure-attribution
- observer metrics and reports now preserve dependency-attributed failures
- `mf evidence show` now displays dependency blame from canonical evidence data

## Why

Dogfooding exposed the product gap directly: when Claude or Codex or another
external platform fails, Miniforge needs enough retained evidence to say that
the run was blocked by a dependency, not by Miniforge itself.

The earlier stack slices already established the canonical attribution model,
classification, health projection, events, degradation signals, and live UX.
This slice closes the historical/reporting path so offline evidence and observer
reports tell the same story.

## What Changed

### Evidence Bundle

- extended the evidence bundle schema with optional:
  - `:evidence/dependency-health`
  - `:evidence/failure-attribution`
- updated bundle assembly to collect canonical dependency attribution from:
  - explicit `opts`
  - workflow-state
  - dependency-health events when available

### Observer

- extended workflow metrics records with:
  - `:dependency-health`
  - `:failure-attribution`
- updated failure-pattern analysis to summarize dependency-attributed failures
- updated markdown summary/recommendation reports to surface dependency blame

### CLI Evidence Display

- normalized canonical evidence bundles for `evidence show`
- added dependency issue count and failure attribution summary to the detail view

## Validation

- `clj-kondo --lint` on touched files
- `bb pre-commit`

## Follow-On

Once this lands, the dependency-health stack is complete enough to go back to
dogfooding with:

- canonical dependency attribution
- rolling dependency health projection
- degradation signals
- live workflow UX
- persisted evidence and observer reporting
