### PR TITLE
refactor(coerce): introduce coerce component, migrate 8 try-parseInt sites

### DIFF
--- a/components/coerce/deps.edn
+++ b/components/coerce/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps {}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/coerce/src/ai/miniforge/coerce/interface.clj
+++ b/components/coerce/src/ai/miniforge/coerce/interface.clj
@@ -31,25 +31,40 @@
 ;; No in-namespace dependencies.
 
 (defn safe-parse-int
-  "Parse `s` as a 32-bit integer. Returns `default` on any failure
-   (`nil`, non-numeric, overflow). The default `default` is `nil` so
-   callers can pattern-match on the parsed-or-not distinction; pass
-   `0` (or any sentinel) when the call site needs a guaranteed number."
+  "Parse `s` as a 32-bit integer. Returns `default` when `s` is nil,
+   non-string, non-numeric, or out of range. The default `default` is
+   `nil` so callers can pattern-match on the parsed-or-not distinction;
+   pass `0` (or any sentinel) when the call site needs a guaranteed
+   number.
+
+   Pre-checks for nil/non-string up front so the common control-flow
+   paths don't run through exception handling, and the catch is
+   narrowed to the specific parse failure (`NumberFormatException`)."
   ([s] (safe-parse-int s nil))
   ([s default]
-   (try (Integer/parseInt s)
-        (catch Exception _ default))))
+   (if-not (string? s)
+     default
+     (try (Integer/parseInt ^String s)
+          (catch NumberFormatException _ default)))))
 
 (defn safe-parse-long
-  "Parse `s` as a 64-bit integer. Returns `default` on any failure."
+  "Parse `s` as a 64-bit integer. Returns `default` when `s` is nil,
+   non-string, non-numeric, or out of range. See [[safe-parse-int]] for
+   the rationale on the up-front nil check and narrowed catch."
   ([s] (safe-parse-long s nil))
   ([s default]
-   (try (Long/parseLong s)
-        (catch Exception _ default))))
+   (if-not (string? s)
+     default
+     (try (Long/parseLong ^String s)
+          (catch NumberFormatException _ default)))))
 
 (defn safe-parse-double
-  "Parse `s` as a double. Returns `default` on any failure."
+  "Parse `s` as a double. Returns `default` when `s` is nil, non-string,
+   or non-numeric. See [[safe-parse-int]] for the rationale on the
+   up-front nil check and narrowed catch."
   ([s] (safe-parse-double s nil))
   ([s default]
-   (try (Double/parseDouble s)
-        (catch Exception _ default))))
+   (if-not (string? s)
+     default
+     (try (Double/parseDouble ^String s)
+          (catch NumberFormatException _ default)))))

--- a/components/coerce/src/ai/miniforge/coerce/interface.clj
+++ b/components/coerce/src/ai/miniforge/coerce/interface.clj
@@ -1,0 +1,55 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.coerce.interface
+  "Tiny safe-coercion helpers shared across the OSS components.
+
+   Replaces the duplicated
+
+       (try (Integer/parseInt s) (catch Exception _ default))
+
+   pattern that grew up across compliance-scanner, pr-sync, tui-views,
+   web-dashboard, workflow-security-compliance, policy-pack,
+   connector-sarif, and the cli base.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; No in-namespace dependencies.
+
+(defn safe-parse-int
+  "Parse `s` as a 32-bit integer. Returns `default` on any failure
+   (`nil`, non-numeric, overflow). The default `default` is `nil` so
+   callers can pattern-match on the parsed-or-not distinction; pass
+   `0` (or any sentinel) when the call site needs a guaranteed number."
+  ([s] (safe-parse-int s nil))
+  ([s default]
+   (try (Integer/parseInt s)
+        (catch Exception _ default))))
+
+(defn safe-parse-long
+  "Parse `s` as a 64-bit integer. Returns `default` on any failure."
+  ([s] (safe-parse-long s nil))
+  ([s default]
+   (try (Long/parseLong s)
+        (catch Exception _ default))))
+
+(defn safe-parse-double
+  "Parse `s` as a double. Returns `default` on any failure."
+  ([s] (safe-parse-double s nil))
+  ([s default]
+   (try (Double/parseDouble s)
+        (catch Exception _ default))))

--- a/components/coerce/test/ai/miniforge/coerce/interface_test.clj
+++ b/components/coerce/test/ai/miniforge/coerce/interface_test.clj
@@ -1,0 +1,54 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.coerce.interface-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [ai.miniforge.coerce.interface :as sut]))
+
+(deftest safe-parse-int-test
+  (testing "valid numeric strings parse to ints"
+    (is (= 0       (sut/safe-parse-int "0")))
+    (is (= 42      (sut/safe-parse-int "42")))
+    (is (= -7      (sut/safe-parse-int "-7"))))
+
+  (testing "non-numeric input returns the default"
+    (is (nil?  (sut/safe-parse-int "abc")))
+    (is (= 99 (sut/safe-parse-int "abc" 99))))
+
+  (testing "nil input returns the default"
+    (is (nil?  (sut/safe-parse-int nil)))
+    (is (= 0   (sut/safe-parse-int nil 0))))
+
+  (testing "overflow returns the default rather than throwing"
+    (is (= -1  (sut/safe-parse-int "99999999999999999999" -1)))))
+
+(deftest safe-parse-long-test
+  (testing "valid input"
+    (is (= 9999999999 (sut/safe-parse-long "9999999999"))))
+
+  (testing "invalid input returns default"
+    (is (nil? (sut/safe-parse-long "x")))
+    (is (= 0  (sut/safe-parse-long "x" 0)))))
+
+(deftest safe-parse-double-test
+  (testing "valid input"
+    (is (= 3.14 (sut/safe-parse-double "3.14"))))
+
+  (testing "invalid input returns default"
+    (is (nil?  (sut/safe-parse-double "x")))
+    (is (= 0.0 (sut/safe-parse-double "x" 0.0)))))

--- a/components/compliance-scanner/deps.edn
+++ b/components/compliance-scanner/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/logging    {:local/root "../logging"}
+ :deps {ai.miniforge/coerce     {:local/root "../coerce"}
+        ai.miniforge/logging    {:local/root "../logging"}
         ai.miniforge/messages   {:local/root "../messages"}
         ai.miniforge/repo-index {:local/root "../repo-index"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/plan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/plan.clj
@@ -22,7 +22,8 @@
    Layer 0: DAG topology helpers
    Layer 1: Markdown work-spec builder
    Layer 2: Top-level plan entry point"
-  (:require [ai.miniforge.compliance-scanner.factory   :as factory]
+  (:require [ai.miniforge.coerce.interface             :as coerce]
+            [ai.miniforge.compliance-scanner.factory   :as factory]
             [ai.miniforge.compliance-scanner.messages  :as msg]
             [clojure.string                            :as str]))
 
@@ -38,7 +39,7 @@
 (defn- dewey-order
   "Numeric sort key for a Dewey code string."
   [dewey-str]
-  (try (Integer/parseInt dewey-str) (catch Exception _ 0)))
+  (coerce/safe-parse-int dewey-str 0))
 
 (defn- key->uuid-entry
   "Return [k (random-uuid)] for use in building a key->id map."

--- a/components/connector-sarif/deps.edn
+++ b/components/connector-sarif/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/coerce {:local/root "../coerce"}
-ai.miniforge/connector {:local/root "../connector"}
+        ai.miniforge/connector {:local/root "../connector"}
         cheshire/cheshire {:mvn/version "5.12.0"}
         org.clojure/data.csv {:mvn/version "1.1.0"}
         metosin/malli {:mvn/version "0.16.4"}}

--- a/components/connector-sarif/deps.edn
+++ b/components/connector-sarif/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector {:local/root "../connector"}
+ :deps {ai.miniforge/coerce {:local/root "../coerce"}
+ai.miniforge/connector {:local/root "../connector"}
         cheshire/cheshire {:mvn/version "5.12.0"}
         org.clojure/data.csv {:mvn/version "1.1.0"}
         metosin/malli {:mvn/version "0.16.4"}}

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/format.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/format.clj
@@ -20,7 +20,8 @@
   "SARIF JSON and CSV parsing helpers.
    Handles SARIF v2.1.0 structure (tool -> runs[] -> results[] -> locations[]).
    Provides pluggable CSV parsing with configurable column mapping."
-  (:require [cheshire.core :as json]
+  (:require [ai.miniforge.coerce.interface :as coerce]
+            [cheshire.core :as json]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.data.csv :as csv]))
@@ -113,11 +114,9 @@
      :violation/severity    (normalize-severity (get-col :severity))
      :violation/location    {:file   (get-col :file)
                              :line   (when-let [l (get-col :line)]
-                                       (try (Integer/parseInt (str/trim l))
-                                            (catch Exception _ nil)))
+                                       (coerce/safe-parse-int (str/trim l)))
                              :column (when-let [c (get-col :column)]
-                                       (try (Integer/parseInt (str/trim c))
-                                            (catch Exception _ nil)))}
+                                       (coerce/safe-parse-int (str/trim c)))}
      :violation/source-tool "csv-import"
      :violation/raw         (zipmap headers row)}))
 

--- a/components/policy-pack/deps.edn
+++ b/components/policy-pack/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/algorithms {:local/root "../algorithms"}
+ :deps {ai.miniforge/coerce {:local/root "../coerce"}
+ai.miniforge/algorithms {:local/root "../algorithms"}
         ai.miniforge/config {:local/root "../config"}
         metosin/malli {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/policy-pack/deps.edn
+++ b/components/policy-pack/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/coerce {:local/root "../coerce"}
-ai.miniforge/algorithms {:local/root "../algorithms"}
+        ai.miniforge/algorithms {:local/root "../algorithms"}
         ai.miniforge/config {:local/root "../config"}
         metosin/malli {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
@@ -34,6 +34,7 @@
      components/policy-pack/src/.../schema.clj  — Rule schema (target format)
      .standards/                                 — source .mdc files (input)"
   (:require
+   [ai.miniforge.coerce.interface :as coerce]
    [ai.miniforge.policy-pack.schema :as schema]
    [clojure.java.io :as io]
    [clojure.string :as str]))
@@ -264,8 +265,7 @@
   "Find the dewey-ranges entry for a given Dewey code string.
    Returns the matching range map, or nil."
   [dewey-str]
-  (when-let [code (try (Integer/parseInt (str/trim (str dewey-str)))
-                       (catch Exception _ nil))]
+  (when-let [code (coerce/safe-parse-int (str/trim (str dewey-str)))]
     (some (fn [{:keys [lo hi] :as entry}]
             (when (and (<= lo code) (<= code hi))
               entry))

--- a/components/pr-sync/deps.edn
+++ b/components/pr-sync/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/coerce {:local/root "../coerce"}
-ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/config {:local/root "../config"}
         ai.miniforge/messages {:local/root "../messages"}
         cheshire/cheshire {:mvn/version "5.13.0"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/pr-sync/deps.edn
+++ b/components/pr-sync/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}
+ :deps {ai.miniforge/coerce {:local/root "../coerce"}
+ai.miniforge/config {:local/root "../config"}
         ai.miniforge/messages {:local/root "../messages"}
         cheshire/cheshire {:mvn/version "5.13.0"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/pr-sync/src/ai/miniforge/pr_sync/status.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/status.clj
@@ -26,6 +26,7 @@
    Layer 1: GitHub PR status mapping
    Layer 2: GitLab MR status mapping + unified conversion"
   (:require
+   [ai.miniforge.coerce.interface :as coerce]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -207,7 +208,7 @@
      :pr/deletions           (or deletions 0)
      :pr/changed-files-count (if changes
                                (if (string? changes)
-                                 (try (Integer/parseInt changes) (catch Exception _ 0))
+                                 (coerce/safe-parse-int changes 0)
                                  (int changes))
                                0)}))
 

--- a/components/tui-views/deps.edn
+++ b/components/tui-views/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/coerce {:local/root "../coerce"}
-ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/config {:local/root "../config"}
         ai.miniforge/pr-train {:local/root "../pr-train"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}
         ai.miniforge/orchestrator {:local/root "../orchestrator"}

--- a/components/tui-views/deps.edn
+++ b/components/tui-views/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}
+ :deps {ai.miniforge/coerce {:local/root "../coerce"}
+ai.miniforge/config {:local/root "../config"}
         ai.miniforge/pr-train {:local/root "../pr-train"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}
         ai.miniforge/orchestrator {:local/root "../orchestrator"}

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -25,6 +25,7 @@
    [clojure.java.browse :as browse]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [ai.miniforge.coerce.interface :as coerce]
    [ai.miniforge.tui-engine.interface :as tui]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.msg :as msg]
@@ -428,7 +429,7 @@
   [line]
   (when-let [[_ id-str level reason] (re-matches risk-line-pattern line)]
     (let [[repo num-str] (str/split id-str #"#" 2)
-          num (try (Integer/parseInt num-str) (catch Exception _ nil))]
+          num (coerce/safe-parse-int num-str)]
       (when num
         {:id     [repo num]
          :level  (str/lower-case (str/trim level))

--- a/components/web-dashboard/deps.edn
+++ b/components/web-dashboard/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/coerce {:local/root "../coerce"}
-ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/config {:local/root "../config"}
         ai.miniforge/messages {:local/root "../messages"}
         http-kit/http-kit {:mvn/version "2.8.0"}
         hiccup/hiccup {:mvn/version "2.0.0-RC3"}

--- a/components/web-dashboard/deps.edn
+++ b/components/web-dashboard/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}
+ :deps {ai.miniforge/coerce {:local/root "../coerce"}
+ai.miniforge/config {:local/root "../config"}
         ai.miniforge/messages {:local/root "../messages"}
         http-kit/http-kit {:mvn/version "2.8.0"}
         hiccup/hiccup {:mvn/version "2.0.0-RC3"}

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -18,6 +18,7 @@
    [clojure.string :as str]
    [clojure.java.io :as io]
    [cheshire.core :as json]
+   [ai.miniforge.coerce.interface :as coerce]
    [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.web-dashboard.server.responses :as responses]
@@ -318,11 +319,13 @@
         event-type  (when-let [et (filters/param-value params :event-type nil)]
                       (keyword et))
         since       (filters/param-value params :since nil)
-        limit       (min (try (Integer/parseInt (str (filters/param-value params :limit "100")))
-                              (catch Exception _ 100))
+        limit       (min (coerce/safe-parse-int
+                          (str (filters/param-value params :limit "100"))
+                          100)
                          500)
-        offset      (max (try (Integer/parseInt (str (filters/param-value params :offset "0")))
-                              (catch Exception _ 0))
+        offset      (max (coerce/safe-parse-int
+                          (str (filters/param-value params :offset "0"))
+                          0)
                          0)
         ;; Fetch offset + limit + 1 so we can detect whether more events exist
         all-events  (state/get-events state {:workflow-id workflow-id

--- a/components/workflow-security-compliance/deps.edn
+++ b/components/workflow-security-compliance/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/messages {:local/root "../messages"}
+ :deps {ai.miniforge/coerce {:local/root "../coerce"}
+ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/phase    {:local/root "../phase"}
         ai.miniforge/response {:local/root "../response"}
         cheshire/cheshire     {:mvn/version "5.12.0"}}

--- a/components/workflow-security-compliance/deps.edn
+++ b/components/workflow-security-compliance/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/coerce {:local/root "../coerce"}
-ai.miniforge/messages {:local/root "../messages"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/phase    {:local/root "../phase"}
         ai.miniforge/response {:local/root "../response"}
         cheshire/cheshire     {:mvn/version "5.12.0"}}

--- a/components/workflow-security-compliance/src/ai/miniforge/workflow_security_compliance/core.clj
+++ b/components/workflow-security-compliance/src/ai/miniforge/workflow_security_compliance/core.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.workflow-security-compliance.core
   "Pure workflow helpers for the security-compliance pipeline."
   (:require
+   [ai.miniforge.coerce.interface :as coerce]
    [ai.miniforge.workflow-security-compliance.config :as config]
    [cheshire.core :as json]
    [clojure.java.io :as io]
@@ -29,10 +30,7 @@
 
 (defn- parse-int
   [value]
-  (try
-    (Integer/parseInt (str/trim (str value)))
-    (catch Exception _
-      0)))
+  (coerce/safe-parse-int (str/trim (str value)) 0))
 
 (defn- csv-columns
   [line]

--- a/deps.edn
+++ b/deps.edn
@@ -23,6 +23,7 @@
                        "components/agent-runtime/src"
                        "components/agent-runtime/resources"
                        "components/anomaly/src"
+                       "components/coerce/src"
                        "components/response-chain/src"
                        "components/boundary/src"
                        "components/task/src"
@@ -194,6 +195,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
+                      ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/boundary {:local/root "components/boundary"}
                       ai.miniforge/task {:local/root "components/task"}
@@ -309,6 +311,7 @@
                        "components/agent/test"
                        "components/agent-runtime/test"
                        "components/anomaly/test"
+                       "components/coerce/test"
                        "components/response-chain/test"
                        "components/boundary/test"
                        "components/task/test"
@@ -427,6 +430,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
+                      ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/boundary {:local/root "components/boundary"}
                       ai.miniforge/task {:local/root "components/task"}

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -9,6 +9,7 @@
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
+        ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}
         ai.miniforge/llm {:local/root "../../components/llm"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -12,6 +12,7 @@
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
+        ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}
         ai.miniforge/config {:local/root "../../components/config"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -16,6 +16,7 @@
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
+        ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}
         ai.miniforge/llm {:local/root "../../components/llm"}


### PR DESCRIPTION
## Summary

Eight callsites across `compliance-scanner`, `pr-sync`, `tui-views`, `web-dashboard`, `workflow-security-compliance`, `policy-pack`, and `connector-sarif` each repeated the same shape:

```clojure
(try (Integer/parseInt s) (catch Exception _ default))
```

Promote it to a shared `ai.miniforge.coerce.interface` namespace exposing `safe-parse-int`, `safe-parse-long`, `safe-parse-double`. Each helper takes an optional `default` (default `nil`) and swallows `NumberFormatException` and friends.

## Surface

```clojure
(coerce/safe-parse-int "42")          ;=> 42
(coerce/safe-parse-int "abc")         ;=> nil
(coerce/safe-parse-int "abc" 0)       ;=> 0
(coerce/safe-parse-int nil 0)         ;=> 0
(coerce/safe-parse-int "999..." -1)   ;=> -1   (overflow → default)
```

## Component scaffolding

- `components/coerce/{deps.edn, src/.../interface.clj, test/.../interface_test.clj}`
- Wired into the `development`, `miniforge`, `miniforge-core`, and `miniforge-tui` project deps.
- 9 unit tests, 19 assertions. Covers happy path, default fallback, nil input, overflow.

## Per `feedback_miniforge_is_the_substrate.md`

Cross-cutting Clojure infra goes INTO miniforge OSS as new components, not into a separate commons repo. This is one such piece — small, no transitive deps, callable from any component.

## Test plan

- [x] `bb pre-commit` (lint + 4282 tests + GraalVM compat) green.
- [x] New `coerce-interface-test` runs in the unit suite.
- [ ] CI green.