### PR TITLE
refactor(clock): introduce clock component, migrate timing callsites

### DIFF
--- a/components/clock/deps.edn
+++ b/components/clock/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps {}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/clock/src/ai/miniforge/clock/interface.clj
+++ b/components/clock/src/ai/miniforge/clock/interface.clj
@@ -38,15 +38,25 @@
   (System/currentTimeMillis))
 
 (defn elapsed-since
-  "Milliseconds since `start-ms`. Pair with `now-ms` at entry:
+  "Milliseconds since `start-ms`. Pair with `now-ms` at entry — call
+   `now-ms` BEFORE the work, then `elapsed-since` AFTER:
 
        (let [start (clock/now-ms)]
          …work…
          {:duration-ms (clock/elapsed-since start)})
 
-   Equivalent to `(- (now-ms) start-ms)` but reads as the intent."
+   Note: `(elapsed-since (now-ms))` would measure ~0 because the start
+   timestamp is created at the end of the work. The two-step pattern
+   above is the only correct usage.
+
+   Wall-clock based, so an NTP step or VM clock adjustment could in
+   principle make `(now-ms)` go backwards. Clamp the result to
+   non-negative so downstream `:duration-ms` consumers (which model the
+   field as non-negative; see `components/loop/schema.clj`,
+   `components/schema/core.clj`, `components/agent/reviewer.clj`)
+   never see a negative duration."
   [start-ms]
-  (- (now-ms) start-ms))
+  (max 0 (- (now-ms) start-ms)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Composes Layer 0.

--- a/components/clock/src/ai/miniforge/clock/interface.clj
+++ b/components/clock/src/ai/miniforge/clock/interface.clj
@@ -1,0 +1,65 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.clock.interface
+  "Tiny timing helpers shared across the OSS components.
+
+   Replaces the duplicated
+
+       (let [start (System/currentTimeMillis)]
+         …work…
+         (- (System/currentTimeMillis) start))
+
+   pattern that grew up across loop/gates, connector-linter,
+   compliance-scanner, and similar places that report a
+   `:duration-ms` alongside the result of a single block.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; No in-namespace dependencies.
+
+(defn now-ms
+  "Wall-clock millis. Wrapped so tests can `with-redefs` the clock."
+  []
+  (System/currentTimeMillis))
+
+(defn elapsed-since
+  "Milliseconds since `start-ms`. Pair with `now-ms` at entry:
+
+       (let [start (clock/now-ms)]
+         …work…
+         {:duration-ms (clock/elapsed-since start)})
+
+   Equivalent to `(- (now-ms) start-ms)` but reads as the intent."
+  [start-ms]
+  (- (now-ms) start-ms))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
+(defmacro with-duration
+  "Evaluate `body`, return `{:result <body-value> :duration-ms <ms>}`.
+
+   Use when the call site wants both the result and the elapsed time
+   in a single envelope. For branching code where each branch builds a
+   bespoke result map and attaches its own `:duration-ms`, prefer the
+   simpler `(elapsed-since (now-ms))` form."
+  [& body]
+  `(let [start# (now-ms)
+         result# (do ~@body)]
+     {:result      result#
+      :duration-ms (elapsed-since start#)}))

--- a/components/clock/test/ai/miniforge/clock/interface_test.clj
+++ b/components/clock/test/ai/miniforge/clock/interface_test.clj
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.clock.interface-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [ai.miniforge.clock.interface :as sut]))
+
+(deftest now-ms-test
+  (testing "returns a positive long that increases monotonically across two calls"
+    (let [a (sut/now-ms)
+          b (sut/now-ms)]
+      (is (pos-int? a))
+      (is (>= b a)))))
+
+(deftest elapsed-since-test
+  (testing "elapsed is computed against current now-ms"
+    (with-redefs [sut/now-ms (constantly 1000)]
+      (is (= 250 (sut/elapsed-since 750)))))
+
+  (testing "negative skew clamps to negative (caller is responsible for forward times)"
+    (with-redefs [sut/now-ms (constantly 1000)]
+      (is (= -50 (sut/elapsed-since 1050))))))
+
+(deftest with-duration-test
+  (testing "returns the body result + elapsed millis"
+    (with-redefs [sut/now-ms (let [calls (atom 0)]
+                               (fn []
+                                 (swap! calls inc)
+                                 (case @calls
+                                   1 100
+                                   2 175
+                                   nil)))]
+      (let [out (sut/with-duration
+                  (+ 1 2 3))]
+        (is (= 6   (:result out)))
+        (is (= 75  (:duration-ms out))))))
+
+  (testing "body executes once, even with multiple forms"
+    (let [counter (atom 0)
+          out     (sut/with-duration
+                    (swap! counter inc)
+                    (swap! counter inc))]
+      (is (= 2 (:result out)))
+      (is (= 2 @counter)))))

--- a/components/clock/test/ai/miniforge/clock/interface_test.clj
+++ b/components/clock/test/ai/miniforge/clock/interface_test.clj
@@ -32,9 +32,9 @@
     (with-redefs [sut/now-ms (constantly 1000)]
       (is (= 250 (sut/elapsed-since 750)))))
 
-  (testing "negative skew clamps to negative (caller is responsible for forward times)"
+  (testing "clock skew (start in the future) clamps to 0 instead of returning negative"
     (with-redefs [sut/now-ms (constantly 1000)]
-      (is (= -50 (sut/elapsed-since 1050))))))
+      (is (= 0 (sut/elapsed-since 1050))))))
 
 (deftest with-duration-test
   (testing "returns the body result + elapsed millis"

--- a/components/connector-linter/deps.edn
+++ b/components/connector-linter/deps.edn
@@ -1,3 +1,4 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/compliance-scanner {:local/root "../compliance-scanner"}}
+ :deps {ai.miniforge/clock              {:local/root "../clock"}
+        ai.miniforge/compliance-scanner {:local/root "../compliance-scanner"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
@@ -12,6 +12,7 @@
    Layer 2 — `run-all`, `run-fixes` (public orchestration; compose
              Layer 1)."
   (:require
+   [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.connector-linter.etl :as etl]
    [babashka.process :as process]))
 
@@ -53,7 +54,7 @@
   [repo-path tech-id linter-config]
   (let [{:keys [command args parser check-cmd]} linter-config
         available? (linter-available? (or check-cmd [command "--version"]))
-        start-ms   (System/currentTimeMillis)]
+        start-ms   (clock/now-ms)]
     (if-not available?
       {:tech tech-id :violations [] :available? false :duration-ms 0}
       (let [result     (run-subprocess repo-path command args)
@@ -61,12 +62,11 @@
             mapping    (etl/get-mapping parser)
             violations (if mapping
                          (etl/apply-mapping mapping output)
-                         [])
-            end-ms     (System/currentTimeMillis)]
+                         [])]
         {:tech        tech-id
          :violations  violations
          :available?  true
-         :duration-ms (- end-ms start-ms)}))))
+         :duration-ms (clock/elapsed-since start-ms)}))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public orchestration — composes Layer 1 (`run-linter`) + Layer 0

--- a/components/loop/deps.edn
+++ b/components/loop/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/fsm {:local/root "../fsm"}
+ :deps {ai.miniforge/clock    {:local/root "../clock"}
+        ai.miniforge/fsm      {:local/root "../fsm"}
         ai.miniforge/decision {:local/root "../decision"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -336,11 +336,12 @@
     (let [start (clock/now-ms)]
       (try
         (let [result (check-fn artifact context)]
-          (if (:gate/passed? result)
-            (assoc result :gate/duration-ms (clock/elapsed-since start))
-            (assoc result :gate/duration-ms (clock/elapsed-since start))))
+          (assoc result :gate/duration-ms (clock/elapsed-since start)))
         (catch Exception e
-          (fail-result id :custom
+          ;; Use the gate's declared `type-kw` rather than a hard-coded
+          ;; `:custom` so the result map matches the gate's
+          ;; `(gate-type)` on both success and failure paths.
+          (fail-result id type-kw
                        [(make-error :custom-gate-error (.getMessage e))]
                        :duration-ms (clock/elapsed-since start))))))
 

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -27,6 +27,7 @@
    Layer 1: Built-in gates (syntax, lint, test, policy)
    Layer 2: Gate runner and composition"
   (:require
+   [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.loop.interface.protocols.gate :as p]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
@@ -93,7 +94,7 @@
 (defrecord SyntaxGate [id config]
   p/Gate
   (check [_this artifact context]
-    (let [start (System/currentTimeMillis)
+    (let [start (clock/now-ms)
           content (:artifact/content artifact)
           artifact-type (:artifact/type artifact)
           logger (:logger context)]
@@ -109,14 +110,14 @@
             #_{:clj-kondo/ignore [:unused-value]}
             (read-string content)  ; Parse to check syntax; result intentionally unused
             (pass-result id :syntax
-                         :duration-ms (- (System/currentTimeMillis) start)))
+                         :duration-ms (clock/elapsed-since start)))
           ;; For non-code artifacts, pass by default
           (pass-result id :syntax
-                       :duration-ms (- (System/currentTimeMillis) start)))
+                       :duration-ms (clock/elapsed-since start)))
         (catch Exception e
           (fail-result id :syntax
                        [(make-error :syntax-error (.getMessage e))]
-                       :duration-ms (- (System/currentTimeMillis) start))))))
+                       :duration-ms (clock/elapsed-since start))))))
 
   (gate-id [_this] id)
   (gate-type [_this] :syntax)
@@ -138,7 +139,7 @@
 (defrecord LintGate [id config]
   p/Gate
   (check [_this artifact context]
-    (let [start (System/currentTimeMillis)
+    (let [start (clock/now-ms)
           content (:artifact/content artifact)
           artifact-type (:artifact/type artifact)
           logger (:logger context)
@@ -163,13 +164,13 @@
                                            "Unused namespace alias found")))]
           (if (and fail-on-warning? (seq warnings))
             (fail-result id :lint warnings
-                         :duration-ms (- (System/currentTimeMillis) start))
+                         :duration-ms (clock/elapsed-since start))
             (pass-result id :lint
                          :warnings (when (seq warnings) warnings)
-                         :duration-ms (- (System/currentTimeMillis) start))))
+                         :duration-ms (clock/elapsed-since start))))
         ;; Non-code artifacts pass lint
         (pass-result id :lint
-                     :duration-ms (- (System/currentTimeMillis) start)))))
+                     :duration-ms (clock/elapsed-since start)))))
 
   (gate-id [_this] id)
   (gate-type [_this] :lint)
@@ -203,7 +204,7 @@
 (defrecord TestGate [id config]
   p/Gate
   (check [_this artifact context]
-    (let [start (System/currentTimeMillis)
+    (let [start (clock/now-ms)
           logger (:logger context)
           test-fn (:test-fn config)
           artifact-type (:artifact/type artifact)]
@@ -216,19 +217,19 @@
           (let [result (test-fn artifact context)]
             (if (passed? result)
               (pass-result id :test
-                           :duration-ms (- (System/currentTimeMillis) start))
+                           :duration-ms (clock/elapsed-since start))
               (fail-result id :test
                            (or (:errors result)
                                [(make-error :test-failed "Test execution failed")])
-                           :duration-ms (- (System/currentTimeMillis) start))))
+                           :duration-ms (clock/elapsed-since start))))
           (catch Exception e
             (fail-result id :test
                          [(make-error :test-error (.getMessage e))]
-                         :duration-ms (- (System/currentTimeMillis) start))))
+                         :duration-ms (clock/elapsed-since start))))
         ;; No test function provided, pass by default
         (pass-result id :test
                      :warnings [(make-error :no-test-fn "No test function configured")]
-                     :duration-ms (- (System/currentTimeMillis) start)))))
+                     :duration-ms (clock/elapsed-since start)))))
 
   (gate-id [_this] id)
   (gate-type [_this] :test)
@@ -251,7 +252,7 @@
 (defrecord PolicyGate [id config]
   p/Gate
   (check [_this artifact context]
-    (let [start (System/currentTimeMillis)
+    (let [start (clock/now-ms)
           logger (:logger context)
           policies (:policies config [])
           artifact-type (:artifact/type artifact)
@@ -295,9 +296,9 @@
                     policies)]
         (if (seq errors)
           (fail-result id :policy errors
-                       :duration-ms (- (System/currentTimeMillis) start))
+                       :duration-ms (clock/elapsed-since start))
           (pass-result id :policy
-                       :duration-ms (- (System/currentTimeMillis) start))))))
+                       :duration-ms (clock/elapsed-since start))))))
 
   (gate-id [_this] id)
   (gate-type [_this] :policy)
@@ -332,16 +333,16 @@
 (defrecord CustomGate [id type-kw check-fn]
   p/Gate
   (check [_this artifact context]
-    (let [start (System/currentTimeMillis)]
+    (let [start (clock/now-ms)]
       (try
         (let [result (check-fn artifact context)]
           (if (:gate/passed? result)
-            (assoc result :gate/duration-ms (- (System/currentTimeMillis) start))
-            (assoc result :gate/duration-ms (- (System/currentTimeMillis) start))))
+            (assoc result :gate/duration-ms (clock/elapsed-since start))
+            (assoc result :gate/duration-ms (clock/elapsed-since start))))
         (catch Exception e
           (fail-result id :custom
                        [(make-error :custom-gate-error (.getMessage e))]
-                       :duration-ms (- (System/currentTimeMillis) start))))))
+                       :duration-ms (clock/elapsed-since start))))))
 
   (gate-id [_this] id)
   (gate-type [_this] type-kw)

--- a/deps.edn
+++ b/deps.edn
@@ -23,6 +23,7 @@
                        "components/agent-runtime/src"
                        "components/agent-runtime/resources"
                        "components/anomaly/src"
+                       "components/clock/src"
                        "components/coerce/src"
                        "components/response-chain/src"
                        "components/boundary/src"
@@ -195,6 +196,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
+                      ai.miniforge/clock {:local/root "components/clock"}
                       ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/boundary {:local/root "components/boundary"}
@@ -311,6 +313,7 @@
                        "components/agent/test"
                        "components/agent-runtime/test"
                        "components/anomaly/test"
+                       "components/clock/test"
                        "components/coerce/test"
                        "components/response-chain/test"
                        "components/boundary/test"
@@ -430,6 +433,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
+                      ai.miniforge/clock {:local/root "components/clock"}
                       ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/boundary {:local/root "components/boundary"}

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -9,6 +9,7 @@
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
+        ai.miniforge/clock {:local/root "../../components/clock"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -12,6 +12,7 @@
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
+        ai.miniforge/clock {:local/root "../../components/clock"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -16,6 +16,7 @@
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
+        ai.miniforge/clock {:local/root "../../components/clock"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}


### PR DESCRIPTION
## Summary

New tiny `components/clock` exposes:

```clojure
(clock/now-ms)            ; (System/currentTimeMillis), wrapped so tests can with-redefs
(clock/elapsed-since ms)  ; (- (now-ms) ms)
(clock/with-duration …)   ; macro: returns {:result <body> :duration-ms <ms>}
```

Replaces the duplicated `start (System/currentTimeMillis)` / `(- (System/currentTimeMillis) start)` pattern that grew up across the codebase. Two consuming components migrated in this PR:

- `components/connector-linter/src/.../runner.clj` — `run-linter` returns `:duration-ms (clock/elapsed-since start-ms)`.
- `components/loop/src/.../gates.clj` — ~10 callsites in cond/try-catch branches across `SyntaxGate`, `LintGate`, `TestGate`, `PolicyGate`, and the gate runner.

The macro form is reserved for the simple "compute one body, return result+duration" cases. The branch-heavy gate code uses `now-ms`/`elapsed-since` directly because each branch builds a bespoke result map.

## Component scaffolding

- `components/clock/{deps.edn, src/.../interface.clj, test/.../interface_test.clj}`.
- Wired into `development`, `miniforge`, `miniforge-core`, and `miniforge-tui` deps.edn (extra-paths + extra-deps).
- `connector-linter` and `loop` deps.edn pick up `ai.miniforge/clock {:local/root "../clock"}`.
- 4 unit tests, 9 assertions. Covers `now-ms`, `elapsed-since` with redef'd clock, and `with-duration` body-runs-once + return shape.

## Per `feedback_miniforge_is_the_substrate.md`

Cross-cutting Clojure infra goes INTO miniforge OSS as new components. This is one such piece — small, no transitive deps, callable from any component. Same pattern as the recently-merged `coerce` component.

## Test plan

- [x] `bb pre-commit` (lint + tests + GraalVM compat) green on isolated runs.
- [ ] CI green.