### PR TITLE
fix: harden dogfood review boundaries

### DIFF
--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -141,6 +141,34 @@
                       (run-single-gate gate idx artifact context logger)))
        vec))
 
+(defn implementation-handoff-gate
+  "Reject degraded implement handoffs before semantic review.
+
+   This catches environment-model cases where implement recovered a code artifact
+   from disk after an agent-side failure, or where the curator flagged
+   out-of-scope writes. Both are strong signals that review must not silently
+   approve the handoff."
+  []
+  (loop/custom-gate
+   :implementation-handoff
+   :policy
+   (fn [artifact _context]
+     (let [degraded? (true? (:code/degraded-handoff? artifact))
+           scope-deviations (vec (:code/scope-deviations artifact))
+           errors (cond-> []
+                    degraded?
+                    (conj (loop/make-error
+                           :degraded-implement-handoff
+                           "Implement handoff is degraded: the artifact was recovered after an implementer-side failure"))
+                    (seq scope-deviations)
+                    (conj (loop/make-error
+                           :scope-deviations
+                           (str "Artifact includes out-of-scope writes: "
+                                (str/join ", " scope-deviations)))))]
+       (if (seq errors)
+         (loop/fail-result :implementation-handoff :policy errors)
+         (loop/pass-result :implementation-handoff :policy))))))
+
 (defn extract-blocking-issues
   "Extract blocking errors from failed gates."
   [failed-gates]
@@ -310,6 +338,22 @@
   (->> issues
        (filter #(= :warning (:severity %)))
        (mapv :description)))
+
+(def ^:private unparseable-review-message
+  "Blocking issue used when the reviewer LLM returns content that cannot be parsed
+   into the canonical review artifact shape."
+  "Reviewer LLM output could not be parsed into a review artifact")
+
+(defn- review-failure-message
+  "Derive the blocking issue recorded when the reviewer LLM response cannot
+   be converted into a canonical review artifact."
+  [response content]
+  (let [content-present? (not (str/blank? (or content "")))
+        llm-error (llm/get-error response)]
+    (cond
+      content-present? unparseable-review-message
+      (string? (:message llm-error)) (:message llm-error)
+      :else "Reviewer LLM invocation failed before producing a review artifact")))
 
 (defn llm-issues->recommendations
   "Extract suggestions from LLM issues as recommendations."
@@ -502,6 +546,7 @@
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))
         default-gates [(loop/syntax-gate)
+                       (implementation-handoff-gate)
                        (loop/lint-gate)
                        (loop/policy-gate :security {:policies [:no-secrets]})]
         gates (get opts :gates default-gates)
@@ -544,6 +589,7 @@
                              (llm/chat llm-client user-prompt
                                        {:system @reviewer-system-prompt
                                         :max-turns 20}))
+                  content (or (llm/get-content response) "")
                   tokens (get response :tokens 0)
                   cost-usd (get response :cost-usd)]
 
@@ -553,10 +599,13 @@
                                 :streaming? (boolean on-chunk)}})
 
               (let [;; Parse LLM review
-                    llm-review (when (llm/success? response)
-                                 (parse-review-response (llm/get-content response)))
-                    llm-decision (when llm-review
-                                  (normalize-llm-decision (:review/decision llm-review)))
+                    llm-review (when-not (str/blank? content)
+                                 (parse-review-response content))
+                    failure-message (review-failure-message response content)
+                    parse-failed? (nil? llm-review)
+                    llm-decision (cond
+                                   parse-failed? :rejected
+                                   llm-review (normalize-llm-decision (:review/decision llm-review)))
                     llm-issues (get llm-review :review/issues [])
                     llm-strengths (get llm-review :review/strengths [])
                     llm-summary (:review/summary llm-review)
@@ -572,8 +621,10 @@
                                      (:decision gate-result))
 
                     ;; Merge issues from both sources
-                    all-blocking (into (vec (:blocking-issues gate-result))
-                                       (llm-issues->blocking-strings llm-issues))
+                    all-blocking (cond-> (into (vec (:blocking-issues gate-result))
+                                               (llm-issues->blocking-strings llm-issues))
+                                   parse-failed?
+                                   (conj failure-message))
                     all-warnings (into (vec (:warnings gate-result))
                                        (llm-issues->warning-strings llm-issues))
 
@@ -598,6 +649,7 @@
                 (log/info logger :reviewer :reviewer/review-complete
                           {:data {:decision final-decision
                                   :llm-decision llm-decision
+                                  :llm-parse-failed? parse-failed?
                                   :gates-passed (:passed counts)
                                   :gates-failed (:failed counts)
                                   :llm-issues (count llm-issues)

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -20,8 +20,10 @@
   "Tests for the reviewer agent."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.reviewer :as reviewer]
    [ai.miniforge.agent.core :as core]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.loop.interface :as loop]
    [ai.miniforge.response.interface :as response]))
 
@@ -178,6 +180,70 @@
 
       (is (= 0 (get-in result [:metrics :tokens]))
           "Should use 0 tokens - no LLM calls"))))
+
+(deftest test-reviewer-rejects-unparseable-llm-output
+  (testing "successful LLM calls that cannot be parsed fail closed"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             {:success? true
+                              :content "not valid edn"
+                              :tokens 42})
+                  llm/success? :success?
+                  llm/get-content :content]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates []})
+            result (core/invoke reviewer {} sample-artifact)
+            review (:artifact result)]
+        (is (= :rejected (:review/decision review)))
+        (is (= ["Reviewer LLM output could not be parsed into a review artifact"]
+               (:review/blocking-issues review)))
+        (is (= 42 (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-uses-parseable-content-even-when-backend-flags-failure
+  (testing "parseable review content still drives the decision when backend success? is false"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             {:success? false
+                              :content "```clojure\n{:review/decision :changes-requested\n :review/issues [{:severity :blocking :description \"Needs changes\"}]}\n```"
+                              :tokens 7
+                              :error {:message "artifact file not found"}})
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error :error]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates []})
+            result (core/invoke reviewer {} sample-artifact)
+            review (:artifact result)]
+        (is (= :changes-requested (:review/decision review)))
+        (is (some #{"Needs changes"} (:review/blocking-issues review)))
+        (is (= 7 (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-rejects-degraded-implement-handoff
+  (testing "default reviewer rejects curated artifacts marked as degraded handoffs"
+    (let [reviewer (reviewer/create-reviewer {:llm-backend nil})
+          artifact {:code/id (random-uuid)
+                    :code/files [{:path "src/example.clj"
+                                  :content "(ns example)"
+                                  :action :create}]
+                    :code/degraded-handoff? true
+                    :code/scope-deviations []}
+          result (core/invoke reviewer {} artifact)
+          review (:artifact result)]
+      (is (= :rejected (:review/decision review)))
+      (is (seq (:review/blocking-issues review))))))
+
+(deftest test-reviewer-rejects-scope-deviations
+  (testing "default reviewer rejects artifacts with curator-reported scope deviations"
+    (let [reviewer (reviewer/create-reviewer {:llm-backend nil})
+          artifact {:code/id (random-uuid)
+                    :code/files [{:path "docs/out-of-scope.md"
+                                  :content "oops"
+                                  :action :modify}]
+                    :code/scope-deviations ["docs/out-of-scope.md"]}
+          result (core/invoke reviewer {} artifact)
+          review (:artifact result)]
+      (is (= :rejected (:review/decision review)))
+      (is (some #(re-find #"out-of-scope" %) (:review/blocking-issues review))))))
 
 ;------------------------------------------------------------------------------ Schema validation tests
 

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -88,11 +88,13 @@
   "Check if review is approved."
   [artifact _ctx]
   (let [decision (get artifact :review/decision)
-        approved? (or (= :approved decision)
-                      (= :conditionally-approved decision)
-                      (get-in artifact [:metadata :approved])
-                      (get-in artifact [:artifact/metadata :approved])
-                      (get-in artifact [:review :approved]))]
+        explicit-decision? (some? decision)
+        approved? (if explicit-decision?
+                    (or (= :approved decision)
+                        (= :conditionally-approved decision))
+                    (or (get-in artifact [:metadata :approved])
+                        (get-in artifact [:artifact/metadata :approved])
+                        (get-in artifact [:review :approved])))]
     (if approved?
       {:passed? true}
       {:passed? false

--- a/components/gate/test/ai/miniforge/gate/interface_test.clj
+++ b/components/gate/test/ai/miniforge/gate/interface_test.clj
@@ -247,6 +247,15 @@
                                    {:review/decision :rejected}
                                    {})]
       (is (not (:passed? result)))
+      (is (= :not-approved (get-in (first (:errors result)) [:type])))))
+
+  (testing "explicit negative review decisions override legacy fallback approval flags"
+    (let [result (gate/check-gate :review-approved
+                                  {:review/decision :changes-requested
+                                   :metadata {:approved true}
+                                   :review {:approved true}}
+                                  {})]
+      (is (not (:passed? result)))
       (is (= :not-approved (get-in (first (:errors result)) [:type]))))))
 
 (deftest check-gate-review-approved-fallback-paths-test

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -286,13 +286,20 @@
         curator-terminal?
         (= :curator/no-files-written
            (get-in curator-result [:error :data :code]))
+        impl-succeeded? (phase/result-succeeded? impl-result)
         result (cond
                  ;; Curator found files — use its artifact, even if the
                  ;; implementer reported error. Merge implementer metrics through.
                  (phase/result-succeeded? curator-result)
                  (-> impl-result
-                     (assoc :status :success)
+                     (assoc :status :success
+                            :success? true)
                      (assoc :output (:output curator-result))
+                     (cond-> (not impl-succeeded?)
+                       (assoc :degraded-handoff? true
+                              :raw-agent-status (:status impl-result)
+                              :raw-error (:error impl-result)))
+                     (dissoc :error)
                      (update :metrics merge (:metrics curator-result)))
                  ;; Curator said no-files (terminal). This wins over any
                  ;; implementer error — the implementer's error is the symptom,
@@ -377,6 +384,24 @@
    :rate-limited? (boolean rate-limited?)
    :iterations iterations})
 
+(defn- successful-curated-artifact
+  "Extract the curated artifact from a successful implement phase result."
+  [result]
+  (or (:artifact result)
+      (:output result)))
+
+(defn- lightweight-curated-artifact
+  "Persist only lightweight curated metadata in phase results.
+   Serialized code stays in the worktree and can be rehydrated later."
+  [artifact]
+  (when artifact
+    (let [files (:code/files artifact)]
+      (cond-> (dissoc artifact :code/files)
+        (seq files)
+        (assoc :code/file-paths (mapv :path files)
+               :code/file-actions (mapv :action files)
+               :code/file-count (count files))))))
+
 (defn leave-implement
   "Post-processing for implementation phase.
 
@@ -419,6 +444,9 @@
                      (* (get metrics :tokens 0) 0.000015)))
         metrics (assoc metrics :cost-usd cost-usd :duration-ms duration-ms)
         env-id (get ctx :execution/environment-id)
+        curated-artifact (successful-curated-artifact result)
+        degraded-handoff? (true? (:degraded-handoff? result))
+        raw-agent-status (or (:raw-agent-status result) agent-status)
         summary (or (get-in result [:output :code/summary])
                     (when (string? (:output result)) (:output result))
                     (messages/t :implement/summary-default))
@@ -429,7 +457,6 @@
                         (assoc-in [:phase :metrics] metrics)
                         (assoc-in [:metrics :implementation :duration-ms] duration-ms)
                         (assoc-in [:metrics :implementation :repair-cycles] (dec iterations))
-                        (update-in [:execution :phases-completed] (fnil conj []) :implement)
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :cost-usd] (fnil + 0.0) cost-usd)
@@ -441,9 +468,18 @@
        (get-in ctx [:execution/input :title]) iterations))
     ;; Handle retrying, failure, completed, or already-implemented outcomes
     (cond-> updated-ctx
+      (contains? #{:completed :already-implemented} phase-status)
+      (update-in [:execution :phases-completed] (fnil conj []) :implement)
+
       ;; On success: store lightweight result — code is in the environment, not here
       (= :completed phase-status)
-      (assoc-in [:phase :result] (phase/success env-id summary))
+      (-> (assoc-in [:phase :result] (phase/success env-id summary))
+          (assoc-in [:phase :artifact]
+                    (cond-> (lightweight-curated-artifact curated-artifact)
+                      degraded-handoff?
+                      (assoc :code/degraded-handoff? true
+                             :code/raw-agent-status raw-agent-status
+                             :code/raw-error (:raw-error result)))))
       (phase/retrying? (:phase updated-ctx))
       (-> (update-in [:phase :iterations] (fnil inc 1))
           (assoc-in [:phase :last-error]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -52,32 +52,60 @@
   "Resolve the implement-phase artifact using three strategies:
    1. Serialized :artifact key in the implement result (legacy model)
    2. The result itself when it already contains :code/files (it IS the artifact)
-   3. Fall back to collecting all changed files from the worktree on disk
-      (environment-promotion model where the agent writes directly to the worktree)"
-  [implement-result ctx]
-  (or
-   ;; Strategy 1 — explicit :artifact in result
-   (:artifact implement-result)
-   ;; Strategy 2 — result already is the artifact (has :code/files)
-   (when (:code/files implement-result)
-     implement-result)
-   ;; Strategy 3 — read changed files from worktree (env-promotion model)
-   (let [worktree-path (or (get ctx :execution/worktree-path)
-                           (get ctx :worktree-path))]
-     (when worktree-path
-       (agent/collect-written-files (agent/empty-snapshot)
-                                            worktree-path)))))
+   3. Serialized artifact under inner result :output
+   4. Fall back to collecting all changed files from the worktree on disk
+      (environment-promotion model where the agent writes directly to the worktree)
+   If the persisted outer artifact is metadata-only, merge that metadata over the
+   worktree-collected artifact so review sees full file content plus curator flags."
+  [implement-phase-result ctx]
+  (let [outer-artifact (:artifact implement-phase-result)
+        inner-artifact (get-in implement-phase-result [:result :artifact])
+        inner-output (get-in implement-phase-result [:result :output])
+        worktree-path (or (get ctx :execution/worktree-path)
+                          (get ctx :worktree-path))
+        worktree-artifact (when worktree-path
+                            (agent/collect-written-files (agent/empty-snapshot)
+                                                         worktree-path))]
+    (or
+     ;; Strategy 1 — persisted outer artifact already includes file content
+     (when (:code/files outer-artifact)
+       outer-artifact)
+     ;; Strategy 2 — explicit :artifact in inner result
+     (when (:code/files inner-artifact)
+       inner-artifact)
+     ;; Strategy 3 — result already is the artifact (has :code/files)
+     (when (:code/files implement-phase-result)
+       implement-phase-result)
+     ;; Strategy 4 — serialized artifact under inner :output
+     (when (:code/files inner-output)
+       inner-output)
+     ;; Strategy 5 — metadata-only outer artifact merged over worktree content
+     (when (and outer-artifact worktree-artifact)
+       (merge worktree-artifact outer-artifact))
+     ;; Strategy 6 — read changed files from worktree (env-promotion model)
+     worktree-artifact)))
+
+(defn- build-verify-review-input
+  "Build a stable verify summary for the reviewer prompt from the full verify phase result."
+  [verify-phase-result]
+  (when verify-phase-result
+    {:phase/status (get verify-phase-result :status)
+     :result/status (get-in verify-phase-result [:result :status])
+     :summary (or (get-in verify-phase-result [:result :summary])
+                  (get-in verify-phase-result [:result :output :summary]))
+     :metrics (get verify-phase-result :metrics
+                   (get-in verify-phase-result [:result :metrics]))}))
 
 (defn- build-review-task
   "Build the task map for the reviewer agent from execution context.
    Returns {:task task-map :rules-manifest manifest-or-nil}."
   [ctx]
   (let [input (get-in ctx [:execution/input])
-        implement-result (get-in ctx [:execution/phase-results :implement :result :output])
-        verify-result (get-in ctx [:execution/phase-results :verify :result :output])
+        implement-phase-result (get-in ctx [:execution/phase-results :implement])
+        verify-phase-result (get-in ctx [:execution/phase-results :verify])
         {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
                                        (:knowledge-store ctx) :reviewer (get input :tags []))
-        artifact (resolve-implement-artifact implement-result ctx)
+        artifact (resolve-implement-artifact implement-phase-result ctx)
         task (cond-> {:task/id (random-uuid)
                       :task/type :review
                       :task/description (:description input)
@@ -85,7 +113,7 @@
                       :task/intent (:intent input)
                       :task/constraints (:constraints input)
                       :task/artifact artifact
-                      :task/tests verify-result}
+                      :task/tests (build-verify-review-input verify-phase-result)}
                formatted
                (assoc :task/knowledge-context formatted))]
     {:task task
@@ -158,7 +186,6 @@
                         (assoc-in [:phase :metrics] metrics)
                         (assoc-in [:metrics :review :duration-ms] duration-ms)
                         (assoc-in [:metrics :review :repair-cycles] (dec iterations))
-                        (update-in [:execution :phases-completed] (fnil conj []) :review)
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
@@ -176,7 +203,9 @@
                                      (assoc :review-feedback feedback)
                                      (phase/request-redirect :implement))]
                 (assoc updated-ctx :phase phase-result)))
-            updated-ctx)
+            (cond-> updated-ctx
+              (= :completed phase-status)
+              (update-in [:execution :phases-completed] (fnil conj []) :review)))
       (phase/emit-phase-completed! :review
         {:outcome     (if (= :completed phase-status) :success :failure)
          :duration-ms duration-ms

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -232,7 +232,6 @@
                         (assoc-in [:phase :metrics] metrics)
                         (assoc-in [:metrics :verification :duration-ms] duration-ms)
                         (assoc-in [:metrics :verification :repair-cycles] (dec iterations))
-                        (update-in [:execution :phases-completed] (fnil conj []) :verify)
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))
@@ -252,6 +251,8 @@
                                      (phase/request-redirect on-fail))]
                 (assoc updated-ctx :phase phase-result))
               (cond-> updated-ctx
+                (= :completed phase-status)
+                (update-in [:execution :phases-completed] (fnil conj []) :verify)
                 (= :failed phase-status)
                 (assoc-in [:phase :error]
                           {:message       error-message

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -171,6 +171,32 @@
         (is (= :success (get-in final-result [:phase :result :status]))
             "Result status should be :success")))))
 
+(deftest implement-marks-curator-recovered-errors-as-degraded-handoff-test
+  (testing "curator recovery after an implementer-side error is marked as a degraded handoff"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 (response/error "LLM output parse failed"
+                                                 {:tokens 50 :duration-ms 250}))
+                  agent/curate-implement-output
+                  (fn [_]
+                    (response/success {:code/files [{:path "src/core.clj"
+                                                     :content "(ns core)"
+                                                     :action :create}]
+                                       :code/summary "curated recovery"}
+                                      {:metrics {:tokens 25 :duration-ms 50}}))]
+      (let [ctx (create-base-context)
+            ctx-with-config (assoc ctx :phase-config {:phase :implement})
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) ctx-with-config)
+            final-result ((:leave interceptor) enter-result)]
+        (is (= :completed (get-in final-result [:phase :status])))
+        (is (true? (get-in enter-result [:phase :result :degraded-handoff?]))
+            "Recovered curator output must mark the handoff as degraded")
+        (is (true? (get-in enter-result [:phase :result :success?]))
+            "Recovered curator output must normalize the result to success for downstream phase accounting")
+        (is (true? (get-in final-result [:phase :artifact :code/degraded-handoff?])))
+        (is (= :error (get-in final-result [:phase :artifact :code/raw-agent-status])))))))
+
 (deftest implement-handles-agent-exception-test
   (testing "implement phase handles agent exceptions gracefully"
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
@@ -228,6 +254,49 @@
         (is (= :implement (first (get-in final-result [:execution :phases-completed])))
             "Implement should be added to phases-completed")))))
 
+(deftest leave-implement-preserves-curated-artifact-test
+  (testing "successful implement preserves curated artifact on the outer phase map for downstream review"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 (response/success nil {:tokens 200 :duration-ms 500}))
+                  agent/curate-implement-output
+                  (fn [_]
+                    (response/success {:code/files [{:path "src/core.clj"
+                                                     :content "(ns core)"
+                                                     :action :create}]
+                                       :code/summary "curated artifact"
+                                       :code/scope-deviations []}
+                                      {:metrics {:tokens 200 :duration-ms 500}}))]
+      (let [ctx (create-base-context)
+            ctx-with-config (assoc ctx :phase-config {:phase :implement})
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) ctx-with-config)
+            final-result ((:leave interceptor) enter-result)]
+        (is (= "curated artifact" (get-in final-result [:phase :artifact :code/summary])))
+        (is (= ["src/core.clj"] (get-in final-result [:phase :artifact :code/file-paths])))
+        (is (= :success (get-in final-result [:phase :result :status]))
+            "The persisted phase result stays lightweight")
+        (is (nil? (get-in final-result [:phase :result :output]))
+            "Serialized code does not go back into the environment-model result")
+        (is (nil? (get-in final-result [:phase :artifact :code/files]))
+            "Serialized code should not be persisted on the outer phase artifact")))))
+
+(deftest leave-implement-does-not-count-failed-phase-as-completed-test
+  (testing "failed implement does not append to :execution/phases-completed"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 (response/error "LLM timeout" {:tokens 0 :duration-ms 5000}))
+                  agent/curate-implement-output mock-curator-error]
+      (let [ctx (-> (create-base-context)
+                    (assoc-in [:phase :iterations] 8))
+            ctx-with-config (assoc ctx :phase-config {:phase :implement})
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) ctx-with-config)
+            final-result ((:leave interceptor) enter-result)]
+        (is (= :failed (get-in final-result [:phase :status])))
+        (is (empty? (get-in final-result [:execution :phases-completed] []))
+            "Failed implement must not be counted as completed")))))
+
 ;------------------------------------------------------------------------------ Layer 3: Capsule File Loading
 
 (deftest load-files-from-capsule-reads-via-execute-fn-test
@@ -270,7 +339,7 @@
 (deftest resolve-existing-files-uses-capsule-in-governed-mode-test
   (testing "resolve-existing-files prefers capsule path when execute-fn is on context"
     (let [capsule-called (atom false)
-          execute-fn (fn [_executor _env-id cmd _opts]
+          execute-fn (fn [_executor _env-id _cmd _opts]
                        (reset! capsule-called true)
                        {:data {:stdout "(ns capsule)" :exit-code 0}})
           ctx {:execution/execute-fn execute-fn

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_artifact_resolution_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_artifact_resolution_test.clj
@@ -86,6 +86,33 @@
       (is (= "serialized artifact" (:code/summary resolved))
           "Should preserve the artifact's summary"))))
 
+(deftest resolve-outer-phase-artifact-test
+  (testing "metadata-only outer phase artifact rehydrates file contents from the worktree"
+    (let [impl-phase-result {:status :completed
+                             :artifact {:code/summary "serialized artifact"
+                                        :code/scope-deviations ["docs/out-of-scope.md"]
+                                        :code/file-paths ["src/core.clj"]}}
+          worktree-artifact (make-serialized-artifact)
+          ctx (make-ctx)
+          resolved (with-redefs [agent/collect-written-files
+                                 (fn [_snapshot working-dir]
+                                   (is (= "/tmp/test-worktree" working-dir))
+                                   worktree-artifact)]
+                     (resolve-implement-artifact impl-phase-result ctx))]
+      (is (= "serialized artifact" (:code/summary resolved)))
+      (is (= ["docs/out-of-scope.md"] (:code/scope-deviations resolved)))
+      (is (= 1 (count (:code/files resolved)))))))
+
+(deftest resolve-inner-output-artifact-test
+  (testing "environment-model implement phase can carry artifact under [:result :output]"
+    (let [artifact (make-code-files-result)
+          impl-phase-result {:status :completed
+                             :result {:status :success
+                                      :output artifact}}
+          ctx (make-ctx)
+          resolved (resolve-implement-artifact impl-phase-result ctx)]
+      (is (= artifact resolved)))))
+
 (deftest resolve-code-files-artifact-test
   (testing "Strategy 2: when implement-result has :code/files, returns the result itself"
     (let [impl-result (make-code-files-result)

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -253,7 +253,7 @@
   [context]
   (cond-> {:disable-dag-execution true
            :skip-lifecycle-events true
-           :quiet true
+           :quiet (boolean (get-in context [:execution/opts :quiet]))
            :create-pr? true}
     (:llm-backend context)      (assoc :llm-backend (:llm-backend context))
     (:event-stream context)     (assoc :event-stream (:event-stream context))

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
@@ -420,3 +420,11 @@
           sub-wf (dag-orch/task-sub-workflow task-def context)
           phase-names (mapv :phase (:workflow/pipeline sub-wf))]
       (is (= [:implement :release :done] phase-names)))))
+
+(deftest test-task-sub-opts-inherits-parent-quiet-setting
+  (testing "DAG sub-workflows inherit parent quiet=false so nested agent output stays visible"
+    (let [opts (#'dag-orch/task-sub-opts {:execution/opts {:quiet false}})]
+      (is (false? (:quiet opts)))))
+  (testing "DAG sub-workflows still honor explicit quiet=true from parent opts"
+    (let [opts (#'dag-orch/task-sub-opts {:execution/opts {:quiet true}})]
+      (is (true? (:quiet opts))))))

--- a/docs/pull-requests/2026-05-02-fix-dogfood-review-boundaries.md
+++ b/docs/pull-requests/2026-05-02-fix-dogfood-review-boundaries.md
@@ -1,0 +1,44 @@
+## Summary
+
+This PR hardens the dogfood phase boundaries that were allowing a failed DAG
+task subworkflow to drift from `:implement` into `:verify` and `:review`, and
+it tightens reviewer behavior so review fails closed instead of approving weak
+or degraded handoffs.
+
+## Problem
+
+During live Claude dogfooding, a DAG task subworkflow showed three boundary failures:
+
+- `:implement` failed, but the subworkflow still advanced
+- `:review` could pass even with an explicit negative reviewer outcome
+- nested task execution looked silent because DAG subworkflows were forced into quiet mode
+
+That produced a misleading path where bad implement output reached review and
+the operator could not reliably see nested task progress.
+
+## Changes
+
+- reviewer now parses usable review content even when the backend marks the
+  response unsuccessful, and rejects when the output is unparseable
+- reviewer adds an implementation handoff gate that rejects degraded curator
+  recoveries and curator-reported scope deviations
+- `:review-approved` now fails closed when there is an explicit negative review
+  decision, even if legacy fallback approval flags are present
+- implement curator recovery now normalizes recovered output to a successful
+  handoff while preserving degraded provenance on the curated artifact
+- implement preserves the curated artifact on the outer phase map so downstream
+  review resolves the right handoff artifact
+- implement, verify, and review no longer append failed phases to `:execution/phases-completed`
+- DAG task subworkflows now inherit the parent `:quiet` setting instead of forcing nested execution to be silent
+
+## Validation
+
+- focused agent / gate / phase-software-factory / workflow regression tests
+- live Claude dogfood confirmed review now fails and redirects back to
+  `:implement` instead of slipping through to release
+
+## Follow-up
+
+The next dogfood run should verify the post-fix path end to end on both Claude
+and Codex, with particular attention to nested output visibility and whether
+any remaining implement-to-verify drift still exists elsewhere in the DAG path.


### PR DESCRIPTION
## Summary

This PR hardens the dogfood phase boundaries that were allowing a failed DAG
task subworkflow to drift from `:implement` into `:verify` and `:review`, and
it tightens reviewer behavior so review fails closed instead of approving weak
or degraded handoffs.

## Problem

During live Claude dogfooding, a DAG task subworkflow showed three boundary failures:

- `:implement` failed, but the subworkflow still advanced
- `:review` could pass even with an explicit negative reviewer outcome
- nested task execution looked silent because DAG subworkflows were forced into quiet mode

That produced a misleading path where bad implement output reached review and
the operator could not reliably see nested task progress.

## Changes

- reviewer now parses usable review content even when the backend marks the
  response unsuccessful, and rejects when the output is unparseable
- reviewer adds an implementation handoff gate that rejects degraded curator
  recoveries and curator-reported scope deviations
- `:review-approved` now fails closed when there is an explicit negative review
  decision, even if legacy fallback approval flags are present
- implement curator recovery now normalizes recovered output to a successful
  handoff while preserving degraded provenance on the curated artifact
- implement preserves the curated artifact on the outer phase map so downstream
  review resolves the right handoff artifact
- implement, verify, and review no longer append failed phases to `:execution/phases-completed`
- DAG task subworkflows now inherit the parent `:quiet` setting instead of forcing nested execution to be silent

## Validation

- focused agent / gate / phase-software-factory / workflow regression tests
- live Claude dogfood confirmed review now fails and redirects back to
  `:implement` instead of slipping through to release

## Follow-up

The next dogfood run should verify the post-fix path end to end on both Claude
and Codex, with particular attention to nested output visibility and whether
any remaining implement-to-verify drift still exists elsewhere in the DAG path.
