### PR TITLE
feat(logging): nil-safe level wrappers; remove the (when logger ...) cliff

### DIFF
--- a/components/logging/src/ai/miniforge/logging/interface.clj
+++ b/components/logging/src/ai/miniforge/logging/interface.clj
@@ -40,13 +40,17 @@
 
 (defn with-context
   "Return a new logger with additional context merged into all entries.
-   Context keys are typically namespaced like :ctx/workflow-id, :ctx/agent-id.
+   Context keys are typically namespaced like :ctx/workflow-id,
+   :ctx/agent-id. Nil logger passes through (the result is still nil)
+   so chained `(-> logger (with-context …) (with-context …))` works
+   without an outer nil-check.
 
    Example:
      (with-context logger {:ctx/workflow-id (random-uuid)
                            :ctx/task-id task-id})"
   [logger context-map]
-  (core/with-context* logger context-map))
+  (when logger
+    (core/with-context* logger context-map)))
 
 (defn get-context
   "Return the current context map from a logger."
@@ -83,60 +87,69 @@
    Example:
      (log logger :info :agent :agent/task-started
           {:message \"Starting implementation\"
-           :data {:agent-role :implementer}})"
-  [logger level category event opts]
-  (core/log* logger level category event opts))
+           :data {:agent-role :implementer}})
 
-;; Level-specific convenience functions
+   Nil logger is a no-op. Callers no longer need to wrap with
+   `(when logger …)`; passing nil through is safe at every level."
+  [logger level category event opts]
+  (when logger
+    (core/log* logger level category event opts)))
+
+;; Level-specific convenience functions. Each wrapper is nil-safe so
+;; callers don't have to repeat `(when logger …)` at every call site
+;; — passing a nil logger drops the entry on the floor.
 
 (defn trace
-  "Log at :trace level (detailed internal state)."
+  "Log at :trace level (detailed internal state). Nil logger = no-op."
   ([logger category event] (trace logger category event {}))
   ([logger category event opts]
-   (core/log* logger :trace category event opts)))
+   (when logger (core/log* logger :trace category event opts))))
 
 (defn debug
-  "Log at :debug level (operational detail)."
+  "Log at :debug level (operational detail). Nil logger = no-op."
   ([logger category event] (debug logger category event {}))
   ([logger category event opts]
-   (core/log* logger :debug category event opts)))
+   (when logger (core/log* logger :debug category event opts))))
 
 (defn info
-  "Log at :info level (business events)."
+  "Log at :info level (business events). Nil logger = no-op."
   ([logger category event] (info logger category event {}))
   ([logger category event opts]
-   (core/log* logger :info category event opts)))
+   (when logger (core/log* logger :info category event opts))))
 
 (defn warn
-  "Log at :warn level (recoverable issues)."
+  "Log at :warn level (recoverable issues). Nil logger = no-op."
   ([logger category event] (warn logger category event {}))
   ([logger category event opts]
-   (core/log* logger :warn category event opts)))
+   (when logger (core/log* logger :warn category event opts))))
 
 (defn error
-  "Log at :error level (failed operations)."
+  "Log at :error level (failed operations). Nil logger = no-op."
   ([logger category event] (error logger category event {}))
   ([logger category event opts]
-   (core/log* logger :error category event opts)))
+   (when logger (core/log* logger :error category event opts))))
 
 (defn fatal
-  "Log at :fatal level (system-level failures)."
+  "Log at :fatal level (system-level failures). Nil logger = no-op."
   ([logger category event] (fatal logger category event {}))
   ([logger category event opts]
-   (core/log* logger :fatal category event opts)))
+   (when logger (core/log* logger :fatal category event opts))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Timed execution
 
 (defn timed
   "Execute f and log start/completion with duration.
-   Returns the result of f.
+   Returns the result of f. Nil logger skips both log entries and just
+   returns `(f)`.
 
    Example:
      (timed logger :info :system :system/health-check
             #(check-health))"
   [logger level category event f]
-  (first (core/timed* logger level category event f)))
+  (if logger
+    (first (core/timed* logger level category event f))
+    (f)))
 
 (defmacro with-timing
   "Execute body and log start/completion with duration.

--- a/components/logging/test/ai/miniforge/logging/interface_test.clj
+++ b/components/logging/test/ai/miniforge/logging/interface_test.clj
@@ -186,6 +186,26 @@
       (is (= "Escalating to human" (:log/message entry)))
       (is (= {:reason "budget exceeded"} (:data entry))))))
 
+(deftest nil-logger-is-no-op-test
+  (testing "every level wrapper is nil-safe"
+    (is (nil? (log/trace nil :system :event)))
+    (is (nil? (log/debug nil :system :event)))
+    (is (nil? (log/info  nil :system :event)))
+    (is (nil? (log/warn  nil :system :event)))
+    (is (nil? (log/error nil :system :event)))
+    (is (nil? (log/fatal nil :system :event)))
+    (is (nil? (log/log   nil :info :system :event {}))))
+
+  (testing "with-context passes nil through"
+    (is (nil? (log/with-context nil {:ctx/workflow-id "x"}))))
+
+  (testing "timed with nil logger executes f and returns its result"
+    (let [calls (atom 0)
+          result (log/timed nil :info :system :event
+                            (fn [] (swap! calls inc) :done))]
+      (is (= :done result))
+      (is (= 1 @calls)))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.logging.interface-test)


### PR DESCRIPTION
## Summary

Resolves the `(when logger (log/info logger …))` pattern that exists at ~255 callsites across miniforge. The pattern's only reason to exist was that `log/info` (and friends) delegate to a `Logger` protocol method that NPEs on nil. Push the nil-check into the API itself.

Six level wrappers (`trace`/`debug`/`info`/`warn`/`error`/`fatal`) plus the generic `log`, `with-context`, and `timed` are now nil-safe:

```clojure
(log/info nil :system :event)              ; no-op, returns nil
(log/log  nil :info :system :event {})     ; no-op, returns nil
(log/with-context nil {:ctx/k :v})          ; passes nil through
(log/timed nil :info :system :event #(do-x)) ; just calls (f), returns result
```

Existing call sites keep working unchanged. The `(when logger …)` guards now read as noise — they can be scrubbed in passing as files are touched, but no big-bang rollout is required. New code can drop the guard entirely.

## Why the guard existed

Three reasons callers pass nil today, in order of legitimacy:

1. **Tests** — minimal context maps without a logger, exercising production code paths.
2. **BB-runtime paths** — code that crosses bb/jvm and the logging component isn't loaded on the bb side.
3. **Old callers** — code written before logging was wired through that path; defaulted to no-op rather than threading a logger to every caller.

The fix is the API itself, not a 255-site call-site rewrite.

## Test plan

- [x] New `nil-logger-is-no-op-test` covers all 6 level wrappers + `log` + `with-context` + `timed` (verifies `(f)` runs once and the result is returned when logger is nil).
- [x] `bb pre-commit` (lint + tests + GraalVM compat) green.
- [ ] CI green.

## Follow-up

`(when logger …)` and `(when-let [logger …] …)` guards can be progressively scrubbed as files are touched in unrelated work. No tracking PR needed — they're now harmless noise rather than load-bearing.