### PR TITLE
fix(workflow): release reads env, not impl-status; failure events carry payload

### DIFF
--- a/components/phase-software-factory/resources/config/phase/messages/en-US.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/en-US.edn
@@ -20,8 +20,6 @@
   :verify/failed              "Verification failed"
 
   ;; Release phase
-  :release/no-implement-artifact        "Release phase has no code artifact from implement phase"
-  :release/no-implement-hint            "Implement phase may have failed or produced no output"
   :release/zero-files                   "Release phase received code artifact with zero files"
   :release/skipped-already-implemented  "Release skipped — task was already implemented"
   :release/changes-description          "Changes from implementation"

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -65,26 +65,17 @@
       (log/info logger :release :release/skipped-already-implemented
                 {:data {:summary (get-in ctx [:execution/phase-results :implement :result :summary])}}))))
 
-(defn- assert-implement-artifact!
-  "Throw when implement phase has no result or has not succeeded.
-
-   In the new environment model, the implement result carries :status,
-   :environment-id, :summary, and :metrics — NOT a serialized :output map.
-   We check :status to confirm the phase completed successfully."
-  [ctx impl-result]
-  (let [impl-status (:status impl-result)
-        succeeded?  (phase/result-succeeded? impl-result)]
-    (when (or (nil? impl-result) (not succeeded?))
-      (let [phase-results-keys (vec (keys (:execution/phase-results ctx)))
-            logger (or (get-in ctx [:execution/logger])
-                       (log/create-logger {:min-level :error :output :human}))]
-        (log/error logger :release :release/no-implement-artifact
-                   {:data {:implement-status impl-status
-                           :phase-results-keys phase-results-keys}})
-        (throw (ex-info (messages/t :release/no-implement-artifact)
-                        {:phase            :release
-                         :implement-status impl-status
-                         :hint             (messages/t :release/no-implement-hint)}))))))
+;; assert-implement-artifact! used to throw when the implement phase
+;; reported anything other than :status :success. That gate disagreed with
+;; verify and review, which read the environment directly and run regardless
+;; of what the implement result map said. The disagreement surfaced under
+;; the curator's :curator/no-files-written path: the agent narrates code in
+;; chat, curator marks implement :failed, but persist still captures whatever
+;; landed on disk and verify+review work fine against it. Release would
+;; then explode with `:release/no-implement-artifact` even though there was
+;; real work to release. Removed — the env-based `:release/zero-files`
+;; check below is the authoritative gate, matching what verify and review
+;; already do.
 
 (defn- ctx-worktree-path
   "Resolve the working directory from phase context."
@@ -164,25 +155,26 @@
 (defn build-workflow-state
   "Build workflow state from phase context for the release executor.
 
-   In the new environment model, code changes live in the execution environment's
-   git working tree (:execution/worktree-path) rather than being serialized
-   into phase results. This function reads the current git diff from the
-   worktree to discover which files need to be released.
+   In the new environment model, code changes live in the execution
+   environment's git working tree (:execution/worktree-path) rather than
+   being serialized into phase results. This function reads the current
+   git diff from the worktree to discover which files need to be released.
 
-   Falls back gracefully if implement was :already-implemented (other phases
-   such as verify or review may have produced git changes that still need
-   releasing).
+   The environment is the authoritative source — release proceeds when the
+   worktree has dirty paths, regardless of what the implement phase's
+   result map said. This matches verify and review, which both read the
+   environment directly. The previous behavior (gating on
+   `[:execution/phase-results :implement :result :status]`) disagreed with
+   verify/review and dropped real work whenever the curator marked
+   implement :failed despite persist capturing files on disk.
 
-   Throws :release/zero-files when no changed files are found in the worktree."
+   Throws :release/zero-files when no changed files are found in the
+   worktree — that's the only legitimate \"nothing to release\" condition
+   in the env model."
   [ctx]
   (let [impl-result   (get-in ctx [:execution/phase-results :implement :result])
-        impl-status   (:status impl-result)
-        already-impl? (= :already-implemented impl-status)]
+        impl-status   (:status impl-result)]
     (log-already-implemented! ctx impl-status)
-    ;; Assert implement phase succeeded (unless :already-implemented).
-    ;; In the environment model we check :status on the result map directly.
-    (when-not already-impl?
-      (assert-implement-artifact! ctx impl-result))
     ;; Discover files via the environment's git working tree.
     ;; Code provenance is environment-based: the agent writes to the worktree
     ;; and the PR diff is the authoritative record of what changed.

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/artifact_persistence_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/artifact_persistence_test.clj
@@ -127,16 +127,32 @@
       (is (= :completed (get-in result [:phase :status]))
           "Release should skip (complete) when implement status is nil and no dirty files"))))
 
-(deftest test-release-fails-with-failed-implement
-  (testing "release phase throws when implement result shows failure status"
+(deftest test-release-gate-is-env-not-impl-status
+  (testing "release fails on the env-based zero-files gate, not on impl-status"
+    ;; Regression contract change: the previous behavior was to throw
+    ;; `:release/no-implement-artifact` whenever the implement result map
+    ;; had `:status :failed`, even if the environment had real work. That
+    ;; gate disagreed with verify and review, which both read the worktree
+    ;; directly. Under the curator's `:curator/no-files-written` path the
+    ;; implement result reports failure while persist still captures
+    ;; whatever DID land on disk — release would explode and drop the
+    ;; work. The current behavior: release fails only when the env is
+    ;; genuinely empty (`:release/zero-files`), matching the downstream
+    ;; phases.
+    ;;
+    ;; This test pins the new error MESSAGE shape — release no longer
+    ;; references the implement artifact at all when it fails.
     (let [ctx (-> (create-base-context)
-                  ;; Simulate implement phase that failed
                   (assoc-in [:execution/phase-results :implement :result]
                             {:status :failed :error {:message "Agent timeout"}})
                   (assoc :worktree-path *test-worktree*))]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Release phase has no code artifact"
-                            (execute-phase-enter :release ctx))))))
+                            #"zero files"
+                            (execute-phase-enter :release ctx))
+          "release fails on env-based gate, not on impl-status — and the
+           error message now names the actual condition (env empty) rather
+           than the previously-misleading 'no code artifact from implement'
+           message"))))
 
 (deftest test-implement-writes-to-environment
   (testing "implement phase completes with environment-id when agent writes files directly"

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -110,7 +110,7 @@
 (defn- build-phase-event-data
   "Build event data map for a phase completion event.
 
-   `error-info` is sourced from any of four shapes the phase machinery uses:
+   `error-info` is sourced from any of five shapes the phase machinery uses:
 
    1. `(:error result)`          — top-level error map (early failures)
    2. `[:result :error]`         — inner agent result error (post-inner-fail)

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -108,7 +108,20 @@
         (false? (get-in result [:result :success?])))))
 
 (defn- build-phase-event-data
-  "Build event data map for a phase completion event."
+  "Build event data map for a phase completion event.
+
+   `error-info` is sourced from any of four shapes the phase machinery uses:
+
+   1. `(:error result)`          — top-level error map (early failures)
+   2. `[:result :error]`         — inner agent result error (post-inner-fail)
+   3. `[:phase :error]`          — error attached by an `error-*` interceptor
+                                   that fell through to `phase/fail-phase`
+                                   (the release-phase no-files path before
+                                   this fix landed produced bare failure
+                                   events with no payload because of this
+                                   missing branch)
+   4. `:phase/gate-errors`       — gate validation failures
+   5. `(:message result)`        — last-resort string message"
   [result]
   (let [succeeded? (and (get result :success? (phase/succeeded-or-done? result))
                         (not (inner-result-failed? result)))
@@ -119,6 +132,7 @@
         error-info (when-not succeeded?
                      (or (:error result)
                          (get-in result [:result :error])
+                         (get-in result [:phase :error])
                          (when-let [msg (get-in result [:phase/gate-errors])]
                            {:message (messages/t :status/gate-failed) :details msg})
                          (when-let [msg (:message result)]

--- a/components/workflow/test/ai/miniforge/workflow/phase_outcome_from_inner_result_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_outcome_from_inner_result_test.clj
@@ -79,3 +79,24 @@
         (is evt "phase-completed event should be published")
         (is (= :failure (:phase/outcome evt)))
         (is (= {:message "boom"} (:phase/error evt)))))))
+
+(deftest error-attached-at-phase-error-surfaces-test
+  (testing "[:phase :error] is read when nothing higher carries the payload"
+    ;; Regression: error-* interceptors that fall through to
+    ;; `phase/fail-phase` attach the error map at `[:phase :error]` rather
+    ;; than at the top level or at `[:result :error]`. Before this branch
+    ;; was added, `build-phase-event-data` couldn't find that error and
+    ;; emitted a bare failure event with no payload — observed on the
+    ;; 2026-05-02 dogfood as "Phase :release failure (0ms)" with no
+    ;; diagnostic context whatsoever.
+    (let [phase-result {:name :release
+                        :status :failed
+                        :phase {:error {:message "Release phase received code artifact with zero files"
+                                        :data {:phase :release :worktree-path "/tmp/x"}}}}
+          data (build phase-result)]
+      (is (= :failure (:outcome data)))
+      (is (= "Release phase received code artifact with zero files"
+             (get-in data [:error :message])))
+      (is (= "/tmp/x" (get-in data [:error :data :worktree-path]))
+          "the error data payload is preserved end-to-end so consumers can
+           debug the failure without parsing the run log"))))


### PR DESCRIPTION
## Summary

The `:canonical-sdlc` dogfood for the per-task-base-chaining spec reported `Phase :release failure (0ms)` with no diagnostic context, and the workflow died with `:tasks-completed 0` even though plan, implement-with-persist, verify, and review had all run and produced real work captured in a bundle. Two fixes for one symptom.

## The chain that produced the silent failure

1. implement marks `[:result :status] :failed` because the curator's `:curator/no-files-written` branch fires when codex-cli emits code in chat. (Persist captures whatever DID land on disk anyway, and verify and review later read the env directly and succeed.)
2. `release.clj/assert-implement-artifact!` reads `[:result :status]`, sees `:failed`, throws `:release/no-implement-artifact`.
3. `error-release` catches with no `:on-fail` route, falls through to `phase/fail-phase`, which attaches the error map at `[:phase :error]`.
4. `build-phase-event-data` checks `(:error result)`, `[:result :error]`, gate errors, and `(:message result)` — but **NOT** `[:phase :error]`. Bare failure event emitted with `:phase/error` absent.
5. CLI display reads `:phase/duration-ms` (computed before the error path can update it) and renders `(0ms)`. Operator sees a phase that "failed instantly with no message".

## Fix #1 — release reads env, not impl-status

Removed `assert-implement-artifact!` from `release.clj`. The function disagreed with verify and review, which read the worktree directly and run regardless of what the implement result map says. The env-based gate downstream (`:release/zero-files`) is the legitimate "nothing to release" condition; the impl-status check was a redundant strict gate dropping real work whenever the curator misreported implement.

Removed message keys: `:release/no-implement-artifact`, `:release/no-implement-hint`. Explanatory comment kept in source where the function used to live so the next reader sees why this gate was removed.

## Fix #2 — `[:phase :error]` is a real failure-payload source

Added `[:phase :error]` to `build-phase-event-data`'s `error-info` lookup chain. Now the same chain catches failures attached by `error-*` interceptors via `phase/fail-phase`. Existing branches (`:error`, `[:result :error]`, gate errors, `:message`) all stay; the new branch fits between `[:result :error]` and gate errors. Updated docstring documents all five sources.

## Test plan

- [x] `error-attached-at-phase-error-surfaces-test` — pins the new branch with the exact failure shape `error-release` produces; asserts both `:outcome :failure` and that the error data payload (worktree-path, etc.) round-trips end to end so consumers can debug from the event alone.
- [x] `test-release-fails-with-failed-implement` rewritten to `test-release-gate-is-env-not-impl-status` — pins the new contract: failed implement + empty env → `:release/zero-files`, never the old `:release/no-implement-artifact`.
- [x] All 14 `release_test.clj` tests still pass without modification.
- [x] All 7 existing `phase_outcome_from_inner_result_test.clj` tests still pass.
- [x] Full `bb pre-commit`: 4784 tests, 22205 passes, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)