### PR TITLE
feat: project direct workflow agents into supervisory state

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface/runtime.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/runtime.clj
@@ -20,7 +20,8 @@
   "Agent creation, execution, and lifecycle operations."
   (:require
    [ai.miniforge.agent.core :as core]
-   [ai.miniforge.agent.interface.protocols.agent :as agent-proto]))
+   [ai.miniforge.agent.interface.protocols.agent :as agent-proto]
+   [ai.miniforge.agent.supervisory-bridge :as supervisory-bridge]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Agent creation and execution
@@ -35,7 +36,11 @@
 
 (defn invoke
   [agent task context]
-  (agent-proto/invoke agent task context))
+  (supervisory-bridge/invoke-with-projection
+   agent
+   task
+   context
+   #(agent-proto/invoke agent task context)))
 
 (defn validate
   [agent output context]

--- a/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
+++ b/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
@@ -1,0 +1,269 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.supervisory-bridge
+  "Bridge direct workflow agent invocations into the control-plane event family.
+
+   Live workflow phases invoke internal agents directly, bypassing the polling
+   control-plane orchestrator that already emits `:control-plane/agent-*`
+   events. Supervisory-state projects AgentSession entities from that event
+   family, so this bridge emits equivalent events for direct in-process agents
+  when a workflow event-stream is present."
+  (:require
+   [ai.miniforge.agent.core :as core]
+   [ai.miniforge.event-stream.interface :as events])
+  (:import
+   (java.nio ByteBuffer)
+   (java.security MessageDigest)
+   (java.util UUID)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants
+
+(def ^:private direct-agent-vendor
+  :miniforge)
+
+(def ^:private default-heartbeat-interval-ms
+  30000)
+
+(def ^:private agent-session-namespace
+  (UUID/fromString "4882f381-e57d-582f-95ab-3a9b36e11df8"))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Core helpers
+
+(defn- uuid-v5
+  "Deterministically derive a UUID v5 from a namespace UUID and string key."
+  [^UUID ns-uuid ^String key]
+  (let [digest (MessageDigest/getInstance "SHA-1")
+        ns-buf (ByteBuffer/wrap (byte-array 16))]
+    (.putLong ns-buf (.getMostSignificantBits ns-uuid))
+    (.putLong ns-buf (.getLeastSignificantBits ns-uuid))
+    (.update digest (.array ns-buf))
+    (.update digest (.getBytes key "UTF-8"))
+    (let [hash (.digest digest)
+          msb-raw (.getLong (ByteBuffer/wrap hash 0 8))
+          lsb-raw (.getLong (ByteBuffer/wrap hash 8 8))
+          hi (bit-or (bit-and msb-raw (unchecked-long -61441)) 0x5000)
+          lo (bit-or (bit-and lsb-raw 0x3FFFFFFFFFFFFFFF) Long/MIN_VALUE)]
+      (UUID. hi lo))))
+
+(defn- workflow-id
+  [context]
+  (or (:execution/id context)
+      (:workflow/id context)
+      (:workflow-id context)))
+
+(defn- event-stream
+  [context]
+  (or (:event-stream context)
+      (:execution/event-stream context)))
+
+(defn- direct-agent-role
+  [agent]
+  (or (:role agent) :agent))
+
+(defn- workflow-phase
+  [task context]
+  (or (get-in task [:task/metadata :phase-id])
+      (:task/type task)
+      (:execution/current-phase context)
+      (:workflow/phase context)))
+
+(defn- task-identity-fragment
+  [role task]
+  (or (some-> (:task/id task) str)
+      (some-> (get-in task [:task/metadata :dag-task-id]) str)
+      (:task/title task)
+      (:task/description task)
+      (name role)))
+
+(defn- session-id
+  [agent task context]
+  (when-let [wf-id (workflow-id context)]
+    (let [role (direct-agent-role agent)
+          phase (workflow-phase task context)
+          task-fragment (task-identity-fragment role task)
+          session-key (str wf-id "|" (name role) "|" (name (or phase :unknown)) "|" task-fragment)]
+      (uuid-v5 agent-session-namespace session-key))))
+
+(defn- task-summary
+  [task]
+  (let [task-type (some-> (:task/type task) name)
+        title (:task/title task)]
+    (cond
+      (and task-type (seq title)) (str task-type ": " title)
+      (seq title) title
+      task-type task-type
+      :else nil)))
+
+(defn- phase-context
+  [task]
+  (or (:task/description task)
+      (:task/title task)))
+
+(defn- workflow-spec
+  [context]
+  (or (get-in context [:execution/workflow :workflow/spec])
+      (get-in context [:execution/input :workflow-spec])
+      (get-in context [:execution/input :workflow/spec])
+      (get-in context [:execution/input :spec])
+      (let [input (:execution/input context)
+            title (:title input)
+            description (:description input)]
+        (when (or title description)
+          (cond-> {}
+            title (assoc :title title)
+            description (assoc :description description))))))
+
+(defn- registration-metadata
+  [agent task context]
+  (let [phase (workflow-phase task context)
+        spec (workflow-spec context)
+        agent-summary (task-summary task)
+        phase-summary (phase-context task)]
+    (cond-> {:workflow-id (workflow-id context)}
+      spec (assoc :workflow-spec spec)
+      phase (assoc :workflow-phase phase)
+      agent-summary (assoc :agent-context agent-summary)
+      phase-summary (assoc :phase-context phase-summary)
+      (get-in agent [:config :model]) (assoc :model (get-in agent [:config :model])))))
+
+(defn- registration-options
+  [agent task context session-id-value]
+  (let [role (direct-agent-role agent)
+        capabilities (or (:capabilities agent)
+                         (get core/role-capabilities role #{}))
+        tags (cond-> [(name role) "workflow"]
+               (workflow-phase task context) (conj (name (workflow-phase task context))))]
+    {:name (name role)
+     :external-id (str session-id-value)
+     :capabilities (sort-by name capabilities)
+     :metadata (registration-metadata agent task context)
+     :tags tags
+     :heartbeat-interval-ms default-heartbeat-interval-ms}))
+
+(defn- executable-context?
+  [context]
+  (and (event-stream context)
+       (workflow-id context)))
+
+(defn- result-failed?
+  [result]
+  (boolean
+   (or (contains? #{:error :failed :failure} (:status result))
+       (false? (:success result))
+       (false? (:success? result))
+       (:error result))))
+
+(defn- completion-status
+  [result]
+  (if (result-failed? result) :failed :completed))
+
+(defn- heartbeat-options
+  [task result]
+  (cond-> {}
+    (task-summary task) (assoc :task (task-summary task))
+    (:metrics result) (assoc :metrics (:metrics result))))
+
+(defn- emit-started!
+  [agent task context session-id-value]
+  (let [stream (event-stream context)
+        wf-id (workflow-id context)]
+    (events/publish! stream
+                     (events/cp-agent-registered
+                      stream
+                      wf-id
+                      session-id-value
+                      direct-agent-vendor
+                      (registration-options agent task context session-id-value)))
+    (events/publish! stream
+                     (events/cp-agent-state-changed
+                      stream
+                      wf-id
+                      session-id-value
+                      :idle
+                      :executing))
+    (events/publish! stream
+                     (events/cp-agent-heartbeat
+                      stream
+                      wf-id
+                      session-id-value
+                      :executing
+                      {:task (task-summary task)}))))
+
+(defn- emit-finished!
+  [task context session-id-value result]
+  (let [stream (event-stream context)
+        wf-id (workflow-id context)
+        status (completion-status result)]
+    (events/publish! stream
+                     (events/cp-agent-heartbeat
+                      stream
+                      wf-id
+                      session-id-value
+                      status
+                      (heartbeat-options task result)))
+    (events/publish! stream
+                     (events/cp-agent-state-changed
+                      stream
+                      wf-id
+                      session-id-value
+                      :executing
+                      status))))
+
+(defn- emit-failed!
+  [task context session-id-value]
+  (let [stream (event-stream context)
+        wf-id (workflow-id context)]
+    (events/publish! stream
+                     (events/cp-agent-heartbeat
+                      stream
+                      wf-id
+                      session-id-value
+                      :failed
+                      {:task (task-summary task)}))
+    (events/publish! stream
+                     (events/cp-agent-state-changed
+                      stream
+                      wf-id
+                      session-id-value
+                      :executing
+                      :failed))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Public wrapper
+
+(defn invoke-with-projection
+  "Run `invoke-fn` while mirroring the invocation into `:control-plane/agent-*`
+   events when the context is bound to a workflow event-stream."
+  [agent task context invoke-fn]
+  (if-not (executable-context? context)
+    (invoke-fn)
+    (let [session-id-value (session-id agent task context)]
+      (if-not session-id-value
+        (invoke-fn)
+        (do
+          (emit-started! agent task context session-id-value)
+          (try
+            (let [result (invoke-fn)]
+              (emit-finished! task context session-id-value result)
+              result)
+            (catch Exception e
+              (emit-failed! task context session-id-value)
+              (throw e))))))))

--- a/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
+++ b/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
@@ -119,7 +119,9 @@
 
 (defn- workflow-spec
   [context]
-  (or (get-in context [:execution/workflow :workflow/spec])
+  (or (:workflow/spec context)
+      (:workflow-spec context)
+      (get-in context [:execution/workflow :workflow/spec])
       (get-in context [:execution/input :workflow-spec])
       (get-in context [:execution/input :workflow/spec])
       (get-in context [:execution/input :spec])

--- a/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
+++ b/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
@@ -1,0 +1,104 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.runtime-supervisory-projection-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.supervisory-state.interface :as supervisory]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Fixtures
+
+(defn- create-stream
+  []
+  (event-stream/create-event-stream {:sinks []}))
+
+(defn- invoke-task
+  []
+  {:task/id (random-uuid)
+   :task/type :implement
+   :task/title "Implement auth repair"
+   :task/description "Update the auth flow to reject stale session tokens."
+   :task/status :pending
+   :task/inputs []
+   :task/metadata {:phase-id :implement}})
+
+(defn- invoke-context
+  [stream workflow-id]
+  {:event-stream stream
+   :execution/id workflow-id
+   :execution/current-phase :implement
+   :execution/input {:title "Auth repair"
+                     :description "Repair the stale-session failure in login."
+                     :spec {:spec/id "auth-repair"
+                            :title "Auth repair"
+                            :description "Repair the stale-session failure in login."}}
+   :llm-backend (agent/create-mock-llm {:content "(defn auth [] :ok)"
+                                        :usage {:input-tokens 11 :output-tokens 7}
+                                        :model "mock"})})
+
+(defn- event-types
+  [stream]
+  (map :event/type (event-stream/get-events stream)))
+
+(defn- first-event
+  [stream event-type]
+  (first (filter #(= event-type (:event/type %))
+                 (event-stream/get-events stream))))
+
+(defn- last-event
+  [stream event-type]
+  (last (filter #(= event-type (:event/type %))
+                (event-stream/get-events stream))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Projection coverage
+
+(deftest direct-agent-invoke-emits-control-plane-and-supervisory-events
+  (testing "workflow-bound agent/invoke produces rich agent session snapshots"
+    (let [stream (create-stream)
+          _supervisor (supervisory/attach! stream)
+          workflow-id (random-uuid)
+          task (invoke-task)
+          ctx (invoke-context stream workflow-id)
+          impl-agent (agent/create-agent :implementer)
+          result (agent/invoke impl-agent task ctx)
+          types (event-types stream)
+          registered (first-event stream :control-plane/agent-registered)
+          heartbeat (last-event stream :control-plane/agent-heartbeat)
+          agent-upserted (last-event stream :supervisory/agent-upserted)
+          agent-entity (:supervisory/entity agent-upserted)]
+      (is (:success result))
+      (is (some #{:control-plane/agent-registered} types))
+      (is (some #{:control-plane/agent-heartbeat} types))
+      (is (some #{:control-plane/agent-state-changed} types))
+      (is (some #{:supervisory/agent-upserted} types))
+      (is (= :miniforge (:cp/vendor registered)))
+      (is (= :implement (:workflow-phase (:cp/metadata registered))))
+      (is (= "implement: Implement auth repair"
+             (:agent-context (:cp/metadata registered))))
+      (is (= "Update the auth flow to reject stale session tokens."
+             (:phase-context (:cp/metadata registered))))
+      (is (= :completed (:cp/status heartbeat)))
+      (is (= "Auth repair"
+             (get-in agent-entity [:agent/metadata :workflow-spec :title])))
+      (is (= :implement (get-in agent-entity [:agent/metadata :workflow-phase])))
+      (is (= :completed (:agent/status agent-entity)))
+      (is (= "implement: Implement auth repair" (:agent/task agent-entity))))))

--- a/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
+++ b/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
@@ -20,6 +20,8 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.agent.interface.protocols.agent :as agent-proto]
+   [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.supervisory-state.interface :as supervisory]))
 
@@ -54,6 +56,13 @@
                                         :usage {:input-tokens 11 :output-tokens 7}
                                         :model "mock"})})
 
+(defn- invoke-context-with-top-level-workflow-spec
+  [stream workflow-id]
+  (assoc (invoke-context stream workflow-id)
+         :workflow/spec {:spec/id "top-level-auth-repair"
+                         :title "Top-level auth repair"
+                         :description "Workflow spec carried on the legacy top-level shape."}))
+
 (defn- event-types
   [stream]
   (map :event/type (event-stream/get-events stream)))
@@ -67,6 +76,22 @@
   [stream event-type]
   (last (filter #(= event-type (:event/type %))
                 (event-stream/get-events stream))))
+
+(defn- failure-agent
+  [result]
+  (specialized/create-base-agent
+   {:role :implementer
+    :system-prompt "spy"
+    :invoke-fn (fn [_ctx _input] result)
+    :validate-fn (fn [_] {:valid? true})
+    :repair-fn (fn [output _ _] output)}))
+
+(defn- throwing-agent
+  [ex]
+  (reify agent-proto/Agent
+    (invoke [_ _ _] (throw ex))
+    (validate [_ _ _] {:valid? true})
+    (repair [_ output _ _] output)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Projection coverage
@@ -102,3 +127,60 @@
       (is (= :implement (get-in agent-entity [:agent/metadata :workflow-phase])))
       (is (= :completed (:agent/status agent-entity)))
       (is (= "implement: Implement auth repair" (:agent/task agent-entity))))))
+
+(deftest direct-agent-invoke-preserves-top-level-workflow-spec-context
+  (testing "workflow-bound agent/invoke keeps the canonical top-level workflow/spec metadata"
+    (let [stream (create-stream)
+          _supervisor (supervisory/attach! stream)
+          workflow-id (random-uuid)
+          task (invoke-task)
+          ctx (invoke-context-with-top-level-workflow-spec stream workflow-id)
+          impl-agent (agent/create-agent :implementer)
+          _result (agent/invoke impl-agent task ctx)
+          agent-upserted (last-event stream :supervisory/agent-upserted)
+          agent-entity (:supervisory/entity agent-upserted)]
+      (is (= "Top-level auth repair"
+             (get-in agent-entity [:agent/metadata :workflow-spec :title])))
+      (is (= "Workflow spec carried on the legacy top-level shape."
+             (get-in agent-entity [:agent/metadata :workflow-spec :description]))))))
+
+(deftest direct-agent-invoke-projects-returned-error-results-as-failed
+  (testing "returned {:status :error ...} results still publish terminal failed supervisory state"
+    (let [stream (create-stream)
+          _supervisor (supervisory/attach! stream)
+          workflow-id (random-uuid)
+          task (invoke-task)
+          ctx (invoke-context stream workflow-id)
+          error-result {:status :error
+                        :error {:message "mock failure"}
+                        :metrics {:duration-ms 17}}
+          result (agent/invoke (failure-agent error-result) task ctx)
+          heartbeat (last-event stream :control-plane/agent-heartbeat)
+          state-change (last-event stream :control-plane/agent-state-changed)
+          agent-upserted (last-event stream :supervisory/agent-upserted)
+          agent-entity (:supervisory/entity agent-upserted)]
+      (is (= error-result result))
+      (is (= :failed (:cp/status heartbeat)))
+      (is (= :failed (:cp/to-status state-change)))
+      (is (= :failed (:agent/status agent-entity))))))
+
+(deftest direct-agent-invoke-emits-failure-events-before-rethrow
+  (testing "a thrown exception still projects terminal failed events before the exception escapes"
+    (let [stream (create-stream)
+          _supervisor (supervisory/attach! stream)
+          workflow-id (random-uuid)
+          task (invoke-task)
+          ctx (invoke-context stream workflow-id)
+          ex (ex-info "projection boom" {:cause :test})]
+      (try
+        (agent/invoke (throwing-agent ex) task ctx)
+        (is false "expected invoke to rethrow the original exception")
+        (catch clojure.lang.ExceptionInfo caught
+          (is (= "projection boom" (ex-message caught)))))
+      (let [heartbeat (last-event stream :control-plane/agent-heartbeat)
+            state-change (last-event stream :control-plane/agent-state-changed)
+            agent-upserted (last-event stream :supervisory/agent-upserted)
+            agent-entity (:supervisory/entity agent-upserted)]
+        (is (= :failed (:cp/status heartbeat)))
+        (is (= :failed (:cp/to-status state-change)))
+        (is (= :failed (:agent/status agent-entity)))))))

--- a/docs/pull-requests/2026-05-02-feat-direct-workflow-agent-supervisory-projection.md
+++ b/docs/pull-requests/2026-05-02-feat-direct-workflow-agent-supervisory-projection.md
@@ -1,0 +1,82 @@
+# feat/direct-workflow-agent-supervisory-projection
+
+## Summary
+
+This PR makes direct in-process workflow agents visible to supervisory-state and
+downstream clients.
+
+Before this slice, live workflow runs emitted fresh `:supervisory/workflow-*`
+snapshots but still produced **zero** `AgentSession` entities unless they went
+through the separate control-plane orchestrator path. The TUI could therefore
+show current runs while still rendering empty agent panes and sparse dossiers.
+
+This PR bridges that gap by mirroring direct `agent/invoke` calls into the
+existing `:control-plane/agent-*` event family that supervisory-state already
+projects.
+
+## Why
+
+The control surface needs a single authoritative source for agent sessions and
+their status history. Supervisory-state already builds that from
+`control-plane/agent-registered`, `control-plane/agent-heartbeat`, and
+`control-plane/agent-state-changed`.
+
+The product gap was not in supervisory-state. It was that ordinary workflow
+phases still invoked internal agents directly and never emitted that event
+family.
+
+Using the existing control-plane vocabulary keeps the producer congruent with
+the spec and avoids inventing a second agent projection path just for internal
+workflow agents.
+
+## What Changed
+
+- added
+  [supervisory_bridge.clj](../../components/agent/src/ai/miniforge/agent/supervisory_bridge.clj)
+  to:
+  - derive deterministic per-invocation agent session ids
+  - emit `:control-plane/agent-registered`
+  - emit `:control-plane/agent-heartbeat`
+  - emit `:control-plane/agent-state-changed`
+  - attach richer metadata using the vocabulary the clients already consume:
+    - `:workflow-spec`
+    - `:workflow-phase`
+    - `:agent-context`
+    - `:phase-context`
+    - `:model`
+- updated
+  [runtime.clj](../../components/agent/src/ai/miniforge/agent/interface/runtime.clj)
+  so `agent/invoke` routes through the new bridge when the invocation context
+  is bound to a workflow event stream
+- added
+  [runtime_supervisory_projection_test.clj](../../components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj)
+  covering:
+  - control-plane event emission from direct workflow-bound `agent/invoke`
+  - derived `:supervisory/agent-upserted` snapshots
+  - preservation of run/spec/phase/task metadata
+
+## Behavior Change
+
+- direct workflow agents now appear as real `AgentSession` entities in
+  supervisory-state
+- those sessions transition through `:executing` to `:completed` or `:failed`
+  without requiring the external control-plane orchestrator
+- clients consuming supervisory snapshots can now show miniforge-run agents
+  during live runs instead of empty agent panes
+
+## What This PR Does Not Do
+
+- it does not yet enrich policy-derived attention
+- it does not yet create new decision or PR producer paths
+- it does not change external non-miniforge agent discovery
+
+Those remain separate slices.
+
+## Validation
+
+- `clj-kondo --lint` on touched agent files
+- `clojure -M:dev:test` with:
+  - `ai.miniforge.agent.runtime-supervisory-projection-test`
+  - `ai.miniforge.agent.interface-test`
+  - `ai.miniforge.workflow.runner-test`
+  - `ai.miniforge.supervisory-state.attention-test`


### PR DESCRIPTION
# feat/direct-workflow-agent-supervisory-projection

## Summary

This PR makes direct in-process workflow agents visible to supervisory-state and
downstream clients.

Before this slice, live workflow runs emitted fresh `:supervisory/workflow-*`
snapshots but still produced **zero** `AgentSession` entities unless they went
through the separate control-plane orchestrator path. The TUI could therefore
show current runs while still rendering empty agent panes and sparse dossiers.

This PR bridges that gap by mirroring direct `agent/invoke` calls into the
existing `:control-plane/agent-*` event family that supervisory-state already
projects.

## Why

The control surface needs a single authoritative source for agent sessions and
their status history. Supervisory-state already builds that from
`control-plane/agent-registered`, `control-plane/agent-heartbeat`, and
`control-plane/agent-state-changed`.

The product gap was not in supervisory-state. It was that ordinary workflow
phases still invoked internal agents directly and never emitted that event
family.

Using the existing control-plane vocabulary keeps the producer congruent with
the spec and avoids inventing a second agent projection path just for internal
workflow agents.

## What Changed

- added
  [supervisory_bridge.clj](../../components/agent/src/ai/miniforge/agent/supervisory_bridge.clj)
  to:
  - derive deterministic per-invocation agent session ids
  - emit `:control-plane/agent-registered`
  - emit `:control-plane/agent-heartbeat`
  - emit `:control-plane/agent-state-changed`
  - attach richer metadata using the vocabulary the clients already consume:
    - `:workflow-spec`
    - `:workflow-phase`
    - `:agent-context`
    - `:phase-context`
    - `:model`
- updated
  [runtime.clj](../../components/agent/src/ai/miniforge/agent/interface/runtime.clj)
  so `agent/invoke` routes through the new bridge when the invocation context
  is bound to a workflow event stream
- added
  [runtime_supervisory_projection_test.clj](../../components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj)
  covering:
  - control-plane event emission from direct workflow-bound `agent/invoke`
  - derived `:supervisory/agent-upserted` snapshots
  - preservation of run/spec/phase/task metadata

## Behavior Change

- direct workflow agents now appear as real `AgentSession` entities in
  supervisory-state
- those sessions transition through `:executing` to `:completed` or `:failed`
  without requiring the external control-plane orchestrator
- clients consuming supervisory snapshots can now show miniforge-run agents
  during live runs instead of empty agent panes

## What This PR Does Not Do

- it does not yet enrich policy-derived attention
- it does not yet create new decision or PR producer paths
- it does not change external non-miniforge agent discovery

Those remain separate slices.

## Validation

- `clj-kondo --lint` on touched agent files
- `clojure -M:dev:test` with:
  - `ai.miniforge.agent.runtime-supervisory-projection-test`
  - `ai.miniforge.agent.interface-test`
  - `ai.miniforge.workflow.runner-test`
  - `ai.miniforge.supervisory-state.attention-test`
