### PR TITLE
refactor: exceptions-as-data cleanup of repo-dag

### DIFF
--- a/components/repo-dag/deps.edn
+++ b/components/repo-dag/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps {metosin/malli                 {:mvn/version "0.16.4"}
+        ai.miniforge/anomaly          {:local/root "../anomaly"}
         ai.miniforge/dag-primitives   {:local/root "../dag-primitives"}}
  :aliases
  {:test {:extra-paths ["test"]

--- a/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
@@ -26,21 +26,47 @@
    [clojure.string :as str]
    [malli.core :as m]
    [malli.error :as me]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-primitives.interface :as dag]
    [ai.miniforge.repo-dag.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure functions for DAG operations
 
-(defn validate-schema
-  "Validate a value against a schema, returning the value or throwing."
+(defn validate-schema-anomaly
+  "Validate a value against a schema. Return the value on success, or an
+   `:invalid-input` anomaly map describing the validation failure.
+
+   The anomaly's `:anomaly/data` carries:
+   - `:schema` — the schema definition that rejected the value
+   - `:value`  — the offending value
+   - `:errors` — humanized malli error map
+
+   Prefer this over [[validate-schema]] in non-boundary code."
   [schema-def value]
   (if (m/validate schema-def value)
     value
-    (throw (ex-info "Schema validation failed"
-                    {:schema schema-def
-                     :value value
-                     :errors (me/humanize (m/explain schema-def value))}))))
+    (anomaly/anomaly :invalid-input
+                     "Schema validation failed"
+                     {:schema schema-def
+                      :value value
+                      :errors (me/humanize (m/explain schema-def value))})))
+
+(defn validate-schema
+  "Validate a value against a schema, returning the value or throwing.
+
+   DEPRECATED: prefer [[validate-schema-anomaly]], which returns an anomaly
+   map rather than throwing. Retained for backward compatibility with
+   existing callers that rely on the ex-info shape."
+  {:deprecated "exceptions-as-data — prefer validate-schema-anomaly"}
+  [schema-def value]
+  (let [result (validate-schema-anomaly schema-def value)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info "Schema validation failed"
+                      {:schema schema-def
+                       :value value
+                       :errors (get-in result [:anomaly/data :errors])}))
+      result)))
 
 (defn make-repo-node
   "Create a repo node with layer inference if not specified."
@@ -247,6 +273,126 @@
     {:valid? (empty? @errors)
      :errors @errors}))
 
+;------------------------------------------------------------------------------ Layer 0.8
+;; Anomaly-returning shape helpers
+;;
+;; These are private store-shaped helpers; they consume the manager's
+;; mutable atom directly so the protocol method bodies stay thin and
+;; the anomaly-returning siblings have a single, shared implementation.
+
+(defn- dag-not-found-anomaly
+  "Construct the canonical `:not-found` anomaly for a missing DAG."
+  [dag-id]
+  (anomaly/anomaly :not-found
+                   "DAG not found"
+                   {:dag-id dag-id}))
+
+(defn- add-repo-impl
+  "Anomaly-returning add-repo. `store` is the manager's atom. Returns the
+   updated DAG on success, or an anomaly on lookup/conflict failure."
+  [store dag-id repo-config]
+  (if-let [dag (get @store dag-id)]
+    (let [node (make-repo-node repo-config)
+          rname (:repo/name node)]
+      (if (find-repo-by-name dag rname)
+        (anomaly/anomaly :conflict
+                         "Repo already exists"
+                         {:dag-id dag-id :repo-name rname})
+        (let [updated (update dag :dag/repos conj node)]
+          (swap! store assoc dag-id updated)
+          updated)))
+    (dag-not-found-anomaly dag-id)))
+
+(defn- remove-repo-impl
+  "Anomaly-returning remove-repo. Returns the updated DAG on success, or a
+   `:not-found` anomaly if the DAG does not exist."
+  [store dag-id repo-name]
+  (if-let [dag (get @store dag-id)]
+    (let [updated-repos (filterv #(not= repo-name (:repo/name %)) (:dag/repos dag))
+          updated-edges (filterv #(and (not= repo-name (:edge/from %))
+                                       (not= repo-name (:edge/to %)))
+                                 (:dag/edges dag))
+          updated (assoc dag
+                         :dag/repos updated-repos
+                         :dag/edges updated-edges)]
+      (swap! store assoc dag-id updated)
+      updated)
+    (dag-not-found-anomaly dag-id)))
+
+(defn- add-edge-impl
+  "Anomaly-returning add-edge. Returns the updated DAG on success, or an
+   anomaly classifying the failure (:not-found, :invalid-input, or :conflict)."
+  [store dag-id from-repo to-repo constraint merge-ordering]
+  (if-let [dag (get @store dag-id)]
+    (let [repo-name-set (repo-names dag)]
+      (cond
+        (not (contains? repo-name-set from-repo))
+        (anomaly/anomaly :not-found
+                         "From repo not found in DAG"
+                         {:dag-id dag-id :repo-name from-repo})
+
+        (not (contains? repo-name-set to-repo))
+        (anomaly/anomaly :not-found
+                         "To repo not found in DAG"
+                         {:dag-id dag-id :repo-name to-repo})
+
+        (= from-repo to-repo)
+        (anomaly/anomaly :invalid-input
+                         "Self-loop not allowed"
+                         {:dag-id dag-id :repo-name from-repo})
+
+        (find-edge dag from-repo to-repo)
+        (anomaly/anomaly :conflict
+                         "Edge already exists"
+                         {:dag-id dag-id :from from-repo :to to-repo})
+
+        :else
+        (let [edge (make-repo-edge {:edge/from from-repo
+                                    :edge/to to-repo
+                                    :edge/constraint constraint
+                                    :edge/merge-ordering merge-ordering})
+              updated (update dag :dag/edges conj edge)
+              result (topo-sort updated)]
+          (if (:success result)
+            (do
+              (swap! store assoc dag-id updated)
+              updated)
+            (anomaly/anomaly :conflict
+                             "Adding edge would create cycle"
+                             {:dag-id dag-id
+                              :from from-repo
+                              :to to-repo
+                              :cycle-nodes (:cycle-nodes result)})))))
+    (dag-not-found-anomaly dag-id)))
+
+(defn- remove-edge-impl
+  "Anomaly-returning remove-edge. Returns the updated DAG on success, or a
+   `:not-found` anomaly if the DAG does not exist."
+  [store dag-id from-repo to-repo]
+  (if-let [dag (get @store dag-id)]
+    (let [updated-edges (filterv #(not (and (= from-repo (:edge/from %))
+                                            (= to-repo (:edge/to %))))
+                                 (:dag/edges dag))
+          updated (assoc dag :dag/edges updated-edges)]
+      (swap! store assoc dag-id updated)
+      updated)
+    (dag-not-found-anomaly dag-id)))
+
+(defn- with-dag-or-anomaly
+  "Look up `dag-id` in `store`; on hit, apply `f` to the DAG and return its
+   result. On miss, return a `:not-found` anomaly. Shared helper for the
+   read-only protocol methods."
+  [store dag-id f]
+  (if-let [dag (get @store dag-id)]
+    (f dag)
+    (dag-not-found-anomaly dag-id)))
+
+(defn- anomaly->ex-info
+  "Translate a repo-dag anomaly back into an ex-info for backward-compat
+   throwing wrappers. Preserves the anomaly's `:anomaly/data` as ex-data."
+  [a]
+  (ex-info (:anomaly/message a) (:anomaly/data a)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Protocol definition
 
@@ -260,14 +406,30 @@
   (add-repo [this dag-id repo-config]
     "Add a repository node to the DAG. Returns updated DAG.")
 
+  (add-repo-anomaly [this dag-id repo-config]
+    "Anomaly-returning sibling of `add-repo`. Returns the updated DAG or
+     an anomaly map on failure.")
+
   (remove-repo [this dag-id repo-name]
     "Remove a repository from the DAG (and its edges). Returns updated DAG.")
+
+  (remove-repo-anomaly [this dag-id repo-name]
+    "Anomaly-returning sibling of `remove-repo`. Returns the updated DAG
+     or a `:not-found` anomaly when the DAG is missing.")
 
   (add-edge [this dag-id from-repo to-repo constraint merge-ordering]
     "Add a dependency edge between repos. Returns updated DAG or error if invalid.")
 
+  (add-edge-anomaly [this dag-id from-repo to-repo constraint merge-ordering]
+    "Anomaly-returning sibling of `add-edge`. Returns the updated DAG or
+     an anomaly map on failure.")
+
   (remove-edge [this dag-id from-repo to-repo]
     "Remove a dependency edge. Returns updated DAG.")
+
+  (remove-edge-anomaly [this dag-id from-repo to-repo]
+    "Anomaly-returning sibling of `remove-edge`. Returns the updated DAG
+     or a `:not-found` anomaly when the DAG is missing.")
 
   ;; Queries
   (get-dag [this dag-id]
@@ -276,18 +438,38 @@
   (compute-topo-order [this dag-id]
     "Compute topological sort of repos. Returns {:success true :order [...]} or error.")
 
+  (compute-topo-order-anomaly [this dag-id]
+    "Anomaly-returning sibling of `compute-topo-order`. Returns the topo
+     result or a `:not-found` anomaly when the DAG is missing.")
+
   (affected-repos [this dag-id changed-repo]
     "Given a changed repo, return all downstream repos that may be affected.")
+
+  (affected-repos-anomaly [this dag-id changed-repo]
+    "Anomaly-returning sibling of `affected-repos`. Returns the downstream
+     repo set or a `:not-found` anomaly when the DAG is missing.")
 
   (upstream-repos [this dag-id repo-name]
     "Return all repos that this repo depends on.")
 
+  (upstream-repos-anomaly [this dag-id repo-name]
+    "Anomaly-returning sibling of `upstream-repos`. Returns the upstream
+     repo set or a `:not-found` anomaly when the DAG is missing.")
+
   (merge-order [this dag-id pr-set]
     "Given a set of PRs across repos, return valid merge order.")
 
+  (merge-order-anomaly [this dag-id pr-set]
+    "Anomaly-returning sibling of `merge-order`. Returns the merge-order
+     result or a `:not-found` anomaly when the DAG is missing.")
+
   ;; Validation
   (validate-dag [this dag-id]
-    "Check for cycles, orphans, invalid references. Returns {:valid? bool :errors [...]}."))
+    "Check for cycles, orphans, invalid references. Returns {:valid? bool :errors [...]}.")
+
+  (validate-dag-anomaly [this dag-id]
+    "Anomaly-returning sibling of `validate-dag`. Returns the validation
+     result or a `:not-found` anomaly when the DAG is missing."))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; In-memory implementation
@@ -301,108 +483,89 @@
       (swap! store assoc id dag)
       dag))
 
-  (add-repo [_this dag-id repo-config]
-    (if-let [dag (get @store dag-id)]
-      (let [node (make-repo-node repo-config)
-            rname (:repo/name node)]
-        ;; Check for duplicate
-        (when (find-repo-by-name dag rname)
-          (throw (ex-info "Repo already exists"
-                          {:dag-id dag-id :repo-name rname})))
-        (let [updated (update dag :dag/repos conj node)]
-          (swap! store assoc dag-id updated)
-          updated))
-      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+  (add-repo-anomaly [_this dag-id repo-config]
+    (add-repo-impl store dag-id repo-config))
 
-  (remove-repo [_this dag-id repo-name]
-    (if-let [dag (get @store dag-id)]
-      (let [;; Remove the repo
-            updated-repos (filterv #(not= repo-name (:repo/name %)) (:dag/repos dag))
-            ;; Remove edges referencing this repo
-            updated-edges (filterv #(and (not= repo-name (:edge/from %))
-                                         (not= repo-name (:edge/to %)))
-                                   (:dag/edges dag))
-            updated (assoc dag
-                           :dag/repos updated-repos
-                           :dag/edges updated-edges)]
-        (swap! store assoc dag-id updated)
-        updated)
-      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+  (add-repo [this dag-id repo-config]
+    (let [result (add-repo-anomaly this dag-id repo-config)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result)))
 
-  (add-edge [_this dag-id from-repo to-repo constraint merge-ordering]
-    (if-let [dag (get @store dag-id)]
-      (let [repo-name-set (repo-names dag)]
-        ;; Validate repos exist
-        (when-not (contains? repo-name-set from-repo)
-          (throw (ex-info "From repo not found in DAG"
-                          {:dag-id dag-id :repo-name from-repo})))
-        (when-not (contains? repo-name-set to-repo)
-          (throw (ex-info "To repo not found in DAG"
-                          {:dag-id dag-id :repo-name to-repo})))
-        ;; Check for self-loop
-        (when (= from-repo to-repo)
-          (throw (ex-info "Self-loop not allowed"
-                          {:dag-id dag-id :repo-name from-repo})))
-        ;; Check for existing edge
-        (when (find-edge dag from-repo to-repo)
-          (throw (ex-info "Edge already exists"
-                          {:dag-id dag-id :from from-repo :to to-repo})))
-        ;; Create edge
-        (let [edge (make-repo-edge {:edge/from from-repo
-                                    :edge/to to-repo
-                                    :edge/constraint constraint
-                                    :edge/merge-ordering merge-ordering})
-              updated (update dag :dag/edges conj edge)
-              ;; Check for cycles
-              result (topo-sort updated)]
-          (if (:success result)
-            (do
-              (swap! store assoc dag-id updated)
-              updated)
-            (throw (ex-info "Adding edge would create cycle"
-                            {:dag-id dag-id
-                             :from from-repo
-                             :to to-repo
-                             :cycle-nodes (:cycle-nodes result)})))))
-      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+  (remove-repo-anomaly [_this dag-id repo-name]
+    (remove-repo-impl store dag-id repo-name))
 
-  (remove-edge [_this dag-id from-repo to-repo]
-    (if-let [dag (get @store dag-id)]
-      (let [updated-edges (filterv #(not (and (= from-repo (:edge/from %))
-                                              (= to-repo (:edge/to %))))
-                                   (:dag/edges dag))
-            updated (assoc dag :dag/edges updated-edges)]
-        (swap! store assoc dag-id updated)
-        updated)
-      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+  (remove-repo [this dag-id repo-name]
+    (let [result (remove-repo-anomaly this dag-id repo-name)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result)))
+
+  (add-edge-anomaly [_this dag-id from-repo to-repo constraint merge-ordering]
+    (add-edge-impl store dag-id from-repo to-repo constraint merge-ordering))
+
+  (add-edge [this dag-id from-repo to-repo constraint merge-ordering]
+    (let [result (add-edge-anomaly this dag-id from-repo to-repo constraint merge-ordering)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result)))
+
+  (remove-edge-anomaly [_this dag-id from-repo to-repo]
+    (remove-edge-impl store dag-id from-repo to-repo))
+
+  (remove-edge [this dag-id from-repo to-repo]
+    (let [result (remove-edge-anomaly this dag-id from-repo to-repo)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result)))
 
   (get-dag [_this dag-id]
     (get @store dag-id))
 
-  (compute-topo-order [_this dag-id]
-    (if-let [dag (get @store dag-id)]
-      (topo-sort dag)
-      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+  (compute-topo-order-anomaly [_this dag-id]
+    (with-dag-or-anomaly store dag-id topo-sort))
 
-  (affected-repos [_this dag-id changed-repo]
-    (if-let [dag (get @store dag-id)]
-      (downstream-repos dag changed-repo)
-      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+  (compute-topo-order [this dag-id]
+    (let [result (compute-topo-order-anomaly this dag-id)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result)))
 
-  (upstream-repos [_this dag-id repo-name]
-    (if-let [dag (get @store dag-id)]
-      (upstream-repos-impl dag repo-name)
-      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+  (affected-repos-anomaly [_this dag-id changed-repo]
+    (with-dag-or-anomaly store dag-id #(downstream-repos % changed-repo)))
 
-  (merge-order [_this dag-id pr-set]
-    (if-let [dag (get @store dag-id)]
-      (compute-merge-order dag pr-set)
-      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+  (affected-repos [this dag-id changed-repo]
+    (let [result (affected-repos-anomaly this dag-id changed-repo)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result)))
 
-  (validate-dag [_this dag-id]
-    (if-let [dag (get @store dag-id)]
-      (validate-dag-impl dag)
-      (throw (ex-info "DAG not found" {:dag-id dag-id})))))
+  (upstream-repos-anomaly [_this dag-id repo-name]
+    (with-dag-or-anomaly store dag-id #(upstream-repos-impl % repo-name)))
+
+  (upstream-repos [this dag-id repo-name]
+    (let [result (upstream-repos-anomaly this dag-id repo-name)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result)))
+
+  (merge-order-anomaly [_this dag-id pr-set]
+    (with-dag-or-anomaly store dag-id #(compute-merge-order % pr-set)))
+
+  (merge-order [this dag-id pr-set]
+    (let [result (merge-order-anomaly this dag-id pr-set)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result)))
+
+  (validate-dag-anomaly [_this dag-id]
+    (with-dag-or-anomaly store dag-id validate-dag-impl))
+
+  (validate-dag [this dag-id]
+    (let [result (validate-dag-anomaly this dag-id)]
+      (if (anomaly/anomaly? result)
+        (throw (anomaly->ex-info result))
+        result))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Factory functions
@@ -479,5 +642,11 @@
     (catch Exception e
       (ex-data e)))
   ;; => {:dag-id ..., :from "k8s-manifests", :to "terraform-modules", :cycle-nodes #{"terraform-modules" "terraform-live" "k8s-manifests"}}
+
+  ;; Anomaly-returning sibling
+  (add-edge-anomaly mgr (:dag/id dag)
+                    "k8s-manifests" "terraform-modules"
+                    :library-before-consumer :sequential)
+  ;; => {:anomaly/type :conflict ...}
 
   :leave-this-here)

--- a/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
@@ -68,30 +68,65 @@
                        :errors (get-in result [:anomaly/data :errors])}))
       result)))
 
-(defn make-repo-node
-  "Create a repo node with layer inference if not specified."
+(defn- build-repo-node
+  "Internal: assemble the repo-node map (no validation). Shared between
+   the throwing and anomaly-returning constructors so the two never drift."
   [{:keys [repo/url repo/name repo/org repo/type repo/layer repo/default-branch repo/watch-config]
     :or {default-branch "main"}}]
-  (let [inferred-layer (or layer (schema/infer-layer type))
-        node (cond-> {:repo/url url
-                      :repo/name name
-                      :repo/type type
-                      :repo/layer inferred-layer
-                      :repo/default-branch default-branch}
-               org (assoc :repo/org org)
-               watch-config (assoc :repo/watch-config watch-config))]
-    (validate-schema schema/RepoNode node)))
+  (let [inferred-layer (or layer (schema/infer-layer type))]
+    (cond-> {:repo/url url
+             :repo/name name
+             :repo/type type
+             :repo/layer inferred-layer
+             :repo/default-branch default-branch}
+      org (assoc :repo/org org)
+      watch-config (assoc :repo/watch-config watch-config))))
 
-(defn make-repo-edge
-  "Create a repo edge with default merge ordering."
+(defn make-repo-node-anomaly
+  "Build a repo node from `repo-config`, returning the validated node or
+   an `:invalid-input` anomaly when schema validation rejects it (e.g.
+   missing `:repo/type`, malformed `:repo/url`, …).
+
+   Prefer this over [[make-repo-node]] in non-boundary code."
+  [repo-config]
+  (validate-schema-anomaly schema/RepoNode (build-repo-node repo-config)))
+
+(defn make-repo-node
+  "Create a repo node with layer inference if not specified.
+
+   DEPRECATED: prefer [[make-repo-node-anomaly]], which returns an anomaly
+   map rather than throwing on schema validation failure."
+  {:deprecated "exceptions-as-data — prefer make-repo-node-anomaly"}
+  [repo-config]
+  (validate-schema schema/RepoNode (build-repo-node repo-config)))
+
+(defn- build-repo-edge
+  "Internal: assemble the edge map (no validation). Shared between the
+   throwing and anomaly-returning constructors."
   [{:keys [edge/from edge/to edge/constraint edge/merge-ordering edge/validation]
     :or {merge-ordering :sequential}}]
-  (let [edge (cond-> {:edge/from from
-                      :edge/to to
-                      :edge/constraint constraint
-                      :edge/merge-ordering merge-ordering}
-               validation (assoc :edge/validation validation))]
-    (validate-schema schema/RepoEdge edge)))
+  (cond-> {:edge/from from
+           :edge/to to
+           :edge/constraint constraint
+           :edge/merge-ordering merge-ordering}
+    validation (assoc :edge/validation validation)))
+
+(defn make-repo-edge-anomaly
+  "Build a repo edge from `edge-config`, returning the validated edge or
+   an `:invalid-input` anomaly when schema validation rejects it (unknown
+   `:edge/constraint`, unknown `:edge/merge-ordering`, missing endpoints, …).
+
+   Prefer this over [[make-repo-edge]] in non-boundary code."
+  [edge-config]
+  (validate-schema-anomaly schema/RepoEdge (build-repo-edge edge-config)))
+
+(defn make-repo-edge
+  "Create a repo edge with default merge ordering.
+
+   DEPRECATED: prefer [[make-repo-edge-anomaly]]."
+  {:deprecated "exceptions-as-data — prefer make-repo-edge-anomaly"}
+  [edge-config]
+  (validate-schema schema/RepoEdge (build-repo-edge edge-config)))
 
 (defn make-dag
   "Create a new empty DAG."
@@ -289,18 +324,22 @@
 
 (defn- add-repo-impl
   "Anomaly-returning add-repo. `store` is the manager's atom. Returns the
-   updated DAG on success, or an anomaly on lookup/conflict failure."
+   updated DAG on success, or an anomaly on missing DAG (`:not-found`),
+   schema-invalid `repo-config` (`:invalid-input`), or duplicate repo name
+   (`:conflict`)."
   [store dag-id repo-config]
   (if-let [dag (get @store dag-id)]
-    (let [node (make-repo-node repo-config)
-          rname (:repo/name node)]
-      (if (find-repo-by-name dag rname)
-        (anomaly/anomaly :conflict
-                         "Repo already exists"
-                         {:dag-id dag-id :repo-name rname})
-        (let [updated (update dag :dag/repos conj node)]
-          (swap! store assoc dag-id updated)
-          updated)))
+    (let [node-or-anomaly (make-repo-node-anomaly repo-config)]
+      (if (anomaly/anomaly? node-or-anomaly)
+        node-or-anomaly
+        (let [rname (:repo/name node-or-anomaly)]
+          (if (find-repo-by-name dag rname)
+            (anomaly/anomaly :conflict
+                             "Repo already exists"
+                             {:dag-id dag-id :repo-name rname})
+            (let [updated (update dag :dag/repos conj node-or-anomaly)]
+              (swap! store assoc dag-id updated)
+              updated)))))
     (dag-not-found-anomaly dag-id)))
 
 (defn- remove-repo-impl
@@ -347,22 +386,25 @@
                          {:dag-id dag-id :from from-repo :to to-repo})
 
         :else
-        (let [edge (make-repo-edge {:edge/from from-repo
-                                    :edge/to to-repo
-                                    :edge/constraint constraint
-                                    :edge/merge-ordering merge-ordering})
-              updated (update dag :dag/edges conj edge)
-              result (topo-sort updated)]
-          (if (:success result)
-            (do
-              (swap! store assoc dag-id updated)
-              updated)
-            (anomaly/anomaly :conflict
-                             "Adding edge would create cycle"
-                             {:dag-id dag-id
-                              :from from-repo
-                              :to to-repo
-                              :cycle-nodes (:cycle-nodes result)})))))
+        (let [edge-or-anomaly (make-repo-edge-anomaly
+                               {:edge/from from-repo
+                                :edge/to to-repo
+                                :edge/constraint constraint
+                                :edge/merge-ordering merge-ordering})]
+          (if (anomaly/anomaly? edge-or-anomaly)
+            edge-or-anomaly
+            (let [updated (update dag :dag/edges conj edge-or-anomaly)
+                  result (topo-sort updated)]
+              (if (:success result)
+                (do
+                  (swap! store assoc dag-id updated)
+                  updated)
+                (anomaly/anomaly :conflict
+                                 "Adding edge would create cycle"
+                                 {:dag-id dag-id
+                                  :from from-repo
+                                  :to to-repo
+                                  :cycle-nodes (:cycle-nodes result)})))))))
     (dag-not-found-anomaly dag-id)))
 
 (defn- remove-edge-impl

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -135,8 +135,11 @@
   "Anomaly-returning variant of [[add-repo]].
 
    Returns the updated DAG on success, or an anomaly map on failure:
-   - `:not-found` — DAG with `dag-id` does not exist
-   - `:conflict`  — a repo with the same `:repo/name` already exists in the DAG
+   - `:not-found`     — DAG with `dag-id` does not exist
+   - `:invalid-input` — `repo-config` fails schema validation (e.g.
+                        missing `:repo/type`, malformed `:repo/url`)
+   - `:conflict`      — a repo with the same `:repo/name` already exists
+                        in the DAG
 
    Prefer this over [[add-repo]] in non-boundary code."
   [manager dag-id repo-config]
@@ -203,7 +206,10 @@
 
    Returns the updated DAG on success, or an anomaly map on failure:
    - `:not-found`     — DAG, from-repo, or to-repo does not exist
-   - `:invalid-input` — self-loop attempted (`from-repo` = `to-repo`)
+   - `:invalid-input` — self-loop attempted (`from-repo` = `to-repo`),
+                        or the edge payload fails schema validation
+                        (unknown `constraint`, unknown `merge-ordering`,
+                        missing endpoints)
    - `:conflict`      — edge already exists, or adding the edge would
                         introduce a cycle (`:cycle-nodes` carried in data)
 

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -119,13 +119,28 @@
    - DAG not found
    - Repo with same name already exists
 
+   DEPRECATED: prefer [[add-repo-anomaly]], which returns an anomaly map
+   instead of throwing. Retained for backward compatibility.
+
    Example:
      (add-repo mgr dag-id
                {:repo/url \"https://github.com/acme/terraform-modules\"
                 :repo/name \"terraform-modules\"
                 :repo/type :terraform-module})"
+  {:deprecated "exceptions-as-data — prefer add-repo-anomaly"}
   [manager dag-id repo-config]
   (core/add-repo manager dag-id repo-config))
+
+(defn add-repo-anomaly
+  "Anomaly-returning variant of [[add-repo]].
+
+   Returns the updated DAG on success, or an anomaly map on failure:
+   - `:not-found` — DAG with `dag-id` does not exist
+   - `:conflict`  — a repo with the same `:repo/name` already exists in the DAG
+
+   Prefer this over [[add-repo]] in non-boundary code."
+  [manager dag-id repo-config]
+  (core/add-repo-anomaly manager dag-id repo-config))
 
 (defn remove-repo
   "Remove a repository from the DAG.
@@ -138,9 +153,20 @@
    Returns the updated DAG.
    Also removes all edges referencing this repo.
 
-   Throws if DAG not found."
+   Throws if DAG not found.
+
+   DEPRECATED: prefer [[remove-repo-anomaly]]."
+  {:deprecated "exceptions-as-data — prefer remove-repo-anomaly"}
   [manager dag-id repo-name]
   (core/remove-repo manager dag-id repo-name))
+
+(defn remove-repo-anomaly
+  "Anomaly-returning variant of [[remove-repo]].
+
+   Returns the updated DAG on success, or a `:not-found` anomaly when the
+   DAG does not exist."
+  [manager dag-id repo-name]
+  (core/remove-repo-anomaly manager dag-id repo-name))
 
 (defn add-edge
   "Add a dependency edge between repos.
@@ -162,12 +188,28 @@
    - Edge already exists
    - Self-loop attempted
 
+   DEPRECATED: prefer [[add-edge-anomaly]].
+
    Example:
      (add-edge mgr dag-id
                \"terraform-modules\" \"terraform-live\"
                :module-before-live :sequential)"
+  {:deprecated "exceptions-as-data — prefer add-edge-anomaly"}
   [manager dag-id from-repo to-repo constraint merge-ordering]
   (core/add-edge manager dag-id from-repo to-repo constraint merge-ordering))
+
+(defn add-edge-anomaly
+  "Anomaly-returning variant of [[add-edge]].
+
+   Returns the updated DAG on success, or an anomaly map on failure:
+   - `:not-found`     — DAG, from-repo, or to-repo does not exist
+   - `:invalid-input` — self-loop attempted (`from-repo` = `to-repo`)
+   - `:conflict`      — edge already exists, or adding the edge would
+                        introduce a cycle (`:cycle-nodes` carried in data)
+
+   Prefer this over [[add-edge]] in non-boundary code."
+  [manager dag-id from-repo to-repo constraint merge-ordering]
+  (core/add-edge-anomaly manager dag-id from-repo to-repo constraint merge-ordering))
 
 (defn remove-edge
   "Remove a dependency edge.
@@ -180,9 +222,20 @@
 
    Returns the updated DAG.
 
-   Throws if DAG not found."
+   Throws if DAG not found.
+
+   DEPRECATED: prefer [[remove-edge-anomaly]]."
+  {:deprecated "exceptions-as-data — prefer remove-edge-anomaly"}
   [manager dag-id from-repo to-repo]
   (core/remove-edge manager dag-id from-repo to-repo))
+
+(defn remove-edge-anomaly
+  "Anomaly-returning variant of [[remove-edge]].
+
+   Returns the updated DAG on success, or a `:not-found` anomaly when the
+   DAG does not exist."
+  [manager dag-id from-repo to-repo]
+  (core/remove-edge-anomaly manager dag-id from-repo to-repo))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Query operations
@@ -198,11 +251,24 @@
    - On success: {:success true :order [repo-names...]}
    - On failure: {:success false :error :cycle-detected :cycle-nodes #{...}}
 
+   Throws ex-info when the DAG does not exist.
+
+   DEPRECATED: prefer [[compute-topo-order-anomaly]].
+
    Example:
      (compute-topo-order mgr dag-id)
      ;; => {:success true :order [\"terraform-modules\" \"terraform-live\" \"k8s\"]}"
+  {:deprecated "exceptions-as-data — prefer compute-topo-order-anomaly"}
   [manager dag-id]
   (core/compute-topo-order manager dag-id))
+
+(defn compute-topo-order-anomaly
+  "Anomaly-returning variant of [[compute-topo-order]].
+
+   Returns the topo-sort result map on success, or a `:not-found` anomaly
+   when the DAG does not exist."
+  [manager dag-id]
+  (core/compute-topo-order-anomaly manager dag-id))
 
 (defn affected-repos
   "Given a changed repo, return all downstream repos that may be affected.
@@ -214,11 +280,24 @@
 
    Returns a set of repo names that are downstream (depend on) the changed repo.
 
+   Throws ex-info when the DAG does not exist.
+
+   DEPRECATED: prefer [[affected-repos-anomaly]].
+
    Example:
      (affected-repos mgr dag-id \"terraform-modules\")
      ;; => #{\"terraform-live\" \"k8s-manifests\"}"
+  {:deprecated "exceptions-as-data — prefer affected-repos-anomaly"}
   [manager dag-id changed-repo]
   (core/affected-repos manager dag-id changed-repo))
+
+(defn affected-repos-anomaly
+  "Anomaly-returning variant of [[affected-repos]].
+
+   Returns the set of downstream repo names on success, or a `:not-found`
+   anomaly when the DAG does not exist."
+  [manager dag-id changed-repo]
+  (core/affected-repos-anomaly manager dag-id changed-repo))
 
 (defn upstream-repos
   "Return all repos that the given repo depends on.
@@ -230,11 +309,24 @@
 
    Returns a set of repo names that are upstream (dependencies of) the given repo.
 
+   Throws ex-info when the DAG does not exist.
+
+   DEPRECATED: prefer [[upstream-repos-anomaly]].
+
    Example:
      (upstream-repos mgr dag-id \"k8s-manifests\")
      ;; => #{\"terraform-modules\" \"terraform-live\"}"
+  {:deprecated "exceptions-as-data — prefer upstream-repos-anomaly"}
   [manager dag-id repo-name]
   (core/upstream-repos manager dag-id repo-name))
+
+(defn upstream-repos-anomaly
+  "Anomaly-returning variant of [[upstream-repos]].
+
+   Returns the set of upstream repo names on success, or a `:not-found`
+   anomaly when the DAG does not exist."
+  [manager dag-id repo-name]
+  (core/upstream-repos-anomaly manager dag-id repo-name))
 
 (defn merge-order
   "Given a set of repos with PRs, compute valid merge order.
@@ -250,11 +342,24 @@
 
    Only considers dependencies between repos in the pr-set.
 
+   Throws ex-info when the DAG does not exist.
+
+   DEPRECATED: prefer [[merge-order-anomaly]].
+
    Example:
      (merge-order mgr dag-id #{\"terraform-modules\" \"terraform-live\"})
      ;; => {:success true :order [\"terraform-modules\" \"terraform-live\"]}"
+  {:deprecated "exceptions-as-data — prefer merge-order-anomaly"}
   [manager dag-id pr-set]
   (core/merge-order manager dag-id pr-set))
+
+(defn merge-order-anomaly
+  "Anomaly-returning variant of [[merge-order]].
+
+   Returns the merge-order result map on success, or a `:not-found`
+   anomaly when the DAG does not exist."
+  [manager dag-id pr-set]
+  (core/merge-order-anomaly manager dag-id pr-set))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Validation
@@ -276,11 +381,24 @@
    - Edges referencing missing repos
    - Self-loops
 
+   Throws ex-info when the DAG does not exist.
+
+   DEPRECATED: prefer [[validate-dag-anomaly]].
+
    Example:
      (validate-dag mgr dag-id)
      ;; => {:valid? true :errors []}"
+  {:deprecated "exceptions-as-data — prefer validate-dag-anomaly"}
   [manager dag-id]
   (core/validate-dag manager dag-id))
+
+(defn validate-dag-anomaly
+  "Anomaly-returning variant of [[validate-dag]].
+
+   Returns the validation result map on success, or a `:not-found` anomaly
+   when the DAG does not exist."
+  [manager dag-id]
+  (core/validate-dag-anomaly manager dag-id))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Pure functions (no manager required)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_edge_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_edge_test.clj
@@ -18,16 +18,19 @@
 
 (ns ai.miniforge.repo-dag.anomaly.add-edge-test
   "Coverage for `dag/add-edge-anomaly` and its deprecated throwing
-   sibling `dag/add-edge`. Five failure modes:
-   - `:not-found` when DAG missing
-   - `:not-found` when from-repo missing
-   - `:not-found` when to-repo missing
+   sibling `dag/add-edge`. Seven failure modes:
+   - `:not-found`     when DAG missing
+   - `:not-found`     when from-repo missing
+   - `:not-found`     when to-repo missing
    - `:invalid-input` on self-loop
-   - `:conflict` on duplicate edge
-   - `:conflict` when adding the edge would introduce a cycle"
+   - `:invalid-input` on schema-invalid edge payload (unknown constraint,
+                      unknown merge-ordering)
+   - `:conflict`      on duplicate edge
+   - `:conflict`      when adding the edge would introduce a cycle"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ai.miniforge.anomaly.interface :as anomaly]
-            [ai.miniforge.repo-dag.interface :as dag]))
+            [ai.miniforge.repo-dag.interface :as dag]
+            [ai.miniforge.repo-dag.schema :as schema]))
 
 (def ^:dynamic *manager* nil)
 (def ^:dynamic *dag-id* nil)
@@ -102,6 +105,29 @@
       (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
       (is (= "repo-a" (get-in result [:anomaly/data :repo-name]))))))
+
+;------------------------------------------------------------------------------ Failure: schema-invalid edge payload
+
+(deftest add-edge-anomaly-invalid-input-on-unknown-constraint
+  (testing "unknown :edge/constraint yields :invalid-input anomaly — schema rejection
+            short-circuits via make-repo-edge-anomaly before the edge is appended.
+            Pre-fix this path threw an ExceptionInfo via the deprecated throwing
+            validate-schema and silently violated the anomaly-returning contract."
+    (let [result (dag/add-edge-anomaly *manager* *dag-id*
+                                       "repo-a" "repo-b"
+                                       :not-a-real-constraint :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (some? (get-in result [:anomaly/data :errors])))
+      (is (= schema/RepoEdge (get-in result [:anomaly/data :schema]))))))
+
+(deftest add-edge-anomaly-invalid-input-on-unknown-merge-ordering
+  (testing "unknown :edge/merge-ordering yields :invalid-input anomaly"
+    (let [result (dag/add-edge-anomaly *manager* *dag-id*
+                                       "repo-a" "repo-b"
+                                       :library-before-consumer :not-an-ordering)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ Failure: duplicate edge
 

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_edge_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_edge_test.clj
@@ -1,0 +1,155 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.repo-dag.anomaly.add-edge-test
+  "Coverage for `dag/add-edge-anomaly` and its deprecated throwing
+   sibling `dag/add-edge`. Five failure modes:
+   - `:not-found` when DAG missing
+   - `:not-found` when from-repo missing
+   - `:not-found` when to-repo missing
+   - `:invalid-input` on self-loop
+   - `:conflict` on duplicate edge
+   - `:conflict` when adding the edge would introduce a cycle"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.repo-dag.interface :as dag]))
+
+(def ^:dynamic *manager* nil)
+(def ^:dynamic *dag-id* nil)
+
+(defn manager-and-dag-fixture [f]
+  (binding [*manager* (dag/create-manager)]
+    (let [d (dag/create-dag *manager* "test-dag")]
+      (dag/add-repo-anomaly *manager* (:dag/id d)
+                            {:repo/url "https://github.com/acme/a"
+                             :repo/name "repo-a"
+                             :repo/type :library})
+      (dag/add-repo-anomaly *manager* (:dag/id d)
+                            {:repo/url "https://github.com/acme/b"
+                             :repo/name "repo-b"
+                             :repo/type :application})
+      (binding [*dag-id* (:dag/id d)]
+        (f)))))
+
+(use-fixtures :each manager-and-dag-fixture)
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest add-edge-anomaly-returns-updated-dag
+  (testing "successful add returns the updated DAG, not an anomaly"
+    (let [result (dag/add-edge-anomaly *manager* *dag-id*
+                                       "repo-a" "repo-b"
+                                       :library-before-consumer :sequential)]
+      (is (not (anomaly/anomaly? result)))
+      (is (= 1 (count (:dag/edges result)))))))
+
+;------------------------------------------------------------------------------ Failure: DAG not found
+
+(deftest add-edge-anomaly-not-found-when-dag-missing
+  (testing "missing DAG yields :not-found anomaly"
+    (let [missing-id (random-uuid)
+          result (dag/add-edge-anomaly *manager* missing-id
+                                       "repo-a" "repo-b"
+                                       :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
+
+;------------------------------------------------------------------------------ Failure: from-repo not found
+
+(deftest add-edge-anomaly-not-found-when-from-repo-missing
+  (testing "missing from-repo yields :not-found anomaly"
+    (let [result (dag/add-edge-anomaly *manager* *dag-id*
+                                       "ghost" "repo-b"
+                                       :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= "ghost" (get-in result [:anomaly/data :repo-name]))))))
+
+;------------------------------------------------------------------------------ Failure: to-repo not found
+
+(deftest add-edge-anomaly-not-found-when-to-repo-missing
+  (testing "missing to-repo yields :not-found anomaly"
+    (let [result (dag/add-edge-anomaly *manager* *dag-id*
+                                       "repo-a" "ghost"
+                                       :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= "ghost" (get-in result [:anomaly/data :repo-name]))))))
+
+;------------------------------------------------------------------------------ Failure: self-loop
+
+(deftest add-edge-anomaly-invalid-input-on-self-loop
+  (testing "self-loop yields :invalid-input anomaly — input shape rejected"
+    (let [result (dag/add-edge-anomaly *manager* *dag-id*
+                                       "repo-a" "repo-a"
+                                       :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "repo-a" (get-in result [:anomaly/data :repo-name]))))))
+
+;------------------------------------------------------------------------------ Failure: duplicate edge
+
+(deftest add-edge-anomaly-conflict-on-duplicate
+  (testing "duplicate edge yields :conflict anomaly"
+    (dag/add-edge-anomaly *manager* *dag-id*
+                          "repo-a" "repo-b"
+                          :library-before-consumer :sequential)
+    (let [result (dag/add-edge-anomaly *manager* *dag-id*
+                                       "repo-a" "repo-b"
+                                       :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (= "repo-a" (get-in result [:anomaly/data :from])))
+      (is (= "repo-b" (get-in result [:anomaly/data :to]))))))
+
+;------------------------------------------------------------------------------ Failure: cycle
+
+(deftest add-edge-anomaly-conflict-on-cycle
+  (testing "cycle-introducing edge yields :conflict anomaly carrying cycle-nodes"
+    (dag/add-edge-anomaly *manager* *dag-id*
+                          "repo-a" "repo-b"
+                          :library-before-consumer :sequential)
+    (let [result (dag/add-edge-anomaly *manager* *dag-id*
+                                       "repo-b" "repo-a"
+                                       :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (set? (get-in result [:anomaly/data :cycle-nodes]))))))
+
+;------------------------------------------------------------------------------ Throwing-variant compat
+
+(deftest add-edge-still-throws-on-missing-from-repo
+  (testing "deprecated throwing variant still throws ex-info on missing from-repo"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"From repo not found"
+          (dag/add-edge *manager* *dag-id* "ghost" "repo-b"
+                        :library-before-consumer :sequential)))))
+
+(deftest add-edge-still-throws-on-self-loop
+  (testing "deprecated throwing variant still throws on self-loop"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Self-loop not allowed"
+          (dag/add-edge *manager* *dag-id* "repo-a" "repo-a"
+                        :library-before-consumer :sequential)))))
+
+(deftest add-edge-still-throws-on-cycle
+  (testing "deprecated throwing variant still throws on cycle introduction"
+    (dag/add-edge *manager* *dag-id* "repo-a" "repo-b"
+                  :library-before-consumer :sequential)
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"create cycle"
+          (dag/add-edge *manager* *dag-id* "repo-b" "repo-a"
+                        :library-before-consumer :sequential)))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_repo_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_repo_test.clj
@@ -18,12 +18,15 @@
 
 (ns ai.miniforge.repo-dag.anomaly.add-repo-test
   "Coverage for `dag/add-repo-anomaly` and its deprecated throwing
-   sibling `dag/add-repo`. Two anomaly classes:
-   - `:not-found` — DAG missing
-   - `:conflict`  — repo with same name already exists"
+   sibling `dag/add-repo`. Three anomaly classes:
+   - `:not-found`     — DAG missing
+   - `:invalid-input` — `repo-config` fails schema validation (missing
+                        `:repo/type`, malformed `:repo/url`, …)
+   - `:conflict`      — repo with same name already exists"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ai.miniforge.anomaly.interface :as anomaly]
-            [ai.miniforge.repo-dag.interface :as dag]))
+            [ai.miniforge.repo-dag.interface :as dag]
+            [ai.miniforge.repo-dag.schema :as schema]))
 
 (def ^:dynamic *manager* nil)
 
@@ -57,6 +60,23 @@
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result)))
       (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
+
+;------------------------------------------------------------------------------ Failure path: schema-invalid repo-config
+
+(deftest add-repo-anomaly-invalid-input-on-missing-repo-type
+  (testing "repo-config without :repo/type yields :invalid-input anomaly —
+            schema rejection short-circuits via make-repo-node-anomaly
+            before the node is appended. Pre-fix this path threw
+            ExceptionInfo via the deprecated throwing validate-schema and
+            silently violated the anomaly-returning contract."
+    (let [d (dag/create-dag *manager* "test-dag")
+          bad-config {:repo/url "https://github.com/acme/x"
+                      :repo/name "x"} ;; missing :repo/type
+          result (dag/add-repo-anomaly *manager* (:dag/id d) bad-config)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (some? (get-in result [:anomaly/data :errors])))
+      (is (= schema/RepoNode (get-in result [:anomaly/data :schema]))))))
 
 ;------------------------------------------------------------------------------ Failure path: duplicate
 

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_repo_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_repo_test.clj
@@ -1,0 +1,84 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.repo-dag.anomaly.add-repo-test
+  "Coverage for `dag/add-repo-anomaly` and its deprecated throwing
+   sibling `dag/add-repo`. Two anomaly classes:
+   - `:not-found` — DAG missing
+   - `:conflict`  — repo with same name already exists"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.repo-dag.interface :as dag]))
+
+(def ^:dynamic *manager* nil)
+
+(defn manager-fixture [f]
+  (binding [*manager* (dag/create-manager)]
+    (f)))
+
+(use-fixtures :each manager-fixture)
+
+(def repo-config
+  {:repo/url "https://github.com/acme/tf"
+   :repo/name "tf"
+   :repo/type :terraform-module})
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest add-repo-anomaly-returns-updated-dag
+  (testing "successful add returns the updated DAG, not an anomaly"
+    (let [d (dag/create-dag *manager* "test-dag")
+          result (dag/add-repo-anomaly *manager* (:dag/id d) repo-config)]
+      (is (not (anomaly/anomaly? result)))
+      (is (= 1 (count (:dag/repos result))))
+      (is (= "tf" (-> result :dag/repos first :repo/name))))))
+
+;------------------------------------------------------------------------------ Failure path: DAG not found
+
+(deftest add-repo-anomaly-not-found-when-dag-missing
+  (testing "missing DAG yields :not-found anomaly"
+    (let [missing-id (random-uuid)
+          result (dag/add-repo-anomaly *manager* missing-id repo-config)]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
+
+;------------------------------------------------------------------------------ Failure path: duplicate
+
+(deftest add-repo-anomaly-conflict-on-duplicate
+  (testing "duplicate repo name yields :conflict anomaly"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo-anomaly *manager* (:dag/id d) repo-config)
+          result (dag/add-repo-anomaly *manager* (:dag/id d) repo-config)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (= "tf" (get-in result [:anomaly/data :repo-name]))))))
+
+;------------------------------------------------------------------------------ Throwing-variant compat
+
+(deftest add-repo-still-throws-on-missing-dag
+  (testing "deprecated throwing variant still throws ex-info on missing DAG"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
+          (dag/add-repo *manager* (random-uuid) repo-config)))))
+
+(deftest add-repo-still-throws-on-duplicate
+  (testing "deprecated throwing variant still throws on duplicate repo"
+    (let [d (dag/create-dag *manager* "test-dag")]
+      (dag/add-repo *manager* (:dag/id d) repo-config)
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Repo already exists"
+            (dag/add-repo *manager* (:dag/id d) repo-config))))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/queries_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/queries_test.clj
@@ -1,0 +1,146 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.repo-dag.anomaly.queries-test
+  "Coverage for the read-only anomaly-returning protocol methods:
+   compute-topo-order, affected-repos, upstream-repos, merge-order,
+   and validate-dag. All five share the same failure path
+   (`:not-found` when the DAG is missing) and pass through their
+   normal return shape on success."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.repo-dag.interface :as dag]))
+
+(def ^:dynamic *manager* nil)
+(def ^:dynamic *dag-id* nil)
+
+(defn manager-and-dag-fixture [f]
+  (binding [*manager* (dag/create-manager)]
+    (let [d (dag/create-dag *manager* "test-dag")]
+      (dag/add-repo-anomaly *manager* (:dag/id d)
+                            {:repo/url "https://github.com/acme/a"
+                             :repo/name "repo-a"
+                             :repo/type :library})
+      (dag/add-repo-anomaly *manager* (:dag/id d)
+                            {:repo/url "https://github.com/acme/b"
+                             :repo/name "repo-b"
+                             :repo/type :application})
+      (dag/add-edge-anomaly *manager* (:dag/id d) "repo-a" "repo-b"
+                            :library-before-consumer :sequential)
+      (binding [*dag-id* (:dag/id d)]
+        (f)))))
+
+(use-fixtures :each manager-and-dag-fixture)
+
+;------------------------------------------------------------------------------ compute-topo-order
+
+(deftest compute-topo-order-anomaly-happy-path
+  (testing "successful topo-order returns the result map, not an anomaly"
+    (let [result (dag/compute-topo-order-anomaly *manager* *dag-id*)]
+      (is (not (anomaly/anomaly? result)))
+      (is (true? (:success result)))
+      (is (= ["repo-a" "repo-b"] (:order result))))))
+
+(deftest compute-topo-order-anomaly-not-found
+  (testing "missing DAG yields :not-found anomaly"
+    (let [result (dag/compute-topo-order-anomaly *manager* (random-uuid))]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
+
+(deftest compute-topo-order-still-throws
+  (testing "deprecated throwing variant still throws on missing DAG"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
+          (dag/compute-topo-order *manager* (random-uuid))))))
+
+;------------------------------------------------------------------------------ affected-repos
+
+(deftest affected-repos-anomaly-happy-path
+  (testing "successful query returns downstream set, not an anomaly"
+    (let [result (dag/affected-repos-anomaly *manager* *dag-id* "repo-a")]
+      (is (not (anomaly/anomaly? result)))
+      (is (= #{"repo-b"} result)))))
+
+(deftest affected-repos-anomaly-not-found
+  (testing "missing DAG yields :not-found anomaly"
+    (let [result (dag/affected-repos-anomaly *manager* (random-uuid) "repo-a")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
+
+(deftest affected-repos-still-throws
+  (testing "deprecated throwing variant still throws on missing DAG"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
+          (dag/affected-repos *manager* (random-uuid) "repo-a")))))
+
+;------------------------------------------------------------------------------ upstream-repos
+
+(deftest upstream-repos-anomaly-happy-path
+  (testing "successful query returns upstream set, not an anomaly"
+    (let [result (dag/upstream-repos-anomaly *manager* *dag-id* "repo-b")]
+      (is (not (anomaly/anomaly? result)))
+      (is (= #{"repo-a"} result)))))
+
+(deftest upstream-repos-anomaly-not-found
+  (testing "missing DAG yields :not-found anomaly"
+    (let [result (dag/upstream-repos-anomaly *manager* (random-uuid) "repo-b")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
+
+(deftest upstream-repos-still-throws
+  (testing "deprecated throwing variant still throws on missing DAG"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
+          (dag/upstream-repos *manager* (random-uuid) "repo-b")))))
+
+;------------------------------------------------------------------------------ merge-order
+
+(deftest merge-order-anomaly-happy-path
+  (testing "successful query returns merge-order map, not an anomaly"
+    (let [result (dag/merge-order-anomaly *manager* *dag-id* #{"repo-a" "repo-b"})]
+      (is (not (anomaly/anomaly? result)))
+      (is (true? (:success result)))
+      (is (= ["repo-a" "repo-b"] (:order result))))))
+
+(deftest merge-order-anomaly-not-found
+  (testing "missing DAG yields :not-found anomaly"
+    (let [result (dag/merge-order-anomaly *manager* (random-uuid) #{"repo-a"})]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
+
+(deftest merge-order-still-throws
+  (testing "deprecated throwing variant still throws on missing DAG"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
+          (dag/merge-order *manager* (random-uuid) #{"repo-a"})))))
+
+;------------------------------------------------------------------------------ validate-dag
+
+(deftest validate-dag-anomaly-happy-path
+  (testing "successful validate returns the result map, not an anomaly"
+    (let [result (dag/validate-dag-anomaly *manager* *dag-id*)]
+      (is (not (anomaly/anomaly? result)))
+      (is (true? (:valid? result)))
+      (is (= [] (:errors result))))))
+
+(deftest validate-dag-anomaly-not-found
+  (testing "missing DAG yields :not-found anomaly"
+    (let [result (dag/validate-dag-anomaly *manager* (random-uuid))]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
+
+(deftest validate-dag-still-throws
+  (testing "deprecated throwing variant still throws on missing DAG"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
+          (dag/validate-dag *manager* (random-uuid))))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_edge_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_edge_test.clj
@@ -1,0 +1,68 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.repo-dag.anomaly.remove-edge-test
+  "Coverage for `dag/remove-edge-anomaly` and its deprecated throwing
+   sibling `dag/remove-edge`. Only failure mode is `:not-found` — DAG missing."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.repo-dag.interface :as dag]))
+
+(def ^:dynamic *manager* nil)
+
+(defn manager-fixture [f]
+  (binding [*manager* (dag/create-manager)]
+    (f)))
+
+(use-fixtures :each manager-fixture)
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest remove-edge-anomaly-returns-updated-dag
+  (testing "successful remove returns the updated DAG, not an anomaly"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo-anomaly *manager* (:dag/id d)
+                                  {:repo/url "https://github.com/acme/a"
+                                   :repo/name "repo-a"
+                                   :repo/type :library})
+          _ (dag/add-repo-anomaly *manager* (:dag/id d)
+                                  {:repo/url "https://github.com/acme/b"
+                                   :repo/name "repo-b"
+                                   :repo/type :application})
+          _ (dag/add-edge-anomaly *manager* (:dag/id d) "repo-a" "repo-b"
+                                  :library-before-consumer :sequential)
+          result (dag/remove-edge-anomaly *manager* (:dag/id d) "repo-a" "repo-b")]
+      (is (not (anomaly/anomaly? result)))
+      (is (= 0 (count (:dag/edges result)))))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest remove-edge-anomaly-not-found-when-dag-missing
+  (testing "missing DAG yields :not-found anomaly"
+    (let [missing-id (random-uuid)
+          result (dag/remove-edge-anomaly *manager* missing-id "repo-a" "repo-b")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
+
+;------------------------------------------------------------------------------ Throwing-variant compat
+
+(deftest remove-edge-still-throws-on-missing-dag
+  (testing "deprecated throwing variant still throws ex-info on missing DAG"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
+          (dag/remove-edge *manager* (random-uuid) "repo-a" "repo-b")))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_repo_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_repo_test.clj
@@ -1,0 +1,64 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.repo-dag.anomaly.remove-repo-test
+  "Coverage for `dag/remove-repo-anomaly` and its deprecated throwing
+   sibling `dag/remove-repo`. Only failure mode is `:not-found` — DAG missing."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.repo-dag.interface :as dag]))
+
+(def ^:dynamic *manager* nil)
+
+(defn manager-fixture [f]
+  (binding [*manager* (dag/create-manager)]
+    (f)))
+
+(use-fixtures :each manager-fixture)
+
+(def repo-config
+  {:repo/url "https://github.com/acme/tf"
+   :repo/name "tf"
+   :repo/type :terraform-module})
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest remove-repo-anomaly-returns-updated-dag
+  (testing "successful remove returns the updated DAG, not an anomaly"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo-anomaly *manager* (:dag/id d) repo-config)
+          result (dag/remove-repo-anomaly *manager* (:dag/id d) "tf")]
+      (is (not (anomaly/anomaly? result)))
+      (is (= 0 (count (:dag/repos result)))))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest remove-repo-anomaly-not-found-when-dag-missing
+  (testing "missing DAG yields :not-found anomaly"
+    (let [missing-id (random-uuid)
+          result (dag/remove-repo-anomaly *manager* missing-id "tf")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
+
+;------------------------------------------------------------------------------ Throwing-variant compat
+
+(deftest remove-repo-still-throws-on-missing-dag
+  (testing "deprecated throwing variant still throws ex-info on missing DAG"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
+          (dag/remove-repo *manager* (random-uuid) "tf")))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/validate_schema_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/validate_schema_test.clj
@@ -1,0 +1,88 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.repo-dag.anomaly.validate-schema-test
+  "Coverage for `core/validate-schema-anomaly` and its deprecated
+   throwing sibling `core/validate-schema`. Schema rejection is an
+   :invalid-input anomaly; valid values pass through unchanged."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.repo-dag.core :as core]
+            [ai.miniforge.repo-dag.interface :as dag]))
+
+(def valid-repo
+  {:repo/url "https://github.com/acme/tf"
+   :repo/name "tf"
+   :repo/type :terraform-module
+   :repo/layer :foundations
+   :repo/default-branch "main"})
+
+(def invalid-repo
+  {:repo/name "missing-required-fields"})
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest validate-schema-anomaly-returns-value-on-success
+  (testing "valid value passes through unchanged"
+    (is (= valid-repo (core/validate-schema-anomaly dag/RepoNode valid-repo))))
+  (testing "result is identical to the input (no copy)"
+    (is (identical? valid-repo
+                    (core/validate-schema-anomaly dag/RepoNode valid-repo)))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest validate-schema-anomaly-returns-anomaly-on-failure
+  (testing "invalid value yields a canonical anomaly"
+    (let [result (core/validate-schema-anomaly dag/RepoNode invalid-repo)]
+      (is (anomaly/anomaly? result)))))
+
+(deftest validate-schema-anomaly-uses-invalid-input-type
+  (testing "schema validation failure is :invalid-input"
+    (let [result (core/validate-schema-anomaly dag/RepoNode invalid-repo)]
+      (is (= :invalid-input (:anomaly/type result))))))
+
+(deftest validate-schema-anomaly-data-carries-context
+  (testing "anomaly carries schema, value, and humanized errors"
+    (let [result (core/validate-schema-anomaly dag/RepoNode invalid-repo)
+          data   (:anomaly/data result)]
+      (is (= dag/RepoNode (:schema data)))
+      (is (= invalid-repo (:value data)))
+      (is (some? (:errors data)))
+      (is (map? (:errors data))))))
+
+;------------------------------------------------------------------------------ Throwing-variant compat
+
+(deftest validate-schema-still-returns-on-success
+  (testing "deprecated throwing variant returns the value unchanged"
+    (is (= valid-repo (core/validate-schema dag/RepoNode valid-repo)))))
+
+(deftest validate-schema-still-throws-ex-info
+  (testing "deprecated throwing variant still throws on bad input"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Schema validation failed"
+          (core/validate-schema dag/RepoNode invalid-repo)))))
+
+(deftest validate-schema-thrown-ex-data-carries-errors
+  (testing "ex-data preserves :schema, :value, and :errors for legacy callers"
+    (try
+      (core/validate-schema dag/RepoNode invalid-repo)
+      (is false "should have thrown")
+      (catch clojure.lang.ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= dag/RepoNode (:schema data)))
+          (is (= invalid-repo (:value data)))
+          (is (map? (:errors data))))))))

--- a/docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md
+++ b/docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md
@@ -2,15 +2,22 @@
 
 ## Overview
 
-Migrates every `:cleanup-needed` throw site in `repo-dag` (12 of 12 per the merged inventory) to anomaly-returning variants alongside the existing throwers. The throwing public API is preserved for backward compatibility — every existing caller sees identical `ex-info` shapes — but new callers can opt into the data-first variants.
+Migrates every `:cleanup-needed` throw site in `repo-dag` (12 of 12 per the merged inventory) to anomaly-returning
+variants alongside the existing throwers. The throwing public API is preserved for backward compatibility — every
+existing caller sees identical `ex-info` shapes — but new callers can opt into the data-first variants.
 
-`repo-dag` was the highest-density single-file cleanup target per `work/exception-cleanup-inventory.md` (recommended ordering item #1 after the foundation tier).
+`repo-dag` was the highest-density single-file cleanup target per `work/exception-cleanup-inventory.md` (recommended
+ordering item #1 after the foundation tier).
 
 ## Motivation
 
-The merged foundation cleanup (PR #704) extracted `schema/validate-anomaly` and `dag-primitives/unwrap-anomaly` as the canonical anomaly-returning patterns. The merged connector callsite migration (PR #734) demonstrated the per-component cleanup shape. This PR continues the workstream into the highest-leverage non-connector component.
+The merged foundation cleanup (PR #704) extracted `schema/validate-anomaly` and `dag-primitives/unwrap-anomaly` as the
+canonical anomaly-returning patterns. The merged connector callsite migration (PR #734) demonstrated the per-component
+cleanup shape. This PR continues the workstream into the highest-leverage non-connector component.
 
-Per the inventory, all 12 sites in `repo-dag` cluster around DAG existence checks, edge-relation lookups, and structural-invariant guards — mechanical to convert with high downstream payoff (every caller of repo-dag's read-shaped methods can now compose with response-chains and inference-evidence cleanly).
+Per the inventory, all 12 sites in `repo-dag` cluster around DAG existence checks, edge-relation lookups, and
+structural-invariant guards — mechanical to convert with high downstream payoff (every caller of repo-dag's read-shaped
+methods can now compose with response-chains and inference-evidence cleanly).
 
 ## Base Branch
 
@@ -23,7 +30,8 @@ Per the inventory, all 12 sites in `repo-dag` cluster around DAG existence check
 
 ## Layer
 
-Refactor / per-component cleanup tier. `repo-dag` only — no other component touched. Per-callsite migration of repo-dag consumers (web-dashboard, bases/cli/monitoring, fleet-onboarding integration tests) is a separate workstream.
+Refactor / per-component cleanup tier. `repo-dag` only — no other component touched. Per-callsite migration of repo-dag
+consumers (web-dashboard, bases/cli/monitoring, fleet-onboarding integration tests) is a separate workstream.
 
 ## What This Adds / Changes
 
@@ -33,17 +41,22 @@ Refactor / per-component cleanup tier. `repo-dag` only — no other component to
 
 `components/repo-dag/src/.../core.clj`:
 
-- Added 5 anomaly-returning protocol methods + `validate-schema-anomaly` + private `*-impl` helpers
-- Throwing methods now delegate to the anomaly variants and translate any returned anomaly back into the original `ex-info` shape for backward-compat callers
+- Added 9 anomaly-returning protocol methods + `validate-schema-anomaly` + `make-repo-node-anomaly` +
+  `make-repo-edge-anomaly` + private `*-impl` and `build-*` helpers
+- Throwing methods now delegate to the anomaly variants and translate any returned anomaly back into the original
+  `ex-info` shape for backward-compat callers
 
 `components/repo-dag/src/.../interface.clj`:
 
 - Exported 9 new anomaly-returning fns alongside the existing throwers
-- The 8 deprecated throwers carry `{:deprecated "exceptions-as-data — prefer *-anomaly"}` markers and updated docstrings pointing at the new variants
+- The 9 deprecated throwers carry `{:deprecated "exceptions-as-data — prefer *-anomaly"}` markers and updated docstrings
+  pointing at the new variants
 
 `components/repo-dag/test/.../anomaly/`:
 
-- Six new decomposed test files: `validate_schema_test.clj`, `add_repo_test.clj`, `remove_repo_test.clj`, `add_edge_test.clj`, `remove_edge_test.clj`, `queries_test.clj`. Each file pins happy-path / failure-path / throwing-variant compatibility for its scope.
+- Six new decomposed test files: `validate_schema_test.clj`, `add_repo_test.clj`, `remove_repo_test.clj`,
+  `add_edge_test.clj`, `remove_edge_test.clj`, `queries_test.clj`. Each file pins happy-path / failure-path /
+  throwing-variant compatibility for its scope.
 
 ## Per-site classification
 
@@ -80,7 +93,13 @@ validate-schema  ; now delegates to the anomaly variant
 
 ## Inventory delta
 
-**12 of 12 `:cleanup-needed` repo-dag sites retired.** Every throw in `core.clj` after this PR lives only inside the deprecated thrower wrappers, where it translates an anomaly back into `ex-info`. No new throw sites in the anomaly-returning code paths.
+**12 of 12 `:cleanup-needed` repo-dag sites retired.** Every throw in `core.clj` after this PR lives only inside the
+  deprecated thrower wrappers (`validate-schema`, `make-repo-node`, `make-repo-edge`, and the protocol-layer throwing
+  methods that delegate to their anomaly siblings and re-wrap). The anomaly-returning code path through
+  `add-repo-anomaly` / `add-edge-anomaly` no longer reaches a throw — `make-repo-node-anomaly` /
+  `make-repo-edge-anomaly` short-circuit on schema validation failure with `:invalid-input` instead of escaping as
+  `ExceptionInfo` (the original draft of this PR missed that — `add-*-anomaly` called the throwing constructors and
+  silently violated the contract; tests in `add_repo_test` / `add_edge_test` pin the schema-invalid path now).
 
 ## Strata Affected
 
@@ -94,7 +113,8 @@ validate-schema  ; now delegates to the anomaly variant
   - `fmt:md` — clean
   - `test` — **4848 tests / 22386 assertions / 0 failures / 0 errors**
   - `test:graalvm` — 6 tests / 487 assertions / 0 failures
-- Component-scoped: 65 tests / 188 assertions / 0 failures across the existing 5 test files + the 6 new anomaly test files
+- Component-scoped: 65 tests / 188 assertions / 0 failures across the existing 5 test files + the 6 new anomaly test
+  files
 
 ## Deployment Plan
 
@@ -102,17 +122,28 @@ No migration required. Backward-compatible.
 
 - Existing throwing-API callers see no change. Same signatures, same `ex-info` shape on failure.
 - New code opts into the anomaly-returning variants (`*-anomaly` suffix).
-- Per-callsite migration of `repo-dag` consumers (web-dashboard / bases-cli-monitoring / fleet-onboarding integration tests) is queued as follow-on work.
+- Per-callsite migration of `repo-dag` consumers (web-dashboard / bases-cli-monitoring / fleet-onboarding integration
+  tests) is queued as follow-on work.
 
 ## Notes / Surprises
 
-- **`compute-topo-order` was previously asymmetric.** It already returned an anomaly-shaped `{:success bool ...}` for the cycle case but threw for the missing-DAG case. The new `compute-topo-order-anomaly` carries the same success/failure map on hit and a canonical `:not-found` anomaly on miss, ending the two-error-system mix on this method.
-- **Commit-budget gate friction.** The merged commit-budget gate (PR #752) treated this many-site refactor as over-budget by default (1099 lines, mostly tests + delegated wrappers). Override path documented and rationale recorded in the commit body — the protocol body must change atomically because the throwing methods delegate to the anomaly methods, so splitting would leave intermediate commits uncompilable. Worth flagging as a likely repeat friction point for the rest of the exceptions-cleanup workstream; an alternate path is to authorize larger budgets explicitly for `:exceptions-as-data` cleanup PRs.
-- **External callers are sparse.** `web-dashboard/state/trains.clj` (via `safe-call`), `bases/cli/.../monitoring.clj` (lazy-required), and `projects/miniforge/test/.../fleet_onboarding_integration_test.clj` — all exercise read-shaped paths and are unbroken by the deprecation. Per-callsite migration is queued as follow-on.
+- **`compute-topo-order` was previously asymmetric.** It already returned an anomaly-shaped `{:success bool ...}` for
+  the cycle case but threw for the missing-DAG case. The new `compute-topo-order-anomaly` carries the same
+  success/failure map on hit and a canonical `:not-found` anomaly on miss, ending the two-error-system mix on this method.
+- **Commit-budget gate friction.** The merged commit-budget gate (PR #752) treated this many-site refactor as
+  over-budget by default (1099 lines, mostly tests + delegated wrappers). Override path documented and rationale
+  recorded in the commit body — the protocol body must change atomically because the throwing methods delegate to the
+  anomaly methods, so splitting would leave intermediate commits uncompilable. Worth flagging as a likely repeat
+  friction point for the rest of the exceptions-cleanup workstream; an alternate path is to authorize larger budgets
+  explicitly for `:exceptions-as-data` cleanup PRs.
+- **External callers are sparse.** `web-dashboard/state/trains.clj` (via `safe-call`), `bases/cli/.../monitoring.clj`
+  (lazy-required), and `projects/miniforge/test/.../fleet_onboarding_integration_test.clj` — all exercise read-shaped
+  paths and are unbroken by the deprecation. Per-callsite migration is queued as follow-on.
 
 ## Related Issues/PRs
 
-- Built on PR miniforge#704 (foundation cleanup — `schema/validate-anomaly`, `dag-primitives/unwrap-anomaly`, `connector/require-handle`)
+- Built on PR miniforge#704 (foundation cleanup — `schema/validate-anomaly`, `dag-primitives/unwrap-anomaly`,
+  `connector/require-handle`)
 - Built on PR miniforge#734 (per-connector callsite migration)
 - Tracked in PR miniforge#691 (`work/exception-cleanup-inventory.md`)
 - Sibling PR: thesium-workflows#34 (submodule bump pulling in boundary)

--- a/docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md
+++ b/docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md
@@ -1,0 +1,129 @@
+# refactor: exceptions-as-data cleanup of repo-dag
+
+## Overview
+
+Migrates every `:cleanup-needed` throw site in `repo-dag` (12 of 12 per the merged inventory) to anomaly-returning variants alongside the existing throwers. The throwing public API is preserved for backward compatibility — every existing caller sees identical `ex-info` shapes — but new callers can opt into the data-first variants.
+
+`repo-dag` was the highest-density single-file cleanup target per `work/exception-cleanup-inventory.md` (recommended ordering item #1 after the foundation tier).
+
+## Motivation
+
+The merged foundation cleanup (PR #704) extracted `schema/validate-anomaly` and `dag-primitives/unwrap-anomaly` as the canonical anomaly-returning patterns. The merged connector callsite migration (PR #734) demonstrated the per-component cleanup shape. This PR continues the workstream into the highest-leverage non-connector component.
+
+Per the inventory, all 12 sites in `repo-dag` cluster around DAG existence checks, edge-relation lookups, and structural-invariant guards — mechanical to convert with high downstream payoff (every caller of repo-dag's read-shaped methods can now compose with response-chains and inference-evidence cleanly).
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary and constructor
+- `005 exceptions-as-data` standards rule (merged) — defines the discipline this PR applies
+
+## Layer
+
+Refactor / per-component cleanup tier. `repo-dag` only — no other component touched. Per-callsite migration of repo-dag consumers (web-dashboard, bases/cli/monitoring, fleet-onboarding integration tests) is a separate workstream.
+
+## What This Adds / Changes
+
+`components/repo-dag/deps.edn`:
+
+- Added `:local/root` dep on `ai.miniforge/anomaly`.
+
+`components/repo-dag/src/.../core.clj`:
+
+- Added 5 anomaly-returning protocol methods + `validate-schema-anomaly` + private `*-impl` helpers
+- Throwing methods now delegate to the anomaly variants and translate any returned anomaly back into the original `ex-info` shape for backward-compat callers
+
+`components/repo-dag/src/.../interface.clj`:
+
+- Exported 9 new anomaly-returning fns alongside the existing throwers
+- The 8 deprecated throwers carry `{:deprecated "exceptions-as-data — prefer *-anomaly"}` markers and updated docstrings pointing at the new variants
+
+`components/repo-dag/test/.../anomaly/`:
+
+- Six new decomposed test files: `validate_schema_test.clj`, `add_repo_test.clj`, `remove_repo_test.clj`, `add_edge_test.clj`, `remove_edge_test.clj`, `queries_test.clj`. Each file pins happy-path / failure-path / throwing-variant compatibility for its scope.
+
+## Per-site classification
+
+| Original throw site | `:anomaly/type` | Why |
+|---|---|---|
+| Schema validation failures | `:invalid-input` | Input shape rejected by malli |
+| "Repo already exists" / "Edge already exists" | `:conflict` | Operation conflicts with existing state |
+| "Adding edge would create cycle" | `:conflict` | Operation conflicts with structural invariant |
+| "DAG not found" / "From repo not found" / "To repo not found" | `:not-found` | Referenced entity missing |
+| "Self-loop not allowed" | `:invalid-input` | Caller-supplied data shape rejected |
+
+## New API surface
+
+Added to `ai.miniforge.repo-dag.interface`:
+
+```clojure
+add-repo-anomaly
+remove-repo-anomaly
+add-edge-anomaly
+remove-edge-anomaly
+compute-topo-order-anomaly
+affected-repos-anomaly
+upstream-repos-anomaly
+merge-order-anomaly
+validate-dag-anomaly
+```
+
+Added to `ai.miniforge.repo-dag.core` (internal; accessible to tests via `#'ns/private`):
+
+```clojure
+validate-schema-anomaly
+validate-schema  ; now delegates to the anomaly variant
+```
+
+## Inventory delta
+
+**12 of 12 `:cleanup-needed` repo-dag sites retired.** Every throw in `core.clj` after this PR lives only inside the deprecated thrower wrappers, where it translates an anomaly back into `ex-info`. No new throw sites in the anomaly-returning code paths.
+
+## Strata Affected
+
+- `ai.miniforge.repo-dag.core` — added anomaly methods + private impl helpers; throwing methods now delegate
+- `ai.miniforge.repo-dag.interface` — anomaly-method exports added; deprecation markers on throwers
+
+## Testing Plan
+
+- **`bb pre-commit` green:**
+  - `lint:clj` — clean
+  - `fmt:md` — clean
+  - `test` — **4848 tests / 22386 assertions / 0 failures / 0 errors**
+  - `test:graalvm` — 6 tests / 487 assertions / 0 failures
+- Component-scoped: 65 tests / 188 assertions / 0 failures across the existing 5 test files + the 6 new anomaly test files
+
+## Deployment Plan
+
+No migration required. Backward-compatible.
+
+- Existing throwing-API callers see no change. Same signatures, same `ex-info` shape on failure.
+- New code opts into the anomaly-returning variants (`*-anomaly` suffix).
+- Per-callsite migration of `repo-dag` consumers (web-dashboard / bases-cli-monitoring / fleet-onboarding integration tests) is queued as follow-on work.
+
+## Notes / Surprises
+
+- **`compute-topo-order` was previously asymmetric.** It already returned an anomaly-shaped `{:success bool ...}` for the cycle case but threw for the missing-DAG case. The new `compute-topo-order-anomaly` carries the same success/failure map on hit and a canonical `:not-found` anomaly on miss, ending the two-error-system mix on this method.
+- **Commit-budget gate friction.** The merged commit-budget gate (PR #752) treated this many-site refactor as over-budget by default (1099 lines, mostly tests + delegated wrappers). Override path documented and rationale recorded in the commit body — the protocol body must change atomically because the throwing methods delegate to the anomaly methods, so splitting would leave intermediate commits uncompilable. Worth flagging as a likely repeat friction point for the rest of the exceptions-cleanup workstream; an alternate path is to authorize larger budgets explicitly for `:exceptions-as-data` cleanup PRs.
+- **External callers are sparse.** `web-dashboard/state/trains.clj` (via `safe-call`), `bases/cli/.../monitoring.clj` (lazy-required), and `projects/miniforge/test/.../fleet_onboarding_integration_test.clj` — all exercise read-shaped paths and are unbroken by the deprecation. Per-callsite migration is queued as follow-on.
+
+## Related Issues/PRs
+
+- Built on PR miniforge#704 (foundation cleanup — `schema/validate-anomaly`, `dag-primitives/unwrap-anomaly`, `connector/require-handle`)
+- Built on PR miniforge#734 (per-connector callsite migration)
+- Tracked in PR miniforge#691 (`work/exception-cleanup-inventory.md`)
+- Sibling PR: thesium-workflows#34 (submodule bump pulling in boundary)
+
+## Checklist
+
+- [x] All 12 `:cleanup-needed` repo-dag sites retired
+- [x] Existing throwing API preserved (delegated, behavior identical)
+- [x] Anomaly-returning variants for every public protocol method
+- [x] Deprecation markers on throwers + docstring pointers
+- [x] Decomposed test files (six new) — happy / failure / compat per scope
+- [x] No new throws in anomaly-returning code paths
+- [x] `bb pre-commit` green
+- [x] Apache 2 license headers preserved


### PR DESCRIPTION
# refactor: exceptions-as-data cleanup of repo-dag

## Overview

Migrates every `:cleanup-needed` throw site in `repo-dag` (12 of 12 per the merged inventory) to anomaly-returning variants alongside the existing throwers. The throwing public API is preserved for backward compatibility — every existing caller sees identical `ex-info` shapes — but new callers can opt into the data-first variants.

`repo-dag` was the highest-density single-file cleanup target per `work/exception-cleanup-inventory.md` (recommended ordering item #1 after the foundation tier).

## Motivation

The merged foundation cleanup (PR #704) extracted `schema/validate-anomaly` and `dag-primitives/unwrap-anomaly` as the canonical anomaly-returning patterns. The merged connector callsite migration (PR #734) demonstrated the per-component cleanup shape. This PR continues the workstream into the highest-leverage non-connector component.

Per the inventory, all 12 sites in `repo-dag` cluster around DAG existence checks, edge-relation lookups, and structural-invariant guards — mechanical to convert with high downstream payoff (every caller of repo-dag's read-shaped methods can now compose with response-chains and inference-evidence cleanly).

## Base Branch

`main`

## Depends On

- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary and constructor
- `005 exceptions-as-data` standards rule (merged) — defines the discipline this PR applies

## Layer

Refactor / per-component cleanup tier. `repo-dag` only — no other component touched. Per-callsite migration of repo-dag consumers (web-dashboard, bases/cli/monitoring, fleet-onboarding integration tests) is a separate workstream.

## What This Adds / Changes

`components/repo-dag/deps.edn`:

- Added `:local/root` dep on `ai.miniforge/anomaly`.

`components/repo-dag/src/.../core.clj`:

- Added 5 anomaly-returning protocol methods + `validate-schema-anomaly` + private `*-impl` helpers
- Throwing methods now delegate to the anomaly variants and translate any returned anomaly back into the original `ex-info` shape for backward-compat callers

`components/repo-dag/src/.../interface.clj`:

- Exported 9 new anomaly-returning fns alongside the existing throwers
- The 8 deprecated throwers carry `{:deprecated "exceptions-as-data — prefer *-anomaly"}` markers and updated docstrings pointing at the new variants

`components/repo-dag/test/.../anomaly/`:

- Six new decomposed test files: `validate_schema_test.clj`, `add_repo_test.clj`, `remove_repo_test.clj`, `add_edge_test.clj`, `remove_edge_test.clj`, `queries_test.clj`. Each file pins happy-path / failure-path / throwing-variant compatibility for its scope.

## Per-site classification

| Original throw site | `:anomaly/type` | Why |
|---|---|---|
| Schema validation failures | `:invalid-input` | Input shape rejected by malli |
| "Repo already exists" / "Edge already exists" | `:conflict` | Operation conflicts with existing state |
| "Adding edge would create cycle" | `:conflict` | Operation conflicts with structural invariant |
| "DAG not found" / "From repo not found" / "To repo not found" | `:not-found` | Referenced entity missing |
| "Self-loop not allowed" | `:invalid-input` | Caller-supplied data shape rejected |

## New API surface

Added to `ai.miniforge.repo-dag.interface`:

```clojure
add-repo-anomaly
remove-repo-anomaly
add-edge-anomaly
remove-edge-anomaly
compute-topo-order-anomaly
affected-repos-anomaly
upstream-repos-anomaly
merge-order-anomaly
validate-dag-anomaly
```

Added to `ai.miniforge.repo-dag.core` (internal; accessible to tests via `#'ns/private`):

```clojure
validate-schema-anomaly
validate-schema  ; now delegates to the anomaly variant
```

## Inventory delta

**12 of 12 `:cleanup-needed` repo-dag sites retired.** Every throw in `core.clj` after this PR lives only inside the deprecated thrower wrappers, where it translates an anomaly back into `ex-info`. No new throw sites in the anomaly-returning code paths.

## Strata Affected

- `ai.miniforge.repo-dag.core` — added anomaly methods + private impl helpers; throwing methods now delegate
- `ai.miniforge.repo-dag.interface` — anomaly-method exports added; deprecation markers on throwers

## Testing Plan

- **`bb pre-commit` green:**
  - `lint:clj` — clean
  - `fmt:md` — clean
  - `test` — **4848 tests / 22386 assertions / 0 failures / 0 errors**
  - `test:graalvm` — 6 tests / 487 assertions / 0 failures
- Component-scoped: 65 tests / 188 assertions / 0 failures across the existing 5 test files + the 6 new anomaly test files

## Deployment Plan

No migration required. Backward-compatible.

- Existing throwing-API callers see no change. Same signatures, same `ex-info` shape on failure.
- New code opts into the anomaly-returning variants (`*-anomaly` suffix).
- Per-callsite migration of `repo-dag` consumers (web-dashboard / bases-cli-monitoring / fleet-onboarding integration tests) is queued as follow-on work.

## Notes / Surprises

- **`compute-topo-order` was previously asymmetric.** It already returned an anomaly-shaped `{:success bool ...}` for the cycle case but threw for the missing-DAG case. The new `compute-topo-order-anomaly` carries the same success/failure map on hit and a canonical `:not-found` anomaly on miss, ending the two-error-system mix on this method.
- **Commit-budget gate friction.** The merged commit-budget gate (PR #752) treated this many-site refactor as over-budget by default (1099 lines, mostly tests + delegated wrappers). Override path documented and rationale recorded in the commit body — the protocol body must change atomically because the throwing methods delegate to the anomaly methods, so splitting would leave intermediate commits uncompilable. Worth flagging as a likely repeat friction point for the rest of the exceptions-cleanup workstream; an alternate path is to authorize larger budgets explicitly for `:exceptions-as-data` cleanup PRs.
- **External callers are sparse.** `web-dashboard/state/trains.clj` (via `safe-call`), `bases/cli/.../monitoring.clj` (lazy-required), and `projects/miniforge/test/.../fleet_onboarding_integration_test.clj` — all exercise read-shaped paths and are unbroken by the deprecation. Per-callsite migration is queued as follow-on.

## Related Issues/PRs

- Built on PR miniforge#704 (foundation cleanup — `schema/validate-anomaly`, `dag-primitives/unwrap-anomaly`, `connector/require-handle`)
- Built on PR miniforge#734 (per-connector callsite migration)
- Tracked in PR miniforge#691 (`work/exception-cleanup-inventory.md`)
- Sibling PR: thesium-workflows#34 (submodule bump pulling in boundary)

## Checklist

- [x] All 12 `:cleanup-needed` repo-dag sites retired
- [x] Existing throwing API preserved (delegated, behavior identical)
- [x] Anomaly-returning variants for every public protocol method
- [x] Deprecation markers on throwers + docstring pointers
- [x] Decomposed test files (six new) — happy / failure / compat per scope
- [x] No new throws in anomaly-returning code paths
- [x] `bb pre-commit` green
- [x] Apache 2 license headers preserved
