### PR TITLE
spec: I-DAG-MULTI-PARENT-MERGE (v2 of per-task base chaining)

### DIFF
--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -276,6 +276,8 @@ These documents provide guidance, examples, and context but do NOT define contra
 - [informative/I-ANOMALY-SYSTEM.md](informative/I-ANOMALY-SYSTEM.md) - Canonical error representation and boundary
   translators
 - [informative/I-DAG-ORCHESTRATION.md](informative/I-DAG-ORCHESTRATION.md) - DAG executor with PR lifecycle
+- [informative/I-DAG-MULTI-PARENT-MERGE.md](informative/I-DAG-MULTI-PARENT-MERGE.md) - v2 of per-task base
+  chaining: deterministic octopus merge of multi-parent task bases
 - [informative/I-TASK-EXECUTOR.md](informative/I-TASK-EXECUTOR.md) - DAG-to-PR lifecycle integration
 
 ### Operational Workflows (N10 Extensions)

--- a/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
+++ b/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
@@ -6,12 +6,37 @@
 
 # I-DAG-MULTI-PARENT-MERGE — Multi-Parent DAG Merge Strategy (v2 of Per-Task Base Chaining)
 
-**Status:** Informative — iteration round 2 complete; ready for implementation.
+**Status:** Informative — iteration round 3 complete; ready for implementation.
 **Date:** 2026-05-03
-**Version:** 0.3.0
+**Version:** 0.4.0
 
 **Changelog:**
 
+- **0.4.0** — Iteration round 3: settled the five §11 open questions
+  from v0.3. Smaller revision than round-2; mostly captures decisions
+  rather than reshaping the design.
+  - **Curator is an extension** of the existing curator multimethod
+    (§7.3), not a new component. If a future need forces a split, it
+    will require refactoring the existing polymorphism — accepted
+    cost; don't pre-emptively split.
+  - **Policy trumps default agent prompts** (§6.1.3 added). Build
+    descriptive defaults, but the resolution agent's instructions
+    are policy-overridable so governed deployments can substitute
+    their own.
+  - **No artificial max-concurrent cap on resolution sub-workflows.**
+    Use Clojure's concurrency primitives correctly and trust default
+    pools (§3.4 added). Documents the side-effect-free constraint
+    on `dosync` and the agent-pattern for controlled side effects.
+  - **Per-run cache key path is correct for v2.** Highest-value
+    duplication is intra-run replay/retry, which the per-run path
+    serves perfectly. Cross-run sharing is a schema-additive v3
+    optimization (a `global/<input-key>` ref under the same
+    namespace), not a correctness issue today (§10.15).
+  - **Granular cost breakdown preserved** (§3.5 added). Multi-
+    dimensional cost views require the components to be visible
+    distinctly, not rolled up into aggregates. Resolution sub-
+    workflow tokens roll into the parent task's totals AND surface
+    separately under `:cost/breakdown :task/merge-resolution`.
 - **0.3.0** — Iteration round 2: settled all five §11 open questions
   (resolution budget shape, verify gate, curator role, telemetry
   tagging, out-of-band parent tip changes) AND folded in a technical
@@ -246,6 +271,85 @@ run-id as the "datacenter" component and plan-id/task-id as the
 upper-bit slots) would give the same ordering naturally. Either path
 is acceptable; the contract is the dashboard-sortable
 `<run>.<plan>.<task>.<resolution>` key.
+
+### 3.4 Concurrency model
+
+Multiple resolution sub-workflows can run simultaneously when
+sibling multi-parent tasks at the same stratum each hit a conflict.
+The orchestrator does NOT impose a max-concurrent cap; instead, it
+relies on Clojure's concurrency primitives matched to the access
+pattern:
+
+- **Atoms** for the registry's `task-id → branch-info` map and any
+  per-workflow shared state with synchronous, independent updates.
+- **Refs + STM (`dosync`)** for any case where multiple registry
+  updates must compose atomically (e.g. registering a multi-parent
+  merge result alongside the parents' per-task entries). Critical
+  caveat: aborted transactions retry, so the body of a `dosync` MUST
+  be side-effect free. Any IO (event emission, log writes, git
+  invocations) belongs OUTSIDE the transaction or inside an agent
+  send invoked from within it.
+
+  ```clojure
+  (dosync
+    ;; pure transactional updates only:
+    (alter task-registry assoc task-id branch-info)
+    (alter merge-cache assoc input-key resolution-ref)
+    ;; controlled side effect — agent send is queued and executed
+    ;; only after the transaction commits, so retries are safe:
+    (send log-agent emit-event {:event/path ... :merge/input-key ...}))
+  ```
+
+- **Agents** for the resolution-sub-workflow scheduling pool.
+  Asynchronous, independent dispatch. Each resolution sub-workflow
+  runs on its own thread via `send-off` (it does blocking IO — git,
+  agent calls, file system); the JVM thread pool sizing is the
+  default, not orchestrator-tuned.
+- **Vars** for context-thread-local config (e.g. `*current-run-id*`
+  bound around a workflow execution).
+
+Avoid blocking primary core.async go-blocks on long-running work;
+the resolution sub-workflow uses `send-off` or a dedicated thread,
+not the core.async dispatch pool.
+
+The reason for no max-concurrent cap: artificial caps starve
+legitimate work as often as they prevent overload, and they hide
+the real cost signal (which would otherwise show up as LLM rate-
+limit anomalies on a real bottleneck rather than as queue depth on
+an arbitrary line in the orchestrator). If telemetry surfaces a
+case where the runtime IS being overwhelmed by parallel resolution
+sub-workflows, that's the signal to tune — not pre-emptively cap
+without data.
+
+### 3.5 Cost telemetry shape
+
+Each task's metrics include a `:cost/breakdown` keyed by phase or
+sub-phase, NOT just a single rolled-up token total:
+
+```clojure
+{:cost/total      <tokens>
+ :cost/breakdown  {:task/explore           N
+                   :task/plan              M
+                   :task/implement         K
+                   :task/verify            L
+                   :task/merge-resolution  P
+                   :task/release           Q}
+ :cost/iterations {:task/implement         I-implement
+                   :task/merge-resolution  I-resolution}}
+```
+
+The resolution sub-workflow's tokens roll into the parent task's
+`:task/merge-resolution` slot AND remain visible separately on the
+sub-workflow's own metrics record (events tagged per §3.3). This
+gives multi-dimensional cost views: per-run aggregate, per-task
+breakdown, per-phase aggregate, per-stratum aggregate.
+
+The dashboard surfacing this answers questions like "what fraction
+of run cost is coming from merge-conflict resolution?" without
+requiring the operator to drill into individual task records.
+Granular components are preserved on purpose — rolling them up
+into aggregates loses the placement-of-attention signal that's the
+whole reason for collecting the data.
 
 ---
 
@@ -512,6 +616,26 @@ checks:
 
 Both checks are pure-data inspections of the worktree state; they
 don't need the agent's narration to fire.
+
+#### 6.1.3 Agent prompt scaffolding (policy-overridable)
+
+The resolution agent ships with descriptive default instructions
+(roughly: "Here are the conflicting paths, the parent SHAs, the raw
+git stderr, and the on-disk worktree with conflict markers. Resolve
+the markers and explain each resolution. Don't pick `ours`/`theirs`
+without justification."). These defaults are tunable based on
+iteration-count telemetry from §10.6 once we have dogfood data.
+
+**Policy trumps defaults.** When a workflow loads under a policy
+pack that defines a merge-resolution prompt template, that template
+overrides the default. Governed deployments often have specific
+language they need the resolution agent to produce (e.g., compliance-
+flavored explanations of every resolution decision, or restrictions
+on what the agent can do during resolution). The policy interface
+already governs prompts elsewhere; the resolution agent reuses that
+plumbing rather than introducing its own override surface.
+
+This is the round-3 question 2 answer — see §10.13.
 
 ### 6.2 Ancestor parent (informational, not an anomaly)
 
@@ -976,58 +1100,106 @@ all answers; this section preserves the reasoning trail.
     Replays of the same effective input reuse the same ref instead
     of accumulating new ones.
 
+### 10.12 Curator integration is an extension, not a new component
+
+- **User direction:** "Extension. If we need to move to components
+  then we would need refactoring of the existing polymorphism."
+- **Decision:** the merge-resolution curator extends the existing
+  curator multimethod with the §6.1.2 checks
+  (`:curator/markers-not-resolved`, `:curator/recurring-conflict`).
+  No new component. Default-on for the resolution sub-workflow only;
+  the existing implement loop doesn't see the new checks (where they
+  would just be noise — there are no conflict markers in normal
+  implement output).
+- **Refactor cost accepted:** if a future need forces a curator
+  split into a separate component, the existing polymorphism will
+  need refactoring. That's accepted as future cost; don't pre-
+  emptively split.
+
+### 10.13 Resolution agent prompt: descriptive defaults, policy-overridable
+
+- **User direction:** "I am not sure. It is tempting to give
+  descriptive instructions. Although I am also aware that policy
+  should trump our defaults if policy exists."
+- **Decision:** ship descriptive default prompt scaffolding (§6.1.3),
+  tune it via dogfood telemetry from §10.6 (iteration counts,
+  resolution success rates). When a policy pack is loaded that
+  defines a merge-resolution prompt template, the policy template
+  takes precedence — same plumbing the policy interface already uses
+  to govern other agent prompts. Governed deployments often need
+  specific resolution-justification language (compliance, audit) or
+  restrictions on agent behavior; this gives them a hook without
+  miniforge defaults getting in the way.
+
+### 10.14 No artificial max-concurrent cap; use Clojure primitives correctly
+
+- **User direction:** "Unsure we should have a max concurrent cap
+  vs a sane management of thread pools .. or use core async well
+  and trust default pools. Avoid starvation, avoid blocking all
+  that much. Clojure has great concurrency primitives we can use
+  for these. [Refs / Agents / Atoms / Vars / STM, with note that
+  aborted transactions replay so dosync must be side-effect free.]"
+- **Decision:** §3.4 documents the concurrency model. No
+  max-concurrent cap; each resolution sub-workflow runs on its own
+  thread (`send-off`) with default JVM thread-pool sizing.
+  Clojure primitives are matched to access pattern (atoms / refs+STM
+  / agents / vars). The side-effect-free constraint on `dosync`
+  bodies is documented explicitly with the agent-send pattern for
+  controlled side effects.
+- **Why no cap:** artificial caps starve legitimate work as often
+  as they prevent overload, and they hide the real cost signal.
+  Cost surfaces correctly via §3.5 telemetry; LLM rate limits
+  surface as their own anomalies. If telemetry shows the runtime IS
+  being overwhelmed in practice, that's the signal to tune — not
+  pre-emptively cap without data.
+
+### 10.15 Per-run cache key is correct for v2; cross-run is a v3 optimization
+
+- **User direction:** "Cache keys should be chosen for optimal
+  caching, is `:merge/input-key` better than a more specialized
+  key? Or would it result in a high rate of cache breaks? .. where
+  is the duplication the highest value to eliminate?"
+- **Decision:** `refs/miniforge/dag-base/<run-id>/<task-id>/<input-key>`
+  stays as v2's cache path. Reasoning:
+  - **Highest-value duplication is intra-run:** resume from
+    checkpoint, retry after a transient failure, replay of the same
+    workflow run. The per-run path serves these perfectly.
+  - **Cross-run cache hits** (re-running the same plan from scratch)
+    require stable plan-id / task-id across runs, which depends on
+    plan compilation reproducibility — true for some plan sources,
+    not all. Hit rate would be low and unpredictable.
+  - **Stale-cache risk:** a cross-run cache shadows under-tested
+    older resolutions when policy or agent versions change.
+    Per-run scoping eliminates that whole class of footgun.
+- **Schema-additive v3 path:** a global content-addressable ref
+  (`refs/miniforge/dag-base/global/<input-key>`) under the same
+  namespace would let cross-run sharing happen explicitly when
+  something opts in. Defer until v2 telemetry shows whether the
+  duplication exists in practice.
+
+### 10.16 Cost breakdown preserves granular components
+
+- **User direction:** "We should have the ability to view cost along
+  many dimensions. So preserve the components, it is how we can see
+  where to place our attention on performance and cost improvements.
+  If it is not granular enough, we will be missing the data needed
+  to identify where the problem is."
+- **Decision:** §3.5 shape preserves per-phase components in
+  `:cost/breakdown`. Resolution sub-workflow tokens roll into the
+  parent task's `:task/merge-resolution` slot AND remain visible
+  separately on the sub-workflow's own metrics. Multi-dimensional
+  views (per-run, per-task, per-phase, per-stratum) can all be
+  derived without losing the placement-of-attention signal.
+
 ---
 
-## 11. Open Questions for Iteration Round 3
+## 11. Iteration Closure
 
-Round 1's five questions and Round 2's five questions are all settled
-(§10.1–§10.10) plus the GPT-5.5 review issues (§10.11). These are the
-remaining design questions surfaced during the v0.3 pass:
-
-1. **Curator integration shape.** The §6.1.2 curator wraps the
-   resolution agent's iteration loop. Is it a new component (a
-   sibling to `phase-software-factory`'s implementer curator) or an
-   extension of the existing curator multimethod? Lean extension —
-   the merge-resolution checks (`:curator/markers-not-resolved`,
-   `:curator/recurring-conflict`) compose naturally with the existing
-   `:curator/no-files-written` check. Default-on for the resolution
-   sub-workflow only; off for the regular implement loop where it
-   would be noise.
-
-2. **Resolution agent prompt scaffolding.** The agent gets the
-   conflict info, the parent SHAs, the strategy. What prompt-template
-   gives the best resolution rate? Open question for the
-   implementation phase — start with a literal "here are the
-   conflicts, resolve them and explain the resolution" prompt, tune
-   based on iteration-count telemetry from §10.6.
-
-3. **Concurrent resolution sub-workflows.** Two sibling tasks at the
-   same stratum could both hit conflicts and trigger resolution
-   sub-workflows simultaneously. Each gets its own ephemeral worktree
-   (different paths) and its own resolution agent (different sub-
-   workflow ids), so they don't fight. But they may compete for LLM
-   rate-limit budget. Worth a max-concurrent cap on the resolution
-   pool? Defer to dogfood telemetry.
-
-4. **Resolution success — should we also push the resolution to a
-   persistent ref?** §7.2's namespaced ref already lives at
-   `refs/miniforge/dag-base/<run-id>/<task-id>/<input-key>`, which is
-   per-run. If a future replay of the same run hits the same input-
-   key, it reuses. But cross-run replay (e.g., re-running an entire
-   workflow from scratch with the same plan) gets a different
-   `<run-id>` and re-resolves from scratch. Acceptable for v2 (the
-   resolution work isn't free but isn't catastrophic), but worth
-   considering whether the input-key alone (without `<run-id>`) is a
-   better cache key.
-
-5. **Resolution-sub-workflow telemetry attribution to the parent
-   task's cost report.** The parent task's metrics include implement
-   tokens, verify wall-clock, etc. Resolution-sub-workflow tokens
-   should roll up into the parent task's totals (the merge IS work
-   the parent task incurred), but ALSO be visible separately so the
-   dashboard can answer "where is the cost coming from in this run?"
-   Likely a `:cost/breakdown {:task/implement N :task/verify M
-   :task/merge-resolution K}` shape. Worth specifying explicitly?
+Three rounds of iteration captured 16 design decisions (§10.1–§10.16).
+The remaining work is implementation, not further design. Any new
+questions surfaced during implementation should land as PR review
+comments on the v2 work-spec PR rather than as another spec round —
+the design is settled enough to start coding against.
 
 ---
 

--- a/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
+++ b/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
@@ -6,21 +6,61 @@
 
 # I-DAG-MULTI-PARENT-MERGE — Multi-Parent DAG Merge Strategy (v2 of Per-Task Base Chaining)
 
-**Status:** Informative — iteration round 1 complete; ready for implementation.
+**Status:** Informative — iteration round 2 complete; ready for implementation.
 **Date:** 2026-05-03
-**Version:** 0.2.0
+**Version:** 0.3.0
 
 **Changelog:**
 
-- **0.2.0** — Iteration round 1: settled all five §10 open questions.
-  Branches now ephemeral (Q1). Cherry-pick order pinned to plan
-  declaration (Q2). Criss-cross histories silently fall back to
-  recursive merges (Q3). **Conflict-resolution agent loop pulled
-  in-scope** (Q4) — both pre-task octopus failures and mid-PR-
-  lifecycle MERGEABLE→NON_MERGEABLE transitions trigger an automated
-  resolution sub-workflow rather than failing to a human.
-  **Strict-forest opt-out flag dropped entirely** (Q5) — v2's
-  always-on conflict handling makes plan-time fail-loud unnecessary.
+- **0.3.0** — Iteration round 2: settled all five §11 open questions
+  (resolution budget shape, verify gate, curator role, telemetry
+  tagging, out-of-band parent tip changes) AND folded in a technical
+  review of v0.2 (Git semantics tightening). Major changes:
+  - Renamed default strategy `:octopus` → `:git-merge`. Git uses
+    `ort` for two-head merge and `octopus` only for 3+ heads;
+    exposing `:octopus` as the user-facing default was misleading
+    for the common two-parent case.
+  - Replaced `:sequential-cherry-pick` with `:sequential-merge` as
+    the alternate strategy — cherry-pick over parent branches that
+    contain merge commits is unsafe without `--mainline` plumbing
+    and loses merge-resolution history. Sequential merge preserves
+    history correctly.
+  - Tightened determinism: spec now claims "same effective merge
+    result" (tree + parent ordering), not "same commit SHA". Pinned
+    the merge flags (`--no-edit --no-gpg-sign --no-verify --no-ff
+    -m <deterministic message>`) so config drift doesn't change
+    behavior.
+  - Registry shape now resolves parents to immutable SHAs at
+    resolution time (not branch tips). Added `:sha`, `:order`, and
+    `:merge/input-key` (idempotency key derived from task-id +
+    strategy + ordered parent SHAs). Branch names are mutable; SHAs
+    are not.
+  - Specified the parent collapse / first-parent rule precedence
+    explicitly (collapse duplicates and ancestors first, preserve
+    plan order on remaining tips, then assign first-parent). Closes
+    a contradiction in v0.2.
+  - Renamed §6.3 from "empty parent intersection" to "duplicate /
+    identical parent tips" — the prior name was misleading.
+  - Added §6.5 unrelated-histories anomaly. Git refuses unrelated
+    histories by default; v2 must NOT use `--allow-unrelated-
+    histories` for normal DAG parent merges.
+  - Adjusted the §6.1 conflict shape: `:merge/conflicts` entries now
+    carry `:parent-candidates` and `:attribution` (precise pairwise
+    attribution may not be available from octopus output). Added
+    `:git/exit-code` and `:git/stderr` for raw diagnostics.
+  - Round-2 outcomes documented in the new §10.6–§10.10. Notable:
+    resolution-budget philosophy is "prevent exhaustion from
+    stagnation" (small iteration cap, telemetry-driven optimization,
+    not a hammer on token totals); a merge-resolution curator
+    detects persistent conflicts; events use a hierarchical
+    `<run>.<plan>.<task>.<resolution>` taxonomy.
+- **0.2.0** — Iteration round 1: settled v0.1's five open questions.
+  Branches ephemeral (Q1). Cherry-pick order pinned to plan
+  declaration (Q2). Criss-cross histories silently fall back (Q3).
+  **Conflict-resolution agent loop pulled in-scope** (Q4) — both
+  pre-task failures and mid-PR-lifecycle NON_MERGEABLE transitions
+  trigger an automated resolution sub-workflow.
+  **Strict-forest opt-out flag dropped entirely** (Q5).
 - **0.1.0** — Initial draft.
 
 Specifies how a DAG task with multiple completed parents acquires a base for its
@@ -90,139 +130,265 @@ Four properties this preserves:
    anomaly with the conflicting parents and paths — never as a silent
    overwrite.
 
-### 3.1 Determinism
+### 3.1 Determinism (what we promise vs. what git gives us)
 
-"Deterministic" means the same plan + the same parent commits always
-produces the same merge commit, including the same git parent ordering
-in that commit. The ordering source is the task's
-`:task/dependencies` vector **as authored in the plan**, not the runtime
-completion order of those parents. Concretely:
+"Deterministic" here means **same effective merge result** — same input
+parent SHAs, same merge strategy, same first-parent choice, same
+resulting tree — modulo Git version and config differences. It does
+NOT mean the same commit SHA across runs. A Git commit object also
+depends on author, committer, timestamps, message bytes, signing
+config, and merge hooks; pinning a SHA across replays would require
+pinning all of those, which is brittle and not worth the complexity
+for v2.
 
-- The first parent of the merge commit is `:task/dependencies[0]`'s
-  registered branch — this becomes the base (`git checkout -b ... <p0>`).
-- Subsequent parents are passed to `git merge` in
-  `:task/dependencies[1..N]` order.
-- Octopus merges are commutative for non-conflicting changes (git
-  computes the same tree regardless of the order of the second-and-after
-  parents), so the order matters only for the human-visible parent
-  sequence in the merge commit; we pin it anyway so logs and history
-  match across replays.
-- If `:task/dependencies` is a set rather than a vector at the schema
-  layer (the plan/task schema currently allows either), the orchestrator
-  sorts by `str` of the task-id before merging — same convention as
-  `task-defs->forest-shape` in the orchestrator today, which sorts deps
-  for deterministic anomaly payloads.
+The orchestrator pins what it CAN pin so config drift between
+machines doesn't change behavior:
+
+```bash
+git merge --no-edit \
+          --no-gpg-sign \
+          --no-verify \
+          --no-ff \
+          -m "<deterministic generated message>" \
+          <p1-sha> [<p2-sha> ...]
+```
+
+- `--no-edit` skips the editor.
+- `--no-gpg-sign` defeats `commit.gpgsign=true` in user config.
+- `--no-verify` skips merge / pre-commit hooks (the orchestrator
+  runs its own verify gates downstream).
+- `--no-ff` forces a real merge commit even when fast-forward is
+  possible — without this, a single-effective-parent merge would
+  produce no merge commit and the registry would have nothing to
+  point at.
+
+The first parent of the merge commit is the parent that the
+worktree was checked out on (`git checkout -B <tmp> <p0-sha>`); its
+identity is determined by §3.2.
+
+Subsequent parents are passed to `git merge` in plan-declaration
+order on the (possibly collapsed) parent set from §3.2.
+
+If `:task/dependencies` is a set rather than a vector (current schema
+allows either), the orchestrator sorts by `str` of the task-id before
+collapsing — same convention as `task-defs->forest-shape` today.
+
+### 3.2 Parent resolution and collapse algorithm
+
+A multi-parent task's `merge-parent-branches!` runs this sequence:
+
+1. **Resolve to SHAs.** For each declared dependency, look up the
+   registered branch and snapshot its tip SHA at this moment. Subsequent
+   force-pushes on the parent branch don't affect THIS task's merge —
+   the SHAs are the immutable inputs (see §6.6 for force-push handling).
+2. **Order normally.** If `:task/dependencies` is a vector, keep its
+   order. If it's a set, sort by `str` of task-id. Call the result
+   `[p0, p1, ..., pN-1]` of `{:task/id ... :branch ... :sha ...}`
+   maps.
+3. **De-duplicate identical tips.** Drop later entries whose `:sha`
+   already appears earlier. Emit `:dag/multi-parent-no-op` log per
+   §6.3 if any duplicates were dropped.
+4. **Collapse ancestors.** Drop any parent whose tip is reachable
+   from another parent's tip (`git merge-base --is-ancestor`).
+   Preserve order among the surviving "maximal" tips. Emit
+   `:dag/multi-parent-ancestor-collapsed` log per §6.2 for each
+   collapsed parent, naming both the dropped parent and the parent
+   that absorbed it.
+5. **Decide the merge action.**
+   - 0 effective parents: impossible (we wouldn't be here).
+   - 1 effective parent: no merge needed; return that parent's SHA
+     as the base. Single-parent fast path (matches v1's chained-
+     base behavior exactly).
+   - 2 effective parents: two-head merge via `-s ort`.
+   - 3+ effective parents: octopus merge via `-s octopus`.
+6. **Compute the idempotency key.** Hash
+   `[:task-id, :strategy, [p0-sha, p1-sha, ...]]` to produce
+   `:merge/input-key`. Used for §7's namespaced ref naming so
+   replays of the same effective input reuse the same merge ref
+   instead of accumulating new ones.
+7. **Execute the merge** in a clean temporary worktree per §3.1.
+8. **On success**, capture the resulting commit SHA and push under
+   the namespaced ref (§7). Drop the temp worktree.
+9. **On conflict**, hand the conflict information to the resolution
+   sub-workflow per §6.1. The temp worktree's conflict state is
+   serialized into the sub-workflow input rather than left on disk.
+
+This sequencing resolves a contradiction in v0.2: §3.1 said
+dep[0] is always the first parent, while §6.2 said an ancestor
+parent collapses. The new explicit ordering is **collapse first,
+then assign first-parent**, so an ancestor that would have been
+dep[0] disappears and the surviving leftmost dep becomes the first
+parent. No surprise.
+
+### 3.3 Hierarchical event tagging
+
+Events emitted by multi-parent merges (and by the resolution sub-
+workflow) follow a `<run>.<plan>.<task>.<resolution>` namespacing
+convention. Concretely each event carries:
+
+```clojure
+:event/path [<run-id> <plan-id> <task-id> <resolution-id-or-nil>]
+```
+
+- `run-id` is the workflow run.
+- `plan-id` is the plan within that run.
+- `task-id` is the multi-parent task whose merge needed resolving.
+- `resolution-id` is the resolution sub-workflow's id when the event
+  is from inside that sub-workflow; nil for orchestrator-level merge
+  events.
+
+The path produces a sortable key for the dashboard so per-task
+merge-resolution work doesn't conflate with the parent task's own
+implement work, AND the parent-child chain stays traceable end-to-end.
+
+Implementation hint: a Snowflake-style ordered ID generator (with
+run-id as the "datacenter" component and plan-id/task-id as the
+upper-bit slots) would give the same ordering naturally. Either path
+is acceptable; the contract is the dashboard-sortable
+`<run>.<plan>.<task>.<resolution>` key.
 
 ---
 
 ## 4. Strategy Options
 
 Four strategies were considered. The recommendation in §5 is to ship one as
-default and allow per-task override via plan annotation.
+default (§4.1) and allow per-task override via plan annotation (§4.4).
 
-### 4.1 Octopus merge (recommended default)
+### 4.1 `:git-merge` (recommended default)
+
+A single git merge invocation against the collapsed parent set from §3.2,
+with `git` selecting `ort` for two-head merges and `octopus` for 3+:
 
 ```bash
-git checkout -b task-N-base parent-A
-git merge parent-B parent-C ...           # one commit
+# 2 effective parents (the common fan-in case):
+git checkout -B <tmp> <p0-sha>
+git merge -s ort     <pinned merge flags from §3.1> <p1-sha>
+
+# 3+ effective parents:
+git checkout -B <tmp> <p0-sha>
+git merge -s octopus <pinned merge flags from §3.1> <p1-sha> <p2-sha> ...
 ```
+
+The strategy keyword is `:git-merge` — NOT `:octopus`, which v0.2 used.
+Git's `octopus` strategy is specifically for merging 3+ heads at once;
+calling the user-facing default "octopus" was misleading for two-parent
+fan-in (the most common shape in real plans). The internal sub-mode
+(`ort` vs. `octopus`) is selected by parent count, not exposed to plan
+authors.
 
 **Pros:**
 
-- Native git operation. Single merge commit reflects fan-in faithfully.
-- Conflict-detection is git's, not ours — well-understood semantics.
+- Native git operation. Single merge commit, clear parent ordering.
+- Conflict detection is git's, not ours — well-understood semantics.
 - Round-trips cleanly through `git push` / GitHub.
 - Cheap when parents touch disjoint files (the common case for
   well-decomposed work).
 
 **Cons:**
 
-- Octopus refuses on any conflict. We need a fallback path (see §6).
-- Octopus disallows criss-cross merges in some git versions; needs a
-  topology check up front.
+- Octopus refuses on conflicts and on criss-cross histories. v2's
+  conflict handling is the resolution sub-workflow (§6.1); criss-cross
+  fallback is automatic recursive chaining (§10.8).
 
-### 4.2 Sequential cherry-pick
+### 4.2 `:sequential-merge` (alternate)
+
+Apply parents one at a time via two-parent merges, in plan-declaration
+order:
 
 ```bash
-git checkout -b task-N-base parent-A
-# Cherry-pick the commits unique to each non-chosen parent.
-# git's A..B selects commits reachable from B but not A, so the range
-# is (merge-base ↔ parent-tip), NOT the reverse.
-git cherry-pick $(git merge-base parent-A parent-B)..parent-B
-git cherry-pick $(git merge-base parent-A parent-C)..parent-C
+git checkout -B <tmp> <p0-sha>
+git merge -s ort <pinned merge flags> <p1-sha>
+git merge -s ort <pinned merge flags> <p2-sha>
+# ...
 ```
 
-Parents are applied in **plan-declaration order** (same source as octopus
-parent ordering — see §3.1). Deterministic, author-controlled, and
-matches what an author would write if they listed deps in priority order.
-
 **Pros:**
 
-- Linear history.
-- Per-commit conflict resolution is easier to reason about than an n-way
+- Each merge is a two-parent merge — `ort` is robust and well-
+  characterized.
+- Per-step conflict resolution is easier to reason about than an n-way
   octopus when conflicts do happen.
+- Handles parent branches that themselves contain merge commits
+  (those branches are intermediate fan-in points in the same plan)
+  without special plumbing.
+- Preserves merge-resolution history correctly (unlike cherry-pick;
+  see §4.3).
 
 **Cons:**
 
-- Loses the fan-in shape — history reads as if the work were sequential.
-- O(commits-in-each-parent) operations per merge, slower than octopus on
-  big parent branches.
-- Cherry-pick conflicts on shared ancestors can be subtle.
+- History looks artificially serial — the resulting commit graph
+  shows a chain of pairwise merges rather than a single fan-in.
+- Slower than octopus when there are 3+ parents and no conflicts.
 
-### 4.3 Last-parent-wins
+### 4.3 `:sequential-cherry-pick` — explicitly NOT supported in v2
 
-Pick the parent that completed most recently; ignore the others. Each
-non-chosen parent's work is silently dropped from the base.
+v0.2 listed sequential cherry-pick as the alternate strategy. v0.3
+removes it because:
 
-**Pros:**
+- Cherry-picking a parent branch that contains merge commits requires
+  `--mainline` to choose which side of the merge to apply — and v2
+  has no principled way to choose. Plans that produce intermediate
+  fan-in (which v2 explicitly enables!) will hit this immediately.
+- Even on linear parent branches, ranges like
+  `$(git merge-base p0 p1)..p1` re-apply patch-equivalent commits
+  from earlier parents that the prior cherry-pick already landed.
+  Avoiding this requires `rev-list --cherry-pick --right-only` plumbing,
+  which interacts badly with the merge-commit case above.
+- Cherry-pick discards merge-resolution edits that exist only in
+  merge commits. Once miniforge produces fan-in branches, that's
+  silent data loss.
 
-- Trivial to implement; matches current single-parent code path exactly.
-
-**Cons:**
-
-- Reproduces the v0 bug (sibling tasks not seeing upstream output) for
-  every parent except one. **Rejected.** Listed only for completeness.
+If a future v3 wants linear-history plans, `:sequential-cherry-pick`
+can be revisited under a stricter precondition (e.g.
+`:dag-merge-strategy-unsupported-topology` anomaly when parent branches
+contain merges). Out of scope for v2.
 
 ### 4.4 Plan-annotated strategy
 
-Plan emits `:task/merge-strategy` per multi-parent task; default to one of
-4.1 / 4.2 when absent.
+Plan emits `:task/merge-strategy` per multi-parent task; default to
+`:git-merge` when absent.
 
 **Pros:**
 
 - Lets plan authors override per task when they know better than the
-  default (e.g. force cherry-pick when they expect conflicts).
-- Backwards-compatible — existing plans without the key get the default.
+  default (e.g. force `:sequential-merge` when they expect conflicts
+  and want easier per-step resolution).
+- Backwards-compatible — existing plans without the key get the
+  default.
 
 **Cons:**
 
 - Adds a key to the plan schema. Plan agents must learn to emit it.
 
+### 4.5 Last-parent-wins
+
+Pick the parent that completed most recently; ignore the others.
+**Rejected.** Reproduces the v0 silent-overwrite bug for every parent
+except one. Listed only for completeness.
+
 ---
 
 ## 5. Recommendation
 
-**Default to 4.1 octopus merge. Allow per-task override via 4.4
+**Default to `:git-merge`. Allow per-task override via
 `:task/merge-strategy`.** Concretely:
 
-| Strategy keyword          | Behavior                                          |
-| ------------------------- | ------------------------------------------------- |
-| `:octopus` (default)      | §4.1; on conflict, spawn resolution sub-          |
-|                           | workflow per §6.1 — does NOT fail to a human.     |
-| `:sequential-cherry-pick` | §4.2; same conflict path.                         |
+| Strategy keyword       | Behavior                                              |
+| ---------------------- | ----------------------------------------------------- |
+| `:git-merge` (default) | §4.1; `ort` for 2 effective parents, `octopus` for    |
+|                        | 3+. On conflict, spawn resolution sub-workflow per    |
+|                        | §6.1 — does NOT fail to a human.                      |
+| `:sequential-merge`    | §4.2; pairwise merges in plan-declaration order.      |
+|                        | Same conflict path.                                   |
 
-`:last-parent-wins` is intentionally not exposed (would reproduce the
-v0 silent-overwrite class).
+`:sequential-cherry-pick` and `:last-parent-wins` are intentionally not
+exposed. See §4.3 / §4.5.
 
-**No `:fail-on-multi-parent` mode.** The v0.1 draft proposed a
-`:plan/strict-forest?` opt-in that emitted the v1
-`:anomalies/dag-non-forest` anomaly. The iteration round dropped it:
-v2's always-on automated conflict resolution makes plan-time fail-loud
-unnecessary, and it muddied the contract — every additional knob is a
-foot-gun. If a workflow truly needs linear history (formal-verification
-batches, regulatory pipelines), the right answer is to author plans
-that are forests by construction, not to add a runtime mode that turns
-the orchestrator back into v1.
+**No `:fail-on-multi-parent` mode.** v0.1 proposed a
+`:plan/strict-forest?` opt-in; v0.2 dropped it. v2's automated conflict
+resolution makes plan-time fail-loud unnecessary. Workflows that
+genuinely need linear history author plans as forests; no runtime mode
+duplicates the constraint.
 
 ---
 
@@ -239,46 +405,113 @@ transitions — is handled by the same resolution path; see §6.4.
 
 ### 6.1 Merge conflict — automated resolution
 
-When octopus (or `:sequential-cherry-pick`) hits a conflict, the
+When `:git-merge` (or `:sequential-merge`) hits a conflict, the
 orchestrator does NOT auto-pick `-X ours` / `-X theirs` (would reproduce
 v0 silent overwrites) and does NOT fail to a human. It spawns a
 **resolution sub-workflow** seeded with:
 
 ```clojure
-{:resolution/parents    [{:task/id ... :branch ...} ...]
- :resolution/conflicts  [{:path ... :parents [...]} ...]
- :resolution/strategy   :octopus  ; or :sequential-cherry-pick
- :resolution/parent-task :task/id ; the multi-parent task this is for
- :resolution/budget     <iterations | tokens>}
+{:resolution/parents    [{:task/id ... :branch ... :sha ... :order ...} ...]
+ :resolution/conflicts  [{:path                ...
+                          :parent-candidates   [...]   ; task-ids whose tips touch this path
+                          :attribution         :all-candidates ; or :pairwise-derived
+                          } ...]
+ :resolution/strategy        :git-merge   ; or :sequential-merge
+ :resolution/parent-task     :task/id     ; the multi-parent task this is for
+ :resolution/input-key       <hash>       ; from §3.2 step 6
+ :resolution/git-exit-code   <int>
+ :resolution/git-stderr      "..."
+ :resolution/budget          {:max-iterations N
+                              :stagnation-cap M}}
 ```
+
+A few notes on the shape:
+
+- **`:parent-candidates` instead of `:parents`.** Octopus / sequential-
+  merge output doesn't always tell us "these exact two parents
+  conflicted on this path." Conservative attribution — "this path
+  conflicted, and these are the parent tips that touched it" — is
+  what the orchestrator can reliably emit. The resolution agent has
+  enough information to investigate (the path, the parent tips, the
+  raw git stderr); it doesn't need a guaranteed minimal pair.
+- **`:attribution` is honest.** `:all-candidates` is the default
+  (we listed every parent whose tip touched the path). If a future
+  v2.x runs pairwise diagnostic merges to narrow down the responsible
+  pair, that switches to `:pairwise-derived`.
+- **`:git/exit-code` and `:git/stderr`** carry the raw git output so
+  the resolution agent has direct access to whatever git thought went
+  wrong, not just our re-projection of it.
 
 The resolution sub-workflow's contract:
 
-- **Goal:** produce a merge commit that resolves all conflicts and
+- **Goal:** produce a merge commit that resolves all conflicts AND
   passes the task's verify gates.
 - **Pipeline:** `implement` (agent edits the conflicted files) →
-  `verify` (project tests) → terminate when verify passes or budget
-  exhausts.
-- **Output (success):** a ref name on the task's persisted branch, with
-  the merge commit at the tip. The orchestrator continues the original
-  task using this ref as `:branch`.
-- **Output (failure, budget exhausted or verify never passes):** the
-  terminal anomaly below — only path that surfaces to a human.
+  `verify` (project tests + the same hard gates the task itself
+  would have run; see §6.1.1 for the policy) → terminate when verify
+  passes or budget exhausts.
+- **Curator:** specialized merge-resolution curator (§6.1.2) checks
+  that conflict markers are gone AND that the resolution isn't
+  recurring (same conflict, same paths, no progress). Recurring
+  conflicts trigger early termination instead of burning the full
+  budget on a stuck loop.
+- **Output (success):** a ref name on the namespaced merge-base ref
+  (§7), with the resolution commit at the tip. The orchestrator
+  continues the original task using this ref as `:branch`.
+- **Output (failure):** the terminal anomaly below — only path that
+  surfaces to a human.
 
 ```clojure
 {:anomaly/category :anomalies/dag-multi-parent-unresolvable
- :anomaly/message  "Octopus merge conflict could not be auto-resolved within budget"
+ :anomaly/message  "Merge conflict could not be auto-resolved"
  :task/id          ...
- :merge/parents    [{:task/id ... :branch ...} ...]
- :merge/conflicts  [{:path ... :parents [...]} ...]
- :merge/strategy   :octopus
+ :merge/parents    [{:task/id ... :branch ... :sha ... :order ...} ...]
+ :merge/conflicts  [{:path ... :parent-candidates [...] :attribution ...} ...]
+ :merge/strategy   :git-merge  ; or :sequential-merge
+ :merge/input-key  <hash>
  :resolution/last-attempt-ref ...
- :resolution/reason :budget-exhausted | :verify-never-passed}
+ :resolution/reason :budget-exhausted
+                   | :verify-never-passed
+                   | :curator/recurring-conflict
+                   | :curator/markers-not-resolved}
 ```
 
-The unresolvable anomaly carries the last-attempt ref so an operator
-inspecting the dashboard can see exactly what state the resolution
-agent left the merge in.
+#### 6.1.1 Verify gate policy
+
+The verify gate inside the resolution sub-workflow runs exactly what
+the parent task's verify phase would run — project tests plus any
+policy-enforced hard gates (in miniforge-local, the pre-commit chain;
+in governed mode, whatever policy attaches to the workflow). This
+matches the user-stated rule that "if the PR monitor loop makes
+changes re: comment, it moves through verification."
+
+For the §6.4 PR-lifecycle path the same rule applies, with one
+optimization: if GitHub already reports `MERGEABLE` after pushing
+the resolution commit AND the diff is purely conflict-marker
+deletions (no semantic change), the verify gate can short-circuit
+on the GitHub state alone. Any substantive change reaches the full
+verify pipeline. This is a round-2 question 2 outcome — see §10.7.
+
+#### 6.1.2 Merge-resolution curator
+
+Curators in miniforge today check that the agent actually did the
+work it was supposed to (e.g. `:curator/no-files-written`). The
+merge-resolution curator extends the pattern with two additional
+checks:
+
+1. **`:curator/markers-not-resolved`** — the agent terminated but
+   conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) are still in
+   the working tree. Treat as immediate failure of this iteration;
+   if it recurs, escalate to terminal anomaly per §6.1.
+2. **`:curator/recurring-conflict`** — the conflicted file set
+   from this iteration matches the previous iteration's set
+   (same paths, same conflict markers post-edit). The agent isn't
+   making progress; escalate to terminal anomaly to avoid burning
+   the rest of the budget on a stuck loop. This is the Round 2 Q3
+   answer — see §10.8.
+
+Both checks are pure-data inspections of the worktree state; they
+don't need the agent's narration to fire.
 
 ### 6.2 Ancestor parent (informational, not an anomaly)
 
@@ -290,13 +523,17 @@ parent and the parent it collapsed into, so the operator knows the plan
 was implicitly simpler than declared. **No anomaly** — the merge
 succeeded; this case only matters for plan-quality observability.
 
-### 6.3 Empty parent intersection (informational, not an anomaly)
+### 6.3 Duplicate / identical parent tips (informational, not an anomaly)
 
-When parents share a merge-base and the merge is a no-op because the
-parents are identical (no commits unique to any of them since the merge-
-base), proceed as if single-parent against any of them. Emit a
-`:dag/multi-parent-no-op` log entry. **No anomaly** — the merge
-succeeded.
+(v0.2 called this "empty parent intersection" — misleading. The case
+described here is parents-are-the-same, not parents-have-no-shared-
+history. The unrelated-histories case is §6.5.)
+
+When parents share a merge-base and the §3.2 collapse step finds
+identical tips (one parent's `:sha` equals another's), the merge is a
+no-op. Drop the duplicate, proceed as if single-parent against the
+remaining tip. Emit a `:dag/multi-parent-no-op` log entry. **No
+anomaly** — the merge succeeded trivially.
 
 ### 6.4 Mid-PR-lifecycle conflict (NON_MERGEABLE)
 
@@ -330,51 +567,170 @@ whole point: one merge-conflict-resolution agent, two trigger sites.
 Without this, miniforge would have a hole in the release flow large
 enough to make every multi-day workflow fragile.
 
+### 6.5 Unrelated histories (anomaly)
+
+If the §3.2 collapse step finds parents that share NO common ancestor
+(`git merge-base` returns nothing), git would refuse the merge by
+default. v2 explicitly does NOT use `--allow-unrelated-histories` for
+DAG parent merges — that flag exists for one-time repo grafts, not
+for routine fan-in. Surface the situation as a typed anomaly:
+
+```clojure
+{:anomaly/category :anomalies/dag-multi-parent-unrelated-histories
+ :anomaly/message  "Parents share no common ancestor — refusing to merge"
+ :task/id          ...
+ :merge/parents    [{:task/id ... :branch ... :sha ... :order ...} ...]
+ :merge/strategy   :git-merge}
+```
+
+This is a plan-quality / repo-state anomaly, not a routine conflict.
+The resolution sub-workflow does NOT auto-engage on this category —
+unrelated histories almost always mean someone did something the
+orchestrator wasn't expecting (a stray `git init`, a force-push that
+rewrote a parent's entire history, an accidental cross-repo branch).
+Surface to a human via the normal anomaly path.
+
+### 6.6 Out-of-band parent tip change (round-2 question 5)
+
+The §3.2 step 1 snapshot pins each parent's `:sha` at resolution
+time. If a parent task's branch is force-pushed between resolution
+and the orchestrator's actual merge attempt — rare in normal flow,
+possible during retries — the merge runs against the SHA we
+snapshotted, not the branch's current tip. That's the right
+behavior: it preserves determinism and idempotency.
+
+What if the snapshot is stale by the time we register the merge
+result? Two cases per the user's round-2 answer:
+
+- **Simple to refresh** (the snapshotted SHA is still reachable
+  from the current tip — the parent did a normal push, not a
+  history-rewriting force-push): emit a
+  `:dag/multi-parent-parent-tip-advanced` log naming the old and
+  new tips and proceed using the snapshotted SHA. The tip move is
+  informational; the merge is unaffected.
+- **Non-deterministic / policy violation** (the snapshotted SHA
+  is no longer reachable — history was rewritten): surface as
+
+  ```clojure
+  {:anomaly/category :anomalies/dag-multi-parent-parent-rewritten
+   :anomaly/message  "Parent branch was rewritten; snapshot SHA unreachable"
+   :task/id          ...
+   :merge/parent     {:task/id ... :branch ... :snapshot-sha ... :current-sha ...}}
+  ```
+
+  The orchestrator does not retry automatically — the rewrite was
+  out-of-band, and silently re-snapshotting would let upstream
+  drift quietly mutate the merge inputs. Surface to a human for a
+  conscious decision (re-resolve the parent? cancel the dependent
+  task? roll back the force-push?).
+
 ---
 
 ## 7. Integration Points (where it lands in the code)
 
-Five surfaces touch:
+Five surfaces touch.
 
-- **`branch-registry`** (`components/dag-executor/src/.../branch_registry.clj`):
-  - Replace `resolve-base-branch`'s multi-parent anomaly path with a
-    `resolve-multi-parent-base` that returns
-    `{:strategy ... :parents [{:task/id ... :branch ...}]}`. The actual
-    merge is the orchestrator's job; the registry only resolves
-    *which* branches to merge.
-  - Drop the v1 forest-only anomaly. Keep `validate-forest` /
-    `forest?` as informational helpers for plan-quality reporting.
+### 7.1 `branch-registry` (`components/dag-executor/src/.../branch_registry.clj`)
 
-- **`dag-orchestrator`** (`components/workflow/src/.../dag_orchestrator.clj`):
-  - New helper `merge-parent-branches!` that performs the chosen
-    strategy in an **ephemeral** worktree (see §11), returns either the
-    new merge-commit ref OR triggers the resolution sub-workflow per
-    §6.1 on conflict.
-  - `task-sub-opts` calls it for multi-parent tasks; `:branch` becomes
-    the merge-commit ref. Single-parent tasks keep their current path
-    unchanged.
-  - `execute-plan-as-dag` no longer rejects non-forest plans. v1's
-    forest validator is dropped from the gate path; `validate-forest`
-    survives as an informational helper.
+- Replace `resolve-base-branch`'s multi-parent anomaly path with
+  `resolve-multi-parent-base`, which returns the §3.2 normalized
+  result:
 
-- **Resolution sub-workflow** (new — likely a workflow definition under
-  `components/workflow/src/.../merge_resolution.clj` or a specialized
-  invocation of the standard implement/verify pipeline with a curated
-  agent prompt). Inputs and outputs per §6.1. Reused by both the
-  pre-task path (§6.1 trigger) and the PR-lifecycle path (§6.4 trigger).
+  ```clojure
+  {:merge/strategy   :git-merge       ; or :sequential-merge
+   :merge/parents    [{:task/id ... :branch ... :sha ... :order 0}
+                      {:task/id ... :branch ... :sha ... :order 1} ...]
+   :merge/input-key  <hash>}
+  ```
 
-- **`pr-lifecycle`** (`components/pr-lifecycle/src/...`):
-  - The PR monitor loop already detects state transitions. Hook the
-    MERGEABLE→NON_MERGEABLE transition to invoke the resolution
-    sub-workflow with the two-parent input shape from §6.4. On success,
-    push the resolution commit and let the lifecycle resume. On
-    `dag-multi-parent-unresolvable`, surface to the human review path
-    that already exists for other lifecycle failures.
+  The actual merge is the orchestrator's job; the registry only
+  resolves *which* SHAs to merge and in what order.
+- Drop the v1 forest-only anomaly. Keep `validate-forest` /
+  `forest?` as informational helpers for plan-quality reporting (the
+  dashboard can still surface "this plan has fan-in at task X" as
+  metadata even though it's no longer a hard rejection).
 
-- **Plan schema:**
-  - New optional `:task/merge-strategy` enum
-    (`#{:octopus :sequential-cherry-pick}`).
-  - **No** `:plan/strict-forest?` flag (dropped per §5).
+### 7.2 `dag-orchestrator` (`components/workflow/src/.../dag_orchestrator.clj`)
+
+New helper `merge-parent-branches!` running this algorithm:
+
+```clojure
+(defn merge-parent-branches!
+  "Multi-parent merge per the §3.2 algorithm. Returns either
+   {:merge/ok? true :merge/ref <ref-name> :merge/sha <sha>}
+   or one of the §6 anomalies."
+  [{:keys [run-id task-id strategy parents]}]
+  ;; parents are already SHA-pinned and order-normalized
+  ;; per resolve-multi-parent-base.
+  ...)
+```
+
+Step-by-step:
+
+1. **Validate** all parents have `:sha` set (resolution-time snapshots,
+   not lazy lookups).
+2. **Collapse** duplicates (§6.3) and ancestors (§6.2). If 0 or 1
+   effective parent remains: no merge needed; return the surviving
+   SHA. If unrelated histories: §6.5 anomaly.
+3. **Compute the namespaced ref name** from `:merge/input-key`:
+
+   ```text
+   refs/miniforge/dag-base/<run-id>/<task-id>/<input-key>
+   ```
+
+   Living under `refs/miniforge/...` keeps it out of the normal
+   branch namespace; living under `<run-id>` is per-run-isolated.
+   If the ref already exists with the same input-key (replay /
+   retry), reuse its tip — the input is byte-identical so the
+   output is too.
+4. **Stage in a clean temporary worktree.** Worktree path
+   `/tmp/miniforge-merge/<task-id>/<input-key>`; cleaned up on
+   completion regardless of outcome.
+5. **Run the merge** with the §3.1 pinned flags. For 2 effective
+   parents: `git merge -s ort`; for 3+: `git merge -s octopus`.
+6. **On success**, push the resulting commit to the namespaced ref.
+   Drop the temp worktree.
+7. **On conflict**, capture
+   `{:git/exit-code :git/stderr :merge/conflicts}` and hand to the
+   resolution sub-workflow per §6.1. Drop the temp worktree (the
+   sub-workflow re-stages from the conflict info, not the residual
+   on-disk state).
+
+`task-sub-opts` calls `merge-parent-branches!` for multi-parent tasks
+and uses the returned `:merge/ref` (or the bare `:merge/sha` for
+single-effective-parent fast path) as the sub-workflow's `:branch`.
+Single-parent tasks keep their current code path entirely unchanged.
+
+`execute-plan-as-dag` no longer rejects non-forest plans. v1's forest
+validator is dropped from the gate path; `validate-forest` survives
+as an informational helper.
+
+### 7.3 Resolution sub-workflow (new component)
+
+Likely lives under `components/merge-resolution/` as a sibling to the
+existing phase-software-factory workflow definition, OR as a
+specialized invocation of the standard implement / verify pipeline
+with a curated agent prompt and the §6.1.2 curator wired in. Either
+shape is acceptable; the contract is what §6.1 specifies. Reused by
+both the §6.1 pre-task trigger and the §6.4 PR-lifecycle trigger.
+
+### 7.4 `pr-lifecycle` (`components/pr-lifecycle/src/...`)
+
+The PR monitor loop already detects state transitions. Hook the
+MERGEABLE→NON_MERGEABLE transition to invoke the resolution sub-
+workflow with the two-parent input shape from §6.4. On success, push
+the resolution commit and let the lifecycle resume. On
+`dag-multi-parent-unresolvable`, surface to the human review path
+that already exists for other lifecycle failures.
+
+### 7.5 Plan schema
+
+- New optional `:task/merge-strategy` enum:
+  `#{:git-merge :sequential-merge}`.
+- **No** `:plan/strict-forest?` flag (dropped per §5).
+- `:task/dependencies`: vector strongly preferred for new plans
+  (ordered merge behavior matters); set still accepted, sorted
+  deterministically per §3.1.
 
 ---
 
@@ -412,12 +768,38 @@ multi-task workflows.
     budget (round-trip test of the `dag-multi-parent-unresolvable`
     anomaly).
 
+- **Round-2 / GPT-5.5 review additions** (test cases that verify the
+  Git-semantics decisions from §10.11):
+
+  | Case                                                                  | Expected result                                                            |
+  | --------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+  | Two-parent diamond                                                    | Uses `git merge -s ort`, not octopus; one merge commit with two parents.   |
+  | Three-parent fan-in with disjoint files                               | Uses `git merge -s octopus`; one merge commit with three parents.          |
+  | Parent order replay                                                   | Same ordered SHA list across repeated runs of the same plan.               |
+  | Branch name moves after resolution but before merge                   | Merge still uses captured `:sha` snapshot.                                 |
+  | Duplicate parent tips (same SHA via different declarations)           | Collapses to single-parent fast path; emits `:dag/multi-parent-no-op`.     |
+  | Parent A is ancestor of B, A first in dependency vector               | Collapses A into B deterministically; first-parent rule applies post-collapse; no contradiction. |
+  | Unrelated histories                                                   | `:anomalies/dag-multi-parent-unrelated-histories`; no `--allow-unrelated-histories` invoked. |
+  | GPG signing configured in user config                                 | `--no-gpg-sign` prevents signing; merge succeeds with unsigned commit.     |
+  | Pre-commit hook configured to fail                                    | `--no-verify` skips the hook; merge succeeds (orchestrator runs verify downstream). |
+  | Existing namespaced ref with same input-key                           | Idempotently reuses the existing merge commit instead of creating a new one. |
+  | Existing namespaced ref with same task-id but different parent SHAs   | Different `:merge/input-key` ⇒ different ref ⇒ no collision.               |
+  | Octopus refuses on conflict                                           | Triggers resolution sub-workflow with conflict info, NOT a hard failure to a human. |
+  | Resolution sub-workflow recurring-conflict (curator)                  | Terminates early with `:resolution/reason :curator/recurring-conflict` instead of burning full budget. |
+  | Resolution sub-workflow markers-not-resolved (curator)                | Iteration fails and re-prompts; persistent recurrence escalates to terminal anomaly. |
+  | Out-of-band parent fast-forward push (snapshot still reachable)       | `:dag/multi-parent-parent-tip-advanced` log; merge proceeds with snapshot SHA. |
+  | Out-of-band parent force-push (snapshot unreachable)                  | `:anomalies/dag-multi-parent-parent-rewritten`; no auto-retry.             |
+  | PR-lifecycle MERGEABLE→NON_MERGEABLE with marker-only diff            | Verify gate short-circuits on GitHub's MERGEABLE confirmation per §6.1.1.  |
+  | PR-lifecycle MERGEABLE→NON_MERGEABLE with substantive diff            | Verify gate runs full project test pipeline.                               |
+
 ---
 
-## 10. Iteration Round 1 — Resolved Decisions
+## 10. Resolved Decisions (audit trail)
 
-The five §10 questions in v0.1 are all settled in v0.2. Captured here
-for the audit trail; the design above already reflects the answers.
+§10.1–§10.5 are round-1 outcomes (settled in v0.2). §10.6–§10.10 are
+round-2 outcomes (settled in v0.3 from the user's answers + the
+GPT-5.5 technical review). The design sections above already reflect
+all answers; this section preserves the reasoning trail.
 
 ### 10.1 Merged base lives on an ephemeral branch
 
@@ -472,49 +854,180 @@ for the audit trail; the design above already reflects the answers.
   genuinely need linear history author plans as forests; no runtime
   mode duplicates the constraint.
 
+### 10.6 Resolution budget — "prevent exhaustion from stagnation"
+
+- **User direction:** "We need a default, but I really want that to be
+  set from 'prevent exhaustion'. Most token exhaustion is caused by
+  repetitive loops that have no progress. Work that gets done is not
+  something we want to reduce using a hammer. We want to have telemetry
+  that allows us accounting to extract places to optimize (performance
+  monitoring)."
+- **Decision:** budget shape is `{:max-iterations N :stagnation-cap M}`,
+  not a token cap. The `:stagnation-cap` is the actionable lever — it
+  ends loops that aren't making progress, which is where waste actually
+  comes from. `:max-iterations` is a backstop. Tokens are tracked as
+  telemetry for performance optimization, NOT used to terminate work
+  that's still progressing.
+- **Defaults to start at:** `{:max-iterations 5 :stagnation-cap 2}` —
+  five iterations is enough headroom for genuine resolution work; two
+  consecutive stagnant iterations (caught by §6.1.2 curator's
+  `:curator/recurring-conflict`) is the early-out for stuck loops.
+  Numbers re-tunable based on dogfood telemetry.
+- **Telemetry:** every resolution iteration emits
+  `:resolution/iteration-completed` with iteration index, conflict-
+  set delta from prior iteration, tokens consumed, wall-clock. The
+  dashboard reads these to surface "merges that needed N iterations"
+  / "merges that hit stagnation" — that's the optimization signal,
+  not the limit.
+
+### 10.7 Verify gate runs the standard pipeline
+
+- **User direction:** "That depends on the policy. For miniforge local,
+  we have pre-commit that will run those and other hard gates. If the
+  PR monitor loop makes changes re: comment it moves through
+  verification. If we are doing merge, then [...]." (Sentence trails
+  off; the rule the user sketched is consistent: verification follows
+  the same policy the parent task's verify phase uses.)
+- **Decision:** the resolution sub-workflow's verify gate runs the same
+  pipeline as the parent task — project tests + policy-enforced hard
+  gates (in miniforge-local, the pre-commit chain). For §6.4 PR-
+  lifecycle resolution the verify gate can short-circuit on GitHub-
+  reports-MERGEABLE if the resolution diff is purely conflict-marker
+  deletions; any substantive change reaches the full pipeline.
+- **Documented in §6.1.1** as the verify-gate-policy rule.
+
+### 10.8 Curator detects recurring / failed merges
+
+- **User direction:** "We should be able to detect that merge conflicts
+  have recurred, but a failed merge should fail. If that needs a
+  curator we should add one, it is a failure point. Agent might give up
+  on a rebase or merge strategy or exhaust budgets."
+- **Decision:** add a merge-resolution curator with two checks
+  (`:curator/markers-not-resolved` and `:curator/recurring-conflict`)
+  per §6.1.2. The recurring-conflict check is the "detect that merge
+  conflicts have recurred" lever the user named — when iteration N's
+  conflict set matches iteration N-1's, the curator escalates rather
+  than letting the agent burn the rest of the budget. A failed merge
+  surfaces as the §6.1 terminal anomaly with a `:resolution/reason`
+  that names which curator condition triggered.
+
+### 10.9 Hierarchical event tagging (§3.3)
+
+- **User direction:** "Namespaced event tags, with `<parent>.<sub>.<task>`
+  type taxonomy. Not exactly that likely, but something similar. That
+  or use analog of the twitter snowflake algo where the spec is the
+  'data center', parents the server, etc. Would produce sortable
+  dependency ordering on tags."
+- **Decision:** events carry an `:event/path` of
+  `[<run-id> <plan-id> <task-id> <resolution-id-or-nil>]` per §3.3.
+  Snowflake-style ordered IDs are an acceptable implementation
+  technique; the contract is the dashboard-sortable hierarchical key,
+  not a specific encoding.
+
+### 10.10 Out-of-band parent tip changes — refresh or anomaly per consequence (§6.6)
+
+- **User direction:** "If it leaves us in a non deterministic state, or
+  in violation of policy, would be an anomaly. If it is simple to
+  handle the detect and refresh."
+- **Decision:** §6.6 implements exactly that split. Snapshotted SHA
+  still reachable (parent did a normal advance) → log and proceed
+  with the snapshotted SHA. Snapshotted SHA unreachable (parent was
+  rewritten) → typed anomaly, surface to a human. The orchestrator
+  does not silently re-snapshot; that would let upstream drift quietly
+  mutate the merge inputs, which is the same class of footgun v0 had.
+
+### 10.11 GPT-5.5 review — Git semantics tightening
+
+- **Source:** technical review of v0.2 catching real Git issues.
+- **Decisions** (all reflected in v0.3 above):
+  - **Strategy rename `:octopus` → `:git-merge`** — git uses `ort` for
+    two-head merge and `octopus` only for 3+. Calling the user-facing
+    default "octopus" was misleading for the most common (two-parent)
+    case. The internal sub-mode is selected by parent count.
+  - **`:sequential-cherry-pick` removed**, `:sequential-merge` added —
+    cherry-pick over parent branches that contain merge commits is
+    unsafe without `--mainline` plumbing and silently drops merge-
+    resolution edits. Sequential merge preserves history correctly.
+  - **Determinism reframed** — same effective merge result (tree +
+    parent ordering) modulo Git version/config. SHA-equality across
+    runs is not promised; it would require pinning author, committer,
+    timestamps, message bytes, signing config, and hooks. Pinned what
+    we CAN pin: `--no-edit --no-gpg-sign --no-verify --no-ff -m
+    <generated>`.
+  - **Parents resolved to SHAs at resolution time** — branch names are
+    mutable; SHAs are not. Registry shape carries `:sha`, `:order`,
+    and `:merge/input-key` (idempotency hash).
+  - **Parent collapse precedence pinned** — collapse duplicates and
+    ancestors first, preserve plan order on remaining tips, then
+    assign first-parent. Resolves the §3.1 / §6.2 contradiction in
+    v0.2.
+  - **§6.3 renamed** "empty parent intersection" → "duplicate /
+    identical parent tips". The prior name suggested unrelated
+    histories, which is a different (and dangerous) condition.
+  - **§6.5 added — unrelated histories anomaly.** Git refuses these
+    by default; v2 does NOT use `--allow-unrelated-histories`.
+  - **§6.1 conflict shape adjusted** — conflict entries carry
+    `:parent-candidates` and `:attribution`, not "exact pair";
+    octopus output doesn't always give us a guaranteed minimal
+    pair. Added `:git/exit-code` and `:git/stderr` for raw
+    diagnostics.
+  - **Namespaced ref name** —
+    `refs/miniforge/dag-base/<run-id>/<task-id>/<input-key>`.
+    Replays of the same effective input reuse the same ref instead
+    of accumulating new ones.
+
 ---
 
-## 11. Open Questions for Iteration Round 2
+## 11. Open Questions for Iteration Round 3
 
-These surfaced during the round-1 design pass and weren't pre-existing
-in v0.1.
+Round 1's five questions and Round 2's five questions are all settled
+(§10.1–§10.10) plus the GPT-5.5 review issues (§10.11). These are the
+remaining design questions surfaced during the v0.3 pass:
 
-1. **Resolution sub-workflow budget shape.** Iteration count? Token
-   budget? Wall-clock? Lean iteration-bounded with a token cap, since
-   that's how the rest of the implementer/verify loops are gated.
-   Default budget needs picking. Lean small (e.g., 3 iterations) since
-   merge-conflict resolution is a focused task — if the agent can't
-   converge in a few rounds the conflict probably needs human eyes.
+1. **Curator integration shape.** The §6.1.2 curator wraps the
+   resolution agent's iteration loop. Is it a new component (a
+   sibling to `phase-software-factory`'s implementer curator) or an
+   extension of the existing curator multimethod? Lean extension —
+   the merge-resolution checks (`:curator/markers-not-resolved`,
+   `:curator/recurring-conflict`) compose naturally with the existing
+   `:curator/no-files-written` check. Default-on for the resolution
+   sub-workflow only; off for the regular implement loop where it
+   would be noise.
 
-2. **Resolution sub-workflow's verify gate.** Project-test-suite seems
-   right for the §6.1 pre-task path (the merge has to compile/test
-   before the dependent task runs). For the §6.4 PR-lifecycle path,
-   project tests are also right but slower than just "does git think
-   it's mergeable now?" Should §6.4 short-circuit on
-   GitHub-says-MERGEABLE before running tests, and only run tests
-   if there's a substantive content change?
+2. **Resolution agent prompt scaffolding.** The agent gets the
+   conflict info, the parent SHAs, the strategy. What prompt-template
+   gives the best resolution rate? Open question for the
+   implementation phase — start with a literal "here are the
+   conflicts, resolve them and explain the resolution" prompt, tune
+   based on iteration-count telemetry from §10.6.
 
-3. **Curator role for the resolution agent.** Current implement-phase
-   curators check that files were actually written by the agent (the
-   `:curator/no-files-written` failure mode). Does the resolution agent
-   need a specialized curator that also checks the merge-conflict
-   markers were resolved? Lean yes; otherwise budget exhaustion can
-   happen with markers still in the tree.
+3. **Concurrent resolution sub-workflows.** Two sibling tasks at the
+   same stratum could both hit conflicts and trigger resolution
+   sub-workflows simultaneously. Each gets its own ephemeral worktree
+   (different paths) and its own resolution agent (different sub-
+   workflow ids), so they don't fight. But they may compete for LLM
+   rate-limit budget. Worth a max-concurrent cap on the resolution
+   pool? Defer to dogfood telemetry.
 
-4. **Per-task-id telemetry for the resolution path.** The
-   per-task-base-chaining v1 events already carry `:task/id`; the
-   resolution sub-workflow's events should be tagged with both the
-   parent task-id (the multi-parent task whose merge needed resolving)
-   and a sub-workflow id, so the dashboard can show "this task needed
-   merge resolution for N iterations" without conflating it with the
-   parent task's own implement work.
+4. **Resolution success — should we also push the resolution to a
+   persistent ref?** §7.2's namespaced ref already lives at
+   `refs/miniforge/dag-base/<run-id>/<task-id>/<input-key>`, which is
+   per-run. If a future replay of the same run hits the same input-
+   key, it reuses. But cross-run replay (e.g., re-running an entire
+   workflow from scratch with the same plan) gets a different
+   `<run-id>` and re-resolves from scratch. Acceptable for v2 (the
+   resolution work isn't free but isn't catastrophic), but worth
+   considering whether the input-key alone (without `<run-id>`) is a
+   better cache key.
 
-5. **Out-of-band conflicts on the persisted branch.** If a parent task
-   force-pushes to its persisted branch between batch completion and
-   the merge attempt (rare in normal flow, possible during retries),
-   the merge sees a different tip than the registry recorded. Detect
-   and refresh, or fail with a fresh anomaly? Lean detect-and-refresh
-   with a log; matches the no-HIL-by-default principle from §10.3.
+5. **Resolution-sub-workflow telemetry attribution to the parent
+   task's cost report.** The parent task's metrics include implement
+   tokens, verify wall-clock, etc. Resolution-sub-workflow tokens
+   should roll up into the parent task's totals (the merge IS work
+   the parent task incurred), but ALSO be visible separately so the
+   dashboard can answer "where is the cost coming from in this run?"
+   Likely a `:cost/breakdown {:task/implement N :task/verify M
+   :task/merge-resolution K}` shape. Worth specifying explicitly?
 
 ---
 
@@ -539,27 +1052,37 @@ The dogfood proved per-task base chaining v1 works: zero token waste,
 the gate fires before any task runs. It also proved the v1 forest
 restriction blocks every non-trivial spec, because real plans fan in.
 
-v2 closes that gap by performing a deterministic octopus merge of
-multi-parent task bases at orchestration time. When the merge
-conflicts, an automated resolution sub-workflow takes the parents and
-the conflicts as input and produces a clean merge commit; only when
-the sub-workflow itself exhausts its budget does anything surface to
-a human. The same sub-workflow handles mid-PR-lifecycle
-MERGEABLE→NON_MERGEABLE transitions, so the release flow is closed
-end-to-end without HIL touch points in the common case.
+v2 closes that gap by performing a deterministic git merge of
+multi-parent task bases at orchestration time — `ort` for the common
+two-parent fan-in, `octopus` for 3+ parents, `:sequential-merge` as
+an alternate per-task strategy. When the merge conflicts, an
+automated resolution sub-workflow takes the parents and conflicts as
+input and produces a clean merge commit, gated by a merge-resolution
+curator that detects stagnant loops; only when the sub-workflow
+itself exhausts its budget does anything surface to a human. The
+same sub-workflow handles mid-PR-lifecycle MERGEABLE→NON_MERGEABLE
+transitions, so the release flow is closed end-to-end without HIL
+touch points in the common case.
 
 The work this spec covers, roughly:
 
 1. Extend the plan schema with `:task/merge-strategy`
-   (`#{:octopus :sequential-cherry-pick}`).
-2. Replace `resolve-base-branch`'s multi-parent anomaly with the new
-   `resolve-multi-parent-base` data shape; drop the v1 forest gate.
-3. Implement `merge-parent-branches!` in the orchestrator (octopus +
-   sequential-cherry-pick + criss-cross fallback to recursive).
-4. Build the merge-conflict resolution sub-workflow (§6.1 contract).
+   (`#{:git-merge :sequential-merge}`).
+2. Replace `resolve-base-branch`'s multi-parent anomaly with
+   `resolve-multi-parent-base` returning SHA-pinned parent tips +
+   collapse normalization + `:merge/input-key` per §3.2; drop the
+   v1 forest gate.
+3. Implement `merge-parent-branches!` in the orchestrator per §7.2
+   (clean temp worktree, namespaced ref naming, pinned merge flags
+   from §3.1, criss-cross fallback to chained recursive).
+4. Build the merge-conflict resolution sub-workflow (§6.1 contract)
+   with the §6.1.2 curator wired in (both `:curator/markers-not-resolved`
+   and `:curator/recurring-conflict` checks).
 5. Wire `task-sub-opts` to call `merge-parent-branches!` for
    multi-parent tasks.
 6. Hook `pr-lifecycle`'s monitor loop on MERGEABLE→NON_MERGEABLE to
    invoke the resolution sub-workflow per §6.4.
-7. Tests + a re-run of the 2026-05-03 dogfood (against the same
-   `I-CLASSIFICATION-RUNTIME.md` plan) to prove the gap closes.
+7. Hierarchical event tagging per §3.3 across all v2 events.
+8. Tests (§9 plus the GPT-5.5 review additions) + a re-run of the
+   2026-05-03 dogfood against `I-CLASSIFICATION-RUNTIME.md` to
+   prove the gap closes.

--- a/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
+++ b/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
@@ -6,9 +6,22 @@
 
 # I-DAG-MULTI-PARENT-MERGE — Multi-Parent DAG Merge Strategy (v2 of Per-Task Base Chaining)
 
-**Status:** Informative — design draft, awaiting iteration before implementation.
+**Status:** Informative — iteration round 1 complete; ready for implementation.
 **Date:** 2026-05-03
-**Version:** 0.1.0
+**Version:** 0.2.0
+
+**Changelog:**
+
+- **0.2.0** — Iteration round 1: settled all five §10 open questions.
+  Branches now ephemeral (Q1). Cherry-pick order pinned to plan
+  declaration (Q2). Criss-cross histories silently fall back to
+  recursive merges (Q3). **Conflict-resolution agent loop pulled
+  in-scope** (Q4) — both pre-task octopus failures and mid-PR-
+  lifecycle MERGEABLE→NON_MERGEABLE transitions trigger an automated
+  resolution sub-workflow rather than failing to a human.
+  **Strict-forest opt-out flag dropped entirely** (Q5) — v2's
+  always-on conflict handling makes plan-time fail-loud unnecessary.
+- **0.1.0** — Initial draft.
 
 Specifies how a DAG task with multiple completed parents acquires a base for its
 scratch worktree. Closes the gap left open by per-task base chaining v1
@@ -59,15 +72,23 @@ too strict for real workloads. **Real specs naturally produce fan-in.**
 > orchestrator at the boundary where v1 currently aborts; the sub-workflow
 > sees a single ref like any single-parent task does.
 
-Three properties this preserves:
+Four properties this preserves:
 
 1. **Each task still has one base branch from its sub-workflow's
    perspective.** No protocol change to `acquire-environment!` /
    `task-sub-opts` / the scratch-worktree contract.
 2. **The merge happens once, at orchestration time.** Sub-agents never see
    half-merged state.
-3. **Failure is loud.** Conflicts surface as a typed anomaly with the
-   conflicting parents and paths, not silent overwrites.
+3. **Conflicts are resolved automatically, not punted to humans.** Both
+   pre-task octopus failures and mid-PR-lifecycle
+   MERGEABLE→NON_MERGEABLE transitions trigger a resolution sub-workflow
+   (§6.1) rather than blocking on a human. HIL is a fallback for the
+   resolution sub-workflow itself failing, not the default path. Each
+   incidental HIL ask makes miniforge less useful.
+4. **Failure is loud when it does occur.** When the resolution sub-
+   workflow can't produce a clean merge, the result surfaces as a typed
+   anomaly with the conflicting parents and paths — never as a silent
+   overwrite.
 
 ### 3.1 Determinism
 
@@ -131,6 +152,10 @@ git cherry-pick $(git merge-base parent-A parent-B)..parent-B
 git cherry-pick $(git merge-base parent-A parent-C)..parent-C
 ```
 
+Parents are applied in **plan-declaration order** (same source as octopus
+parent ordering — see §3.1). Deterministic, author-controlled, and
+matches what an author would write if they listed deps in priority order.
+
 **Pros:**
 
 - Linear history.
@@ -180,43 +205,80 @@ Plan emits `:task/merge-strategy` per multi-parent task; default to one of
 **Default to 4.1 octopus merge. Allow per-task override via 4.4
 `:task/merge-strategy`.** Concretely:
 
-| Strategy keyword               | Behavior                                             |
-| ------------------------------ | ---------------------------------------------------- |
-| `:octopus` (default)           | §4.1; fall back to anomaly on conflict (§6).         |
-| `:sequential-cherry-pick`      | §4.2; same fallback.                                 |
-| `:fail-on-multi-parent`        | Today's v1 behavior — emits the canonical            |
-|                                | `:anomalies/dag-non-forest` anomaly. Useful for      |
-|                                | plans that **must** be forests (e.g. release         |
-|                                | trains).                                             |
+| Strategy keyword          | Behavior                                          |
+| ------------------------- | ------------------------------------------------- |
+| `:octopus` (default)      | §4.1; on conflict, spawn resolution sub-          |
+|                           | workflow per §6.1 — does NOT fail to a human.     |
+| `:sequential-cherry-pick` | §4.2; same conflict path.                         |
 
-`:last-parent-wins` is intentionally not exposed.
+`:last-parent-wins` is intentionally not exposed (would reproduce the
+v0 silent-overwrite class).
+
+**No `:fail-on-multi-parent` mode.** The v0.1 draft proposed a
+`:plan/strict-forest?` opt-in that emitted the v1
+`:anomalies/dag-non-forest` anomaly. The iteration round dropped it:
+v2's always-on automated conflict resolution makes plan-time fail-loud
+unnecessary, and it muddied the contract — every additional knob is a
+foot-gun. If a workflow truly needs linear history (formal-verification
+batches, regulatory pipelines), the right answer is to author plans
+that are forests by construction, not to add a runtime mode that turns
+the orchestrator back into v1.
 
 ---
 
-## 6. Failure Modes and Edge Cases
+## 6. Conflict Handling and Edge Cases
 
-Multi-parent merges have one **failure mode** that the orchestrator must
-surface as a typed anomaly (§6.1, the only state where the merge cannot
-complete) and two **degenerate edge cases** where the merge succeeds
-trivially but the topology is informational and worth logging
-(§6.2/§6.3). The two are deliberately separated: anomalies stop work,
-edge-case logs do not.
+Multi-parent merges have one **conflict path** that triggers an automated
+resolution sub-workflow (§6.1) and two **degenerate edge cases** where
+the merge succeeds trivially but the topology is informational and worth
+logging (§6.2/§6.3). The two are deliberately separated: §6.1 invokes
+real work, edge-case logs do not.
 
-### 6.1 Merge conflict (anomaly)
+A second conflict surface — mid-PR-lifecycle MERGEABLE→NON_MERGEABLE
+transitions — is handled by the same resolution path; see §6.4.
+
+### 6.1 Merge conflict — automated resolution
+
+When octopus (or `:sequential-cherry-pick`) hits a conflict, the
+orchestrator does NOT auto-pick `-X ours` / `-X theirs` (would reproduce
+v0 silent overwrites) and does NOT fail to a human. It spawns a
+**resolution sub-workflow** seeded with:
 
 ```clojure
-{:anomaly/category :anomalies/dag-multi-parent-conflict
- :anomaly/message  "Octopus merge of N parents conflicted on M paths"
+{:resolution/parents    [{:task/id ... :branch ...} ...]
+ :resolution/conflicts  [{:path ... :parents [...]} ...]
+ :resolution/strategy   :octopus  ; or :sequential-cherry-pick
+ :resolution/parent-task :task/id ; the multi-parent task this is for
+ :resolution/budget     <iterations | tokens>}
+```
+
+The resolution sub-workflow's contract:
+
+- **Goal:** produce a merge commit that resolves all conflicts and
+  passes the task's verify gates.
+- **Pipeline:** `implement` (agent edits the conflicted files) →
+  `verify` (project tests) → terminate when verify passes or budget
+  exhausts.
+- **Output (success):** a ref name on the task's persisted branch, with
+  the merge commit at the tip. The orchestrator continues the original
+  task using this ref as `:branch`.
+- **Output (failure, budget exhausted or verify never passes):** the
+  terminal anomaly below — only path that surfaces to a human.
+
+```clojure
+{:anomaly/category :anomalies/dag-multi-parent-unresolvable
+ :anomaly/message  "Octopus merge conflict could not be auto-resolved within budget"
  :task/id          ...
  :merge/parents    [{:task/id ... :branch ...} ...]
  :merge/conflicts  [{:path ... :parents [...]} ...]
- :merge/strategy   :octopus}
+ :merge/strategy   :octopus
+ :resolution/last-attempt-ref ...
+ :resolution/reason :budget-exhausted | :verify-never-passed}
 ```
 
-The orchestrator MUST NOT auto-resolve. Auto-resolution (e.g.
-`-X ours` / `-X theirs`) chooses arbitrarily and reproduces the v0 silent-
-overwrite class. Surface the conflict, fail the task, let a human or a
-follow-up agent decide.
+The unresolvable anomaly carries the last-attempt ref so an operator
+inspecting the dashboard can see exactly what state the resolution
+agent left the merge in.
 
 ### 6.2 Ancestor parent (informational, not an anomaly)
 
@@ -236,11 +298,43 @@ base), proceed as if single-parent against any of them. Emit a
 `:dag/multi-parent-no-op` log entry. **No anomaly** — the merge
 succeeded.
 
+### 6.4 Mid-PR-lifecycle conflict (NON_MERGEABLE)
+
+A PR that was MERGEABLE when opened can drift to NON_MERGEABLE when
+something else lands on the base branch first. The release-flow PR
+lifecycle today is:
+
+```text
+open PR
+  → respond to comments (fix, push, resolve)
+  → wait for comments to settle
+  → ensure GitHub merge-state is MERGEABLE
+  → merge
+```
+
+A NON_MERGEABLE state at the "ensure mergeable" gate is the same
+problem class as §6.1: a multi-parent fan-in (the PR's branch + main's
+new state) with conflicts. v2 reuses the §6.1 resolution sub-workflow
+verbatim — same input shape, same agent contract, same terminal
+anomaly. The only differences:
+
+- **Trigger:** PR-lifecycle monitor detects the MERGEABLE→NON_MERGEABLE
+  transition rather than an octopus-merge fault.
+- **Parent set:** `[{:branch <pr-branch>} {:branch <pr-base>}]` —
+  always two-parent, never N-parent.
+- **Output success:** push the resolution commit onto the PR branch;
+  let GitHub re-evaluate mergeability; resume the lifecycle.
+
+Sharing the resolution sub-workflow across the two surfaces is the
+whole point: one merge-conflict-resolution agent, two trigger sites.
+Without this, miniforge would have a hole in the release flow large
+enough to make every multi-day workflow fragile.
+
 ---
 
 ## 7. Integration Points (where it lands in the code)
 
-All on the dag-executor / dag-orchestrator stack from PR #755:
+Five surfaces touch:
 
 - **`branch-registry`** (`components/dag-executor/src/.../branch_registry.clj`):
   - Replace `resolve-base-branch`'s multi-parent anomaly path with a
@@ -252,20 +346,35 @@ All on the dag-executor / dag-orchestrator stack from PR #755:
     `forest?` as informational helpers for plan-quality reporting.
 
 - **`dag-orchestrator`** (`components/workflow/src/.../dag_orchestrator.clj`):
-  - New helper `merge-parent-branches!` that performs the chosen strategy
-    in a temporary worktree, returns either a freshly-created
-    `task-N-base` branch ref or one of the §6 anomalies.
+  - New helper `merge-parent-branches!` that performs the chosen
+    strategy in an **ephemeral** worktree (see §11), returns either the
+    new merge-commit ref OR triggers the resolution sub-workflow per
+    §6.1 on conflict.
   - `task-sub-opts` calls it for multi-parent tasks; `:branch` becomes
-    the merged ref's name. Single-parent tasks keep their current path
+    the merge-commit ref. Single-parent tasks keep their current path
     unchanged.
-  - `execute-plan-as-dag` no longer rejects non-forest plans by default.
-    It rejects when the plan opts in via
-    `:plan/strict-forest? true`, preserving today's behavior for callers
-    that need it (release trains, formal-verification batches).
+  - `execute-plan-as-dag` no longer rejects non-forest plans. v1's
+    forest validator is dropped from the gate path; `validate-forest`
+    survives as an informational helper.
+
+- **Resolution sub-workflow** (new — likely a workflow definition under
+  `components/workflow/src/.../merge_resolution.clj` or a specialized
+  invocation of the standard implement/verify pipeline with a curated
+  agent prompt). Inputs and outputs per §6.1. Reused by both the
+  pre-task path (§6.1 trigger) and the PR-lifecycle path (§6.4 trigger).
+
+- **`pr-lifecycle`** (`components/pr-lifecycle/src/...`):
+  - The PR monitor loop already detects state transitions. Hook the
+    MERGEABLE→NON_MERGEABLE transition to invoke the resolution
+    sub-workflow with the two-parent input shape from §6.4. On success,
+    push the resolution commit and let the lifecycle resume. On
+    `dag-multi-parent-unresolvable`, surface to the human review path
+    that already exists for other lifecycle failures.
 
 - **Plan schema:**
-  - New optional `:task/merge-strategy` enum.
-  - New optional plan-level `:plan/strict-forest?` boolean.
+  - New optional `:task/merge-strategy` enum
+    (`#{:octopus :sequential-cherry-pick}`).
+  - **No** `:plan/strict-forest?` flag (dropped per §5).
 
 ---
 
@@ -286,72 +395,171 @@ multi-task workflows.
 ## 9. Migration / Rollback
 
 - **No data migration.** Plans authored under v1 are forests by
-  construction (the validator rejected anything else); they keep working.
-- **Rollback path:** set `:plan/strict-forest? true` at plan time, or
-  default the strategy to `:fail-on-multi-parent` via config. Either
-  reverts the orchestrator to v1 behavior.
+  construction (the validator rejected anything else); they keep working
+  unchanged in v2.
+- **No rollback flag.** v0.1 proposed a `:plan/strict-forest?` opt-in
+  preserving v1 behavior; iteration round 1 dropped it (§5). If a
+  workflow truly needs forest-only, it should be authored as a forest;
+  no runtime mode duplicates the constraint.
 - **Test additions:**
   - Unit: `merge-parent-branches!` happy path / each anomaly shape /
-    each strategy.
+    each strategy / criss-cross fallback path (§10.3).
   - Integration: 4-task diamond plan running end-to-end through the
     orchestrator with mocked parent branches on a real test git repo.
+  - Integration: induced merge conflict that the resolution sub-workflow
+    succeeds on (round-trip test of §6.1 happy path).
+  - Integration: induced merge conflict that exhausts the resolution
+    budget (round-trip test of the `dag-multi-parent-unresolvable`
+    anomaly).
 
 ---
 
-## 10. Open Questions
+## 10. Iteration Round 1 — Resolved Decisions
 
-1. **Should the merged base be persisted as a permanent branch, or only
-   exist for the lifetime of the task's worktree?** Permanent makes resume
-   easier; ephemeral keeps the branch namespace clean. Lean ephemeral; the
-   commit is reachable from the task's persisted branch via parentage.
+The five §10 questions in v0.1 are all settled in v0.2. Captured here
+for the audit trail; the design above already reflects the answers.
 
-2. **For `:sequential-cherry-pick`, what order do we apply parents?**
-   Probably plan-declaration order (deterministic, author-controlled).
-   Need to specify.
+### 10.1 Merged base lives on an ephemeral branch
 
-3. **Octopus refuses on criss-cross histories.** Do we silently fall back
-   to recursive (two-parent merges chained), or surface the topology and
-   ask the user? Lean fall-back-with-log; criss-cross is rare on
-   well-decomposed work but real.
+- **Decision:** ephemeral.
+- **Rationale:** the merge commit is reachable from the task's persisted
+  branch via parentage — that's the contract the task makes when it
+  pushes its branch with the merge as part of its history. On resume,
+  the commit's parents (and its tree) are recoverable from the persisted
+  branch alone; no separate ref is needed for checkpointing.
+- **Implication for `merge-parent-branches!`:** create the merge commit
+  in a temporary worktree on a temp ref, hand the commit-sha to the
+  caller, then drop the temp ref. The branch namespace stays clean.
+- **Mitigation if a future replay path needs the ref:** if we later
+  discover that some replay or audit flow can't navigate to the merge
+  commit purely via parentage, we add a deterministic `merges/<task-id>`
+  ref written at the same time as the persisted branch. That's a
+  schema-additive change; not a redesign.
 
-4. **Conflict-resolution agent loop?** Future-future: when octopus fails,
-   spawn a sub-workflow whose only job is to land a merge commit
-   resolving the conflict, then re-attempt. Out of scope for v2 but the
-   anomaly shape in §6.1 should leave room for it.
+### 10.2 Cherry-pick order = plan declaration order
 
-5. **What's the right metric for "this is a strict release train, fail
-   on multi-parent"?** A workflow-level config, a per-plan flag, both?
-   Lean per-plan flag; release-train workflows can default-set it.
+- **Decision:** plan-declaration order, same source as octopus parent
+  ordering (§3.1). Deterministic, author-controlled.
+
+### 10.3 Criss-cross histories: silent fallback to recursive merges
+
+- **Decision:** when octopus refuses on a criss-cross topology, the
+  orchestrator silently chains two-parent recursive merges in
+  declaration order (`merge p0 + p1 → tmp`, `merge tmp + p2 → tmp`, …)
+  and emits a `:dag/multi-parent-recursive-fallback` log entry naming
+  the criss-cross detection signal. **No HIL ask.** Each incidental HIL
+  ask is a tax on miniforge's usefulness; criss-cross is rare on
+  well-decomposed plans, and the fallback is well-defined.
+
+### 10.4 Conflict-resolution agent loop is in-scope
+
+- **Decision:** in-scope for v2, not future-future. v0.1 proposed
+  surfacing conflicts as a terminal anomaly to a human; the user
+  pointed out that this would let HIL drive everyday merge-conflict
+  resolution, eroding miniforge's autonomy guarantee. The redesign
+  (§6.1) makes the conflict path automated: spawn a resolution
+  sub-workflow, only surface to a human when the sub-workflow itself
+  exhausts its budget.
+- **Reuse:** the same resolution sub-workflow handles the §6.4
+  PR-lifecycle MERGEABLE→NON_MERGEABLE case. One agent, two trigger
+  sites.
+
+### 10.5 No strict-forest flag
+
+- **Decision:** dropped entirely (§5). Per the user, "not sure why we
+  would want this" — and they're right. v2's automated conflict
+  resolution makes plan-time fail-loud unnecessary. Workflows that
+  genuinely need linear history author plans as forests; no runtime
+  mode duplicates the constraint.
 
 ---
 
-## 11. Out of Scope
+## 11. Open Questions for Iteration Round 2
 
-- Conflict-resolution agent loops (see §10.4).
-- Cross-repo / multi-repo DAGs (orthogonal; covered by repo-dag).
-- Plan-time DAG simplification (e.g., auto-linearizing fan-in into chains
-  when the parents are commutative). Could be a v3 optimization.
-- N-way diff visualization / merge-conflict UI on the dashboard.
+These surfaced during the round-1 design pass and weren't pre-existing
+in v0.1.
+
+1. **Resolution sub-workflow budget shape.** Iteration count? Token
+   budget? Wall-clock? Lean iteration-bounded with a token cap, since
+   that's how the rest of the implementer/verify loops are gated.
+   Default budget needs picking. Lean small (e.g., 3 iterations) since
+   merge-conflict resolution is a focused task — if the agent can't
+   converge in a few rounds the conflict probably needs human eyes.
+
+2. **Resolution sub-workflow's verify gate.** Project-test-suite seems
+   right for the §6.1 pre-task path (the merge has to compile/test
+   before the dependent task runs). For the §6.4 PR-lifecycle path,
+   project tests are also right but slower than just "does git think
+   it's mergeable now?" Should §6.4 short-circuit on
+   GitHub-says-MERGEABLE before running tests, and only run tests
+   if there's a substantive content change?
+
+3. **Curator role for the resolution agent.** Current implement-phase
+   curators check that files were actually written by the agent (the
+   `:curator/no-files-written` failure mode). Does the resolution agent
+   need a specialized curator that also checks the merge-conflict
+   markers were resolved? Lean yes; otherwise budget exhaustion can
+   happen with markers still in the tree.
+
+4. **Per-task-id telemetry for the resolution path.** The
+   per-task-base-chaining v1 events already carry `:task/id`; the
+   resolution sub-workflow's events should be tagged with both the
+   parent task-id (the multi-parent task whose merge needed resolving)
+   and a sub-workflow id, so the dashboard can show "this task needed
+   merge resolution for N iterations" without conflating it with the
+   parent task's own implement work.
+
+5. **Out-of-band conflicts on the persisted branch.** If a parent task
+   force-pushes to its persisted branch between batch completion and
+   the merge attempt (rare in normal flow, possible during retries),
+   the merge sees a different tip than the registry recorded. Detect
+   and refresh, or fail with a fresh anomaly? Lean detect-and-refresh
+   with a log; matches the no-HIL-by-default principle from §10.3.
 
 ---
 
-## 12. Summary
+## 12. Out of Scope
 
-The dogfood proved per-task base chaining v1 works: zero token waste, the
-gate fires before any task runs. It also proved the v1 forest restriction
-blocks every non-trivial spec, because real plans fan in. v2 closes that
-gap by performing a deterministic octopus merge of multi-parent task bases
-at orchestration time, with a per-task override and an explicit fail-loud
-mode for callers that need v1 strictness.
+- **Cross-repo / multi-repo DAGs** — orthogonal; covered by repo-dag.
+- **Plan-time DAG simplification** — auto-linearizing fan-in into
+  chains when the parents are commutative. Could be a v3 optimization
+  once we have data on which fan-ins compose vs. conflict in practice.
+- **N-way diff visualization / merge-conflict UI on the dashboard** —
+  the resolution sub-workflow makes this less urgent (the dashboard
+  shows the resolution agent's edits naturally), but a dedicated
+  conflict view would be a nice-to-have once the substrate is in place.
+- **Conflict-resolution agent loops** were in this list in v0.1; they
+  are now in scope (§6.1 / §10.4).
 
-The work this spec covers is roughly:
+---
 
-1. Extend the plan schema with `:task/merge-strategy` and
-   `:plan/strict-forest?`.
+## 13. Summary
+
+The dogfood proved per-task base chaining v1 works: zero token waste,
+the gate fires before any task runs. It also proved the v1 forest
+restriction blocks every non-trivial spec, because real plans fan in.
+
+v2 closes that gap by performing a deterministic octopus merge of
+multi-parent task bases at orchestration time. When the merge
+conflicts, an automated resolution sub-workflow takes the parents and
+the conflicts as input and produces a clean merge commit; only when
+the sub-workflow itself exhausts its budget does anything surface to
+a human. The same sub-workflow handles mid-PR-lifecycle
+MERGEABLE→NON_MERGEABLE transitions, so the release flow is closed
+end-to-end without HIL touch points in the common case.
+
+The work this spec covers, roughly:
+
+1. Extend the plan schema with `:task/merge-strategy`
+   (`#{:octopus :sequential-cherry-pick}`).
 2. Replace `resolve-base-branch`'s multi-parent anomaly with the new
-   `resolve-multi-parent-base` data shape.
+   `resolve-multi-parent-base` data shape; drop the v1 forest gate.
 3. Implement `merge-parent-branches!` in the orchestrator (octopus +
-   sequential-cherry-pick).
-4. Wire `task-sub-opts` to call the new helper.
-5. Update `execute-plan-as-dag` to gate on `:plan/strict-forest?`.
-6. Tests + a re-run of the 2026-05-03 dogfood to prove the gap closes.
+   sequential-cherry-pick + criss-cross fallback to recursive).
+4. Build the merge-conflict resolution sub-workflow (§6.1 contract).
+5. Wire `task-sub-opts` to call `merge-parent-branches!` for
+   multi-parent tasks.
+6. Hook `pr-lifecycle`'s monitor loop on MERGEABLE→NON_MERGEABLE to
+   invoke the resolution sub-workflow per §6.4.
+7. Tests + a re-run of the 2026-05-03 dogfood (against the same
+   `I-CLASSIFICATION-RUNTIME.md` plan) to prove the gap closes.

--- a/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
+++ b/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
@@ -1,0 +1,321 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# I-DAG-MULTI-PARENT-MERGE — Multi-Parent DAG Merge Strategy (v2 of Per-Task Base Chaining)
+
+**Status:** Informative — design draft, awaiting iteration before implementation.
+**Date:** 2026-05-03
+**Version:** 0.1.0
+
+Specifies how a DAG task with multiple completed parents acquires a base for its
+scratch worktree. Closes the gap left open by per-task base chaining v1
+([PR #755](https://github.com/miniforge-ai/miniforge/pull/755) /
+[spec #732](https://github.com/miniforge-ai/miniforge/issues/732)), which
+explicitly punted multi-parent support and rejected non-forest plans at
+plan-validation time.
+
+---
+
+## 1. Purpose
+
+Allow a DAG task whose `:task/dependencies` list includes more than one entry
+to start its sub-workflow off a base that **incorporates work from every
+parent**, not just one. Without this, real specs cannot run end-to-end on
+miniforge — see §2.
+
+---
+
+## 2. Evidence — Why v1 is Too Strict
+
+**Dogfood, 2026-05-03**, against
+`specs/informative/I-CLASSIFICATION-RUNTIME.md` from a fresh main with
+per-task base chaining wired in:
+
+- The plan agent decomposed the spec into **9 tasks across 5 strata**.
+- Two tasks were legitimately multi-parent:
+  - `agent-runtime cleanup` depended on both `engine` and
+    `failure-classifier migration` — semantically correct (it needs both
+    surfaces to delegate to).
+  - `candidate domain evaluation` depended on multiple prior steps —
+    semantically correct (the "have we proven the pattern?" task fans in
+    from the migrations).
+- v1's plan-time forest validator rejected the plan with
+  `:anomalies/dag-non-forest`. **Zero tasks ran.** Total cost 0 tokens,
+  duration 5.9m (mostly the plan agent itself).
+
+The forest validator did exactly what the v1 spec promised — short-circuit
+non-forest plans early. The signal it surfaced is that the restriction is
+too strict for real workloads. **Real specs naturally produce fan-in.**
+
+---
+
+## 3. Core Design Principle
+
+> A multi-parent DAG task starts on a base that is the **deterministic merge
+> of all its parents' persisted branches**. The merge is performed by the
+> orchestrator at the boundary where v1 currently aborts; the sub-workflow
+> sees a single ref like any single-parent task does.
+
+Three properties this preserves:
+
+1. **Each task still has one base branch from its sub-workflow's
+   perspective.** No protocol change to `acquire-environment!` /
+   `task-sub-opts` / the scratch-worktree contract.
+2. **The merge happens once, at orchestration time.** Sub-agents never see
+   half-merged state.
+3. **Failure is loud.** Conflicts surface as a typed anomaly with the
+   conflicting parents and paths, not silent overwrites.
+
+---
+
+## 4. Strategy Options
+
+Four strategies were considered. The recommendation in §5 is to ship one as
+default and allow per-task override via plan annotation.
+
+### 4.1 Octopus merge (recommended default)
+
+```bash
+git checkout -b task-N-base parent-A
+git merge parent-B parent-C ...           # one commit
+```
+
+**Pros:**
+
+- Native git operation. Single merge commit reflects fan-in faithfully.
+- Conflict-detection is git's, not ours — well-understood semantics.
+- Round-trips cleanly through `git push` / GitHub.
+- Cheap when parents touch disjoint files (the common case for
+  well-decomposed work).
+
+**Cons:**
+
+- Octopus refuses on any conflict. We need a fallback path (see §6).
+- Octopus disallows criss-cross merges in some git versions; needs a
+  topology check up front.
+
+### 4.2 Sequential cherry-pick
+
+```bash
+git checkout -b task-N-base parent-A
+git cherry-pick parent-B-tip..parent-A-merge-base
+git cherry-pick parent-C-tip..parent-A-merge-base
+```
+
+**Pros:**
+
+- Linear history.
+- Per-commit conflict resolution is easier to reason about than an n-way
+  octopus when conflicts do happen.
+
+**Cons:**
+
+- Loses the fan-in shape — history reads as if the work were sequential.
+- O(commits-in-each-parent) operations per merge, slower than octopus on
+  big parent branches.
+- Cherry-pick conflicts on shared ancestors can be subtle.
+
+### 4.3 Last-parent-wins
+
+Pick the parent that completed most recently; ignore the others. Each
+non-chosen parent's work is silently dropped from the base.
+
+**Pros:**
+
+- Trivial to implement; matches current single-parent code path exactly.
+
+**Cons:**
+
+- Reproduces the v0 bug (sibling tasks not seeing upstream output) for
+  every parent except one. **Rejected.** Listed only for completeness.
+
+### 4.4 Plan-annotated strategy
+
+Plan emits `:task/merge-strategy` per multi-parent task; default to one of
+4.1 / 4.2 when absent.
+
+**Pros:**
+
+- Lets plan authors override per task when they know better than the
+  default (e.g. force cherry-pick when they expect conflicts).
+- Backwards-compatible — existing plans without the key get the default.
+
+**Cons:**
+
+- Adds a key to the plan schema. Plan agents must learn to emit it.
+
+---
+
+## 5. Recommendation
+
+**Default to 4.1 octopus merge. Allow per-task override via 4.4
+`:task/merge-strategy`.** Concretely:
+
+| Strategy keyword               | Behavior                                             |
+| ------------------------------ | ---------------------------------------------------- |
+| `:octopus` (default)           | §4.1; fall back to anomaly on conflict (§6).         |
+| `:sequential-cherry-pick`      | §4.2; same fallback.                                 |
+| `:fail-on-multi-parent`        | Today's v1 behavior — emits the dag-non-forest      |
+|                                | anomaly. Useful for plans that **must** be forests   |
+|                                | (e.g. release trains).                              |
+
+`:last-parent-wins` is intentionally not exposed.
+
+---
+
+## 6. Failure Modes
+
+Multi-parent merges have three failure shapes the orchestrator must surface
+as typed anomalies, not let escape as raw git errors:
+
+### 6.1 Merge conflict
+
+```clj
+{:anomaly/category :anomalies/dag-multi-parent-conflict
+ :anomaly/message  "Octopus merge of N parents conflicted on M paths"
+ :task/id          ...
+ :merge/parents    [{:task/id ... :branch ...} ...]
+ :merge/conflicts  [{:path ... :parents [...]} ...]
+ :merge/strategy   :octopus}
+```
+
+The orchestrator MUST NOT auto-resolve. Auto-resolution (e.g.
+`-X ours` / `-X theirs`) chooses arbitrarily and reproduces the v0 silent-
+overwrite class. Surface the conflict, fail the task, let a human or a
+follow-up agent decide.
+
+### 6.2 Ancestor parent
+
+If parent B is an ancestor of parent A (i.e., B's tip is reachable from A),
+B contributes nothing. Treat as single-parent against A; emit
+`:dag/multi-parent-ancestor-collapsed` log so the user knows the plan was
+implicitly simpler than declared.
+
+### 6.3 Empty parent intersection
+
+When parents have a merge-base but the merge is a no-op (parents are
+identical), proceed as if single-parent against any of them. No anomaly;
+log only.
+
+---
+
+## 7. Integration Points (where it lands in the code)
+
+All on the dag-executor / dag-orchestrator stack from PR #755:
+
+- **`branch-registry`** (`components/dag-executor/src/.../branch_registry.clj`):
+  - Replace `resolve-base-branch`'s multi-parent anomaly path with a
+    `resolve-multi-parent-base` that returns
+    `{:strategy ... :parents [{:task/id ... :branch ...}]}`. The actual
+    merge is the orchestrator's job; the registry only resolves
+    *which* branches to merge.
+  - Drop the v1 forest-only anomaly. Keep `validate-forest` /
+    `forest?` as informational helpers for plan-quality reporting.
+
+- **`dag-orchestrator`** (`components/workflow/src/.../dag_orchestrator.clj`):
+  - New helper `merge-parent-branches!` that performs the chosen strategy
+    in a temporary worktree, returns either a freshly-created
+    `task-N-base` branch ref or one of the §6 anomalies.
+  - `task-sub-opts` calls it for multi-parent tasks; `:branch` becomes
+    the merged ref's name. Single-parent tasks keep their current path
+    unchanged.
+  - `execute-plan-as-dag` no longer rejects non-forest plans by default.
+    It rejects when the plan opts in via
+    `:plan/strict-forest? true`, preserving today's behavior for callers
+    that need it (release trains, formal-verification batches).
+
+- **Plan schema:**
+  - New optional `:task/merge-strategy` enum.
+  - New optional plan-level `:plan/strict-forest?` boolean.
+
+---
+
+## 8. Why Not Defer to Manual Merging?
+
+A reviewer might suggest: when the orchestrator hits a multi-parent task,
+just push the parent branches and let a human merge them upstream first.
+
+This re-introduces the v0 dogfood problem one level up: the orchestrator
+stops being able to drive a real spec to completion without human
+intervention. Multi-parent fan-in is not exotic; it's the natural shape of
+"now wire these two pieces together" tasks. Automating the merge — and
+failing loudly when it can't — is the table stakes for autonomous
+multi-task workflows.
+
+---
+
+## 9. Migration / Rollback
+
+- **No data migration.** Plans authored under v1 are forests by
+  construction (the validator rejected anything else); they keep working.
+- **Rollback path:** set `:plan/strict-forest? true` at plan time, or
+  default the strategy to `:fail-on-multi-parent` via config. Either
+  reverts the orchestrator to v1 behavior.
+- **Test additions:**
+  - Unit: `merge-parent-branches!` happy path / each anomaly shape /
+    each strategy.
+  - Integration: 4-task diamond plan running end-to-end through the
+    orchestrator with mocked parent branches on a real test git repo.
+
+---
+
+## 10. Open Questions
+
+1. **Should the merged base be persisted as a permanent branch, or only
+   exist for the lifetime of the task's worktree?** Permanent makes resume
+   easier; ephemeral keeps the branch namespace clean. Lean ephemeral; the
+   commit is reachable from the task's persisted branch via parentage.
+
+2. **For `:sequential-cherry-pick`, what order do we apply parents?**
+   Probably plan-declaration order (deterministic, author-controlled).
+   Need to specify.
+
+3. **Octopus refuses on criss-cross histories.** Do we silently fall back
+   to recursive (two-parent merges chained), or surface the topology and
+   ask the user? Lean fall-back-with-log; criss-cross is rare on
+   well-decomposed work but real.
+
+4. **Conflict-resolution agent loop?** Future-future: when octopus fails,
+   spawn a sub-workflow whose only job is to land a merge commit
+   resolving the conflict, then re-attempt. Out of scope for v2 but the
+   anomaly shape in §6.1 should leave room for it.
+
+5. **What's the right metric for "this is a strict release train, fail
+   on multi-parent"?** A workflow-level config, a per-plan flag, both?
+   Lean per-plan flag; release-train workflows can default-set it.
+
+---
+
+## 11. Out of Scope
+
+- Conflict-resolution agent loops (see §10.4).
+- Cross-repo / multi-repo DAGs (orthogonal; covered by repo-dag).
+- Plan-time DAG simplification (e.g., auto-linearizing fan-in into chains
+  when the parents are commutative). Could be a v3 optimization.
+- N-way diff visualization / merge-conflict UI on the dashboard.
+
+---
+
+## 12. Summary
+
+The dogfood proved per-task base chaining v1 works: zero token waste, the
+gate fires before any task runs. It also proved the v1 forest restriction
+blocks every non-trivial spec, because real plans fan in. v2 closes that
+gap by performing a deterministic octopus merge of multi-parent task bases
+at orchestration time, with a per-task override and an explicit fail-loud
+mode for callers that need v1 strictness.
+
+The work this spec covers is roughly:
+
+1. Extend the plan schema with `:task/merge-strategy` and
+   `:plan/strict-forest?`.
+2. Replace `resolve-base-branch`'s multi-parent anomaly with the new
+   `resolve-multi-parent-base` data shape.
+3. Implement `merge-parent-branches!` in the orchestrator (octopus +
+   sequential-cherry-pick).
+4. Wire `task-sub-opts` to call the new helper.
+5. Update `execute-plan-as-dag` to gate on `:plan/strict-forest?`.
+6. Tests + a re-run of the 2026-05-03 dogfood to prove the gap closes.

--- a/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
+++ b/specs/informative/I-DAG-MULTI-PARENT-MERGE.md
@@ -69,6 +69,29 @@ Three properties this preserves:
 3. **Failure is loud.** Conflicts surface as a typed anomaly with the
    conflicting parents and paths, not silent overwrites.
 
+### 3.1 Determinism
+
+"Deterministic" means the same plan + the same parent commits always
+produces the same merge commit, including the same git parent ordering
+in that commit. The ordering source is the task's
+`:task/dependencies` vector **as authored in the plan**, not the runtime
+completion order of those parents. Concretely:
+
+- The first parent of the merge commit is `:task/dependencies[0]`'s
+  registered branch — this becomes the base (`git checkout -b ... <p0>`).
+- Subsequent parents are passed to `git merge` in
+  `:task/dependencies[1..N]` order.
+- Octopus merges are commutative for non-conflicting changes (git
+  computes the same tree regardless of the order of the second-and-after
+  parents), so the order matters only for the human-visible parent
+  sequence in the merge commit; we pin it anyway so logs and history
+  match across replays.
+- If `:task/dependencies` is a set rather than a vector at the schema
+  layer (the plan/task schema currently allows either), the orchestrator
+  sorts by `str` of the task-id before merging — same convention as
+  `task-defs->forest-shape` in the orchestrator today, which sorts deps
+  for deterministic anomaly payloads.
+
 ---
 
 ## 4. Strategy Options
@@ -101,8 +124,11 @@ git merge parent-B parent-C ...           # one commit
 
 ```bash
 git checkout -b task-N-base parent-A
-git cherry-pick parent-B-tip..parent-A-merge-base
-git cherry-pick parent-C-tip..parent-A-merge-base
+# Cherry-pick the commits unique to each non-chosen parent.
+# git's A..B selects commits reachable from B but not A, so the range
+# is (merge-base ↔ parent-tip), NOT the reverse.
+git cherry-pick $(git merge-base parent-A parent-B)..parent-B
+git cherry-pick $(git merge-base parent-A parent-C)..parent-C
 ```
 
 **Pros:**
@@ -158,22 +184,27 @@ Plan emits `:task/merge-strategy` per multi-parent task; default to one of
 | ------------------------------ | ---------------------------------------------------- |
 | `:octopus` (default)           | §4.1; fall back to anomaly on conflict (§6).         |
 | `:sequential-cherry-pick`      | §4.2; same fallback.                                 |
-| `:fail-on-multi-parent`        | Today's v1 behavior — emits the dag-non-forest      |
-|                                | anomaly. Useful for plans that **must** be forests   |
-|                                | (e.g. release trains).                              |
+| `:fail-on-multi-parent`        | Today's v1 behavior — emits the canonical            |
+|                                | `:anomalies/dag-non-forest` anomaly. Useful for      |
+|                                | plans that **must** be forests (e.g. release         |
+|                                | trains).                                             |
 
 `:last-parent-wins` is intentionally not exposed.
 
 ---
 
-## 6. Failure Modes
+## 6. Failure Modes and Edge Cases
 
-Multi-parent merges have three failure shapes the orchestrator must surface
-as typed anomalies, not let escape as raw git errors:
+Multi-parent merges have one **failure mode** that the orchestrator must
+surface as a typed anomaly (§6.1, the only state where the merge cannot
+complete) and two **degenerate edge cases** where the merge succeeds
+trivially but the topology is informational and worth logging
+(§6.2/§6.3). The two are deliberately separated: anomalies stop work,
+edge-case logs do not.
 
-### 6.1 Merge conflict
+### 6.1 Merge conflict (anomaly)
 
-```clj
+```clojure
 {:anomaly/category :anomalies/dag-multi-parent-conflict
  :anomaly/message  "Octopus merge of N parents conflicted on M paths"
  :task/id          ...
@@ -187,18 +218,23 @@ The orchestrator MUST NOT auto-resolve. Auto-resolution (e.g.
 overwrite class. Surface the conflict, fail the task, let a human or a
 follow-up agent decide.
 
-### 6.2 Ancestor parent
+### 6.2 Ancestor parent (informational, not an anomaly)
 
 If parent B is an ancestor of parent A (i.e., B's tip is reachable from A),
-B contributes nothing. Treat as single-parent against A; emit
-`:dag/multi-parent-ancestor-collapsed` log so the user knows the plan was
-implicitly simpler than declared.
+B contributes nothing — A already includes B's work. The merge is a no-op
+relative to A. Treat as single-parent against A; emit a
+`:dag/multi-parent-ancestor-collapsed` log entry naming the collapsed
+parent and the parent it collapsed into, so the operator knows the plan
+was implicitly simpler than declared. **No anomaly** — the merge
+succeeded; this case only matters for plan-quality observability.
 
-### 6.3 Empty parent intersection
+### 6.3 Empty parent intersection (informational, not an anomaly)
 
-When parents have a merge-base but the merge is a no-op (parents are
-identical), proceed as if single-parent against any of them. No anomaly;
-log only.
+When parents share a merge-base and the merge is a no-op because the
+parents are identical (no commits unique to any of them since the merge-
+base), proceed as if single-parent against any of them. Emit a
+`:dag/multi-parent-no-op` log entry. **No anomaly** — the merge
+succeeded.
 
 ---
 


### PR DESCRIPTION
## Summary

Captures the architectural design surfaced by the **2026-05-03 dogfood** of per-task base chaining v1 (PR #755). The v1 forest validator works as designed — short-circuits non-forest plans before any task runs, zero tokens burned — but the dogfood proved the forest restriction is too strict for real workloads. Real specs naturally produce multi-parent fan-in (e.g. an "agent-runtime cleanup" task legitimately depends on both an `engine` task and a `failure-classifier migration` task).

This spec specifies how a multi-parent DAG task acquires its scratch-worktree base when v2 lands: a **deterministic octopus merge of all parents' persisted branches**, with per-task override and an explicit fail-loud mode for callers that need v1 strictness (release trains).

Lands as informative spec following the I-* convention. **Iterating on the design before implementation** — happy to revise based on review.

## Highlights

- **Strategy options analyzed**: octopus / sequential-cherry-pick / last-parent-wins / plan-annotated. last-parent-wins explicitly rejected because it reproduces the v0 silent-overwrite class.
- **Recommendation**: octopus merge as default, `:task/merge-strategy` per-task override, `:plan/strict-forest?` plan-level flag preserving v1 behavior.
- **Three typed anomaly shapes** for failure modes: merge conflict, ancestor parent, empty parent intersection. Orchestrator MUST NOT auto-resolve conflicts (would reintroduce silent overwrites).
- **Concrete integration points** in `branch-registry` and `dag-orchestrator` (six numbered §7 changes), so when this lands as a work-spec the implementation footprint is already mapped.
- **Migration is data-free**; rollback path is the `:plan/strict-forest?` flag, equivalent to v1 behavior.
- **Five open questions in §10** flagged for the iteration round (persistence of merged base, cherry-pick ordering, criss-cross fallback, conflict-resolution agent loop, strict-forest scope).

## Test plan

- [x] markdownlint clean
- [x] Pre-commit chain passed
- [ ] Iteration round on design — settle the five open questions
- [ ] Convert to a work-spec (`work/<id>.spec.edn`) once design settles
- [ ] Implement per the integration points in §7
- [ ] Re-dogfood the 2026-05-03 spec (`I-CLASSIFICATION-RUNTIME.md`) end-to-end as the v2 acceptance test

🤖 Generated with [Claude Code](https://claude.com/claude-code)