### PR TITLE
fix(cli): anchor dogfood exploration to the source repo

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -86,9 +86,7 @@
    Returns the workflow result map, or nil on validation failure."
   [spec-path opts]
   (display/print-info (messages/t :run/parsing-spec {:path spec-path}))
-  (let [;; Resolve source-dir: --worktree flag > spec file's parent directory
-        source-dir (or (:worktree opts)
-                       (str (fs/parent (fs/absolutize spec-path))))
+  (let [source-dir (str (fs/parent (fs/absolutize spec-path)))
         execution-opts (cond-> {}
                          (:worktree opts) (assoc :worktree-path (:worktree opts)))
         parsed-spec (-> (spec-parser/parse-spec-file spec-path)

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -148,12 +148,18 @@
 
 (defn- normalize-path
   [path]
-  (some-> path fs/absolutize str))
+  (when path
+    (let [resolved (-> path
+                       fs/path
+                       fs/absolutize)]
+      (str (if (fs/exists? resolved)
+             (fs/canonicalize resolved)
+             (.normalize resolved))))))
 
 (defn- source-dir-under-root?
   [source-dir source-root]
-  (let [source-dir-path (some-> source-dir fs/absolutize fs/path)
-        source-root-path (some-> source-root fs/absolutize fs/path)]
+  (let [source-dir-path (some-> source-dir normalize-path fs/path)
+        source-root-path (some-> source-root normalize-path fs/path)]
     (or (nil? source-dir-path)
         (nil? source-root-path)
         (.startsWith source-dir-path source-root-path))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -140,6 +140,79 @@
         (println (display/colorize :yellow (messages/t :workflow-runner/artifact-store-warning))))
       nil)))
 
+(defn- valid-source-root?
+  [source-root]
+  (and source-root
+       (fs/exists? source-root)
+       (fs/exists? (fs/path source-root ".git"))))
+
+(defn- normalize-path
+  [path]
+  (some-> path fs/absolutize str))
+
+(defn- source-dir-under-root?
+  [source-dir source-root]
+  (let [source-dir-path (some-> source-dir fs/absolutize fs/path)
+        source-root-path (some-> source-root fs/absolutize fs/path)]
+    (or (nil? source-dir-path)
+        (nil? source-root-path)
+        (.startsWith source-dir-path source-root-path))))
+
+(defn- assert-valid-source-root!
+  [context]
+  (let [source-root (:source-root context)]
+    (when-not (valid-source-root? source-root)
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Invalid workflow source root: " source-root)
+                               {:source-root source-root
+                                :worktree-path (:worktree-path context)}))))
+
+(defn- assert-execution-worktree!
+  [context]
+  (let [expected (normalize-path (get-in context [:execution/opts :worktree-path]))
+        actual (normalize-path (:worktree-path context))]
+    (when (and expected actual (not= expected actual))
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Execution worktree mismatch: expected "
+                                    expected " but runtime is using " actual)
+                               {:expected-worktree expected
+                                :actual-worktree actual
+                                :source-root (:source-root context)}))))
+
+(defn- assert-source-dir-alignment!
+  [spec context]
+  (let [source-dir (:spec/source-dir spec)
+        source-root (:source-root context)]
+    (when-not (source-dir-under-root? source-dir source-root)
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Spec source directory is outside the workflow source root: "
+                                    source-dir)
+                               {:source-dir source-dir
+                                :source-root source-root
+                                :worktree-path (:worktree-path context)}))))
+
+(defn- assert-runtime-alignment!
+  [spec context]
+  (assert-valid-source-root! context)
+  (assert-execution-worktree! context)
+  (assert-source-dir-alignment! spec context))
+
+(defn- print-runtime-provenance!
+  [quiet context]
+  (when-not quiet
+    (println (display/colorize :cyan (str "   Source: " (:source-root context))))
+    (println (display/colorize :cyan (str "   Worktree: " (:worktree-path context))))
+    (when-let [branch (:git-branch context)]
+      (println (display/colorize :cyan (str "   Branch: " branch))))
+    (when-let [commit (:git-commit context)]
+      (println (display/colorize :cyan (str "   Commit: " commit))))
+    (when-let [upstream (:git-upstream context)]
+      (println (display/colorize :cyan (str "   Upstream: " upstream))))
+    (when (:git-detached? context)
+      (println (display/colorize :yellow "   Warning: source checkout is detached HEAD")))
+    (when (:git-dirty? context)
+      (println (display/colorize :yellow "   Warning: source checkout has uncommitted changes")))))
+
 (defn close-artifact-store [artifact-store]
   (when artifact-store
     (try
@@ -391,7 +464,8 @@
                               :spec-title (:spec/title spec)
                               :control-state control-state
                               :skip-lifecycle-events true
-                              :execution-opts (:execution-opts opts)})]
+                              :execution-opts (:execution-opts opts)
+                              :source-dir (:spec/source-dir spec)})]
                         ;; Assoc repo-url, branch, and (optionally) execution-mode
                         ;; so runner.clj can clone into Docker or create a worktree.
                         (cond-> (assoc ctx
@@ -405,6 +479,8 @@
       (when-not quiet
         (display/print-workflow-header (keyword (str "adhoc-" (hash spec))) "adhoc" quiet))
       (dashboard/print-dashboard-status! quiet)
+      (assert-runtime-alignment! spec context)
+      (print-runtime-provenance! quiet context)
       (let [provenance (move-spec-to-in-progress! (:spec/provenance enriched-spec))]
         (try
           (let [result (execute-with-events {:run-pipeline run-pipeline

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -70,6 +70,10 @@
     (when (zero? exit)
       (some-> out str/trim not-empty))))
 
+(defn- resolve-git-bool
+  [dir & args]
+  (boolean (apply resolve-git-field dir args)))
+
 (defn get-git-info
   ([] (get-git-info nil))
   ([start-path]
@@ -82,9 +86,33 @@
             :git-commit commit})))
      (catch Exception _ nil))))
 
+(defn get-git-state
+  ([] (get-git-state nil))
+  ([start-path]
+   (try
+     (when-let [root (worktree/worktree-root start-path)]
+       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
+             commit (resolve-git-field root "rev-parse" "--short" "HEAD")
+             upstream (resolve-git-field root "rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
+             dirty? (resolve-git-bool root "status" "--porcelain")]
+         (when (and branch commit)
+           {:git-branch branch
+            :git-commit commit
+            :git-upstream upstream
+            :git-dirty? dirty?
+            :git-detached? (= "HEAD" branch)})))
+     (catch Exception _ nil))))
+
 (defn- execution-worktree-path
   [execution-opts]
   (get execution-opts :worktree-path))
+
+(defn- source-root-path
+  [source-dir]
+  (or (worktree/worktree-root source-dir)
+      source-dir
+      (worktree/worktree-root)
+      (System/getProperty "user.dir")))
 
 (defn get-files-in-scope
   "Resolve scope paths to actual file paths.
@@ -168,9 +196,11 @@
 (defn create-workflow-context [{:keys [callbacks artifact-store event-stream workflow-id
                                        workflow-type workflow-version llm-client quiet
                                        spec-title control-state skip-lifecycle-events
-                                       execution-opts]}]
+                                       execution-opts source-dir]}]
   (let [on-chunk (es/create-streaming-callback event-stream workflow-id :agent
                                                {:print? (not quiet) :quiet? quiet})
+        source-root (source-root-path source-dir)
+        git-info (get-git-state source-root)
         worktree-path (or (execution-worktree-path execution-opts)
                           (worktree/worktree-root)
                           (System/getProperty "user.dir"))]
@@ -186,4 +216,6 @@
       control-state (assoc :control-state control-state)
       skip-lifecycle-events (assoc :skip-lifecycle-events true)
       execution-opts (assoc :execution/opts execution-opts)
+      source-root (assoc :source-root source-root)
+      git-info (merge git-info)
       true (assoc :worktree-path worktree-path))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/run_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/run_test.clj
@@ -27,7 +27,8 @@
 
 (deftest run-spec-workflow-propagates-worktree-into-execution-opts-test
   (testing "--worktree becomes authoritative execution worktree metadata"
-    (let [captured-opts (atom nil)]
+    (let [captured-spec (atom nil)
+          captured-opts (atom nil)]
       (with-redefs [display/print-info (fn [& _])
                     messages/t (fn
                                  ([k] (name k))
@@ -36,12 +37,16 @@
                                                   {:spec/title "Behavioral Verification"})
                     spec-parser/validate-spec (fn [_]
                                                 {:valid? true})
-                    workflow-runner/run-workflow-from-spec! (fn [_ opts]
+                    workflow-runner/run-workflow-from-spec! (fn [spec opts]
+                                                              (reset! captured-spec spec)
                                                               (reset! captured-opts opts)
                                                               :ok)]
         (#'sut/run-spec-workflow "/tmp/behavioral.md" {:worktree "/tmp/custom-worktree"})
         (is (= {:worktree-path "/tmp/custom-worktree"}
-               (:execution-opts @captured-opts)))))))
+               (:execution-opts @captured-opts)))
+        (is (= "/tmp"
+               (:spec/source-dir @captured-spec))
+            "source-dir should stay anchored to the spec's repo, not the execution worktree")))))
 
 (deftest detect-input-type-and-markdown-spec-regression-test
   (testing "markdown-spec? recognizes markdown spec files"

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
@@ -35,8 +35,10 @@
                       :workflow-id (random-uuid)
                       :workflow-type :canonical-sdlc
                       :workflow-version "1.0.0"
+                      :source-dir "/tmp/repo-root/work"
                       :execution-opts {:worktree-path "/tmp/execution-worktree"}})]
         (is (= "/tmp/execution-worktree" (:worktree-path context)))
+        (is (= "/tmp/repo-root" (:source-root context)))
         (is (= {:worktree-path "/tmp/execution-worktree"}
                (:execution/opts context)))))))
 
@@ -52,4 +54,5 @@
                       :workflow-id (random-uuid)
                       :workflow-type :canonical-sdlc
                       :workflow-version "1.0.0"})]
-        (is (= "/tmp/repo-root" (:worktree-path context)))))))
+        (is (= "/tmp/repo-root" (:worktree-path context)))
+        (is (= "/tmp/repo-root" (:source-root context)))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -76,3 +76,15 @@
       (is (str/includes? output "Upstream: origin/main"))
       (is (str/includes? output "detached HEAD"))
       (is (str/includes? output "uncommitted changes")))))
+
+(deftest assert-runtime-alignment-normalizes-parent-segments-test
+  (testing "source-dir alignment accepts normalized paths under the source root"
+    (let [source-root (temp-repo-root)
+          nested-work (str (fs/path source-root "work" "nested"))]
+      (fs/create-dirs nested-work)
+      (#'sut/assert-runtime-alignment!
+       {:spec/source-dir (str (fs/path nested-work ".."))}
+       {:source-root source-root
+        :worktree-path "/tmp/runtime-worktree"
+        :execution/opts {:worktree-path "/tmp/runtime-worktree"}})
+      (is true))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.workflow-runner.preflight-test
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [slingshot.slingshot :refer [try+]]
+   [ai.miniforge.cli.workflow-runner :as sut]))
+
+(defn- temp-repo-root []
+  (let [root (str (fs/create-temp-dir {:prefix "mf-preflight-"}))]
+    (fs/create-dirs (fs/path root ".git"))
+    root))
+
+(deftest assert-runtime-alignment-rejects-worktree-mismatch-test
+  (testing "explicit execution worktree must survive into runtime context"
+    (let [source-root (temp-repo-root)
+          source-dir (str (fs/path source-root "work"))]
+      (try+
+        (#'sut/assert-runtime-alignment!
+         {:spec/source-dir source-dir}
+         {:source-root source-root
+          :worktree-path "/tmp/runtime-worktree"
+          :execution/opts {:worktree-path "/tmp/expected-worktree"}})
+        (is false "expected execution worktree mismatch anomaly")
+        (catch [:anomaly/category :anomalies/incorrect]
+               {:keys [expected-worktree actual-worktree]}
+          (is (= "/tmp/expected-worktree" expected-worktree))
+          (is (= "/tmp/runtime-worktree" actual-worktree)))))))
+
+(deftest assert-runtime-alignment-rejects-source-dir-outside-root-test
+  (testing "spec source directory must stay under the resolved source root"
+    (let [source-root (temp-repo-root)]
+      (try+
+        (#'sut/assert-runtime-alignment!
+         {:spec/source-dir "/tmp/outside-spec-root"}
+         {:source-root source-root
+          :worktree-path "/tmp/runtime-worktree"
+          :execution/opts {:worktree-path "/tmp/runtime-worktree"}})
+        (is false "expected source-dir alignment anomaly")
+        (catch [:anomaly/category :anomalies/incorrect]
+               {:keys [source-dir]}
+          (is (= "/tmp/outside-spec-root" source-dir)))))))
+
+(deftest print-runtime-provenance-includes-startup-warnings-test
+  (testing "startup provenance prints upstream and source checkout warnings"
+    (let [output (with-out-str
+                   (#'sut/print-runtime-provenance!
+                    false
+                    {:source-root "/tmp/source-root"
+                     :worktree-path "/tmp/runtime-worktree"
+                     :git-branch "HEAD"
+                     :git-commit "abc1234"
+                     :git-upstream "origin/main"
+                     :git-detached? true
+                     :git-dirty? true}))]
+      (is (str/includes? output "Source: /tmp/source-root"))
+      (is (str/includes? output "Worktree: /tmp/runtime-worktree"))
+      (is (str/includes? output "Upstream: origin/main"))
+      (is (str/includes? output "detached HEAD"))
+      (is (str/includes? output "uncommitted changes")))))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -104,7 +104,7 @@
   (try
     (let [args (cond-> ["rg" "--no-heading" "-n" pattern-str]
                  path-or-glob (conj path-or-glob))
-          {:keys [out]} (apply shell/sh (concat [:dir (source-root)] args))]
+          {:keys [out]} (apply shell/sh (concat args [:dir (source-root)]))]
       (when-not (str/blank? out)
         (->> (str/split-lines out)
              (map (fn [line]
@@ -124,12 +124,18 @@
   [pattern]
   (try
     (let [root (io/file (source-root))
-          root-path (.getCanonicalPath root)
-          prefix-len (inc (count root-path))
-          matches (->> (file-seq root)
+          root-path (.toPath (.getAbsoluteFile root))
+          matches (->> (tree-seq (fn [^java.io.File file]
+                                   (and (.isDirectory file)
+                                        (not= ".git" (.getName file))))
+                                 #(.listFiles ^java.io.File %)
+                                 root)
+                       rest
                        (filter #(.isFile ^java.io.File %))
-                       (map #(.getCanonicalPath ^java.io.File %))
-                       (map #(subs % prefix-len))
+                       (map (fn [^java.io.File file]
+                              (-> root-path
+                                  (.relativize (.toPath (.getAbsoluteFile file)))
+                                  str)))
                        (filter #(glob-matches? pattern %))
                        sort
                        vec)]

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -95,6 +95,8 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Shell fallbacks
 
+(declare source-root)
+
 (defn shell-grep
   "Fall back to ripgrep for files not in cache.
    Returns vector of {:path :line-number :text} or nil."
@@ -102,7 +104,7 @@
   (try
     (let [args (cond-> ["rg" "--no-heading" "-n" pattern-str]
                  path-or-glob (conj path-or-glob))
-          {:keys [out]} (apply shell/sh args)]
+          {:keys [out]} (apply shell/sh (concat [:dir (source-root)] args))]
       (when-not (str/blank? out)
         (->> (str/split-lines out)
              (map (fn [line]
@@ -117,16 +119,22 @@
     (catch Exception _e nil)))
 
 (defn shell-glob
-  "Fall back to filesystem glob via find.
+  "Fall back to filesystem glob by walking source-root.
    Returns vector of relative file paths or nil."
   [pattern]
   (try
-    (let [{:keys [out]} (shell/sh "find" "." "-path" (str "./" pattern) "-type" "f")]
-      (when-not (str/blank? out)
-        (->> (str/split-lines out)
-             (map #(str/replace-first % #"^\.\/" ""))
-             (filter #(not (str/blank? %)))
-             vec)))
+    (let [root (io/file (source-root))
+          root-path (.getCanonicalPath root)
+          prefix-len (inc (count root-path))
+          matches (->> (file-seq root)
+                       (filter #(.isFile ^java.io.File %))
+                       (map #(.getCanonicalPath ^java.io.File %))
+                       (map #(subs % prefix-len))
+                       (filter #(glob-matches? pattern %))
+                       sort
+                       vec)]
+      (when (seq matches)
+        matches))
     (catch Exception _e nil)))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -134,27 +142,40 @@
 
 ;; Cache atom holding :files (path → content) and :misses (recorded cache misses).
 (defonce cache-state
-  (atom {:files {} :misses []}))
+  (atom {:files {} :misses [] :source-root nil}))
 
 (defn reset-state!
   "Reset cache state. Intended for test isolation."
   []
-  (reset! cache-state {:files {} :misses []}))
+  (reset! cache-state {:files {} :misses [] :source-root nil}))
+
+(defn- source-root
+  []
+  (or (:source-root @cache-state) "."))
+
+(defn- resolve-source-path
+  [path]
+  (let [f (io/file path)]
+    (if (.isAbsolute f)
+      (.getPath f)
+      (.getPath (io/file (source-root) path)))))
 
 (defn load-cache!
   "Load context-cache.edn from artifact-dir into the cache atom."
-  [artifact-dir]
-  (let [path (str artifact-dir "/context-cache.edn")
-        f (io/file path)]
-    (when (.exists f)
-      (try
-        (let [data (edn/read-string (slurp f))]
-          (swap! cache-state assoc :files (get data :files {}))
-          (binding [*out* *err*]
-            (println (msg/t :cache/loaded {:count (count (:files data))}))))
-        (catch Exception e
-          (binding [*out* *err*]
-            (println (msg/t :cache/load-failed {:error (ex-message e)}))))))))
+  ([artifact-dir] (load-cache! artifact-dir nil))
+  ([artifact-dir source-root]
+   (let [path (str artifact-dir "/context-cache.edn")
+         f (io/file path)]
+     (swap! cache-state assoc :source-root source-root)
+     (when (.exists f)
+       (try
+         (let [data (edn/read-string (slurp f))]
+           (swap! cache-state assoc :files (get data :files {}))
+           (binding [*out* *err*]
+             (println (msg/t :cache/loaded {:count (count (:files data))}))))
+         (catch Exception e
+           (binding [*out* *err*]
+             (println (msg/t :cache/load-failed {:error (ex-message e)})))))))))
 
 (defn flush-misses!
   "Write accumulated cache misses to context-misses.edn in artifact-dir."
@@ -199,7 +220,7 @@
   [path]
   (or (cache-get path)
       (try
-        (let [content (slurp path)]
+        (let [content (slurp (resolve-source-path path))]
           (cache-put! path content)
           (record-miss! "context_read" {:path path} (estimate-tokens content))
           content)
@@ -252,7 +273,7 @@
   (doseq [path (distinct (map :path results))
           :when (not (contains? known-files path))]
     (try
-      (let [content (slurp path)]
+      (let [content (slurp (resolve-source-path path))]
         (cache-put! path content)
         (record-miss! "context_grep" {:path path :pattern pattern-str}
                       (estimate-tokens content)))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/interface.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/interface.clj
@@ -35,8 +35,10 @@
 
    Arguments:
    - artifact-dir — directory path for context cache and miss tracking"
-  [artifact-dir]
-  (server/run-server artifact-dir))
+  ([artifact-dir]
+   (server/run-server artifact-dir nil))
+  ([artifact-dir source-root]
+   (server/run-server artifact-dir source-root)))
 
 (defn handle-tool-call
   "Invoke a tool handler directly (for testing without JSON-RPC).

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/main.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/main.clj
@@ -31,13 +31,16 @@
       (case (first args)
         "--artifact-dir" (recur (drop 2 args)
                                 (assoc opts :artifact-dir (second args)))
+        "--source-root" (recur (drop 2 args)
+                               (assoc opts :source-root (second args)))
         (recur (rest args) opts)))))
 
 (defn -main [& args]
   (let [opts (parse-args args)
-        artifact-dir (:artifact-dir opts)]
+        artifact-dir (:artifact-dir opts)
+        source-root (:source-root opts)]
     (when-not artifact-dir
       (binding [*out* *err*]
         (println "ERROR: --artifact-dir is required"))
       (System/exit 1))
-    (server/run-server artifact-dir)))
+    (server/run-server artifact-dir source-root)))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
@@ -124,10 +124,11 @@
    4. Flush accumulated cache misses to artifact-dir
 
    Arguments:
-   - artifact-dir — directory path for context cache and miss tracking"
-  [artifact-dir]
-  (log-stderr "miniforge-context MCP server started, artifact-dir:" artifact-dir)
-  (context-cache/load-cache! artifact-dir)
+   - artifact-dir — directory path for context cache and miss tracking
+   - source-root — repo root for filesystem fallback"
+  [artifact-dir source-root]
+  (log-stderr "miniforge-context MCP server started, artifact-dir:" artifact-dir "source-root:" source-root)
+  (context-cache/load-cache! artifact-dir source-root)
   (register-context-handlers!)
   (try
     (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in "UTF-8"))]

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -237,6 +237,21 @@
             (is (re-find #"components/alpha/src/demo/core\.clj"
                          (get-in result [:content 0 :text])))))))))
 
+(deftest handle-context-glob-source-root-fallback-prunes-git-test
+  (testing "filesystem glob fallback ignores .git contents"
+    (with-temp-dir
+      (fn [dir]
+        (let [repo-root (str dir "/repo")]
+          (.mkdirs (io/file (str repo-root "/components/alpha/src/demo")))
+          (.mkdirs (io/file (str repo-root "/.git/objects/aa")))
+          (spit (str repo-root "/components/alpha/src/demo/core.clj") "(ns demo.core)")
+          (spit (str repo-root "/.git/objects/aa/hidden.clj") "(ns hidden)")
+          (cache/load-cache! dir repo-root)
+          (let [result (cache/handle-context-glob {"pattern" "**/*.clj"})
+                text (get-in result [:content 0 :text])]
+            (is (re-find #"components/alpha/src/demo/core\.clj" text))
+            (is (not (re-find #"\.git/objects/aa/hidden\.clj" text)))))))))
+
 (deftest flush-misses-roundtrip-test
   (testing "flush-misses! writes misses to context-misses.edn"
     (with-temp-dir

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -206,9 +206,36 @@
       (fn [dir]
         (spit (str dir "/context-cache.edn")
               (pr-str {:files {"src/a.clj" "(ns a)" "src/b.clj" "(ns b)"}}))
-        (cache/load-cache! dir)
+        (cache/load-cache! dir "/tmp/repo-root")
         (is (= "(ns a)" (get-in @cache/cache-state [:files "src/a.clj"])))
-        (is (= "(ns b)" (get-in @cache/cache-state [:files "src/b.clj"])))))))
+        (is (= "(ns b)" (get-in @cache/cache-state [:files "src/b.clj"])))
+        (is (= "/tmp/repo-root" (:source-root @cache/cache-state)))))))
+
+(deftest handle-context-read-source-root-fallback-test
+  (testing "relative file reads resolve from source-root when cache is empty"
+    (with-temp-dir
+      (fn [dir]
+        (let [repo-root (str dir "/repo")
+              file-path (str repo-root "/components/demo/core.clj")]
+          (.mkdirs (io/file (str repo-root "/components/demo")))
+          (spit file-path "(ns demo.core)")
+          (cache/load-cache! dir repo-root)
+          (let [result (cache/handle-context-read {"path" "components/demo/core.clj"})]
+            (is (= "(ns demo.core)" (get-in result [:content 0 :text])))
+            (is (= "(ns demo.core)"
+                   (get-in @cache/cache-state [:files "components/demo/core.clj"])))))))))
+
+(deftest handle-context-glob-source-root-fallback-test
+  (testing "relative glob fallback searches from source-root"
+    (with-temp-dir
+      (fn [dir]
+        (let [repo-root (str dir "/repo")]
+          (.mkdirs (io/file (str repo-root "/components/alpha/src/demo")))
+          (spit (str repo-root "/components/alpha/src/demo/core.clj") "(ns demo.core)")
+          (cache/load-cache! dir repo-root)
+          (let [result (cache/handle-context-glob {"pattern" "components/*/src/**/*.clj"})]
+            (is (re-find #"components/alpha/src/demo/core\.clj"
+                         (get-in result [:content 0 :text])))))))))
 
 (deftest flush-misses-roundtrip-test
   (testing "flush-misses! writes misses to context-misses.edn"

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -146,7 +146,7 @@
    Returns:
    - {:dir <path>, :mcp-config-path <path>, :artifact-path <path>}"
   ([] (create-session! nil))
-  ([{:keys [workdir]}]
+  ([{:keys [workdir source-root]}]
   (let [dir (str (Files/createTempDirectory
                   "miniforge-artifact-"
                   (into-array FileAttribute [])))
@@ -156,6 +156,7 @@
     {:dir dir
      :workdir working-dir
      :config-root (or workdir dir)
+     :source-root source-root
      :mcp-config-path config-path
      :artifact-path artifact-path
      :pre-session-snapshot (try
@@ -179,8 +180,9 @@
 
    The server reads context-cache.edn from artifact-dir on startup and
    serves context_read/context_grep/context_glob to the inner LLM agent."
-  [artifact-dir]
-  (let [mcp-args ["--artifact-dir" artifact-dir]
+  [artifact-dir source-root]
+  (let [mcp-args (cond-> ["--artifact-dir" artifact-dir]
+                   source-root (into ["--source-root" source-root]))
         bb-root  (find-bb-root)]
     (cond
       (System/getenv "MINIFORGE_MCP_CMD")
@@ -355,7 +357,7 @@
 
    Returns: session (for threading)"
   [session]
-  (let [srv-cmd       (server-command (:dir session))
+  (let [srv-cmd       (server-command (:dir session) (:source-root session))
         config-root   (:config-root session)
         mcp-config    {"mcpServers" {"context" {"command" (:command srv-cmd)
                                                 "args"    (:args srv-cmd)}}}
@@ -790,8 +792,9 @@
       (run-session session body-fn read-capsule-artifact cleanup-capsule-session! :capsule))
     (let [workdir (:execution/worktree-path context)
           session (-> (if workdir
-                        (create-session! {:workdir workdir})
-                        (create-session!))
+                        (create-session! {:workdir workdir
+                                          :source-root (:source-root context)})
+                        (create-session! {:source-root (:source-root context)}))
                       write-mcp-config!)]
       (run-session session body-fn read-artifact cleanup-session! :host))))
 

--- a/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
@@ -235,12 +235,14 @@
 
 (deftest server-command-test
   (testing "returns a map with :command and :args including --artifact-dir"
-    (let [result (session/server-command "/tmp/artifacts")]
+    (let [result (session/server-command "/tmp/artifacts" "/tmp/source-root")]
       (is (map? result))
       (is (string? (:command result)))
       (is (vector? (:args result)))
       (is (some #(= "--artifact-dir" %) (:args result)))
       (is (some #(= "/tmp/artifacts" %) (:args result)))
+      (is (some #(= "--source-root" %) (:args result)))
+      (is (some #(= "/tmp/source-root" %) (:args result)))
       (is (some #(= "mcp-context-server" %) (:args result))))))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -124,7 +124,8 @@
   [:llm-backend :artifact-store :knowledge-store
    :on-phase-start :on-phase-complete
    :executor :environment-id :sandbox-workdir
-   :on-chunk :event-stream :worktree-path])
+   :on-chunk :event-stream :worktree-path
+   :source-root])
 
 (defn- passthrough-option-values
   [opts]

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -61,6 +61,14 @@
       (is (vector? (:execution/artifacts ctx)))
       (is (number? (:execution/started-at ctx))))))
 
+(deftest create-context-preserves-source-root-test
+  (testing "create-context preserves :source-root passthrough options"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"}
+          source-root "/tmp/miniforge-source-root"
+          ctx (ctx/create-context workflow {:task "Test"} {:source-root source-root})]
+      (is (= source-root (:source-root ctx))))))
+
 ;; ============================================================================
 ;; Pipeline building tests
 ;; ============================================================================

--- a/docs/pull-requests/2026-05-03-fix-dogfood-source-root-mcp.md
+++ b/docs/pull-requests/2026-05-03-fix-dogfood-source-root-mcp.md
@@ -1,0 +1,55 @@
+## Summary
+
+This PR fixes the Claude dogfood regression where planner exploration could start from the execution worktree instead of
+the actual source repository.
+
+That made the MCP context server explore the wrong tree, which is exactly the kind of mistake that can silently produce
+greenfield planning or wrong-base edits.
+
+## What Changed
+
+### Source root is now distinct from execution worktree
+
+- keep `:spec/source-dir` anchored to the spec file instead of aliasing it to `--worktree`
+- derive and preserve a canonical `:source-root` in CLI runtime context
+- pass `:source-root` through workflow context into nested agent execution
+- thread `--source-root` into artifact sessions and the MCP context server
+
+### MCP filesystem fallback now reads from the real repo
+
+- context cache state stores `:source-root`
+- filesystem fallback reads, grep, glob, and cache writes resolve relative to that root
+- generated MCP session config now tells the context server both:
+  - artifact dir
+  - source root
+
+### Startup provenance is louder and stricter
+
+- print `Source`, `Worktree`, `Branch`, `Commit`, and `Upstream` before execution
+- warn when the source checkout is detached or dirty
+- fail closed if:
+  - the source root is not a git checkout
+  - the explicit execution worktree was lost before runtime
+  - the spec source dir no longer aligns with the resolved source root
+
+## Validation
+
+- `clj-kondo` on touched CLI, workflow, agent, and MCP context files
+- focused tests:
+  - `ai.miniforge.cli.main.commands.run-test`
+  - `ai.miniforge.cli.workflow-runner.context-test`
+  - `ai.miniforge.cli.workflow-runner.preflight-test`
+  - `ai.miniforge.workflow.runner-test`
+  - `ai.miniforge.mcp-context-server.context-cache-test`
+  - `ai.miniforge.agent.artifact-session-extended-test`
+- full `bb pre-commit`
+
+## Live Result
+
+- live dogfood confirmed generated session config now includes `--source-root`
+- planner exploration used MCP context tools against the source repo instead of the execution worktree
+
+## Follow-up
+
+The next PR in the stack adds backend startup preflight and tighter Claude CLI timeout handling so unhealthy
+non-interactive backends fail early instead of drifting into long silent waits.


### PR DESCRIPTION
## Summary

This PR fixes the Claude dogfood regression where planner exploration could start from the execution worktree instead of
the actual source repository.

That made the MCP context server explore the wrong tree, which is exactly the kind of mistake that can silently produce
greenfield planning or wrong-base edits.

## What Changed

### Source root is now distinct from execution worktree

- keep `:spec/source-dir` anchored to the spec file instead of aliasing it to `--worktree`
- derive and preserve a canonical `:source-root` in CLI runtime context
- pass `:source-root` through workflow context into nested agent execution
- thread `--source-root` into artifact sessions and the MCP context server

### MCP filesystem fallback now reads from the real repo

- context cache state stores `:source-root`
- filesystem fallback reads, grep, glob, and cache writes resolve relative to that root
- generated MCP session config now tells the context server both:
  - artifact dir
  - source root

### Startup provenance is louder and stricter

- print `Source`, `Worktree`, `Branch`, `Commit`, and `Upstream` before execution
- warn when the source checkout is detached or dirty
- fail closed if:
  - the source root is not a git checkout
  - the explicit execution worktree was lost before runtime
  - the spec source dir no longer aligns with the resolved source root

## Validation

- `clj-kondo` on touched CLI, workflow, agent, and MCP context files
- focused tests:
  - `ai.miniforge.cli.main.commands.run-test`
  - `ai.miniforge.cli.workflow-runner.context-test`
  - `ai.miniforge.cli.workflow-runner.preflight-test`
  - `ai.miniforge.workflow.runner-test`
  - `ai.miniforge.mcp-context-server.context-cache-test`
  - `ai.miniforge.agent.artifact-session-extended-test`
- full `bb pre-commit`

## Live Result

- live dogfood confirmed generated session config now includes `--source-root`
- planner exploration used MCP context tools against the source repo instead of the execution worktree

## Follow-up

The next PR in the stack adds backend startup preflight and tighter Claude CLI timeout handling so unhealthy
non-interactive backends fail early instead of drifting into long silent waits.
