### PR TITLE
refactor: exceptions-as-data cleanup of workflow (runtime side)

### DIFF
--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -3,6 +3,7 @@
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}
+        ai.miniforge/anomaly {:local/root "../anomaly"}    ; Canonical anomaly maps for exceptions-as-data
         ai.miniforge/response {:local/root "../response"}  ; Response chains
         ai.miniforge/fsm {:local/root "../fsm"}            ; State machines
         ai.miniforge/agent {:local/root "../agent"}

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -27,7 +27,8 @@
    - context            — context management
    - execution          — phase execution
    - monitoring         — health monitoring"
-  (:require [ai.miniforge.dag-executor.interface :as dag-exec]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.dag-executor.interface :as dag-exec]
             [ai.miniforge.llm.interface :as llm-impl]
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
@@ -281,45 +282,88 @@
     {:on-phase-start on-phase-start
      :on-phase-complete on-phase-complete}))
 
-(defn- build-initial-context
-  "Build the initial execution context from workflow, input, and opts."
+(defn- governed-capsule-missing-anomaly
+  "Return an `:invalid-input` anomaly when `:governed` mode is requested
+   without a pre-acquired capsule executor + environment-id, otherwise nil.
+
+   Governed mode forbids worktree fallback (N11 §7.4); the runner refuses
+   to silently downgrade. Pre-flight check shared between the throwing
+   and anomaly-returning context builders."
+  [opts]
+  (let [mode      (get opts :execution-mode :local)
+        governed? (and (= :governed mode)
+                       (get opts :executor)
+                       (get opts :environment-id))]
+    (when (and (= :governed mode) (not governed?))
+      (anomaly/anomaly :invalid-input
+                       (messages/t :governed/no-capsule)
+                       {:execution-mode :governed
+                        :has-executor? (some? (get opts :executor))
+                        :has-environment-id? (some? (get opts :environment-id))}))))
+
+(defn- assemble-initial-context
+  "Construct the initial execution context map. Caller is responsible for
+   running [[governed-capsule-missing-anomaly]] first; reaching this function
+   with `:governed` mode but no capsule is a programmer error."
   [workflow input opts]
   (let [resume-machine-snapshot (:resume-machine-snapshot opts)
         resume-phase-results (:resume-phase-results opts)
         mode      (get opts :execution-mode :local)
         governed? (and (= :governed mode)
                        (get opts :executor)
-                       (get opts :environment-id))]
-    (when (and (= :governed mode) (not governed?))
+                       (get opts :environment-id))
+        capsule-exec-fn (when governed?
+                          (llm-impl/capsule-exec-fn
+                           dag-exec/execute!
+                           (get opts :executor)
+                           (get opts :environment-id)
+                           (get opts :worktree-path (defaults/default-workdir))))]
+    (-> (if (and resume-machine-snapshot resume-phase-results)
+          (ctx/restore-context workflow input
+                               resume-machine-snapshot
+                               resume-phase-results
+                               opts)
+          (ctx/create-context workflow input opts))
+        (assoc :execution/executor (get opts :executor)
+               :execution/environment-id (get opts :environment-id)
+               :execution/worktree-path (get opts :worktree-path
+                                             (get opts :sandbox-workdir))
+               :execution/mode mode
+               :execution/started-at (java.time.Instant/now)
+               :execution/environment-metadata (get opts :environment-metadata)
+               :execution/execute-fn (when governed? dag-exec/execute!)
+               :execution/exec-fn capsule-exec-fn
+               :execution/task-branch (when governed?
+                                        (str (defaults/task-branch-prefix)
+                                             (get opts :environment-id
+                                                  (subs (str (random-uuid)) 0 8))))
+               :execution/run-pipeline-fn run-pipeline))))
+
+(defn build-initial-context-anomaly
+  "Anomaly-returning variant of [[build-initial-context]].
+
+   Returns the assembled execution context on success, or an
+   `:invalid-input` anomaly when `:governed` mode is requested but no
+   capsule executor + `:environment-id` were supplied in `opts`. Governed
+   mode forbids worktree fallback (N11 §7.4)."
+  [workflow input opts]
+  (or (governed-capsule-missing-anomaly opts)
+      (assemble-initial-context workflow input opts)))
+
+(defn- build-initial-context
+  "Build the initial execution context from workflow, input, and opts.
+
+   DEPRECATED: prefer [[build-initial-context-anomaly]], which returns
+   an anomaly map instead of throwing. Retained for backward compatibility
+   with the orchestrator entry point."
+  {:deprecated "exceptions-as-data — prefer build-initial-context-anomaly"}
+  [workflow input opts]
+  (let [result (build-initial-context-anomaly workflow input opts)]
+    (if (anomaly/anomaly? result)
       (response/throw-anomaly! :anomalies.workflow/no-capsule-executor
-                               (messages/t :governed/no-capsule)
-                               {}))
-    (let [capsule-exec-fn (when governed?
-                            (llm-impl/capsule-exec-fn
-                             dag-exec/execute!
-                             (get opts :executor)
-                             (get opts :environment-id)
-                             (get opts :worktree-path (defaults/default-workdir))))]
-      (-> (if (and resume-machine-snapshot resume-phase-results)
-            (ctx/restore-context workflow input
-                                 resume-machine-snapshot
-                                 resume-phase-results
-                                 opts)
-            (ctx/create-context workflow input opts))
-          (assoc :execution/executor (get opts :executor)
-                 :execution/environment-id (get opts :environment-id)
-                 :execution/worktree-path (get opts :worktree-path
-                                               (get opts :sandbox-workdir))
-                 :execution/mode mode
-                 :execution/started-at (java.time.Instant/now)
-                 :execution/environment-metadata (get opts :environment-metadata)
-                 :execution/execute-fn (when governed? dag-exec/execute!)
-                 :execution/exec-fn capsule-exec-fn
-                 :execution/task-branch (when governed?
-                                          (str (defaults/task-branch-prefix)
-                                               (get opts :environment-id
-                                                    (subs (str (random-uuid)) 0 8))))
-                 :execution/run-pipeline-fn run-pipeline)))))
+                               (:anomaly/message result)
+                               {})
+      result)))
 
 (defn- execute-pipeline-loop
   "Execute the phase pipeline loop. Returns final context."

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -22,6 +22,7 @@
    Manages worktree and Docker capsule acquisition, release, and
    workspace persistence at phase boundaries. Extracted from runner.clj."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
@@ -69,14 +70,36 @@
     (when-not (and (= :governed mode) raw (= :worktree (executor-type raw)))
       raw)))
 
-(defn assert-executor-for-mode!
-  "Throws for :governed mode when no capsule executor is available."
+(defn check-executor-for-mode-anomaly
+  "Anomaly-returning variant of [[assert-executor-for-mode!]].
+
+   Returns nil when the `executor`/`mode` pair is acceptable, or an
+   `:unavailable` anomaly when `:governed` mode was requested but no
+   capsule executor was supplied. The anomaly's `:anomaly/data` carries
+   `:mode` and a `:hint` string for surface code that wants to suggest
+   remediation.
+
+   Prefer this over [[assert-executor-for-mode!]] in non-boundary code."
   [executor mode]
   (when (and (nil? executor) (= :governed mode))
+    (anomaly/anomaly :unavailable
+                     (messages/t :governed/no-capsule)
+                     {:mode :governed
+                      :hint (messages/t :governed/no-capsule-hint)})))
+
+(defn assert-executor-for-mode!
+  "Throws for :governed mode when no capsule executor is available.
+
+   DEPRECATED: prefer [[check-executor-for-mode-anomaly]], which returns
+   an anomaly map instead of throwing. Retained for backward compatibility
+   with callers that rely on the slingshot throw shape."
+  {:deprecated "exceptions-as-data — prefer check-executor-for-mode-anomaly"}
+  [executor mode]
+  (when-let [a (check-executor-for-mode-anomaly executor mode)]
     (response/throw-anomaly! :anomalies.executor/unavailable
-                             (messages/t :governed/no-capsule)
-                             {:anomaly.executor/mode :governed
-                              :hint (messages/t :governed/no-capsule-hint)})))
+                             (:anomaly/message a)
+                             {:anomaly.executor/mode (get-in a [:anomaly/data :mode])
+                              :hint (get-in a [:anomaly/data :hint])})))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Environment record construction

--- a/components/workflow/src/ai/miniforge/workflow/state.clj
+++ b/components/workflow/src/ai/miniforge/workflow/state.clj
@@ -22,6 +22,7 @@
    Uses a formal FSM (see fsm.clj) for state transitions.
    Tracks runtime state separately from workflow configuration."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.fsm :as fsm]))
@@ -91,6 +92,33 @@
         (update :execution/history conj transition)
         (assoc :execution/updated-at (System/currentTimeMillis)))))
 
+(defn transition-status-anomaly
+  "Anomaly-returning variant of [[transition-status]].
+
+   Returns the updated execution state on success, or an
+   `:invalid-input` anomaly when the FSM rejects the transition.
+
+   The anomaly's `:anomaly/data` carries:
+   - `:current-status` — the status the run was in at call time
+   - `:event`          — the rejected event keyword
+   - `:error`          — the FSM error keyword
+   - `:fsm-message`    — the FSM-supplied diagnostic message
+
+   Prefer this over [[transition-status]] in non-boundary code."
+  [state event]
+  (let [current-status (:execution/status state)
+        result (fsm/transition current-status event)]
+    (if (fsm/succeeded? result)
+      (-> state
+          (assoc :execution/status (:state result))
+          (record-fsm-transition current-status (:state result) event))
+      (anomaly/anomaly :invalid-input
+                       "Invalid state transition"
+                       {:current-status current-status
+                        :event event
+                        :error (:error result)
+                        :fsm-message (:message result)}))))
+
 (defn transition-status
   "Transition workflow status using FSM.
 
@@ -100,20 +128,23 @@
 
    Returns:
    - Updated state if transition valid
-   - Throws ex-info if transition invalid"
+   - Throws ex-info if transition invalid
+
+   DEPRECATED: prefer [[transition-status-anomaly]], which returns an
+   anomaly map instead of throwing. Retained for backward compatibility
+   with callers that rely on the slingshot throw shape."
+  {:deprecated "exceptions-as-data — prefer transition-status-anomaly"}
   [state event]
-  (let [current-status (:execution/status state)
-        result (fsm/transition current-status event)]
-    (if (fsm/succeeded? result)
-      (-> state
-          (assoc :execution/status (:state result))
-          (record-fsm-transition current-status (:state result) event))
-      (response/throw-anomaly! :anomalies.workflow/invalid-transition
-                              "Invalid state transition"
-                              {:current-status current-status
-                               :event event
-                               :error (:error result)
-                               :message (:message result)}))))
+  (let [result (transition-status-anomaly state event)]
+    (if (anomaly/anomaly? result)
+      (let [data (:anomaly/data result)]
+        (response/throw-anomaly! :anomalies.workflow/invalid-transition
+                                 "Invalid state transition"
+                                 {:current-status (:current-status data)
+                                  :event (:event data)
+                                  :error (:error data)
+                                  :message (:fsm-message data)}))
+      result)))
 
 (defn transition-to-phase
   "Transition execution to a new phase.

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
@@ -82,9 +82,16 @@
 ;;
 ;; `build-initial-context` is `defn-` (private) — the runner namespace
 ;; never intends it as a public API. We reach in via #'var to verify
-;; the slingshot throw shape that legacy try+ callers (none upstream
-;; today, but the catch site at runner.clj's top-level Object handler
-;; wraps it) will continue to see.
+;; the slingshot throw shape preserved for backward compat.
+;;
+;; Important: in `runner/run-pipeline`, `initial-ctx` is built *before*
+;; the pipeline-loop `try+` is entered. The runner does NOT catch this
+;; throw itself; it propagates up to whatever boundary called
+;; `run-pipeline` (the CLI handler, MCP tool entry, or in-process
+;; orchestrator above). Those boundaries are responsible for
+;; converting the slingshot ex-data into a user-facing error. This
+;; test pins only the throw shape — not the catch site — because no
+;; runner-level catch participates.
 
 (deftest build-initial-context-still-throws-on-governed-without-capsule
   (testing "deprecated throwing variant still throws via slingshot for legacy callers"

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
@@ -1,0 +1,104 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.build-initial-context-test
+  "Coverage for `runner/build-initial-context-anomaly` and its deprecated
+   throwing sibling `runner/build-initial-context`.
+
+   The single failure mode this site protects is the N11 §7.4 invariant:
+   `:governed` execution-mode requires a pre-acquired capsule executor +
+   environment-id; missing either is `:invalid-input`. The happy path is
+   covered indirectly by the existing `runner_pipeline_test`; here we
+   only exercise the failure-path contract."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.runner :as runner])
+  (:import (clojure.lang ExceptionInfo)))
+
+(def workflow
+  {:workflow/id :test
+   :workflow/version "1.0.0"
+   :workflow/phases [{:phase/id :start}]
+   :workflow/pipeline [{:phase :start}]})
+
+(def input {:repo-url "https://example.test/repo"})
+
+;------------------------------------------------------------------------------ Happy path
+;;
+;; :local mode bypasses the capsule check and assembles a context. We
+;; only assert non-anomaly here because the assembled map's full shape
+;; is the responsibility of the existing runner_pipeline_test suite.
+
+(deftest build-initial-context-anomaly-local-mode-returns-context
+  (testing ":local mode produces a context map (not an anomaly)"
+    (let [result (runner/build-initial-context-anomaly workflow input
+                                                       {:execution-mode :local})]
+      (is (not (anomaly/anomaly? result)))
+      (is (= :local (:execution/mode result))))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest build-initial-context-anomaly-governed-without-capsule
+  (testing ":governed mode with no executor + env-id yields :invalid-input anomaly"
+    (let [result (runner/build-initial-context-anomaly workflow input
+                                                       {:execution-mode :governed})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
+
+(deftest build-initial-context-anomaly-data-carries-flags
+  (testing "anomaly data carries enough triage info for the caller"
+    (let [result (runner/build-initial-context-anomaly workflow input
+                                                       {:execution-mode :governed})
+          data   (:anomaly/data result)]
+      (is (= :governed (:execution-mode data)))
+      (is (false? (:has-executor? data)))
+      (is (false? (:has-environment-id? data))))))
+
+(deftest build-initial-context-anomaly-governed-with-executor-only
+  (testing "executor without env-id is still an anomaly — both must be present"
+    (let [result (runner/build-initial-context-anomaly workflow input
+                                                       {:execution-mode :governed
+                                                        :executor :some-exec})]
+      (is (anomaly/anomaly? result))
+      (is (true? (get-in result [:anomaly/data :has-executor?])))
+      (is (false? (get-in result [:anomaly/data :has-environment-id?]))))))
+
+;------------------------------------------------------------------------------ Throwing-variant compat
+;;
+;; `build-initial-context` is `defn-` (private) — the runner namespace
+;; never intends it as a public API. We reach in via #'var to verify
+;; the slingshot throw shape that legacy try+ callers (none upstream
+;; today, but the catch site at runner.clj's top-level Object handler
+;; wraps it) will continue to see.
+
+(deftest build-initial-context-still-throws-on-governed-without-capsule
+  (testing "deprecated throwing variant still throws via slingshot for legacy callers"
+    (let [build! @#'runner/build-initial-context]
+      (is (thrown? ExceptionInfo
+                   (build! workflow input {:execution-mode :governed}))))))
+
+(deftest build-initial-context-thrown-ex-data-preserves-slingshot-shape
+  (testing "ex-data carries :anomalies.workflow/no-capsule-executor for try+ catches"
+    (let [build! @#'runner/build-initial-context]
+      (try
+        (build! workflow input {:execution-mode :governed})
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (let [data (ex-data e)]
+            (is (= :anomalies.workflow/no-capsule-executor
+                   (:anomaly/category data)))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/check_executor_for_mode_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/check_executor_for_mode_test.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.check-executor-for-mode-test
+  "Coverage for `runner-environment/check-executor-for-mode-anomaly`
+   and its deprecated throwing sibling `assert-executor-for-mode!`.
+
+   The N11 §7.4 invariant — :governed mode must not silently downgrade
+   to a worktree fallback — is now expressed as an `:unavailable`
+   anomaly returnable from non-boundary code, with the throwing wrapper
+   preserved for slingshot callers."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.runner-environment :as env])
+  (:import (clojure.lang ExceptionInfo)))
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest check-executor-anomaly-nil-when-executor-present
+  (testing ":governed mode with a capsule executor returns nil (no anomaly)"
+    (is (nil? (env/check-executor-for-mode-anomaly :some-executor :governed)))))
+
+(deftest check-executor-anomaly-nil-for-local-mode
+  (testing ":local mode without a capsule is fine — returns nil"
+    (is (nil? (env/check-executor-for-mode-anomaly nil :local)))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest check-executor-anomaly-when-governed-without-capsule
+  (testing ":governed mode with no capsule yields :unavailable anomaly"
+    (let [result (env/check-executor-for-mode-anomaly nil :governed)]
+      (is (anomaly/anomaly? result))
+      (is (= :unavailable (:anomaly/type result))))))
+
+(deftest check-executor-anomaly-data-carries-mode-and-hint
+  (testing "anomaly data carries :mode and :hint for surface-level remediation"
+    (let [result (env/check-executor-for-mode-anomaly nil :governed)
+          data   (:anomaly/data result)]
+      (is (= :governed (:mode data)))
+      (is (string? (:hint data)))
+      (is (seq (:hint data))))))
+
+;------------------------------------------------------------------------------ Throwing-variant compat
+
+(deftest assert-executor-still-noop-on-valid-args
+  (testing "deprecated throwing variant is a no-op when an executor is present"
+    (is (nil? (env/assert-executor-for-mode! :some-executor :governed)))))
+
+(deftest assert-executor-still-noop-on-local-mode
+  (testing "deprecated throwing variant is a no-op for :local mode"
+    (is (nil? (env/assert-executor-for-mode! nil :local)))))
+
+(deftest assert-executor-still-throws-when-governed-without-capsule
+  (testing "deprecated throwing variant still throws via slingshot for legacy callers"
+    (is (thrown? ExceptionInfo
+                 (env/assert-executor-for-mode! nil :governed)))))
+
+(deftest assert-executor-thrown-ex-data-preserves-slingshot-shape
+  (testing "ex-data carries :anomalies.executor/unavailable for try+ catches"
+    (try
+      (env/assert-executor-for-mode! nil :governed)
+      (is false "should have thrown")
+      (catch ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= :anomalies.executor/unavailable (:anomaly/category data)))
+          (is (= :governed (:anomaly.executor/mode data)))
+          (is (string? (:hint data))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/transition_status_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/transition_status_test.clj
@@ -1,0 +1,94 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.transition-status-test
+  "Coverage for `state/transition-status-anomaly` and its deprecated
+   throwing sibling `state/transition-status`. The FSM rejection path
+   becomes an `:invalid-input` anomaly; the throwing variant continues
+   to surface a slingshot `:anomalies.workflow/invalid-transition` for
+   legacy try+ callers."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.state :as state])
+  (:import (clojure.lang ExceptionInfo)))
+
+(def sample-workflow
+  {:workflow/id :test
+   :workflow/version "1.0.0"
+   :workflow/phases [{:phase/id :start}]})
+
+(defn- pending-state []
+  (state/create-execution-state sample-workflow {:input "x"}))
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest transition-status-anomaly-returns-state-on-valid-event
+  (testing "valid :start event from :pending advances to :running"
+    (let [s (pending-state)
+          result (state/transition-status-anomaly s :start)]
+      (is (not (anomaly/anomaly? result)))
+      (is (= :running (:execution/status result))))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest transition-status-anomaly-returns-anomaly-on-invalid-event
+  (testing "invalid event yields :invalid-input anomaly with FSM diagnostics"
+    (let [s (pending-state)
+          result (state/transition-status-anomaly s :complete)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (let [data (:anomaly/data result)]
+        (is (= :pending (:current-status data)))
+        (is (= :complete (:event data)))
+        (is (some? (:error data)))
+        (is (some? (:fsm-message data)))))))
+
+(deftest transition-status-anomaly-leaves-state-untouched-on-rejection
+  (testing "rejected transition does not mutate execution status"
+    (let [s (pending-state)]
+      (state/transition-status-anomaly s :complete)
+      (is (= :pending (:execution/status s))
+          "anomaly path is functionally pure — no FSM transition recorded"))))
+
+;------------------------------------------------------------------------------ Throwing-variant compat
+
+(deftest transition-status-still-returns-on-valid-event
+  (testing "deprecated throwing variant still returns updated state on success"
+    (let [s (pending-state)
+          result (state/transition-status s :start)]
+      (is (= :running (:execution/status result))))))
+
+(deftest transition-status-still-throws-on-invalid-event
+  (testing "deprecated throwing variant still throws ExceptionInfo on FSM rejection"
+    (let [s (pending-state)]
+      (is (thrown-with-msg? ExceptionInfo #"Invalid state transition"
+            (state/transition-status s :complete))))))
+
+(deftest transition-status-thrown-ex-data-preserves-shape
+  (testing "ex-data preserves the legacy slingshot anomaly shape"
+    (let [s (pending-state)]
+      (try
+        (state/transition-status s :complete)
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (let [data (ex-data e)]
+            (is (= :anomalies.workflow/invalid-transition (:anomaly/category data)))
+            (is (= :pending (:current-status data)))
+            (is (= :complete (:event data)))
+            (is (some? (:error data)))
+            (is (some? (:message data)))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/transition_status_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/transition_status_test.clj
@@ -58,12 +58,22 @@
         (is (some? (:error data)))
         (is (some? (:fsm-message data)))))))
 
-(deftest transition-status-anomaly-leaves-state-untouched-on-rejection
-  (testing "rejected transition does not mutate execution status"
-    (let [s (pending-state)]
-      (state/transition-status-anomaly s :complete)
-      (is (= :pending (:execution/status s))
-          "anomaly path is functionally pure — no FSM transition recorded"))))
+(deftest transition-status-anomaly-rejection-does-not-advance-status
+  (testing "rejected transition produces an anomaly whose data still reports the
+            pre-transition status — verifies the FSM did not partially advance
+            before flagging the rejection"
+    (let [s      (pending-state)
+          result (state/transition-status-anomaly s :complete)
+          data   (:anomaly/data result)]
+      (is (anomaly/anomaly? result))
+      ;; The anomaly carries the status the FSM was in *at evaluation time*.
+      ;; If a buggy implementation advanced the status before deciding the
+      ;; transition was invalid, this would report the wrong current-status.
+      (is (= :pending (:current-status data)))
+      ;; Returned value is the anomaly itself, not a partially-transitioned
+      ;; state map — ie. the function does not return a map carrying both
+      ;; an updated :execution/status and the anomaly.
+      (is (not (contains? result :execution/status))))))
 
 ;------------------------------------------------------------------------------ Throwing-variant compat
 

--- a/docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md
+++ b/docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md
@@ -62,15 +62,15 @@ Other runtime-area files (`runner_cleanup.clj`, `monitoring.clj`, `observe_phase
 
 ## Per-site classification
 
-| Site | `:anomaly/type` | Why |
-|---|---|---|
-| `state.clj` `transition-status` | `:invalid-input` | FSM rejection is validation-shaped — the caller passed an event the current state cannot accept. `:conflict` was tempting, but the FSM treats this as malformed input, not a state-vs-state collision. |
-| `runner_environment.clj` `assert-executor-for-mode!` | `:unavailable` | Governed mode requires capsule; absence is downstream/system unavailability (no capsule executor present). Mirrors the existing `:anomalies.executor/unavailable` slingshot mapping. |
-| `runner.clj` `build-initial-context` | `:invalid-input` | Caller supplied `:execution-mode :governed` without the matching `:executor` + `:environment-id` — caller-side input mismatch. Pre-flight guard runs before any environment lookup. |
+| File | Function | `:anomaly/type` | Why |
+|---|---|---|---|
+| `state.clj` | `transition-status` | `:invalid-input` | FSM rejection is validation-shaped — the caller passed an event the current state cannot accept. `:conflict` was tempting, but the FSM treats this as malformed input, not a state-vs-state collision. |
+| `runner_environment.clj` | `assert-executor-for-mode!` | `:unavailable` | Governed mode requires capsule; absence is downstream/system unavailability (no capsule executor present). Mirrors the existing `:anomalies.executor/unavailable` slingshot mapping. |
+| `runner.clj` | `build-initial-context` | `:invalid-input` | Caller supplied `:execution-mode :governed` without the matching `:executor` + `:environment-id` — caller-side input mismatch. Pre-flight guard runs before any environment lookup. |
 
-## Slingshot at `runner.clj:156` — kept as control-flow
+## Slingshot stop-anomaly in `runner.clj` — kept as control-flow
 
-The inventory flagged `runner.clj:156` (`response/throw-anomaly!` to `:anomalies.dashboard/stop`) as `:ambiguous`. Verified by reading the catch site at `runner.clj:391`:
+The inventory flagged the dashboard-stop throw inside `runner.clj`'s `check-stopped!` helper (`response/throw-anomaly!` to `:anomalies.dashboard/stop`) as `:ambiguous`. Verified by reading the matching catch in the same file's pipeline-loop `try+`:
 
 ```clojure
 (catch [:anomaly/category :anomalies.dashboard/stop] {:keys [anomaly/message]} ...)

--- a/docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md
+++ b/docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md
@@ -1,0 +1,145 @@
+# refactor: exceptions-as-data cleanup of workflow (runtime side)
+
+## Overview
+
+Migrates the runtime-side `:cleanup-needed` throw sites in the `workflow` component to anomaly-returning variants alongside the existing throwers. Three sites retired: `runner/build-initial-context`, `runner-environment/assert-executor-for-mode!`, and `state/transition-status`. Loader/registry-side sites (~9) are deferred to a follow-on PR per the inventory's recommended split.
+
+## Motivation
+
+Per `work/exception-cleanup-inventory.md`, `workflow` is the second-highest-density cleanup target after `repo-dag` (now merged in PR #758). The inventory explicitly recommended a 2-PR split (runtime + loader/registry) due to the risk surface — this PR is the runtime side only.
+
+Runtime cleanup has the highest downstream payoff: every workflow execution path now composes cleanly with response-chains and inference-evidence rather than relying on slingshot exceptions for non-control-flow failures.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary and constructor
+- `005 exceptions-as-data` standards rule (merged)
+
+## Layer
+
+Refactor / per-component cleanup tier. `workflow` runtime namespaces only — no loader/registry change in this PR.
+
+## What This Adds / Changes
+
+`components/workflow/deps.edn`:
+
+- Added `:local/root` dep on `ai.miniforge/anomaly`.
+
+Source files modified (3):
+
+- `components/workflow/src/ai/miniforge/workflow/runner.clj` — `build-initial-context-anomaly` added; private `governed-capsule-missing-anomaly` extracted; throwing variant delegates and re-wraps via `response/throw-anomaly!`
+- `components/workflow/src/ai/miniforge/workflow/runner_environment.clj` — `check-executor-for-mode-anomaly` added; throwing variant delegates
+- `components/workflow/src/ai/miniforge/workflow/state.clj` — `transition-status-anomaly` added; throwing variant delegates
+
+New decomposed test files (3):
+
+- `components/workflow/test/.../anomaly/build_initial_context_test.clj`
+- `components/workflow/test/.../anomaly/check_executor_for_mode_test.clj`
+- `components/workflow/test/.../anomaly/transition_status_test.clj`
+
+Each pins happy-path / failure-path / throwing-variant-compatibility for its scope.
+
+## Cleavage line
+
+The inventory's 9 cleanup-needed sites for `workflow` are loader-side; the runtime sites came from the broader inventory recount. Final split:
+
+**Runtime side (this PR, 3 sites retired):**
+- `runner.clj` — `build-initial-context`
+- `runner_environment.clj` — `check-executor-for-mode!`
+- `state.clj` — `transition-status`
+
+**Loader side (deferred, 9 sites):**
+- `loader.clj` (×3)
+- `chain_loader.clj` (×1)
+- `registry.clj` (×4)
+- `schemas.clj` (×1)
+
+Other runtime-area files (`runner_cleanup.clj`, `monitoring.clj`, `observe_phase.clj`, `agent_factory.clj`, `supervision.clj`, `dag_orchestrator.clj`) had no `:cleanup-needed` sites — only `:fatal-only` (boot-time) and `:boundary` (re-throws / event payloads). No changes required in those files.
+
+## Per-site classification
+
+| Site | `:anomaly/type` | Why |
+|---|---|---|
+| `state.clj` `transition-status` | `:invalid-input` | FSM rejection is validation-shaped — the caller passed an event the current state cannot accept. `:conflict` was tempting, but the FSM treats this as malformed input, not a state-vs-state collision. |
+| `runner_environment.clj` `assert-executor-for-mode!` | `:unavailable` | Governed mode requires capsule; absence is downstream/system unavailability (no capsule executor present). Mirrors the existing `:anomalies.executor/unavailable` slingshot mapping. |
+| `runner.clj` `build-initial-context` | `:invalid-input` | Caller supplied `:execution-mode :governed` without the matching `:executor` + `:environment-id` — caller-side input mismatch. Pre-flight guard runs before any environment lookup. |
+
+## Slingshot at `runner.clj:156` — kept as control-flow
+
+The inventory flagged `runner.clj:156` (`response/throw-anomaly!` to `:anomalies.dashboard/stop`) as `:ambiguous`. Verified by reading the catch site at `runner.clj:391`:
+
+```clojure
+(catch [:anomaly/category :anomalies.dashboard/stop] {:keys [anomaly/message]} ...)
+```
+
+This is true cooperative cancellation control flow — the inner `try+` selectively unwinds when the dashboard issues a stop, then transitions the workflow to `:failed`. Rewriting it as a return value would require threading a sentinel through every layer between `check-stopped!` and the outer pipeline loop. Kept as-is; rationale documented in the commit body.
+
+## New API surface
+
+Added to public interfaces:
+
+```clojure
+ai.miniforge.workflow.state/transition-status-anomaly
+ai.miniforge.workflow.runner-environment/check-executor-for-mode-anomaly
+ai.miniforge.workflow.runner/build-initial-context-anomaly
+```
+
+Throwing siblings retained, marked `^{:deprecated "exceptions-as-data — prefer *-anomaly"}`, and now delegate to the anomaly variants — re-wrapping the returned anomaly into the original `response/throw-anomaly!` shape so existing callers see no behavior change.
+
+## Inventory delta
+
+- **Runtime side:** 3 of 3 `:cleanup-needed` sites retired in this PR (plus the 1 ambiguous slingshot resolved as keep-as-is).
+- **Loader side:** 9 sites deferred to follow-on PR (`loader.clj` ×3, `chain_loader.clj` ×1, `registry.clj` ×4, `schemas.clj` ×1).
+
+## Strata Affected
+
+- `ai.miniforge.workflow.runner` — `build-initial-context-anomaly` added; thrower delegates
+- `ai.miniforge.workflow.runner-environment` — `check-executor-for-mode-anomaly` added
+- `ai.miniforge.workflow.state` — `transition-status-anomaly` added; downstream `mark-completed` / `mark-failed` / `transition-to-phase` continue to call the deprecated thrower (out of scope)
+
+## Testing Plan
+
+- **`bb pre-commit` green:**
+  - `lint:clj` — clean
+  - `fmt:md` — clean
+  - `test` — **4930 tests / 22631 passes / 0 failures / 0 errors**
+  - `test:graalvm` — 6 tests / 487 assertions / 0 failures
+- 16 expected clj-kondo deprecation warnings on the deprecated throwers; only fire from in-component callers that exercise the legacy path.
+- **Commit-budget overridden** (358 reportable lines > 200 threshold). Rationale recorded in commit body: protocol-body changes must be atomic; splitting leaves intermediate commits uncompilable. Same precedent as PR #758 (repo-dag).
+
+## Deployment Plan
+
+No migration required. Backward-compatible.
+
+- Existing throwing-API callers see no change. Same signatures, same `slingshot` `:anomaly/category` shape on failure.
+- New code reaches for `*-anomaly` variants; existing call sites can migrate at their leisure or be migrated by follow-ons.
+
+## Notes / Surprises
+
+- **`:anomalies.workflow/no-capsule-executor` is not in `response/anomaly/workflow-anomalies` taxonomy.** Pre-existing latent bug — `throw-anomaly!` doesn't validate against the taxonomy. Preserved in the throwing wrapper to keep behavior identical; flagged for the loader-side cleanup or a separate hygiene pass.
+- **`runner-test` and `runner-extended-test` have 14 errors / 1 failure on `main` when run in isolation against the workflow component.** They require the broader phase registry loaded via the polylith development project. Confirmed by stashing changes and rerunning — not regressions caused by this PR; project-level `bb test` passes 4930/4930.
+- **Commit-budget gate friction.** Same pattern as repo-dag (PR #758): mechanical many-site refactor + delegated wrappers + decomposed tests trips the line budget. Override path documented and worked. Worth flagging again as repeating friction; an `:exceptions-as-data` budget profile would simplify.
+
+## Related Issues/PRs
+
+- Built on PR #704 (foundation cleanup)
+- Built on PR #734 (per-connector callsite migration)
+- Built on PR #758 (repo-dag cleanup)
+- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
+- Loader-side follow-on: deferred (separate PR)
+
+## Checklist
+
+- [x] All 3 runtime-side `:cleanup-needed` workflow sites retired
+- [x] Existing throwing API preserved (delegated, behavior identical)
+- [x] Anomaly-returning variants for every migrated site
+- [x] Deprecation markers on throwers + docstring pointers
+- [x] Decomposed test files (three new) — happy / failure / compat per scope
+- [x] Slingshot control-flow site documented and kept as-is
+- [x] No new throws in anomaly-returning code paths
+- [x] `bb pre-commit` green
+- [x] Apache 2 license headers preserved


### PR DESCRIPTION
# refactor: exceptions-as-data cleanup of workflow (runtime side)

## Overview

Migrates the runtime-side `:cleanup-needed` throw sites in the `workflow` component to anomaly-returning variants alongside the existing throwers. Three sites retired: `runner/build-initial-context`, `runner-environment/assert-executor-for-mode!`, and `state/transition-status`. Loader/registry-side sites (~9) are deferred to a follow-on PR per the inventory's recommended split.

## Motivation

Per `work/exception-cleanup-inventory.md`, `workflow` is the second-highest-density cleanup target after `repo-dag` (now merged in PR #758). The inventory explicitly recommended a 2-PR split (runtime + loader/registry) due to the risk surface — this PR is the runtime side only.

Runtime cleanup has the highest downstream payoff: every workflow execution path now composes cleanly with response-chains and inference-evidence rather than relying on slingshot exceptions for non-control-flow failures.

## Base Branch

`main`

## Depends On

- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary and constructor
- `005 exceptions-as-data` standards rule (merged)

## Layer

Refactor / per-component cleanup tier. `workflow` runtime namespaces only — no loader/registry change in this PR.

## What This Adds / Changes

`components/workflow/deps.edn`:

- Added `:local/root` dep on `ai.miniforge/anomaly`.

Source files modified (3):

- `components/workflow/src/ai/miniforge/workflow/runner.clj` — `build-initial-context-anomaly` added; private `governed-capsule-missing-anomaly` extracted; throwing variant delegates and re-wraps via `response/throw-anomaly!`
- `components/workflow/src/ai/miniforge/workflow/runner_environment.clj` — `check-executor-for-mode-anomaly` added; throwing variant delegates
- `components/workflow/src/ai/miniforge/workflow/state.clj` — `transition-status-anomaly` added; throwing variant delegates

New decomposed test files (3):

- `components/workflow/test/.../anomaly/build_initial_context_test.clj`
- `components/workflow/test/.../anomaly/check_executor_for_mode_test.clj`
- `components/workflow/test/.../anomaly/transition_status_test.clj`

Each pins happy-path / failure-path / throwing-variant-compatibility for its scope.

## Cleavage line

The inventory's 9 cleanup-needed sites for `workflow` are loader-side; the runtime sites came from the broader inventory recount. Final split:

**Runtime side (this PR, 3 sites retired):**
- `runner.clj` — `build-initial-context`
- `runner_environment.clj` — `check-executor-for-mode!`
- `state.clj` — `transition-status`

**Loader side (deferred, 9 sites):**
- `loader.clj` (×3)
- `chain_loader.clj` (×1)
- `registry.clj` (×4)
- `schemas.clj` (×1)

Other runtime-area files (`runner_cleanup.clj`, `monitoring.clj`, `observe_phase.clj`, `agent_factory.clj`, `supervision.clj`, `dag_orchestrator.clj`) had no `:cleanup-needed` sites — only `:fatal-only` (boot-time) and `:boundary` (re-throws / event payloads). No changes required in those files.

## Per-site classification

| Site | `:anomaly/type` | Why |
|---|---|---|
| `state.clj` `transition-status` | `:invalid-input` | FSM rejection is validation-shaped — the caller passed an event the current state cannot accept. `:conflict` was tempting, but the FSM treats this as malformed input, not a state-vs-state collision. |
| `runner_environment.clj` `assert-executor-for-mode!` | `:unavailable` | Governed mode requires capsule; absence is downstream/system unavailability (no capsule executor present). Mirrors the existing `:anomalies.executor/unavailable` slingshot mapping. |
| `runner.clj` `build-initial-context` | `:invalid-input` | Caller supplied `:execution-mode :governed` without the matching `:executor` + `:environment-id` — caller-side input mismatch. Pre-flight guard runs before any environment lookup. |

## Slingshot at `runner.clj:156` — kept as control-flow

The inventory flagged `runner.clj:156` (`response/throw-anomaly!` to `:anomalies.dashboard/stop`) as `:ambiguous`. Verified by reading the catch site at `runner.clj:391`:

```clojure
(catch [:anomaly/category :anomalies.dashboard/stop] {:keys [anomaly/message]} ...)
```

This is true cooperative cancellation control flow — the inner `try+` selectively unwinds when the dashboard issues a stop, then transitions the workflow to `:failed`. Rewriting it as a return value would require threading a sentinel through every layer between `check-stopped!` and the outer pipeline loop. Kept as-is; rationale documented in the commit body.

## New API surface

Added to public interfaces:

```clojure
ai.miniforge.workflow.state/transition-status-anomaly
ai.miniforge.workflow.runner-environment/check-executor-for-mode-anomaly
ai.miniforge.workflow.runner/build-initial-context-anomaly
```

Throwing siblings retained, marked `^{:deprecated "exceptions-as-data — prefer *-anomaly"}`, and now delegate to the anomaly variants — re-wrapping the returned anomaly into the original `response/throw-anomaly!` shape so existing callers see no behavior change.

## Inventory delta

- **Runtime side:** 3 of 3 `:cleanup-needed` sites retired in this PR (plus the 1 ambiguous slingshot resolved as keep-as-is).
- **Loader side:** 9 sites deferred to follow-on PR (`loader.clj` ×3, `chain_loader.clj` ×1, `registry.clj` ×4, `schemas.clj` ×1).

## Strata Affected

- `ai.miniforge.workflow.runner` — `build-initial-context-anomaly` added; thrower delegates
- `ai.miniforge.workflow.runner-environment` — `check-executor-for-mode-anomaly` added
- `ai.miniforge.workflow.state` — `transition-status-anomaly` added; downstream `mark-completed` / `mark-failed` / `transition-to-phase` continue to call the deprecated thrower (out of scope)

## Testing Plan

- **`bb pre-commit` green:**
  - `lint:clj` — clean
  - `fmt:md` — clean
  - `test` — **4930 tests / 22631 passes / 0 failures / 0 errors**
  - `test:graalvm` — 6 tests / 487 assertions / 0 failures
- 16 expected clj-kondo deprecation warnings on the deprecated throwers; only fire from in-component callers that exercise the legacy path.
- **Commit-budget overridden** (358 reportable lines > 200 threshold). Rationale recorded in commit body: protocol-body changes must be atomic; splitting leaves intermediate commits uncompilable. Same precedent as PR #758 (repo-dag).

## Deployment Plan

No migration required. Backward-compatible.

- Existing throwing-API callers see no change. Same signatures, same `slingshot` `:anomaly/category` shape on failure.
- New code reaches for `*-anomaly` variants; existing call sites can migrate at their leisure or be migrated by follow-ons.

## Notes / Surprises

- **`:anomalies.workflow/no-capsule-executor` is not in `response/anomaly/workflow-anomalies` taxonomy.** Pre-existing latent bug — `throw-anomaly!` doesn't validate against the taxonomy. Preserved in the throwing wrapper to keep behavior identical; flagged for the loader-side cleanup or a separate hygiene pass.
- **`runner-test` and `runner-extended-test` have 14 errors / 1 failure on `main` when run in isolation against the workflow component.** They require the broader phase registry loaded via the polylith development project. Confirmed by stashing changes and rerunning — not regressions caused by this PR; project-level `bb test` passes 4930/4930.
- **Commit-budget gate friction.** Same pattern as repo-dag (PR #758): mechanical many-site refactor + delegated wrappers + decomposed tests trips the line budget. Override path documented and worked. Worth flagging again as repeating friction; an `:exceptions-as-data` budget profile would simplify.

## Related Issues/PRs

- Built on PR #704 (foundation cleanup)
- Built on PR #734 (per-connector callsite migration)
- Built on PR #758 (repo-dag cleanup)
- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
- Loader-side follow-on: deferred (separate PR)

## Checklist

- [x] All 3 runtime-side `:cleanup-needed` workflow sites retired
- [x] Existing throwing API preserved (delegated, behavior identical)
- [x] Anomaly-returning variants for every migrated site
- [x] Deprecation markers on throwers + docstring pointers
- [x] Decomposed test files (three new) — happy / failure / compat per scope
- [x] Slingshot control-flow site documented and kept as-is
- [x] No new throws in anomaly-returning code paths
- [x] `bb pre-commit` green
- [x] Apache 2 license headers preserved
