### PR TITLE
fix(review): rehydrate :code/files from recorded paths

### DIFF
--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -196,6 +196,49 @@
       (catch Exception _
         nil))))
 
+(defn rehydrate-files
+  "Read file content from `working-dir` for each path in `paths`,
+   producing the `:code/files` vector callers expect.
+
+   Used when an upstream phase persisted only paths-as-metadata
+   (`:code/file-paths` / `:code/file-actions` from
+   `lightweight-curated-artifact`) and a downstream phase needs the
+   content reconstituted. After the implement phase boundary persists
+   dirty work as a commit on the task branch, the worktree is clean
+   at HEAD — `git status --porcelain` returns empty and the existing
+   `collect-written-files` fallback yields no content. This function
+   reads the still-on-disk content directly so the reviewer (and any
+   later phase) can see what landed.
+
+   `paths` is the sequence of file paths to read (relative to
+   `working-dir`). `actions` is the parallel sequence of action
+   keywords (`:create` / `:modify` / `:delete`); when omitted, every
+   present path is treated as `:modify`. For `:delete` actions the
+   content is the empty string. Files recorded in `paths` but absent
+   from disk are skipped — better to under-report than to invent
+   content that no longer exists.
+
+   Returns a vector of `{:path :content :action}` maps, possibly
+   empty. Returns nil when `working-dir` is nil."
+  ([working-dir paths]
+   (rehydrate-files working-dir paths nil))
+  ([working-dir paths actions]
+   (when working-dir
+     (let [action-by-path (zipmap paths (or actions (repeat :modify)))]
+       (->> paths
+            (keep (fn [path]
+                    (let [action (get action-by-path path :modify)
+                          file   (io/file working-dir path)]
+                      (cond
+                        (= :delete action)
+                        {:path path :content "" :action :delete}
+
+                        (.exists file)
+                        {:path path :content (slurp file) :action action}
+
+                        :else nil))))
+            vec)))))
+
 (defn- read-file-via-executor
   "Read a file's content from the capsule. Returns empty string on failure."
   [exec! executor env-id working-dir path]

--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -196,6 +196,52 @@
       (catch Exception _
         nil))))
 
+(defn- safe-resolve
+  "Resolve `path` under `working-dir` defensively. Returns a regular-file
+   `java.io.File` when:
+   - `path` is non-blank
+   - the canonical target stays inside `working-dir` (rejects absolute
+     paths, `..` escapes, and symlinks pointing outside)
+   - the target exists and is a regular file (not a directory)
+   Returns nil otherwise. Paths come from agent-produced artifacts, so
+   this is a real boundary check, not paranoia."
+  [working-dir path]
+  (try
+    (when (and (string? path) (not (str/blank? path)))
+      (let [base   (.getCanonicalFile (io/file working-dir))
+            target (.getCanonicalFile (io/file working-dir path))]
+        (when (and (.exists target)
+                   (.isFile target)
+                   (.startsWith (.toPath target) (.toPath base)))
+          target)))
+    (catch java.io.IOException _ nil)
+    (catch SecurityException _ nil)
+    (catch IllegalArgumentException _ nil)))
+
+(defn- read-rehydrated-file
+  "Read one rehydration entry. Returns the file map or nil for any
+   failure (path traversal, missing/non-regular file, permissions,
+   read errors). Skipping unreadable paths is preferable to bubbling
+   an exception that fails the entire review phase."
+  [working-dir path action]
+  (if (= :delete action)
+    {:path path :content "" :action :delete}
+    (when-let [file (safe-resolve working-dir path)]
+      (try
+        {:path path :content (slurp file) :action action}
+        (catch java.io.IOException _ nil)
+        (catch SecurityException _ nil)))))
+
+(defn- rehydration-entry
+  "Build one `:code/files` entry for `path` under `working-dir`,
+   honoring the action recorded in `action-by-path` (defaulting to
+   `:modify`). Named so callers can pass it via `partial` instead of
+   hoisting the closure into an inline `fn`."
+  [working-dir action-by-path path]
+  (read-rehydrated-file working-dir
+                        path
+                        (get action-by-path path :modify)))
+
 (defn rehydrate-files
   "Read file content from `working-dir` for each path in `paths`,
    producing the `:code/files` vector callers expect.
@@ -214,9 +260,12 @@
    `working-dir`). `actions` is the parallel sequence of action
    keywords (`:create` / `:modify` / `:delete`); when omitted, every
    present path is treated as `:modify`. For `:delete` actions the
-   content is the empty string. Files recorded in `paths` but absent
-   from disk are skipped — better to under-report than to invent
-   content that no longer exists.
+   content is the empty string.
+
+   Paths that fail validation (absolute, `..` escape, symlink-out,
+   directory at path), do not exist, or are unreadable for any reason
+   are skipped — better to under-report than to invent content or
+   fail a downstream phase on a stray path produced by an agent.
 
    Returns a vector of `{:path :content :action}` maps, possibly
    empty. Returns nil when `working-dir` is nil."
@@ -226,17 +275,7 @@
    (when working-dir
      (let [action-by-path (zipmap paths (or actions (repeat :modify)))]
        (->> paths
-            (keep (fn [path]
-                    (let [action (get action-by-path path :modify)
-                          file   (io/file working-dir path)]
-                      (cond
-                        (= :delete action)
-                        {:path path :content "" :action :delete}
-
-                        (.exists file)
-                        {:path path :content (slurp file) :action action}
-
-                        :else nil))))
+            (keep (partial rehydration-entry working-dir action-by-path))
             vec)))))
 
 (defn- read-file-via-executor

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -186,6 +186,12 @@
   "Collect files written during the agent session into a synthetic code artifact."
   file-artifacts/collect-written-files)
 
+(def rehydrate-files
+  "Reconstitute :code/files from recorded paths by reading the worktree.
+   Used by downstream phases when the implement phase persisted only
+   paths-as-metadata and the worktree has since been committed clean."
+  file-artifacts/rehydrate-files)
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Tool supervision
 

--- a/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
@@ -191,6 +191,47 @@
       (try
         (is (= [] (sut/rehydrate-files dir ["src/missing.clj"] [:modify])))
         (finally
+          (delete-tree! dir)))))
+
+  (testing "absolute paths are rejected (no read outside working-dir)"
+    (let [dir    (temp-dir)
+          escape (temp-dir)]
+      (try
+        (write-file! escape "secret.txt" "outside-the-worktree")
+        (let [outside (str (io/file escape "secret.txt"))]
+          (is (= [] (sut/rehydrate-files dir [outside] [:modify]))
+              "Absolute path outside working-dir must be skipped"))
+        (finally
+          (delete-tree! dir)
+          (delete-tree! escape)))))
+
+  (testing "../ escapes are rejected after canonicalization"
+    (let [dir    (temp-dir)
+          parent (.getParent (io/file dir))]
+      (try
+        (spit (io/file parent "leak.txt") "outside-the-worktree")
+        (try
+          (is (= [] (sut/rehydrate-files dir ["../leak.txt"] [:modify]))
+              "../ path resolving outside working-dir must be skipped")
+          (finally
+            (.delete (io/file parent "leak.txt"))))
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "directories at a path are skipped (not slurped)"
+    (let [dir (temp-dir)]
+      (try
+        (.mkdirs (io/file dir "src" "is-a-dir"))
+        (is (= [] (sut/rehydrate-files dir ["src/is-a-dir"] [:modify]))
+            "Directories must not be passed to slurp")
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "blank/nil paths are skipped"
+    (let [dir (temp-dir)]
+      (try
+        (is (= [] (sut/rehydrate-files dir ["" "   "] [:modify :modify])))
+        (finally
           (delete-tree! dir))))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
@@ -141,6 +141,58 @@
         (finally
           (delete-tree! dir))))))
 
+(deftest rehydrate-files-test
+  (testing "reads file content from disk for each recorded path"
+    (let [dir (temp-dir)]
+      (try
+        (write-file! dir "src/new.clj" "(ns new)")
+        (write-file! dir "src/changed.clj" "(ns changed)")
+        (is (= [{:path "src/new.clj"     :content "(ns new)"     :action :create}
+                {:path "src/changed.clj" :content "(ns changed)" :action :modify}]
+               (sut/rehydrate-files dir
+                                    ["src/new.clj" "src/changed.clj"]
+                                    [:create :modify])))
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "delete actions emit empty content without touching disk"
+    (let [dir (temp-dir)]
+      (try
+        (is (= [{:path "src/gone.clj" :content "" :action :delete}]
+               (sut/rehydrate-files dir ["src/gone.clj"] [:delete])))
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "paths absent from disk are skipped rather than invented"
+    (let [dir (temp-dir)]
+      (try
+        (write-file! dir "src/here.clj" "(ns here)")
+        (is (= [{:path "src/here.clj" :content "(ns here)" :action :modify}]
+               (sut/rehydrate-files dir
+                                    ["src/here.clj" "src/missing.clj"]
+                                    [:modify :modify])))
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "default action is :modify when no actions are supplied"
+    (let [dir (temp-dir)]
+      (try
+        (write-file! dir "src/x.clj" "(ns x)")
+        (is (= [{:path "src/x.clj" :content "(ns x)" :action :modify}]
+               (sut/rehydrate-files dir ["src/x.clj"])))
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "returns nil for nil working-dir"
+    (is (nil? (sut/rehydrate-files nil ["src/x.clj"] [:modify]))))
+
+  (testing "returns empty vector when no recorded path is present on disk"
+    (let [dir (temp-dir)]
+      (try
+        (is (= [] (sut/rehydrate-files dir ["src/missing.clj"] [:modify])))
+        (finally
+          (delete-tree! dir))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.agent.file-artifacts-test)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -49,41 +49,60 @@
   [ctx phase-name]
   (phase/create-streaming-callback ctx phase-name))
 
+(defn- rehydrate-from-paths
+  "Reconstitute `:code/files` for an outer-artifact that was persisted as
+   paths-only metadata by `lightweight-curated-artifact`.
+
+   The implement phase boundary commits dirty work onto the task branch
+   immediately after `leave-implement`, so by the time review runs the
+   worktree is clean at HEAD and `git status --porcelain` reports
+   nothing — the prior fallback (`collect-written-files (empty-snapshot)
+   worktree-path`) returned an empty `:code/files` and the reviewer
+   reported 'no files were created in the worktree' even though the
+   committed branch had everything (observed: codex/event-log-tool-
+   visibility dogfood, 2026-05-04). Reading the recorded paths off disk
+   is cheap, deterministic, and avoids re-running git plumbing."
+  [outer-artifact worktree-path]
+  (when-let [paths (and outer-artifact
+                        worktree-path
+                        (seq (:code/file-paths outer-artifact)))]
+    (let [files (agent/rehydrate-files worktree-path paths
+                                       (:code/file-actions outer-artifact))]
+      (when (seq files)
+        (assoc outer-artifact :code/files files)))))
+
 (defn- resolve-implement-artifact
-  "Resolve the implement-phase artifact using three strategies:
-   1. Serialized :artifact key in the implement result (legacy model)
-   2. The result itself when it already contains :code/files (it IS the artifact)
-   3. Serialized artifact under inner result :output
-   4. Fall back to collecting all changed files from the worktree on disk
-      (environment-promotion model where the agent writes directly to the worktree)
-   If the persisted outer artifact is metadata-only, merge that metadata over the
-   worktree-collected artifact so review sees full file content plus curator flags."
+  "Resolve the implement-phase artifact using ordered strategies, from
+   most-direct (full content already in the result) to last-resort
+   (rebuild from the worktree).
+
+   1. Outer `:artifact` already includes `:code/files`.
+   2. Inner result's `:artifact` already includes `:code/files`.
+   3. Result map IS the artifact (has `:code/files`).
+   4. Inner result's `:output` includes `:code/files`.
+   5. Lightweight outer artifact (paths-only) — read content from disk
+      using `:code/file-paths` so review sees what landed even though
+      the phase-boundary persist already cleaned the worktree.
+   6. Metadata-only outer artifact merged over a worktree
+      git-status snapshot (legacy fallback).
+   7. Worktree git-status snapshot alone (env-promotion model)."
   [implement-phase-result ctx]
-  (let [outer-artifact (:artifact implement-phase-result)
-        inner-artifact (get-in implement-phase-result [:result :artifact])
-        inner-output (get-in implement-phase-result [:result :output])
-        worktree-path (or (get ctx :execution/worktree-path)
-                          (get ctx :worktree-path))
-        worktree-artifact (when worktree-path
-                            (agent/collect-written-files (agent/empty-snapshot)
-                                                         worktree-path))]
+  (let [outer-artifact     (:artifact implement-phase-result)
+        inner-artifact     (get-in implement-phase-result [:result :artifact])
+        inner-output       (get-in implement-phase-result [:result :output])
+        worktree-path      (or (get ctx :execution/worktree-path)
+                               (get ctx :worktree-path))
+        worktree-artifact  (when worktree-path
+                             (agent/collect-written-files (agent/empty-snapshot)
+                                                          worktree-path))]
     (or
-     ;; Strategy 1 — persisted outer artifact already includes file content
-     (when (:code/files outer-artifact)
-       outer-artifact)
-     ;; Strategy 2 — explicit :artifact in inner result
-     (when (:code/files inner-artifact)
-       inner-artifact)
-     ;; Strategy 3 — result already is the artifact (has :code/files)
-     (when (:code/files implement-phase-result)
-       implement-phase-result)
-     ;; Strategy 4 — serialized artifact under inner :output
-     (when (:code/files inner-output)
-       inner-output)
-     ;; Strategy 5 — metadata-only outer artifact merged over worktree content
+     (when (:code/files outer-artifact)        outer-artifact)
+     (when (:code/files inner-artifact)        inner-artifact)
+     (when (:code/files implement-phase-result) implement-phase-result)
+     (when (:code/files inner-output)          inner-output)
+     (rehydrate-from-paths outer-artifact worktree-path)
      (when (and outer-artifact worktree-artifact)
        (merge worktree-artifact outer-artifact))
-     ;; Strategy 6 — read changed files from worktree (env-promotion model)
      worktree-artifact)))
 
 (defn- build-verify-review-input

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -66,8 +66,10 @@
   (when-let [paths (and outer-artifact
                         worktree-path
                         (seq (:code/file-paths outer-artifact)))]
-    (let [files (agent/rehydrate-files worktree-path paths
-                                       (:code/file-actions outer-artifact))]
+    (let [files (try
+                  (agent/rehydrate-files worktree-path paths
+                                         (:code/file-actions outer-artifact))
+                  (catch Exception _ nil))]
       (when (seq files)
         (assoc outer-artifact :code/files files)))))
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_artifact_resolution_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_artifact_resolution_test.clj
@@ -188,6 +188,50 @@
       (is (nil? resolved)
           "Should return nil when implement-result is nil"))))
 
+(deftest resolve-rehydrate-from-paths-test
+  (testing "Strategy 5: paths-only outer artifact rehydrates content from worktree"
+    (let [outer-artifact {:code/summary "lightweight artifact"
+                          :code/file-paths ["src/core.clj" "src/util.clj"]
+                          :code/file-actions [:create :modify]
+                          :code/file-count 2}
+          impl-result {:status :completed :artifact outer-artifact}
+          ctx (make-ctx)
+          rehydrated [{:path "src/core.clj" :content "(ns core)"  :action :create}
+                      {:path "src/util.clj" :content "(ns util)" :action :modify}]
+          resolved (with-redefs [agent/rehydrate-files
+                                 (fn [working-dir paths actions]
+                                   (is (= "/tmp/test-worktree" working-dir))
+                                   (is (= ["src/core.clj" "src/util.clj"] paths))
+                                   (is (= [:create :modify] actions))
+                                   rehydrated)
+                                 agent/collect-written-files
+                                 (fn [_ _]
+                                   {:code/files [{:path "should-not-win.clj"
+                                                  :content "x" :action :create}]
+                                    :code/summary "should-not-win"})]
+                     (resolve-implement-artifact impl-result ctx))]
+      (is (= rehydrated (:code/files resolved)))
+      (is (= "lightweight artifact" (:code/summary resolved)))
+      (is (= ["src/core.clj" "src/util.clj"] (:code/file-paths resolved))
+          "Outer-artifact metadata is preserved alongside the rehydrated files")))
+
+  (testing "Strategy 5 falls through to strategy 6/7 when rehydration finds no files"
+    (let [outer-artifact {:code/summary "lightweight artifact"
+                          :code/file-paths ["src/missing.clj"]}
+          impl-result {:status :completed :artifact outer-artifact}
+          fallback-artifact {:code/files [{:path "src/picked.clj"
+                                           :content "(ns picked)"
+                                           :action :create}]
+                             :code/summary "from worktree"}
+          resolved (with-redefs [agent/rehydrate-files (fn [_ _ _] [])
+                                 agent/collect-written-files (fn [_ _] fallback-artifact)]
+                     (resolve-implement-artifact impl-result (make-ctx)))]
+      (is (= [{:path "src/picked.clj" :content "(ns picked)" :action :create}]
+             (:code/files resolved))
+          "Strategy 6 (worktree merge) takes over when strategy 5 returns nothing")
+      (is (= "lightweight artifact" (:code/summary resolved))
+          "Outer-artifact metadata still wins on the merge"))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (clojure.test/run-tests 'ai.miniforge.phase-software-factory.review-artifact-resolution-test)


### PR DESCRIPTION
## Summary

- Adds `agent/rehydrate-files` — companion to `collect-written-files` that reads file content off disk for a recorded list of paths (handles `:create` / `:modify` / `:delete`, skips paths absent on disk).
- Wires a new strategy 5 into `review/resolve-implement-artifact` that fires when the outer artifact is paths-only (`:code/file-paths` / `:code/file-actions`), reconstituting `:code/files` so the reviewer sees what actually landed.
- Regression tests for the helper and for strategy 5 ordering vs the worktree-merge fallback.

## Why

Observed in the `event-log-tool-visibility` codex dogfood (2026-05-04, see `project_dogfood_findings_2026_05_03.md`): implement #1 ran for 10.2m and reported success, the curator's file-artifact-fallback fired, and the implementation landed on the task branch. But review #1 :rejected with "File does not exist. No file was created anywhere in the worktree."

Cause: by the time review runs, the implement phase boundary has already committed dirty work onto the task branch via `dag/persist-workspace!` → `archive-bundle!`. The worktree is now clean at HEAD. `lightweight-curated-artifact` had already stripped `:code/files` and recorded only `:code/file-paths` / `:code/file-actions` on the outer artifact. The previous fallback chain ended with `collect-written-files (empty-snapshot) worktree-path` — `git status --porcelain` reports nothing, the synthesized artifact has no files, and the reviewer had no way to see the diff.

Strategy 5 reads the recorded paths off disk before falling through to the worktree-merge fallback. Cheap, deterministic, no new git plumbing.

## Test plan

- [x] `bb test` — 4916 tests, 0 failures, 0 errors
- [x] New tests: `rehydrate-files-test` (6 cases) + `resolve-rehydrate-from-paths-test` (2 cases)
- [ ] Re-run `event-log-tool-visibility` dogfood and confirm review sees `:code/files` content

🤖 Generated with [Claude Code](https://claude.com/claude-code)