### PR TITLE
feat(workflow): v2 multi-parent merge wiring (Stage 1B)

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -75,4 +75,19 @@
   :env/acquisition-failed   "Environment acquisition failed: {error}"
   :env/release-failed       "Environment release failed: {error}"
   :env/persist-message      "{phase} phase completed"
-  :env/persist-failed       "Workspace persist failed: {error}"}}
+  :env/persist-failed       "Workspace persist failed: {error}"
+
+  ;; v2 multi-parent merge (DAG orchestrator) — anomaly + log messages
+  :dag.merge/branch-unresolvable     "Parent branch could not be resolved to a commit"
+  :dag.merge/unrelated-histories     "Parents share no common ancestor — refusing to merge"
+  :dag.merge/strategy-unsupported    "Merge strategy {strategy} is not supported in this stage"
+  :dag.merge/conflict                "Multi-parent merge conflicted"
+  :dag.merge/merge-failed-worktree   "Could not create temp worktree for merge"
+  :dag.merge/merge-failed-ref-write  "Failed to write merge result to namespaced ref"
+  :dag.merge/commit-message-header   "miniforge dag-merge for task {task-id}"
+  :dag.merge/commit-message-parent   "  {index}. {task-id} @ {commit-sha}"
+
+  ;; v2 multi-parent merge — system-locale strings (operator-internal,
+  ;; never user-localized, but routed through the catalog so we have one
+  ;; place to audit and change them).
+  :dag.merge.system/git-test-failure "git {args} failed: {err}"}}

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -40,6 +40,7 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.dag-resilience :as resilience]
+   [ai.miniforge.workflow.messages :as messages]
    [babashka.fs :as fs]
    [clojure.java.shell :as shell]
    [clojure.set :as set]
@@ -283,6 +284,168 @@
 ;; happy path; conflict / unrelated-histories surface as terminal anomalies
 ;; that Stage 2 will replace with an automated resolution sub-workflow.
 
+;; Constants -----------------------------------------------------------
+
+(def ^:private merge-base-ref-prefix
+  "Namespace under refs/ where multi-parent merge bases live (spec §7.2)."
+  "refs/miniforge/dag-base")
+
+(def ^:private supported-merge-strategies
+  "Strategies `merge-parent-branches!` knows how to execute today.
+   `:git-merge` ships in Stage 1B; `:sequential-merge` is Stage 4
+   (per spec §4 / §10.11). Plans that explicitly request an unsupported
+   strategy get a typed anomaly rather than silently falling through
+   to `:git-merge` (which would misreport the executed strategy in
+   logs and the resolution-sub-workflow payload)."
+  #{:git-merge})
+
+(def ^:private octopus-merge-min-parents
+  "git's `octopus` strategy is required for 3+ parents. The default
+   `ort` strategy handles only 2-head merges. The threshold lives
+   here so the comparison sites are self-describing — no magic 2 / 3."
+  3)
+
+(def ^:private merge-base-default-max-parents
+  "git merge-base without --octopus only handles 2 parents. For 3+
+   we pass --octopus to find the n-way common ancestor. Same magic
+   number as octopus-merge-min-parents but a different code path,
+   named separately so the rationale is explicit at each site."
+  2)
+
+(def ^:private fallback-run-id
+  "Used when context lacks a workflow-id (test scaffolding mostly).
+   The merge ref namespace requires a non-nil run-id segment."
+  "no-run-id")
+
+;; Anomaly factories ---------------------------------------------------
+;; Each factory takes the minimum data needed and produces the canonical
+;; anomaly shape (`:anomaly/category` + `:anomaly/message` + rich data
+;; under `:merge/*` and `:git/*` keys). All messages route through the
+;; workflow message catalog.
+
+(defn- branch-unresolvable-anomaly
+  "Anomaly: a parent's registered branch could not be rev-parsed in
+   the host repo. Usually the registry is out of sync with the repo
+   (test scaffolding without the actual branches, or a registry
+   carry-over after a force-push that rewrote the branch's tip)."
+  [parent git-result]
+  {:anomaly/category :anomalies/dag-multi-parent-branch-unresolvable
+   :anomaly/message  (messages/t :dag.merge/branch-unresolvable)
+   :merge/parent     parent
+   :git/exit-code    (:exit git-result)
+   :git/stderr       (:err git-result)})
+
+(defn- unrelated-histories-anomaly
+  "Anomaly: parents share no common ancestor. v2 refuses to use
+   --allow-unrelated-histories per spec §6.5; this is almost always a
+   plan-quality / repo-state issue (stray git init, cross-repo branch)."
+  [task-id strategy parents]
+  {:anomaly/category :anomalies/dag-multi-parent-unrelated-histories
+   :anomaly/message  (messages/t :dag.merge/unrelated-histories)
+   :task/id          task-id
+   :merge/parents    parents
+   :merge/strategy   strategy})
+
+(defn- strategy-unsupported-anomaly
+  "Anomaly: plan requested a merge strategy this stage doesn't
+   implement. Echoes the requested strategy and the supported set so
+   the operator/dashboard knows what's available right now."
+  [task-id strategy]
+  {:anomaly/category :anomalies/dag-multi-parent-strategy-unsupported
+   :anomaly/message  (messages/t :dag.merge/strategy-unsupported
+                                 {:strategy strategy})
+   :task/id          task-id
+   :merge/strategy   strategy
+   :merge/supported  supported-merge-strategies})
+
+(defn- conflict-anomaly
+  "Anomaly: git merge produced conflicts. Carries the parents,
+   conflict paths, strategy, input-key, and raw git diagnostics.
+   Stage 2 will use this shape as the resolution-sub-workflow input
+   per spec §6.1."
+  [task-id strategy parents conflicts input-key git-result]
+  {:anomaly/category :anomalies/dag-multi-parent-conflict
+   :anomaly/message  (messages/t :dag.merge/conflict)
+   :task/id          task-id
+   :merge/parents    parents
+   :merge/conflicts  conflicts
+   :merge/strategy   strategy
+   :merge/input-key  input-key
+   :git/exit-code    (:exit git-result)
+   :git/stderr       (:err git-result)})
+
+(defn- worktree-setup-failed-anomaly
+  "Anomaly: couldn't create the temp worktree for the merge attempt.
+   Usually a filesystem / git-state issue from a prior crashed run."
+  [task-id git-result]
+  {:anomaly/category :anomalies/dag-multi-parent-merge-failed
+   :anomaly/message  (messages/t :dag.merge/merge-failed-worktree)
+   :task/id          task-id
+   :git/exit-code    (:exit git-result)
+   :git/stderr       (:err git-result)})
+
+(defn- ref-write-failed-anomaly
+  "Anomaly: merge succeeded but `git update-ref` for the namespaced
+   ref failed. Surfacing this matters because returning a 'success'
+   result with an unresolvable :merge/ref would mislead downstream
+   tasks."
+  [task-id ref-name commit-sha git-result]
+  {:anomaly/category :anomalies/dag-multi-parent-merge-failed
+   :anomaly/message  (messages/t :dag.merge/merge-failed-ref-write)
+   :task/id          task-id
+   :merge/ref        ref-name
+   :merge/commit-sha commit-sha
+   :git/exit-code    (:exit git-result)
+   :git/stderr       (:err git-result)})
+
+(defn- merge-error?
+  "True when a value is one of our merge anomalies (the canonical
+   shape with :anomaly/category). Lets callers branch on the result
+   without coupling to specific categories."
+  [x]
+  (and (map? x) (some? (:anomaly/category x))))
+
+;; Result factories ----------------------------------------------------
+;; Successful merge outcomes go through the existing dag/ok result-monad
+;; constructor so consumers can use the same dag/ok? / dag/unwrap
+;; predicates that the rest of the orchestrator already uses for task
+;; results. The inner shape is consistent across the three success
+;; varieties (full merge / single-parent fast-path / fallback) so the
+;; consumer only needs to look for :branch and (optionally) :commit-sha.
+
+(defn- merge-ok-result
+  "Successful merge commit on the namespaced ref. Includes the input-key
+   and a `:cache-hit?` flag for observability."
+  [{:keys [ref-name commit-sha input-key strategy parents collapsed cache-hit?]}]
+  (dag/ok (cond-> {:branch       ref-name
+                   :commit-sha   commit-sha
+                   :input-key    input-key
+                   :strategy     strategy
+                   :parents      parents
+                   :cache-hit?   (boolean cache-hit?)}
+            (seq collapsed) (assoc :collapsed collapsed))))
+
+(defn- single-parent-fast-path-result
+  "Successful resolution where collapse left exactly one effective
+   parent — no merge commit needed; downstream task forks off the
+   surviving parent's branch directly. Spec §6.2 / §6.3."
+  [survivor collapsed]
+  (dag/ok (cond-> {:branch         (:branch survivor)
+                   :commit-sha     (:commit-sha survivor)
+                   :single-parent? true}
+            (seq collapsed) (assoc :collapsed collapsed))))
+
+(defn- empty-registry-fallback-result
+  "Successful (defensive) resolution where the registry has no parents
+   for the declared deps. Mirrors the v1 single-parent path's
+   fail-soft semantics; production scheduling should prevent this."
+  [default-branch]
+  (dag/ok {:branch         default-branch
+           :single-parent? true
+           :fallback-reason :no-registered-parents}))
+
+;; Helpers -------------------------------------------------------------
+
 (defn- run-git
   "Invoke git in `cwd` with `args`. Returns `{:exit :out :err}` matching
    `clojure.java.shell/sh`. Defensive against shell exceptions so callers
@@ -314,11 +477,7 @@
         (if (zero? (:exit r))
           (recur (rest remaining)
                  (conj! out (assoc p :commit-sha (str/trim (:out r)))))
-          {:anomaly/category :anomalies/dag-multi-parent-branch-unresolvable
-           :anomaly/message "Parent branch could not be resolved to a commit"
-           :merge/parent p
-           :git/exit-code (:exit r)
-           :git/stderr (:err r)}))
+          (branch-unresolvable-anomaly p r)))
       {:parents (persistent! out)})))
 
 (defn- ancestor-of?
@@ -326,51 +485,66 @@
   [host-repo sha-a sha-b]
   (zero? (:exit (run-git host-repo "merge-base" "--is-ancestor" sha-a sha-b))))
 
+(defn- maximal-tip?
+  "True when `p`'s commit-sha is NOT reachable from any other parent's
+   commit-sha. Maximal tips survive the spec §3.2 step-4 ancestor
+   collapse; ancestors-of-other-parents are dropped because their
+   contributions are already included in the descendants."
+  [p parents ancestor?-fn]
+  (not-any? (fn ancestor-relates? [other]
+              (and (not= (:task/id other) (:task/id p))
+                   (not= (:commit-sha other) (:commit-sha p))
+                   (ancestor?-fn (:commit-sha p) (:commit-sha other))))
+            parents))
+
+(defn- find-absorber
+  "Among `survivors`, find the first whose tip is a descendant of
+   `dropped`'s tip. That's the parent that absorbed `dropped`'s
+   contribution during ancestor collapse."
+  [dropped survivors ancestor?-fn]
+  (->> survivors
+       (filter (fn descends-from-dropped? [s]
+                 (ancestor?-fn (:commit-sha dropped) (:commit-sha s))))
+       first))
+
+(defn- collapse-record
+  "Build a single `{:dropped :absorbed-into}` record for the
+   collapse-ancestors audit log."
+  [dropped survivors ancestor?-fn]
+  {:dropped       (:task/id dropped)
+   :absorbed-into (:task/id (find-absorber dropped survivors ancestor?-fn))})
+
 (defn- collapse-ancestors
-  "Spec §3.2 step 4. Drop any parent whose tip is reachable from another
-   parent's tip; preserve order among surviving maximal tips. Returns
-   `{:parents [...] :collapsed [{:dropped :absorbed-into}]}`."
+  "Spec §3.2 step 4. Drop any parent whose tip is reachable from
+   another parent's tip; preserve order among surviving maximal tips.
+   Returns `{:parents [...] :collapsed [{:dropped :absorbed-into}]}`."
   [host-repo parents]
   (let [ancestor? (memoize (fn [a b] (ancestor-of? host-repo a b)))
-        survivors (filter (fn [p]
-                            (not-any? (fn [other]
-                                        (and (not= (:task/id other) (:task/id p))
-                                             (not= (:commit-sha other) (:commit-sha p))
-                                             (ancestor? (:commit-sha p) (:commit-sha other))))
-                                      parents))
-                          parents)
-        survivor-set (set (map :task/id survivors))
+        survivors (filterv #(maximal-tip? % parents ancestor?) parents)
+        survivor-ids (set (map :task/id survivors))
         collapsed (->> parents
-                       (remove #(contains? survivor-set (:task/id %)))
-                       (mapv (fn [dropped]
-                               {:dropped (:task/id dropped)
-                                :absorbed-into
-                                (->> survivors
-                                     (filter #(ancestor? (:commit-sha dropped) (:commit-sha %)))
-                                     first
-                                     :task/id)})))]
-    {:parents (vec survivors)
+                       (remove (comp survivor-ids :task/id))
+                       (mapv #(collapse-record % survivors ancestor?)))]
+    {:parents survivors
      :collapsed collapsed}))
 
 (defn- shared-ancestry?
   "True when at least one common ancestor exists across all parent SHAs.
-   Two-parent case is the common one; for 3+, git's merge-base requires
-   `--octopus` to find the n-way common ancestor."
+   For the 3+-parent case git's merge-base requires --octopus to find
+   the n-way common ancestor (the default only handles two heads)."
   [host-repo parents]
   (let [shas (mapv :commit-sha parents)
         args (cond-> ["merge-base"]
-               (> (count shas) 2) (conj "--octopus")
+               (> (count shas) merge-base-default-max-parents) (conj "--octopus")
                :always (into shas))
         r (apply run-git host-repo args)]
     (and (zero? (:exit r))
          (not (str/blank? (:out r))))))
 
-(def ^:private merge-base-ref-prefix "refs/miniforge/dag-base")
-
 (defn- merge-base-ref-name
-  "Spec §7.2 step 3. Namespaced ref under `refs/miniforge/dag-base/...`
-   isolating the merge by run-id, task-id, and the input-key (so retries
-   of the same effective input reuse the same ref)."
+  "Spec §7.2 step 3. Namespaced ref isolating the merge by run-id,
+   task-id, and input-key (so retries of the same effective input
+   reuse the same ref instead of accumulating new ones)."
   [run-id task-id input-key]
   (str merge-base-ref-prefix "/" run-id "/" task-id "/" input-key))
 
@@ -381,22 +555,62 @@
   [message]
   ["--no-edit" "--no-gpg-sign" "--no-verify" "--no-ff" "-m" message])
 
+(defn- format-parent-line
+  "Format one line of the merge commit message, naming the parent's
+   declaration order, task-id, and commit SHA."
+  [index parent]
+  (messages/t :dag.merge/commit-message-parent
+              {:index      index
+               :task-id    (:task/id parent)
+               :commit-sha (:commit-sha parent)}))
+
 (defn- deterministic-merge-message
   "Generate the merge commit message. Includes task-id and ordered
    parent task-ids so the commit is self-describing in `git log`."
   [task-id parents]
-  (str "miniforge dag-merge for task " task-id "\n\n"
-       "Parents (declaration order):\n"
-       (str/join "\n"
-                 (map-indexed (fn [i p]
-                                (format "  %d. %s @ %s"
-                                        i (:task/id p) (:commit-sha p)))
-                              parents))))
+  (let [header (messages/t :dag.merge/commit-message-header
+                           {:task-id task-id})
+        parent-lines (->> parents
+                          (map-indexed format-parent-line)
+                          (str/join "\n"))]
+    (str header "\n\n" parent-lines)))
 
 (defn- temp-merge-worktree-path
+  "Spec §7.2 step 4: ephemeral worktree path scoped by run-id /
+   task-id / input-key so concurrent merges across sibling tasks
+   never share a directory."
   [run-id task-id input-key]
   (str (System/getProperty "java.io.tmpdir")
        "/miniforge-merge/" run-id "/" task-id "/" input-key))
+
+(defn- needs-octopus-strategy?
+  "True when the merge has enough parents that git's `octopus`
+   strategy is required (vs. the default `ort` 2-head merge)."
+  [parents]
+  (>= (count parents) octopus-merge-min-parents))
+
+(defn- merge-strategy-name
+  "Git strategy keyword (string) for the n-way merge: `octopus` for
+   3+ parents, `ort` otherwise."
+  [parents]
+  (if (needs-octopus-strategy? parents) "octopus" "ort"))
+
+(defn- parse-unmerged-line
+  "Parse one line of `git ls-files --unmerged` output:
+   `<mode> <sha> <stage>\\t<path>` → `{:path <path> :stage <stage>}`."
+  [line]
+  (let [[head path] (str/split line #"\t" 2)
+        [_mode _sha stage] (str/split head #"\s+")]
+    {:path path :stage stage}))
+
+(defn- summarize-conflicts-by-path
+  "Collapse a sequence of `{:path :stage}` entries to one map per
+   unique path, with `:stages` carrying the observed stage values."
+  [entries]
+  (->> entries
+       (group-by :path)
+       (mapv (fn path-summary [[path es]]
+               {:path path :stages (mapv :stage es)}))))
 
 (defn- enumerate-conflicts
   "Parse `git ls-files --unmerged` output into a per-path summary
@@ -410,53 +624,32 @@
   [worktree-path]
   (let [r (run-git worktree-path "ls-files" "--unmerged")
         lines (when (zero? (:exit r))
-                (->> (str/split-lines (str (:out r)))
-                     (remove str/blank?)))]
+                (->> r :out str str/split-lines (remove str/blank?)))]
     (->> lines
-         (map (fn [line]
-                ;; format: <mode> <sha> <stage>\t<path>
-                (let [[head path] (str/split line #"\t" 2)
-                      [_mode _sha stage] (str/split head #"\s+")]
-                  {:path path :stage stage})))
-         (group-by :path)
-         (mapv (fn [[path entries]]
-                 {:path path
-                  :stages (mapv :stage entries)})))))
+         (map parse-unmerged-line)
+         summarize-conflicts-by-path)))
 
 (defn- run-merge!
   "Invoke `git merge` in the temp worktree per spec §3.1 / §6.1.
-   Returns `{:ok? true :commit-sha ...}` or
-   `{:ok? false :anomaly ...}`. Caller is responsible for cleanup."
-  [worktree-path host-repo task-id strategy parents input-key]
-  (let [[p0 & rest-parents] parents
+   Returns `{:ok? true :commit-sha ...}` or `{:ok? false :anomaly ...}`.
+   Caller is responsible for cleanup."
+  [worktree-path task-id strategy parents input-key]
+  (let [rest-parents (rest parents)
         message (deterministic-merge-message task-id parents)
-        merge-strategy (if (> (count parents) 2) "octopus" "ort")
-        merge-args (concat ["merge" "-s" merge-strategy]
+        merge-args (concat ["merge" "-s" (merge-strategy-name parents)]
                            (pinned-merge-flags message)
                            (map :commit-sha rest-parents))
         r (apply run-git worktree-path merge-args)]
-    (cond
-      (zero? (:exit r))
+    (if (zero? (:exit r))
       (let [head (run-git worktree-path "rev-parse" "HEAD")]
         (if (zero? (:exit head))
           {:ok? true :commit-sha (str/trim (:out head))}
           {:ok? false
-           :anomaly {:anomaly/category :anomalies/dag-multi-parent-merge-failed
-                     :anomaly/message "Merge succeeded but rev-parse HEAD failed"
-                     :git/exit-code (:exit head)
-                     :git/stderr (:err head)}}))
-
-      :else
+           :anomaly (ref-write-failed-anomaly task-id nil nil head)}))
       {:ok? false
-       :anomaly {:anomaly/category :anomalies/dag-multi-parent-conflict
-                 :anomaly/message  "Multi-parent merge conflicted"
-                 :task/id          task-id
-                 :merge/parents    parents
-                 :merge/conflicts  (enumerate-conflicts worktree-path)
-                 :merge/strategy   strategy
-                 :merge/input-key  input-key
-                 :git/exit-code    (:exit r)
-                 :git/stderr       (:err r)}})))
+       :anomaly (conflict-anomaly task-id strategy parents
+                                  (enumerate-conflicts worktree-path)
+                                  input-key r)})))
 
 (defn- ensure-clean-worktree!
   "Remove any pre-existing temp worktree at `path` and re-create it
@@ -466,26 +659,20 @@
   [host-repo worktree-path commit-sha]
   (try (fs/delete-tree worktree-path) (catch Throwable _ nil))
   (run-git host-repo "worktree" "prune")
-  (let [parent-dir (.getParent (java.io.File. ^String worktree-path))]
-    (when parent-dir (.mkdirs (java.io.File. ^String parent-dir))))
+  (when-let [parent-dir (.getParent (java.io.File. ^String worktree-path))]
+    (.mkdirs (java.io.File. ^String parent-dir)))
   (run-git host-repo "worktree" "add" "--detach" worktree-path commit-sha))
 
 (defn- cleanup-worktree!
+  "Best-effort cleanup of the merge temp worktree. Errors here are
+   intentionally swallowed: by the time we're cleaning up, the merge
+   has already completed (success or anomaly) and a cleanup failure
+   shouldn't mask that result."
   [host-repo worktree-path]
   (try (run-git host-repo "worktree" "remove" "--force" worktree-path)
        (catch Throwable _ nil))
   (try (fs/delete-tree worktree-path) (catch Throwable _ nil))
   (run-git host-repo "worktree" "prune"))
-
-(def ^:private supported-merge-strategies
-  "Strategies `merge-parent-branches!` knows how to execute today.
-   `:git-merge` ships in Stage 1B; `:sequential-merge` is Stage 4
-   (per the spec §4 / §10.11 strategy table). Plans that explicitly
-   request an unsupported strategy get a typed anomaly rather than
-   silently falling through to `:git-merge` (which would misreport
-   the executed strategy in logs and the resolution-sub-workflow
-   payload)."
-  #{:git-merge})
 
 (defn- existing-merge-ref-sha
   "If the namespaced merge ref already exists from a prior replay,
@@ -499,6 +686,82 @@
     (when (zero? (:exit r))
       (str/trim (:out r)))))
 
+;; Decomposition: prepare → attempt → orchestrate ----------------------
+
+(defn- prepare-effective-parents
+  "Run the spec §3.2 collapse pipeline (snapshot SHAs → dedupe →
+   ancestor-collapse) and return one of:
+
+   - `{:fallback :no-registered-parents}` — no deps in registry; caller
+     should return `empty-registry-fallback-result`.
+   - `{:single-parent <p> :collapsed [...]}` — collapse left one
+     effective parent; caller should return `single-parent-fast-path-result`.
+   - `{:effective-parents [...] :collapsed [...]}` — ready to merge.
+   - An anomaly map — branch unresolvable, unrelated histories.
+
+   Pure pipeline of registry + git; doesn't touch worktrees or refs.
+   Keeps `merge-parent-branches!` focused on orchestration."
+  [host-repo registry deps task-id strategy]
+  (let [resolved (dag/resolve-multi-parent-base
+                  (or registry (dag/create-branch-registry))
+                  deps)]
+    (if-not (seq (:merge/parents resolved))
+      {:fallback :no-registered-parents}
+      (let [snapshot (snapshot-parent-shas host-repo (:merge/parents resolved))]
+        (if (merge-error? snapshot)
+          snapshot
+          (let [deduped (dag/collapse-duplicate-tips (:parents snapshot))
+                {:keys [parents collapsed]} (collapse-ancestors host-repo (:parents deduped))
+                all-collapsed (vec (concat (:collapsed deduped) collapsed))]
+            (cond
+              (= 1 (count parents))
+              {:single-parent (first parents) :collapsed all-collapsed}
+
+              (not (shared-ancestry? host-repo parents))
+              (unrelated-histories-anomaly task-id strategy parents)
+
+              :else
+              {:effective-parents parents :collapsed all-collapsed})))))))
+
+(defn- attempt-merge-with-cache!
+  "Cache-aware merge attempt. Checks for an existing namespaced ref
+   first (spec §7.2 idempotency); if present, reuses its SHA. Otherwise
+   stages a temp worktree, runs the merge, writes the ref, and cleans
+   up. Returns a `dag/ok` result on success or an anomaly on failure."
+  [host-repo run-id task-id strategy parents collapsed]
+  (let [input-key (dag/compute-merge-input-key task-id strategy parents)
+        ref-name  (merge-base-ref-name run-id task-id input-key)
+        cached    (existing-merge-ref-sha host-repo ref-name)]
+    (if cached
+      (merge-ok-result {:ref-name   ref-name
+                        :commit-sha cached
+                        :input-key  input-key
+                        :strategy   strategy
+                        :parents    parents
+                        :collapsed  collapsed
+                        :cache-hit? true})
+      (let [worktree (temp-merge-worktree-path run-id task-id input-key)
+            setup    (ensure-clean-worktree! host-repo worktree
+                                             (:commit-sha (first parents)))]
+        (if-not (zero? (:exit setup))
+          (do (cleanup-worktree! host-repo worktree)
+              (worktree-setup-failed-anomaly task-id setup))
+          (let [outcome (run-merge! worktree task-id strategy parents input-key)]
+            (if-not (:ok? outcome)
+              (do (cleanup-worktree! host-repo worktree)
+                  (:anomaly outcome))
+              (let [upd (run-git host-repo "update-ref" ref-name (:commit-sha outcome))]
+                (cleanup-worktree! host-repo worktree)
+                (if (zero? (:exit upd))
+                  (merge-ok-result {:ref-name   ref-name
+                                    :commit-sha (:commit-sha outcome)
+                                    :input-key  input-key
+                                    :strategy   strategy
+                                    :parents    parents
+                                    :collapsed  collapsed})
+                  (ref-write-failed-anomaly task-id ref-name
+                                            (:commit-sha outcome) upd))))))))))
+
 (defn merge-parent-branches!
   "Multi-parent merge entry point per spec §6.1.
 
@@ -509,12 +772,14 @@
      `:task/deps` and (optional) `:task/merge-strategy` drive the work.
 
    Returns one of:
-   - `{:merge/ok? true :merge/ref <ref-name> :merge/commit-sha <sha>}` —
-     merge succeeded; downstream task forks off `:merge/ref`.
-   - `{:merge/ok? true :merge/ref <branch> :merge/single-parent? true}` —
-     after collapse, only one effective parent; downstream task forks off
-     that parent's branch directly (no merge commit needed). This is the
-     §6.2 / §6.3 informational fast-path.
+   - A `dag/ok` result wrapping `{:branch :commit-sha ...}` — merge
+     succeeded; downstream task forks off `:branch`. The map carries
+     `:single-parent?` (collapse fast-path), `:cache-hit?` (idempotency
+     replay), `:fallback-reason` (defensive empty-registry fallback),
+     `:collapsed` ([{:dropped :absorbed-into}] for any collapsed
+     parents) — callers branch on these for observability but the
+     `:branch` is uniformly the right value to use as the sub-workflow
+     base.
    - An anomaly map — `:dag-multi-parent-conflict`,
      `:dag-multi-parent-unrelated-histories`,
      `:dag-multi-parent-branch-unresolvable`,
@@ -523,119 +788,32 @@
      conflict path with the resolution sub-workflow; for Stage 1B,
      anomalies surface to the caller and the task fails."
   [context task-def]
-  (let [registry (some-> (get context :dag/branch-registry) deref)
-        deps (vec (or (:task/deps task-def) []))
-        task-id (:task/id task-def)
-        strategy (or (:task/merge-strategy task-def) :git-merge)
-        run-id (or (:workflow-id context) "no-run-id")
-        host-repo (host-repo-path context)
-        resolved (dag/resolve-multi-parent-base
-                  (or registry (dag/create-branch-registry))
-                  deps)]
+  (let [registry  (some-> (get context :dag/branch-registry) deref)
+        deps      (vec (or (:task/deps task-def) []))
+        task-id   (:task/id task-def)
+        strategy  (or (:task/merge-strategy task-def) :git-merge)
+        run-id    (or (:workflow-id context) fallback-run-id)
+        host-repo (host-repo-path context)]
     (cond
-      ;; Strategy guard — fail fast for unsupported strategies rather
-      ;; than silently executing a different one. :sequential-merge
-      ;; ships in Stage 4.
       (not (contains? supported-merge-strategies strategy))
-      {:anomaly/category :anomalies/dag-multi-parent-strategy-unsupported
-       :anomaly/message  (str "Merge strategy " strategy " is not supported in this stage")
-       :task/id          task-id
-       :merge/strategy   strategy
-       :merge/supported  supported-merge-strategies}
-
-      ;; No deps registered — fall back to default branch (matches the
-      ;; single-parent fast-path's defensive semantics).
-      (not (seq (:merge/parents resolved)))
-      {:merge/ok? true
-       :merge/ref (default-spec-branch context)
-       :merge/single-parent? true
-       :merge/fallback-reason :no-registered-parents}
+      (strategy-unsupported-anomaly task-id strategy)
 
       :else
-      (let [snapshot (snapshot-parent-shas host-repo (:merge/parents resolved))]
-        (if (:anomaly/category snapshot)
-          snapshot
-          (let [;; Spec §3.2 step 3 — pure-data dedupe (already in registry layer)
-                deduped (dag/collapse-duplicate-tips (:parents snapshot))
-                ;; Spec §3.2 step 4 — git-side ancestor collapse
-                {:keys [parents collapsed]} (collapse-ancestors host-repo (:parents deduped))
-                all-collapsed (vec (concat (:collapsed deduped) collapsed))]
-            (cond
-              ;; Single effective parent after collapse — no merge needed.
-              (= 1 (count parents))
-              (cond-> {:merge/ok? true
-                       :merge/ref (:branch (first parents))
-                       :merge/commit-sha (:commit-sha (first parents))
-                       :merge/single-parent? true}
-                (seq all-collapsed) (assoc :merge/collapsed all-collapsed))
+      (let [prep (prepare-effective-parents host-repo registry deps task-id strategy)]
+        (cond
+          (merge-error? prep)
+          prep
 
-              ;; No shared ancestry → unrelated-histories anomaly per §6.5.
-              (not (shared-ancestry? host-repo parents))
-              {:anomaly/category :anomalies/dag-multi-parent-unrelated-histories
-               :anomaly/message  "Parents share no common ancestor — refusing to merge"
-               :task/id          task-id
-               :merge/parents    parents
-               :merge/strategy   strategy}
+          (= :no-registered-parents (:fallback prep))
+          (empty-registry-fallback-result (default-spec-branch context))
 
-              :else
-              (let [input-key (dag/compute-merge-input-key task-id strategy parents)
-                    ref-name (merge-base-ref-name run-id task-id input-key)
-                    cached-sha (existing-merge-ref-sha host-repo ref-name)]
-                (if cached-sha
-                  ;; Spec §7.2 idempotency: ref already exists from a
-                  ;; prior replay with byte-identical input. Reuse it
-                  ;; instead of producing a fresh merge commit (which
-                  ;; would have a different timestamp despite the same
-                  ;; tree — defeating the cache and accumulating
-                  ;; duplicate refs).
-                  (cond-> {:merge/ok?         true
-                           :merge/ref         ref-name
-                           :merge/commit-sha  cached-sha
-                           :merge/input-key   input-key
-                           :merge/strategy    strategy
-                           :merge/parents     parents
-                           :merge/cache-hit?  true}
-                    (seq all-collapsed) (assoc :merge/collapsed all-collapsed))
-                  (let [worktree (temp-merge-worktree-path run-id task-id input-key)
-                        setup (ensure-clean-worktree! host-repo worktree (:commit-sha (first parents)))]
-                    (if-not (zero? (:exit setup))
-                      (do (cleanup-worktree! host-repo worktree)
-                          {:anomaly/category :anomalies/dag-multi-parent-merge-failed
-                           :anomaly/message  "Could not create temp worktree for merge"
-                           :task/id          task-id
-                           :git/exit-code    (:exit setup)
-                           :git/stderr       (:err setup)})
-                      (let [outcome (run-merge! worktree host-repo task-id strategy parents input-key)]
-                        (if (:ok? outcome)
-                          ;; Capture update-ref's exit code so a failed
-                          ;; ref write surfaces as an anomaly rather than
-                          ;; a false-positive success.
-                          (let [upd (run-git host-repo "update-ref"
-                                             ref-name (:commit-sha outcome))]
-                            (cleanup-worktree! host-repo worktree)
-                            (if (zero? (:exit upd))
-                              (cond-> {:merge/ok?        true
-                                       :merge/ref        ref-name
-                                       :merge/commit-sha (:commit-sha outcome)
-                                       :merge/input-key  input-key
-                                       :merge/strategy   strategy
-                                       :merge/parents    parents}
-                                (seq all-collapsed) (assoc :merge/collapsed all-collapsed))
-                              {:anomaly/category :anomalies/dag-multi-parent-merge-failed
-                               :anomaly/message  "Failed to write merge result to namespaced ref"
-                               :task/id          task-id
-                               :merge/ref        ref-name
-                               :merge/commit-sha (:commit-sha outcome)
-                               :git/exit-code    (:exit upd)
-                               :git/stderr       (:err upd)}))
-                          (do (cleanup-worktree! host-repo worktree)
-                              (:anomaly outcome)))))))))))))))
+          (:single-parent prep)
+          (single-parent-fast-path-result (:single-parent prep) (:collapsed prep))
 
-(defn- merge-error?
-  "True when `merge-parent-branches!` returned an anomaly rather than
-   a usable merge result."
-  [result]
-  (and (map? result) (:anomaly/category result)))
+          :else
+          (attempt-merge-with-cache! host-repo run-id task-id strategy
+                                     (:effective-parents prep)
+                                     (:collapsed prep)))))))
 
 (defn task-sub-opts
   "Build execution opts for a DAG task's sub-workflow.
@@ -682,12 +860,19 @@
                        (merge-parent-branches! context task-def)
 
                        :else
-                       (resolve-task-base-branch context task-def))
-         resolved-branch (cond
-                           (string? base-result)            base-result
-                           (and (map? base-result)
-                                (:merge/ok? base-result))   (:merge/ref base-result)
-                           :else                            nil)
+                       ;; v1 single-parent path returns a branch string for
+                       ;; 0/1-dep tasks; lift to dag/ok so downstream
+                       ;; branching has a single shape (success → dag/ok,
+                       ;; failure → anomaly map). If the v1 path ever
+                       ;; produces a map (legacy multi-parent anomaly via
+                       ;; stratum auto-wiring or similar), pass it through
+                       ;; unchanged so merge-error? still catches it.
+                       (let [s (resolve-task-base-branch context task-def)]
+                         (if (string? s)
+                           (dag/ok {:branch s})
+                           s)))
+         resolved-branch (when (and base-result (dag/ok? base-result))
+                           (:branch (:data base-result)))
          merge-anomaly (when (merge-error? base-result) base-result)
          base-opts {:disable-dag-execution true
                     :skip-lifecycle-events true

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -399,8 +399,15 @@
        "/miniforge-merge/" run-id "/" task-id "/" input-key))
 
 (defn- enumerate-conflicts
-  "Parse `git ls-files --unmerged` output into `[{:path ... :stage ...}]`."
-  [host-repo worktree-path]
+  "Parse `git ls-files --unmerged` output into a per-path summary
+   `[{:path <path> :stages [<stage>...]}]`.
+
+   `git ls-files --unmerged` emits one line per stage entry per
+   conflicted path (typically stages 1/2/3 = base/ours/theirs); we
+   collapse to one entry per path with the observed stages so the
+   resolution sub-workflow (Stage 2) sees each conflicted path once
+   alongside which stages git surfaced for it."
+  [worktree-path]
   (let [r (run-git worktree-path "ls-files" "--unmerged")
         lines (when (zero? (:exit r))
                 (->> (str/split-lines (str (:out r)))
@@ -445,7 +452,7 @@
                  :anomaly/message  "Multi-parent merge conflicted"
                  :task/id          task-id
                  :merge/parents    parents
-                 :merge/conflicts  (enumerate-conflicts host-repo worktree-path)
+                 :merge/conflicts  (enumerate-conflicts worktree-path)
                  :merge/strategy   strategy
                  :merge/input-key  input-key
                  :git/exit-code    (:exit r)
@@ -470,6 +477,28 @@
   (try (fs/delete-tree worktree-path) (catch Throwable _ nil))
   (run-git host-repo "worktree" "prune"))
 
+(def ^:private supported-merge-strategies
+  "Strategies `merge-parent-branches!` knows how to execute today.
+   `:git-merge` ships in Stage 1B; `:sequential-merge` is Stage 4
+   (per the spec §4 / §10.11 strategy table). Plans that explicitly
+   request an unsupported strategy get a typed anomaly rather than
+   silently falling through to `:git-merge` (which would misreport
+   the executed strategy in logs and the resolution-sub-workflow
+   payload)."
+  #{:git-merge})
+
+(defn- existing-merge-ref-sha
+  "If the namespaced merge ref already exists from a prior replay,
+   return its current SHA; else nil. Used for spec §7.2's
+   idempotency: replays of the same effective input MUST reuse the
+   same ref instead of producing a new merge commit (whose timestamp
+   would differ even though the tree is identical, defeating the
+   cache)."
+  [host-repo ref-name]
+  (let [r (run-git host-repo "rev-parse" "--verify" (str ref-name "^{commit}"))]
+    (when (zero? (:exit r))
+      (str/trim (:out r)))))
+
 (defn merge-parent-branches!
   "Multi-parent merge entry point per spec §6.1.
 
@@ -488,7 +517,9 @@
      §6.2 / §6.3 informational fast-path.
    - An anomaly map — `:dag-multi-parent-conflict`,
      `:dag-multi-parent-unrelated-histories`,
-     `:dag-multi-parent-branch-unresolvable`. Stage 2 will replace the
+     `:dag-multi-parent-branch-unresolvable`,
+     `:dag-multi-parent-strategy-unsupported`,
+     `:dag-multi-parent-merge-failed`. Stage 2 will replace the
      conflict path with the resolution sub-workflow; for Stage 1B,
      anomalies surface to the caller and the task fails."
   [context task-def]
@@ -501,29 +532,42 @@
         resolved (dag/resolve-multi-parent-base
                   (or registry (dag/create-branch-registry))
                   deps)]
-    (if-not (seq (:merge/parents resolved))
+    (cond
+      ;; Strategy guard — fail fast for unsupported strategies rather
+      ;; than silently executing a different one. :sequential-merge
+      ;; ships in Stage 4.
+      (not (contains? supported-merge-strategies strategy))
+      {:anomaly/category :anomalies/dag-multi-parent-strategy-unsupported
+       :anomaly/message  (str "Merge strategy " strategy " is not supported in this stage")
+       :task/id          task-id
+       :merge/strategy   strategy
+       :merge/supported  supported-merge-strategies}
+
       ;; No deps registered — fall back to default branch (matches the
       ;; single-parent fast-path's defensive semantics).
+      (not (seq (:merge/parents resolved)))
       {:merge/ok? true
        :merge/ref (default-spec-branch context)
        :merge/single-parent? true
        :merge/fallback-reason :no-registered-parents}
 
+      :else
       (let [snapshot (snapshot-parent-shas host-repo (:merge/parents resolved))]
         (if (:anomaly/category snapshot)
           snapshot
           (let [;; Spec §3.2 step 3 — pure-data dedupe (already in registry layer)
                 deduped (dag/collapse-duplicate-tips (:parents snapshot))
                 ;; Spec §3.2 step 4 — git-side ancestor collapse
-                {:keys [parents collapsed]} (collapse-ancestors host-repo (:parents deduped))]
+                {:keys [parents collapsed]} (collapse-ancestors host-repo (:parents deduped))
+                all-collapsed (vec (concat (:collapsed deduped) collapsed))]
             (cond
               ;; Single effective parent after collapse — no merge needed.
               (= 1 (count parents))
-              {:merge/ok? true
-               :merge/ref (:branch (first parents))
-               :merge/commit-sha (:commit-sha (first parents))
-               :merge/single-parent? true
-               :merge/collapsed (concat (:collapsed deduped) collapsed)}
+              (cond-> {:merge/ok? true
+                       :merge/ref (:branch (first parents))
+                       :merge/commit-sha (:commit-sha (first parents))
+                       :merge/single-parent? true}
+                (seq all-collapsed) (assoc :merge/collapsed all-collapsed))
 
               ;; No shared ancestry → unrelated-histories anomaly per §6.5.
               (not (shared-ancestry? host-repo parents))
@@ -536,29 +580,56 @@
               :else
               (let [input-key (dag/compute-merge-input-key task-id strategy parents)
                     ref-name (merge-base-ref-name run-id task-id input-key)
-                    worktree (temp-merge-worktree-path run-id task-id input-key)
-                    setup (ensure-clean-worktree! host-repo worktree (:commit-sha (first parents)))]
-                (if-not (zero? (:exit setup))
-                  (do (cleanup-worktree! host-repo worktree)
-                      {:anomaly/category :anomalies/dag-multi-parent-merge-failed
-                       :anomaly/message  "Could not create temp worktree for merge"
-                       :task/id          task-id
-                       :git/exit-code    (:exit setup)
-                       :git/stderr       (:err setup)})
-                  (let [outcome (run-merge! worktree host-repo task-id strategy parents input-key)]
-                    (cond-> (if (:ok? outcome)
-                              (do (run-git host-repo "update-ref" ref-name (:commit-sha outcome))
-                                  (cleanup-worktree! host-repo worktree)
-                                  {:merge/ok? true
-                                   :merge/ref ref-name
-                                   :merge/commit-sha (:commit-sha outcome)
-                                   :merge/input-key input-key
-                                   :merge/strategy strategy
-                                   :merge/parents parents})
-                              (do (cleanup-worktree! host-repo worktree)
-                                  (:anomaly outcome)))
-                      (seq (concat (:collapsed deduped) collapsed))
-                      (assoc :merge/collapsed (vec (concat (:collapsed deduped) collapsed))))))))))))))
+                    cached-sha (existing-merge-ref-sha host-repo ref-name)]
+                (if cached-sha
+                  ;; Spec §7.2 idempotency: ref already exists from a
+                  ;; prior replay with byte-identical input. Reuse it
+                  ;; instead of producing a fresh merge commit (which
+                  ;; would have a different timestamp despite the same
+                  ;; tree — defeating the cache and accumulating
+                  ;; duplicate refs).
+                  (cond-> {:merge/ok?         true
+                           :merge/ref         ref-name
+                           :merge/commit-sha  cached-sha
+                           :merge/input-key   input-key
+                           :merge/strategy    strategy
+                           :merge/parents     parents
+                           :merge/cache-hit?  true}
+                    (seq all-collapsed) (assoc :merge/collapsed all-collapsed))
+                  (let [worktree (temp-merge-worktree-path run-id task-id input-key)
+                        setup (ensure-clean-worktree! host-repo worktree (:commit-sha (first parents)))]
+                    (if-not (zero? (:exit setup))
+                      (do (cleanup-worktree! host-repo worktree)
+                          {:anomaly/category :anomalies/dag-multi-parent-merge-failed
+                           :anomaly/message  "Could not create temp worktree for merge"
+                           :task/id          task-id
+                           :git/exit-code    (:exit setup)
+                           :git/stderr       (:err setup)})
+                      (let [outcome (run-merge! worktree host-repo task-id strategy parents input-key)]
+                        (if (:ok? outcome)
+                          ;; Capture update-ref's exit code so a failed
+                          ;; ref write surfaces as an anomaly rather than
+                          ;; a false-positive success.
+                          (let [upd (run-git host-repo "update-ref"
+                                             ref-name (:commit-sha outcome))]
+                            (cleanup-worktree! host-repo worktree)
+                            (if (zero? (:exit upd))
+                              (cond-> {:merge/ok?        true
+                                       :merge/ref        ref-name
+                                       :merge/commit-sha (:commit-sha outcome)
+                                       :merge/input-key  input-key
+                                       :merge/strategy   strategy
+                                       :merge/parents    parents}
+                                (seq all-collapsed) (assoc :merge/collapsed all-collapsed))
+                              {:anomaly/category :anomalies/dag-multi-parent-merge-failed
+                               :anomaly/message  "Failed to write merge result to namespaced ref"
+                               :task/id          task-id
+                               :merge/ref        ref-name
+                               :merge/commit-sha (:commit-sha outcome)
+                               :git/exit-code    (:exit upd)
+                               :git/stderr       (:err upd)}))
+                          (do (cleanup-worktree! host-repo worktree)
+                              (:anomaly outcome)))))))))))))))
 
 (defn- merge-error?
   "True when `merge-parent-branches!` returned an anomaly rather than
@@ -576,15 +647,18 @@
    When `task-def` is supplied, resolves its dependency to a persisted
    branch and passes it as `:branch` so the sub-workflow's
    `acquire-environment!` forks off that branch instead of the spec
-   branch. `:branch` is ALWAYS set when task-def is given:
-   - Zero deps or single-dep unregistered → the spec branch.
-   - Single-dep registered → dep's branch (v1 chaining payoff).
-   - Multi-dep (v2) → the merged ref produced by `merge-parent-branches!`.
-     If the merge produces a typed anomaly (conflict / unrelated
-     histories / branch unresolvable), it propagates back to the caller
-     via `:dag/merge-anomaly` on opts; `execute-single-task` checks for
-     this and fails the task with the anomaly instead of running the
-     sub-workflow.
+   branch:
+   - Zero deps or single-dep unregistered → spec branch (`:branch` set).
+   - Single-dep registered → dep's branch (v1 chaining payoff;
+     `:branch` set).
+   - Multi-dep (v2), merge succeeds → the merged ref produced by
+     `merge-parent-branches!` (`:branch` set).
+   - Multi-dep (v2), merge produces a typed anomaly (conflict /
+     unrelated histories / branch unresolvable / strategy unsupported)
+     → `:branch` is OMITTED and the anomaly is surfaced via
+     `:dag/merge-anomaly` on opts. `run-mini-workflow` checks for this
+     and short-circuits with a structured failure rather than running a
+     doomed sub-workflow against a stale base.
 
    The single-arity form `(task-sub-opts context)` is for callers that
    don't yet thread task-def (kept for compatibility with the
@@ -700,11 +774,13 @@
         merge-anomaly (:dag/merge-anomaly sub-opts)]
     (if merge-anomaly
       ;; Multi-parent merge failed before we even entered the sub-workflow.
-      ;; Surface the anomaly directly; Stage 2 will replace conflicts with
-      ;; the resolution sub-workflow.
-      (workflow-failure (or (:anomaly/message merge-anomaly)
-                            "Multi-parent merge failed")
-                        nil)
+      ;; Surface the FULL typed anomaly map (not just its message) so
+      ;; downstream consumers — workflow-result->dag-result, the dashboard,
+      ;; the evidence bundle — can classify the failure by
+      ;; `:anomaly/category` and access the raw `:merge/conflicts`,
+      ;; `:merge/parents`, `:git/stderr` etc. Stage 2 will use this
+      ;; structured shape as the resolution sub-workflow's input.
+      (workflow-failure merge-anomaly nil)
       (let [run-pipeline (:execution/run-pipeline-fn context)
             result       (run-pipeline sub-workflow sub-input sub-opts)
             artifacts    (:execution/artifacts result)

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -26,13 +26,24 @@
    Each DAG task receives a full sub-workflow pipeline (explore → plan → implement
    → verify → ...) rather than just an implementer agent. The sub-workflow is
    derived from the parent workflow config, with the plan phase skipped (the plan
-   already exists) and DAG execution disabled (to prevent infinite recursion)."
+   already exists) and DAG execution disabled (to prevent infinite recursion).
+
+   v2 multi-parent: tasks with `>1` declared dependencies trigger the
+   orchestrator's `merge-parent-branches!`, which performs a deterministic
+   git merge of the parents' persisted branches and hands the resulting
+   ref to the sub-workflow. See specs/informative/I-DAG-MULTI-PARENT-MERGE.md.
+   Stage 1B (this code path) handles the no-conflict happy path; conflict
+   surfaces as a typed anomaly, which Stage 2 will replace with the
+   resolution sub-workflow."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.dag-resilience :as resilience]
-   [clojure.set :as set]))
+   [babashka.fs :as fs]
+   [clojure.java.shell :as shell]
+   [clojure.set :as set]
+   [clojure.string :as str]))
 
 ;--- Layer 0: Result Constructors
 
@@ -266,6 +277,295 @@
     (dag/resolve-base-branch (or registry (dag/create-branch-registry))
                              deps default)))
 
+;--- Layer 1.5: Multi-parent merge (v2)
+;; See specs/informative/I-DAG-MULTI-PARENT-MERGE.md §3.2 for the algorithm
+;; and §6 for the failure-mode catalog. Stage 1B implements the no-conflict
+;; happy path; conflict / unrelated-histories surface as terminal anomalies
+;; that Stage 2 will replace with an automated resolution sub-workflow.
+
+(defn- run-git
+  "Invoke git in `cwd` with `args`. Returns `{:exit :out :err}` matching
+   `clojure.java.shell/sh`. Defensive against shell exceptions so callers
+   can branch on `:exit` rather than wrapping in try/catch."
+  [cwd & args]
+  (try
+    (apply shell/sh "git" "-C" cwd args)
+    (catch Exception e
+      {:exit -1 :out "" :err (.getMessage e)})))
+
+(defn- host-repo-path
+  "Resolve the host repository path for orchestrator-level git operations.
+   Falls back through the standard context keys orchestrators populate."
+  [context]
+  (or (get context :execution/repo-path)
+      (get-in context [:execution/environment-metadata :repo-path])
+      (get context :execution/worktree-path)
+      (System/getProperty "user.dir")))
+
+(defn- snapshot-parent-shas
+  "Resolve each parent's branch tip to a SHA at this moment (spec §3.2
+   step 1). Returns the parents vector with `:commit-sha` populated, or
+   an anomaly when any branch can't be resolved."
+  [host-repo parents]
+  (loop [remaining parents
+         out (transient [])]
+    (if-let [p (first remaining)]
+      (let [r (run-git host-repo "rev-parse" "--verify" (str (:branch p) "^{commit}"))]
+        (if (zero? (:exit r))
+          (recur (rest remaining)
+                 (conj! out (assoc p :commit-sha (str/trim (:out r)))))
+          {:anomaly/category :anomalies/dag-multi-parent-branch-unresolvable
+           :anomaly/message "Parent branch could not be resolved to a commit"
+           :merge/parent p
+           :git/exit-code (:exit r)
+           :git/stderr (:err r)}))
+      {:parents (persistent! out)})))
+
+(defn- ancestor-of?
+  "True when `sha-a` is an ancestor of (reachable from) `sha-b`."
+  [host-repo sha-a sha-b]
+  (zero? (:exit (run-git host-repo "merge-base" "--is-ancestor" sha-a sha-b))))
+
+(defn- collapse-ancestors
+  "Spec §3.2 step 4. Drop any parent whose tip is reachable from another
+   parent's tip; preserve order among surviving maximal tips. Returns
+   `{:parents [...] :collapsed [{:dropped :absorbed-into}]}`."
+  [host-repo parents]
+  (let [ancestor? (memoize (fn [a b] (ancestor-of? host-repo a b)))
+        survivors (filter (fn [p]
+                            (not-any? (fn [other]
+                                        (and (not= (:task/id other) (:task/id p))
+                                             (not= (:commit-sha other) (:commit-sha p))
+                                             (ancestor? (:commit-sha p) (:commit-sha other))))
+                                      parents))
+                          parents)
+        survivor-set (set (map :task/id survivors))
+        collapsed (->> parents
+                       (remove #(contains? survivor-set (:task/id %)))
+                       (mapv (fn [dropped]
+                               {:dropped (:task/id dropped)
+                                :absorbed-into
+                                (->> survivors
+                                     (filter #(ancestor? (:commit-sha dropped) (:commit-sha %)))
+                                     first
+                                     :task/id)})))]
+    {:parents (vec survivors)
+     :collapsed collapsed}))
+
+(defn- shared-ancestry?
+  "True when at least one common ancestor exists across all parent SHAs.
+   Two-parent case is the common one; for 3+, git's merge-base requires
+   `--octopus` to find the n-way common ancestor."
+  [host-repo parents]
+  (let [shas (mapv :commit-sha parents)
+        args (cond-> ["merge-base"]
+               (> (count shas) 2) (conj "--octopus")
+               :always (into shas))
+        r (apply run-git host-repo args)]
+    (and (zero? (:exit r))
+         (not (str/blank? (:out r))))))
+
+(def ^:private merge-base-ref-prefix "refs/miniforge/dag-base")
+
+(defn- merge-base-ref-name
+  "Spec §7.2 step 3. Namespaced ref under `refs/miniforge/dag-base/...`
+   isolating the merge by run-id, task-id, and the input-key (so retries
+   of the same effective input reuse the same ref)."
+  [run-id task-id input-key]
+  (str merge-base-ref-prefix "/" run-id "/" task-id "/" input-key))
+
+(defn- pinned-merge-flags
+  "Spec §3.1 — flags that protect the merge from config drift. Without
+   these, user-level `commit.gpgsign=true`, merge hooks, etc. would
+   change merge behavior in surprising ways across machines."
+  [message]
+  ["--no-edit" "--no-gpg-sign" "--no-verify" "--no-ff" "-m" message])
+
+(defn- deterministic-merge-message
+  "Generate the merge commit message. Includes task-id and ordered
+   parent task-ids so the commit is self-describing in `git log`."
+  [task-id parents]
+  (str "miniforge dag-merge for task " task-id "\n\n"
+       "Parents (declaration order):\n"
+       (str/join "\n"
+                 (map-indexed (fn [i p]
+                                (format "  %d. %s @ %s"
+                                        i (:task/id p) (:commit-sha p)))
+                              parents))))
+
+(defn- temp-merge-worktree-path
+  [run-id task-id input-key]
+  (str (System/getProperty "java.io.tmpdir")
+       "/miniforge-merge/" run-id "/" task-id "/" input-key))
+
+(defn- enumerate-conflicts
+  "Parse `git ls-files --unmerged` output into `[{:path ... :stage ...}]`."
+  [host-repo worktree-path]
+  (let [r (run-git worktree-path "ls-files" "--unmerged")
+        lines (when (zero? (:exit r))
+                (->> (str/split-lines (str (:out r)))
+                     (remove str/blank?)))]
+    (->> lines
+         (map (fn [line]
+                ;; format: <mode> <sha> <stage>\t<path>
+                (let [[head path] (str/split line #"\t" 2)
+                      [_mode _sha stage] (str/split head #"\s+")]
+                  {:path path :stage stage})))
+         (group-by :path)
+         (mapv (fn [[path entries]]
+                 {:path path
+                  :stages (mapv :stage entries)})))))
+
+(defn- run-merge!
+  "Invoke `git merge` in the temp worktree per spec §3.1 / §6.1.
+   Returns `{:ok? true :commit-sha ...}` or
+   `{:ok? false :anomaly ...}`. Caller is responsible for cleanup."
+  [worktree-path host-repo task-id strategy parents input-key]
+  (let [[p0 & rest-parents] parents
+        message (deterministic-merge-message task-id parents)
+        merge-strategy (if (> (count parents) 2) "octopus" "ort")
+        merge-args (concat ["merge" "-s" merge-strategy]
+                           (pinned-merge-flags message)
+                           (map :commit-sha rest-parents))
+        r (apply run-git worktree-path merge-args)]
+    (cond
+      (zero? (:exit r))
+      (let [head (run-git worktree-path "rev-parse" "HEAD")]
+        (if (zero? (:exit head))
+          {:ok? true :commit-sha (str/trim (:out head))}
+          {:ok? false
+           :anomaly {:anomaly/category :anomalies/dag-multi-parent-merge-failed
+                     :anomaly/message "Merge succeeded but rev-parse HEAD failed"
+                     :git/exit-code (:exit head)
+                     :git/stderr (:err head)}}))
+
+      :else
+      {:ok? false
+       :anomaly {:anomaly/category :anomalies/dag-multi-parent-conflict
+                 :anomaly/message  "Multi-parent merge conflicted"
+                 :task/id          task-id
+                 :merge/parents    parents
+                 :merge/conflicts  (enumerate-conflicts host-repo worktree-path)
+                 :merge/strategy   strategy
+                 :merge/input-key  input-key
+                 :git/exit-code    (:exit r)
+                 :git/stderr       (:err r)}})))
+
+(defn- ensure-clean-worktree!
+  "Remove any pre-existing temp worktree at `path` and re-create it
+   fresh from `commit-sha`. The merge ref namespace already de-dupes
+   replays, but if a prior crash left state on disk we want a clean
+   slate, not a half-merged residual."
+  [host-repo worktree-path commit-sha]
+  (try (fs/delete-tree worktree-path) (catch Throwable _ nil))
+  (run-git host-repo "worktree" "prune")
+  (let [parent-dir (.getParent (java.io.File. ^String worktree-path))]
+    (when parent-dir (.mkdirs (java.io.File. ^String parent-dir))))
+  (run-git host-repo "worktree" "add" "--detach" worktree-path commit-sha))
+
+(defn- cleanup-worktree!
+  [host-repo worktree-path]
+  (try (run-git host-repo "worktree" "remove" "--force" worktree-path)
+       (catch Throwable _ nil))
+  (try (fs/delete-tree worktree-path) (catch Throwable _ nil))
+  (run-git host-repo "worktree" "prune"))
+
+(defn merge-parent-branches!
+  "Multi-parent merge entry point per spec §6.1.
+
+   Inputs:
+   - `context` — the orchestrator's per-workflow context (provides host
+     repo path, run-id, registry).
+   - `task-def` — the multi-parent task being scheduled. Its
+     `:task/deps` and (optional) `:task/merge-strategy` drive the work.
+
+   Returns one of:
+   - `{:merge/ok? true :merge/ref <ref-name> :merge/commit-sha <sha>}` —
+     merge succeeded; downstream task forks off `:merge/ref`.
+   - `{:merge/ok? true :merge/ref <branch> :merge/single-parent? true}` —
+     after collapse, only one effective parent; downstream task forks off
+     that parent's branch directly (no merge commit needed). This is the
+     §6.2 / §6.3 informational fast-path.
+   - An anomaly map — `:dag-multi-parent-conflict`,
+     `:dag-multi-parent-unrelated-histories`,
+     `:dag-multi-parent-branch-unresolvable`. Stage 2 will replace the
+     conflict path with the resolution sub-workflow; for Stage 1B,
+     anomalies surface to the caller and the task fails."
+  [context task-def]
+  (let [registry (some-> (get context :dag/branch-registry) deref)
+        deps (vec (or (:task/deps task-def) []))
+        task-id (:task/id task-def)
+        strategy (or (:task/merge-strategy task-def) :git-merge)
+        run-id (or (:workflow-id context) "no-run-id")
+        host-repo (host-repo-path context)
+        resolved (dag/resolve-multi-parent-base
+                  (or registry (dag/create-branch-registry))
+                  deps)]
+    (if-not (seq (:merge/parents resolved))
+      ;; No deps registered — fall back to default branch (matches the
+      ;; single-parent fast-path's defensive semantics).
+      {:merge/ok? true
+       :merge/ref (default-spec-branch context)
+       :merge/single-parent? true
+       :merge/fallback-reason :no-registered-parents}
+
+      (let [snapshot (snapshot-parent-shas host-repo (:merge/parents resolved))]
+        (if (:anomaly/category snapshot)
+          snapshot
+          (let [;; Spec §3.2 step 3 — pure-data dedupe (already in registry layer)
+                deduped (dag/collapse-duplicate-tips (:parents snapshot))
+                ;; Spec §3.2 step 4 — git-side ancestor collapse
+                {:keys [parents collapsed]} (collapse-ancestors host-repo (:parents deduped))]
+            (cond
+              ;; Single effective parent after collapse — no merge needed.
+              (= 1 (count parents))
+              {:merge/ok? true
+               :merge/ref (:branch (first parents))
+               :merge/commit-sha (:commit-sha (first parents))
+               :merge/single-parent? true
+               :merge/collapsed (concat (:collapsed deduped) collapsed)}
+
+              ;; No shared ancestry → unrelated-histories anomaly per §6.5.
+              (not (shared-ancestry? host-repo parents))
+              {:anomaly/category :anomalies/dag-multi-parent-unrelated-histories
+               :anomaly/message  "Parents share no common ancestor — refusing to merge"
+               :task/id          task-id
+               :merge/parents    parents
+               :merge/strategy   strategy}
+
+              :else
+              (let [input-key (dag/compute-merge-input-key task-id strategy parents)
+                    ref-name (merge-base-ref-name run-id task-id input-key)
+                    worktree (temp-merge-worktree-path run-id task-id input-key)
+                    setup (ensure-clean-worktree! host-repo worktree (:commit-sha (first parents)))]
+                (if-not (zero? (:exit setup))
+                  (do (cleanup-worktree! host-repo worktree)
+                      {:anomaly/category :anomalies/dag-multi-parent-merge-failed
+                       :anomaly/message  "Could not create temp worktree for merge"
+                       :task/id          task-id
+                       :git/exit-code    (:exit setup)
+                       :git/stderr       (:err setup)})
+                  (let [outcome (run-merge! worktree host-repo task-id strategy parents input-key)]
+                    (cond-> (if (:ok? outcome)
+                              (do (run-git host-repo "update-ref" ref-name (:commit-sha outcome))
+                                  (cleanup-worktree! host-repo worktree)
+                                  {:merge/ok? true
+                                   :merge/ref ref-name
+                                   :merge/commit-sha (:commit-sha outcome)
+                                   :merge/input-key input-key
+                                   :merge/strategy strategy
+                                   :merge/parents parents})
+                              (do (cleanup-worktree! host-repo worktree)
+                                  (:anomaly outcome)))
+                      (seq (concat (:collapsed deduped) collapsed))
+                      (assoc :merge/collapsed (vec (concat (:collapsed deduped) collapsed))))))))))))))
+
+(defn- merge-error?
+  "True when `merge-parent-branches!` returned an anomaly rather than
+   a usable merge result."
+  [result]
+  (and (map? result) (:anomaly/category result)))
+
 (defn task-sub-opts
   "Build execution opts for a DAG task's sub-workflow.
 
@@ -274,15 +574,17 @@
    (parent workflow owns those).
 
    When `task-def` is supplied, resolves its dependency to a persisted
-   branch via the registry on context and passes it as `:branch` so the
-   sub-workflow's `acquire-environment!` forks off that branch instead
-   of the spec branch. `:branch` is ALWAYS set when task-def is given:
-   - Single-dep registered → dep's branch (chaining payoff).
-   - Single-dep unregistered or zero deps → the spec branch.
-   - Multi-dep → the registry returns an anomaly; we omit `:branch` here
-     because there's no usable string. In practice the orchestrator
-     short-circuits multi-parent plans at validation time
-     (`execute-plan-as-dag`), so this path is unreachable in production.
+   branch and passes it as `:branch` so the sub-workflow's
+   `acquire-environment!` forks off that branch instead of the spec
+   branch. `:branch` is ALWAYS set when task-def is given:
+   - Zero deps or single-dep unregistered → the spec branch.
+   - Single-dep registered → dep's branch (v1 chaining payoff).
+   - Multi-dep (v2) → the merged ref produced by `merge-parent-branches!`.
+     If the merge produces a typed anomaly (conflict / unrelated
+     histories / branch unresolvable), it propagates back to the caller
+     via `:dag/merge-anomaly` on opts; `execute-single-task` checks for
+     this and fails the task with the anomaly instead of running the
+     sub-workflow.
 
    The single-arity form `(task-sub-opts context)` is for callers that
    don't yet thread task-def (kept for compatibility with the
@@ -297,19 +599,33 @@
   ([context]
    (task-sub-opts context nil))
   ([context task-def]
-   (let [base-branch (when task-def (resolve-task-base-branch context task-def))
-         resolved-branch (when (and (string? base-branch)
-                                    (not (dag/resolve-base-branch-error? base-branch)))
-                           base-branch)]
-     (cond-> {:disable-dag-execution true
-              :skip-lifecycle-events true
-              :quiet (boolean (get-in context [:execution/opts :quiet]))
-              :create-pr? true}
+   (let [deps (vec (or (:task/deps task-def) []))
+         base-result (cond
+                       (nil? task-def)
+                       nil
+
+                       (dag/multi-parent? deps)
+                       (merge-parent-branches! context task-def)
+
+                       :else
+                       (resolve-task-base-branch context task-def))
+         resolved-branch (cond
+                           (string? base-result)            base-result
+                           (and (map? base-result)
+                                (:merge/ok? base-result))   (:merge/ref base-result)
+                           :else                            nil)
+         merge-anomaly (when (merge-error? base-result) base-result)
+         base-opts {:disable-dag-execution true
+                    :skip-lifecycle-events true
+                    :quiet (boolean (get-in context [:execution/opts :quiet]))
+                    :create-pr? true}]
+     (cond-> base-opts
        (:llm-backend context)      (assoc :llm-backend (:llm-backend context))
        (:event-stream context)     (assoc :event-stream (:event-stream context))
        (get-in context [:execution/opts :event-stream])
        (assoc :event-stream (get-in context [:execution/opts :event-stream]))
-       resolved-branch (assoc :branch resolved-branch)))))
+       resolved-branch (assoc :branch resolved-branch)
+       merge-anomaly  (assoc :dag/merge-anomaly merge-anomaly)))))
 
 ;--- Layer 1: Mini-Workflow Execution
 
@@ -367,9 +683,13 @@
    Threads `task-def` to `task-sub-opts` so per-task base chaining can
    resolve the right base branch from the workflow's branch registry —
    downstream tasks acquire off the prior task's persisted branch instead
-   of the spec branch. Extracts the task's resulting branch from the
-   sub-workflow result and includes it in the success envelope so
-   `execute-dag-loop` can register it for downstream consumers.
+   of the spec branch. v2 multi-parent path: when `task-def` has 2+
+   deps, `task-sub-opts` invokes `merge-parent-branches!` which performs
+   a deterministic git merge and returns a `:merge/ref`; the sub-workflow
+   forks off that merged base. If the merge produces a typed anomaly
+   (conflict / unrelated histories / unresolvable parent), `task-sub-opts`
+   surfaces it via `:dag/merge-anomaly` on opts and we fail the task
+   here rather than running a doomed sub-workflow.
 
    Extracts PR info from the release phase result and includes it in the
    workflow result."
@@ -377,23 +697,31 @@
   (let [sub-workflow (task-sub-workflow task-def context)
         sub-input    (task-sub-input task-def)
         sub-opts     (task-sub-opts context task-def)
-        run-pipeline (:execution/run-pipeline-fn context)
-        result       (run-pipeline sub-workflow sub-input sub-opts)
-        artifacts    (:execution/artifacts result)
-        metrics      (:execution/metrics result)
-        pr-info      (extract-pr-info-from-result result task-def)
-        task-branch  (task-result-branch result)]
-    (if (phase/succeeded? result)
-      (cond-> (workflow-success (first artifacts) metrics)
-        pr-info (assoc :pr-info pr-info)
-        ;; Carry sub-workflow's worktree path so apply-dag-success can
-        ;; merge changes back into the parent worktree for release.
-        (:execution/worktree-path result)
-        (assoc :worktree-path (:execution/worktree-path result))
-        ;; Carry the persisted branch name so the orchestrator can register
-        ;; it for downstream tasks' base resolution.
-        task-branch (assoc :task-branch task-branch))
-      (workflow-failure (extract-sub-workflow-error result) metrics))))
+        merge-anomaly (:dag/merge-anomaly sub-opts)]
+    (if merge-anomaly
+      ;; Multi-parent merge failed before we even entered the sub-workflow.
+      ;; Surface the anomaly directly; Stage 2 will replace conflicts with
+      ;; the resolution sub-workflow.
+      (workflow-failure (or (:anomaly/message merge-anomaly)
+                            "Multi-parent merge failed")
+                        nil)
+      (let [run-pipeline (:execution/run-pipeline-fn context)
+            result       (run-pipeline sub-workflow sub-input sub-opts)
+            artifacts    (:execution/artifacts result)
+            metrics      (:execution/metrics result)
+            pr-info      (extract-pr-info-from-result result task-def)
+            task-branch  (task-result-branch result)]
+        (if (phase/succeeded? result)
+          (cond-> (workflow-success (first artifacts) metrics)
+            pr-info (assoc :pr-info pr-info)
+            ;; Carry sub-workflow's worktree path so apply-dag-success can
+            ;; merge changes back into the parent worktree for release.
+            (:execution/worktree-path result)
+            (assoc :worktree-path (:execution/worktree-path result))
+            ;; Carry the persisted branch name so the orchestrator can register
+            ;; it for downstream tasks' base resolution.
+            task-branch (assoc :task-branch task-branch))
+          (workflow-failure (extract-sub-workflow-error result) metrics))))))
 
 (defn workflow-result->dag-result [task-id description wf-result]
   (if (:success? wf-result)
@@ -768,14 +1096,13 @@
   "Adapt post-wiring task-defs (`:task/deps` set) to the shape
    `validate-dag-forest` expects (`:task/dependencies` vec).
 
-   Validation runs AFTER stratum wiring on purpose: stratum auto-wiring
-   can introduce multi-parent edges that the raw plan doesn't show, and
-   we want the orchestrator to reject those at plan-validation time too.
+   In v1 this fed the plan-time gate; in v2 the gate is dropped and
+   the result is used only for informational logging (so the operator
+   sees `:dag/multi-parent-detected` for fan-in plans, but the
+   orchestrator runs them anyway via `merge-parent-branches!`).
 
-   Sorts deps before vectorizing so anomaly payloads (`:dependencies`
-   in `:multi-parent-tasks`) are deterministic across runs — sets have
-   no iteration order, and `vec` of a set would otherwise produce
-   different log/error output run-to-run for the same plan."
+   Sorts deps before vectorizing so logged payloads are deterministic
+   across runs — sets have no iteration order."
   [task-defs]
   (mapv (fn [t]
           {:task/id (:task/id t)
@@ -785,26 +1112,31 @@
            :task/dependencies (vec (sort-by str (:task/deps t #{})))})
         task-defs))
 
+(defn- log-multi-parent-detected!
+  "Emit an informational log (NOT an anomaly) when the plan has
+   multi-parent tasks. v2 runs them via the merge path; the log
+   surfaces plan shape on the dashboard so operators can see fan-in
+   patterns without the orchestrator rejecting work."
+  [logger plan task-defs]
+  (when-let [non-forest (dag/validate-dag-forest (task-defs->forest-shape task-defs))]
+    (log/info logger :dag-orchestrator :dag/multi-parent-detected
+              {:data {:plan-id (:plan/id plan)
+                      :multi-parent-tasks (:multi-parent-tasks non-forest)}})))
+
 (defn execute-plan-as-dag [plan context]
   (let [logger (or (:logger context) (log/create-logger {:min-level :info}))
         _ (warn-potential-monolith plan logger)
         task-defs (plan->dag-tasks plan context)
-        forest-anomaly (dag/validate-dag-forest (task-defs->forest-shape task-defs))]
-    (if forest-anomaly
-      (do
-        (log/info logger :dag-orchestrator :dag/non-forest-rejected
-                  {:data {:plan-id (:plan/id plan)
-                          :violations (:multi-parent-tasks forest-anomaly)}})
-        (dag-execution-error 0 (count task-defs) forest-anomaly))
-      (let [tasks-map (->> task-defs (map (fn [t] [(:task/id t) t])) (into {}))
-            pre-completed (get context :pre-completed-ids #{})
-            ctx (cond-> context
-                  (seq pre-completed) (assoc :pre-completed-ids pre-completed))]
-        (log/info logger :dag-orchestrator :dag/starting
-                  {:data {:plan-id (:plan/id plan)
-                          :task-count (count task-defs)
-                          :pre-completed (count pre-completed)}})
-        (execute-dag-loop tasks-map ctx logger)))))
+        _ (log-multi-parent-detected! logger plan task-defs)
+        tasks-map (->> task-defs (map (fn [t] [(:task/id t) t])) (into {}))
+        pre-completed (get context :pre-completed-ids #{})
+        ctx (cond-> context
+              (seq pre-completed) (assoc :pre-completed-ids pre-completed))]
+    (log/info logger :dag-orchestrator :dag/starting
+              {:data {:plan-id (:plan/id plan)
+                      :task-count (count task-defs)
+                      :pre-completed (count pre-completed)}})
+    (execute-dag-loop tasks-map ctx logger)))
 
 ;--- Layer 3: Workflow Integration
 

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -235,25 +235,39 @@
       (is (= "main" (:branch opts))
           "unregistered dep falls back to spec branch — no block"))))
 
-(deftest task-sub-opts-multi-dep-omits-branch-test
-  (testing "multi-parent task: registry returns an anomaly map; opts must
-            NOT carry :branch (we'd be passing a map where a string is
-            expected). v1 is supposed to reject these at plan time via
-            execute-plan-as-dag, so reaching this branch in production
-            is a bug — but the local fallback keeps the orchestrator
-            from crashing if validation is ever bypassed."
+(deftest task-sub-opts-multi-dep-attempts-merge-test
+  (testing "Multi-parent task: v2 invokes merge-parent-branches! instead of
+            rejecting at plan time. In a test context whose host repo
+            doesn't have these branches, the merge attempt fails fast with
+            a typed :anomalies/dag-multi-parent-branch-unresolvable
+            anomaly, which task-sub-opts surfaces via :dag/merge-anomaly.
+            The sub-workflow MUST NOT run with a stale :branch — opts
+            should not silently fall through to a default branch on the
+            multi-parent path. (Stage 2 will replace this anomaly path
+            with the resolution sub-workflow.)"
     (let [task-def {:task/id id-c :task/description "C" :task/deps #{id-a id-b}}
-          ctx (registry-context {id-a {:branch "task-a"}
-                                 id-b {:branch "task-b"}}
+          ctx (registry-context {id-a {:branch "task-a-not-in-test-repo"}
+                                 id-b {:branch "task-b-not-in-test-repo"}}
                                 "main")
           opts (dag-orch/task-sub-opts ctx task-def)]
       (is (not (contains? opts :branch))
-          "anomaly result must not be passed through as a branch name"))))
+          "merge anomaly must not produce a branch — sub-workflow would otherwise
+           fork off a stale value")
+      (is (some? (:dag/merge-anomaly opts))
+          "the anomaly is surfaced for the caller (run-mini-workflow) to
+           short-circuit on")
+      (is (= :anomalies/dag-multi-parent-branch-unresolvable
+             (get-in opts [:dag/merge-anomaly :anomaly/category]))
+          "branch-unresolvable is the right category — branches don't exist in
+           the test repo, so rev-parse fails before any merge is attempted"))))
 
 ;------------------------------------------------------------------------------ Layer 3
-;; Forest validation at plan time — multi-parent DAGs are rejected
-;; before any task starts so non-forest plans fail loud and early
-;; instead of after some tasks have already burned tokens.
+;; v2 multi-parent: forest gate is dropped (informational logging only).
+;; Diamond plans run end-to-end via merge-parent-branches!. With no
+;; llm-backend in the test context, sub-workflows resolve to placeholder
+;; results and don't actually invoke the merge path; the test below pins
+;; that the gate is dropped and the run reaches completion. Real merge
+;; behavior is exercised by the integration tests.
 
 (deftest execute-plan-as-dag-accepts-forest-test
   (testing "linear chain is a forest — orchestrator runs to completion"
@@ -268,13 +282,16 @@
       (is (:success? result) "forest plan should run to success")
       (is (= 2 (:tasks-completed result))))))
 
-(deftest execute-plan-as-dag-rejects-diamond-test
-  (testing "diamond (multi-parent) plan rejected before any task runs.
-            The orchestrator surfaces the anomaly at plan-validation
-            time rather than at task-execution time so callers can
-            linearize or split — and so we don't burn tokens on tasks
-            that will end up in a doomed merge."
-    (let [[logger _] (log/collecting-logger)
+(deftest execute-plan-as-dag-accepts-diamond-test-v2
+  (testing "v2: diamond (multi-parent) plan is no longer rejected at plan
+            time. The forest gate is dropped; multi-parent tasks run
+            through `merge-parent-branches!`. With placeholder execution
+            (no llm-backend) all four tasks complete; the merge code path
+            isn't exercised here because placeholder-result short-circuits
+            before sub-workflow invocation. Real merge behavior is in
+            the integration tests; this test is the unit-level pin that
+            v1's plan-time rejection is gone."
+    (let [[logger entries] (log/collecting-logger)
           plan {:plan/id (random-uuid)
                 :plan/name "diamond"
                 :plan/tasks [{:task/id id-a :task/description "A"
@@ -286,16 +303,13 @@
                              {:task/id id-d :task/description "D"
                               :task/type :implement :task/dependencies [id-b id-c]}]}
           result (dag-orch/execute-plan-as-dag plan {:logger logger})]
-      (is (false? (:success? result))
-          "non-forest plans must short-circuit the orchestrator")
-      (is (= 0 (:tasks-completed result))
-          "no tasks should run when the plan is rejected at validation time")
-      (is (= :anomalies/dag-non-forest
-             (get-in result [:error :anomaly/category]))
-          "error carries the canonical anomaly category for downstream surfaces")
-      (is (some #(= id-d (:task/id %))
-                (get-in result [:error :multi-parent-tasks]))
-          "the violation list pinpoints the offending task id"))))
+      (is (:success? result)
+          "v2 runs diamond plans end-to-end")
+      (is (= 4 (:tasks-completed result))
+          "all four tasks complete (placeholder execution, no real merge)")
+      (is (some #(= :dag/multi-parent-detected (:log/event %)) @entries)
+          "the multi-parent detection is logged for plan-quality observability —
+           dashboard surfaces fan-in even though it doesn't reject"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
@@ -1,0 +1,250 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.merge-parent-branches-integration-test
+  "Integration tests for the v2 `merge-parent-branches!` orchestrator
+   helper. Each test sets up a real git repo in a temp directory, runs
+   real `git` commands, and asserts on the resulting refs / anomalies.
+   Slow-ish but high-fidelity — these test the actual git behavior the
+   spec depends on (ort vs octopus, ancestor collapse, unrelated
+   histories, conflict surfacing)."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.workflow.dag-orchestrator :as dag-orch]))
+
+;------------------------------------------------------------------------------ Fixture: temp git repo
+
+(def ^:dynamic *repo* nil)
+
+(defn- run-git!
+  "Run a git command in `cwd`. Throws on non-zero exit so test setup
+   bugs surface immediately rather than as cryptic downstream failures."
+  [cwd & args]
+  (let [r (apply shell/sh "git" "-C" cwd args)]
+    (when-not (zero? (:exit r))
+      (throw (ex-info (str "git " (str/join " " args) " failed: " (:err r))
+                      {:cwd cwd :args args :result r})))
+    r))
+
+(defn- write-file! [cwd path content]
+  (let [f (java.io.File. ^String cwd ^String path)]
+    (.mkdirs (.getParentFile f))
+    (spit f content)))
+
+(defn- commit-file! [cwd path content message]
+  (write-file! cwd path content)
+  (run-git! cwd "add" path)
+  (run-git! cwd "commit" "-m" message))
+
+(defn temp-repo-fixture [f]
+  (let [repo (str (fs/create-temp-dir {:prefix "mpb-test-"}))]
+    (try
+      (run-git! repo "init" "-b" "main")
+      (run-git! repo "config" "user.email" "test@miniforge.ai")
+      (run-git! repo "config" "user.name" "miniforge-test")
+      (commit-file! repo "README.md" "initial\n" "init")
+      (binding [*repo* repo]
+        (f))
+      (finally
+        (try (fs/delete-tree repo) (catch Throwable _ nil))))))
+
+(use-fixtures :each temp-repo-fixture)
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- ctx-with-registry
+  "Build a context map shaped like the orchestrator's runtime context.
+   Registers parents in the registry so resolve-multi-parent-base sees
+   them, and points host-repo-path at *repo*."
+  [parent-entries]
+  {:execution/repo-path *repo*
+   :execution/worktree-path *repo*
+   :workflow-id "test-run"
+   :dag/branch-registry (atom (reduce-kv dag/register-branch
+                                         (dag/create-branch-registry)
+                                         parent-entries))})
+
+(defn- create-parent-branch!
+  "Branch off main, commit a file, return to main. Used to set up
+   parent branches with disjoint changes."
+  [branch-name path content]
+  (run-git! *repo* "checkout" "-b" branch-name "main")
+  (commit-file! *repo* path content (str "edit on " branch-name))
+  (run-git! *repo* "checkout" "main"))
+
+;------------------------------------------------------------------------------ Tests: 2-parent happy path
+
+(deftest two-parent-disjoint-files-happy-path-test
+  (testing "Two parents touching disjoint files merge cleanly via -s ort.
+            The result is a real merge commit; the namespaced ref points
+            at it; the orchestrator returns :merge/ok? true with the
+            ref name and commit SHA."
+    (create-parent-branch! "task-a" "src/a.txt" "from a\n")
+    (create-parent-branch! "task-b" "src/b.txt" "from b\n")
+    (let [task-id "task-c"
+          task-def {:task/id task-id
+                    :task/deps [:a :b]}
+          ctx (ctx-with-registry {:a {:branch "task-a"}
+                                  :b {:branch "task-b"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (:merge/ok? result))
+      (is (str/starts-with? (:merge/ref result) "refs/miniforge/dag-base/test-run/"))
+      (is (string? (:merge/commit-sha result)))
+      (is (= 40 (count (:merge/commit-sha result)))
+          "commit SHA is full 40-char hex (rev-parse default)")
+      ;; The merge commit should have two parents
+      (let [parents-cmd (run-git! *repo* "rev-list" "--parents" "-n" "1"
+                                  (:merge/commit-sha result))
+            parts (str/split (str/trim (:out parents-cmd)) #"\s+")]
+        (is (= 3 (count parts))
+            "merge commit + 2 parents = 3 SHAs"))
+      ;; Both files should be present in the merged tree
+      (let [tree (run-git! *repo* "ls-tree" "-r" "--name-only"
+                           (:merge/commit-sha result))
+            files (set (str/split-lines (str/trim (:out tree))))]
+        (is (contains? files "src/a.txt"))
+        (is (contains? files "src/b.txt"))))))
+
+;------------------------------------------------------------------------------ Tests: ancestor collapse
+
+(deftest ancestor-collapses-to-single-parent-test
+  (testing "When parent A is an ancestor of parent B, A's contributions
+            are already in B. The collapse algorithm drops A and
+            returns single-parent fast path against B — no merge commit
+            needed, the existing branch is the right base."
+    ;; task-a is an ancestor of task-b (b is built on top of a)
+    (run-git! *repo* "checkout" "-b" "task-a" "main")
+    (commit-file! *repo* "src/a.txt" "from a\n" "edit on a")
+    (run-git! *repo* "checkout" "-b" "task-b" "task-a")
+    (commit-file! *repo* "src/b.txt" "from b\n" "edit on b")
+    (run-git! *repo* "checkout" "main")
+    (let [task-def {:task/id "task-c" :task/deps [:a :b]}
+          ctx (ctx-with-registry {:a {:branch "task-a"}
+                                  :b {:branch "task-b"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (:merge/ok? result))
+      (is (:merge/single-parent? result)
+          "after ancestor collapse, only task-b remains as effective parent")
+      (is (= "task-b" (:merge/ref result))
+          "the surviving parent's branch is returned directly")
+      (is (some #(= :a (:dropped %)) (:merge/collapsed result))
+          ":collapsed records what was absorbed")
+      (is (some #(= :b (:absorbed-into %)) (:merge/collapsed result))
+          "and which surviving parent absorbed it"))))
+
+;------------------------------------------------------------------------------ Tests: duplicate parent tips
+
+(deftest duplicate-tips-collapse-test
+  (testing "When two declared parents resolve to the same SHA (e.g.
+            both branches advanced to the same commit), the duplicate
+            collapses and the merge becomes single-parent."
+    (run-git! *repo* "checkout" "-b" "task-a" "main")
+    (commit-file! *repo* "src/x.txt" "shared\n" "shared edit")
+    ;; task-a-alias points at exactly the same commit as task-a
+    (run-git! *repo* "branch" "task-a-alias" "task-a")
+    (run-git! *repo* "checkout" "main")
+    (let [task-def {:task/id "task-c" :task/deps [:a :alias]}
+          ctx (ctx-with-registry {:a     {:branch "task-a"}
+                                  :alias {:branch "task-a-alias"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (:merge/ok? result))
+      (is (:merge/single-parent? result)
+          "duplicate tips collapse to one effective parent"))))
+
+;------------------------------------------------------------------------------ Tests: unrelated histories
+
+(deftest unrelated-histories-anomaly-test
+  (testing "When parents share no common ancestor (e.g. one came from a
+            separate `git init`), v2 surfaces a typed anomaly rather than
+            using `--allow-unrelated-histories`. This protects against
+            accidental cross-repo / stray-init situations."
+    (create-parent-branch! "task-a" "src/a.txt" "from a\n")
+    ;; Build task-b on a synthetic root commit unrelated to main
+    (run-git! *repo* "checkout" "--orphan" "task-b")
+    (run-git! *repo* "rm" "-rf" ".")
+    (commit-file! *repo* "src/b.txt" "from b — unrelated\n" "unrelated root")
+    (run-git! *repo* "checkout" "main")
+    (let [task-def {:task/id "task-c" :task/deps [:a :b]}
+          ctx (ctx-with-registry {:a {:branch "task-a"}
+                                  :b {:branch "task-b"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (= :anomalies/dag-multi-parent-unrelated-histories
+             (:anomaly/category result))))))
+
+;------------------------------------------------------------------------------ Tests: conflict
+
+(deftest conflict-surfaces-typed-anomaly-test
+  (testing "When two parents touch the same file with different content,
+            the merge conflicts. v2 (Stage 1B) surfaces the conflict as
+            a typed anomaly carrying the parent SHAs, conflict paths,
+            and raw git stderr. Stage 2 will replace this with the
+            resolution sub-workflow; for 1B the task fails."
+    (run-git! *repo* "checkout" "-b" "task-a" "main")
+    (commit-file! *repo* "src/conflict.txt" "from a\n" "a edit")
+    (run-git! *repo* "checkout" "-b" "task-b" "main")
+    (commit-file! *repo* "src/conflict.txt" "from b\n" "b edit")
+    (run-git! *repo* "checkout" "main")
+    (let [task-def {:task/id "task-c" :task/deps [:a :b]}
+          ctx (ctx-with-registry {:a {:branch "task-a"}
+                                  :b {:branch "task-b"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (= :anomalies/dag-multi-parent-conflict
+             (:anomaly/category result)))
+      (is (some #(= "src/conflict.txt" (:path %))
+                (:merge/conflicts result))
+          "the conflicting path is enumerated for the resolution agent
+           (Stage 2) to consume"))))
+
+;------------------------------------------------------------------------------ Tests: branch unresolvable
+
+(deftest unregistered-branch-falls-back-to-default-test
+  (testing "When no parents are registered (orchestrator state shouldn't
+            allow this in production but defensive code is correct
+            anyway), merge-parent-branches! falls back to the spec
+            default branch."
+    (let [task-def {:task/id "task-c" :task/deps [:a :b]}
+          ;; Empty registry context
+          ctx {:execution/repo-path *repo*
+               :execution/opts {:branch "main"}
+               :workflow-id "test-run"
+               :dag/branch-registry (atom (dag/create-branch-registry))}
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (:merge/ok? result))
+      (is (:merge/single-parent? result))
+      (is (= :no-registered-parents (:merge/fallback-reason result))))))
+
+(deftest registered-branch-not-in-repo-anomaly-test
+  (testing "When a registered branch doesn't exist in the host repo
+            (the registry is out of sync with reality), v2 surfaces a
+            typed branch-unresolvable anomaly instead of crashing."
+    (let [task-def {:task/id "task-c" :task/deps [:a :b]}
+          ctx (ctx-with-registry {:a {:branch "task-a-does-not-exist"}
+                                  :b {:branch "task-b-does-not-exist"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (= :anomalies/dag-multi-parent-branch-unresolvable
+             (:anomaly/category result))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.workflow.merge-parent-branches-integration-test)
+
+  :leave-this-here)

--- a/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
@@ -61,6 +61,13 @@
       (run-git! repo "init" "-b" "main")
       (run-git! repo "config" "user.email" "test@miniforge.ai")
       (run-git! repo "config" "user.name" "miniforge-test")
+      ;; Defeat any global signing config (1Password, GPG agents, etc.)
+      ;; that would otherwise prompt or fail during commits in this
+      ;; ephemeral repo. Mirrors the orchestrator's --no-gpg-sign flag
+      ;; per spec §3.1: tests run hermetically regardless of dev-machine
+      ;; signing setup.
+      (run-git! repo "config" "commit.gpgsign" "false")
+      (run-git! repo "config" "tag.gpgsign" "false")
       (commit-file! repo "README.md" "initial\n" "init")
       (binding [*repo* repo]
         (f))
@@ -242,6 +249,63 @@
           result (dag-orch/merge-parent-branches! ctx task-def)]
       (is (= :anomalies/dag-multi-parent-branch-unresolvable
              (:anomaly/category result))))))
+
+;------------------------------------------------------------------------------ Tests: idempotency cache
+
+(deftest idempotency-second-call-reuses-merge-ref-test
+  (testing "Spec §7.2 idempotency: a second call to merge-parent-branches!
+            with the same effective inputs reuses the existing namespaced
+            ref instead of producing a fresh merge commit. Without the
+            cache check, merge commit timestamps would differ on every
+            call — same tree, different SHA — defeating the spec's
+            'replays of the same effective input reuse the same ref'
+            guarantee."
+    (create-parent-branch! "task-a" "src/a.txt" "from a\n")
+    (create-parent-branch! "task-b" "src/b.txt" "from b\n")
+    (let [task-def {:task/id "task-c" :task/deps [:a :b]}
+          ctx (ctx-with-registry {:a {:branch "task-a"}
+                                  :b {:branch "task-b"}})
+          first-result  (dag-orch/merge-parent-branches! ctx task-def)
+          second-result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (:merge/ok? first-result))
+      (is (:merge/ok? second-result))
+      (is (= (:merge/ref first-result) (:merge/ref second-result))
+          "same ref name (input-key is deterministic)")
+      (is (= (:merge/commit-sha first-result) (:merge/commit-sha second-result))
+          "same commit SHA — second call hit the cache, did NOT produce a
+           fresh merge commit. This is the property that justifies the
+           input-key derivation in spec §3.2 step 6.")
+      (is (true? (:merge/cache-hit? second-result))
+          "cache-hit flag exposed for observability — dashboard can show
+           how often replays are reusing existing merge work")
+      (is (not (contains? first-result :merge/cache-hit?))
+          "first call sets up the cache; cache-hit? only appears on
+           subsequent calls"))))
+
+;------------------------------------------------------------------------------ Tests: unsupported strategy
+
+(deftest unsupported-strategy-anomaly-test
+  (testing "Strategies other than :git-merge fail fast with a typed
+            anomaly rather than silently falling through. :sequential-merge
+            ships in Stage 4; until then plans that explicitly request it
+            should see the unsupported-strategy anomaly so they don't
+            silently get :git-merge behavior under a different label."
+    (create-parent-branch! "task-a" "src/a.txt" "from a\n")
+    (create-parent-branch! "task-b" "src/b.txt" "from b\n")
+    (let [task-def {:task/id "task-c"
+                    :task/deps [:a :b]
+                    :task/merge-strategy :sequential-merge}
+          ctx (ctx-with-registry {:a {:branch "task-a"}
+                                  :b {:branch "task-b"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (= :anomalies/dag-multi-parent-strategy-unsupported
+             (:anomaly/category result)))
+      (is (= :sequential-merge (:merge/strategy result))
+          "the requested strategy is echoed back in the anomaly so the
+           operator/dashboard knows what was rejected")
+      (is (contains? (:merge/supported result) :git-merge)
+          "the anomaly carries the supported-strategies set so the user
+           can see what's available right now"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
@@ -29,7 +29,8 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.dag-executor.interface :as dag]
-   [ai.miniforge.workflow.dag-orchestrator :as dag-orch]))
+   [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
+   [ai.miniforge.workflow.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Fixture: temp git repo
 
@@ -37,11 +38,17 @@
 
 (defn- run-git!
   "Run a git command in `cwd`. Throws on non-zero exit so test setup
-   bugs surface immediately rather than as cryptic downstream failures."
+   bugs surface immediately rather than as cryptic downstream failures.
+   The throw is dev-internal — it never reaches a user — but the
+   message is still routed through the workflow message catalog
+   (system-locale entries) so we have one place to audit / change
+   error wording."
   [cwd & args]
   (let [r (apply shell/sh "git" "-C" cwd args)]
     (when-not (zero? (:exit r))
-      (throw (ex-info (str "git " (str/join " " args) " failed: " (:err r))
+      (throw (ex-info (messages/t :dag.merge.system/git-test-failure
+                                  {:args (str/join " " args)
+                                   :err  (:err r)})
                       {:cwd cwd :args args :result r})))
     r))
 
@@ -103,8 +110,8 @@
 (deftest two-parent-disjoint-files-happy-path-test
   (testing "Two parents touching disjoint files merge cleanly via -s ort.
             The result is a real merge commit; the namespaced ref points
-            at it; the orchestrator returns :merge/ok? true with the
-            ref name and commit SHA."
+            at it; the orchestrator returns dag/ok wrapping {:branch
+            :commit-sha ...}."
     (create-parent-branch! "task-a" "src/a.txt" "from a\n")
     (create-parent-branch! "task-b" "src/b.txt" "from b\n")
     (let [task-id "task-c"
@@ -112,21 +119,22 @@
                     :task/deps [:a :b]}
           ctx (ctx-with-registry {:a {:branch "task-a"}
                                   :b {:branch "task-b"}})
-          result (dag-orch/merge-parent-branches! ctx task-def)]
-      (is (:merge/ok? result))
-      (is (str/starts-with? (:merge/ref result) "refs/miniforge/dag-base/test-run/"))
-      (is (string? (:merge/commit-sha result)))
-      (is (= 40 (count (:merge/commit-sha result)))
+          result (dag-orch/merge-parent-branches! ctx task-def)
+          data (:data result)]
+      (is (dag/ok? result))
+      (is (str/starts-with? (:branch data) "refs/miniforge/dag-base/test-run/"))
+      (is (string? (:commit-sha data)))
+      (is (= 40 (count (:commit-sha data)))
           "commit SHA is full 40-char hex (rev-parse default)")
       ;; The merge commit should have two parents
       (let [parents-cmd (run-git! *repo* "rev-list" "--parents" "-n" "1"
-                                  (:merge/commit-sha result))
+                                  (:commit-sha data))
             parts (str/split (str/trim (:out parents-cmd)) #"\s+")]
         (is (= 3 (count parts))
             "merge commit + 2 parents = 3 SHAs"))
       ;; Both files should be present in the merged tree
       (let [tree (run-git! *repo* "ls-tree" "-r" "--name-only"
-                           (:merge/commit-sha result))
+                           (:commit-sha data))
             files (set (str/split-lines (str/trim (:out tree))))]
         (is (contains? files "src/a.txt"))
         (is (contains? files "src/b.txt"))))))
@@ -147,15 +155,16 @@
     (let [task-def {:task/id "task-c" :task/deps [:a :b]}
           ctx (ctx-with-registry {:a {:branch "task-a"}
                                   :b {:branch "task-b"}})
-          result (dag-orch/merge-parent-branches! ctx task-def)]
-      (is (:merge/ok? result))
-      (is (:merge/single-parent? result)
+          result (dag-orch/merge-parent-branches! ctx task-def)
+          data (:data result)]
+      (is (dag/ok? result))
+      (is (:single-parent? data)
           "after ancestor collapse, only task-b remains as effective parent")
-      (is (= "task-b" (:merge/ref result))
+      (is (= "task-b" (:branch data))
           "the surviving parent's branch is returned directly")
-      (is (some #(= :a (:dropped %)) (:merge/collapsed result))
+      (is (some #(= :a (:dropped %)) (:collapsed data))
           ":collapsed records what was absorbed")
-      (is (some #(= :b (:absorbed-into %)) (:merge/collapsed result))
+      (is (some #(= :b (:absorbed-into %)) (:collapsed data))
           "and which surviving parent absorbed it"))))
 
 ;------------------------------------------------------------------------------ Tests: duplicate parent tips
@@ -173,8 +182,8 @@
           ctx (ctx-with-registry {:a     {:branch "task-a"}
                                   :alias {:branch "task-a-alias"}})
           result (dag-orch/merge-parent-branches! ctx task-def)]
-      (is (:merge/ok? result))
-      (is (:merge/single-parent? result)
+      (is (dag/ok? result))
+      (is (:single-parent? (:data result))
           "duplicate tips collapse to one effective parent"))))
 
 ;------------------------------------------------------------------------------ Tests: unrelated histories
@@ -234,10 +243,11 @@
                :execution/opts {:branch "main"}
                :workflow-id "test-run"
                :dag/branch-registry (atom (dag/create-branch-registry))}
-          result (dag-orch/merge-parent-branches! ctx task-def)]
-      (is (:merge/ok? result))
-      (is (:merge/single-parent? result))
-      (is (= :no-registered-parents (:merge/fallback-reason result))))))
+          result (dag-orch/merge-parent-branches! ctx task-def)
+          data (:data result)]
+      (is (dag/ok? result))
+      (is (:single-parent? data))
+      (is (= :no-registered-parents (:fallback-reason data))))))
 
 (deftest registered-branch-not-in-repo-anomaly-test
   (testing "When a registered branch doesn't exist in the host repo
@@ -266,21 +276,22 @@
           ctx (ctx-with-registry {:a {:branch "task-a"}
                                   :b {:branch "task-b"}})
           first-result  (dag-orch/merge-parent-branches! ctx task-def)
-          second-result (dag-orch/merge-parent-branches! ctx task-def)]
-      (is (:merge/ok? first-result))
-      (is (:merge/ok? second-result))
-      (is (= (:merge/ref first-result) (:merge/ref second-result))
+          second-result (dag-orch/merge-parent-branches! ctx task-def)
+          first-data    (:data first-result)
+          second-data   (:data second-result)]
+      (is (dag/ok? first-result))
+      (is (dag/ok? second-result))
+      (is (= (:branch first-data) (:branch second-data))
           "same ref name (input-key is deterministic)")
-      (is (= (:merge/commit-sha first-result) (:merge/commit-sha second-result))
+      (is (= (:commit-sha first-data) (:commit-sha second-data))
           "same commit SHA — second call hit the cache, did NOT produce a
            fresh merge commit. This is the property that justifies the
            input-key derivation in spec §3.2 step 6.")
-      (is (true? (:merge/cache-hit? second-result))
+      (is (true? (:cache-hit? second-data))
           "cache-hit flag exposed for observability — dashboard can show
            how often replays are reusing existing merge work")
-      (is (not (contains? first-result :merge/cache-hit?))
-          "first call sets up the cache; cache-hit? only appears on
-           subsequent calls"))))
+      (is (false? (:cache-hit? first-data))
+          "first call sets up the cache; cache-hit? is false there"))))
 
 ;------------------------------------------------------------------------------ Tests: unsupported strategy
 


### PR DESCRIPTION
## Summary

Stage 1B of v2 per-task base chaining (per [I-DAG-MULTI-PARENT-MERGE.md](https://github.com/miniforge-ai/miniforge/blob/main/specs/informative/I-DAG-MULTI-PARENT-MERGE.md)). Lights up the multi-parent code path that Stage 1A's pure-data primitives (PR #770) shipped.

After this PR, multi-parent DAG plans no longer reject at plan-validation time — they run end-to-end via a deterministic git merge. The conflict path surfaces as a typed anomaly (terminal failure for now); Stage 2 will replace that with an automated resolution sub-workflow per spec §6.1.

## What's in this PR

**`merge-parent-branches!`** in the orchestrator implements the spec §3.2 algorithm:
1. Snapshot parent SHAs at merge time (mutable branch names → immutable SHAs).
2. Collapse duplicate tips via the Stage 1A `dag/collapse-duplicate-tips`.
3. Collapse ancestors via `git merge-base --is-ancestor`; preserve plan order on surviving maximal tips.
4. Refuse unrelated histories — surface `:anomalies/dag-multi-parent-unrelated-histories` rather than using `--allow-unrelated-histories` (spec §6.5).
5. Compute `:merge/input-key` via the Stage 1A `dag/compute-merge-input-key`; namespaced ref `refs/miniforge/dag-base/<run-id>/<task-id>/<input-key>`.
6. Run `git merge -s ort` for 2 effective parents, `-s octopus` for 3+, with the spec §3.1 pinned flags (`--no-edit --no-gpg-sign --no-verify --no-ff -m <generated>`) in a clean temp worktree.
7. On success: push the resulting commit to the namespaced ref and clean up. On conflict: enumerate conflicts, surface a typed anomaly, clean up.

**`task-sub-opts`** now calls `merge-parent-branches!` for multi-parent tasks. The merged ref is passed as `:branch`. Merge anomalies are surfaced via `:dag/merge-anomaly` on opts; `run-mini-workflow` short-circuits before running a doomed sub-workflow.

**`execute-plan-as-dag`** no longer rejects non-forest plans. `validate-dag-forest` survives as an informational helper: multi-parent plans log `:dag/multi-parent-detected` for dashboard plan-quality observability and run through the new merge path.

## Test coverage

- **New integration tests** (`merge_parent_branches_integration_test.clj`, 7 tests / 16 assertions) exercise the helper against real git temp repos:
  - 2-parent disjoint-files happy path (asserts merge commit has 2 parents and both files are in the tree)
  - Ancestor collapse → single-parent fast path
  - Duplicate-tip collapse → single-parent fast path
  - Unrelated histories → typed anomaly
  - Conflict on same-file divergence → typed anomaly with conflict paths
  - Empty registry → fallback to default branch
  - Branch unresolvable in repo → typed anomaly
- **Updated unit tests** in `dag_orchestrator_test.clj`:
  - `task-sub-opts-multi-dep` reflects the v2 anomaly surfacing via `:dag/merge-anomaly`
  - `execute-plan-as-dag-rejects-diamond-test` → `execute-plan-as-dag-accepts-diamond-test-v2`; pins that diamond plans run AND log `:dag/multi-parent-detected`

Full suite: **4941 tests / 22684 passes / 0 failures / 0 errors**.

## What's NOT in this PR (deferred to Stage 2)

- Resolution sub-workflow that automates conflict resolution (spec §6.1).
- Merge-resolution curator (`:curator/markers-not-resolved`, `:curator/recurring-conflict`) per spec §6.1.2.
- Policy-overridable agent prompt scaffolding per spec §6.1.3.

For Stage 1B, conflicts are terminal failures with a typed anomaly. Stage 2 makes them recoverable.

## Spec traceability

| Spec section | Implemented in this PR |
| ------------ | ---------------------- |
| §3.1 pinned merge flags | `pinned-merge-flags` |
| §3.2 step 1 SHA snapshot | `snapshot-parent-shas` |
| §3.2 step 4 ancestor collapse | `collapse-ancestors` |
| §3.2 step 5 strategy selection | `run-merge!` (ort vs octopus by parent count) |
| §3.2 step 6 input-key | `dag/compute-merge-input-key` (Stage 1A re-used) |
| §3.2 step 7-9 merge execution | `merge-parent-branches!` orchestration |
| §6.1 conflict anomaly shape | `run-merge!` non-zero-exit branch |
| §6.2 ancestor parent collapse | `collapse-ancestors` |
| §6.3 duplicate parent tips | `dag/collapse-duplicate-tips` (Stage 1A re-used) |
| §6.5 unrelated histories anomaly | `shared-ancestry?` branch |
| §7.2 namespaced ref | `merge-base-ref-name` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)