### PR TITLE
fix: harden Claude dogfood preflight and planner stream supervision

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -446,8 +446,17 @@
     (let [parsed (parse-preflight-payload candidate)
           nested (or (some-> parsed :result str/trim not-empty)
                      (some-> parsed :content str/trim not-empty))]
-      (if (and nested (not= nested candidate))
+      (cond
+        (and (:result parsed)
+             (not (and (= "result" (:type parsed))
+                       (= "success" (:subtype parsed))
+                       (not (:is_error parsed)))))
+        nil
+
+        (and nested (not= nested candidate))
         (recur nested)
+
+        :else
         candidate))))
 
 (defn- preflight-success?

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -440,9 +440,19 @@
     (some-> content str/trim not-empty (json/parse-string true))
     (catch Exception _ nil)))
 
+(defn- normalized-preflight-content
+  [content]
+  (loop [candidate (some-> content str/trim not-empty)]
+    (let [parsed (parse-preflight-payload candidate)
+          nested (or (some-> parsed :result str/trim not-empty)
+                     (some-> parsed :content str/trim not-empty))]
+      (if (and nested (not= nested candidate))
+        (recur nested)
+        candidate))))
+
 (defn- preflight-success?
   [content]
-  (= {:ok true} (parse-preflight-payload content)))
+  (= {:ok true} (parse-preflight-payload (normalized-preflight-content content))))
 
 (defn- backend-stream-content
   [stream-parser output]
@@ -509,7 +519,7 @@
                         {:cmd-path cmd-path
                          :stdout (some-> out str/trim not-empty)
                          :stderr (some-> err str/trim not-empty)
-                         :content content
+                         :content (normalized-preflight-content content)
                          :exit-code exit}))))
 
 (defn- run-claude-backend-preflight
@@ -517,7 +527,8 @@
   (let [{:keys [out err exit timeout-ms]} (run-cli-command (claude-preflight-command cmd-path)
                                                            (backend-preflight-timeout-ms)
                                                            :workdir workdir)
-        trimmed (some-> out str/trim)]
+        trimmed (some-> out str/trim)
+        content (normalized-preflight-content trimmed)]
     (cond
       timeout-ms
       (assoc (failure-response :anomalies/unavailable
@@ -539,11 +550,11 @@
                                 :exit-code exit})
              :exit-code exit)
 
-      (preflight-success? trimmed)
-      (-> (success-response {:content trimmed
+      (preflight-success? content)
+      (-> (success-response {:content content
                              :exit-code exit})
           (assoc :exit-code exit
-                 :content trimmed))
+                 :content content))
 
       :else
       (assoc (failure-response :anomalies/unavailable
@@ -551,6 +562,7 @@
                                (messages/t :workflow-runner/claude-preflight-unexpected-output)
                                {:cmd-path cmd-path
                                 :stdout trimmed
+                                :content content
                                 :stderr (some-> err str/trim not-empty)
                                 :exit-code exit})
              :exit-code exit))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -159,6 +159,28 @@
       (is (str/includes? output "Backend Path: /opt/homebrew/bin/claude"))
       (is (str/includes? output "Backend Version: 2.1.118 (Claude Code)")))))
 
+(deftest run-backend-preflight-rejects-claude-error-wrapper-test
+  (testing "Claude preflight rejects wrapped payloads when the outer result envelope is not successful"
+    (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})]
+      (try+
+        (with-redefs-fn {#'sut/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
+                         #'sut/read-cli-version (fn [_] {:success true :version "2.1.118 (Claude Code)"})
+                         #'sut/run-cli-command (fn [_cmd _timeout-ms & _]
+                                                 {:out "{\"type\":\"result\",\"subtype\":\"error\",\"is_error\":true,\"result\":\"{\\\"ok\\\":true}\"}"
+                                                  :err ""
+                                                  :exit 0})}
+          (fn []
+            (#'sut/run-backend-preflight!
+             false
+             llm-client
+             {:worktree-path "/tmp/runtime-worktree"})))
+        (is false "expected wrapped error result to fail preflight")
+        (catch [:anomaly/category :anomalies/unavailable]
+               {:keys [probe-response]}
+          (is (= "backend_preflight_unexpected_output"
+                 (get-in probe-response [:error :data :type])))
+          (is (nil? (:content probe-response))))))))
+
 (deftest run-backend-preflight-exercises-generic-cli-success-path-test
   (testing "non-Claude CLI backends decode streamed CLI output and accept the canonical ok payload"
     (let [llm-client (llm/create-client {:backend :codex})

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -140,6 +140,25 @@
           (is (= "2.1.89" cmd-version))
           (is (= "backend_preflight_timeout" (get-in probe-response [:error :type]))))))))
 
+(deftest run-backend-preflight-accepts-claude-result-wrapper-test
+  (testing "Claude preflight accepts success envelopes whose result field contains the canonical payload"
+    (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
+          output (with-out-str
+                   (with-redefs-fn {#'sut/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
+                                    #'sut/read-cli-version (fn [_] {:success true :version "2.1.118 (Claude Code)"})
+                                    #'sut/run-cli-command (fn [_cmd _timeout-ms & _]
+                                                            {:out "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"{\\\"ok\\\":true}\"}"
+                                                             :err ""
+                                                             :exit 0})}
+                     (fn []
+                       (#'sut/run-backend-preflight!
+                        false
+                        llm-client
+                        {:worktree-path "/tmp/runtime-worktree"}))))]
+      (is (str/includes? output "Backend: claude"))
+      (is (str/includes? output "Backend Path: /opt/homebrew/bin/claude"))
+      (is (str/includes? output "Backend Version: 2.1.118 (Claude Code)")))))
+
 (deftest run-backend-preflight-exercises-generic-cli-success-path-test
   (testing "non-Claude CLI backends decode streamed CLI output and accept the canonical ok payload"
     (let [llm-client (llm/create-client {:backend :codex})

--- a/components/llm/src/ai/miniforge/llm/progress_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/progress_monitor.clj
@@ -98,6 +98,24 @@
                     :stagnant-cycles 0
                     :file-writes (conj (:file-writes state) file-path))))))
 
+(defn record-activity!
+  "Record semantic activity that should keep the monitor alive even when
+   repeated events do not produce new substantive text.
+
+   Arguments:
+   - monitor - Progress monitor atom
+   - activity-key - Stable keyword/string describing the activity type"
+  [monitor activity-key]
+  (let [now (System/currentTimeMillis)]
+    (swap! monitor
+           (fn [state]
+             (-> state
+                 (assoc :last-activity-at now
+                        :stagnant-cycles 0)
+                 (update :chunk-count inc)
+                 (update :unique-chunks conj activity-key)))))
+  true)
+
 (defn check-timeout
   "Check if the monitor has timed out.
 

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -112,11 +112,12 @@
   "Build a failed LLM response with anomaly."
   ([category error-type message]
    (llm-error category error-type message nil))
-  ([category error-type message {:keys [exit-code stderr stdout timeout]}]
+  ([category error-type message {:keys [exit-code stderr stdout raw-stdout timeout]}]
    (cond-> {:success false
             :error (cond-> {:type error-type :message message}
                      stderr  (assoc :stderr stderr)
                      stdout  (assoc :stdout stdout)
+                     raw-stdout (assoc :raw-stdout raw-stdout)
                      timeout (assoc :timeout timeout))
             :anomaly (response/make-anomaly
                       category message
@@ -657,10 +658,9 @@
         (enqueue-stream-line! line-queue (stream-read-failure e))))))
 
 (defn- record-stream-line!
-  [out-lines monitor dump-writer on-line last-line-at now line]
+  [out-lines dump-writer on-line last-line-at now line]
   (reset! last-line-at now)
   (swap! out-lines conj line)
-  (pm/record-chunk! monitor line)
   (when dump-writer
     (.println dump-writer line)
     (.flush dump-writer))
@@ -697,7 +697,7 @@
                                  (System/currentTimeMillis))})
 
 (defn- process-stream-signal
-  [line-or-signal out-lines monitor dump-writer on-line last-line-at line-timeout-ms]
+  [line-or-signal out-lines dump-writer on-line last-line-at line-timeout-ms]
   (cond
     (anomaly-signal? line-or-signal)
     (throw+ line-or-signal)
@@ -707,7 +707,6 @@
 
     (some? line-or-signal)
     (do (record-stream-line! out-lines
-                             monitor
                              dump-writer
                              on-line
                              last-line-at
@@ -733,7 +732,6 @@
           (let [{:keys [done? timeout]}
                 (process-stream-signal (stream-poll-signal line-queue)
                                        out-lines
-                                       monitor
                                        dump-writer
                                        on-line
                                        last-line-at
@@ -840,7 +838,28 @@
                  :content (:content result)}))
     result))
 
-(defn stream-with-parser [stream-parser on-chunk accumulated-content accumulated-usage accumulated-cost accumulated-tools accumulated-session-id accumulated-stop-reason accumulated-turns]
+(defn- record-parsed-progress!
+  [progress-monitor parsed accumulated-content]
+  (cond
+    (:tool-use parsed)
+    (pm/record-chunk!
+     progress-monitor
+     (str "tool-use:"
+          (or (:tool-name parsed)
+              (some->> (:tool-names parsed) seq sort (str/join ","))
+              "unknown")))
+
+    (:heartbeat parsed)
+    (pm/record-chunk! progress-monitor "stream-heartbeat")
+
+    (contains? parsed :done?)
+    (pm/record-chunk! progress-monitor "stream-result")
+
+    :else
+    (pm/record-chunk! progress-monitor @accumulated-content)))
+
+(defn stream-with-parser
+  [stream-parser on-chunk progress-monitor accumulated-content accumulated-usage accumulated-cost accumulated-tools accumulated-session-id accumulated-stop-reason accumulated-turns]
   (fn [line]
     (when-let [parsed (stream-parser line)]
       (when-let [usage (:usage parsed)]
@@ -865,10 +884,12 @@
             (swap! accumulated-tools conj tool-name))
           (when-let [tool-names (:tool-names parsed)]
             (swap! accumulated-tools into tool-names))
+          (record-parsed-progress! progress-monitor parsed accumulated-content)
           (on-chunk (assoc parsed :content @accumulated-content)))
         ;; Normal text deltas
         (when-let [delta (:delta parsed)]
           (swap! accumulated-content str delta)
+          (record-parsed-progress! progress-monitor parsed accumulated-content)
           (on-chunk (assoc parsed :content @accumulated-content)))))))
 
 (defn log-streaming-result [logger timeout-info content-length]
@@ -932,14 +953,18 @@
    - :num-turns            — number of conversation turns consumed
    - :tool-call-count      — total number of tool invocations during the run
    - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)"
-  [content exit-code err-result timeout-info stop-reason num-turns tool-call-count final-message-preview]
+  [content exit-code err-result raw-stdout timeout-info stop-reason num-turns tool-call-count final-message-preview]
   (let [error-message (or err-result
                           (when (str/blank? content) "Process failed with no output")
                           "Process failed")
         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
         error-type (if timeout-info "adaptive_timeout" "cli_error")]
     (cond-> (llm-error category error-type (str/trim error-message)
-                       {:exit-code exit-code :stderr err-result :stdout content :timeout timeout-info})
+                       {:exit-code exit-code
+                        :stderr err-result
+                        :stdout content
+                        :raw-stdout raw-stdout
+                        :timeout timeout-info})
       stop-reason                 (assoc :stop-reason stop-reason)
       num-turns                   (assoc :num-turns num-turns)
       (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
@@ -967,7 +992,7 @@
                          :prompt-length (count prompt)}}))
     (let [result (stream-fn
                   full-cmd
-                  (stream-with-parser stream-parser on-chunk
+                  (stream-with-parser stream-parser on-chunk progress-monitor
                                       accumulated-content accumulated-usage
                                       accumulated-cost accumulated-tools
                                       accumulated-session-id
@@ -977,12 +1002,16 @@
           exit-code (:exit result)
           timeout-info (:timeout result)
           final-content @accumulated-content
+          raw-output (:out result)
+          diagnostic-content (if (str/blank? final-content)
+                               raw-output
+                               final-content)
           tools @accumulated-tools
           session-id @accumulated-session-id
           stop-reason @accumulated-stop-reason
           num-turns @accumulated-turns
           tool-call-count (count tools)
-          final-message-preview (message-preview final-content)
+          final-message-preview (message-preview diagnostic-content)
           usage @accumulated-usage
           fallback-response (when (blank-streaming-success? exit-code
                                                             final-content
@@ -1023,6 +1052,7 @@
               (seq tools) (assoc :tools-called tools)
               session-id  (assoc :session-id session-id))
             (cond-> (streaming-error-response final-content exit-code (:err result)
+                                              diagnostic-content
                                               timeout-info stop-reason num-turns
                                               tool-call-count final-message-preview)
               session-id (assoc :session-id session-id))))))))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -842,7 +842,7 @@
   [progress-monitor parsed accumulated-content]
   (cond
     (:tool-use parsed)
-    (pm/record-chunk!
+    (pm/record-activity!
      progress-monitor
      (str "tool-use:"
           (or (:tool-name parsed)
@@ -850,10 +850,10 @@
               "unknown")))
 
     (:heartbeat parsed)
-    (pm/record-chunk! progress-monitor "stream-heartbeat")
+    (pm/record-activity! progress-monitor :stream-heartbeat)
 
     (contains? parsed :done?)
-    (pm/record-chunk! progress-monitor "stream-result")
+    (pm/record-activity! progress-monitor :stream-result)
 
     :else
     (pm/record-chunk! progress-monitor @accumulated-content)))

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -334,7 +334,8 @@
 
 (deftest stream-parser-accumulates-usage-test
   (testing "stream-with-parser stores usage from parsed events"
-    (let [content (atom "")
+    (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+          content (atom "")
           usage (atom nil)
           cost (atom nil)
           chunks (atom [])
@@ -345,6 +346,7 @@
           handler (impl/stream-with-parser
                     #'impl/parse-claude-stream-line
                     (fn [chunk] (swap! chunks conj chunk))
+                    monitor
                     content
                     usage
                     cost
@@ -369,7 +371,8 @@
 
 (deftest stream-parser-accumulates-stop-reason-and-turns-test
   (testing "latest stop_reason wins, num_turns captured from result event"
-    (let [content (atom "")
+    (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+          content (atom "")
           usage (atom nil)
           cost (atom nil)
           chunks (atom [])
@@ -380,6 +383,7 @@
           handler (impl/stream-with-parser
                     #'impl/parse-claude-stream-line
                     (fn [chunk] (swap! chunks conj chunk))
+                    monitor
                     content usage cost tools session-id stop-reason turns)]
       ;; First assistant message with tool_use (not the final stop)
       (handler (json/generate-string
@@ -404,7 +408,8 @@
 
 (deftest stream-parser-codex-increment-turns-test
   (testing "turn.completed events increment the turns accumulator"
-    (let [content (atom "")
+    (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+          content (atom "")
           usage (atom nil)
           cost (atom nil)
           chunks (atom [])
@@ -415,6 +420,7 @@
           handler (impl/stream-with-parser
                     #'impl/parse-codex-stream-line
                     (fn [chunk] (swap! chunks conj chunk))
+                    monitor
                     content usage cost tools session-id stop-reason turns)]
       ;; First turn.completed — turns goes from nil to 1
       (handler (json/generate-string
@@ -428,7 +434,8 @@
       (is (= 2 @turns))))
 
   (testing "turn.completed with finish_reason sets stop-reason accumulator"
-    (let [content (atom "")
+    (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+          content (atom "")
           usage (atom nil)
           cost (atom nil)
           chunks (atom [])
@@ -439,6 +446,7 @@
           handler (impl/stream-with-parser
                     #'impl/parse-codex-stream-line
                     (fn [chunk] (swap! chunks conj chunk))
+                    monitor
                     content usage cost tools session-id stop-reason turns)]
       (handler (json/generate-string
                  {:type "turn.completed"
@@ -542,24 +550,33 @@
 
 (deftest streaming-error-response-diagnostic-test
   (testing "tool-call-count is surfaced on error responses"
-    (let [resp (impl/streaming-error-response "" -1 "process died" nil nil nil 5 nil)]
+    (let [resp (impl/streaming-error-response "" -1 "process died" "" nil nil nil 5 nil)]
       (is (not (:success resp)))
       (is (= 5 (:tool-call-count resp)))))
 
   (testing "final-message-preview is surfaced on error responses"
-    (let [resp (impl/streaming-error-response "partial output" -1 "process died" nil nil nil nil "partial output")]
+    (let [resp (impl/streaming-error-response "partial output" -1 "process died" "partial output" nil nil nil nil "partial output")]
       (is (not (:success resp)))
       (is (= "partial output" (:final-message-preview resp)))))
 
   (testing "stop-reason and num-turns appear on error response top level"
     (let [resp (impl/streaming-error-response "" -1 "timed out"
+                                              ""
                                               {:type :stream-idle :message "idle" :elapsed-ms 1000}
                                               "max_turns" 12 3 "last bit")]
       (is (not (:success resp)))
       (is (= "max_turns" (:stop-reason resp)))
       (is (= 12 (:num-turns resp)))
       (is (= 3 (:tool-call-count resp)))
-      (is (= "last bit" (:final-message-preview resp))))))
+      (is (= "last bit" (:final-message-preview resp)))))
+
+  (testing "raw stdout is preserved when parsed content is empty"
+    (let [resp (impl/streaming-error-response "" -1 "timed out"
+                                              "{\"type\":\"system\"}"
+                                              {:type :stagnation :message "stalled" :elapsed-ms 1000}
+                                              nil nil nil nil)]
+      (is (not (:success resp)))
+      (is (= "{\"type\":\"system\"}" (get-in resp [:error :raw-stdout]))))))
 
 (deftest process-stream-lines-eof-is-not-timeout-test
   (testing "clean EOF with no lines does not synthesize a stream-idle timeout"
@@ -593,6 +610,40 @@
             (is (= timeout (:timeout result)))))
         (finally
           (.close writer))))))
+
+(deftest stream-with-parser-records-tool-progress-test
+  (testing "tool-use events reset semantic progress even without text deltas"
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms 1000
+                    :max-total-ms 1000
+                    :min-activity-interval-ms 1})
+          chunks (atom [])
+          accumulated-content (atom "")
+          accumulated-usage (atom nil)
+          accumulated-cost (atom nil)
+          accumulated-tools (atom [])
+          accumulated-session-id (atom nil)
+          accumulated-stop-reason (atom nil)
+          accumulated-turns (atom nil)
+          parse-line (:stream-parser (get impl/backends :claude))
+          on-line (impl/stream-with-parser parse-line
+                                           #(swap! chunks conj %)
+                                           monitor
+                                           accumulated-content
+                                           accumulated-usage
+                                           accumulated-cost
+                                           accumulated-tools
+                                           accumulated-session-id
+                                           accumulated-stop-reason
+                                           accumulated-turns)
+          before (:last-activity-at @monitor)]
+      (Thread/sleep 5)
+      (on-line "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"mcp__context__grep\"}],\"stop_reason\":\"tool_use\"}}")
+      (is (= ["mcp__context__grep"] @accumulated-tools))
+      (is (= "tool_use" @accumulated-stop-reason))
+      (is (< before (:last-activity-at @monitor)))
+      (is (= "" @accumulated-content))
+      (is (= 1 (count @chunks))))))
 
 (deftest message-preview-via-streaming-success-test
   (testing "short content is returned in full as preview"

--- a/docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md
+++ b/docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md
@@ -24,11 +24,18 @@ out even though the agent was still active.
 - record planner/LLM progress from parsed stream events instead of raw stdout
   lines
 - treat tool-use, heartbeat, and result events as semantic progress signals
+- refresh progress for repeated semantic activity even when the marker text is
+  unchanged
 - preserve raw streamed stdout in timeout error payloads when parsed content is
   empty
+- accept wrapped Claude preflight success output only when the outer result
+  envelope is itself successful
 - add regression coverage for:
   - tool-use progress preventing false stagnation
+  - repeated heartbeat activity extending liveness correctly
   - raw stdout preservation on streaming timeout failures
+  - rejecting wrapped preflight error envelopes that contain an inner
+    `{"ok":true}`
 
 ## Validation
 

--- a/docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md
+++ b/docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md
@@ -1,0 +1,50 @@
+# Fix Claude Plan Stream Progress
+
+## Summary
+
+This PR fixes a real dogfood failure in the Claude planner path after `#767`.
+
+The workflow now gets past backend preflight, but Claude planning could still
+fail with a false stagnation timeout during tool-heavy planning. The immediate
+symptoms from live dogfood were:
+
+- `:plan` failed with `Adaptive timeout: Stagnation timeout`
+- the progress monitor reported only `2` chunks and `1` unique chunk
+- planner artifact-session diagnostics logged a missing `artifact.edn`
+- timeout errors dropped the raw streamed stdout that would have made the
+  failure diagnosable
+
+The root issue was that stream supervision was treating raw stdout lines as the
+progress signal instead of parsed semantic activity. When Claude spent time in
+MCP/tool-use without substantive text deltas, the progress monitor could time
+out even though the agent was still active.
+
+## Changes
+
+- record planner/LLM progress from parsed stream events instead of raw stdout
+  lines
+- treat tool-use, heartbeat, and result events as semantic progress signals
+- preserve raw streamed stdout in timeout error payloads when parsed content is
+  empty
+- add regression coverage for:
+  - tool-use progress preventing false stagnation
+  - raw stdout preservation on streaming timeout failures
+
+## Validation
+
+- `clj-kondo --lint` on touched LLM files
+- focused `ai.miniforge.llm.interface-test`
+- full `bb pre-commit`
+
+## Dogfood Context
+
+This stacks on the already-committed preflight result-wrapper fix on
+`fix/claude-preflight-result-wrapper`.
+
+Live dogfood sequence on this branch:
+
+1. backend preflight was fixed to accept Claude's wrapped success result
+2. workflow then advanced into `:plan`
+3. `:plan` exposed the next real issue: false stagnation during tool-heavy
+   planner execution
+4. this PR addresses that second failure mode directly

--- a/projects/miniforge/test/ai/miniforge/llm/progress_monitor_test.clj
+++ b/projects/miniforge/test/ai/miniforge/llm/progress_monitor_test.clj
@@ -77,6 +77,19 @@
       (pm/record-file-write! monitor "src/bar.clj")
       (is (zero? (:stagnant-cycles @monitor))))))
 
+(deftest record-activity-test
+  (testing "repeated semantic activity refreshes last-activity even with the same marker"
+    (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1000})
+          before (:last-activity-at @monitor)]
+      (Thread/sleep 10)
+      (is (true? (pm/record-activity! monitor :stream-heartbeat)))
+      (let [after-first (:last-activity-at @monitor)]
+        (Thread/sleep 10)
+        (is (true? (pm/record-activity! monitor :stream-heartbeat)))
+        (is (< before after-first))
+        (is (< after-first (:last-activity-at @monitor))))
+      (is (zero? (:stagnant-cycles @monitor))))))
+
 (deftest check-timeout-test
   (testing "returns nil when making progress"
     (let [monitor (pm/create-progress-monitor {})]


### PR DESCRIPTION
# Fix Claude Plan Stream Progress

## Summary

This PR fixes a real dogfood failure in the Claude planner path after `#767`.

The workflow now gets past backend preflight, but Claude planning could still
fail with a false stagnation timeout during tool-heavy planning. The immediate
symptoms from live dogfood were:

- `:plan` failed with `Adaptive timeout: Stagnation timeout`
- the progress monitor reported only `2` chunks and `1` unique chunk
- planner artifact-session diagnostics logged a missing `artifact.edn`
- timeout errors dropped the raw streamed stdout that would have made the
  failure diagnosable

The root issue was that stream supervision was treating raw stdout lines as the
progress signal instead of parsed semantic activity. When Claude spent time in
MCP/tool-use without substantive text deltas, the progress monitor could time
out even though the agent was still active.

## Changes

- record planner/LLM progress from parsed stream events instead of raw stdout
  lines
- treat tool-use, heartbeat, and result events as semantic progress signals
- preserve raw streamed stdout in timeout error payloads when parsed content is
  empty
- add regression coverage for:
  - tool-use progress preventing false stagnation
  - raw stdout preservation on streaming timeout failures

## Validation

- `clj-kondo --lint` on touched LLM files
- focused `ai.miniforge.llm.interface-test`
- full `bb pre-commit`

## Dogfood Context

This stacks on the already-committed preflight result-wrapper fix on
`fix/claude-preflight-result-wrapper`.

Live dogfood sequence on this branch:

1. backend preflight was fixed to accept Claude's wrapped success result
2. workflow then advanced into `:plan`
3. `:plan` exposed the next real issue: false stagnation during tool-heavy
   planner execution
4. this PR addresses that second failure mode directly
