### PR TITLE
feat(agent): curator multimethod + :merge-resolution (Stage 2A)

### DIFF
--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -67,6 +67,8 @@
    [ai.miniforge.schema.interface :as schema]
    [babashka.fs :as fs]
    [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
    [clojure.string :as str]
    [malli.core :as m]))
 
@@ -419,32 +421,102 @@
 ;; narration to fire.
 
 (def ^:private conflict-marker-re
-  "Match a line that begins (after optional whitespace) with one of
-   git's three conflict-marker tokens. The exact-7 form is git's
-   default; longer runs are also legal so we match `+`."
-  #"(?m)^[<>=]{7,}")
+  "Match a line that begins (column 0, no leading whitespace per git's
+   default emit format) with a run of 7+ identical conflict-marker
+   characters. The three valid tokens are <<<<<<<, =======, >>>>>>>;
+   we match each as a single-character run rather than `[<>=]{7,}`
+   so a stray `<>=<>=<` mid-line on a non-marker line doesn't false-
+   positive. The 7+ length matches git's default (exactly 7) plus the
+   variable-length form git's parser also accepts."
+  #"(?m)^(?:<{7,}|={7,}|>{7,})")
+
+(defn- line-matches-marker?
+  "True when `line` matches the conflict-marker pattern. Pulled out so
+   the file-streaming reducer below stays focused on the streaming
+   plumbing."
+  [line]
+  (boolean (re-find conflict-marker-re line)))
 
 (defn- file-has-conflict-markers?
-  "True when `path` contains git conflict markers. Returns false on
-   read failure (file gone, permission denied) — those failures are
-   the caller's problem (curator can only judge what it can read)."
+  "True when `path`'s contents contain a git conflict marker. Streams
+   the file line-by-line and short-circuits on the first match — the
+   first marker line answers the question, so we never load large
+   files into memory just to scan them. Returns false on any read
+   failure (file gone, permission denied, binary garbage) since the
+   curator can only judge what it can read."
   [path]
   (try
     (and (fs/regular-file? path)
-         (boolean (re-find conflict-marker-re (slurp (str path)))))
+         (with-open [r (io/reader (str path))]
+           (boolean (some line-matches-marker? (line-seq r)))))
     (catch Throwable _ false)))
 
-(defn- scan-conflicted-paths
-  "Walk `worktree-path` and return the set of relative paths whose file
-   contents contain conflict markers. The return is a set so callers
-   can compare iterations directly."
+(defn- conflicted-paths-via-git-grep
+  "Use `git grep` to find tracked files containing conflict markers.
+   When the worktree is a git tree (always true for v2 merge-resolution
+   runs — `merge-parent-branches!` creates the worktree via
+   `git worktree add`), this is much faster than walking the
+   filesystem: git grep skips ignored / untracked files, uses its own
+   indexed grep, and avoids slurping vendor / build dirs.
+
+   Returns the set of relative paths on success, or nil to signal
+   'fall back to the file walk' (worktree isn't a git tree, git grep
+   isn't available, or some other failure mode)."
   [worktree-path]
-  (when (fs/directory? worktree-path)
-    (let [root (fs/canonicalize worktree-path)]
-      (->> (fs/glob root "**" {:hidden false})
-           (filter file-has-conflict-markers?)
-           (map (fn rel-path [p] (str (fs/relativize root p))))
-           set))))
+  (let [r (try
+            (shell/sh "git" "-C" (str worktree-path)
+                      "grep" "--no-color" "-lE"
+                      "^(<<<<<<<|=======|>>>>>>>)")
+            (catch Throwable _ nil))]
+    (cond
+      ;; git grep convention: exit 0 = matches found; 1 = no matches.
+      ;; Both are valid 'this worktree is grep-scannable' outcomes.
+      (and r (zero? (:exit r)))
+      (->> (str/split-lines (str (:out r)))
+           (remove str/blank?)
+           set)
+
+      (and r (= 1 (:exit r)))
+      #{}
+
+      ;; Anything else — not a git tree, or git binary missing — bails
+      ;; to the caller's fallback path.
+      :else nil)))
+
+(defn- conflicted-paths-via-file-walk
+  "Fallback when git grep can't run (non-git worktree, etc.). Walks
+   the worktree and streams each file looking for markers. Slower
+   than git grep on large trees but correct."
+  [worktree-path]
+  (let [root (fs/canonicalize worktree-path)]
+    (->> (fs/glob root "**" {:hidden false})
+         (filter file-has-conflict-markers?)
+         (map (fn rel-path [p] (str (fs/relativize root p))))
+         set)))
+
+(defn- scan-conflicted-paths
+  "Return the set of relative paths in `worktree-path` whose contents
+   contain a git conflict marker. Returns nil when `worktree-path` is
+   not an existing directory — the caller (`:merge-resolution`
+   curator) treats nil as a fault and surfaces a typed error rather
+   than silently reporting 'no markers'."
+  [worktree-path]
+  (when (and (some? worktree-path) (fs/directory? worktree-path))
+    (or (conflicted-paths-via-git-grep worktree-path)
+        (conflicted-paths-via-file-walk worktree-path))))
+
+(defn- worktree-missing-error
+  "Terminal error when `worktree-path` is missing or not a directory.
+   Surfacing this prevents the silent-success failure mode where a
+   misconfigured input would report `:resolution/markers-cleared? true`
+   purely because the scanner couldn't find any files (it never
+   looked)."
+  [worktree-path]
+  (response/error
+   (messages/t :error/curator-worktree-missing
+               {:path (or worktree-path "<nil>")})
+   {:data {:code :curator/worktree-missing
+           :worktree-path worktree-path}}))
 
 (defn- markers-not-resolved-error
   "Terminal error when conflict markers remain after the agent's
@@ -475,8 +547,20 @@
 (defmethod curate :merge-resolution
   [{:keys [worktree-path prior-conflicted-paths]
     :as input}]
-  (let [current-paths (scan-conflicted-paths worktree-path)]
+  (let [current-paths (scan-conflicted-paths worktree-path)
+        ;; Coerce prior-conflicted-paths to a set so callers can feed
+        ;; the previous iteration's :conflicted-paths (a sorted vector
+        ;; in our error data) back in directly without a type
+        ;; mismatch hiding recurrence detection.
+        prior-set (when (some? prior-conflicted-paths)
+                    (set prior-conflicted-paths))]
     (cond
+      ;; Worktree missing or not a directory — fault, not "markers
+      ;; cleared". Surface explicitly so a misconfigured input doesn't
+      ;; silently report success.
+      (nil? current-paths)
+      (worktree-missing-error worktree-path)
+
       ;; No markers remain — the agent did its job for this iteration.
       ;; The verify gate above will then check whether tests pass; the
       ;; curator's role is just the marker check.
@@ -488,8 +572,7 @@
 
       ;; Markers still present AND the path set hasn't changed since
       ;; the prior iteration — agent is stuck. Terminate early.
-      (and (set? prior-conflicted-paths)
-           (= prior-conflicted-paths current-paths))
+      (and prior-set (= prior-set current-paths))
       (recurring-conflict-error worktree-path current-paths)
 
       ;; Markers still present but the path set has changed (some

--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -17,25 +17,37 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.agent.curator
-  "Curator agent — converts the implementer's environment writes into a
-   structured code artifact.
+  "Curator agent — extension surface for validating what an agent did
+   in the executor environment.
 
-   Background. In the environment-promotion model, the implementer writes
-   files directly into the executor environment (capsule or worktree); the
-   environment itself is the artifact. The curator reads the resulting
-   file diff and produces the structured metadata that downstream phases
-   (verify, review, release, PR-doc generation) expect: a :code/... map
-   with summary, file list, scope validation, and test-addition detection.
+   Background. The implement-style flow has the agent writing directly
+   into the executor environment (capsule or worktree); the environment
+   itself is the artifact. The curator runs after the agent, reads the
+   resulting state, and produces either a structured artifact (the
+   `:implement` path) or a verdict on the agent's iteration progress
+   (the `:merge-resolution` path added in v2 Stage 2 per spec §6.1.2).
 
-   Why a separate agent. The implementer's job is to code. Expecting it to
-   also emit a structured Clojure-map artifact via an MCP tool was brittle
-   (observed: implementer exhausts turn budget exploring the codebase and
-   never calls submit_code_artifact, producing no artifact at all). The
-   curator runs after the implementer, is specialized for structured
-   output, and fast-fails when no files were written — replacing silent
-   multi-retry failure with a single clear terminal error.
+   Multimethod surface. `curate` dispatches on `:curator/kind` so each
+   agent flow gets its own check pipeline without forcing a one-size-
+   fits-all shape on every call site:
 
-   Two-layer design:
+   - `:implement`         (default) — produces a CuratedArtifact;
+                          terminal `:curator/no-files-written` on empty
+                          diff.
+   - `:merge-resolution`  — validates the resolution agent's iteration:
+                          terminal `:curator/markers-not-resolved` when
+                          conflict markers remain in the worktree;
+                          `:curator/recurring-conflict` when the
+                          conflicted path set hasn't changed from the
+                          prior iteration (the agent is stuck and the
+                          loop should terminate before exhausting the
+                          full budget).
+
+   `curate-implement-output` is kept as a deprecated alias to
+   `(curate (assoc input :curator/kind :implement))` so existing
+   callers (`phase-software-factory.implement`) keep working unchanged.
+
+   Two-layer design (the `:implement` path):
    - Layer 1 is deterministic (git-diff parsing, path heuristics). This
      path alone produces a valid artifact and never fails when a diff
      exists.
@@ -53,6 +65,7 @@
    [ai.miniforge.repo-index.interface :as messages]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]
+   [babashka.fs :as fs]
    [clojure.edn :as edn]
    [clojure.string :as str]
    [malli.core :as m]))
@@ -353,25 +366,13 @@
            :env-id (:env-id input)
            :intent-scope (:intent-scope input)}}))
 
-(defn curate-implement-output
-  "Take an implementer's result + environment state → structured code artifact.
+(defmulti curate
+  "Curator entry point. Dispatches on `:curator/kind` so each agent
+   flow gets its own check pipeline. See namespace docstring for the
+   full method roster."
+  (fn [input] (or (:curator/kind input) :implement)))
 
-   Fast-fails when no files were written (replacing the silent-retry failure
-   mode where the implementer exhausts turns without producing output).
-
-   Input keys:
-     :implementer-result    (required)  the map returned by the implementer agent
-     :worktree-path         (required)  path to the environment's working dir
-     :pre-session-snapshot              enables accurate diff (recommended)
-     :env-id, :executor, :execute-fn    required for capsule-mode diff
-     :intent-scope                      vec of paths declared in :spec/intent :scope
-     :spec-description                  for LLM context
-     :llm-client                        optional pre-resolved LLM client
-     :logger                            optional
-
-   Output:
-     response/success with :output being a CuratedArtifact, or
-     response/error when the implementer wrote no files."
+(defmethod curate :implement
   [{:keys [intent-scope spec-description llm-client] :as input}]
   (let [files (collect-files input)]
     (if (empty? files)
@@ -394,6 +395,139 @@
         (response/success
          artifact
          {:metrics (artifact-metrics files deviations tests-added? source)})))))
+
+;------------------------------------------------------------------------------ Layer 4.5
+;; Merge-resolution method (v2 Stage 2 — spec §6.1.2)
+;;
+;; The resolution sub-workflow runs an implementer-style agent against a
+;; conflicted worktree. Between iterations, this curator method validates
+;; whether the agent's edits actually resolved the conflicts and whether
+;; it's making progress. The two terminal codes match the spec's curator
+;; contract:
+;;
+;; - :curator/markers-not-resolved — git's conflict markers
+;;   (`<<<<<<<`, `=======`, `>>>>>>>`) are still present in the worktree.
+;;   The agent terminated but didn't finish the job. The loop above
+;;   should re-prompt or, on persistent recurrence, terminate.
+;; - :curator/recurring-conflict — the conflicted path set this
+;;   iteration matches the prior iteration's path set, meaning the
+;;   agent isn't making progress. The loop above should terminate
+;;   instead of burning the rest of the budget.
+;;
+;; Both checks operate on pure-data inspections of the worktree state
+;; (file scan + path-set comparison). They don't need the agent's
+;; narration to fire.
+
+(def ^:private conflict-marker-re
+  "Match a line that begins (after optional whitespace) with one of
+   git's three conflict-marker tokens. The exact-7 form is git's
+   default; longer runs are also legal so we match `+`."
+  #"(?m)^[<>=]{7,}")
+
+(defn- file-has-conflict-markers?
+  "True when `path` contains git conflict markers. Returns false on
+   read failure (file gone, permission denied) — those failures are
+   the caller's problem (curator can only judge what it can read)."
+  [path]
+  (try
+    (and (fs/regular-file? path)
+         (boolean (re-find conflict-marker-re (slurp (str path)))))
+    (catch Throwable _ false)))
+
+(defn- scan-conflicted-paths
+  "Walk `worktree-path` and return the set of relative paths whose file
+   contents contain conflict markers. The return is a set so callers
+   can compare iterations directly."
+  [worktree-path]
+  (when (fs/directory? worktree-path)
+    (let [root (fs/canonicalize worktree-path)]
+      (->> (fs/glob root "**" {:hidden false})
+           (filter file-has-conflict-markers?)
+           (map (fn rel-path [p] (str (fs/relativize root p))))
+           set))))
+
+(defn- markers-not-resolved-error
+  "Terminal error when conflict markers remain after the agent's
+   iteration. `paths` is the set returned by `scan-conflicted-paths`."
+  [worktree-path paths]
+  (response/error
+   (messages/t :error/curator-markers-not-resolved
+               {:file-count (count paths)
+                :s (if (= 1 (count paths)) "" "s")})
+   {:data {:code :curator/markers-not-resolved
+           :worktree-path worktree-path
+           :conflicted-paths (vec (sort paths))}}))
+
+(defn- recurring-conflict-error
+  "Terminal error when the conflict path set is identical to the
+   prior iteration's. Signals that the agent has stopped making
+   progress; the resolution loop should terminate before exhausting
+   the full budget."
+  [worktree-path paths]
+  (response/error
+   (messages/t :error/curator-recurring-conflict
+               {:path-count (count paths)
+                :s (if (= 1 (count paths)) "" "s")})
+   {:data {:code :curator/recurring-conflict
+           :worktree-path worktree-path
+           :conflicted-paths (vec (sort paths))}}))
+
+(defmethod curate :merge-resolution
+  [{:keys [worktree-path prior-conflicted-paths]
+    :as input}]
+  (let [current-paths (scan-conflicted-paths worktree-path)]
+    (cond
+      ;; No markers remain — the agent did its job for this iteration.
+      ;; The verify gate above will then check whether tests pass; the
+      ;; curator's role is just the marker check.
+      (empty? current-paths)
+      (response/success
+       {:resolution/markers-cleared? true}
+       {:metrics {:conflicted-paths 0
+                  :curator-source :deterministic}})
+
+      ;; Markers still present AND the path set hasn't changed since
+      ;; the prior iteration — agent is stuck. Terminate early.
+      (and (set? prior-conflicted-paths)
+           (= prior-conflicted-paths current-paths))
+      (recurring-conflict-error worktree-path current-paths)
+
+      ;; Markers still present but the path set has changed (some
+      ;; resolved, others surfaced, or the conflict shape shifted).
+      ;; The loop should re-prompt; this is a "keep going" terminal
+      ;; for THIS iteration, not the whole loop.
+      :else
+      (markers-not-resolved-error worktree-path current-paths))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Backward-compatible entry point
+
+(defn curate-implement-output
+  "Take an implementer's result + environment state → structured code artifact.
+
+   Fast-fails when no files were written (replacing the silent-retry failure
+   mode where the implementer exhausts turns without producing output).
+
+   This is a thin wrapper around `(curate (assoc input :curator/kind :implement))`.
+   Existing callers (e.g. `phase-software-factory.implement`) keep working
+   unchanged; new callers should prefer `curate` directly so the dispatch
+   key is explicit.
+
+   Input keys:
+     :implementer-result    (required)  the map returned by the implementer agent
+     :worktree-path         (required)  path to the environment's working dir
+     :pre-session-snapshot              enables accurate diff (recommended)
+     :env-id, :executor, :execute-fn    required for capsule-mode diff
+     :intent-scope                      vec of paths declared in :spec/intent :scope
+     :spec-description                  for LLM context
+     :llm-client                        optional pre-resolved LLM client
+     :logger                            optional
+
+   Output:
+     response/success with :output being a CuratedArtifact, or
+     response/error when the implementer wrote no files."
+  [input]
+  (curate (assoc input :curator/kind :implement)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -112,6 +112,7 @@
 (def create-tester specialized/create-tester)
 (def create-reviewer specialized/create-reviewer)
 (def create-releaser specialized/create-releaser)
+(def curate specialized/curate)
 (def curate-implement-output specialized/curate-implement-output)
 (def CuratedArtifact specialized/CuratedArtifact)
 (def CuratedFileEntry specialized/CuratedFileEntry)

--- a/components/agent/src/ai/miniforge/agent/interface/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/specialized.clj
@@ -40,9 +40,13 @@
 (def create-reviewer reviewer/create-reviewer)
 (def create-releaser releaser/create-releaser)
 
-;; Curator is a pure function (not an Agent record) — it post-processes the
-;; implementer's environment writes into a structured code artifact. Exposed
-;; here so phases and interop code can reach it via the standard interface.
+;; Curator is a multimethod (not an Agent record) — it post-processes the
+;; environment state an agent left behind. Dispatches on `:curator/kind`:
+;; - `:implement`        (default) — produces a CuratedArtifact.
+;; - `:merge-resolution` (v2 §6.1.2) — validates the resolution agent's
+;;                       iteration; surfaces :curator/markers-not-resolved
+;;                       and :curator/recurring-conflict terminals.
+(def curate curator/curate)
 (def curate-implement-output curator/curate-implement-output)
 (def CuratedArtifact curator/CuratedArtifact)
 (def CuratedFileEntry curator/FileEntry)

--- a/components/agent/test/ai/miniforge/agent/curator_merge_resolution_test.clj
+++ b/components/agent/test/ai/miniforge/agent/curator_merge_resolution_test.clj
@@ -1,0 +1,162 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.curator-merge-resolution-test
+  "Tests for the curator's `:merge-resolution` method (v2 Stage 2).
+
+   The resolution sub-workflow's iteration loop calls `(curate (assoc
+   input :curator/kind :merge-resolution))` between iterations to
+   decide whether the agent's edits cleared the conflict markers and
+   whether progress is being made. These tests pin the three
+   outcomes — clean, markers-not-resolved, recurring-conflict —
+   against synthetic worktree state."
+  (:require
+   [ai.miniforge.agent.curator :as sut]
+   [ai.miniforge.response.interface :as response]
+   [babashka.fs :as fs]
+   [clojure.test :refer [deftest is testing use-fixtures]]))
+
+;------------------------------------------------------------------------------ Fixture: temp worktree
+
+(def ^:dynamic *worktree* nil)
+
+(defn temp-worktree-fixture [f]
+  (let [w (str (fs/create-temp-dir {:prefix "curator-resolution-test-"}))]
+    (try
+      (binding [*worktree* w] (f))
+      (finally (try (fs/delete-tree w) (catch Throwable _ nil))))))
+
+(use-fixtures :each temp-worktree-fixture)
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- write-file! [rel content]
+  (let [f (java.io.File. ^String *worktree* ^String rel)]
+    (.mkdirs (.getParentFile f))
+    (spit f content)))
+
+(def conflict-marker-content
+  "Synthetic file content with git's conflict markers. Uses the
+   default 7-character marker length git emits."
+  (str "before\n"
+       "<<<<<<< HEAD\n"
+       "ours\n"
+       "=======\n"
+       "theirs\n"
+       ">>>>>>> branch-b\n"
+       "after\n"))
+
+(def resolved-content
+  "Same logical file with markers gone (the agent picked a side)."
+  "before\nresolved\nafter\n")
+
+;------------------------------------------------------------------------------ Tests
+
+(deftest merge-resolution-success-when-no-markers-test
+  (testing "When the worktree has no files with conflict markers, the
+            curator returns response/success. The verify gate above
+            then runs project tests; the curator's role is just the
+            marker check."
+    (write-file! "src/a.clj" "(ns a)\n;; clean code\n")
+    (write-file! "src/b.clj" resolved-content)
+    (let [result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path *worktree*})]
+      (is (response/success? result))
+      (is (true? (get-in result [:output :resolution/markers-cleared?]))
+          "the success envelope flags that markers were cleared so the
+           caller can distinguish 'no work needed' from 'work happened'"))))
+
+(deftest merge-resolution-markers-not-resolved-test
+  (testing "Conflict markers in the tree on first iteration produce a
+            terminal :curator/markers-not-resolved error with the
+            offending paths in :data."
+    (write-file! "src/conflict.clj" conflict-marker-content)
+    (write-file! "src/clean.clj" "(ns clean)\n")
+    (let [result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path *worktree*})]
+      (is (response/error? result))
+      (is (= :curator/markers-not-resolved
+             (get-in result [:error :data :code])))
+      (is (= ["src/conflict.clj"]
+             (get-in result [:error :data :conflicted-paths]))
+          "only the file that actually had markers is listed"))))
+
+(deftest merge-resolution-recurring-conflict-when-paths-unchanged-test
+  (testing "When the conflicted-path set this iteration matches the
+            prior iteration's, the curator returns the
+            :curator/recurring-conflict terminal — the loop should
+            terminate before exhausting the rest of the budget. This
+            is the 'agent is stuck' early-out per spec §6.1.2."
+    (write-file! "src/x.clj" conflict-marker-content)
+    (write-file! "src/y.clj" conflict-marker-content)
+    (let [result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path *worktree*
+                              :prior-conflicted-paths #{"src/x.clj" "src/y.clj"}})]
+      (is (response/error? result))
+      (is (= :curator/recurring-conflict
+             (get-in result [:error :data :code]))
+          "same path set ⇒ recurring, not just markers-not-resolved"))))
+
+(deftest merge-resolution-progress-yields-markers-not-resolved-test
+  (testing "When markers remain but the path set has shifted (some
+            resolved, others surfaced), it's NOT recurring — the
+            terminal is :curator/markers-not-resolved so the loop
+            re-prompts. The recurring-conflict terminal only fires
+            when the agent makes literally zero progress."
+    (write-file! "src/x.clj" conflict-marker-content)
+    (write-file! "src/z.clj" conflict-marker-content)
+    (let [result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path *worktree*
+                              :prior-conflicted-paths #{"src/x.clj" "src/y.clj"}})]
+      (is (response/error? result))
+      (is (= :curator/markers-not-resolved
+             (get-in result [:error :data :code]))
+          "different path set ⇒ make-progress, not recurring"))))
+
+(deftest merge-resolution-no-prior-paths-acts-like-first-iteration-test
+  (testing "When `prior-conflicted-paths` is nil/missing, recurrence
+            can't be detected — only :curator/markers-not-resolved
+            fires. This is the first-iteration call shape; the loop
+            above sets prior-conflicted-paths from this iteration's
+            result for the next call."
+    (write-file! "src/conflict.clj" conflict-marker-content)
+    (let [result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path *worktree*})]
+      (is (response/error? result))
+      (is (= :curator/markers-not-resolved
+             (get-in result [:error :data :code]))))))
+
+(deftest merge-resolution-default-dispatch-still-implements-test
+  (testing "Backward compatibility: an input WITHOUT `:curator/kind`
+            still dispatches to `:implement` (so the legacy
+            `curate-implement-output` wrapper and any direct callers
+            of `curate` that haven't been updated keep working)."
+    (let [result (sut/curate {:implementer-result {:output {:code/files []}}
+                              :worktree-path *worktree*})]
+      (is (response/error? result))
+      (is (= :curator/no-files-written
+             (get-in result [:error :data :code]))
+          "default dispatch hits :implement and produces the implement-flow's
+           empty-diff terminal — proving the multimethod refactor didn't
+           change the legacy contract"))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.agent.curator-merge-resolution-test)
+
+  :leave-this-here)

--- a/components/agent/test/ai/miniforge/agent/curator_merge_resolution_test.clj
+++ b/components/agent/test/ai/miniforge/agent/curator_merge_resolution_test.clj
@@ -155,6 +155,63 @@
            empty-diff terminal — proving the multimethod refactor didn't
            change the legacy contract"))))
 
+(deftest merge-resolution-worktree-missing-test
+  (testing "Missing or invalid `worktree-path` surfaces a typed terminal
+            error, NOT a silent success. Pre-fix the curator returned
+            `:resolution/markers-cleared? true` whenever scanning
+            yielded no paths — including the case where it never
+            scanned anything because the path didn't exist. Now an
+            absent worktree is a typed `:curator/worktree-missing`
+            fault."
+    (let [result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path "/var/folders/this-path-does-not-exist-mpb"})]
+      (is (response/error? result))
+      (is (= :curator/worktree-missing
+             (get-in result [:error :data :code])))))
+
+  (testing "nil :worktree-path likewise surfaces the typed fault"
+    (let [result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path nil})]
+      (is (response/error? result))
+      (is (= :curator/worktree-missing
+             (get-in result [:error :data :code]))))))
+
+(deftest merge-resolution-prior-paths-coerced-from-vector-test
+  (testing "Recurrence detection accepts the curator's own
+            `:conflicted-paths` shape (sorted vector) as input — pre-fix
+            the gate was `(set? prior-conflicted-paths)` so feeding back
+            the prior iteration's `:conflicted-paths` directly never
+            triggered recurrence. Now any collection coerces to a set."
+    (write-file! "src/x.clj" conflict-marker-content)
+    (write-file! "src/y.clj" conflict-marker-content)
+    (let [;; Mimic what a loop driver would feed back: the prior
+          ;; iteration's :conflicted-paths from :error :data — a
+          ;; sorted vector of strings, not a set.
+          prior-as-vector ["src/x.clj" "src/y.clj"]
+          result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path *worktree*
+                              :prior-conflicted-paths prior-as-vector})]
+      (is (response/error? result))
+      (is (= :curator/recurring-conflict
+             (get-in result [:error :data :code]))
+          "vector input is coerced to a set internally; recurrence fires
+           the same way as if the caller had passed a set"))))
+
+(deftest conflict-marker-regex-only-matches-real-tokens-test
+  (testing "The regex `^(<{7,}|={7,}|>{7,})` rejects mixed/short runs.
+            Pre-fix `^[<>=]{7,}` would have matched a stray
+            '<>=<>=<>=' line, false-positiving on docs / fixtures /
+            non-conflict diffs. Lock the new behavior."
+    ;; Mixed-character run: not a conflict marker.
+    (write-file! "docs/decoration.md" "# Section\n<>=<>=<>=\nbody\n")
+    ;; Short run: not a conflict marker (git uses 7+).
+    (write-file! "src/short.clj" "<<<<<<\nfoo\n=====\nbar\n>>>>>>\n")
+    (let [result (sut/curate {:curator/kind :merge-resolution
+                              :worktree-path *worktree*})]
+      (is (response/success? result)
+          "neither file should be flagged — only real conflict markers
+           (7+ same-character runs at column 0) count"))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (clojure.test/run-tests 'ai.miniforge.agent.curator-merge-resolution-test)

--- a/components/repo-index/resources/config/repo-index/messages/en-US.edn
+++ b/components/repo-index/resources/config/repo-index/messages/en-US.edn
@@ -72,6 +72,12 @@
   :error/curator-no-files-written
   "Curator: implementer wrote no files to the environment"
 
+  :error/curator-markers-not-resolved
+  "Curator: conflict markers still present in {file-count} file{s}"
+
+  :error/curator-recurring-conflict
+  "Curator: conflict set unchanged from prior iteration ({path-count} path{s}); agent making no progress"
+
   ;; Curator summaries (deterministic fallback)
   :curator/deterministic-summary
   "{total} file{s} changed ({created} created, {modified} modified, {deleted} deleted)"}}

--- a/components/repo-index/resources/config/repo-index/messages/en-US.edn
+++ b/components/repo-index/resources/config/repo-index/messages/en-US.edn
@@ -78,6 +78,9 @@
   :error/curator-recurring-conflict
   "Curator: conflict set unchanged from prior iteration ({path-count} path{s}); agent making no progress"
 
+  :error/curator-worktree-missing
+  "Curator: worktree-path {path} is missing or not a directory"
+
   ;; Curator summaries (deterministic fallback)
   :curator/deterministic-summary
   "{total} file{s} changed ({created} created, {modified} modified, {deleted} deleted)"}}


### PR DESCRIPTION
## Summary

Stage 2A of v2 multi-parent merge per [I-DAG-MULTI-PARENT-MERGE.md §6.1.2](https://github.com/miniforge-ai/miniforge/blob/main/specs/informative/I-DAG-MULTI-PARENT-MERGE.md). Refactors `agent/curator` from a single function into a multimethod and adds the `:merge-resolution` method that the resolution sub-workflow (Stage 2B) will call between iterations.

After this PR, the curator surface supports the merge-resolution check pipeline; **Stage 2B will land the sub-workflow itself and wire it to `merge-parent-branches!`'s conflict path.**

## What's in this PR

**`curate` multimethod** dispatched on `:curator/kind`:

| Kind | Behavior |
| ---- | -------- |
| `:implement` (default) | Existing logic — produces a CuratedArtifact, terminal `:curator/no-files-written` on empty diff |
| `:merge-resolution` (new) | Validates an iteration of the resolution sub-workflow per spec §6.1.2 |

**Merge-resolution method** runs two pure-data checks against the worktree:

- **`:curator/markers-not-resolved`** — git's conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) are still in the worktree. The agent terminated but didn't finish the job.
- **`:curator/recurring-conflict`** — the conflicted path set this iteration matches the prior iteration's. Agent isn't making progress; the resolution loop should terminate before exhausting the rest of the budget. Per spec §6.1.2 this is the "agent stuck" early-out.

Both checks operate on file-scan + path-set comparison; no agent narration needed.

**Backward compatibility**: `curate-implement-output` is now a thin wrapper around `(curate (assoc input :curator/kind :implement))`. Existing callers (`phase-software-factory.implement`) keep working unchanged. The interface re-exports both `curate` (new entry point) and `curate-implement-output` (legacy alias).

## Test plan

- [x] 6 new tests / 13 assertions in `curator_merge_resolution_test.clj` covering:
  - Clean worktree → success (`:resolution/markers-cleared?` true)
  - Markers present (first iteration) → `:curator/markers-not-resolved`
  - Same path set as prior → `:curator/recurring-conflict`
  - Different path set as prior → `:curator/markers-not-resolved` (not recurring; agent IS making progress)
  - Nil prior-paths → first-iteration behavior
  - Default dispatch (no `:curator/kind`) → `:implement` legacy contract preserved
- [x] Full `bb test` suite: 5011 / 22902 / 0 / 0
- [ ] Stage 2B will exercise the curator method end-to-end against a real conflicted git repo with the resolution sub-workflow loop

## Spec traceability

| Spec section | Implemented in this PR |
| ------------ | ---------------------- |
| §6.1.2 `:curator/markers-not-resolved` check | `markers-not-resolved-error` factory + scan |
| §6.1.2 `:curator/recurring-conflict` check | `recurring-conflict-error` factory + path-set comparison |
| §10.12 curator extension via existing polymorphism | Multimethod refactor; `:implement` keeps legacy contract |

## What's NOT in this PR (deferred to Stage 2B)

- The resolution sub-workflow definition that calls `(curate (assoc input :curator/kind :merge-resolution))` between iterations
- Wiring `merge-parent-branches!`'s conflict path to spawn the resolution sub-workflow
- Policy override hook for the resolution agent prompt (spec §6.1.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)