### PR TITLE
fix(agent): auto-approve Edit + MultiEdit alongside Write

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -330,16 +330,24 @@
    call got permission-denied. Iter-15 follow-on — `Write` wasn't in
    the allowlist at all, so the planner's `.miniforge/plan.edn`
    Write was silently denied (model then narrated 'let me try Edit'
-   and stalled). Both fix back to keeping the structured form honest
-   and adapters translating at the CLI boundary."
+   and stalled). 2026-05-04 follow-on — `Edit` / `MultiEdit` were
+   never added either; the implementer in the
+   event-log-tool-visibility dogfood spent five repair iters
+   producing patch text the CLI refused to apply, then a sixth
+   iter discovered Write worked while Edit did not. Both fixes back
+   to keeping the structured form honest and adapters translating
+   at the CLI boundary."
   [{:mcp/server :context :mcp/tool :context_read}
    {:mcp/server :context :mcp/tool :context_grep}
    {:mcp/server :context :mcp/tool :context_glob}
-   ;; Native tool: container-promotion submission path. Planner
-   ;; writes .miniforge/plan.edn; implementer writes source/tests;
-   ;; releaser writes PR-body drafts. Roles that shouldn't Write
-   ;; filter via :disallowed-tools separately.
-   :Write])
+   ;; Native write tools: implementer needs all three patch shapes.
+   ;; `Write` for full-file rewrites (planner's plan.edn, implementer
+   ;; new files, releaser PR drafts). `Edit` for single-region patches.
+   ;; `MultiEdit` for batched edits within one file. Roles that shouldn't
+   ;; modify files filter via :disallowed-tools separately.
+   :Write
+   :Edit
+   :MultiEdit])
 
 (defn write-mcp-config!
   "Write session config files for all supported CLI backends.

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -334,8 +334,8 @@
    never added either; the implementer in the
    event-log-tool-visibility dogfood spent five repair iters
    producing patch text the CLI refused to apply, then a sixth
-   iter discovered Write worked while Edit did not. Both fixes back
-   to keeping the structured form honest and adapters translating
+   iter discovered Write worked while Edit did not. Both issues trace
+   back to keeping the structured form honest and adapters translating
    at the CLI boundary."
   [{:mcp/server :context :mcp/tool :context_read}
    {:mcp/server :context :mcp/tool :context_grep}

--- a/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
@@ -295,6 +295,16 @@
     (is (some #{:Write} session/mcp-tools)
         "Write must stay auto-approved for container-promotion submissions"))
 
+  (testing "native Edit and MultiEdit are auto-approved — implementer patch path"
+    ;; 2026-05-04 dogfood — Edit / MultiEdit were never in --allowedTools.
+    ;; Implementer spent five repair iterations producing patch text the
+    ;; CLI refused to apply, then a sixth iter independently discovered
+    ;; Write worked while Edit did not. Both must be auto-approved.
+    (is (some #{:Edit} session/mcp-tools)
+        "Edit must be auto-approved for surgical patches")
+    (is (some #{:MultiEdit} session/mcp-tools)
+        "MultiEdit must be auto-approved for batched in-file patches"))
+
   (testing "never contains backend-specific wire strings (regression guard)"
     ;; Claude's `mcp__<server>__<tool>` form belongs in the Claude
     ;; adapter, not here. Native tools go through (name kw).


### PR DESCRIPTION
## Summary

- Adds `:Edit` and `:MultiEdit` to `mcp-tools` in `components/agent/src/ai/miniforge/agent/artifact_session.clj` so they reach Claude CLI's `--allowedTools` flag the same way `:Write` already does.
- Extends the regression test in `artifact_session_extended_test.clj` to assert both keywords stay in the list.

## Why

The 2026-05-04 `event-log-tool-visibility` codex dogfood (post PR #771) ground through five repair iterations all rejected as "implementation absent." Reviewer transcripts confirmed nothing landed on disk; implementer transcripts confirmed why:

> Edit is still blocked, but Write works. Writing core.clj with new constructors inserted

Same failure mode the iter-15 doc comment in `mcp-tools` already references for Write — Edit/MultiEdit needed the same fix. Without them in `--allowedTools`, the Claude CLI's prompt-based approval flow blocks every Edit call non-interactively, agents narrate "let me try Edit" and stall, and the curator's file-artifact-fallback misclassifies the empty result as success.

The supervisor hook (`agent/tool-supervisor`) already allows Edit/Write/NotebookEdit at the policy layer; the gap was strictly at the CLI's own allow-list construction.

## Test plan

- [x] `bb test` — 4992 tests, 0 failures, 0 errors
- [ ] Re-run `event-log-tool-visibility` dogfood — expected: implementer's Edit calls land, no more "implementation absent" rejections from this cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)