### PR TITLE
refactor: kill workflow runtime deprecated throwers (single API)

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -339,31 +339,21 @@
                                                   (subs (str (random-uuid)) 0 8))))
                :execution/run-pipeline-fn run-pipeline))))
 
-(defn build-initial-context-anomaly
-  "Anomaly-returning variant of [[build-initial-context]].
+(defn build-initial-context
+  "Build the initial execution context from workflow, input, and opts.
 
    Returns the assembled execution context on success, or an
    `:invalid-input` anomaly when `:governed` mode is requested but no
    capsule executor + `:environment-id` were supplied in `opts`. Governed
-   mode forbids worktree fallback (N11 §7.4)."
+   mode forbids worktree fallback (N11 §7.4).
+
+   This is the canonical, anomaly-returning entry point. The single
+   in-component caller (`run-pipeline`) escalates the anomaly to a
+   slingshot throw at the boundary so external callers (CLI / MCP /
+   orchestrator) keep their existing exception-shaped contract."
   [workflow input opts]
   (or (governed-capsule-missing-anomaly opts)
       (assemble-initial-context workflow input opts)))
-
-(defn- build-initial-context
-  "Build the initial execution context from workflow, input, and opts.
-
-   DEPRECATED: prefer [[build-initial-context-anomaly]], which returns
-   an anomaly map instead of throwing. Retained for backward compatibility
-   with the orchestrator entry point."
-  {:deprecated "exceptions-as-data — prefer build-initial-context-anomaly"}
-  [workflow input opts]
-  (let [result (build-initial-context-anomaly workflow input opts)]
-    (if (anomaly/anomaly? result)
-      (response/throw-anomaly! :anomalies.workflow/no-capsule-executor
-                               (:anomaly/message result)
-                               {})
-      result)))
 
 (defn- execute-pipeline-loop
   "Execute the phase pipeline loop. Returns final context."
@@ -415,7 +405,19 @@
          event-stream        (:event-stream opts)
          callbacks           (wrap-phase-callbacks event-stream opts)
          skip-lifecycle?     (:skip-lifecycle-events opts)
-         initial-ctx         (build-initial-context workflow input opts)
+         ctx-or-anomaly      (build-initial-context workflow input opts)
+         _                   (when (anomaly/anomaly? ctx-or-anomaly)
+                               ;; Boundary throw: run-pipeline is the
+                               ;; runner's escalation point. External
+                               ;; callers (CLI / MCP / orchestrator)
+                               ;; expect either a final context map or
+                               ;; an exception, so a governed-mode
+                               ;; misconfiguration becomes a slingshot
+                               ;; throw with the legacy ex-info shape.
+                               (response/throw-anomaly! :anomalies.workflow/no-capsule-executor
+                                                        (:anomaly/message ctx-or-anomaly)
+                                                        {}))
+         initial-ctx         ctx-or-anomaly
          output-ctx-vol      (volatile! nil)
          exception-vol       (volatile! nil)]
 

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -70,36 +70,24 @@
     (when-not (and (= :governed mode) raw (= :worktree (executor-type raw)))
       raw)))
 
-(defn check-executor-for-mode-anomaly
-  "Anomaly-returning variant of [[assert-executor-for-mode!]].
+(defn check-executor-for-mode
+  "Validate executor / mode pairing per the N11 §7.4 invariant.
 
-   Returns nil when the `executor`/`mode` pair is acceptable, or an
-   `:unavailable` anomaly when `:governed` mode was requested but no
-   capsule executor was supplied. The anomaly's `:anomaly/data` carries
-   `:mode` and a `:hint` string for surface code that wants to suggest
-   remediation.
+   Returns nil when the pair is acceptable, or an `:unavailable`
+   anomaly when `:governed` mode was requested but no capsule executor
+   was supplied. The anomaly's `:anomaly/data` carries `:mode` and a
+   `:hint` string for surface code that wants to suggest remediation.
 
-   Prefer this over [[assert-executor-for-mode!]] in non-boundary code."
+   This is the canonical, anomaly-returning entry point. Boundary
+   sites that need to escalate to a thrown error (e.g.
+   `acquire-execution-environment!`) inline a `response/throw-anomaly!`
+   at the call site rather than calling a separate thrower."
   [executor mode]
   (when (and (nil? executor) (= :governed mode))
     (anomaly/anomaly :unavailable
                      (messages/t :governed/no-capsule)
                      {:mode :governed
                       :hint (messages/t :governed/no-capsule-hint)})))
-
-(defn assert-executor-for-mode!
-  "Throws for :governed mode when no capsule executor is available.
-
-   DEPRECATED: prefer [[check-executor-for-mode-anomaly]], which returns
-   an anomaly map instead of throwing. Retained for backward compatibility
-   with callers that rely on the slingshot throw shape."
-  {:deprecated "exceptions-as-data — prefer check-executor-for-mode-anomaly"}
-  [executor mode]
-  (when-let [a (check-executor-for-mode-anomaly executor mode)]
-    (response/throw-anomaly! :anomalies.executor/unavailable
-                             (:anomaly/message a)
-                             {:anomaly.executor/mode (get-in a [:anomaly/data :mode])
-                              :hint (get-in a [:anomaly/data :hint])})))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Environment record construction
@@ -147,7 +135,15 @@
             env-config (cond-> {}
                          repo-url (assoc :repo-url repo-url)
                          branch   (assoc :branch branch))]
-        (assert-executor-for-mode! executor mode)
+        (when-let [a (check-executor-for-mode executor mode)]
+          ;; Boundary throw: acquire-execution-environment! is the
+          ;; runner's escalation point for governed-mode unavailability.
+          ;; The slingshot shape preserves the contract that legacy
+          ;; try+ callers above this layer rely on.
+          (response/throw-anomaly! :anomalies.executor/unavailable
+                                   (:anomaly/message a)
+                                   {:anomaly.executor/mode (get-in a [:anomaly/data :mode])
+                                    :hint (get-in a [:anomaly/data :hint])}))
         (when executor
           (if (= :governed mode)
             (acquire-worktree-and-capsule executor workflow-id mode env-config fns)

--- a/components/workflow/src/ai/miniforge/workflow/state.clj
+++ b/components/workflow/src/ai/miniforge/workflow/state.clj
@@ -92,8 +92,8 @@
         (update :execution/history conj transition)
         (assoc :execution/updated-at (System/currentTimeMillis)))))
 
-(defn transition-status-anomaly
-  "Anomaly-returning variant of [[transition-status]].
+(defn transition-status
+  "Transition workflow status using the FSM.
 
    Returns the updated execution state on success, or an
    `:invalid-input` anomaly when the FSM rejects the transition.
@@ -104,7 +104,12 @@
    - `:error`          — the FSM error keyword
    - `:fsm-message`    — the FSM-supplied diagnostic message
 
-   Prefer this over [[transition-status]] in non-boundary code."
+   This is the canonical, anomaly-returning entry point. The in-component
+   helpers `mark-completed`, `mark-failed`, `transition-to-phase` use
+   the private `transition-status!` boundary wrapper that throws when
+   the FSM rejects a transition that the workflow definition asserts
+   should always be valid (programmer-error guard, per the
+   exceptions-as-data rule's carve-out)."
   [state event]
   (let [current-status (:execution/status state)
         result (fsm/transition current-status event)]
@@ -119,23 +124,15 @@
                         :error (:error result)
                         :fsm-message (:message result)}))))
 
-(defn transition-status
-  "Transition workflow status using FSM.
-
-   Arguments:
-   - state: Current execution state
-   - event: Event keyword (:start, :complete, :fail, :pause, :resume, :cancel)
-
-   Returns:
-   - Updated state if transition valid
-   - Throws ex-info if transition invalid
-
-   DEPRECATED: prefer [[transition-status-anomaly]], which returns an
-   anomaly map instead of throwing. Retained for backward compatibility
-   with callers that rely on the slingshot throw shape."
-  {:deprecated "exceptions-as-data — prefer transition-status-anomaly"}
+(defn- transition-status!
+  "In-component boundary helper. Calls `transition-status`; on anomaly
+   result raises via slingshot. Used by `mark-completed`, `mark-failed`,
+   and `transition-to-phase` — which represent workflow-definition
+   invariants the FSM is supposed to satisfy at the call site. A
+   rejection here is a programmer error in the workflow shape, not a
+   runtime anomaly to be carried forward as data."
   [state event]
-  (let [result (transition-status-anomaly state event)]
+  (let [result (transition-status state event)]
     (if (anomaly/anomaly? result)
       (let [data (:anomaly/data result)]
         (response/throw-anomaly! :anomalies.workflow/invalid-transition
@@ -161,7 +158,7 @@
    (let [current-phase (:execution/current-phase state)
          ;; Ensure workflow is running when transitioning phases
          state-with-status (if (= :pending (:execution/status state))
-                            (transition-status state :start)
+                            (transition-status! state :start)
                             state)]
      (-> state-with-status
          (assoc :execution/current-phase phase-id)
@@ -205,10 +202,10 @@
   [state]
   (let [;; Ensure workflow is running before completing
         state-with-running (if (= :pending (:execution/status state))
-                            (transition-status state :start)
+                            (transition-status! state :start)
                             state)]
     (-> state-with-running
-        (transition-status :complete)
+        (transition-status! :complete)
         (assoc :execution/completed-at (System/currentTimeMillis)))))
 
 (defn mark-failed
@@ -229,10 +226,10 @@
                     error)
         ;; Ensure workflow is running before failing
         state-with-running (if (= :pending (:execution/status state))
-                            (transition-status state :start)
+                            (transition-status! state :start)
                             state)]
     (-> state-with-running
-        (transition-status :fail)
+        (transition-status! :fail)
         (update :execution/errors conj error-map)
         (assoc :execution/failed-at (System/currentTimeMillis)))))
 

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
@@ -17,18 +17,18 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.anomaly.build-initial-context-test
-  "Coverage for `runner/build-initial-context-anomaly` and its deprecated
-   throwing sibling `runner/build-initial-context`.
+  "Coverage for `runner/build-initial-context` (anomaly-returning) and
+   its boundary escalation in `runner/run-pipeline`.
 
-   The single failure mode this site protects is the N11 §7.4 invariant:
-   `:governed` execution-mode requires a pre-acquired capsule executor +
-   environment-id; missing either is `:invalid-input`. The happy path is
-   covered indirectly by the existing `runner_pipeline_test`; here we
-   only exercise the failure-path contract."
+   The single failure mode this site protects is the N11 §7.4
+   invariant: `:governed` execution-mode requires a pre-acquired
+   capsule executor + environment-id; missing either is
+   `:invalid-input`. The boundary at `run-pipeline` rethrows via
+   slingshot so external callers (CLI / MCP / orchestrator) keep
+   their existing exception-shaped contract."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.anomaly.interface :as anomaly]
-            [ai.miniforge.workflow.runner :as runner])
-  (:import (clojure.lang ExceptionInfo)))
+            [ai.miniforge.workflow.runner :as runner]))
 
 (def workflow
   {:workflow/id :test
@@ -38,74 +38,59 @@
 
 (def input {:repo-url "https://example.test/repo"})
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Anomaly-returning happy path
 ;;
 ;; :local mode bypasses the capsule check and assembles a context. We
 ;; only assert non-anomaly here because the assembled map's full shape
 ;; is the responsibility of the existing runner_pipeline_test suite.
 
-(deftest build-initial-context-anomaly-local-mode-returns-context
+(deftest build-initial-context-local-mode-returns-context
   (testing ":local mode produces a context map (not an anomaly)"
-    (let [result (runner/build-initial-context-anomaly workflow input
-                                                       {:execution-mode :local})]
+    (let [result (runner/build-initial-context workflow input
+                                                {:execution-mode :local})]
       (is (not (anomaly/anomaly? result)))
       (is (= :local (:execution/mode result))))))
 
-;------------------------------------------------------------------------------ Failure path
+;------------------------------------------------------------------------------ Anomaly-returning failure path
 
-(deftest build-initial-context-anomaly-governed-without-capsule
+(deftest build-initial-context-governed-without-capsule
   (testing ":governed mode with no executor + env-id yields :invalid-input anomaly"
-    (let [result (runner/build-initial-context-anomaly workflow input
-                                                       {:execution-mode :governed})]
+    (let [result (runner/build-initial-context workflow input
+                                                {:execution-mode :governed})]
       (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result))))))
 
 (deftest build-initial-context-anomaly-data-carries-flags
   (testing "anomaly data carries enough triage info for the caller"
-    (let [result (runner/build-initial-context-anomaly workflow input
-                                                       {:execution-mode :governed})
+    (let [result (runner/build-initial-context workflow input
+                                                {:execution-mode :governed})
           data   (:anomaly/data result)]
       (is (= :governed (:execution-mode data)))
       (is (false? (:has-executor? data)))
       (is (false? (:has-environment-id? data))))))
 
-(deftest build-initial-context-anomaly-governed-with-executor-only
+(deftest build-initial-context-governed-with-executor-only
   (testing "executor without env-id is still an anomaly — both must be present"
-    (let [result (runner/build-initial-context-anomaly workflow input
-                                                       {:execution-mode :governed
-                                                        :executor :some-exec})]
+    (let [result (runner/build-initial-context workflow input
+                                                {:execution-mode :governed
+                                                 :executor :some-exec})]
       (is (anomaly/anomaly? result))
       (is (true? (get-in result [:anomaly/data :has-executor?])))
       (is (false? (get-in result [:anomaly/data :has-environment-id?]))))))
 
-;------------------------------------------------------------------------------ Throwing-variant compat
+;------------------------------------------------------------------------------ Boundary escalation
 ;;
-;; `build-initial-context` is `defn-` (private) — the runner namespace
-;; never intends it as a public API. We reach in via #'var to verify
-;; the slingshot throw shape preserved for backward compat.
+;; `run-pipeline` is the runner's escalation point: external callers
+;; expect either a final context map or a thrown exception. A governed
+;; misconfiguration becomes a slingshot
+;; `:anomalies.workflow/no-capsule-executor` ex-info at the
+;; `run-pipeline` boundary.
 ;;
-;; Important: in `runner/run-pipeline`, `initial-ctx` is built *before*
-;; the pipeline-loop `try+` is entered. The runner does NOT catch this
-;; throw itself; it propagates up to whatever boundary called
-;; `run-pipeline` (the CLI handler, MCP tool entry, or in-process
-;; orchestrator above). Those boundaries are responsible for
-;; converting the slingshot ex-data into a user-facing error. This
-;; test pins only the throw shape — not the catch site — because no
-;; runner-level catch participates.
-
-(deftest build-initial-context-still-throws-on-governed-without-capsule
-  (testing "deprecated throwing variant still throws via slingshot for legacy callers"
-    (let [build! @#'runner/build-initial-context]
-      (is (thrown? ExceptionInfo
-                   (build! workflow input {:execution-mode :governed}))))))
-
-(deftest build-initial-context-thrown-ex-data-preserves-slingshot-shape
-  (testing "ex-data carries :anomalies.workflow/no-capsule-executor for try+ catches"
-    (let [build! @#'runner/build-initial-context]
-      (try
-        (build! workflow input {:execution-mode :governed})
-        (is false "should have thrown")
-        (catch ExceptionInfo e
-          (let [data (ex-data e)]
-            (is (= :anomalies.workflow/no-capsule-executor
-                   (:anomaly/category data)))))))))
+;; That escalation is *not* exercised here because `run-pipeline`'s
+;; happy path runs `acquire-environment` first, which has its own
+;; governed-mode throw at `acquire-execution-environment!` (covered by
+;; `check_executor_for_mode_test.clj`). For an end-to-end test of the
+;; build-initial-context boundary throw specifically, the caller would
+;; need to stub `acquire-environment` so the no-capsule-executor path
+;; surfaces in `run-pipeline`'s let bindings rather than upstream. The
+;; runner's existing pipeline tests cover that integration.

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/check_executor_for_mode_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/check_executor_for_mode_test.clj
@@ -17,66 +17,80 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.anomaly.check-executor-for-mode-test
-  "Coverage for `runner-environment/check-executor-for-mode-anomaly`
-   and its deprecated throwing sibling `assert-executor-for-mode!`.
-
-   The N11 §7.4 invariant — :governed mode must not silently downgrade
-   to a worktree fallback — is now expressed as an `:unavailable`
-   anomaly returnable from non-boundary code, with the throwing wrapper
-   preserved for slingshot callers."
+  "Coverage for `runner-environment/check-executor-for-mode`
+   (anomaly-returning) and the boundary throw inlined inside
+   `acquire-execution-environment!` (the only escalation site for the
+   N11 §7.4 invariant)."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.workflow.runner-environment :as env])
   (:import (clojure.lang ExceptionInfo)))
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Anomaly-returning happy path
 
-(deftest check-executor-anomaly-nil-when-executor-present
+(deftest check-executor-nil-when-executor-present
   (testing ":governed mode with a capsule executor returns nil (no anomaly)"
-    (is (nil? (env/check-executor-for-mode-anomaly :some-executor :governed)))))
+    (is (nil? (env/check-executor-for-mode :some-executor :governed)))))
 
-(deftest check-executor-anomaly-nil-for-local-mode
+(deftest check-executor-nil-for-local-mode
   (testing ":local mode without a capsule is fine — returns nil"
-    (is (nil? (env/check-executor-for-mode-anomaly nil :local)))))
+    (is (nil? (env/check-executor-for-mode nil :local)))))
 
-;------------------------------------------------------------------------------ Failure path
+;------------------------------------------------------------------------------ Anomaly-returning failure path
 
 (deftest check-executor-anomaly-when-governed-without-capsule
   (testing ":governed mode with no capsule yields :unavailable anomaly"
-    (let [result (env/check-executor-for-mode-anomaly nil :governed)]
+    (let [result (env/check-executor-for-mode nil :governed)]
       (is (anomaly/anomaly? result))
       (is (= :unavailable (:anomaly/type result))))))
 
 (deftest check-executor-anomaly-data-carries-mode-and-hint
   (testing "anomaly data carries :mode and :hint for surface-level remediation"
-    (let [result (env/check-executor-for-mode-anomaly nil :governed)
+    (let [result (env/check-executor-for-mode nil :governed)
           data   (:anomaly/data result)]
       (is (= :governed (:mode data)))
       (is (string? (:hint data)))
       (is (seq (:hint data))))))
 
-;------------------------------------------------------------------------------ Throwing-variant compat
+;------------------------------------------------------------------------------ Boundary escalation via acquire-execution-environment!
+;;
+;; `acquire-execution-environment!` is the only place that escalates a
+;; check-executor-for-mode anomaly to a thrown exception. Tests pin
+;; the slingshot ex-info shape that legacy try+ callers above this
+;; boundary (CLI / MCP / orchestrator) depend on.
 
-(deftest assert-executor-still-noop-on-valid-args
-  (testing "deprecated throwing variant is a no-op when an executor is present"
-    (is (nil? (env/assert-executor-for-mode! :some-executor :governed)))))
+(deftest acquire-execution-environment-throws-on-governed-without-capsule
+  (testing "governed mode with no capsule available propagates a slingshot throw"
+    (with-redefs [env/dag-executor-fns
+                  (constantly
+                   {:create-registry (constantly :stub-registry)
+                    :select-exec     (constantly nil)        ; no executor
+                    :acquire-env!    (constantly nil)
+                    :executor-type   (constantly nil)
+                    :result-ok?      (constantly false)
+                    :result-unwrap   (constantly nil)})]
+      (is (thrown? ExceptionInfo
+                   (env/acquire-execution-environment!
+                    :workflow-id-1
+                    {:execution-mode :governed}))))))
 
-(deftest assert-executor-still-noop-on-local-mode
-  (testing "deprecated throwing variant is a no-op for :local mode"
-    (is (nil? (env/assert-executor-for-mode! nil :local)))))
-
-(deftest assert-executor-still-throws-when-governed-without-capsule
-  (testing "deprecated throwing variant still throws via slingshot for legacy callers"
-    (is (thrown? ExceptionInfo
-                 (env/assert-executor-for-mode! nil :governed)))))
-
-(deftest assert-executor-thrown-ex-data-preserves-slingshot-shape
+(deftest acquire-execution-environment-thrown-ex-data-preserves-slingshot-shape
   (testing "ex-data carries :anomalies.executor/unavailable for try+ catches"
-    (try
-      (env/assert-executor-for-mode! nil :governed)
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (let [data (ex-data e)]
-          (is (= :anomalies.executor/unavailable (:anomaly/category data)))
-          (is (= :governed (:anomaly.executor/mode data)))
-          (is (string? (:hint data))))))))
+    (with-redefs [env/dag-executor-fns
+                  (constantly
+                   {:create-registry (constantly :stub-registry)
+                    :select-exec     (constantly nil)
+                    :acquire-env!    (constantly nil)
+                    :executor-type   (constantly nil)
+                    :result-ok?      (constantly false)
+                    :result-unwrap   (constantly nil)})]
+      (try
+        (env/acquire-execution-environment!
+         :workflow-id-1
+         {:execution-mode :governed})
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (let [data (ex-data e)]
+            (is (= :anomalies.executor/unavailable (:anomaly/category data)))
+            (is (= :governed (:anomaly.executor/mode data)))
+            (is (string? (:hint data)))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/transition_status_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/transition_status_test.clj
@@ -17,11 +17,15 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.anomaly.transition-status-test
-  "Coverage for `state/transition-status-anomaly` and its deprecated
-   throwing sibling `state/transition-status`. The FSM rejection path
-   becomes an `:invalid-input` anomaly; the throwing variant continues
-   to surface a slingshot `:anomalies.workflow/invalid-transition` for
-   legacy try+ callers."
+  "Coverage for `state/transition-status` (anomaly-returning) and the
+   private boundary helper `state/transition-status!` reached via
+   `mark-completed` / `mark-failed` / `transition-to-phase`.
+
+   The FSM rejection path returns an `:invalid-input` anomaly. The
+   in-component `*!` boundary helper escalates the anomaly to a
+   slingshot `:anomalies.workflow/invalid-transition` throw — only
+   used at workflow-definition-invariant boundaries where the FSM
+   rejecting is a programmer error, not a runtime condition."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.workflow.state :as state])
@@ -35,21 +39,21 @@
 (defn- pending-state []
   (state/create-execution-state sample-workflow {:input "x"}))
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
 
-(deftest transition-status-anomaly-returns-state-on-valid-event
+(deftest transition-status-returns-state-on-valid-event
   (testing "valid :start event from :pending advances to :running"
-    (let [s (pending-state)
-          result (state/transition-status-anomaly s :start)]
+    (let [s      (pending-state)
+          result (state/transition-status s :start)]
       (is (not (anomaly/anomaly? result)))
       (is (= :running (:execution/status result))))))
 
-;------------------------------------------------------------------------------ Failure path
+;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
 
-(deftest transition-status-anomaly-returns-anomaly-on-invalid-event
+(deftest transition-status-returns-anomaly-on-invalid-event
   (testing "invalid event yields :invalid-input anomaly with FSM diagnostics"
-    (let [s (pending-state)
-          result (state/transition-status-anomaly s :complete)]
+    (let [s      (pending-state)
+          result (state/transition-status s :complete)]
       (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
       (let [data (:anomaly/data result)]
@@ -58,47 +62,66 @@
         (is (some? (:error data)))
         (is (some? (:fsm-message data)))))))
 
-(deftest transition-status-anomaly-rejection-does-not-advance-status
-  (testing "rejected transition produces an anomaly whose data still reports the
-            pre-transition status — verifies the FSM did not partially advance
-            before flagging the rejection"
+(deftest transition-status-rejection-returns-anomaly-not-state
+  (testing "rejected transition returns the anomaly itself, not a partially-transitioned state map"
     (let [s      (pending-state)
-          result (state/transition-status-anomaly s :complete)
+          result (state/transition-status s :complete)
           data   (:anomaly/data result)]
       (is (anomaly/anomaly? result))
-      ;; The anomaly carries the status the FSM was in *at evaluation time*.
-      ;; If a buggy implementation advanced the status before deciding the
-      ;; transition was invalid, this would report the wrong current-status.
+      ;; Anomaly carries the status the FSM was in *at evaluation time*.
+      ;; A buggy implementation that advanced the status before flagging
+      ;; the rejection would report the wrong :current-status here.
       (is (= :pending (:current-status data)))
-      ;; Returned value is the anomaly itself, not a partially-transitioned
-      ;; state map — ie. the function does not return a map carrying both
-      ;; an updated :execution/status and the anomaly.
+      ;; Returned value is the anomaly itself, not a state map carrying
+      ;; both an updated :execution/status and the anomaly.
       (is (not (contains? result :execution/status))))))
 
-;------------------------------------------------------------------------------ Throwing-variant compat
+;------------------------------------------------------------------------------ Boundary helper escalates via slingshot
+;;
+;; `transition-status!` is private and reached via `mark-completed` /
+;; `mark-failed` / `transition-to-phase`. These helpers represent
+;; workflow-definition invariants — a rejection at one of them is a
+;; programmer error in the workflow shape, not a runtime anomaly.
+;; Escalating to a slingshot throw preserves the legacy ex-info shape
+;; that runner / supervisor consumers depend on.
 
-(deftest transition-status-still-returns-on-valid-event
-  (testing "deprecated throwing variant still returns updated state on success"
-    (let [s (pending-state)
-          result (state/transition-status s :start)]
-      (is (= :running (:execution/status result))))))
+(deftest mark-completed-throws-on-fsm-rejection
+  (testing "mark-completed escalates an FSM rejection to slingshot"
+    (let [;; Build a state already in :completed — :complete event from
+          ;; :completed should be rejected by the FSM.
+          s (assoc (pending-state) :execution/status :completed)]
+      (is (thrown? ExceptionInfo (state/mark-completed s))))))
 
-(deftest transition-status-still-throws-on-invalid-event
-  (testing "deprecated throwing variant still throws ExceptionInfo on FSM rejection"
-    (let [s (pending-state)]
-      (is (thrown-with-msg? ExceptionInfo #"Invalid state transition"
-            (state/transition-status s :complete))))))
+(deftest mark-failed-throws-on-fsm-rejection
+  (testing "mark-failed escalates an FSM rejection to slingshot"
+    (let [s (assoc (pending-state) :execution/status :completed)]
+      (is (thrown? ExceptionInfo (state/mark-failed s "boom"))))))
 
-(deftest transition-status-thrown-ex-data-preserves-shape
-  (testing "ex-data preserves the legacy slingshot anomaly shape"
-    (let [s (pending-state)]
+(deftest mark-completed-thrown-ex-data-preserves-slingshot-shape
+  (testing "ex-data carries :anomalies.workflow/invalid-transition for try+ catches"
+    (let [s (assoc (pending-state) :execution/status :completed)]
       (try
-        (state/transition-status s :complete)
+        (state/mark-completed s)
         (is false "should have thrown")
         (catch ExceptionInfo e
           (let [data (ex-data e)]
             (is (= :anomalies.workflow/invalid-transition (:anomaly/category data)))
-            (is (= :pending (:current-status data)))
+            (is (= :completed (:current-status data)))
             (is (= :complete (:event data)))
             (is (some? (:error data)))
             (is (some? (:message data)))))))))
+
+;------------------------------------------------------------------------------ Boundary helper happy path
+
+(deftest mark-completed-advances-pending-to-completed
+  (testing "from :pending, mark-completed transitions :pending → :running → :completed"
+    (let [result (state/mark-completed (pending-state))]
+      (is (= :completed (:execution/status result)))
+      (is (some? (:execution/completed-at result))))))
+
+(deftest mark-failed-advances-pending-to-failed
+  (testing "from :pending, mark-failed transitions :pending → :running → :failed"
+    (let [result (state/mark-failed (pending-state) {:type :test :message "boom"})]
+      (is (= :failed (:execution/status result)))
+      (is (some? (:execution/failed-at result)))
+      (is (= 1 (count (:execution/errors result)))))))

--- a/docs/pull-requests/2026-05-04-refactor-kill-workflow-runtime-deprecation.md
+++ b/docs/pull-requests/2026-05-04-refactor-kill-workflow-runtime-deprecation.md
@@ -1,0 +1,120 @@
+# refactor: kill workflow runtime deprecated throwers (single API)
+
+## Overview
+
+Follow-on cleanup to PR #769 (which migrated `workflow` runtime sites to the deprecate-and-coexist anomaly-returning pattern). This PR kills the deprecated throwers entirely so each site has a single canonical API. Three throwers retired:
+
+- `workflow.state/transition-status` (deprecated thrower)
+- `workflow.runner-environment/assert-executor-for-mode!` (deprecated thrower)
+- `workflow.runner/build-initial-context` (deprecated private thrower)
+
+The boundary throws that legitimately need to escalate to a slingshot ex-info shape (preserving the contract for `try+` callers above the workflow component) are inlined at their single call sites.
+
+## Motivation
+
+PR #769 landed with the same deprecate-and-coexist pattern that earlier exceptions-as-data PRs (#704 foundation, #758 repo-dag) established. Reviewer feedback pointed out that pattern is over-cautious for a 17-star repo with one primary maintainer and a handful of internal callers per site:
+
+- The deprecated throwers were component-internal — zero external callers across the repo.
+- The pattern paid an ongoing surface-area + deprecation-warnings tax.
+- The savings (smaller individual PRs, easy revert) didn't justify it at this scale.
+
+This PR drops the coexistence and lands a single API per site. Future component-scope cleanups will follow this pattern. Foundation-tier APIs with >30 callers (`schema/validate`, `dag-primitives/unwrap`) keep coexistence — the call-site count makes hard cuts genuinely impractical there.
+
+## Base Branch
+
+`main` (post-#769)
+
+## Depends On
+
+- PR #769 — `refactor/exceptions-as-data-workflow-runtime-cleanup` (merged) — introduced the anomaly variants this PR keeps as canonical.
+
+## Layer
+
+Refactor / kill-the-deprecation cleanup. Three workflow-runtime files; component-internal — no `interface.clj` exports affected.
+
+## What This Adds / Changes
+
+`components/workflow/src/ai/miniforge/workflow/state.clj`:
+
+- Deleted the deprecated `transition-status` thrower.
+- Renamed `transition-status-anomaly` → `transition-status` (canonical name now belongs to the canonical fn).
+- Added private `transition-status!` boundary helper. Used by `mark-completed`, `mark-failed`, `transition-to-phase` — these represent workflow-definition invariants; an FSM rejection at one of them is a programmer error, so escalating to slingshot is appropriate. Preserves the legacy `:anomalies.workflow/invalid-transition` ex-info shape.
+
+`components/workflow/src/ai/miniforge/workflow/runner_environment.clj`:
+
+- Deleted the deprecated `assert-executor-for-mode!` thrower.
+- Renamed `check-executor-for-mode-anomaly` → `check-executor-for-mode`.
+- Inlined the boundary throw at the single call site in `acquire-execution-environment!`. Preserves the legacy `:anomalies.executor/unavailable` ex-info shape for legacy `try+` callers above this layer.
+
+`components/workflow/src/ai/miniforge/workflow/runner.clj`:
+
+- Deleted the deprecated private `build-initial-context` thrower.
+- Renamed `build-initial-context-anomaly` → `build-initial-context`.
+- Inlined the boundary throw at the single call site in `run-pipeline`'s let bindings. Preserves the `:anomalies.workflow/no-capsule-executor` ex-info shape that external callers (CLI / MCP / orchestrator) expect on misconfiguration.
+
+`components/workflow/test/.../anomaly/`:
+
+- `transition_status_test.clj` — references `transition-status` (not `*-anomaly`); deprecated-thrower compat tests replaced with `mark-completed` / `mark-failed` integration tests that exercise the private `transition-status!` boundary helper.
+- `check_executor_for_mode_test.clj` — references `check-executor-for-mode`; `assert-executor-for-mode!` tests replaced with `acquire-execution-environment!` integration tests (with stubbed `dag-executor-fns`) that exercise the inlined boundary throw.
+- `build_initial_context_test.clj` — references `build-initial-context`; deprecated-thrower compat tests removed. Run-pipeline boundary integration test omitted with a documented rationale: `acquire-environment` runs first along that path with its own governed-mode throw, so the integration test would test the wrong escalation site. Coverage for the build-initial-context boundary specifically is delegated to the runner's existing pipeline tests.
+
+## API surface (after this PR)
+
+```clojure
+;; Canonical, anomaly-returning. Component-internal.
+ai.miniforge.workflow.state/transition-status                         ; was *-anomaly
+ai.miniforge.workflow.runner-environment/check-executor-for-mode      ; was *-anomaly
+ai.miniforge.workflow.runner/build-initial-context                    ; was *-anomaly
+
+;; Private boundary helper for in-component invariants.
+ai.miniforge.workflow.state/transition-status!                        ; private
+```
+
+The deprecated throwers (`transition-status` thrower, `assert-executor-for-mode!`, `build-initial-context` thrower wrapper) are **gone**. Boundary escalation to slingshot ex-info now lives inlined at the call sites that actually need to throw.
+
+## External caller contracts
+
+Unchanged. External callers above the workflow component see the same slingshot `:anomaly/category` shapes as before:
+
+- `acquire-execution-environment!` still throws `:anomalies.executor/unavailable` for governed-mode-without-capsule.
+- `run-pipeline` still throws `:anomalies.workflow/no-capsule-executor` when build-initial-context returns the no-capsule anomaly.
+- `mark-completed` / `mark-failed` / `transition-to-phase` still throw `:anomalies.workflow/invalid-transition` on FSM rejection (now via private `transition-status!`).
+
+## Strata Affected
+
+- `ai.miniforge.workflow.runner` — `build-initial-context` is now anomaly-returning; boundary throw inlined in `run-pipeline`
+- `ai.miniforge.workflow.runner-environment` — `check-executor-for-mode` is anomaly-returning; boundary throw inlined in `acquire-execution-environment!`
+- `ai.miniforge.workflow.state` — `transition-status` is anomaly-returning; private `transition-status!` boundary helper used by `mark-completed` / `mark-failed` / `transition-to-phase`
+
+## Testing Plan
+
+- `bb test` — **5003 tests / 22890 passes / 0 failures / 0 errors** (post-cleanup; deprecated-thrower compat tests removed; new boundary integration tests added).
+- No deprecation warnings emitted (no deprecated throwers remain).
+
+## Deployment Plan
+
+No migration required for external callers — these helpers are component-internal (no `interface.clj` exports). External callers continue to see the same slingshot `:anomaly/category` shapes when escalation happens at the component boundaries.
+
+## Notes / Surprises
+
+- **Policy update.** This PR codifies the kill-the-deprecation pattern for component-scope cleanups. Foundation-tier APIs (>~30 callers; `schema/validate`, `dag-primitives/unwrap`) keep coexistence because hard cuts are genuinely impractical there. Documented in the commit body and reflected in the wave-6 closing summary.
+- **Run-pipeline boundary integration test omitted.** The build-initial-context throw escalation through `run-pipeline` is hard to exercise because `acquire-environment` runs first and has its own throw on the same governed-mode-without-capsule scenario. The boundary escalation pattern is tested via `acquire-execution-environment!` in `check_executor_for_mode_test.clj`. End-to-end coverage of the build-initial-context boundary is the runner's existing pipeline tests.
+- **`:anomalies.workflow/no-capsule-executor` is still not in `response/anomaly/workflow-anomalies` taxonomy.** Pre-existing latent quirk — `throw-anomaly!` doesn't validate against the taxonomy. Preserved at the new inlined boundary throw; flagged for the loader-side cleanup or a separate hygiene pass.
+
+## Related Issues/PRs
+
+- Built on PR #769 (workflow runtime cleanup with deprecate-and-coexist) — which itself built on:
+  - PR #704 (foundation cleanup)
+  - PR #758 (repo-dag cleanup)
+- Loader-side `workflow` cleanup still deferred (~9 sites; separate PR)
+
+## Checklist
+
+- [x] All 3 workflow-runtime deprecated throwers removed
+- [x] Single API per site (no deprecate-and-coexist)
+- [x] Boundary throws inlined at the call sites that escalate
+- [x] External caller contracts preserved — same slingshot `:anomaly/category` shapes
+- [x] Tests updated — anomaly happy / anomaly failure / boundary-escalation per scope
+- [x] No new throws in anomaly-returning code paths
+- [x] `bb test` green: 5003 / 22890 / 0
+- [x] Apache 2 license headers preserved


### PR DESCRIPTION
# refactor: kill workflow runtime deprecated throwers (single API)

## Overview

Follow-on cleanup to PR #769 (which migrated `workflow` runtime sites to the deprecate-and-coexist anomaly-returning pattern). This PR kills the deprecated throwers entirely so each site has a single canonical API. Three throwers retired:

- `workflow.state/transition-status` (deprecated thrower)
- `workflow.runner-environment/assert-executor-for-mode!` (deprecated thrower)
- `workflow.runner/build-initial-context` (deprecated private thrower)

The boundary throws that legitimately need to escalate to a slingshot ex-info shape (preserving the contract for `try+` callers above the workflow component) are inlined at their single call sites.

## Motivation

PR #769 landed with the same deprecate-and-coexist pattern that earlier exceptions-as-data PRs (#704 foundation, #758 repo-dag) established. Reviewer feedback pointed out that pattern is over-cautious for a 17-star repo with one primary maintainer and a handful of internal callers per site:

- The deprecated throwers were component-internal — zero external callers across the repo.
- The pattern paid an ongoing surface-area + deprecation-warnings tax.
- The savings (smaller individual PRs, easy revert) didn't justify it at this scale.

This PR drops the coexistence and lands a single API per site. Future component-scope cleanups will follow this pattern. Foundation-tier APIs with >30 callers (`schema/validate`, `dag-primitives/unwrap`) keep coexistence — the call-site count makes hard cuts genuinely impractical there.

## Base Branch

`main` (post-#769)

## Depends On

- PR #769 — `refactor/exceptions-as-data-workflow-runtime-cleanup` (merged) — introduced the anomaly variants this PR keeps as canonical.

## Layer

Refactor / kill-the-deprecation cleanup. Three workflow-runtime files; component-internal — no `interface.clj` exports affected.

## What This Adds / Changes

`components/workflow/src/ai/miniforge/workflow/state.clj`:

- Deleted the deprecated `transition-status` thrower.
- Renamed `transition-status-anomaly` → `transition-status` (canonical name now belongs to the canonical fn).
- Added private `transition-status!` boundary helper. Used by `mark-completed`, `mark-failed`, `transition-to-phase` — these represent workflow-definition invariants; an FSM rejection at one of them is a programmer error, so escalating to slingshot is appropriate. Preserves the legacy `:anomalies.workflow/invalid-transition` ex-info shape.

`components/workflow/src/ai/miniforge/workflow/runner_environment.clj`:

- Deleted the deprecated `assert-executor-for-mode!` thrower.
- Renamed `check-executor-for-mode-anomaly` → `check-executor-for-mode`.
- Inlined the boundary throw at the single call site in `acquire-execution-environment!`. Preserves the legacy `:anomalies.executor/unavailable` ex-info shape for legacy `try+` callers above this layer.

`components/workflow/src/ai/miniforge/workflow/runner.clj`:

- Deleted the deprecated private `build-initial-context` thrower.
- Renamed `build-initial-context-anomaly` → `build-initial-context`.
- Inlined the boundary throw at the single call site in `run-pipeline`'s let bindings. Preserves the `:anomalies.workflow/no-capsule-executor` ex-info shape that external callers (CLI / MCP / orchestrator) expect on misconfiguration.

`components/workflow/test/.../anomaly/`:

- `transition_status_test.clj` — references `transition-status` (not `*-anomaly`); deprecated-thrower compat tests replaced with `mark-completed` / `mark-failed` integration tests that exercise the private `transition-status!` boundary helper.
- `check_executor_for_mode_test.clj` — references `check-executor-for-mode`; `assert-executor-for-mode!` tests replaced with `acquire-execution-environment!` integration tests (with stubbed `dag-executor-fns`) that exercise the inlined boundary throw.
- `build_initial_context_test.clj` — references `build-initial-context`; deprecated-thrower compat tests removed. Run-pipeline boundary integration test omitted with a documented rationale: `acquire-environment` runs first along that path with its own governed-mode throw, so the integration test would test the wrong escalation site. Coverage for the build-initial-context boundary specifically is delegated to the runner's existing pipeline tests.

## API surface (after this PR)

```clojure
;; Canonical, anomaly-returning. Component-internal.
ai.miniforge.workflow.state/transition-status                         ; was *-anomaly
ai.miniforge.workflow.runner-environment/check-executor-for-mode      ; was *-anomaly
ai.miniforge.workflow.runner/build-initial-context                    ; was *-anomaly

;; Private boundary helper for in-component invariants.
ai.miniforge.workflow.state/transition-status!                        ; private
```

The deprecated throwers (`transition-status` thrower, `assert-executor-for-mode!`, `build-initial-context` thrower wrapper) are **gone**. Boundary escalation to slingshot ex-info now lives inlined at the call sites that actually need to throw.

## External caller contracts

Unchanged. External callers above the workflow component see the same slingshot `:anomaly/category` shapes as before:

- `acquire-execution-environment!` still throws `:anomalies.executor/unavailable` for governed-mode-without-capsule.
- `run-pipeline` still throws `:anomalies.workflow/no-capsule-executor` when build-initial-context returns the no-capsule anomaly.
- `mark-completed` / `mark-failed` / `transition-to-phase` still throw `:anomalies.workflow/invalid-transition` on FSM rejection (now via private `transition-status!`).

## Strata Affected

- `ai.miniforge.workflow.runner` — `build-initial-context` is now anomaly-returning; boundary throw inlined in `run-pipeline`
- `ai.miniforge.workflow.runner-environment` — `check-executor-for-mode` is anomaly-returning; boundary throw inlined in `acquire-execution-environment!`
- `ai.miniforge.workflow.state` — `transition-status` is anomaly-returning; private `transition-status!` boundary helper used by `mark-completed` / `mark-failed` / `transition-to-phase`

## Testing Plan

- `bb test` — **5003 tests / 22890 passes / 0 failures / 0 errors** (post-cleanup; deprecated-thrower compat tests removed; new boundary integration tests added).
- No deprecation warnings emitted (no deprecated throwers remain).

## Deployment Plan

No migration required for external callers — these helpers are component-internal (no `interface.clj` exports). External callers continue to see the same slingshot `:anomaly/category` shapes when escalation happens at the component boundaries.

## Notes / Surprises

- **Policy update.** This PR codifies the kill-the-deprecation pattern for component-scope cleanups. Foundation-tier APIs (>~30 callers; `schema/validate`, `dag-primitives/unwrap`) keep coexistence because hard cuts are genuinely impractical there. Documented in the commit body and reflected in the wave-6 closing summary.
- **Run-pipeline boundary integration test omitted.** The build-initial-context throw escalation through `run-pipeline` is hard to exercise because `acquire-environment` runs first and has its own throw on the same governed-mode-without-capsule scenario. The boundary escalation pattern is tested via `acquire-execution-environment!` in `check_executor_for_mode_test.clj`. End-to-end coverage of the build-initial-context boundary is the runner's existing pipeline tests.
- **`:anomalies.workflow/no-capsule-executor` is still not in `response/anomaly/workflow-anomalies` taxonomy.** Pre-existing latent quirk — `throw-anomaly!` doesn't validate against the taxonomy. Preserved at the new inlined boundary throw; flagged for the loader-side cleanup or a separate hygiene pass.

## Related Issues/PRs

- Built on PR #769 (workflow runtime cleanup with deprecate-and-coexist) — which itself built on:
  - PR #704 (foundation cleanup)
  - PR #758 (repo-dag cleanup)
- Loader-side `workflow` cleanup still deferred (~9 sites; separate PR)

## Checklist

- [x] All 3 workflow-runtime deprecated throwers removed
- [x] Single API per site (no deprecate-and-coexist)
- [x] Boundary throws inlined at the call sites that escalate
- [x] External caller contracts preserved — same slingshot `:anomaly/category` shapes
- [x] Tests updated — anomaly happy / anomaly failure / boundary-escalation per scope
- [x] No new throws in anomaly-returning code paths
- [x] `bb test` green: 5003 / 22890 / 0
- [x] Apache 2 license headers preserved
