### PR TITLE
feat(workflow): v2 multi-parent merge resolution loop (Stage 2B)

### DIFF
--- a/components/workflow/resources/config/workflow/dag/merge-resolution-defaults.edn
+++ b/components/workflow/resources/config/workflow/dag/merge-resolution-defaults.edn
@@ -1,0 +1,22 @@
+;; Default tuning for the v2 multi-parent merge-resolution loop.
+;; Lives as data per the policy that configuration belongs in EDN, not
+;; embedded literals. The loop in `merge_resolution.clj` reads this
+;; file at namespace load time.
+;;
+;; Spec §10.6 calibration:
+;; - :max-iterations is the budget cap. Resolution is a focused task;
+;;   if the agent can't converge in a few rounds the conflict probably
+;;   needs human eyes. Small numbers are correct here.
+;; - :stagnation-cap is the consecutive-recurring-conflict count that
+;;   ends the loop early. Per user direction (spec §10.6): 'we want to
+;;   have telemetry that allows us accounting to extract places to
+;;   optimize... not [reduce work] using a hammer.' Stagnation-cap is
+;;   the actionable lever — it ends loops that aren't making progress,
+;;   where waste actually comes from.
+;; - :min-stagnation-cap floors the cap so a misconfigured zero or
+;;   negative value can't loop forever.
+
+{:default-budget    {:max-iterations 5
+                     :stagnation-cap 2}
+ :min-stagnation-cap 1
+ :no-recurrence-count 0}

--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -90,4 +90,17 @@
   ;; v2 multi-parent merge — system-locale strings (operator-internal,
   ;; never user-localized, but routed through the catalog so we have one
   ;; place to audit and change them).
-  :dag.merge.system/git-test-failure "git {args} failed: {err}"}}
+  :dag.merge.system/git-test-failure "git {args} failed: {err}"
+
+  ;; v2 multi-parent merge — resolution sub-workflow (Stage 2B, spec §6.1)
+  :dag.merge.resolution/unresolvable
+  "Multi-parent merge conflict could not be auto-resolved"
+
+  :dag.merge.resolution/commit-message-header
+  "miniforge dag-merge resolution for task {task-id}"
+
+  :dag.merge.resolution/commit-message-body
+  "Resolved conflicts on {parent-count}-parent merge after {iterations} iteration{s}."
+
+  :dag.merge.resolution/commit-failed
+  "Could not commit the resolution to the worktree"}}

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -40,6 +40,7 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.dag-resilience :as resilience]
+   [ai.miniforge.workflow.merge-resolution :as merge-resolution]
    [ai.miniforge.workflow.messages :as messages]
    [babashka.fs :as fs]
    [clojure.java.shell :as shell]
@@ -723,12 +724,65 @@
               :else
               {:effective-parents parents :collapsed all-collapsed})))))))
 
+(defn- write-ref-and-build-success
+  "After a merge or resolution lands a commit-sha, write it to the
+   namespaced ref and either return the standard merge-success shape
+   or the typed ref-write-failed anomaly. Shared between the
+   no-conflict happy path and the resolution-success path."
+  [host-repo task-id ref-name commit-sha input-key strategy parents collapsed extras]
+  (let [upd (run-git host-repo "update-ref" ref-name commit-sha)]
+    (if (zero? (:exit upd))
+      (merge-ok-result (merge {:ref-name   ref-name
+                               :commit-sha commit-sha
+                               :input-key  input-key
+                               :strategy   strategy
+                               :parents    parents
+                               :collapsed  collapsed}
+                              extras))
+      (ref-write-failed-anomaly task-id ref-name commit-sha upd))))
+
+(defn- attempt-resolution!
+  "Spec §6.1 conflict path. The merge produced a conflict; spawn the
+   resolution sub-workflow to try to resolve it. On success we land a
+   resolution commit, write the namespaced ref, and return the
+   standard merge-success shape (with `:resolved?` and `:resolution-
+   iterations` for observability). On failure we return the
+   `:dag-multi-parent-unresolvable` terminal anomaly.
+
+   Stage 2B's resolution loop uses a no-op stub agent-edit-fn by
+   default, so conflicts still terminate as unresolvable — just via
+   the loop rather than an immediate anomaly. Stage 2C will inject
+   the real LLM-driven implementer."
+  [host-repo task-id ref-name input-key strategy parents collapsed
+   conflict-anomaly worktree resolution-overrides]
+  (let [outcome (merge-resolution/resolve-conflict!
+                 (merge {:conflict-input conflict-anomaly
+                         :host-repo host-repo
+                         :worktree-path worktree
+                         :task-id task-id}
+                        resolution-overrides))]
+    (if (dag/ok? outcome)
+      (let [{:keys [commit-sha iterations]} (:data outcome)]
+        (write-ref-and-build-success
+         host-repo task-id ref-name commit-sha input-key strategy
+         parents collapsed
+         {:resolved? true :resolution-iterations iterations}))
+      ;; Outcome is the unresolvable anomaly itself — pass through.
+      outcome)))
+
 (defn- attempt-merge-with-cache!
   "Cache-aware merge attempt. Checks for an existing namespaced ref
    first (spec §7.2 idempotency); if present, reuses its SHA. Otherwise
    stages a temp worktree, runs the merge, writes the ref, and cleans
-   up. Returns a `dag/ok` result on success or an anomaly on failure."
-  [host-repo run-id task-id strategy parents collapsed]
+   up. On conflict, spawns the resolution sub-workflow per spec §6.1
+   instead of immediately surfacing the conflict — the resolution
+   loop's terminal anomaly is what reaches the caller when the agent
+   can't make the merge clean.
+
+   Returns a `dag/ok` result on success or an anomaly on terminal
+   failure."
+  [host-repo run-id task-id strategy parents collapsed
+   {:keys [resolution-overrides] :as _opts}]
   (let [input-key (dag/compute-merge-input-key task-id strategy parents)
         ref-name  (merge-base-ref-name run-id task-id input-key)
         cached    (existing-merge-ref-sha host-repo ref-name)]
@@ -747,20 +801,23 @@
           (do (cleanup-worktree! host-repo worktree)
               (worktree-setup-failed-anomaly task-id setup))
           (let [outcome (run-merge! worktree task-id strategy parents input-key)]
-            (if-not (:ok? outcome)
-              (do (cleanup-worktree! host-repo worktree)
-                  (:anomaly outcome))
-              (let [upd (run-git host-repo "update-ref" ref-name (:commit-sha outcome))]
+            (if (:ok? outcome)
+              (let [success (write-ref-and-build-success
+                             host-repo task-id ref-name (:commit-sha outcome)
+                             input-key strategy parents collapsed nil)]
                 (cleanup-worktree! host-repo worktree)
-                (if (zero? (:exit upd))
-                  (merge-ok-result {:ref-name   ref-name
-                                    :commit-sha (:commit-sha outcome)
-                                    :input-key  input-key
-                                    :strategy   strategy
-                                    :parents    parents
-                                    :collapsed  collapsed})
-                  (ref-write-failed-anomaly task-id ref-name
-                                            (:commit-sha outcome) upd))))))))))
+                success)
+              ;; Conflict path — spawn the resolution sub-workflow on the
+              ;; same worktree. The conflict-info has the parents, paths,
+              ;; strategy, input-key, exit-code, stderr — everything the
+              ;; resolution agent (or its mock) needs.
+              (let [result (attempt-resolution!
+                            host-repo task-id ref-name input-key strategy
+                            parents collapsed
+                            (:anomaly outcome) worktree
+                            resolution-overrides)]
+                (cleanup-worktree! host-repo worktree)
+                result))))))))
 
 (defn merge-parent-branches!
   "Multi-parent merge entry point per spec §6.1.
@@ -813,7 +870,15 @@
           :else
           (attempt-merge-with-cache! host-repo run-id task-id strategy
                                      (:effective-parents prep)
-                                     (:collapsed prep)))))))
+                                     (:collapsed prep)
+                                     ;; Optional context override — tests
+                                     ;; inject mock agent-edit-fn / verify-fn
+                                     ;; here. Production paths leave this nil
+                                     ;; and the resolution loop uses its
+                                     ;; defaults (no-op stub agent until
+                                     ;; Stage 2C wires the real LLM agent).
+                                     {:resolution-overrides
+                                      (get context :dag/resolution-overrides)}))))))
 
 (defn task-sub-opts
   "Build execution opts for a DAG task's sub-workflow.

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -39,6 +39,7 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.dag-resilience :as resilience]
    [ai.miniforge.workflow.merge-resolution :as merge-resolution]
    [ai.miniforge.workflow.messages :as messages]
@@ -639,8 +640,17 @@
 
 (defn- run-merge!
   "Invoke `git merge` in the temp worktree per spec §3.1 / §6.1.
-   Returns `{:ok? true :commit-sha ...}` or `{:ok? false :anomaly ...}`.
-   Caller is responsible for cleanup."
+   Returns either:
+   - `(response/success {:commit-sha <sha>})` when the merge lands a
+     real commit and rev-parse HEAD reports it cleanly.
+   - The conflict anomaly map (`:anomalies/dag-multi-parent-conflict`)
+     when git's exit code reports a conflict.
+   - The merge-failed anomaly map (`:anomalies/dag-multi-parent-merge-failed`)
+     when the merge succeeded but rev-parse HEAD failed (rare
+     infrastructure case).
+
+   Caller checks `response/success?` for the happy path and dispatches
+   on `:anomaly/category` for the failure path."
   [worktree-path task-id strategy parents input-key]
   (let [rest-parents (rest parents)
         message (deterministic-merge-message task-id parents)
@@ -651,13 +661,11 @@
     (if (zero? (:exit r))
       (let [head (run-git worktree-path "rev-parse" "HEAD")]
         (if (zero? (:exit head))
-          {:ok? true :commit-sha (str/trim (:out head))}
-          {:ok? false
-           :anomaly (ref-write-failed-anomaly task-id nil nil head)}))
-      {:ok? false
-       :anomaly (conflict-anomaly task-id strategy parents
-                                  (enumerate-conflicts worktree-path)
-                                  input-key r)})))
+          (response/success {:commit-sha (str/trim (:out head))} nil)
+          (ref-write-failed-anomaly task-id nil nil head)))
+      (conflict-anomaly task-id strategy parents
+                        (enumerate-conflicts worktree-path)
+                        input-key r))))
 
 (defn- ensure-clean-worktree!
   "Remove any pre-existing temp worktree at `path` and re-create it
@@ -809,26 +817,28 @@
         (if-not (zero? (:exit setup))
           (do (cleanup-worktree! host-repo worktree)
               (worktree-setup-failed-anomaly task-id setup))
-          (let [outcome (run-merge! worktree task-id strategy parents input-key)
-                anomaly (:anomaly outcome)
-                anomaly-category (:anomaly/category anomaly)]
+          (let [outcome (run-merge! worktree task-id strategy parents input-key)]
             (cond
-              (:ok? outcome)
+              ;; Merge succeeded — outcome is response/success carrying
+              ;; the commit-sha.
+              (response/success? outcome)
               (let [success (write-ref-and-build-success
-                             host-repo task-id ref-name (:commit-sha outcome)
+                             host-repo task-id ref-name
+                             (get-in outcome [:output :commit-sha])
                              input-key strategy parents collapsed nil)]
                 (cleanup-worktree! host-repo worktree)
                 success)
 
               ;; Conflict — spawn the resolution sub-workflow on the same
-              ;; worktree. The conflict anomaly has parents, paths,
+              ;; worktree. The conflict anomaly carries parents, paths,
               ;; strategy, input-key, exit-code, stderr — everything the
               ;; resolution agent (or its mock) needs.
-              (= anomaly-category :anomalies/dag-multi-parent-conflict)
+              (= :anomalies/dag-multi-parent-conflict
+                 (:anomaly/category outcome))
               (let [result (attempt-resolution!
                             host-repo task-id ref-name input-key strategy
                             parents collapsed
-                            anomaly worktree resolution-overrides)]
+                            outcome worktree resolution-overrides)]
                 (cleanup-worktree! host-repo worktree)
                 result)
 
@@ -841,7 +851,7 @@
               ;; `:dag-multi-parent-unresolvable`.
               :else
               (do (cleanup-worktree! host-repo worktree)
-                  anomaly))))))))
+                  outcome))))))))
 
 (defn merge-parent-branches!
   "Multi-parent merge entry point per spec §6.1.

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -415,16 +415,23 @@
 ;; consumer only needs to look for :branch and (optionally) :commit-sha.
 
 (defn- merge-ok-result
-  "Successful merge commit on the namespaced ref. Includes the input-key
-   and a `:cache-hit?` flag for observability."
-  [{:keys [ref-name commit-sha input-key strategy parents collapsed cache-hit?]}]
+  "Successful merge commit on the namespaced ref. Includes the
+   input-key and observability flags. `:resolved?` and
+   `:resolution-iterations` are set when the success came via the
+   resolution sub-workflow (Stage 2B+); absent for direct-merge
+   successes."
+  [{:keys [ref-name commit-sha input-key strategy parents collapsed
+           cache-hit? resolved? resolution-iterations]}]
   (dag/ok (cond-> {:branch       ref-name
                    :commit-sha   commit-sha
                    :input-key    input-key
                    :strategy     strategy
                    :parents      parents
                    :cache-hit?   (boolean cache-hit?)}
-            (seq collapsed) (assoc :collapsed collapsed))))
+            (seq collapsed)             (assoc :collapsed collapsed)
+            resolved?                   (assoc :resolved? true)
+            resolution-iterations       (assoc :resolution-iterations
+                                               resolution-iterations))))
 
 (defn- single-parent-fast-path-result
   "Successful resolution where collapse left exactly one effective
@@ -728,7 +735,9 @@
   "After a merge or resolution lands a commit-sha, write it to the
    namespaced ref and either return the standard merge-success shape
    or the typed ref-write-failed anomaly. Shared between the
-   no-conflict happy path and the resolution-success path."
+   no-conflict happy path and the resolution-success path. `extras`
+   may contain :resolved? / :resolution-iterations for the resolution
+   path (merge-ok-result destructures them explicitly so they survive)."
   [host-repo task-id ref-name commit-sha input-key strategy parents collapsed extras]
   (let [upd (run-git host-repo "update-ref" ref-name commit-sha)]
     (if (zero? (:exit upd))
@@ -800,24 +809,39 @@
         (if-not (zero? (:exit setup))
           (do (cleanup-worktree! host-repo worktree)
               (worktree-setup-failed-anomaly task-id setup))
-          (let [outcome (run-merge! worktree task-id strategy parents input-key)]
-            (if (:ok? outcome)
+          (let [outcome (run-merge! worktree task-id strategy parents input-key)
+                anomaly (:anomaly outcome)
+                anomaly-category (:anomaly/category anomaly)]
+            (cond
+              (:ok? outcome)
               (let [success (write-ref-and-build-success
                              host-repo task-id ref-name (:commit-sha outcome)
                              input-key strategy parents collapsed nil)]
                 (cleanup-worktree! host-repo worktree)
                 success)
-              ;; Conflict path — spawn the resolution sub-workflow on the
-              ;; same worktree. The conflict-info has the parents, paths,
+
+              ;; Conflict — spawn the resolution sub-workflow on the same
+              ;; worktree. The conflict anomaly has parents, paths,
               ;; strategy, input-key, exit-code, stderr — everything the
               ;; resolution agent (or its mock) needs.
+              (= anomaly-category :anomalies/dag-multi-parent-conflict)
               (let [result (attempt-resolution!
                             host-repo task-id ref-name input-key strategy
                             parents collapsed
-                            (:anomaly outcome) worktree
-                            resolution-overrides)]
+                            anomaly worktree resolution-overrides)]
                 (cleanup-worktree! host-repo worktree)
-                result))))))))
+                result)
+
+              ;; Non-conflict failure (e.g. rev-parse HEAD failed after a
+              ;; successful merge — `:dag-multi-parent-merge-failed`).
+              ;; This is an infrastructure error, not a conflict to
+              ;; resolve. Surface it directly so the operator sees the
+              ;; real cause; routing it through the resolution loop
+              ;; would hide the original git failure behind a generic
+              ;; `:dag-multi-parent-unresolvable`.
+              :else
+              (do (cleanup-worktree! host-repo worktree)
+                  anomaly))))))))
 
 (defn merge-parent-branches!
   "Multi-parent merge entry point per spec §6.1.

--- a/components/workflow/src/ai/miniforge/workflow/merge_resolution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/merge_resolution.clj
@@ -48,20 +48,48 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.messages :as messages]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.java.shell :as shell]
    [clojure.string :as str]))
 
 ;; Constants -----------------------------------------------------------
+;; Configuration is data, not code. Tunables live under
+;; resources/config/workflow/dag/merge-resolution-defaults.edn so they
+;; can be audited and overridden without touching the namespace.
 
-(def ^:private default-budget
-  "Per spec §10.6: small iteration cap (resolution is a focused task;
-   if the agent can't converge in a few rounds the conflict probably
-   needs human eyes) plus a stagnation cap (the curator detects
-   recurring-conflict and terminates without burning the full budget).
-   The stagnation-cap is the actionable lever — it ends loops that
-   aren't making progress, where waste actually comes from."
-  {:max-iterations 5
-   :stagnation-cap 2})
+(def ^:private resolution-defaults-path
+  "config/workflow/dag/merge-resolution-defaults.edn")
+
+(def ^:private resolution-defaults
+  "Loaded once at namespace load. Throws (loud) if the resource is
+   missing — that would be a packaging bug, not a runtime condition."
+  (delay
+    (-> resolution-defaults-path
+        io/resource
+        slurp
+        edn/read-string)))
+
+(defn- default-budget
+  "Spec §10.6 budget shape: `{:max-iterations N :stagnation-cap M}`.
+   Loaded from the EDN config; see the comments there for the
+   calibration rationale."
+  []
+  (:default-budget @resolution-defaults))
+
+(defn- min-stagnation-cap
+  "Floor on the consecutive-recurrence count that terminates the
+   loop. Misconfigured zero or negative would never terminate; the
+   floor prevents that."
+  []
+  (:min-stagnation-cap @resolution-defaults))
+
+(defn- no-recurrence-count
+  "The 'no recurrence yet' value for the consecutive-recurrence
+   counter. Named so loop arity reads as intent rather than a stray
+   `0`."
+  []
+  (:no-recurrence-count @resolution-defaults))
 
 ;; Stub agent + verify --------------------------------------------------
 
@@ -82,9 +110,11 @@
   "Stage 2B's default `verify-fn`: assumes verify passes once markers
    are gone. Stage 4 will wire this to a real `bb test` invocation per
    spec §6.1.1. Until then, the curator's marker check IS the
-   resolution gate; verify is plumbed but trivial."
+   resolution gate; verify is plumbed but trivial. Returns the standard
+   response/success shape so the loop can use response/success? to
+   branch — no bespoke `{:ok? true}` map invented locally."
   [_worktree-path]
-  {:ok? true})
+  (response/success {:verify/skipped? true} nil))
 
 ;; Anomaly + result factories ------------------------------------------
 
@@ -125,14 +155,19 @@
 
 (defn- commit-resolution!
   "Stage the agent's edits and commit them in `worktree-path`. Returns
-   `{:ok? true :commit-sha <sha>}` or `{:ok? false :anomaly ...}`.
+   `(response/success {:commit-sha <sha>})` on success, or
+   `(response/error <message> {:data {:git-result ...}})` on failure.
    Uses the same pinned-flags convention as the upstream merge
    (no-edit / no-gpg-sign / no-verify) so the resolution commit's
    shape is consistent with the merge it's resolving."
   [worktree-path task-id parents iterations]
-  (let [add (run-git worktree-path "add" "-A")]
+  (let [commit-failed (fn commit-failed [git-result]
+                        (response/error
+                         (messages/t :dag.merge.resolution/commit-failed)
+                         {:data {:git-result git-result}}))
+        add (run-git worktree-path "add" "-A")]
     (if-not (zero? (:exit add))
-      {:ok? false :git-result add}
+      (commit-failed add)
       (let [header (messages/t :dag.merge.resolution/commit-message-header
                                {:task-id task-id})
             body   (messages/t :dag.merge.resolution/commit-message-body
@@ -144,11 +179,11 @@
                             "--no-edit" "--no-gpg-sign" "--no-verify"
                             "-m" message)]
         (if-not (zero? (:exit commit))
-          {:ok? false :git-result commit}
+          (commit-failed commit)
           (let [head (run-git worktree-path "rev-parse" "HEAD")]
             (if (zero? (:exit head))
-              {:ok? true :commit-sha (str/trim (:out head))}
-              {:ok? false :git-result head})))))))
+              (response/success {:commit-sha (str/trim (:out head))} nil)
+              (commit-failed head))))))))
 
 ;; Loop helpers --------------------------------------------------------
 
@@ -220,22 +255,21 @@
      resolution-commit fails)."
   [{:keys [conflict-input host-repo worktree-path task-id budget
            agent-edit-fn verify-fn]
-    :or   {budget         default-budget
-           agent-edit-fn  no-op-agent-edit-fn
+    :or   {agent-edit-fn  no-op-agent-edit-fn
            verify-fn      always-pass-verify-fn}}]
-  (let [parents (:merge/parents conflict-input)
+  (let [budget (or budget (default-budget))
+        parents (:merge/parents conflict-input)
         max-iterations (:max-iterations budget)
-        ;; Per spec §10.6: stagnation-cap is the consecutive-recurrence
-        ;; count that terminates the loop. Default 2 (one extra chance
-        ;; after the first stuck-frame). Setting to 1 makes recurrence
-        ;; terminal on first detection (the v0.1 behavior); higher
-        ;; values give the agent more recovery attempts at the cost of
-        ;; budget. We clamp at 1 because zero or negative would never
-        ;; terminate.
-        stagnation-cap (max 1 (or (:stagnation-cap budget) 1))]
+        stagnation-floor (min-stagnation-cap)
+        no-recurrence (no-recurrence-count)
+        ;; Spec §10.6: stagnation-cap is the consecutive-recurrence
+        ;; count that terminates the loop. Floored at min-stagnation-cap
+        ;; so a misconfigured zero or negative can't loop forever.
+        stagnation-cap (max stagnation-floor
+                            (or (:stagnation-cap budget) stagnation-floor))]
     (loop [iteration 0
            prior-paths nil
-           consecutive-recurrence 0]
+           consecutive-recurrence no-recurrence]
       (cond
         ;; Budget exhausted before resolution.
         (>= iteration max-iterations)
@@ -279,12 +313,13 @@
 
               ;; Markers gone — run verify.
               (response/success? curator)
-              (let [verify (verify-fn worktree-path)]
-                (if (:ok? verify)
+              (let [verify-result (verify-fn worktree-path)]
+                (if (response/success? verify-result)
                   (let [commit (commit-resolution! worktree-path task-id
                                                    parents (inc iteration))]
-                    (if (:ok? commit)
-                      (resolution-success (:commit-sha commit) (inc iteration))
+                    (if (response/success? commit)
+                      (resolution-success (get-in commit [:output :commit-sha])
+                                          (inc iteration))
                       (terminal-result {:conflict-input conflict-input
                                         :reason :resolution-commit-failed
                                         :iterations (inc iteration)
@@ -293,7 +328,7 @@
                   ;; Loop again; markers are gone (path set is empty)
                   ;; so recurrence can't fire — let budget-exhausted
                   ;; catch always-failing verify.
-                  (recur (inc iteration) prior-paths 0)))
+                  (recur (inc iteration) prior-paths no-recurrence)))
 
               ;; Curator: markers-not-resolved. Loop with the new path
               ;; set so recurrence can fire next iteration. Reset the
@@ -303,7 +338,7 @@
               (= code :curator/markers-not-resolved)
               (recur (inc iteration)
                      (set (curator-conflicted-paths curator))
-                     0)
+                     no-recurrence)
 
               ;; Unknown curator code — surface as a resolution-loop
               ;; fault rather than spinning. The catch-all is intentional;

--- a/components/workflow/src/ai/miniforge/workflow/merge_resolution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/merge_resolution.clj
@@ -1,0 +1,290 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.merge-resolution
+  "Automated resolution of multi-parent merge conflicts (v2 Stage 2B,
+   spec §6.1).
+
+   When `merge-parent-branches!` produces a conflict anomaly, the
+   orchestrator hands the conflicted worktree to `resolve-conflict!`
+   here, which iterates an agent → curator → verify loop until either
+   the conflicts are resolved cleanly or a terminal condition fires
+   (budget exhausted, agent stuck, verify never passes).
+
+   Stage 2B scope: the loop scaffolding + the curator/verify wiring +
+   the namespaced-ref commit on success. The agent step is
+   parameterized via an `agent-edit-fn` so tests can inject mock
+   resolutions and the production wiring can default to a no-op stub
+   until Stage 2C lands the real LLM-driven resolution agent. With the
+   default stub, conflicts still terminate as
+   `:dag-multi-parent-unresolvable` (with `:resolution/reason
+   :curator/recurring-conflict` after two no-progress iterations) —
+   exactly as in Stage 1B, just routed through the loop.
+
+   Spec §6.1.2 curator and §10.6 budget shape live in this layer too:
+   the loop calls the `:merge-resolution` curator method between
+   iterations to detect markers-not-resolved and recurring-conflict;
+   the budget defaults to `{:max-iterations 5 :stagnation-cap 2}` per
+   the round-2 user direction (small iteration cap so agents that
+   aren't progressing don't burn the rest of the budget; stagnation
+   cap caught by the curator's recurring-conflict path)."
+  (:require
+   [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.response.interface :as response]
+   [ai.miniforge.workflow.messages :as messages]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]))
+
+;; Constants -----------------------------------------------------------
+
+(def ^:private default-budget
+  "Per spec §10.6: small iteration cap (resolution is a focused task;
+   if the agent can't converge in a few rounds the conflict probably
+   needs human eyes) plus a stagnation cap (the curator detects
+   recurring-conflict and terminates without burning the full budget).
+   The stagnation-cap is the actionable lever — it ends loops that
+   aren't making progress, where waste actually comes from."
+  {:max-iterations 5
+   :stagnation-cap 2})
+
+;; Stub agent + verify --------------------------------------------------
+
+(defn no-op-agent-edit-fn
+  "Stage 2B's default `agent-edit-fn`: does nothing. With this stub the
+   curator finds the same conflict markers each iteration, recurring-
+   conflict fires, and the loop terminates as if the agent gave up.
+   Stage 2C replaces this with a real LLM-driven implementer that reads
+   the conflict info and edits the worktree."
+  [_worktree-path _conflict-info _iteration]
+  ;; Returns response/success with no edits — the curator's marker
+  ;; scan is what actually drives the loop's progress detection.
+  (response/success {:edits/applied 0
+                     :edits/files []}
+                    nil))
+
+(defn always-pass-verify-fn
+  "Stage 2B's default `verify-fn`: assumes verify passes once markers
+   are gone. Stage 4 will wire this to a real `bb test` invocation per
+   spec §6.1.1. Until then, the curator's marker check IS the
+   resolution gate; verify is plumbed but trivial."
+  [_worktree-path]
+  {:ok? true})
+
+;; Anomaly + result factories ------------------------------------------
+
+(defn- unresolvable-anomaly
+  "Spec §6.1 terminal: the resolution sub-workflow couldn't produce a
+   clean merge within budget / before the curator declared the agent
+   stuck. Carries enough context for an operator dashboard to surface
+   what was tried and what state the worktree was last in."
+  [{:keys [task-id strategy parents conflicts input-key
+           reason iterations last-attempt-ref]}]
+  {:anomaly/category :anomalies/dag-multi-parent-unresolvable
+   :anomaly/message  (messages/t :dag.merge.resolution/unresolvable)
+   :task/id          task-id
+   :merge/parents    parents
+   :merge/conflicts  conflicts
+   :merge/strategy   strategy
+   :merge/input-key  input-key
+   :resolution/reason reason
+   :resolution/iterations iterations
+   :resolution/last-attempt-ref last-attempt-ref})
+
+(defn- resolution-success
+  "Successful resolution result. The orchestrator wraps this in
+   `merge-ok-result` after writing the namespaced ref."
+  [commit-sha iterations]
+  (dag/ok {:commit-sha commit-sha
+           :iterations iterations
+           :resolved? true}))
+
+;; Git helpers ---------------------------------------------------------
+;; Defensive against shell exceptions so the loop branches on `:exit`
+;; rather than wrapping in try/catch at every call site.
+
+(defn- run-git
+  [cwd & args]
+  (try (apply shell/sh "git" "-C" cwd args)
+       (catch Exception e {:exit -1 :out "" :err (.getMessage e)})))
+
+(defn- commit-resolution!
+  "Stage the agent's edits and commit them in `worktree-path`. Returns
+   `{:ok? true :commit-sha <sha>}` or `{:ok? false :anomaly ...}`.
+   Uses the same pinned-flags convention as the upstream merge
+   (no-edit / no-gpg-sign / no-verify) so the resolution commit's
+   shape is consistent with the merge it's resolving."
+  [worktree-path task-id parents iterations]
+  (let [add (run-git worktree-path "add" "-A")]
+    (if-not (zero? (:exit add))
+      {:ok? false :git-result add}
+      (let [header (messages/t :dag.merge.resolution/commit-message-header
+                               {:task-id task-id})
+            body   (messages/t :dag.merge.resolution/commit-message-body
+                               {:parent-count (count parents)
+                                :iterations   iterations
+                                :s            (if (= 1 iterations) "" "s")})
+            message (str header "\n\n" body)
+            commit (run-git worktree-path "commit"
+                            "--no-edit" "--no-gpg-sign" "--no-verify"
+                            "-m" message)]
+        (if-not (zero? (:exit commit))
+          {:ok? false :git-result commit}
+          (let [head (run-git worktree-path "rev-parse" "HEAD")]
+            (if (zero? (:exit head))
+              {:ok? true :commit-sha (str/trim (:out head))}
+              {:ok? false :git-result head})))))))
+
+;; Loop helpers --------------------------------------------------------
+
+(defn- run-curator-check
+  "Spec §6.1.2: invoke the merge-resolution curator on the current
+   worktree state, threading the prior iteration's conflicted-paths
+   so recurring-conflict can fire."
+  [worktree-path prior-paths]
+  (agent/curate {:curator/kind :merge-resolution
+                 :worktree-path worktree-path
+                 :prior-conflicted-paths prior-paths}))
+
+(defn- curator-error-code
+  "Pull the structured `:code` keyword from a curator error response.
+   Returns nil for a success response."
+  [curator-result]
+  (when (response/error? curator-result)
+    (get-in curator-result [:error :data :code])))
+
+(defn- curator-conflicted-paths
+  "Pull the conflicted-paths vector from a curator error response —
+   used as the next iteration's `:prior-conflicted-paths` input so
+   recurrence detection can fire."
+  [curator-result]
+  (get-in curator-result [:error :data :conflicted-paths]))
+
+(defn- terminal-result
+  "Build the terminal anomaly when the loop can't make progress.
+   Centralizes message + iteration accounting."
+  [{:keys [conflict-input reason iterations last-attempt-ref]}]
+  (unresolvable-anomaly
+   (-> conflict-input
+       (assoc :reason reason
+              :iterations iterations
+              :last-attempt-ref last-attempt-ref))))
+
+;; Public API ----------------------------------------------------------
+
+(defn resolve-conflict!
+  "Run the v2 conflict-resolution iteration loop per spec §6.1.
+
+   Inputs (a single map for clarity at the call site):
+   - `:conflict-input`  — the conflict anomaly produced by
+     `merge-parent-branches!` (parents, conflicts, strategy, input-key).
+   - `:host-repo`       — host repo path; the resolution commit's SHA
+     is reachable from the host repo via the merge worktree's shared
+     object store.
+   - `:worktree-path`   — the temp worktree where the merge attempt
+     happened; the agent edits run here.
+   - `:task-id`         — for the resolution commit message + anomaly
+     payload.
+   - `:budget`          — `{:max-iterations N :stagnation-cap M}`;
+     defaults to `default-budget`.
+   - `:agent-edit-fn`   — `(fn [worktree-path conflict-input iteration])`;
+     mutates the worktree to (try to) resolve markers. Defaults to
+     `no-op-agent-edit-fn` (no real LLM agent yet — Stage 2C wires it
+     in). Test code injects mocks here.
+   - `:verify-fn`       — `(fn [worktree-path])` returns
+     `{:ok? bool}`. Defaults to `always-pass-verify-fn` (markers-cleared
+     IS the gate until Stage 4 wires real `bb test`).
+
+   Returns either:
+   - `dag/ok {:commit-sha <sha> :iterations <n> :resolved? true}` on
+     successful resolution. The caller writes the SHA to the namespaced
+     ref via `update-ref` and returns the standard merge-success shape.
+   - The `:anomalies/dag-multi-parent-unresolvable` anomaly when the
+     loop terminates without resolving (budget exhausted, recurring-
+     conflict, markers-not-resolved beyond cap, verify never passes,
+     resolution-commit fails)."
+  [{:keys [conflict-input host-repo worktree-path task-id budget
+           agent-edit-fn verify-fn]
+    :or   {budget         default-budget
+           agent-edit-fn  no-op-agent-edit-fn
+           verify-fn      always-pass-verify-fn}}]
+  (let [parents (:merge/parents conflict-input)]
+    (loop [iteration 0
+           prior-paths nil]
+      (cond
+        ;; Budget exhausted before resolution.
+        (>= iteration (:max-iterations budget))
+        (terminal-result {:conflict-input conflict-input
+                          :reason :budget-exhausted
+                          :iterations iteration
+                          :last-attempt-ref worktree-path})
+
+        :else
+        (do
+          ;; The agent edits the worktree (or doesn't, if it's the stub).
+          (agent-edit-fn worktree-path conflict-input iteration)
+          (let [curator (run-curator-check worktree-path prior-paths)
+                code    (curator-error-code curator)]
+            (cond
+              ;; Curator declared the agent stuck.
+              (= code :curator/recurring-conflict)
+              (terminal-result {:conflict-input conflict-input
+                                :reason :curator/recurring-conflict
+                                :iterations (inc iteration)
+                                :last-attempt-ref worktree-path})
+
+              ;; Markers gone — run verify.
+              (response/success? curator)
+              (let [verify (verify-fn worktree-path)]
+                (if (:ok? verify)
+                  (let [commit (commit-resolution! worktree-path task-id
+                                                   parents (inc iteration))]
+                    (if (:ok? commit)
+                      (resolution-success (:commit-sha commit) (inc iteration))
+                      (terminal-result {:conflict-input conflict-input
+                                        :reason :resolution-commit-failed
+                                        :iterations (inc iteration)
+                                        :last-attempt-ref worktree-path})))
+                  ;; Verify failed: the agent's edits broke tests.
+                  ;; Loop again; same paths since markers are gone — but
+                  ;; rather than risk infinite-loop on always-failing
+                  ;; verify, we treat this as a no-progress iteration
+                  ;; and let budget-exhausted catch it.
+                  (recur (inc iteration) prior-paths)))
+
+              ;; Curator says markers-not-resolved (or worktree-missing).
+              ;; Loop with the new path set so recurrence can fire next
+              ;; iteration.
+              :else
+              (recur (inc iteration)
+                     (set (curator-conflicted-paths curator))))))))))
+
+;; Rich Comment --------------------------------------------------------
+(comment
+  ;; A loop with the no-op stub on a worktree that has markers will
+  ;; recurring-conflict on iteration 1 and terminate on iteration 2:
+  (resolve-conflict!
+   {:conflict-input {:task/id "task-c"
+                     :merge/parents [{:task/id :a :commit-sha "aaa"}
+                                     {:task/id :b :commit-sha "bbb"}]
+                     :merge/strategy :git-merge}
+    :host-repo "/tmp/some-host-repo"
+    :worktree-path "/tmp/some-worktree-with-markers"
+    :task-id "task-c"})
+
+  :leave-this-here)

--- a/components/workflow/src/ai/miniforge/workflow/merge_resolution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/merge_resolution.clj
@@ -223,12 +223,22 @@
     :or   {budget         default-budget
            agent-edit-fn  no-op-agent-edit-fn
            verify-fn      always-pass-verify-fn}}]
-  (let [parents (:merge/parents conflict-input)]
+  (let [parents (:merge/parents conflict-input)
+        max-iterations (:max-iterations budget)
+        ;; Per spec §10.6: stagnation-cap is the consecutive-recurrence
+        ;; count that terminates the loop. Default 2 (one extra chance
+        ;; after the first stuck-frame). Setting to 1 makes recurrence
+        ;; terminal on first detection (the v0.1 behavior); higher
+        ;; values give the agent more recovery attempts at the cost of
+        ;; budget. We clamp at 1 because zero or negative would never
+        ;; terminate.
+        stagnation-cap (max 1 (or (:stagnation-cap budget) 1))]
     (loop [iteration 0
-           prior-paths nil]
+           prior-paths nil
+           consecutive-recurrence 0]
       (cond
         ;; Budget exhausted before resolution.
-        (>= iteration (:max-iterations budget))
+        (>= iteration max-iterations)
         (terminal-result {:conflict-input conflict-input
                           :reason :budget-exhausted
                           :iterations iteration
@@ -241,10 +251,29 @@
           (let [curator (run-curator-check worktree-path prior-paths)
                 code    (curator-error-code curator)]
             (cond
-              ;; Curator declared the agent stuck.
+              ;; Curator: agent is stuck on the same path set. Track
+              ;; consecutive recurrences and only terminate when we hit
+              ;; the stagnation cap — gives the agent a chance to break
+              ;; out (relevant once Stage 2C wires the real LLM).
               (= code :curator/recurring-conflict)
+              (let [stagnated (inc consecutive-recurrence)]
+                (if (>= stagnated stagnation-cap)
+                  (terminal-result {:conflict-input conflict-input
+                                    :reason :curator/recurring-conflict
+                                    :iterations (inc iteration)
+                                    :last-attempt-ref worktree-path})
+                  ;; Below the cap — loop with same prior-paths so a
+                  ;; subsequent identical iteration counts as another
+                  ;; consecutive recurrence.
+                  (recur (inc iteration) prior-paths stagnated)))
+
+              ;; Curator: worktree is missing or some other infrastructure
+              ;; fault. Surface immediately rather than spinning to
+              ;; budget exhaustion — the operator needs the original
+              ;; error category, not a generic unresolvable.
+              (= code :curator/worktree-missing)
               (terminal-result {:conflict-input conflict-input
-                                :reason :curator/recurring-conflict
+                                :reason :curator/worktree-missing
                                 :iterations (inc iteration)
                                 :last-attempt-ref worktree-path})
 
@@ -261,18 +290,30 @@
                                         :iterations (inc iteration)
                                         :last-attempt-ref worktree-path})))
                   ;; Verify failed: the agent's edits broke tests.
-                  ;; Loop again; same paths since markers are gone — but
-                  ;; rather than risk infinite-loop on always-failing
-                  ;; verify, we treat this as a no-progress iteration
-                  ;; and let budget-exhausted catch it.
-                  (recur (inc iteration) prior-paths)))
+                  ;; Loop again; markers are gone (path set is empty)
+                  ;; so recurrence can't fire — let budget-exhausted
+                  ;; catch always-failing verify.
+                  (recur (inc iteration) prior-paths 0)))
 
-              ;; Curator says markers-not-resolved (or worktree-missing).
-              ;; Loop with the new path set so recurrence can fire next
-              ;; iteration.
-              :else
+              ;; Curator: markers-not-resolved. Loop with the new path
+              ;; set so recurrence can fire next iteration. Reset the
+              ;; consecutive-recurrence counter — this iteration showed
+              ;; a different path set than the prior, so the agent is
+              ;; making progress (or at least churning differently).
+              (= code :curator/markers-not-resolved)
               (recur (inc iteration)
-                     (set (curator-conflicted-paths curator))))))))))
+                     (set (curator-conflicted-paths curator))
+                     0)
+
+              ;; Unknown curator code — surface as a resolution-loop
+              ;; fault rather than spinning. The catch-all is intentional;
+              ;; new curator error codes added later should land an
+              ;; explicit branch above.
+              :else
+              (terminal-result {:conflict-input conflict-input
+                                :reason (or code :curator/unknown-error)
+                                :iterations (inc iteration)
+                                :last-attempt-ref worktree-path}))))))))
 
 ;; Rich Comment --------------------------------------------------------
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
@@ -208,12 +208,16 @@
 
 ;------------------------------------------------------------------------------ Tests: conflict
 
-(deftest conflict-surfaces-typed-anomaly-test
+(deftest conflict-surfaces-unresolvable-via-resolution-loop-test
   (testing "When two parents touch the same file with different content,
-            the merge conflicts. v2 (Stage 1B) surfaces the conflict as
-            a typed anomaly carrying the parent SHAs, conflict paths,
-            and raw git stderr. Stage 2 will replace this with the
-            resolution sub-workflow; for 1B the task fails."
+            the merge conflicts and Stage 2B routes to the resolution
+            sub-workflow. With the default no-op stub agent (Stage 2C
+            will replace it with a real LLM-driven implementer), the
+            curator detects recurring-conflict on the second iteration
+            and the loop terminates as :dag-multi-parent-unresolvable.
+            Stage 1B's :dag-multi-parent-conflict terminal is now an
+            internal step inside the resolution loop, not a public
+            return value."
     (run-git! *repo* "checkout" "-b" "task-a" "main")
     (commit-file! *repo* "src/conflict.txt" "from a\n" "a edit")
     (run-git! *repo* "checkout" "-b" "task-b" "main")
@@ -223,12 +227,11 @@
           ctx (ctx-with-registry {:a {:branch "task-a"}
                                   :b {:branch "task-b"}})
           result (dag-orch/merge-parent-branches! ctx task-def)]
-      (is (= :anomalies/dag-multi-parent-conflict
+      (is (= :anomalies/dag-multi-parent-unresolvable
              (:anomaly/category result)))
-      (is (some #(= "src/conflict.txt" (:path %))
-                (:merge/conflicts result))
-          "the conflicting path is enumerated for the resolution agent
-           (Stage 2) to consume"))))
+      (is (= :curator/recurring-conflict (:resolution/reason result))
+          "no-op stub agent → curator finds the same conflict path on
+           iteration 2 → recurring-conflict early-out per spec §6.1.2"))))
 
 ;------------------------------------------------------------------------------ Tests: branch unresolvable
 

--- a/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
@@ -233,6 +233,50 @@
           "no-op stub agent → curator finds the same conflict path on
            iteration 2 → recurring-conflict early-out per spec §6.1.2"))))
 
+(deftest conflict-resolves-end-to-end-via-injected-agent-test
+  (testing "Full end-to-end success path through merge-parent-branches!:
+            a conflicted merge whose resolution-overrides inject a mock
+            agent that resolves the markers should write the resolution
+            commit to the namespaced ref and return dag/ok with
+            :resolved? true and :resolution-iterations populated. This
+            is the success contract Stage 2C's real LLM agent will hit;
+            until then, this test pins that the wiring works end-to-end
+            with a mock."
+    (run-git! *repo* "checkout" "-b" "task-a" "main")
+    (commit-file! *repo* "src/conflict.txt" "from a\n" "a edit")
+    (run-git! *repo* "checkout" "-b" "task-b" "main")
+    (commit-file! *repo* "src/conflict.txt" "from b\n" "b edit")
+    (run-git! *repo* "checkout" "main")
+    (let [task-def {:task/id "task-c" :task/deps [:a :b]}
+          mock-edit (fn [worktree _conflict _iteration]
+                      ;; Mock resolves the conflict by overwriting the
+                      ;; file with a clean merged version. A real LLM
+                      ;; agent would pick the actual content.
+                      (spit (str worktree "/src/conflict.txt")
+                            "from a\nfrom b\n")
+                      ;; Stage the fix so the resolution commit picks it up.
+                      (run-git! worktree "add" "src/conflict.txt")
+                      {:edits/applied 1})
+          ctx (-> (ctx-with-registry {:a {:branch "task-a"}
+                                      :b {:branch "task-b"}})
+                  (assoc :dag/resolution-overrides
+                         {:agent-edit-fn mock-edit}))
+          result (dag-orch/merge-parent-branches! ctx task-def)
+          data (:data result)]
+      (is (dag/ok? result)
+          "successful resolution returns dag/ok, not an anomaly")
+      (is (true? (:resolved? data))
+          ":resolved? observability flag set when success came via the
+           resolution loop (vs. direct merge)")
+      (is (pos-int? (:resolution-iterations data))
+          ":resolution-iterations carries through to the final result")
+      (is (str/starts-with? (:branch data) "refs/miniforge/dag-base/")
+          "the namespaced ref still names the merge base — downstream
+           tasks fork off this ref the same way they would for a
+           conflict-free merge")
+      (is (string? (:commit-sha data))
+          "the resolution commit's SHA is the new merge base"))))
+
 ;------------------------------------------------------------------------------ Tests: branch unresolvable
 
 (deftest unregistered-branch-falls-back-to-default-test

--- a/components/workflow/test/ai/miniforge/workflow/merge_resolution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_resolution_test.clj
@@ -212,7 +212,11 @@
                    :worktree-path *worktree*
                    :task-id "task-c"
                    :agent-edit-fn write-resolved-content!
-                   :verify-fn (constantly {:ok? false})
+                   ;; Use response/error so the loop's response/success?
+                   ;; check sees the failure, matching how a real
+                   ;; verify-fn (Stage 4) will signal a failed test run.
+                   :verify-fn (fn always-fails [_]
+                                (response/error "tests failed" nil))
                    :budget {:max-iterations 2 :stagnation-cap 2}})]
       (is (= :anomalies/dag-multi-parent-unresolvable
              (:anomaly/category result)))

--- a/components/workflow/test/ai/miniforge/workflow/merge_resolution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_resolution_test.clj
@@ -1,0 +1,261 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.merge-resolution-test
+  "Tests for the v2 multi-parent merge-resolution iteration loop.
+
+   Each test sets up a real git repo with an induced conflict, then
+   runs `resolve-conflict!` with a parameterized `agent-edit-fn` that
+   simulates what the real LLM-driven agent will do in Stage 2C —
+   resolve markers (success path) or do nothing (terminate path).
+   The curator and verify steps are exercised against the real
+   worktree state."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.response.interface :as response]
+   [ai.miniforge.workflow.merge-resolution :as sut]
+   [babashka.fs :as fs]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing use-fixtures]]))
+
+;------------------------------------------------------------------------------ Fixture: temp git repo with conflict
+
+(def ^:dynamic *repo* nil)
+(def ^:dynamic *worktree* nil)
+
+(defn- run-git! [cwd & args]
+  (let [r (apply shell/sh "git" "-C" cwd args)]
+    (when-not (zero? (:exit r))
+      (throw (ex-info (str "git " (str/join " " args) " failed: " (:err r))
+                      {:cwd cwd :args args :result r})))
+    r))
+
+(defn- write-file! [cwd path content]
+  (let [f (java.io.File. ^String cwd ^String path)]
+    (.mkdirs (.getParentFile f))
+    (spit f content)))
+
+(defn- commit-file! [cwd path content message]
+  (write-file! cwd path content)
+  (run-git! cwd "add" path)
+  (run-git! cwd "commit" "-m" message))
+
+(defn- conflict-fixture [f]
+  (let [host (str (fs/create-temp-dir {:prefix "mr-test-host-"}))]
+    (try
+      (run-git! host "init" "-b" "main")
+      (run-git! host "config" "user.email" "test@miniforge.ai")
+      (run-git! host "config" "user.name" "miniforge-test")
+      (run-git! host "config" "commit.gpgsign" "false")
+      (commit-file! host "README.md" "initial\n" "init")
+      ;; Two branches that conflict on the same file
+      (run-git! host "checkout" "-b" "task-a" "main")
+      (commit-file! host "src/conflict.txt" "from a\n" "a edit")
+      (run-git! host "checkout" "-b" "task-b" "main")
+      (commit-file! host "src/conflict.txt" "from b\n" "b edit")
+      (run-git! host "checkout" "main")
+      ;; Stage the merge worktree off task-a, attempt the merge — it
+      ;; will conflict, leaving markers in src/conflict.txt
+      (let [worktree (str (fs/create-temp-dir {:prefix "mr-test-worktree-"}))]
+        (try
+          (fs/delete-tree worktree)
+          (run-git! host "worktree" "add" "--detach" worktree "task-a")
+          (let [merge-r (shell/sh "git" "-C" worktree "merge" "-s" "ort"
+                                  "--no-edit" "--no-gpg-sign" "--no-verify"
+                                  "--no-ff" "-m" "induced-conflict" "task-b")]
+            ;; merge exits non-zero on conflict; that's expected — the
+            ;; worktree now has conflict markers in src/conflict.txt.
+            (assert (not (zero? (:exit merge-r)))
+                    "fixture setup expected merge to conflict"))
+          (binding [*repo* host *worktree* worktree]
+            (f))
+          (finally
+            (try (run-git! host "worktree" "remove" "--force" worktree)
+                 (catch Throwable _ nil))
+            (try (fs/delete-tree worktree) (catch Throwable _ nil)))))
+      (finally
+        (try (fs/delete-tree host) (catch Throwable _ nil))))))
+
+(use-fixtures :each conflict-fixture)
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- conflict-input
+  "Build the conflict-anomaly shape that resolve-conflict! expects."
+  []
+  {:task/id "task-c"
+   :merge/parents [{:task/id :a :branch "task-a" :commit-sha "a-sha" :order 0}
+                   {:task/id :b :branch "task-b" :commit-sha "b-sha" :order 1}]
+   :merge/strategy :git-merge
+   :merge/input-key "test-key"
+   :merge/conflicts [{:path "src/conflict.txt" :stages ["1" "2" "3"]}]})
+
+(defn- write-resolved-content!
+  "Helper: an agent-edit-fn that resolves the conflict by overwriting
+   the marker file with deterministic content. Mirrors what a real LLM
+   agent would do for a trivial conflict."
+  [worktree _conflict _iteration]
+  (write-file! worktree "src/conflict.txt"
+               "from a\nfrom b\n;; merged by mock agent\n")
+  (response/success {:edits/applied 1
+                     :edits/files ["src/conflict.txt"]}
+                    nil))
+
+;------------------------------------------------------------------------------ Tests: success path
+
+(deftest mock-agent-resolves-on-first-iteration-test
+  (testing "When the agent's edits clear the conflict markers and
+            verify passes, the loop returns dag/ok wrapping the
+            resolution commit's SHA. Verifies the integration-level
+            contract: agent fix → curator success → verify success →
+            commit lands → ok result."
+    (let [result (sut/resolve-conflict!
+                  {:conflict-input (conflict-input)
+                   :host-repo *repo*
+                   :worktree-path *worktree*
+                   :task-id "task-c"
+                   :agent-edit-fn write-resolved-content!})]
+      (is (dag/ok? result))
+      (let [data (:data result)]
+        (is (string? (:commit-sha data)))
+        (is (= 40 (count (:commit-sha data)))
+            "full-length git SHA")
+        (is (= 1 (:iterations data))
+            "first-iteration success")
+        (is (true? (:resolved? data)))))))
+
+;------------------------------------------------------------------------------ Tests: terminal anomalies
+
+(deftest no-op-stub-agent-recurring-conflict-test
+  (testing "With the default no-op stub agent, the curator finds the
+            same conflict path each iteration; recurring-conflict
+            fires on iteration 2 and the loop terminates. The
+            terminal anomaly carries :resolution/reason
+            :curator/recurring-conflict."
+    (let [result (sut/resolve-conflict!
+                  {:conflict-input (conflict-input)
+                   :host-repo *repo*
+                   :worktree-path *worktree*
+                   :task-id "task-c"
+                   ;; default agent-edit-fn = no-op-agent-edit-fn
+                   })]
+      (is (= :anomalies/dag-multi-parent-unresolvable
+             (:anomaly/category result)))
+      (is (= :curator/recurring-conflict
+             (:resolution/reason result))))))
+
+(deftest budget-exhausted-test
+  (testing "When the agent edits 'something' but never resolves the
+            conflict — and the conflict path set keeps shifting so
+            recurring-conflict doesn't fire — the loop runs to
+            budget exhaustion. Carries :resolution/reason
+            :budget-exhausted with iteration count equal to
+            :max-iterations.
+
+            The mock agent fixes the original conflict file but
+            introduces markers in a different newly-tracked file each
+            iteration. Since git grep only sees tracked files, the
+            agent must `git add` each new file for the curator scan
+            to detect it (this is also what a real LLM agent would
+            do — emit code via Edit/Write tools, then have the
+            agent loop run git add)."
+    (let [churn-fn
+          (fn [worktree _conflict iteration]
+            ;; Iteration 0 fixes the original conflict file (so its
+            ;; markers go away) but introduces markers in a new file.
+            ;; Iterations 1+ shift to new files (keeping path-set
+            ;; changing). All files are git-add'd so the scan sees them.
+            (write-file! worktree "src/conflict.txt" "fixed-by-mock\n")
+            (let [new-path (str "src/churn-" iteration ".txt")]
+              (write-file! worktree new-path
+                           "<<<<<<< a\nfoo\n=======\nbar\n>>>>>>> b\n")
+              (run-git! worktree "add" "src/conflict.txt" new-path))
+            (response/success nil nil))
+          result (sut/resolve-conflict!
+                  {:conflict-input (conflict-input)
+                   :host-repo *repo*
+                   :worktree-path *worktree*
+                   :task-id "task-c"
+                   :agent-edit-fn churn-fn
+                   :budget {:max-iterations 3 :stagnation-cap 2}})]
+      (is (= :anomalies/dag-multi-parent-unresolvable
+             (:anomaly/category result)))
+      (is (= :budget-exhausted (:resolution/reason result)))
+      (is (= 3 (:resolution/iterations result))
+          "iteration count matches the budget cap"))))
+
+(deftest verify-failure-counts-as-no-progress-test
+  (testing "When the agent clears markers but verify fails, the loop
+            doesn't immediately terminate — it tries again. With a
+            verify that always fails AND markers always cleared, the
+            loop reaches budget exhaustion (the recurring-conflict
+            path requires markers to remain)."
+    (let [result (sut/resolve-conflict!
+                  {:conflict-input (conflict-input)
+                   :host-repo *repo*
+                   :worktree-path *worktree*
+                   :task-id "task-c"
+                   :agent-edit-fn write-resolved-content!
+                   :verify-fn (constantly {:ok? false})
+                   :budget {:max-iterations 2 :stagnation-cap 2}})]
+      (is (= :anomalies/dag-multi-parent-unresolvable
+             (:anomaly/category result)))
+      (is (= :budget-exhausted (:resolution/reason result))))))
+
+;------------------------------------------------------------------------------ Tests: agent makes partial progress
+
+(deftest progress-then-stuck-test
+  (testing "An agent that makes progress on the first iteration but
+            then gets stuck still surfaces recurring-conflict — the
+            curator fires on the SECOND no-progress iteration, not
+            on the iteration that DID change the path set.
+
+            Iteration 1 fixes src/conflict.txt and introduces a
+            different conflicted file (src/new.txt, git-add'd so
+            git grep sees it). Iteration 2+ does nothing — same
+            path set as left behind ⇒ recurring."
+    (let [iteration (atom 0)
+          partial-fn (fn [worktree _conflict _i]
+                       (let [n (swap! iteration inc)]
+                         (when (= n 1)
+                           (write-file! worktree "src/conflict.txt"
+                                        "resolved\n")
+                           (write-file! worktree "src/new.txt"
+                                        "<<<<<<< a\nfoo\n=======\nbar\n>>>>>>> b\n")
+                           (run-git! worktree "add" "src/conflict.txt"
+                                     "src/new.txt"))
+                         (response/success nil nil)))
+          result (sut/resolve-conflict!
+                  {:conflict-input (conflict-input)
+                   :host-repo *repo*
+                   :worktree-path *worktree*
+                   :task-id "task-c"
+                   :agent-edit-fn partial-fn})]
+      (is (= :anomalies/dag-multi-parent-unresolvable
+             (:anomaly/category result)))
+      (is (= :curator/recurring-conflict
+             (:resolution/reason result))
+          "second iteration sees the same {src/new.txt} set as the
+           first iteration left behind ⇒ recurring"))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.workflow.merge-resolution-test)
+
+  :leave-this-here)


### PR DESCRIPTION
## Summary

Stage 2B of v2 multi-parent merge per [I-DAG-MULTI-PARENT-MERGE.md §6.1](https://github.com/miniforge-ai/miniforge/blob/main/specs/informative/I-DAG-MULTI-PARENT-MERGE.md). Adds the conflict-resolution iteration loop that the conflict path in `merge-parent-branches!` now spawns instead of returning the conflict anomaly directly. With Stage 2C's real LLM agent (deferred), conflicts will resolve end-to-end; Stage 2B ships the scaffolding + curator wiring + verify wiring + resolution commit on success, with a no-op stub agent that defers actual conflict resolution to 2C.

## What's in this PR

**`merge_resolution.clj`** (new) implements `resolve-conflict!`:
- Iteration loop per spec §6.1 / §10.6
- Default budget `{:max-iterations 5 :stagnation-cap 2}` (the stagnation-cap is the actionable lever per spec §10.6 — recurring-conflict catches stuck agents before budget exhaustion)
- Calls `agent/curate :merge-resolution` between iterations (Stage 2A's check pipeline)
- On `:curator/recurring-conflict` → terminal anomaly
- On curator success → run verify-fn → on pass, commit-resolution → return `dag/ok`
- On verify-fail → continue iterating until budget exhausts
- Defaults: `no-op-agent-edit-fn` (Stage 2C replaces) + `always-pass-verify-fn` (Stage 4 wires real `bb test`)

**Wiring in `dag_orchestrator.clj`**:
- New `attempt-resolution!` helper invokes the loop with the conflicted worktree from `run-merge!`
- `attempt-merge-with-cache!` no longer returns the conflict anomaly directly; it calls `attempt-resolution!` and either writes the resolution SHA to the namespaced ref (success) or surfaces the unresolvable anomaly (failure)
- New shared `write-ref-and-build-success` helper used by both the no-conflict happy path and the resolution-success path
- Tests can inject mocks via `:dag/resolution-overrides` on context

**Tests** (5 new in `merge_resolution_test.clj`, 14 assertions):
- Mock agent resolves on first iteration → `dag/ok`
- No-op stub agent → `:curator/recurring-conflict` terminal
- Budget-exhausted (agent churns through tracked files without converging)
- Verify-failure-counts-as-no-progress (always-fail verify hits budget-exhausted, not stuck-loop)
- Progress-then-stuck (curator fires recurring on the SECOND no-progress iteration)

Existing `conflict-surfaces-typed-anomaly-test` updated to assert the new contract — Stage 1B's `:dag-multi-parent-conflict` is now an internal step inside the loop.

**Catalog**: 4 new entries under `:dag.merge.resolution/*`. All messages routed through `workflow.messages/t`.

**Suite**: 5020 / 22942 / 0 / 0.

## Spec traceability

| Spec section | Implemented in this PR |
| ------------ | ---------------------- |
| §6.1 conflict path → resolution sub-workflow | `attempt-resolution!` + `resolve-conflict!` |
| §6.1.2 curator integration | `run-curator-check` calls `:merge-resolution` method |
| §6.1 `:dag-multi-parent-unresolvable` terminal | `unresolvable-anomaly` factory |
| §10.6 budget shape `{:max-iterations :stagnation-cap}` | `default-budget` |
| §7.2 namespaced ref idempotency | shared `write-ref-and-build-success` |

## What's NOT in this PR (deferred to Stage 2C)

- The real LLM-driven resolution agent. `no-op-agent-edit-fn` is the placeholder; conflicts effectively still terminate as unresolvable, just routed through the loop. Stage 2C replaces this with an implementer-style agent that reads conflict info, prompts an LLM, and edits the worktree.
- Real verify-fn wiring (Stage 4 connects `bb test` per spec §6.1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)