### PR TITLE
fix(llm): treat rate_limit_event + system init as stream heartbeats

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -202,9 +202,18 @@
             {:delta "" :done? false :tool-use true
              :tool-name tool-name})
 
-          ;; System and rate_limit_event are known no-ops
+          ;; System init and rate-limit notifications carry no content,
+          ;; but they ARE liveness signals from the CLI. While Claude is
+          ;; thinking on a heavy first turn (Opus on a multi-thousand-
+          ;; token planner prompt can take 30-60s before the first
+          ;; assistant chunk), `rate_limit_event` is often the only
+          ;; thing arriving on stdout. Treat both as heartbeats so the
+          ;; adaptive timeout doesn't fire on a model that's actively
+          ;; working — observed in the 2026-05-04 dogfood: 7 rate-limit
+          ;; events + 1 system init in 60s, stagnation killed the run
+          ;; with zero assistant output produced.
           ("system" "rate_limit_event")
-          nil
+          {:delta "" :done? false :heartbeat true}
 
           ;; Any other unrecognised event type — emit a heartbeat so the
           ;; stream stays alive during tool-heavy phases

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -131,14 +131,24 @@
   "Parse a line from Claude CLI streaming output.
 
    Claude CLI stream-json emits:
-   - {\"type\":\"system\"} — init event (ignored)
+   - {\"type\":\"system\"} — one-shot init event; parsed to a heartbeat
+     so it refreshes stream supervision once at session start
    - {\"type\":\"assistant\",\"message\":{\"content\":[{\"text\":\"...\"}]}} — content
-   - {\"type\":\"result\"} — final result with usage (ignored)
+   - {\"type\":\"tool_use\"} — tool invocation (carries :tool-use)
+   - {\"type\":\"rate_limit_event\"} — periodic liveness pulse from
+     the CLI; parsed to a heartbeat so it keeps the progress monitor
+     alive while the model is mid-think (no assistant chunks yet)
+   - {\"type\":\"result\"} — final usage / stop-reason envelope
+
+   Unrecognised event types also parse to a heartbeat — the stream
+   stays alive even when the CLI introduces new event shapes the
+   miniforge parser hasn't yet learned.
 
    Arguments:
      line - String line from stream
 
-   Returns: {:delta string :done? boolean} or nil"
+   Returns: {:delta string :done? boolean ...} or nil
+            (nil for blank lines or parse failures only)"
   [line]
   (try
     (when-not (str/blank? line)

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -191,7 +191,30 @@
     (let [line (json/generate-string {:type "system" :subtype "init"})
           parsed (impl/parse-claude-stream-line line)]
       (is (true? (:heartbeat parsed))
-          "system init refreshes liveness once at the start of the stream"))))
+          "system init refreshes liveness once at the start of the stream")
+      (is (false? (:done? parsed))))))
+
+(deftest record-parsed-progress-heartbeat-liveness-test
+  (testing "heartbeat-only Claude stream events are recorded as activity"
+    ;; This guards the production regression path more directly than the
+    ;; parser-shape test above: if parsing still succeeds but progress
+    ;; supervision stops treating heartbeats as activity, these assertions
+    ;; fail and catch the 60s false-timeout behavior.
+    (doseq [[label line] [["rate_limit_event"
+                           (json/generate-string
+                            {:type "rate_limit_event"
+                             :rate_limit_info {:status "allowed"}})]
+                          ["system/init"
+                           (json/generate-string
+                            {:type "system" :subtype "init"})]]]
+      (let [parsed (impl/parse-claude-stream-line line)
+            monitor (atom {})
+            before @monitor]
+        (is (true? (:heartbeat parsed))
+            (str label " should parse as a heartbeat prerequisite"))
+        (impl/record-parsed-progress! monitor parsed)
+        (is (not= before @monitor)
+            (str label " heartbeat must advance progress supervision state"))))))
 
 (deftest parse-claude-stream-assistant-stop-reason-test
   (testing "assistant message with text carries stop_reason"

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -170,6 +170,29 @@
       (is (= 42 (:num-turns parsed)))
       (is (= "max_turns" (:stop-reason parsed))))))
 
+(deftest parse-claude-stream-liveness-event-test
+  (testing "rate_limit_event parses as a heartbeat — keeps stream supervision alive"
+    ;; 2026-05-04 dogfood regression: parse-claude-stream-line returned nil
+    ;; for rate_limit_event, so 60s of 'allowed' rate-limit notifications
+    ;; (the only thing the CLI emits while Opus thinks on a heavy first
+    ;; turn) refreshed nothing and stagnation killed an actively-working
+    ;; planner with zero assistant output produced.
+    (let [line (json/generate-string
+                 {:type "rate_limit_event"
+                  :rate_limit_info {:status "allowed"}})
+          parsed (impl/parse-claude-stream-line line)]
+      (is (some? parsed)
+          "rate_limit_event must not parse to nil")
+      (is (true? (:heartbeat parsed))
+          "rate_limit_event must be a heartbeat so the progress monitor refreshes")
+      (is (false? (:done? parsed)))))
+
+  (testing "system init event parses as a heartbeat"
+    (let [line (json/generate-string {:type "system" :subtype "init"})
+          parsed (impl/parse-claude-stream-line line)]
+      (is (true? (:heartbeat parsed))
+          "system init refreshes liveness once at the start of the stream"))))
+
 (deftest parse-claude-stream-assistant-stop-reason-test
   (testing "assistant message with text carries stop_reason"
     (let [line (json/generate-string

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -691,6 +691,50 @@
       (is (= "" @accumulated-content))
       (is (= 1 (count @chunks))))))
 
+(deftest stream-with-parser-records-liveness-progress-test
+  ;; 2026-05-04 dogfood regression — Claude emits rate_limit_event
+  ;; while the model is mid-think (no assistant chunks yet). PR #774
+  ;; mapped these to nil, so they did not advance the activity
+  ;; timestamp. Adaptive stagnation killed the planner at 60s with
+  ;; zero output. This integration test exercises the same
+  ;; stream-with-parser path as production and verifies the activity
+  ;; timestamp moves forward — a parser-shape-only test cannot prove
+  ;; the supervisor actually got the heartbeat.
+  (let [setup (fn []
+                (let [monitor (pm/create-progress-monitor
+                               {:stagnation-threshold-ms 1000
+                                :max-total-ms 1000
+                                :min-activity-interval-ms 1})
+                      parse-line (:stream-parser (get impl/backends :claude))
+                      on-line (impl/stream-with-parser parse-line
+                                                       (fn [_] nil)
+                                                       monitor
+                                                       (atom "")
+                                                       (atom nil)
+                                                       (atom nil)
+                                                       (atom [])
+                                                       (atom nil)
+                                                       (atom nil)
+                                                       (atom nil))]
+                  {:monitor monitor :on-line on-line}))]
+    (testing "rate_limit_event advances the supervisor's activity timestamp"
+      (let [{:keys [monitor on-line]} (setup)
+            before (:last-activity-at @monitor)]
+        (Thread/sleep 5)
+        (on-line (json/generate-string
+                   {:type "rate_limit_event"
+                    :rate_limit_info {:status "allowed"}}))
+        (is (< before (:last-activity-at @monitor))
+            "rate_limit_event must keep the progress monitor alive")))
+
+    (testing "system init event advances the supervisor's activity timestamp"
+      (let [{:keys [monitor on-line]} (setup)
+            before (:last-activity-at @monitor)]
+        (Thread/sleep 5)
+        (on-line (json/generate-string {:type "system" :subtype "init"}))
+        (is (< before (:last-activity-at @monitor))
+            "system init must refresh liveness once at stream start")))))
+
 (deftest message-preview-via-streaming-success-test
   (testing "short content is returned in full as preview"
     (let [short-content "short response"


### PR DESCRIPTION
## Summary

- Changes \`parse-claude-stream-line\` to return \`{:heartbeat true}\` for \`type=\"system\"\` and \`type=\"rate_limit_event\"\` instead of \`nil\`. Both are legitimate liveness signals from the Claude CLI; PR #774 over-excluded them.
- Adds regression coverage for both cases in \`interface_test.clj\`.

## Why

The 2026-05-04 \`event-log-tool-visibility\` dogfood (run on \`main\` after PRs #767 + #774) stalled in \`:plan\` at exactly 60s with adaptive stagnation, **zero assistant output produced**. Run-log dump:

- 1 \`system\` init event (\"connected to context MCP\", \`permissionMode=default\`, model = \`claude-opus-4-6\`)
- 7 \`rate_limit_event\` events (\`status=\"allowed\"\`)
- 0 \`assistant\` events
- 0 \`tool_use\` events
- Total cost: \`\$0.0000\`

Opus on a multi-thousand-token planner prompt can take 30–60s before the first \`assistant\` chunk lands. While it thinks, the CLI keeps emitting \`rate_limit_event\` (typically every 5–10s) — and pre-#774 those raw stdout lines refreshed the progress monitor by virtue of being any output at all. PR #774 swapped to parsed-semantic-progress and explicitly mapped \`rate_limit_event\` and \`system\` to \`nil\`, so they stopped contributing to the monitor. Result: actively-thinking models get killed before producing their first chunk.

## Test plan

- [x] \`bb test\` — 5016 tests, 0 failures, 0 errors (2 new assertions covering rate_limit_event + system init)
- [ ] Re-run the \`event-log-tool-visibility\` dogfood — expected: planner advances past 60s, produces tool calls / assistant deltas, no false stagnation

## Stack

Stacks on PR #774. The mistake there was treating \`rate_limit_event\` as semantically empty; it's empty *of content* but it is *not* empty *of liveness*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)