### PR TITLE
fix(planner): bump stagnation threshold for heavy first-turn prompts

### DIFF
--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -15,13 +15,20 @@
  ;; work/n07-opsv-agent-budgets.spec.edn.
  :prompt/max-turns 80
 
- ;; Main-turn progress monitor. Planner runs should converge quickly
- ;; once exploration is done. A shorter hard limit keeps us from
- ;; burning a full 10+ minutes after the model has gathered enough
- ;; context but failed to submit the plan.
+ ;; Main-turn progress monitor. The planner sees a user prompt that
+ ;; embeds the spec PLUS the explore phase's existing-files section —
+ ;; on real specs that's typically 100k+ tokens. Opus on a 100k-token
+ ;; first turn empirically takes 90-180s to emit its first assistant
+ ;; chunk; while it's thinking the Claude CLI emits one rate_limit_event
+ ;; early in the stream and then nothing more until tokens come back.
+ ;; The 60s stagnation threshold this used to carry fired BEFORE the
+ ;; model had any chance to respond on the event-log-tool-visibility
+ ;; dogfood (2026-05-04, run5: 0 tokens, 0 cost, killed at 60s).
+ ;; 180s gives Opus room for its pre-first-chunk think; 600s overall
+ ;; covers the longest historical successful planner run (6.6m).
  :prompt/progress-monitor
- {:stagnation-threshold-ms     60000
-  :max-total-ms                240000
+ {:stagnation-threshold-ms     180000
+  :max-total-ms                600000
   :min-activity-interval-ms    3000}
 
  ;; Submission-retry runs after the main planner turn already produced

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -493,6 +493,67 @@
                  (:disallowed-tools @captured))
               ":disallowed-tools opt must equal the planner's role-scoped list"))))))
 
+(deftest planner-progress-monitor-thresholds-loaded-test
+  ;; Guards the 2026-05-04 stagnation-threshold fix at the planner
+  ;; boundary: a regression in prompt loading or
+  ;; create-planner-progress-monitor would otherwise let the threshold
+  ;; values silently drift back to a too-tight default. Asserts the
+  ;; loaded :progress-monitor opt carries the resources/prompts/planner.edn
+  ;; values that give Opus room to think on heavy first turns.
+  (testing ":progress-monitor passed to LLM reflects planner.edn thresholds"
+    (let [captured (atom nil)
+          fake-llm-client {:type :fake}
+          fake-plan {:plan/id (random-uuid)
+                     :plan/name "stub"
+                     :plan/tasks [{:task/id (random-uuid)
+                                   :task/description "t"
+                                   :task/type :implement
+                                   :task/acceptance-criteria ["ok"]
+                                   :task/estimated-effort :small}]}]
+      (with-redefs [llm/success? (constantly true)
+                    llm/get-content (constantly (str "```clojure\n"
+                                                     (pr-str fake-plan)
+                                                     "\n```"))
+                    llm/chat (fn [_client _prompt opts]
+                               (reset! captured opts)
+                               {:status :success})
+                    llm/chat-stream (fn [_client _prompt _on-chunk opts]
+                                      (reset! captured opts)
+                                      {:status :success})
+                    model/resolve-llm-client-for-role
+                    (fn [_role provided] provided)
+                    artifact-session/with-session
+                    (fn [_context body-fn]
+                      (let [result (body-fn {:dir "/tmp/fake-session"
+                                             :workdir "/tmp/fake-workdir"
+                                             :mcp-config-path "/tmp/fake-session/mcp-config.json"
+                                             :mcp-allowed-tools []
+                                             :supervision {}
+                                             :pre-session-snapshot {}})]
+                        {:llm-result result
+                         :artifact nil
+                         :worktree-artifacts {}
+                         :context-misses nil
+                         :pre-session-snapshot {}
+                         :session-mode :host}))]
+        (let [agent (planner/create-planner {:llm-backend fake-llm-client})]
+          (try
+            (core/invoke agent {:llm-backend fake-llm-client
+                                :title "t"
+                                :description "t"
+                                :intent "t"}
+                         "build a thing")
+            (catch Exception _))
+          (is (some? @captured) "LLM client should have been called")
+          (let [monitor (:progress-monitor @captured)]
+            (is (some? monitor)
+                ":progress-monitor opt must reach the LLM client")
+            (let [state @monitor]
+              (is (>= (:stagnation-threshold-ms state) 180000)
+                  "Stagnation threshold must be ≥180s — Opus needs room for the pre-first-chunk think on heavy planner prompts")
+              (is (>= (:max-total-ms state) 600000)
+                  "Total budget must be ≥10min — covers the longest historical successful planner run"))))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.agent.planner-test)

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -211,13 +211,20 @@
             monitor (pm/create-progress-monitor {:stagnation-threshold-ms 1000
                                                  :max-total-ms 1000
                                                  :min-activity-interval-ms 1})
-            before @monitor]
+            before-ts (:last-activity-at @monitor)]
         (is (true? (:heartbeat parsed))
             (str label " should parse as a heartbeat prerequisite"))
         (Thread/sleep 5)
         (#'impl/record-parsed-progress! monitor parsed (atom ""))
-        (is (not= before @monitor)
-            (str label " heartbeat must advance progress supervision state"))))))
+        ;; Specifically assert the activity timestamp moved — a weaker
+        ;; (not= before @monitor) check passes even if heartbeats stop
+        ;; refreshing :last-activity-at (e.g. if the code regresses to
+        ;; record-chunk! which mutates other fields without updating
+        ;; the timestamp the stagnation timer reads).
+        (is (< before-ts (:last-activity-at @monitor))
+            (str label " heartbeat must advance :last-activity-at"))
+        (is (nil? (pm/check-timeout monitor))
+            (str label " heartbeat must keep monitor below stagnation threshold"))))))
 
 (deftest parse-claude-stream-assistant-stop-reason-test
   (testing "assistant message with text carries stop_reason"

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -208,11 +208,14 @@
                            (json/generate-string
                             {:type "system" :subtype "init"})]]]
       (let [parsed (impl/parse-claude-stream-line line)
-            monitor (atom {})
+            monitor (pm/create-progress-monitor {:stagnation-threshold-ms 1000
+                                                 :max-total-ms 1000
+                                                 :min-activity-interval-ms 1})
             before @monitor]
         (is (true? (:heartbeat parsed))
             (str label " should parse as a heartbeat prerequisite"))
-        (impl/record-parsed-progress! monitor parsed)
+        (Thread/sleep 5)
+        (#'impl/record-parsed-progress! monitor parsed (atom ""))
         (is (not= before @monitor)
             (str label " heartbeat must advance progress supervision state"))))))
 


### PR DESCRIPTION
## Summary

- Raises the planner's main-turn `:stagnation-threshold-ms` from 60s → 180s
- Raises `:max-total-ms` from 4m → 10m
- Fixes a pre-existing test failure in `record-parsed-progress-heartbeat-liveness-test` (private fn called with wrong arity + uninitialized monitor map)

## Why

PR #779 made `system` and `rate_limit_event` parse to heartbeats so they refresh the supervisor. That fix is correct but insufficient on its own. The 2026-05-04 `event-log-tool-visibility` dogfood (run5, post-#779 merge) still stagnated at 60s with **zero tokens generated**.

I captured the live planner spawn command via a wrapper around `/Users/chris/.local/bin/claude` and replayed it against the binary directly (no miniforge in the loop):

- system prompt: 12,814 chars (planner role prompt)
- user prompt: **395,810 chars** (spec text + explore phase's existing-files section, ≈ 100k tokens)
- flags: `--output-format stream-json --verbose --mcp-config <path> --allowedTools mcp__context__*,Write,Edit,MultiEdit --disallowedTools Read,Bash,Grep,Glob,Agent,LS --settings <path> --max-budget-usd 5.0 --max-turns 80 --model claude-opus-4-6`

Observed event timeline against this prompt:

- T~0s: `system` init lands
- T~10s: one `rate_limit_event` lands ("allowed", five_hour window)
- T~90-180s: **first `assistant` chunk arrives**

Between the rate_limit_event and the first assistant chunk, the CLI emits nothing on stdout — the model is busy on its pre-first-chunk think. With #779's heartbeat fix, the rate_limit_event refreshes activity at T~10s. With `:stagnation-threshold-ms 60000`, supervision then fires at T~70s — well before the model can respond. Run5 confirmed: `:elapsed-ms 60210, :chunks 2, :unique-chunks 1, :stagnant-cycles 0`.

180s gives Opus room to complete its think on a 100k-token prompt. 600s overall covers the longest historical successful planner run (yesterday's 6.6m).

## Test plan

- [x] `bb test` — 5018 tests, 0 failures, 0 errors
- [ ] Re-run `event-log-tool-visibility` dogfood — expected: planner advances past 60s, produces assistant chunks / tool_use, plan.edn written

## Stack

Stacks on PR #779. Together they restore the planner's ability to think through heavy prompts without the supervisor killing it prematurely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)