### PR TITLE
fix(llm): bump stream line-timeout for heavy first-turn prompts

### DIFF
--- a/components/llm/resources/llm/client-defaults.edn
+++ b/components/llm/resources/llm/client-defaults.edn
@@ -5,7 +5,16 @@
  {:default-stagnation-threshold-ms 120000
   :default-max-total-ms 600000
   :default-min-activity-interval-ms 5000
-  :line-timeout-ms 180000
+  ;; Hard "no stdout line at all" timeout. Distinct from stagnation:
+  ;; stagnation tracks meaningful progress (parsed events that refresh
+  ;; activity), while line-timeout fires whenever stdout is empty for
+  ;; this long regardless of what the parser would have done with the
+  ;; line. Opus on a 100k-token first-turn prompt empirically goes
+  ;; silent on stdout for 180-300s after the initial system+rate_limit
+  ;; pair (next line is the first assistant chunk). 180s used to fire
+  ;; before the model could emit anything (event-log-tool-visibility
+  ;; dogfood, 2026-05-04). 360s gives long planner first turns room.
+  :line-timeout-ms 360000
   :process-join-timeout-ms 600000
   :post-kill-join-timeout-ms 5000
   :poll-interval-ms 250}}


### PR DESCRIPTION
## Summary

Raises `:line-timeout-ms` in `components/llm/resources/llm/client-defaults.edn` from 180000 → 360000 (3min → 6min). Distinct from PR #781's `:stagnation-threshold-ms` bump — they guard different things.

## Why

Two layered timeouts on the Claude streaming path:

1. **`:stagnation-threshold-ms`** — tracks *parsed semantic activity*. Refreshed when `parse-claude-stream-line` returns a chunk that calls `record-activity!`. PR #779 made `system` init + `rate_limit_event` parse as heartbeats; PR #781 bumped this to 180s.
2. **`:line-timeout-ms`** — tracks *raw stdout lines*. Fires when no stdout line arrives for this long, regardless of what the parser would do with the line.

Both can fire. The 2026-05-04 dogfood (post #779 + #781 merged) cleared the stagnation barrier (planner ran 4.1m vs prior 60s) but tripped the older `:line-timeout-ms` 180000:

```
Adaptive timeout: No stream output for 180000ms (type: stream-idle, elapsed: 180196ms)
```

Empirical timeline from the live planner spawn (Opus 4.6, 100k-token user prompt, full system prompt, MCP + settings hook):

- T~0s — `system` init lands
- T~10s — one `rate_limit_event` lands
- T 10–? — stdout silent while the API streams nothing
- T 90–300s+ — first `assistant` chunk arrives

The window between the `rate_limit_event` at T~10s and the first assistant chunk is the line-timeout window. With the 100k-token prompt the dogfood actually sends, that gap is consistently > 180s.

360s gives Opus's pre-first-chunk think enough room. `:max-total-ms` (10m) still caps the absolute upper bound, and `:stagnation-threshold-ms` still catches "model emitted output then went silent" regressions.

## Test plan

- [x] `bb test` — 5025 tests, 0 failures, 0 errors
- [ ] Re-run `event-log-tool-visibility` dogfood — expected: planner produces assistant chunks, writes plan.edn

## Stack

Stacks on PR #781. Together with #779 these restore the planner's ability to think through heavy first-turn prompts without any of the three layered guards (stagnation / line-idle / max-total) firing prematurely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)