### PR TITLE
fix(reviewer): wire :prompt/progress-monitor + bump stagnation threshold

### DIFF
--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -6,8 +6,22 @@
 ;; and error handling.
 
 {:prompt/id :reviewer
- :prompt/version "1.0.0"
+ :prompt/version "1.1.0"
  :prompt/agent :reviewer
+
+ ;; Main-turn progress monitor. The reviewer sees the full implement
+ ;; artifact (often 8+ files of newly-created or modified source) plus
+ ;; the spec; on real planner-decomposed tasks that's typically a 50-
+ ;; 100k-token first turn. Opus then does heavy Read/Grep before
+ ;; emitting structured EDN. The framework's 120s default was firing
+ ;; mid-think on the 2026-05-04 event-log-tool-visibility dogfood
+ ;; (review #1: 4/4 gates passed but :rejected with the only blocking
+ ;; issue being "Stagnation timeout: no progress for 120119ms"). 180s
+ ;; matches the planner threshold; 600s overall covers heavy reviews.
+ :prompt/progress-monitor
+ {:stagnation-threshold-ms     180000
+  :max-total-ms                600000
+  :min-activity-interval-ms    3000}
 
  :prompt/system
  "You are a Code Review Agent for an autonomous software development team.

--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -6,8 +6,15 @@
 ;; and error handling.
 
 {:prompt/id :reviewer
- :prompt/version "1.1.0"
+ :prompt/version "1.2.0"
  :prompt/agent :reviewer
+
+ ;; Turn cap for the reviewer's main session. Reviewer reads the
+ ;; implement artifact + spec, runs Read/Grep, and emits one
+ ;; structured EDN review — much shorter agentic loop than planner
+ ;; (80) or implementer (40). 20 is the empirical observed ceiling
+ ;; on the 2026-05-04 event-log-tool-visibility dogfood.
+ :prompt/max-turns 20
 
  ;; Main-turn progress monitor. The reviewer sees the full implement
  ;; artifact (often 8+ files of newly-created or modified source) plus

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -421,8 +421,8 @@
   "Planner main-turn progress monitor. Thresholds live in
    resources/prompts/planner.edn (:prompt/progress-monitor)."
   []
-  (llm/create-progress-monitor
-   (get @planner-prompt-data :prompt/progress-monitor)))
+  (prompts/load-progress-monitor @planner-prompt-data
+                                 :prompt/progress-monitor))
 
 (defn- invoke-planner-session
   "Session body for the planner: build mcp-opts with model hint, call LLM."
@@ -494,8 +494,8 @@
   (let [prompt-data    @planner-prompt-data
         budget-usd     (budget/resolve-cost-budget-usd :planner config context)
         retry-max-turns (get prompt-data :prompt/submission-retry-max-turns)
-        retry-monitor  (llm/create-progress-monitor
-                        (get prompt-data :prompt/submission-retry-monitor))
+        retry-monitor  (prompts/load-progress-monitor
+                        prompt-data :prompt/submission-retry-monitor)
         mcp-opts       (cond-> (artifact-session/session->mcp-opts session budget-usd retry-max-turns)
                          true (assoc :model (model/default-model-for-role :planner)
                                      :disallowed-tools planner-disallowed-tools

--- a/components/agent/src/ai/miniforge/agent/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/prompts.clj
@@ -20,6 +20,7 @@
   "Agent prompt loading utilities.
    Loads system prompts from EDN resources for configurability."
   (:require
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
@@ -72,6 +73,29 @@
                                 {:agent-type agent-type
                                  :resource-path resource-path}))))
 
+;------------------------------------------------------------------------------ Layer 1
+;; Progress-monitor factory
+
+(defn load-progress-monitor
+  "Build a progress monitor from a prompt-data map's monitor-config
+   key. Returns nil when the key is absent so callers can `cond->`
+   the option onto LLM opts only when configured.
+
+   Single source of truth for the EDN → llm/create-progress-monitor
+   adapter; planner and reviewer call this rather than each rolling
+   their own factory.
+
+   Arguments:
+     prompt-data  - map returned by load-prompt-data
+     monitor-key  - keyword pointing at the monitor config block
+                    (e.g. :prompt/progress-monitor,
+                          :prompt/submission-retry-monitor)
+
+   Returns: progress-monitor atom, or nil when block is absent."
+  [prompt-data monitor-key]
+  (when-let [config (get prompt-data monitor-key)]
+    (llm/create-progress-monitor config)))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (load-prompt :implementer)
@@ -79,4 +103,6 @@
   (load-prompt :planner)
   (load-prompt :releaser)
   (load-prompt-data :implementer)
+  (load-progress-monitor (load-prompt-data :reviewer)
+                         :prompt/progress-monitor)
   :leave-this-here)

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -78,6 +78,19 @@
   "System prompt for the reviewer agent."
   (delay (prompts/load-prompt :reviewer)))
 
+(def ^:private reviewer-prompt-data
+  "Full prompt data map for the reviewer agent.
+   Exposes knobs like :prompt/progress-monitor that gate stream supervision."
+  (delay (prompts/load-prompt-data :reviewer)))
+
+(defn- create-reviewer-progress-monitor
+  "Reviewer main-turn progress monitor. Thresholds live in
+   resources/prompts/reviewer.edn (:prompt/progress-monitor). Falls
+   back to the framework default when the EDN omits the block."
+  []
+  (when-let [config (get @reviewer-prompt-data :prompt/progress-monitor)]
+    (llm/create-progress-monitor config)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Gate running and feedback
 
@@ -582,13 +595,14 @@
           (if llm-client
             ;; LLM + gates review
             (let [user-prompt (build-review-prompt input)
+                  monitor (create-reviewer-progress-monitor)
+                  base-opts (cond-> {:system @reviewer-system-prompt
+                                     :max-turns 20}
+                              monitor (assoc :progress-monitor monitor))
                   response (if on-chunk
                              (llm/chat-stream llm-client user-prompt on-chunk
-                                              {:system @reviewer-system-prompt
-                                               :max-turns 20})
-                             (llm/chat llm-client user-prompt
-                                       {:system @reviewer-system-prompt
-                                        :max-turns 20}))
+                                              base-opts)
+                             (llm/chat llm-client user-prompt base-opts))
                   content (or (llm/get-content response) "")
                   tokens (get response :tokens 0)
                   cost-usd (get response :cost-usd)]

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -88,8 +88,14 @@
    resources/prompts/reviewer.edn (:prompt/progress-monitor). Falls
    back to the framework default when the EDN omits the block."
   []
-  (when-let [config (get @reviewer-prompt-data :prompt/progress-monitor)]
-    (llm/create-progress-monitor config)))
+  (prompts/load-progress-monitor @reviewer-prompt-data
+                                 :prompt/progress-monitor))
+
+(def ^:private default-reviewer-max-turns
+  "Fallback when reviewer.edn omits :prompt/max-turns. Authority is
+   the EDN; this constant only protects against malformed prompt
+   resources."
+  20)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Gate running and feedback
@@ -596,8 +602,11 @@
             ;; LLM + gates review
             (let [user-prompt (build-review-prompt input)
                   monitor (create-reviewer-progress-monitor)
+                  max-turns (get @reviewer-prompt-data
+                                 :prompt/max-turns
+                                 default-reviewer-max-turns)
                   base-opts (cond-> {:system @reviewer-system-prompt
-                                     :max-turns 20}
+                                     :max-turns max-turns}
                               monitor (assoc :progress-monitor monitor))
                   response (if on-chunk
                              (llm/chat-stream llm-client user-prompt on-chunk

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -28,6 +28,20 @@
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.logging.interface :as log]))
 
+;------------------------------------------------------------------------------ Regression-floor constants
+
+(def ^:private min-stagnation-threshold-ms
+  "Floor for the planner main-turn :stagnation-threshold-ms. Below
+   this, Opus's pre-first-chunk think on heavy planner prompts trips
+   stagnation before the first structured-EDN chunk lands. This is the
+   regression floor PR #781 establishes."
+  180000)
+
+(def ^:private min-total-budget-ms
+  "Floor for the planner main-turn :max-total-ms. Covers the longest
+   historical successful planner run."
+  600000)
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
 
@@ -549,10 +563,11 @@
             (is (some? monitor)
                 ":progress-monitor opt must reach the LLM client")
             (let [state @monitor]
-              (is (>= (:stagnation-threshold-ms state) 180000)
-                  "Stagnation threshold must be ≥180s — Opus needs room for the pre-first-chunk think on heavy planner prompts")
-              (is (>= (:max-total-ms state) 600000)
-                  "Total budget must be ≥10min — covers the longest historical successful planner run"))))))))
+              (is (>= (:stagnation-threshold-ms state)
+                      min-stagnation-threshold-ms)
+                  "Stagnation threshold must be ≥ min-stagnation-threshold-ms — Opus needs room for the pre-first-chunk think on heavy planner prompts")
+              (is (>= (:max-total-ms state) min-total-budget-ms)
+                  "Total budget must be ≥ min-total-budget-ms — covers the longest historical successful planner run"))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -515,3 +515,45 @@
                {:review/issues [blocking-issue-b]})]
       (is (false? (boolean (reviewer/stagnated? fp1 fp2)))
           "one issue resolved between iterations is real progress"))))
+
+(deftest reviewer-progress-monitor-thresholds-loaded-test
+  ;; Guards the 2026-05-04 reviewer stagnation-threshold fix at the
+  ;; reviewer boundary: a regression in prompt loading or
+  ;; create-reviewer-progress-monitor would otherwise let the threshold
+  ;; values silently drift back to the framework default 120s and
+  ;; reintroduce the false-stagnation rejection that PR #783 fixes.
+  ;; Mirrors planner-progress-monitor-thresholds-loaded-test in
+  ;; planner_test.clj (Copilot review on PR #783 called for parity).
+  (testing ":progress-monitor passed to LLM reflects reviewer.edn thresholds"
+    (let [captured (atom nil)
+          parseable-review (str "```clojure\n"
+                                "{:review/decision :approved\n"
+                                " :review/summary \"ok\"}\n"
+                                "```")]
+      (with-redefs [model/resolve-llm-client-for-role
+                    (fn [_role provided] provided)
+                    llm/chat (fn [_client _prompt opts]
+                               (reset! captured opts)
+                               {:success? true
+                                :content parseable-review
+                                :tokens 1})
+                    llm/chat-stream (fn [_client _prompt _on-chunk opts]
+                                      (reset! captured opts)
+                                      {:success? true
+                                       :content parseable-review
+                                       :tokens 1})
+                    llm/success? :success?
+                    llm/get-content :content]
+        (let [reviewer (reviewer/create-reviewer
+                        {:llm-backend ::mock-backend
+                         :gates       []})]
+          (core/invoke reviewer {} sample-artifact)
+          (is (some? @captured) "LLM client should have been called")
+          (let [monitor (:progress-monitor @captured)]
+            (is (some? monitor)
+                ":progress-monitor opt must reach the LLM client")
+            (let [state @monitor]
+              (is (>= (:stagnation-threshold-ms state) 180000)
+                  "Stagnation threshold must be ≥180s — Opus needs room for the pre-first-chunk think on heavy review prompts (8+ files, 50–100k tokens)")
+              (is (>= (:max-total-ms state) 600000)
+                  "Total budget must be ≥10min — covers heavy reviews"))))))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -27,6 +27,22 @@
    [ai.miniforge.loop.interface :as loop]
    [ai.miniforge.response.interface :as response]))
 
+;------------------------------------------------------------------------------ Regression-floor constants
+
+(def ^:private min-stagnation-threshold-ms
+  "Floor for the reviewer main-turn :stagnation-threshold-ms. Below this,
+   Opus's pre-first-chunk think on heavy review prompts (8+ files,
+   50–100k tokens) trips stagnation before the first structured-EDN
+   chunk lands. This is the regression floor PR #783 establishes; a
+   future drop below it would reintroduce the false-stagnation
+   rejection observed on the 2026-05-04 dogfood."
+  180000)
+
+(def ^:private min-total-budget-ms
+  "Floor for the reviewer main-turn :max-total-ms. Below this, long
+   but legitimate reviews are killed mid-turn."
+  600000)
+
 ;------------------------------------------------------------------------------ Test fixtures
 
 (defn passing-gate
@@ -553,7 +569,8 @@
             (is (some? monitor)
                 ":progress-monitor opt must reach the LLM client")
             (let [state @monitor]
-              (is (>= (:stagnation-threshold-ms state) 180000)
-                  "Stagnation threshold must be ≥180s — Opus needs room for the pre-first-chunk think on heavy review prompts (8+ files, 50–100k tokens)")
-              (is (>= (:max-total-ms state) 600000)
-                  "Total budget must be ≥10min — covers heavy reviews"))))))))
+              (is (>= (:stagnation-threshold-ms state)
+                      min-stagnation-threshold-ms)
+                  "Stagnation threshold must be ≥ min-stagnation-threshold-ms — Opus needs room for the pre-first-chunk think on heavy review prompts (8+ files, 50–100k tokens)")
+              (is (>= (:max-total-ms state) min-total-budget-ms)
+                  "Total budget must be ≥ min-total-budget-ms — covers heavy reviews"))))))))

--- a/components/progress-detector/deps.edn
+++ b/components/progress-detector/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+ :deps {metosin/malli            {:mvn/version "0.16.4"}
+        ai.miniforge/anomaly     {:local/root "../anomaly"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/progress-detector/src/ai/miniforge/progress_detector/config.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/config.clj
@@ -1,0 +1,246 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.progress-detector.config
+  "Detector config merge semantics — overlay resolution.
+
+   Config layers are resolved top-down. Each layer may declare a
+   :config/directive to control how it interacts with layers above it:
+
+     :inherit  - take parent value unchanged; this layer adds nothing
+     :disable  - suppress the detector; all other keys in this layer ignored
+     :enable   - force-enable even when parent has :disable
+     :tune     - deep-merge this layer's :config/params onto parent defaults
+
+   Resolution is transitive: layers are applied left-to-right (outermost →
+   innermost). The first :disable wins unless a later layer has :enable.
+
+   Public API:
+     merge-config      - resolve a sequence of overlay layers into final config
+     apply-directive   - apply one overlay layer onto an accumulated config
+     enabled?          - return true if resolved config enables the detector
+     effective-params  - extract merged :config/params map from resolved config"
+  )
+
+;------------------------------------------------------------------------------ Layer 0
+;; Directive resolution
+
+(def ^:private directive-precedence
+  "Ordered list from lowest to highest priority within a single overlay step.
+   Used to sanity-check overlay intent; resolution itself is positional."
+  [:inherit :tune :enable :disable])
+
+(defn- resolve-directive
+  "Normalize the directive from a config overlay layer.
+   Returns :inherit if no directive declared."
+  [layer]
+  (get layer :config/directive :inherit))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Deep-merge helper
+
+(defn- deep-merge
+  "Recursively merge maps. Non-map values in `b` overwrite `a`."
+  [a b]
+  (if (and (map? a) (map? b))
+    (merge-with deep-merge a b)
+    b))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Single-layer overlay application
+
+(defn apply-directive
+  "Apply one overlay `layer` onto `accumulated` config.
+
+   Directive semantics:
+     :inherit - return accumulated unchanged
+     :disable - mark accumulated as disabled (set :detector/enabled? false)
+     :enable  - re-enable accumulated (set :detector/enabled? true)
+     :tune    - deep-merge layer's :config/params into accumulated :config/params
+
+   The :detector/enabled? flag propagates through subsequent layers.
+
+   Arguments:
+     accumulated - current resolved config map
+     layer       - overlay map with optional :config/directive and :config/params
+
+   Returns: New config map with overlay applied."
+  [accumulated layer]
+  (let [directive (resolve-directive layer)
+        params    (get layer :config/params {})]
+    (case directive
+      :inherit
+      accumulated
+
+      :disable
+      (assoc accumulated :detector/enabled? false)
+
+      :enable
+      (assoc accumulated :detector/enabled? true)
+
+      :tune
+      (-> accumulated
+          (update :config/params deep-merge params)
+          ;; :tune does not affect enabled? unless explicitly set
+          (cond-> (contains? layer :detector/enabled?)
+            (assoc :detector/enabled? (:detector/enabled? layer))))
+
+      ;; fallthrough: treat unknown directives as :inherit
+      accumulated)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Multi-layer resolution
+
+(defn merge-config
+  "Resolve a sequence of overlay layers into a final config map.
+
+   Layers are applied left-to-right (base first, most-specific last).
+   The base layer's `:config/params` and `:detector/enabled?` seed the
+   accumulator. **Directives are only applied to overlay layers** —
+   the base layer's `:config/directive` is recorded in
+   `:config/directives` for audit but never executed (a base
+   `:config/directive :disable` would be self-defeating; if a caller
+   wants a disabled config they should set `:detector/enabled? false`
+   on the base directly). Subsequent layers fold via `apply-directive`.
+
+   Arguments:
+     layers - seq of config maps. Each may have:
+                :config/directive - :inherit | :disable | :enable | :tune
+                                    (overlays only; base records but ignores)
+                :config/params    - map of detector-specific knobs
+                :detector/enabled? - explicit boolean (overrides directive for :tune)
+
+   Returns: Resolved config map with:
+     :detector/enabled? - final boolean (default true if never set)
+     :config/params     - deeply merged tuning parameters
+     :config/directives - vector of recorded directives (audit trail)
+
+   Example:
+     (merge-config
+       [{:config/params {:window-size 10}}
+        {:config/directive :tune :config/params {:window-size 20 :threshold 0.8}}
+        {:config/directive :disable}
+        {:config/directive :enable}])
+     ;; => {:detector/enabled? true
+     ;;     :config/params {:window-size 20 :threshold 0.8}
+     ;;     :config/directives [:inherit :tune :disable :enable]}"
+  [layers]
+  (when (empty? layers)
+    (throw (ex-info "merge-config requires at least one layer"
+                    {:layers layers})))
+  (let [;; The first layer is the base — its :config/params seed the
+        ;; accumulator. Without this seeding the base's params get
+        ;; dropped on its own implicit :inherit directive (see
+        ;; merge-config-tune-test, overlay-test, deep-merge-nested-test
+        ;; — all surfaced this when the base layer's params went
+        ;; missing from the resolved config). Subsequent layers apply
+        ;; via apply-directive normally.
+        [base-layer & overlay-layers] layers
+        seed (-> {:detector/enabled? (get base-layer :detector/enabled? true)
+                  :config/params     (deep-merge {} (get base-layer :config/params {}))
+                  :config/directives [(resolve-directive base-layer)]})
+        resolved (reduce
+                  (fn [acc layer]
+                    (let [directive (resolve-directive layer)
+                          acc'      (apply-directive acc layer)]
+                      (update acc' :config/directives conj directive)))
+                  seed
+                  overlay-layers)]
+    resolved))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Query helpers
+
+(defn enabled?
+  "Return true if resolved config enables the detector.
+
+   Defaults to true if :detector/enabled? is absent (safe default).
+
+   Arguments:
+     resolved-config - result of merge-config or apply-directive"
+  [resolved-config]
+  (get resolved-config :detector/enabled? true))
+
+(defn effective-params
+  "Return the merged :config/params map from a resolved config.
+
+   Arguments:
+     resolved-config - result of merge-config"
+  [resolved-config]
+  (get resolved-config :config/params {}))
+
+(defn directives-applied
+  "Return the ordered vector of directives that were applied.
+
+   Arguments:
+     resolved-config - result of merge-config"
+  [resolved-config]
+  (get resolved-config :config/directives []))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Convenience: merge two configs (parent -> child)
+
+(defn overlay
+  "Overlay child-config onto parent-config using merge-config semantics.
+
+   A shorthand for (merge-config [parent child]).
+
+   Arguments:
+     parent - base config map
+     child  - overlay config map
+
+   Returns: Resolved config map."
+  [parent child]
+  (merge-config [parent child]))
+
+;------------------------------------------------------------------------------ Rich Comment
+;; Rich comment
+
+(comment
+  ;; Inherit — child adds nothing
+  (merge-config [{:config/params {:window-size 10}}
+                 {:config/directive :inherit}])
+  ;; => {:detector/enabled? true
+  ;;     :config/params {:window-size 10}
+  ;;     :config/directives [:inherit :inherit]}
+
+  ;; Tune — merge params
+  (merge-config [{:config/params {:window-size 10 :threshold 0.5}}
+                 {:config/directive :tune
+                  :config/params {:threshold 0.9 :extra "yes"}}])
+  ;; => {:detector/enabled? true
+  ;;     :config/params {:window-size 10 :threshold 0.9 :extra "yes"}
+  ;;     :config/directives [:inherit :tune]}
+
+  ;; Disable then re-enable
+  (merge-config [{:config/params {:window-size 10}}
+                 {:config/directive :disable}
+                 {:config/directive :enable}])
+  ;; => {:detector/enabled? true ...}
+
+  ;; Disable wins if not overridden
+  (enabled? (merge-config [{:config/params {}}
+                            {:config/directive :disable}]))
+  ;; => false
+
+  ;; overlay shorthand
+  (overlay {:config/params {:window-size 5}}
+           {:config/directive :tune :config/params {:window-size 15}})
+  ;; => {:detector/enabled? true :config/params {:window-size 15} ...}
+
+  :leave-this-here)

--- a/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
@@ -1,0 +1,319 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.progress-detector.interface
+  "Progress-detector public API — Stage 1 framework.
+
+   ## Architectural intent
+
+   progress-detector is a *framework + registry mechanism*, not a source
+   of truth for tool behavior or anomaly shape:
+
+   - The canonical anomaly map lives on `ai.miniforge.anomaly.interface`.
+     Detector-specific structure (`:detector/kind`, `:anomaly/class`,
+     `:anomaly/severity`, `:anomaly/category`, `:anomaly/evidence`)
+     goes inside the anomaly's `:anomaly/data` field per the
+     `DetectorAnomalyData` schema below.
+   - Tool profiles are *contributed* by the components that vendor
+     each tool, via `register-tool-profile!`. Stage 1 ships an empty
+     default registry; Stage 2 wires `adapter-claude-code`, `agent`,
+     etc. to contribute their profiles at load time.
+
+   ## Concepts
+
+   An **observation** describes one tool-invocation event:
+     {:tool/id :tool/Read :seq 1 :timestamp inst :tool/duration-ms 80}
+
+   A **detector** implements the Detector protocol — a pure reducer:
+     init    : config → initial-state
+     observe : (detector, state, observation) → state'
+
+   An **anomaly** is a canonical anomaly map (per anomaly/Anomaly) whose
+   `:anomaly/data` carries `DetectorAnomalyData`:
+     {:anomaly/type :fault
+      :anomaly/message \"…\"
+      :anomaly/data {:detector/kind :detector/tool-loop
+                     :detector/version \"stage-1.0\"
+                     :anomaly/class :mechanical
+                     :anomaly/severity :error
+                     :anomaly/category :anomalies.agent/tool-loop
+                     :anomaly/evidence {:summary \"…\" …}}
+      :anomaly/at #inst …}
+
+   **Config layers** compose via overlay resolution:
+     :inherit / :disable / :enable / :tune"
+  (:require
+   [ai.miniforge.anomaly.interface             :as anomaly]
+   [ai.miniforge.progress-detector.protocol    :as proto]
+   [ai.miniforge.progress-detector.schema      :as schema]
+   [ai.miniforge.progress-detector.tool-profile :as tp]
+   [ai.miniforge.progress-detector.config      :as cfg]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Detector protocol (re-exported)
+
+(def null-detector
+  "Return a NullDetector that never flags any anomaly.
+   Useful as a no-op placeholder or base for detector pipelines."
+  proto/null-detector)
+
+(def multi-detector
+  "Compose multiple detectors into one fanout detector.
+   Observations are forwarded to all children; anomalies are merged."
+  proto/multi-detector)
+
+(defn init
+  "Produce initial detector state from config."
+  [detector config]
+  (proto/init detector config))
+
+(defn observe
+  "Pure reducer: fold one observation into accumulated detector state.
+
+   Argument order is [detector state observation] — detector first
+   so this works as a 2-arity reducer step via (partial observe det)
+   in reduce/transduce contexts. For pipelining a single state
+   forward, use `let` bindings (or `as->`) rather than `->` — `->`
+   would put state in the detector slot.
+
+   Contract (per the spec's pure-reducer requirement):
+     - state argument MUST NOT be mutated
+     - return value MUST be threaded back into the next observe call
+     - implementations MUST NOT throw — anomalies surface as data on
+       the returned state's :anomalies vector"
+  [detector state observation]
+  (proto/observe detector state observation))
+
+(def reduce-observations
+  "Fold a seq of observations through a detector, returning final state."
+  proto/reduce-observations)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Schema re-exports — anomaly validation lives on the anomaly component
+
+(def Anomaly
+  "Canonical anomaly schema (re-exported from ai.miniforge.anomaly).
+   progress-detector does NOT define a parallel Anomaly schema."
+  anomaly/Anomaly)
+
+(def valid-anomaly?
+  "Return true if m satisfies the canonical anomaly contract.
+   Re-exported from ai.miniforge.anomaly.interface — progress-detector
+   does NOT validate against a parallel schema."
+  anomaly/anomaly?)
+
+;; Progress-detector-local schemas (not duplicates of anomaly/*).
+(def Observation         schema/Observation)
+(def DetectorConfig      schema/DetectorConfig)
+(def ToolProfile         schema/ToolProfile)
+(def DetectorAnomalyData schema/DetectorAnomalyData)
+
+(def valid-observation?            schema/valid-observation?)
+(def explain-observation           schema/explain-observation)
+(def valid-tool-profile?           schema/valid-tool-profile?)
+(def explain-tool-profile          schema/explain-tool-profile)
+(def valid-detector-config?        schema/valid-detector-config?)
+(def explain-detector-config       schema/explain-detector-config)
+(def valid-detector-anomaly-data?  schema/valid-detector-anomaly-data?)
+(def explain-detector-anomaly-data schema/explain-detector-anomaly-data)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Tool-profile registration (no built-in profiles — components contribute)
+
+(def make-tool-registry
+  "Create a fresh empty tool-profile registry atom. Tests should use
+   this instead of the global default-registry to avoid cross-test
+   leakage."
+  tp/make-registry)
+
+(def default-tool-registry
+  "Process-wide tool-profile registry. Components that vendor tools
+   contribute via `register-tool-profile!` at namespace-load time.
+   Stage 1 ships this empty; Stage 2 wires the contributions."
+  tp/default-registry)
+
+(defn register-tool-profile!
+  "Add or overwrite a tool profile in `registry-atom`.
+
+   Throws via ex-info if the profile fails ToolProfile schema
+   validation — caller bug. Returns the new registry map.
+
+   Arguments:
+     registry-atom - atom holding the registry (typically the
+                     default-tool-registry)
+     profile       - map satisfying ToolProfile schema:
+                       :tool/id            (required, qualified keyword)
+                       :determinism        (required, see schema/determinisms)
+                       :anomaly/categories (optional, set of keywords)
+                       :timeout-ms         (optional, int)"
+  [registry-atom profile]
+  (tp/register! registry-atom profile))
+
+(defn unregister-tool-profile!
+  "Remove the profile for `tool-id` from `registry-atom`.
+   Returns the new registry map."
+  [registry-atom tool-id]
+  (tp/unregister! registry-atom tool-id))
+
+(defn tool-lookup
+  "Return the registered profile for `tool-id`, or nil.
+
+   Arguments:
+     tool-id  - qualified keyword e.g. :tool/Read
+     registry - registry atom or unwrapped map (defaults to
+                default-tool-registry)"
+  ([tool-id]
+   (tp/lookup tool-id))
+  ([tool-id registry]
+   (tp/lookup tool-id registry)))
+
+(defn tool-determinism
+  "Return the :determinism level for `tool-id`, or :unstable if unknown.
+   :unstable is the safe default — unknown tools are treated as
+   heuristic signals only, never as mechanical-eligible loops."
+  ([tool-id]
+   (tp/determinism-of tool-id))
+  ([tool-id registry]
+   (tp/determinism-of tool-id registry)))
+
+(defn tool-categories
+  "Return the anomaly category set for `tool-id`, or #{} if unknown."
+  ([tool-id]
+   (tp/categories-of tool-id))
+  ([tool-id registry]
+   (tp/categories-of tool-id registry)))
+
+(def all-tool-ids
+  "Return sorted vector of all registered tool-id keywords."
+  tp/all-tool-ids)
+
+(def validate-tool-registry
+  "Per-entry ToolProfile validation report for `registry`.
+   Returns: {tool-id -> {:valid? bool :errors humanized-or-nil}}."
+  tp/validate-all)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Config merge semantics (re-exported)
+
+(def resolve-config
+  "Resolve a seq of overlay layers into a final config map.
+
+   Layers apply left-to-right; the base layer's :config/params seed
+   the accumulator. Directives are applied to OVERLAY layers only —
+   the base layer's :config/directive is recorded for audit but never
+   executed (a base :disable would be self-defeating)."
+  cfg/merge-config)
+
+(def apply-config-directive
+  "Apply one overlay layer onto an accumulated config map."
+  cfg/apply-directive)
+
+(def config-enabled?
+  "Return true if resolved config marks the detector as enabled.
+   Defaults to true if :detector/enabled? is absent."
+  cfg/enabled?)
+
+(def effective-config-params
+  "Return the merged :config/params from a resolved config."
+  cfg/effective-params)
+
+(def config-overlay
+  "Overlay child config onto parent config.
+   Shorthand for (resolve-config [parent child])."
+  cfg/overlay)
+
+;------------------------------------------------------------------------------ Layer 3
+;; Convenience constructors and helpers
+
+(defn make-observation
+  "Construct a valid observation map with required fields.
+
+   Arguments:
+     tool-id      - qualified keyword (e.g. :tool/Read)
+     seq-num      - monotonic integer sequence number
+     timestamp    - java.time.Instant of this observation
+     opts         - (optional) map of additional fields:
+                      :tool/duration-ms :tool/input :tool/output :tool/error?
+
+   Returns: observation map."
+  ([tool-id seq-num timestamp]
+   (make-observation tool-id seq-num timestamp {}))
+  ([tool-id seq-num timestamp opts]
+   (merge {:tool/id   tool-id
+           :seq       seq-num
+           :timestamp timestamp}
+          opts)))
+
+(defn current-anomalies
+  "Extract the :anomalies vector from detector state.
+
+   Returns: Vector of anomaly maps (possibly empty); each map conforms
+   to the canonical anomaly contract with detector specifics under
+   :anomaly/data."
+  [state]
+  (get state :anomalies []))
+
+(defn anomalies-by-severity
+  "Return anomalies from state filtered to the given severity.
+
+   Severity reads from `[:anomaly/data :anomaly/severity]` because
+   severity is detector metadata, not part of the canonical anomaly
+   shape. Valid severities (per schema/severities): :info :warn
+   :error :fatal.
+
+   Arguments:
+     state    - detector state map
+     severity - one of #{:info :warn :error :fatal}
+
+   Returns: Vector of matching anomaly maps."
+  [state severity]
+  (filterv #(= severity (get-in % [:anomaly/data :anomaly/severity]))
+           (current-anomalies state)))
+
+(defn fatal-anomalies
+  "Return only severity :fatal anomalies from state."
+  [state]
+  (anomalies-by-severity state :fatal))
+
+;------------------------------------------------------------------------------ Rich Comment
+
+(comment
+  ;; Smoke-test the framework
+  (let [det  (null-detector)
+        cfg  (resolve-config [{:config/params {:window-size 5}}
+                              {:config/directive :tune
+                               :config/params {:window-size 10}}])
+        st0  (init det (effective-config-params cfg))
+        obs1 (make-observation :tool/Read 1 (java.time.Instant/now)
+                               {:tool/duration-ms 120})
+        stf  (reduce-observations det (effective-config-params cfg) [obs1])]
+    {:enabled?  (config-enabled? cfg)
+     :params    (effective-config-params cfg)
+     :anomalies (current-anomalies stf)})
+  ;; => {:enabled? true :params {:window-size 10} :anomalies []}
+
+  ;; Register a tool profile (test-style — explicit registry)
+  (def reg (make-tool-registry))
+  (register-tool-profile! reg
+                          {:tool/id :tool/Read
+                           :determinism :stable-with-resource-version
+                           :anomaly/categories #{:anomalies.agent/tool-loop}})
+  (tool-determinism :tool/Read reg)        ; => :stable-with-resource-version
+  (tool-determinism :tool/Unknown reg)     ; => :unstable (safe default)
+
+  :leave-this-here)

--- a/components/progress-detector/src/ai/miniforge/progress_detector/protocol.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/protocol.clj
@@ -1,0 +1,189 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.progress-detector.protocol
+  "Detector protocol: pure-reducer interface for progress anomaly detection.
+
+   Detectors are stateless pure functions that fold observations into
+   accumulated state. The protocol enforces two operations:
+
+     init    - produce the initial (empty) detector state from config
+     observe - pure reducer: (state, observation) -> state'
+
+   Anomalies are surfaced as a sequence under the :anomalies key in the
+   returned state. Callers accumulate state across observations and read
+   anomalies after each step.
+
+   Determinism guarantee:
+     Given identical config and identical observation sequence, observe
+     MUST return identical state. Side effects are prohibited inside
+     detectors; all I/O happens outside the reduce loop.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Core protocol
+
+(defprotocol Detector
+  "Pure reducer for progress anomaly detection.
+
+   Implementations MUST be:
+   - Pure: no side effects, no hidden I/O
+   - Deterministic: identical inputs → identical outputs
+   - Serializable: state must be EDN-representable (maps/vecs/sets/scalars)
+
+   Usage pattern:
+     (let [state  (init   detector cfg)
+           state' (observe detector state obs)]
+       (:anomalies state'))"
+
+  (init [detector config]
+    "Produce the initial detector state from config map.
+
+     Arguments:
+       config - map of detector-specific configuration. Shape varies by
+                implementation; unknown keys MUST be ignored.
+
+     Returns: Initial state map. Must include at minimum:
+       {:anomalies []   ; empty anomaly log
+        :observations [] ; empty observation window}
+
+     Implementations SHOULD merge config defaults defensively.")
+
+  (observe [detector state observation]
+    "Pure reducer: fold one observation into accumulated state.
+
+     Arguments:
+       state       - current detector state (result of init or prior observe)
+       observation - map describing one tool invocation:
+                       :tool/id       - qualified keyword identifying the tool
+                       :tool/input    - input args map (may be redacted)
+                       :tool/output   - output value (may be nil if pending)
+                       :tool/duration-ms - wall-clock ms for this call
+                       :timestamp     - inst of observation
+                       :seq           - monotonic sequence number
+
+     Returns: New state map (same shape as init return) with :anomalies
+     updated to include any newly detected anomaly maps.
+
+     Contract:
+       - MUST NOT mutate state argument
+       - MUST return a map satisfying the same shape as init output
+       - MUST NOT throw; anomalies surface in-band as data"))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Null detector — reference implementation (pass-through, never flags)
+
+(defrecord NullDetector []
+  Detector
+  (init [_detector _config]
+    {:anomalies    []
+     :observations []
+     :window-size  0})
+
+  (observe [_detector state observation]
+    (-> state
+        (update :observations conj observation)
+        (update :window-size inc))))
+
+(defn null-detector
+  "Return a NullDetector that never flags any anomaly.
+   Useful as a no-op placeholder and for composing detector pipelines."
+  []
+  (->NullDetector))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Multi-detector: fan observations through a seq of detectors
+
+(defrecord MultiDetector [detectors]
+  Detector
+  (init [_detector config]
+    {:anomalies    []
+     :observations []
+     :sub-states   (mapv #(init % config) detectors)})
+
+  (observe [_detector state observation]
+    ;; Compute the DELTA per sub-state — newly emitted anomalies in
+    ;; this step only. The previous implementation appended each
+    ;; sub-state's full :anomalies history on every observe, growing
+    ;; the top-level vector quadratically (Copilot review on PR #784).
+    ;; subvec gives an O(1) view over the trailing slice.
+    (let [old-sub-states  (:sub-states state)
+          old-counts      (mapv #(count (:anomalies %)) old-sub-states)
+          new-sub-states  (mapv (fn [sub-det sub-state]
+                                  (observe sub-det sub-state observation))
+                                detectors
+                                old-sub-states)
+          delta-anomalies (into []
+                                (mapcat (fn [sub-state old-count]
+                                          (subvec (:anomalies sub-state)
+                                                  old-count))
+                                        new-sub-states
+                                        old-counts))]
+      (-> state
+          (update :observations conj observation)
+          (assoc  :sub-states new-sub-states)
+          (update :anomalies into delta-anomalies)))))
+
+(defn multi-detector
+  "Compose multiple detectors into one.
+   Observations are fanned to all children; anomalies are merged.
+
+   Arguments:
+     detectors - seq of Detector implementations
+
+   Returns: MultiDetector record"
+  [detectors]
+  (->MultiDetector (vec detectors)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Helper: reduce a seq of observations through a detector
+
+(defn reduce-observations
+  "Fold a sequence of observations through detector, returning final state.
+
+   Arguments:
+     detector     - Detector implementation
+     config       - config map passed to init
+     observations - seq of observation maps
+
+   Returns: Final detector state after all observations are folded."
+  [detector config observations]
+  (reduce (partial observe detector)
+          (init detector config)
+          observations))
+
+;------------------------------------------------------------------------------ Rich Comment
+;; Rich comment — development examples
+
+(comment
+  ;; Null detector — always passes through
+  (let [det (null-detector)
+        obs {:tool/id :tool/bash
+             :timestamp (java.time.Instant/now)
+             :seq 1
+             :tool/duration-ms 150}]
+    (-> (init det {})
+        (observe det obs)))
+  ;; => {:anomalies [] :observations [{...}] :window-size 1}
+
+  ;; reduce-observations helper
+  (reduce-observations (null-detector) {}
+                       [{:tool/id :tool/write :seq 1 :tool/duration-ms 20}
+                        {:tool/id :tool/bash  :seq 2 :tool/duration-ms 80}])
+  ;; => {:anomalies [] :observations [{...} {...}] :window-size 2}
+
+  :leave-this-here)

--- a/components/progress-detector/src/ai/miniforge/progress_detector/schema.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/schema.clj
@@ -1,0 +1,259 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.progress-detector.schema
+  "Malli schemas for progress-detector data shapes.
+
+   The canonical anomaly shape lives in `ai.miniforge.anomaly.contract`
+   and is re-exported here verbatim — progress-detector does NOT define
+   its own parallel Anomaly schema. Detector-specific structure
+   (severity, class, category, evidence, fingerprint) goes inside
+   `:anomaly/data` as a `DetectorAnomalyData` map.
+
+   Vocabularies (defined here, not in the anomaly contract):
+     ::detector-class    - :mechanical | :heuristic
+     ::detector-severity - :info | :warn | :error | :fatal
+     ::anomaly-category  - :anomalies.agent/tool-loop | …
+     ::determinism       - :stable-with-resource-version | … (per spec)
+
+   Schemas defined here:
+     DetectorAnomalyData - structure under :anomaly/data
+     Observation         - tool invocation event fed to detectors
+     DetectorConfig      - per-detector configuration overlay
+     ToolProfile         - registry entry for a known tool
+
+   Anomaly validation helpers live on `ai.miniforge.anomaly.interface`.
+   Use those, not parallel ones here."
+  (:require
+   [malli.core    :as m]
+   [malli.error   :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Detector vocabularies (mechanical/heuristic + severity ladder)
+
+(def detector-classes
+  "Detector classification per the Stage 1 spec — mechanical detectors
+   produce hard signals (recommended action defaults to terminate);
+   heuristic detectors produce probabilistic signals (default action
+   :warn unless promoted by composite-rules in Stage 3)."
+  #{:mechanical :heuristic})
+
+(def DetectorClass
+  "Schema enum for detector classification."
+  (into [:enum] detector-classes))
+
+(def severities
+  "Severity ladder for detector-emitted anomalies. Matches the Stage 1
+   spec's severity vocabulary (:info :warn :error :fatal)."
+  #{:info :warn :error :fatal})
+
+(def DetectorSeverity
+  "Schema enum for detector severity."
+  (into [:enum] severities))
+
+(def determinisms
+  "Tool determinism levels per the Stage 1 spec's tool capability
+   registry. The level gates whether a fingerprint repeat counts as
+   mechanical or heuristic.
+
+     :stable-with-resource-version - same call, same resource hash, same
+                                     result; mechanical-eligible
+     :stable-ish                   - mostly-deterministic; mechanical with
+                                     bounded false-positives
+     :environment-dependent        - depends on env/state; mechanical only
+                                     when failure fingerprint also matches
+     :unstable                     - inherently variable (network, time);
+                                     heuristic only"
+  #{:stable-with-resource-version
+    :stable-ish
+    :environment-dependent
+    :unstable})
+
+(def Determinism
+  "Schema enum for tool determinism."
+  (into [:enum] determinisms))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Detector-specific anomaly payload (lives under :anomaly/data)
+
+(def AnomalyEvidence
+  "Bounded evidence for a detector anomaly. Per the Stage 1 spec:
+   summary + event-id pointers + fingerprint + threshold metadata
+   + a pointer to the local event log via :raw-log-ref. Raw tool args,
+   raw assistant text, and raw file content do NOT appear here."
+  [:map
+   [:summary       :string]
+   [:event-ids     {:optional true} [:vector :any]]
+   [:fingerprint   {:optional true} :string]
+   [:threshold     {:optional true} [:map-of :any :any]]
+   [:raw-log-ref   {:optional true} :string]
+   [:redacted?     {:optional true} :boolean]])
+
+(def DetectorAnomalyData
+  "Structure that goes inside `:anomaly/data` when a detector emits an
+   anomaly via `ai.miniforge.anomaly.interface/anomaly`. Detectors
+   classify (the keys here); the supervisor disposes (lifecycle action
+   policy lives elsewhere — Stage 3).
+
+   Required:
+     :detector/kind     - keyword identifying which detector fired
+     :detector/version  - string version of the detector implementation
+     :anomaly/class     - :mechanical | :heuristic
+     :anomaly/severity  - :info | :warn | :error | :fatal
+     :anomaly/category  - keyword like :anomalies.agent/tool-loop
+     :anomaly/evidence  - bounded evidence map"
+  [:map
+   [:detector/kind       :keyword]
+   [:detector/version    :string]
+   [:anomaly/class       DetectorClass]
+   [:anomaly/severity    DetectorSeverity]
+   [:anomaly/category    :keyword]
+   [:anomaly/evidence    AnomalyEvidence]])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Observation schema (input to detectors)
+
+(def Observation
+  "A single tool-invocation event fed into the detector reduce loop.
+
+   Stage 1 carries the minimum the tool-loop and repair-loop detectors
+   need; Stage 2 will extend with :resource/version-hash, :semantic/epoch,
+   and richer event kinds."
+  [:map
+   [:tool/id          :keyword]
+   [:seq              :int]
+   [:timestamp        inst?]
+   [:tool/duration-ms {:optional true} [:maybe :int]]
+   [:tool/input       {:optional true} :any]
+   [:tool/output      {:optional true} :any]
+   [:tool/error?      {:optional true} :boolean]])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Detector-config overlay schema (per-layer in the merge stack)
+
+(def ConfigDirective
+  "A single overlay directive in a detector config merge."
+  [:enum
+   :inherit   ; adopt parent config value unchanged
+   :disable   ; suppress this detector/rule entirely
+   :enable    ; force-enable even if parent disables
+   :tune])    ; merge user-supplied overrides onto parent defaults
+
+(def DetectorConfig
+  "Per-detector configuration overlay layer.
+
+   :config/directive controls how this layer merges with parent:
+     :inherit - use parent values; local map adds nothing
+     :disable - detector is suppressed; all other keys ignored
+     :enable  - force-enable detector; overrides parent :disable
+     :tune    - deep-merge this map onto parent defaults
+
+   :config/params holds detector-specific tuning knobs."
+  [:map
+   [:config/directive {:optional true} ConfigDirective]
+   [:config/params    {:optional true} [:map-of :keyword :any]]])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Tool-profile schema (entries the registration API accepts)
+
+(def ToolProfile
+  "Profile entry that components contribute via
+   `ai.miniforge.progress-detector.tool-profile/register!` to describe
+   the determinism + fingerprint shape of a tool the agent calls.
+
+   Stage 1 keeps this shape minimal; Stage 2 will add per-tool
+   :fingerprint/dimensions + :failure/fingerprint-extractor refs."
+  [:map
+   [:tool/id            :keyword]
+   [:determinism        Determinism]
+   [:anomaly/categories {:optional true} [:set :keyword]]
+   [:timeout-ms         {:optional true} [:maybe :int]]
+   [:config             {:optional true} [:map-of :keyword :any]]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Validation helpers (delegate to anomaly component for top-level Anomaly)
+
+(defn valid-observation?
+  "Return true if m satisfies the Observation schema."
+  [m]
+  (m/validate Observation m))
+
+(defn explain-observation
+  "Return humanized error map if m fails Observation validation, else nil."
+  [m]
+  (when-let [exp (m/explain Observation m)]
+    (me/humanize exp)))
+
+(defn valid-tool-profile?
+  "Return true if m satisfies the ToolProfile schema."
+  [m]
+  (m/validate ToolProfile m))
+
+(defn explain-tool-profile
+  "Return humanized error map if m fails ToolProfile validation, else nil."
+  [m]
+  (when-let [exp (m/explain ToolProfile m)]
+    (me/humanize exp)))
+
+(defn valid-detector-config?
+  "Return true if m satisfies the DetectorConfig schema."
+  [m]
+  (m/validate DetectorConfig m))
+
+(defn explain-detector-config
+  "Return humanized error map if m fails DetectorConfig validation, else nil."
+  [m]
+  (when-let [exp (m/explain DetectorConfig m)]
+    (me/humanize exp)))
+
+(defn valid-detector-anomaly-data?
+  "Return true if m satisfies the DetectorAnomalyData schema (the shape
+   that goes inside :anomaly/data on a detector-emitted anomaly)."
+  [m]
+  (m/validate DetectorAnomalyData m))
+
+(defn explain-detector-anomaly-data
+  "Return humanized error map if m fails DetectorAnomalyData validation."
+  [m]
+  (when-let [exp (m/explain DetectorAnomalyData m)]
+    (me/humanize exp)))
+
+;------------------------------------------------------------------------------ Rich Comment
+
+(comment
+  ;; Validate detector-specific anomaly data
+  (valid-detector-anomaly-data?
+   {:detector/kind     :detector/tool-loop
+    :detector/version  "stage-1.0"
+    :anomaly/class     :mechanical
+    :anomaly/severity  :error
+    :anomaly/category  :anomalies.agent/tool-loop
+    :anomaly/evidence  {:summary "Read \"src/foo.clj\" 6 times"
+                        :fingerprint "abc123"
+                        :threshold {:n 5 :window 10}
+                        :redacted? true}})
+  ;; => true
+
+  (valid-observation?
+   {:tool/id   :tool/bash
+    :seq       1
+    :timestamp (java.time.Instant/now)
+    :tool/duration-ms 150})
+  ;; => true
+
+  :leave-this-here)

--- a/components/progress-detector/src/ai/miniforge/progress_detector/tool_profile.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/tool_profile.clj
@@ -1,0 +1,183 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.progress-detector.tool-profile
+  "Tool-profile registration API.
+
+   Architectural intent: progress-detector does NOT own knowledge of
+   which tools exist or what their characteristics are. Each component
+   that vendors a tool the agent can call (LLM client, MCP servers, the
+   adapter layer) is responsible for contributing a profile via
+   `register!` at startup.
+
+   Stage 1 ships an empty default registry. The component layout for
+   tool-profile data lives with the components that vendor each tool —
+   `adapter-claude-code` for the Claude CLI native tools, `agent` for
+   MCP-driven tools, etc. (Stage 2 wires the contributions; Stage 1
+   provides the registration mechanism.)
+
+   Public API (pure unless suffixed with `!`):
+     make-registry         - create a new empty registry atom
+     register!             - add or override a profile (returns new value)
+     unregister!           - remove a profile by tool-id
+     lookup                - retrieve profile by tool-id (or nil)
+     determinism-of        - :determinism level (defaults to :unstable)
+     categories-of         - anomaly category set (defaults to #{})
+     all-tool-ids          - sorted vector of registered ids
+     validate-all          - per-entry ToolProfile validation report
+
+   The framework holds a process-wide `default-registry` atom for
+   convenience; components contribute to it at load time. Tests
+   should use `make-registry` and pass the result explicitly to the
+   2-arity query functions to avoid global state."
+  (:require
+   [ai.miniforge.progress-detector.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Registry construction
+
+(defn make-registry
+  "Create a fresh empty registry atom. Components contribute via
+   `register!`; queries use `lookup` / `determinism-of` / etc."
+  []
+  (atom {}))
+
+(defonce default-registry
+  ;; Process-wide registry. Components contribute at load time:
+  ;;   (tool-profile/register! tool-profile/default-registry
+  ;;                           {:tool/id :tool/Read :determinism ...})
+  ;; Tests should NOT use this — make their own via make-registry.
+  (make-registry))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Mutating API (registration)
+
+(defn register!
+  "Add or overwrite a profile for `(:tool/id profile)` in `registry-atom`.
+
+   Arguments:
+     registry-atom - atom holding the registry map
+     profile       - map satisfying the ToolProfile schema
+
+   Returns the new registry map. Throws via ex-info if profile is
+   missing :tool/id or fails schema validation — caller bug."
+  [registry-atom profile]
+  (let [tool-id (:tool/id profile)]
+    (when-not tool-id
+      (throw (ex-info "Tool profile must include :tool/id"
+                      {:profile profile})))
+    (when-not (schema/valid-tool-profile? profile)
+      (throw (ex-info "Tool profile fails ToolProfile schema validation"
+                      {:profile profile
+                       :errors  (schema/explain-tool-profile profile)}))))
+  (swap! registry-atom assoc (:tool/id profile) profile))
+
+(defn unregister!
+  "Remove the profile for `tool-id` from `registry-atom`.
+   Returns the new registry map."
+  [registry-atom tool-id]
+  (swap! registry-atom dissoc tool-id))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Query API (pure; accepts atom or unwrapped map)
+
+(defn- registry-value
+  "Unwrap an atom-or-map registry argument."
+  [registry-or-atom]
+  (if (instance? clojure.lang.IDeref registry-or-atom)
+    @registry-or-atom
+    registry-or-atom))
+
+(defn lookup
+  "Return the profile for `tool-id` from `registry`, or nil.
+
+   Arguments:
+     tool-id  - qualified keyword e.g. :tool/Read
+     registry - registry atom or unwrapped map (defaults to default-registry)"
+  ([tool-id]
+   (lookup tool-id default-registry))
+  ([tool-id registry]
+   (get (registry-value registry) tool-id)))
+
+(defn determinism-of
+  "Return the :determinism level for `tool-id`, or :unstable if unknown.
+
+   :unstable is the safe default — unknown tools are treated as heuristic
+   signals only, never as mechanical-eligible loops."
+  ([tool-id]
+   (determinism-of tool-id default-registry))
+  ([tool-id registry]
+   (get (lookup tool-id registry) :determinism :unstable)))
+
+(defn categories-of
+  "Return the set of anomaly categories for `tool-id`, or #{} if unknown."
+  ([tool-id]
+   (categories-of tool-id default-registry))
+  ([tool-id registry]
+   (get (lookup tool-id registry) :anomaly/categories #{})))
+
+(defn all-tool-ids
+  "Return sorted vector of all registered tool-id keywords."
+  ([]
+   (all-tool-ids default-registry))
+  ([registry]
+   (vec (sort (keys (registry-value registry))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Audit
+
+(defn validate-all
+  "Validate every entry in `registry` against the ToolProfile schema.
+
+   Returns: Map of tool-id -> {:valid? bool :errors humanized-or-nil}.
+   Uses the ToolProfile humanizer (NOT the Anomaly one) so error
+   messages cite the right schema's fields."
+  [registry]
+  (reduce-kv
+   (fn [acc tool-id profile]
+     (let [valid? (schema/valid-tool-profile? profile)]
+       (assoc acc tool-id
+              {:valid? valid?
+               :errors (when-not valid?
+                         (schema/explain-tool-profile profile))})))
+   {}
+   (registry-value registry)))
+
+;------------------------------------------------------------------------------ Rich Comment
+
+(comment
+  ;; Test-style: explicit registry, no global state
+  (def reg (make-registry))
+  (register! reg {:tool/id :tool/Read
+                  :determinism :stable-with-resource-version
+                  :anomaly/categories #{:anomalies.agent/tool-loop}})
+  (lookup :tool/Read reg)
+  ;; => {:tool/id :tool/Read :determinism ... :anomaly/categories #{...}}
+
+  (determinism-of :tool/Read reg)        ; => :stable-with-resource-version
+  (determinism-of :tool/UnknownTool reg) ; => :unstable (safe default)
+
+  ;; Production-style: components contribute to default-registry at load
+  (register! default-registry
+             {:tool/id :tool/Bash
+              :determinism :environment-dependent})
+
+  (validate-all reg)
+  ;; => {:tool/Read {:valid? true :errors nil}}
+
+  :leave-this-here)

--- a/components/progress-detector/test/ai/miniforge/progress_detector/config_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/config_test.clj
@@ -1,0 +1,184 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.progress-detector.config-test
+  "Tests for detector config merge semantics and overlay resolution."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.progress-detector.config :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; apply-directive — unit tests for each directive
+
+(deftest apply-directive-inherit-test
+  (testing ":inherit returns accumulated unchanged"
+    (let [acc   {:detector/enabled? true :config/params {:x 1} :config/directives []}
+          layer {:config/directive :inherit}
+          result (sut/apply-directive acc layer)]
+      (is (= acc result))))
+
+  (testing "missing directive defaults to :inherit"
+    (let [acc    {:detector/enabled? true :config/params {:x 1} :config/directives []}
+          layer  {}
+          result (sut/apply-directive acc layer)]
+      (is (= acc result)))))
+
+(deftest apply-directive-disable-test
+  (testing ":disable sets :detector/enabled? to false"
+    (let [acc    {:detector/enabled? true :config/params {} :config/directives []}
+          result (sut/apply-directive acc {:config/directive :disable})]
+      (is (false? (:detector/enabled? result)))))
+
+  (testing ":disable does not touch :config/params"
+    (let [acc    {:detector/enabled? true :config/params {:x 5} :config/directives []}
+          result (sut/apply-directive acc {:config/directive :disable})]
+      (is (= {:x 5} (:config/params result))))))
+
+(deftest apply-directive-enable-test
+  (testing ":enable sets :detector/enabled? to true even when previously disabled"
+    (let [acc    {:detector/enabled? false :config/params {} :config/directives []}
+          result (sut/apply-directive acc {:config/directive :enable})]
+      (is (true? (:detector/enabled? result)))))
+
+  (testing ":enable on already-enabled is idempotent"
+    (let [acc    {:detector/enabled? true :config/params {} :config/directives []}
+          result (sut/apply-directive acc {:config/directive :enable})]
+      (is (true? (:detector/enabled? result))))))
+
+(deftest apply-directive-tune-test
+  (testing ":tune deep-merges :config/params"
+    (let [acc   {:detector/enabled? true
+                 :config/params     {:window-size 5 :threshold 0.5}
+                 :config/directives []}
+          layer {:config/directive :tune
+                 :config/params    {:threshold 0.9 :new-key "val"}}
+          result (sut/apply-directive acc layer)]
+      (is (= 5      (get-in result [:config/params :window-size])) "inherited key preserved")
+      (is (= 0.9    (get-in result [:config/params :threshold]))   "overridden key updated")
+      (is (= "val"  (get-in result [:config/params :new-key]))     "new key added")))
+
+  (testing ":tune does not change :detector/enabled? by default"
+    (let [acc    {:detector/enabled? false :config/params {} :config/directives []}
+          result (sut/apply-directive acc {:config/directive :tune :config/params {:x 1}})]
+      (is (false? (:detector/enabled? result)))))
+
+  (testing ":tune respects explicit :detector/enabled? override"
+    (let [acc    {:detector/enabled? false :config/params {} :config/directives []}
+          result (sut/apply-directive acc {:config/directive :tune
+                                           :detector/enabled? true
+                                           :config/params {}})]
+      (is (true? (:detector/enabled? result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; merge-config — integration tests
+
+(deftest merge-config-single-layer-test
+  (testing "single base layer produces valid config"
+    (let [result (sut/merge-config [{:config/params {:window-size 10}}])]
+      (is (true? (sut/enabled? result)))
+      (is (= {:window-size 10} (sut/effective-params result)))
+      (is (= [:inherit] (sut/directives-applied result))))))
+
+(deftest merge-config-tune-test
+  (testing "tune layer merges params onto base"
+    (let [result (sut/merge-config
+                  [{:config/params {:window-size 10 :threshold 0.5}}
+                   {:config/directive :tune
+                    :config/params   {:threshold 0.9 :extra "x"}}])]
+      (is (= 10    (get-in result [:config/params :window-size])))
+      (is (= 0.9   (get-in result [:config/params :threshold])))
+      (is (= "x"   (get-in result [:config/params :extra])))
+      (is (= [:inherit :tune] (sut/directives-applied result))))))
+
+(deftest merge-config-disable-test
+  (testing "disable makes config not enabled"
+    (let [result (sut/merge-config [{:config/params {}}
+                                    {:config/directive :disable}])]
+      (is (false? (sut/enabled? result)))))
+
+  (testing "disable blocks subsequent inherits"
+    (let [result (sut/merge-config [{:config/params {}}
+                                    {:config/directive :disable}
+                                    {:config/directive :inherit}])]
+      (is (false? (sut/enabled? result))))))
+
+(deftest merge-config-enable-after-disable-test
+  (testing "enable after disable re-enables"
+    (let [result (sut/merge-config [{:config/params {}}
+                                    {:config/directive :disable}
+                                    {:config/directive :enable}])]
+      (is (true? (sut/enabled? result)))))
+
+  (testing "disable after enable takes effect"
+    (let [result (sut/merge-config [{:config/params {}}
+                                    {:config/directive :enable}
+                                    {:config/directive :disable}])]
+      (is (false? (sut/enabled? result))))))
+
+(deftest merge-config-directive-audit-test
+  (testing "directives-applied records all applied directives"
+    (let [result (sut/merge-config
+                  [{}
+                   {:config/directive :tune :config/params {}}
+                   {:config/directive :disable}
+                   {:config/directive :enable}])]
+      (is (= [:inherit :tune :disable :enable]
+             (sut/directives-applied result))))))
+
+(deftest merge-config-empty-layers-throws-test
+  (testing "empty layers seq throws"
+    (is (thrown? Exception (sut/merge-config [])))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; enabled? / effective-params / directives-applied
+
+(deftest enabled-default-test
+  (testing "enabled? defaults to true when key absent"
+    (is (true? (sut/enabled? {}))))
+
+  (testing "enabled? returns false when explicitly false"
+    (is (false? (sut/enabled? {:detector/enabled? false})))))
+
+(deftest effective-params-test
+  (testing "returns empty map when :config/params absent"
+    (is (= {} (sut/effective-params {}))))
+
+  (testing "returns the :config/params map"
+    (is (= {:k 1} (sut/effective-params {:config/params {:k 1}})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; overlay
+
+(deftest overlay-test
+  (testing "overlay parent + child is equivalent to merge-config [parent child]"
+    (let [parent {:config/params {:a 1}}
+          child  {:config/directive :tune :config/params {:b 2}}
+          via-overlay    (sut/overlay parent child)
+          via-merge      (sut/merge-config [parent child])]
+      (is (= via-overlay via-merge))))
+
+  (testing "overlay disable child disables"
+    (let [result (sut/overlay {:config/params {:x 1}}
+                              {:config/directive :disable})]
+      (is (false? (sut/enabled? result)))))
+
+  (testing "overlay tune child merges params"
+    (let [result (sut/overlay {:config/params {:x 1}}
+                              {:config/directive :tune
+                               :config/params   {:y 2}})]
+      (is (= {:x 1 :y 2} (sut/effective-params result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Deep merge corner cases
+
+(deftest deep-merge-nested-test
+  (testing "tune deep-merges nested maps"
+    (let [result (sut/merge-config
+                  [{:config/params {:nested {:a 1 :b 2}}}
+                   {:config/directive :tune
+                    :config/params   {:nested {:b 99 :c 3}}}])]
+      (is (= {:a 1 :b 99 :c 3}
+             (get-in result [:config/params :nested]))
+          "nested map keys merged correctly"))))

--- a/components/progress-detector/test/ai/miniforge/progress_detector/interface_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/interface_test.clj
@@ -1,0 +1,204 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.progress-detector.interface-test
+  "Integration tests for the progress-detector public interface."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.progress-detector.interface :as pd]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test factories
+
+(defn- detector-anomaly-data
+  "Build a valid DetectorAnomalyData payload."
+  [& {:keys [class severity category]
+      :or {class :mechanical severity :error category :anomalies.agent/tool-loop}}]
+  {:detector/kind     :detector/test
+   :detector/version  "test-1.0"
+   :anomaly/class     class
+   :anomaly/severity  severity
+   :anomaly/category  category
+   :anomaly/evidence  {:summary "test evidence"}})
+
+(defn- canonical-anomaly
+  "Build a valid canonical anomaly with detector data under :anomaly/data."
+  [& {:as opts}]
+  (anomaly/anomaly :fault "test failure" (apply detector-anomaly-data
+                                                (mapcat identity opts))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Detector lifecycle (init / observe / reduce-observations)
+
+(deftest interface-detector-lifecycle-test
+  (testing "null-detector init returns expected shape"
+    (let [det   (pd/null-detector)
+          state (pd/init det {})]
+      (is (vector? (:anomalies state)))
+      (is (empty?  (:anomalies state)))))
+
+  (testing "observe accumulates observations"
+    (let [det (pd/null-detector)
+          obs (pd/make-observation :tool/Bash 1 (java.time.Instant/now)
+                                   {:tool/duration-ms 80})
+          ;; observe takes [detector state observation] — detector first
+          ;; for protocol-dispatch + (partial observe det) reducer use.
+          ;; A `->` thread on (init …) would put state in detector slot.
+          st0 (pd/init det {})
+          st  (pd/observe det st0 obs)]
+      (is (= 1 (count (:observations st))))
+      (is (empty? (pd/current-anomalies st)))))
+
+  (testing "reduce-observations folds a seq"
+    (let [det  (pd/null-detector)
+          obss (map #(pd/make-observation :tool/Read % (java.time.Instant/now))
+                    (range 1 6))
+          stf  (pd/reduce-observations det {} obss)]
+      (is (= 5 (count (:observations stf)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; multi-detector
+
+(deftest interface-multi-detector-test
+  (testing "multi-detector fans observations to all children"
+    (let [det (pd/multi-detector [(pd/null-detector) (pd/null-detector)])
+          st  (pd/init det {})
+          st' (pd/observe det st
+                          (pd/make-observation :tool/Write 1 (java.time.Instant/now)))]
+      (is (= 2 (count (:sub-states st'))))
+      (is (empty? (pd/current-anomalies st'))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Anomaly validation — delegates to the anomaly component
+
+(deftest interface-valid-anomaly-test
+  (testing "valid-anomaly? accepts a canonical anomaly with detector data"
+    (is (true? (pd/valid-anomaly? (canonical-anomaly)))))
+
+  (testing "valid-anomaly? rejects malformed input"
+    (is (false? (pd/valid-anomaly? {:not "an anomaly"})))
+    (is (false? (pd/valid-anomaly? {})))
+    (is (false? (pd/valid-anomaly? nil)))))
+
+(deftest interface-detector-anomaly-data-test
+  (testing "valid-detector-anomaly-data? accepts a complete payload"
+    (is (true? (pd/valid-detector-anomaly-data?
+                {:detector/kind     :detector/tool-loop
+                 :detector/version  "stage-1.0"
+                 :anomaly/class     :mechanical
+                 :anomaly/severity  :error
+                 :anomaly/category  :anomalies.agent/tool-loop
+                 :anomaly/evidence  {:summary "x"}}))))
+
+  (testing "rejects unknown :anomaly/class value"
+    (is (false? (pd/valid-detector-anomaly-data?
+                 {:detector/kind     :detector/tool-loop
+                  :detector/version  "stage-1.0"
+                  :anomaly/class     :NOT_A_VALID_CLASS
+                  :anomaly/severity  :error
+                  :anomaly/category  :anomalies.agent/tool-loop
+                  :anomaly/evidence  {:summary "x"}}))))
+
+  (testing "rejects unknown :anomaly/severity value"
+    (is (false? (pd/valid-detector-anomaly-data?
+                 {:detector/kind     :detector/tool-loop
+                  :detector/version  "stage-1.0"
+                  :anomaly/class     :mechanical
+                  :anomaly/severity  :NOT_A_VALID_SEVERITY
+                  :anomaly/category  :anomalies.agent/tool-loop
+                  :anomaly/evidence  {:summary "x"}})))))
+
+(deftest interface-valid-observation-test
+  (testing "valid-observation? accepts well-formed observation"
+    (is (true? (pd/valid-observation?
+                {:tool/id :tool/Bash :seq 1
+                 :timestamp (java.time.Instant/now)}))))
+
+  (testing "valid-observation? rejects missing :seq"
+    (is (false? (pd/valid-observation?
+                 {:tool/id :tool/Bash :timestamp (java.time.Instant/now)})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Tool-profile registration
+
+(deftest interface-tool-profile-test
+  (testing "make-tool-registry returns an empty atom-backed registry"
+    (let [reg (pd/make-tool-registry)]
+      (is (instance? clojure.lang.IDeref reg))
+      (is (= [] (pd/all-tool-ids reg)))))
+
+  (testing "register-tool-profile! + tool-determinism round-trip"
+    (let [reg (pd/make-tool-registry)]
+      (pd/register-tool-profile! reg
+                                 {:tool/id :tool/Read
+                                  :determinism :stable-with-resource-version
+                                  :anomaly/categories #{:anomalies.agent/tool-loop}})
+      (is (= :stable-with-resource-version (pd/tool-determinism :tool/Read reg)))
+      (is (= #{:anomalies.agent/tool-loop} (pd/tool-categories  :tool/Read reg)))))
+
+  (testing "tool-determinism returns :unstable for unregistered tools"
+    (is (= :unstable (pd/tool-determinism :tool/Unknown (pd/make-tool-registry)))))
+
+  (testing "register-tool-profile! validates against ToolProfile schema"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (pd/register-tool-profile! (pd/make-tool-registry)
+                                            {:tool/id :tool/Bad
+                                             :determinism :NOT_VALID})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Config merge
+
+(deftest interface-resolve-config-test
+  (testing "resolve-config produces enabled config from base layer"
+    (let [cfg (pd/resolve-config [{:config/params {:window-size 5}}])]
+      (is (true? (pd/config-enabled? cfg)))
+      (is (= {:window-size 5} (pd/effective-config-params cfg)))))
+
+  (testing "resolve-config handles disable then enable"
+    (let [cfg (pd/resolve-config [{:config/params {}}
+                                   {:config/directive :disable}
+                                   {:config/directive :enable}])]
+      (is (true? (pd/config-enabled? cfg)))))
+
+  (testing "config-overlay is shorthand for [parent child]"
+    (let [parent {:config/params {:a 1}}
+          child  {:config/directive :tune :config/params {:b 2}}
+          result (pd/config-overlay parent child)]
+      (is (= {:a 1 :b 2} (pd/effective-config-params result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; make-observation
+
+(deftest make-observation-test
+  (testing "make-observation creates valid observation"
+    (let [now (java.time.Instant/now)
+          obs (pd/make-observation :tool/Bash 1 now)]
+      (is (= :tool/Bash (:tool/id obs)))
+      (is (= 1 (:seq obs)))
+      (is (= now (:timestamp obs)))
+      (is (pd/valid-observation? obs))))
+
+  (testing "make-observation merges optional fields"
+    (let [obs (pd/make-observation :tool/Write 2 (java.time.Instant/now)
+                                   {:tool/duration-ms 30 :tool/error? false})]
+      (is (= 30    (:tool/duration-ms obs)))
+      (is (= false (:tool/error? obs))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; anomalies-by-severity / fatal-anomalies — read severity from :anomaly/data
+
+(deftest anomalies-by-severity-test
+  (testing "anomalies-by-severity reads severity from :anomaly/data"
+    (let [state {:anomalies
+                 [{:anomaly/data {:anomaly/severity :error :x 1}}
+                  {:anomaly/data {:anomaly/severity :warn  :x 2}}
+                  {:anomaly/data {:anomaly/severity :error :x 3}}
+                  {:anomaly/data {:anomaly/severity :fatal :x 4}}]}]
+      (is (= 2 (count (pd/anomalies-by-severity state :error))))
+      (is (= 1 (count (pd/anomalies-by-severity state :warn))))
+      (is (= 1 (count (pd/anomalies-by-severity state :fatal))))
+      (is (= [{:anomaly/data {:anomaly/severity :fatal :x 4}}]
+             (pd/fatal-anomalies state))))))

--- a/components/progress-detector/test/ai/miniforge/progress_detector/protocol_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/protocol_test.clj
@@ -1,0 +1,115 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.progress-detector.protocol-test
+  "Tests for the Detector protocol, NullDetector, and MultiDetector."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.progress-detector.protocol :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers
+
+(defn- make-obs
+  ([seq-num]
+   (make-obs seq-num :tool/bash))
+  ([seq-num tool-id]
+   {:tool/id          tool-id
+    :seq              seq-num
+    :timestamp        (java.time.Instant/now)
+    :tool/duration-ms 100}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; NullDetector
+
+(deftest null-detector-init-test
+  (testing "init returns expected initial shape"
+    (let [det   (sut/null-detector)
+          state (sut/init det {})]
+      (is (vector? (:anomalies state))    "anomalies must be a vector")
+      (is (empty?  (:anomalies state))    "anomalies must be empty initially")
+      (is (vector? (:observations state)) "observations must be a vector")
+      (is (empty?  (:observations state)) "observations must be empty initially")
+      (is (= 0 (:window-size state))      "window-size must start at 0"))))
+
+(deftest null-detector-observe-test
+  (testing "observe accumulates observations without flagging anomalies"
+    (let [det   (sut/null-detector)
+          state (sut/init det {})
+          obs1  (make-obs 1)
+          obs2  (make-obs 2)
+          st1   (sut/observe det state obs1)
+          st2   (sut/observe det st1   obs2)]
+      (is (= 1 (count (:observations st1))) "one observation after first step")
+      (is (= 2 (count (:observations st2))) "two observations after second step")
+      (is (empty? (:anomalies st2))          "NullDetector never flags anomalies")
+      (is (= 2 (:window-size st2))           "window-size tracks call count"))))
+
+(deftest null-detector-immutability-test
+  (testing "observe does not mutate its state argument"
+    (let [det   (sut/null-detector)
+          state (sut/init det {})
+          orig  (dissoc state :__volatile__)
+          _     (sut/observe det state (make-obs 1))]
+      (is (= 0 (:window-size state)) "original state unchanged after observe"))))
+
+(deftest null-detector-pure-test
+  (testing "identical input sequence produces identical output"
+    (let [det    (sut/null-detector)
+          now    (java.time.Instant/parse "2026-01-01T00:00:00Z")
+          obs    {:tool/id :tool/bash :seq 1 :timestamp now}
+          state  (sut/init det {})
+          result-a (sut/observe det state obs)
+          result-b (sut/observe det state obs)]
+      (is (= result-a result-b) "identical inputs produce identical outputs"))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; MultiDetector
+
+(deftest multi-detector-init-test
+  (testing "MultiDetector initializes all sub-detectors"
+    (let [d1  (sut/null-detector)
+          d2  (sut/null-detector)
+          det (sut/multi-detector [d1 d2])
+          st  (sut/init det {})]
+      (is (= 2 (count (:sub-states st))) "two sub-states for two detectors")
+      (is (empty? (:anomalies st)))
+      (is (empty? (:observations st))))))
+
+(deftest multi-detector-observe-fans-out-test
+  (testing "observe fans to all children and merges anomalies"
+    (let [d1  (sut/null-detector)
+          d2  (sut/null-detector)
+          det (sut/multi-detector [d1 d2])
+          st0 (sut/init det {})
+          st1 (sut/observe det st0 (make-obs 1))]
+      ;; Both sub-states should have seen the observation
+      (is (= 1 (:window-size (nth (:sub-states st1) 0))))
+      (is (= 1 (:window-size (nth (:sub-states st1) 1))))
+      (is (empty? (:anomalies st1))))))
+
+(deftest multi-detector-empty-test
+  (testing "MultiDetector with no children is valid"
+    (let [det (sut/multi-detector [])
+          st  (sut/init det {})]
+      (is (empty? (:sub-states st)))
+      (is (empty? (:anomalies st))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; reduce-observations
+
+(deftest reduce-observations-test
+  (testing "reduce-observations folds all observations"
+    (let [det  (sut/null-detector)
+          obss (map make-obs (range 5))
+          st   (sut/reduce-observations det {} obss)]
+      (is (= 5 (count (:observations st))))
+      (is (= 5 (:window-size st)))))
+
+  (testing "reduce-observations on empty seq returns init state"
+    (let [det (sut/null-detector)
+          st  (sut/reduce-observations det {} [])]
+      (is (empty? (:observations st)))
+      (is (= 0 (:window-size st))))))

--- a/components/progress-detector/test/ai/miniforge/progress_detector/schema_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/schema_test.clj
@@ -1,0 +1,183 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.progress-detector.schema-test
+  "Tests for progress-detector Malli schemas.
+
+   Anomaly validation lives on `ai.miniforge.anomaly.interface` and is
+   exercised in that component's tests — schemas here cover only the
+   progress-detector-specific shapes."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.progress-detector.schema :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test factories
+
+(defn- now [] (java.time.Instant/now))
+
+(defn- valid-detector-anomaly-data []
+  {:detector/kind     :detector/tool-loop
+   :detector/version  "stage-1.0"
+   :anomaly/class     :mechanical
+   :anomaly/severity  :error
+   :anomaly/category  :anomalies.agent/tool-loop
+   :anomaly/evidence  {:summary       "Read same file 6 times unchanged"
+                       :event-ids     []
+                       :fingerprint   "abc123"
+                       :threshold     {:n 5 :window 10}
+                       :raw-log-ref   "local://runs/x"
+                       :redacted?     true}})
+
+(defn- valid-observation []
+  {:tool/id          :tool/Bash
+   :seq              1
+   :timestamp        (now)
+   :tool/duration-ms 150})
+
+(defn- valid-tool-profile []
+  {:tool/id            :tool/Bash
+   :determinism        :environment-dependent
+   :anomaly/categories #{:anomalies.agent/repeated-failure}
+   :timeout-ms         120000})
+
+;------------------------------------------------------------------------------ Layer 1
+;; DetectorAnomalyData (the shape that lives under :anomaly/data)
+
+(deftest valid-detector-anomaly-data-test
+  (testing "complete payload is valid"
+    (is (true? (sut/valid-detector-anomaly-data? (valid-detector-anomaly-data)))))
+
+  (testing "evidence with only :summary is valid (other evidence keys optional)"
+    (is (true? (sut/valid-detector-anomaly-data?
+                (assoc (valid-detector-anomaly-data)
+                       :anomaly/evidence {:summary "minimal"}))))))
+
+(deftest invalid-detector-anomaly-data-test
+  (testing "missing :detector/kind fails"
+    (is (false? (sut/valid-detector-anomaly-data?
+                 (dissoc (valid-detector-anomaly-data) :detector/kind)))))
+
+  (testing "missing :detector/version fails"
+    (is (false? (sut/valid-detector-anomaly-data?
+                 (dissoc (valid-detector-anomaly-data) :detector/version)))))
+
+  (testing "invalid :anomaly/class value fails"
+    (is (false? (sut/valid-detector-anomaly-data?
+                 (assoc (valid-detector-anomaly-data) :anomaly/class :NOT_VALID)))))
+
+  (testing "invalid :anomaly/severity value fails"
+    (is (false? (sut/valid-detector-anomaly-data?
+                 (assoc (valid-detector-anomaly-data) :anomaly/severity :critical)))
+        ":critical is not in the spec's severity vocabulary"))
+
+  (testing "missing :anomaly/evidence fails"
+    (is (false? (sut/valid-detector-anomaly-data?
+                 (dissoc (valid-detector-anomaly-data) :anomaly/evidence))))))
+
+(deftest detector-class-vocabulary-test
+  (testing "spec-defined classes are accepted"
+    (doseq [cls [:mechanical :heuristic]]
+      (is (true? (sut/valid-detector-anomaly-data?
+                  (assoc (valid-detector-anomaly-data) :anomaly/class cls)))
+          (str cls " should be a valid detector class")))))
+
+(deftest detector-severity-ladder-test
+  (testing "all four spec-defined severities are accepted"
+    (doseq [sev [:info :warn :error :fatal]]
+      (is (true? (sut/valid-detector-anomaly-data?
+                  (assoc (valid-detector-anomaly-data) :anomaly/severity sev)))
+          (str sev " should be a valid severity")))))
+
+(deftest explain-detector-anomaly-data-test
+  (testing "returns nil for valid payload"
+    (is (nil? (sut/explain-detector-anomaly-data (valid-detector-anomaly-data)))))
+
+  (testing "returns errors for invalid payload"
+    (is (some? (sut/explain-detector-anomaly-data
+                (dissoc (valid-detector-anomaly-data) :detector/kind))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Observation schema
+
+(deftest valid-observation-test
+  (testing "valid observation passes validation"
+    (is (true? (sut/valid-observation? (valid-observation)))))
+
+  (testing "observation with optional fields is valid"
+    (is (true? (sut/valid-observation?
+                (assoc (valid-observation)
+                       :tool/input  {:cmd "ls"}
+                       :tool/output "file.txt\n"
+                       :tool/error? false))))))
+
+(deftest invalid-observation-test
+  (testing "missing :tool/id fails"
+    (is (false? (sut/valid-observation? (dissoc (valid-observation) :tool/id)))))
+
+  (testing "missing :seq fails"
+    (is (false? (sut/valid-observation? (dissoc (valid-observation) :seq)))))
+
+  (testing "missing :timestamp fails"
+    (is (false? (sut/valid-observation? (dissoc (valid-observation) :timestamp))))))
+
+(deftest explain-observation-test
+  (testing "returns nil for valid observation"
+    (is (nil? (sut/explain-observation (valid-observation)))))
+
+  (testing "returns errors for invalid observation"
+    (is (some? (sut/explain-observation {})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; ToolProfile schema
+
+(deftest valid-tool-profile-test
+  (testing "valid tool profile passes validation"
+    (is (true? (sut/valid-tool-profile? (valid-tool-profile)))))
+
+  (testing "minimal profile (only :tool/id + :determinism) is valid"
+    (is (true? (sut/valid-tool-profile?
+                {:tool/id :tool/Read :determinism :stable-with-resource-version})))))
+
+(deftest invalid-tool-profile-test
+  (testing "missing :tool/id fails"
+    (is (false? (sut/valid-tool-profile? (dissoc (valid-tool-profile) :tool/id)))))
+
+  (testing "missing :determinism fails"
+    (is (false? (sut/valid-tool-profile? (dissoc (valid-tool-profile) :determinism)))))
+
+  (testing "invalid :determinism value fails"
+    (is (false? (sut/valid-tool-profile?
+                 (assoc (valid-tool-profile) :determinism :NOT_VALID))))))
+
+(deftest determinism-vocabulary-test
+  (testing "all four spec-defined determinism levels are accepted"
+    (doseq [det [:stable-with-resource-version
+                 :stable-ish
+                 :environment-dependent
+                 :unstable]]
+      (is (true? (sut/valid-tool-profile?
+                  {:tool/id :tool/X :determinism det}))
+          (str det " should be a valid determinism level")))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; DetectorConfig schema
+
+(deftest valid-detector-config-test
+  (testing "empty map is valid (all fields optional)"
+    (is (true? (sut/valid-detector-config? {}))))
+
+  (testing "config with valid directive + params is valid"
+    (is (true? (sut/valid-detector-config?
+                {:config/directive :tune
+                 :config/params    {:window-size 10}}))))
+
+  (testing "each valid directive keyword is accepted"
+    (doseq [d [:inherit :disable :enable :tune]]
+      (is (true? (sut/valid-detector-config? {:config/directive d}))
+          (str d " should be valid"))))
+
+  (testing "invalid directive fails"
+    (is (false? (sut/valid-detector-config? {:config/directive :overwrite})))))

--- a/components/progress-detector/test/ai/miniforge/progress_detector/tool_profile_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/tool_profile_test.clj
@@ -1,0 +1,164 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.progress-detector.tool-profile-test
+  "Tests for the tool-profile registration API.
+
+   The API is registration-based — components contribute profiles via
+   register!. There is no built-in EDN-driven default registry."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.progress-detector.tool-profile :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test factories
+
+(defn- make-profile
+  "Build a valid ToolProfile for tests."
+  [tool-id determinism & {:as opts}]
+  (merge {:tool/id tool-id :determinism determinism} opts))
+
+(defn- seeded-registry
+  "Build a fresh registry pre-populated with three test profiles."
+  []
+  (let [reg (sut/make-registry)]
+    (sut/register! reg (make-profile :tool/Read :stable-with-resource-version
+                                     :anomaly/categories #{:anomalies.agent/tool-loop}
+                                     :timeout-ms 30000))
+    (sut/register! reg (make-profile :tool/Bash :environment-dependent
+                                     :anomaly/categories #{:anomalies.agent/repeated-failure}
+                                     :timeout-ms 120000))
+    (sut/register! reg (make-profile :tool/WebSearch :unstable))
+    reg))
+
+;------------------------------------------------------------------------------ Layer 1
+;; make-registry
+
+(deftest make-registry-test
+  (testing "make-registry returns an atom seeded with empty map"
+    (let [reg (sut/make-registry)]
+      (is (instance? clojure.lang.IDeref reg))
+      (is (= {} @reg)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; register! / unregister!
+
+(deftest register!-test
+  (testing "register! adds the profile keyed by :tool/id"
+    (let [reg (sut/make-registry)
+          profile (make-profile :tool/Read :stable-with-resource-version)]
+      (sut/register! reg profile)
+      (is (= profile (sut/lookup :tool/Read reg)))))
+
+  (testing "register! overwrites an existing profile"
+    (let [reg (sut/make-registry)]
+      (sut/register! reg (make-profile :tool/Read :stable-ish))
+      (sut/register! reg (make-profile :tool/Read :stable-with-resource-version))
+      (is (= :stable-with-resource-version
+             (sut/determinism-of :tool/Read reg)))))
+
+  (testing "register! throws on profile missing :tool/id"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (sut/register! (sut/make-registry)
+                                {:determinism :unstable}))))
+
+  (testing "register! throws on profile failing schema validation"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (sut/register! (sut/make-registry)
+                                {:tool/id :tool/Bad
+                                 :determinism :NOT_A_VALID_LEVEL})))))
+
+(deftest unregister!-test
+  (testing "unregister! removes the profile"
+    (let [reg (seeded-registry)]
+      (sut/unregister! reg :tool/Read)
+      (is (nil? (sut/lookup :tool/Read reg)))
+      (is (= 2 (count @reg)))))
+
+  (testing "unregister! of a missing tool-id is a no-op"
+    (let [reg (seeded-registry)]
+      (sut/unregister! reg :tool/DoesNotExist)
+      (is (= 3 (count @reg))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; lookup
+
+(deftest lookup-test
+  (testing "lookup returns the profile for a registered tool"
+    (let [reg (seeded-registry)
+          profile (sut/lookup :tool/Read reg)]
+      (is (map? profile))
+      (is (= :tool/Read (:tool/id profile)))
+      (is (= :stable-with-resource-version (:determinism profile)))))
+
+  (testing "lookup returns nil for an unregistered tool"
+    (is (nil? (sut/lookup :tool/Unknown (seeded-registry)))))
+
+  (testing "lookup accepts an unwrapped registry map (not just an atom)"
+    (let [reg (seeded-registry)
+          unwrapped @reg]
+      (is (= (sut/lookup :tool/Read reg)
+             (sut/lookup :tool/Read unwrapped))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; determinism-of
+
+(deftest determinism-of-test
+  (testing "returns the registered determinism level"
+    (let [reg (seeded-registry)]
+      (is (= :stable-with-resource-version (sut/determinism-of :tool/Read reg)))
+      (is (= :environment-dependent       (sut/determinism-of :tool/Bash reg)))
+      (is (= :unstable                    (sut/determinism-of :tool/WebSearch reg)))))
+
+  (testing "returns :unstable for unknown tools — safe heuristic-only default"
+    (is (= :unstable (sut/determinism-of :tool/UnknownToolXyz (seeded-registry))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; categories-of
+
+(deftest categories-of-test
+  (testing "returns the registered category set"
+    (let [reg (seeded-registry)]
+      (is (= #{:anomalies.agent/tool-loop}
+             (sut/categories-of :tool/Read reg)))
+      (is (= #{:anomalies.agent/repeated-failure}
+             (sut/categories-of :tool/Bash reg)))))
+
+  (testing "returns #{} for tool with no :anomaly/categories field"
+    (is (= #{} (sut/categories-of :tool/WebSearch (seeded-registry)))))
+
+  (testing "returns #{} for unknown tools"
+    (is (= #{} (sut/categories-of :tool/Unknown (seeded-registry))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; all-tool-ids
+
+(deftest all-tool-ids-test
+  (testing "returns sorted vector of registered tool-ids"
+    (let [reg (seeded-registry)
+          ids (sut/all-tool-ids reg)]
+      (is (vector? ids))
+      (is (= 3 (count ids)))
+      (is (= ids (vec (sort ids))))
+      (is (= #{:tool/Read :tool/Bash :tool/WebSearch} (set ids))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; validate-all
+
+(deftest validate-all-test
+  (testing "all registered profiles report :valid? true"
+    (let [results (sut/validate-all (seeded-registry))]
+      (is (every? :valid? (vals results)))
+      (is (every? nil? (map :errors (vals results))))))
+
+  (testing "validate-all surfaces ToolProfile errors via the right humanizer"
+    ;; Bypass register!'s validation by constructing the registry map
+    ;; directly and feeding it to validate-all.
+    (let [bad-reg (atom {:tool/Bad {:tool/id :tool/Bad
+                                    :determinism :NOT_A_VALID_LEVEL}})
+          results (sut/validate-all bad-reg)]
+      (is (false? (get-in results [:tool/Bad :valid?])))
+      (is (some? (get-in results [:tool/Bad :errors]))
+          "errors must include humanized schema feedback"))))

--- a/deps.edn
+++ b/deps.edn
@@ -23,6 +23,7 @@
                        "components/agent-runtime/src"
                        "components/agent-runtime/resources"
                        "components/anomaly/src"
+                       "components/progress-detector/src"
                        "components/clock/src"
                        "components/coerce/src"
                        "components/response-chain/src"
@@ -196,6 +197,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
+                      ai.miniforge/progress-detector {:local/root "components/progress-detector"}
                       ai.miniforge/clock {:local/root "components/clock"}
                       ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
@@ -313,6 +315,7 @@
                        "components/agent/test"
                        "components/agent-runtime/test"
                        "components/anomaly/test"
+                       "components/progress-detector/test"
                        "components/clock/test"
                        "components/coerce/test"
                        "components/response-chain/test"
@@ -433,6 +436,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
+                      ai.miniforge/progress-detector {:local/root "components/progress-detector"}
                       ai.miniforge/clock {:local/root "components/clock"}
                       ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}

--- a/work/progress-detector-semantic-loop-detection.spec.edn
+++ b/work/progress-detector-semantic-loop-detection.spec.edn
@@ -1,0 +1,407 @@
+;; =============================================================================
+;; Spec: Progress detector stage 1 — tool-loop and repair-loop detection
+;; =============================================================================
+;;
+;; The 2026-05-04 / 2026-05-05 dogfood-fix series (#779, #781, #782, #783)
+;; was a cycle of timeout bumps:
+;;
+;;   60s → 180s          (planner stagnation, #781)
+;;   180s → 360s         (stream line-timeout, #782)
+;;   120s → 180s         (reviewer stagnation, #783)
+;;
+;; Each bump calibrated to whichever spec broke us last. Prompt size,
+;; model latency, and tool-call depth are not knowable from a spec EDN
+;; — every threshold value is a guess that needs re-tuning per spec.
+;;
+;; PR #762 already showed the right primitive at the review-implement
+;; repair-loop level: fingerprint actionable issues, terminate when
+;; the fingerprint stops changing. That's loop detection — observing
+;; what the agent produces, not how long it takes.
+;;
+;; This spec is Stage 1 of a multi-stage rebuild of agent-supervision
+;; semantics. It lands the detector framework + the two mechanical
+;; detectors that directly attack the timeout-bump cycle, plus the
+;; minimal supervisor needed to act on their anomalies. Phase
+;; contracts, progress ledgers, the no-information-gain detector,
+;; and the full supervisor policy map are explicitly deferred to
+;; Stages 2 and 3.
+
+{:spec/title "Progress detector stage 1 — tool-loop and repair-loop anomaly detection"
+
+ :spec/description
+ "Land the agent-supervision substrate: a detector component, a
+  normalized anomaly schema, a tool capability registry, two
+  mechanical detectors (tool-loop, repair-loop), and the minimal
+  supervisor needed to terminate agents on mechanical anomalies.
+  Rename the wallclock guards to :prompt/liveness-watchdog so their
+  meaning matches their behavior. Defer phase contracts, progress
+  ledgers, and full :on-anomaly policy mapping to Stages 2 and 3.
+
+  Layer cake — full target architecture, for orientation:
+
+    Layer 1 — Budget + liveness     (cost, tokens, turns, OS-wedge)
+    Layer 2 — Event normalization   (envelope, tool profile, fingerprints)
+    Layer 3 — Progress / anomaly    (reducer detectors, anomaly facts)
+    Layer 4 — Supervisor policy     (anomaly composition, lifecycle)
+    Layer 5 — Phase contracts       (admissibility validation)
+
+  Stage 1 lands a usable subset:
+
+    Layer 1: rename :prompt/progress-monitor → :prompt/liveness-watchdog;
+             keep cost / token / turn budgets unchanged.
+    Layer 2: minimal tool profile registry; richer tool fingerprints
+             for tool-loop. Full event-envelope normalization deferred
+             to Stage 2.
+    Layer 3: detector framework (reducer protocol), anomaly schema,
+             :detector/tool-loop, :detector/repair-loop refactored
+             from PR #762.
+    Layer 4: minimal supervisor — mechanical anomaly defaults to
+             :terminate; heuristic to :warn; no per-category :on-anomaly
+             policy map yet.
+    Layer 5: not in this stage.
+
+  ## Why three layers instead of one threshold
+
+  Today's progress monitor conflates three different questions:
+  'Is this agent over its blast-radius cap?' (budget),
+  'Is this agent making semantic progress?' (progress detection),
+  'Did this phase produce an admissible artifact?' (phase contract).
+  All three answered with a wallclock check. That's why every dogfood
+  reveals a new threshold to bump. Stage 1 doesn't fix all three —
+  it fixes the second by making it event-driven, and renames Layer 1
+  honestly. Stage 3 will close the third.
+
+  ## Component layout (Stage 1 actual)
+
+  New: components/progress-detector/
+    src/ai/miniforge/progress_detector/
+      interface.clj          ;; public Layer 0/1 boundary
+      protocol.clj           ;; Detector protocol (reducer shape)
+                             ;;   + NullDetector + MultiDetector
+      schema.clj             ;; DetectorAnomalyData / Observation /
+                             ;;   ToolProfile / DetectorConfig schemas
+                             ;;   (anomaly schema lives on
+                             ;;    components/anomaly — re-exported)
+      tool_profile.clj       ;; registration API (register! / lookup)
+      config.clj             ;; layered config merge
+    test/...
+
+  Stage 1 explicitly does NOT ship:
+
+    detectors/tool_loop.clj    — Stage 2 (depends on event envelope)
+    detectors/repair_loop.clj  — Stage 2 (port of PR #762)
+    supervisor.clj             — Stage 3 (full :on-anomaly map)
+    resources/.../tool-profiles.edn — gone; per the user-review on PR
+                                      #784, tool profiles are
+                                      contributed by the components
+                                      that vendor each tool, not held
+                                      centrally here. Stage 2 wires
+                                      adapter-claude-code etc. to
+                                      register their profiles at load.
+
+  ## Detector protocol (Layer 3)
+
+  Detectors are pure reducers over a bounded state. The framework
+  invokes init once per agent run, then observe-event after every
+  parsed agent event. Detectors must NOT scan the event log; the
+  framework gives them events one at a time and bounded windows are
+  the detector's responsibility.
+
+    (defprotocol Detector
+      (init       [this config]                     => state)
+      (observe    [this state event]                => {:state state'
+                                                        :anomalies [...]}))
+
+  Total detector overhead per parsed event: < 5ms across all
+  registered detectors at the framework's default detector set.
+  Measured via criterium with a fixture that replays the
+  event-log-tool-visibility dogfood's recorded event sequence.
+
+  ## Anomaly schema (Layer 3)
+
+  Detectors emit pure description, no lifecycle:
+
+    {:anomaly/id          uuid?
+     :anomaly/category    keyword?           ;; :anomalies.agent/tool-loop, …
+     :anomaly/class       #{:mechanical :heuristic}
+     :anomaly/severity    #{:info :warn :error :fatal}
+     :detector/kind       keyword?
+     :detector/version    string?
+     :anomaly/evidence    {:summary       string?
+                           :event-ids     [uuid?]
+                           :fingerprint   string?
+                           :threshold     {:n int? :window int?}
+                           :raw-log-ref   string?
+                           :redacted?     boolean?}}
+
+  No :recommended-action key — lifecycle is the supervisor's job,
+  not the detector's. No :confidence — Stage 1 uses :class and
+  :severity only; composite signals are a Stage 3 concern.
+
+  Evidence is bounded: summary + event-id pointers + fingerprint +
+  threshold metadata + a pointer to the local event log via
+  :raw-log-ref. Raw tool args, raw assistant text, and raw file
+  content do NOT appear in evidence. The redaction is
+  best-effort against accidental leakage, not a soundness claim
+  against adversarial content.
+
+  ## Tool capability registry (Layer 2 minimum)
+
+  Each known tool has a profile declaring how to fingerprint a call:
+
+    {:tool/name 'Read'
+     :tool/class :filesystem/read
+     :fingerprint/dimensions [:tool/name :args/hash :resource/id
+                              :resource/version-hash :result/hash]
+     :determinism :stable-with-resource-version}
+
+    {:tool/name 'Bash'
+     :tool/class :process/exec
+     :fingerprint/dimensions [:tool/name :cwd/hash :command/hash
+                              :exit-code :failure/fingerprint]
+     :determinism :environment-dependent}
+
+    {:tool/name 'Grep'
+     :tool/class :filesystem/search
+     :fingerprint/dimensions [:tool/name :args/hash :result/hash]
+     :determinism :stable-ish}
+
+    {:tool/name 'WebSearch'
+     :tool/class :network/search
+     :fingerprint/dimensions [:tool/name :args/hash :result/hash :time/window]
+     :determinism :unstable}
+
+  The :determinism field tells the tool-loop detector what kind of
+  signal a fingerprint repeat IS:
+
+    :stable-with-resource-version → mechanical (resource hash unchanged
+                                                = same call same answer)
+    :stable-ish                   → mechanical with bounded false-positives
+    :environment-dependent        → mechanical only when failure
+                                    fingerprint also matches
+    :unstable                     → heuristic only — fingerprint repeats
+                                    are weak signal
+
+  Profiles for unknown tools fall back to a permissive default
+  (:fingerprint/dimensions [:tool/name :args/hash], :determinism
+  :unstable) — they participate as heuristic signals only, never
+  trigger mechanical termination.
+
+  ## :detector/tool-loop (mechanical)
+
+  Fingerprints each tool call from the tool's :fingerprint/dimensions.
+  Tracks a sliding window of recent fingerprints (default size 10).
+  When the same fingerprint appears > N times in the window
+  (default N=5) AND the tool's :determinism is mechanical-eligible
+  (:stable-with-resource-version, :stable-ish, or
+  :environment-dependent with matching :failure/fingerprint),
+  emits :anomalies.agent/tool-loop:
+
+    {:anomaly/category :anomalies.agent/tool-loop
+     :anomaly/class    :mechanical
+     :anomaly/severity :error
+     :detector/kind    :detector/tool-loop
+     :detector/version 'stage-1.0'
+     :anomaly/evidence {:summary       'Read \"src/foo.clj\" 6 times,
+                                       resource hash unchanged'
+                        :event-ids     [uuid uuid uuid uuid uuid uuid]
+                        :fingerprint   '<hex>'
+                        :threshold     {:n 5 :window 10}
+                        :raw-log-ref   'local://runs/<wf>/events.log'
+                        :redacted?     true}}
+
+  Re-reading a file after an Edit changes :resource/version-hash —
+  fingerprint differs, no anomaly. Re-reading the same unchanged
+  file 6 times — fingerprint matches, anomaly fires.
+
+  For tools with :determinism :unstable (WebSearch, etc.), the
+  detector keeps tracking but emits :class :heuristic instead.
+
+  ## :detector/repair-loop (mechanical, port of PR #762)
+
+  PR #762's review-fingerprint logic moves into the new component
+  unchanged. Same anomaly category (:anomalies.review/stagnation),
+  same termination semantics, same regression test. The agent
+  code path becomes a thin call into the detector. One namespace
+  owns 'is the agent making progress?' across both within-turn
+  (tool-loop) and across-turn (repair-loop) cases.
+
+  ## Minimal supervisor (Layer 4)
+
+  Stage 1 supervisor consumes detector anomalies and applies a
+  simple default policy:
+
+    :anomaly/class :mechanical → :terminate
+    :anomaly/class :heuristic  → :warn (logged, no action)
+
+  Stage 3 will replace this with a per-category :on-anomaly map
+  + composite-rules for combining heuristics into mechanical
+  promotions. Stage 1 keeps the policy hard-coded at the class
+  level — enough to make the detectors actually do something
+  without committing to the full policy surface.
+
+  ## :prompt/liveness-watchdog (Layer 1 rename)
+
+  The existing :prompt/progress-monitor block is renamed to
+  :prompt/liveness-watchdog and its semantics are clarified:
+  it's a process-wedge timer, not a progress check. New default
+  values reflect the change in meaning:
+
+    {:no-event-timeout-ms      600000   ;; 10 min — process is dead
+     :process-start-timeout-ms  60000}  ;; 1 min — spawn never produced
+
+  Existing :prompt/progress-monitor blocks keep parsing — but the
+  loader emits a deprecation warning and reinterprets the values
+  conservatively (using the larger of {old-config, new-default} so
+  no existing config gets STRICTER by accident). This is explicit
+  migration, not silent reinterpretation. A bb migration command
+  rewrites old configs in-tree.
+
+  ## Per-agent / per-phase / per-spec detector config
+
+  Detector registration is layered:
+
+    :detectors/defaults [:tool-loop :repair-loop]
+
+    :agent/detectors {…}      ;; per-agent overlay
+    :phase/detectors {…}      ;; per-phase overlay
+    :spec/detectors  {…}      ;; per-spec overlay (escape hatch)
+
+  Merge semantics, applied outermost-to-innermost:
+
+    {:inherit  true                      ;; default true
+     :disable  [:detector-kind …]        ;; remove
+     :enable   [{:kind … :config {…}}]   ;; add
+     :tune     {:detector-kind {…}}}     ;; modify config keys
+
+  Disable beats tune in conflict. Inherit=false at any level
+  drops everything from outer layers. This is the mechanism for
+  the future no-information-gain detector to be tuned per phase
+  (Stage 2 will add it; Stage 1 wires the config plumbing now).
+
+  ## What Stage 1 explicitly does NOT land
+
+  Deferred to Stage 2:
+    - Full normalized event envelope (:event/seq scoped per
+      agent-run, :resource/version-hash on every tool result,
+      richer event kinds)
+    - :detector/no-information-gain (depends on the progress ledger)
+    - Progress ledger reducer + :progress/advanced events
+    - :detector/repeated-failure (depends on parsed-failure
+      fingerprint extraction)
+
+  Deferred to Stage 3:
+    - Phase contracts (:phase/contract block per phase)
+    - Phase status taxonomy (:succeeded / :failed-contract /
+      :failed-anomaly / :failed-budget / :failed-liveness /
+      :failed-tool / :cancelled / :requires-human)
+    - Full supervisor :on-anomaly policy map
+    - Composite-rules for promoting combined heuristics to
+      mechanical anomalies
+    - :detector/text-similarity and :detector/event-motif-loop
+    - Workflow runner enforcement of contracts at phase
+      boundaries"
+
+ :spec/intent
+ {:type  :feature
+  :scope ["components/progress-detector/src"
+          "components/progress-detector/resources"
+          "components/progress-detector/test"
+          "components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj"
+          "components/llm/src/ai/miniforge/llm/progress_monitor.clj"
+          "components/llm/resources/llm/client-defaults.edn"
+          "components/agent/src/ai/miniforge/agent/reviewer.clj"
+          "components/agent/src/ai/miniforge/agent/planner.clj"
+          "components/agent/src/ai/miniforge/agent/implementer.clj"
+          "components/agent/resources/prompts/planner.edn"
+          "components/agent/resources/prompts/implementer.edn"
+          "components/agent/resources/prompts/reviewer.edn"
+          "components/agent/resources/prompts/tester.edn"
+          "components/agent/resources/prompts/releaser.edn"
+          "components/agent/resources/prompts/curator.edn"
+          "components/anomaly/src"]}
+
+ :spec/constraints
+ ["Detectors are pure reducers (init / observe-event), not stream rescans — total detector overhead per parsed event must stay under 5ms across all registered detectors at the framework's default detector set, measured via criterium with a recorded event-fixture"
+  "Detectors emit pure-description anomalies. No :recommended-action key in the anomaly schema. Lifecycle policy lives only in the supervisor"
+  "Anomaly evidence is bounded: summary + event-id pointers + fingerprint + threshold metadata + :raw-log-ref. No raw tool args, raw assistant text, or raw file content in evidence payloads. Redaction is best-effort, not a soundness guarantee"
+  "Tool fingerprint dimensions come from the tool capability registry, not from per-detector logic. Adding a new tool to the registry must NOT require a code change in any detector"
+  "PR #762's review-fingerprint behavior is preserved end-to-end when ported into the new component as :detector/repair-loop — same anomaly category (:anomalies.review/stagnation), same termination semantics, verified against PR #762's existing regression test"
+  "Backward compat: :prompt/progress-monitor blocks parse with a deprecation warning. The reinterpreted values cannot make an existing config stricter than its declared values implied. A bb migration command rewrites old configs to :prompt/liveness-watchdog"
+  "Removing all detectors must still leave Layer 1 (cost / token / turn / liveness) caps enforced — Stage 1 detectors are additive guards, not the only safety net"
+  "Mechanical anomalies default to supervisor action :terminate. Heuristic anomalies default to :warn (logged, no action). The full per-category :on-anomaly policy map is explicitly Stage 3"
+  "Detector / supervisor behavior is data-driven via :detectors and :prompt/liveness-watchdog config blocks. Per-agent / per-phase / per-spec overlays merge with explicit semantics (:inherit / :disable / :enable / :tune)"
+  "Anomaly composition (multiple anomalies in the same turn) follows a deterministic rule: all anomalies are recorded in the event log; supervisor selects one controlling anomaly using order = :fatal > :error > :warn > :info, ties broken by :class :mechanical > :heuristic, further ties broken by earliest :event/seq. The full composite-rules system is Stage 3"]
+
+ :spec/acceptance-criteria
+ [;; Detector framework
+  "components/progress-detector/ exists and exports the Detector protocol, the anomaly schema, the tool capability registry, and the registered detector kinds"
+  "Detectors implement Detector via init / observe-event reducer shape — no detector calls into the event log directly; the framework feeds events one at a time"
+
+  ;; Tool-loop, mechanical positives
+  ":detector/tool-loop fires :anomalies.agent/tool-loop (class :mechanical, severity :error) when an agent calls Read on the same path 6 times AND :resource/version-hash is unchanged each time — verified by integration test"
+  ":detector/tool-loop fires when an agent calls Bash with the same command and the same parsed :failure/fingerprint 6 times in a row — verified by integration test"
+  ":detector/tool-loop fires when an agent calls Glob with the same pattern 6 times AND the matched-paths hash is unchanged — verified by integration test"
+
+  ;; Tool-loop, mechanical negatives
+  ":detector/tool-loop does NOT fire when the same Read args return a different :resource/version-hash after an Edit — verified by integration test"
+  ":detector/tool-loop does NOT fire when an agent calls Read on 6 different files (distinct fingerprints)"
+  ":detector/tool-loop does NOT fire when an agent calls Bash with the same command but the failure fingerprint changes between runs (different parsed errors)"
+  ":detector/tool-loop emits :class :heuristic (not :mechanical) for repeated WebSearch calls — :determinism :unstable disqualifies mechanical termination"
+
+  ;; Repair-loop refactor
+  ":detector/repair-loop reproduces PR #762's :anomalies.review/stagnation behavior end-to-end — same fingerprint composition, same termination semantics, verified against PR #762's existing regression test (no behavior change visible to the agent code path)"
+
+  ;; Supervisor minimal policy
+  "An agent that triggers a mechanical anomaly is terminated by the supervisor. The terminating anomaly is recorded in the event log with full schema (:category, :class, :severity, :detector/kind, :detector/version, :evidence)"
+  "An agent that triggers a heuristic anomaly is logged but NOT terminated by the supervisor (Stage 1's heuristic default is :warn)"
+
+  ;; Layered config
+  "Layered detector config merges correctly: a planner with {:disable [:tool-loop]} must not fire that detector; a tester with {:tune {:tool-loop {:n 8}}} must use the bumped threshold; a per-spec overlay with :inherit false drops outer layers"
+
+  ;; Liveness watchdog rename
+  "Existing :prompt/progress-monitor blocks parse with a deprecation warning — verified by test that asserts the warning fires once per loaded prompt-data"
+  "The reinterpreted :prompt/progress-monitor → :prompt/liveness-watchdog values are never STRICTER than the declared values implied (verified by property test over arbitrary legacy configs)"
+  "bb miniforge migrate-prompts rewrites :prompt/progress-monitor blocks in tree to :prompt/liveness-watchdog with the new keys"
+
+  ;; Performance
+  "Per-event detector overhead in the criterium benchmark suite stays under 5ms total across the framework's default detector set ([:tool-loop :repair-loop]) over a recorded fixture of the event-log-tool-visibility dogfood's event sequence"
+
+  ;; Evidence bounding
+  "Anomaly :evidence does not contain raw tool args, raw assistant text, or raw file content — verified by a fuzzer test that injects synthetic 'secret-shaped' content into agent inputs and asserts none of those strings appear in any emitted anomaly's evidence map"
+
+  ;; Anomaly composition
+  "When multiple anomalies fire in the same turn, all are recorded; the supervisor selects one controlling anomaly using the documented order; the controlling-anomaly choice is reproducible across runs given the same event sequence"
+
+  ;; Dogfood viability
+  "A dogfood run on event-log-tool-visibility EITHER (a) completes through the full SDLC, OR (b) terminates with a detector-emitted anomaly that names which detector fired and includes reproducible evidence — never a bare wallclock timeout from the renamed liveness watchdog (those are reserved for true OS-level wedges with default no-event-timeout-ms 600000)"]
+
+ :spec/deferred
+ [{:stage :stage-2
+   :scope ["full normalized event envelope (:event/seq per agent-run,
+            :resource/version-hash on every tool result,
+            richer event kinds)"
+           ":detector/no-information-gain (depends on progress ledger)"
+           "progress ledger reducer + :progress/advanced events"
+           ":detector/repeated-failure (depends on parsed-failure fingerprints)"]}
+  {:stage :stage-3
+   :scope ["phase contracts (:phase/contract block per phase)"
+           "phase status taxonomy (:succeeded / :failed-contract /
+            :failed-anomaly / :failed-budget / :failed-liveness /
+            :failed-tool / :cancelled / :requires-human)"
+           "full supervisor :on-anomaly policy map per category"
+           "composite-rules for promoting combined heuristics
+            to mechanical anomalies"
+           ":detector/text-similarity"
+           ":detector/event-motif-loop"
+           "workflow runner enforcement of contracts at phase boundaries"]}]
+
+ :spec/priority
+ {:tier        :critical
+  :axes        #{:agent-quality :dogfood-enabler :supervision}
+  :theme       :semantic-supervision
+  :rationale   "Replaces the threshold-bump cycle with semantic loop detection at the within-turn level — the failure mode the dogfood-fix series #779/#781/#782/#783 has been chasing. Tool-loop detection is the dogfood-blocking bottleneck; phase contracts (Stage 3) are required for full success-funnel correctness but Stage 1 alone unblocks the immediate iteration. The minimal supervisor in Stage 1 is enough to make the detectors actually act; the full :on-anomaly policy surface is staged separately to avoid landing runtime constitution alongside detector mechanics."
+  :blocks      ["agent-stream-watchdog-and-resume.spec.edn"]
+  :blocked-by  []}
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
## Summary

Stopgap: wires `:prompt/progress-monitor` into the reviewer agent (mirrors planner.clj/edn from PR #781), with a 180s stagnation threshold.

## Why

The 2026-05-04 `event-log-tool-visibility` dogfood (post #779/#781/#782) walked explore → plan → implement → verify successfully. Review #1 ran 4.3m with **4/4 quality gates passing** but came back `:rejected`. Inspecting the persisted review artifact:

```
:decision :rejected
:gates-passed 4 / :gates-failed 0
:blocking-issues ["Adaptive timeout: Stagnation timeout: no progress for 120119ms"]
```

Same class of bug as the planner stagnation we fixed in #781 — different agent. Reviewer's LLM call passed only `:system + :max-turns` to `llm/chat`, no `:progress-monitor`. Supervisor fell back to the framework default 120s, which is too tight for Opus on a review prompt that embeds the full implement artifact (8+ source files, 50–100k tokens) — the model spent 120s+ on Read/Grep before emitting structured EDN, supervisor killed it, runtime synthesized "Review rejected" with a stagnation-timeout blocking issue.

## Caveat — this is a stopgap

The threshold-bump pattern (60s → 180s for planner, now 120s → 180s for reviewer) is reactive. Each bump calibrates to whichever spec broke us last. Prompt size, model latency, tool-call depth — none of it is knowable from a spec EDN. The proper fix is a real progress detector that watches *what* the agent is doing (loop signatures, no-commitment patterns, repeated tool calls) rather than *whether stdout is alive*. Tracked separately as a follow-up spec; this PR is the threshold-bump that lets the next dogfood reach the next blocker.

## Changes

- `reviewer.edn`: add `:prompt/progress-monitor` block (180s stagnation, 600s max-total). Version 1.0.0 → 1.1.0.
- `reviewer.clj`: introduce `reviewer-prompt-data` delay + `create-reviewer-progress-monitor` (mirrors planner.clj). Wire monitor onto chat / chat-stream opts when config is present; falls back to framework default when EDN omits the block.

## Test plan

- [x] `bb test` — 5025 tests, 0 failures, 0 errors
- [ ] Re-run `event-log-tool-visibility` dogfood (resume from checkpoint) — expected: review completes without timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)