### PR TITLE
feat(workflow): :sequential-merge strategy (Stage 4a)

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -84,6 +84,8 @@
   :dag.merge/conflict                "Multi-parent merge conflicted"
   :dag.merge/merge-failed-worktree   "Could not create temp worktree for merge"
   :dag.merge/merge-failed-ref-write  "Failed to write merge result to namespaced ref"
+  :dag.merge/merge-failed-head-read  "Merge succeeded but rev-parse HEAD failed"
+  :dag.merge/merge-failed-fatal      "git merge failed (non-conflict): {git-exit}"
   :dag.merge/commit-message-header   "miniforge dag-merge for task {task-id}"
   :dag.merge/commit-message-parent   "  {index}. {task-id} @ {commit-sha}"
   :dag.merge/sequential-step-header  "miniforge dag-merge step {step}/{total} for task {task-id}"

--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -86,6 +86,8 @@
   :dag.merge/merge-failed-ref-write  "Failed to write merge result to namespaced ref"
   :dag.merge/commit-message-header   "miniforge dag-merge for task {task-id}"
   :dag.merge/commit-message-parent   "  {index}. {task-id} @ {commit-sha}"
+  :dag.merge/sequential-step-header  "miniforge dag-merge step {step}/{total} for task {task-id}"
+  :dag.merge/sequential-step-body    "Merged parent {parent-task-id} @ {parent-sha}"
 
   ;; v2 multi-parent merge — system-locale strings (operator-internal,
   ;; never user-localized, but routed through the catalog so we have one

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -293,13 +293,22 @@
   "refs/miniforge/dag-base")
 
 (def ^:private supported-merge-strategies
-  "Strategies `merge-parent-branches!` knows how to execute today.
-   `:git-merge` ships in Stage 1B; `:sequential-merge` is Stage 4
-   (per spec §4 / §10.11). Plans that explicitly request an unsupported
-   strategy get a typed anomaly rather than silently falling through
-   to `:git-merge` (which would misreport the executed strategy in
-   logs and the resolution-sub-workflow payload)."
-  #{:git-merge})
+  "Strategies `merge-parent-branches!` knows how to execute. Per spec
+   §4:
+
+   - `:git-merge` (default): one git merge invocation; `ort` for 2
+     effective parents, `octopus` for 3+.
+   - `:sequential-merge`: pairwise `ort` merges in plan-declaration
+     order. Each merge is a two-parent merge (well-characterized);
+     handles parent branches that themselves contain merge commits;
+     preserves merge-resolution history across iterations. Slower
+     than octopus on 3+ parents with no conflicts but easier to
+     reason about per-step when conflicts do happen.
+
+   Plans that explicitly request an unsupported strategy get a typed
+   anomaly rather than silently falling through to a different
+   strategy."
+  #{:git-merge :sequential-merge})
 
 (def ^:private octopus-merge-min-parents
   "git's `octopus` strategy is required for 3+ parents. The default
@@ -638,20 +647,21 @@
          (map parse-unmerged-line)
          summarize-conflicts-by-path)))
 
-(defn- run-merge!
-  "Invoke `git merge` in the temp worktree per spec §3.1 / §6.1.
-   Returns either:
-   - `(response/success {:commit-sha <sha>})` when the merge lands a
-     real commit and rev-parse HEAD reports it cleanly.
-   - The conflict anomaly map (`:anomalies/dag-multi-parent-conflict`)
-     when git's exit code reports a conflict.
-   - The merge-failed anomaly map (`:anomalies/dag-multi-parent-merge-failed`)
-     when the merge succeeded but rev-parse HEAD failed (rare
-     infrastructure case).
+(defn- head-sha-or-anomaly
+  "After a merge invocation succeeds, read HEAD and return either a
+   response/success with the commit sha or the merge-failed anomaly.
+   Shared between :git-merge and :sequential-merge happy paths."
+  [worktree-path task-id]
+  (let [head (run-git worktree-path "rev-parse" "HEAD")]
+    (if (zero? (:exit head))
+      (response/success {:commit-sha (str/trim (:out head))} nil)
+      (ref-write-failed-anomaly task-id nil nil head))))
 
-   Caller checks `response/success?` for the happy path and dispatches
-   on `:anomaly/category` for the failure path."
-  [worktree-path task-id strategy parents input-key]
+(defn- run-git-merge!
+  "The :git-merge strategy: a single git merge invocation against the
+   collapsed parent set. Selects ort for 2 effective parents, octopus
+   for 3+. Spec §4.1."
+  [worktree-path task-id parents input-key strategy]
   (let [rest-parents (rest parents)
         message (deterministic-merge-message task-id parents)
         merge-args (concat ["merge" "-s" (merge-strategy-name parents)]
@@ -659,13 +669,76 @@
                            (map :commit-sha rest-parents))
         r (apply run-git worktree-path merge-args)]
     (if (zero? (:exit r))
-      (let [head (run-git worktree-path "rev-parse" "HEAD")]
-        (if (zero? (:exit head))
-          (response/success {:commit-sha (str/trim (:out head))} nil)
-          (ref-write-failed-anomaly task-id nil nil head)))
+      (head-sha-or-anomaly worktree-path task-id)
       (conflict-anomaly task-id strategy parents
                         (enumerate-conflicts worktree-path)
                         input-key r))))
+
+(defn- sequential-step-message
+  "Per-step commit message for the :sequential-merge strategy. Each
+   pairwise merge gets its own commit message so `git log` reads as a
+   sequence of named integration steps rather than identical headers."
+  [task-id step total parent]
+  (let [header (messages/t :dag.merge/sequential-step-header
+                           {:step  step
+                            :total total
+                            :task-id task-id})
+        body   (messages/t :dag.merge/sequential-step-body
+                           {:parent-task-id (:task/id parent)
+                            :parent-sha     (:commit-sha parent)})]
+    (str header "\n\n" body)))
+
+(defn- run-sequential-merge!
+  "The :sequential-merge strategy: pairwise merges in plan-declaration
+   order. Each step is a two-parent `ort` merge. Spec §4.2.
+
+   Returns response/success on the full chain (with HEAD's sha after
+   all parents merged) or the conflict anomaly on the first step that
+   conflicts. The conflict anomaly's :merge/strategy is preserved as
+   :sequential-merge so downstream consumers see what was actually
+   attempted."
+  [worktree-path task-id parents input-key strategy]
+  (let [pairwise-parents (rest parents)
+        total-steps      (count pairwise-parents)]
+    (loop [remaining pairwise-parents
+           step 1]
+      (if-not (seq remaining)
+        ;; All steps committed cleanly; HEAD is the final merge commit.
+        (head-sha-or-anomaly worktree-path task-id)
+        (let [parent (first remaining)
+              message (sequential-step-message task-id step total-steps parent)
+              merge-args (concat ["merge" "-s" "ort"]
+                                 (pinned-merge-flags message)
+                                 [(:commit-sha parent)])
+              r (apply run-git worktree-path merge-args)]
+          (if (zero? (:exit r))
+            (recur (rest remaining) (inc step))
+            (conflict-anomaly task-id strategy parents
+                              (enumerate-conflicts worktree-path)
+                              input-key r)))))))
+
+(defn- run-merge!
+  "Invoke the merge strategy in the temp worktree per spec §3.1 / §6.1.
+   Returns either:
+   - `(response/success {:commit-sha <sha>})` when the merge lands a
+     real commit and rev-parse HEAD reports it cleanly.
+   - The conflict anomaly map (`:anomalies/dag-multi-parent-conflict`)
+     when git's exit code reports a conflict (sequential-merge: on
+     the first step that conflicts; git-merge: on the single merge).
+   - The merge-failed anomaly map (`:anomalies/dag-multi-parent-merge-failed`)
+     when the merge succeeded but rev-parse HEAD failed (rare
+     infrastructure case).
+
+   Caller checks `response/success?` for the happy path and dispatches
+   on `:anomaly/category` for the failure path."
+  [worktree-path task-id strategy parents input-key]
+  (case strategy
+    :git-merge        (run-git-merge!        worktree-path task-id parents input-key strategy)
+    :sequential-merge (run-sequential-merge! worktree-path task-id parents input-key strategy)
+    ;; Defensive — supported-merge-strategies guards upstream stop us
+    ;; from reaching this branch in normal flow. If we do, surface a
+    ;; typed anomaly rather than silently picking a strategy.
+    (strategy-unsupported-anomaly task-id strategy)))
 
 (defn- ensure-clean-worktree!
   "Remove any pre-existing temp worktree at `path` and re-create it

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -409,6 +409,37 @@
    :git/exit-code    (:exit git-result)
    :git/stderr       (:err git-result)})
 
+(defn- head-read-failed-anomaly
+  "Anomaly: merge succeeded but `git rev-parse HEAD` failed. Distinct
+   from `ref-write-failed-anomaly` because no ref write has been
+   attempted yet (the merge commit exists in HEAD but we couldn't
+   read it back to write the namespaced ref). No `:merge/ref` /
+   `:merge/commit-sha` fields — they don't exist at this point."
+  [task-id git-result]
+  {:anomaly/category :anomalies/dag-multi-parent-merge-failed
+   :anomaly/message  (messages/t :dag.merge/merge-failed-head-read)
+   :task/id          task-id
+   :git/exit-code    (:exit git-result)
+   :git/stderr       (:err git-result)})
+
+(defn- merge-fatal-anomaly
+  "Anomaly: `git merge` exited non-zero AND there are no unmerged
+   entries in the index — meaning git failed for an infrastructure
+   reason (dirty worktree, repo corruption, fatal error) rather than
+   producing conflict markers. Routing this through the conflict-
+   resolution loop would mask the original cause; surface as a
+   merge-failed anomaly so the operator sees the real problem."
+  [task-id strategy parents input-key git-result]
+  {:anomaly/category :anomalies/dag-multi-parent-merge-failed
+   :anomaly/message  (messages/t :dag.merge/merge-failed-fatal
+                                 {:git-exit (:exit git-result)})
+   :task/id          task-id
+   :merge/parents    parents
+   :merge/strategy   strategy
+   :merge/input-key  input-key
+   :git/exit-code    (:exit git-result)
+   :git/stderr       (:err git-result)})
+
 (defn- merge-error?
   "True when a value is one of our merge anomalies (the canonical
    shape with :anomaly/category). Lets callers branch on the result
@@ -649,13 +680,36 @@
 
 (defn- head-sha-or-anomaly
   "After a merge invocation succeeds, read HEAD and return either a
-   response/success with the commit sha or the merge-failed anomaly.
-   Shared between :git-merge and :sequential-merge happy paths."
+   response/success with the commit sha or the head-read-failed
+   anomaly. Shared between :git-merge and :sequential-merge happy
+   paths. Uses `head-read-failed-anomaly` (not `ref-write-failed-anomaly`)
+   because no ref write has been attempted yet — the misuse would
+   mislead operators with an irrelevant message and nil ref/sha
+   fields."
   [worktree-path task-id]
   (let [head (run-git worktree-path "rev-parse" "HEAD")]
     (if (zero? (:exit head))
       (response/success {:commit-sha (str/trim (:out head))} nil)
-      (ref-write-failed-anomaly task-id nil nil head))))
+      (head-read-failed-anomaly task-id head))))
+
+(defn- merge-failure-anomaly
+  "Classify a non-zero `git merge` exit code:
+   - If the index has unmerged entries, the merge produced conflict
+     markers — return the conflict-anomaly so the resolution loop
+     can attempt to fix it.
+   - Otherwise, git failed for an infrastructure reason (fatal
+     error, dirty worktree, etc.) — return the merge-fatal anomaly
+     so the operator sees the real cause without it being masked
+     by the resolution loop's generic unresolvable terminal.
+
+   `git merge`'s exit code is documented as 1 for conflicts but
+   other versions/conditions can return non-zero without conflicts;
+   the unmerged-index check is the reliable signal."
+  [worktree-path task-id strategy parents input-key git-result]
+  (let [conflicts (enumerate-conflicts worktree-path)]
+    (if (seq conflicts)
+      (conflict-anomaly task-id strategy parents conflicts input-key git-result)
+      (merge-fatal-anomaly task-id strategy parents input-key git-result))))
 
 (defn- run-git-merge!
   "The :git-merge strategy: a single git merge invocation against the
@@ -670,9 +724,8 @@
         r (apply run-git worktree-path merge-args)]
     (if (zero? (:exit r))
       (head-sha-or-anomaly worktree-path task-id)
-      (conflict-anomaly task-id strategy parents
-                        (enumerate-conflicts worktree-path)
-                        input-key r))))
+      (merge-failure-anomaly worktree-path task-id strategy parents
+                             input-key r))))
 
 (defn- sequential-step-message
   "Per-step commit message for the :sequential-merge strategy. Each
@@ -713,9 +766,8 @@
               r (apply run-git worktree-path merge-args)]
           (if (zero? (:exit r))
             (recur (rest remaining) (inc step))
-            (conflict-anomaly task-id strategy parents
-                              (enumerate-conflicts worktree-path)
-                              input-key r)))))))
+            (merge-failure-anomaly worktree-path task-id strategy parents
+                                   input-key r)))))))
 
 (defn- run-merge!
   "Invoke the merge strategy in the temp worktree per spec §3.1 / §6.1.

--- a/components/workflow/src/ai/miniforge/workflow/merge_resolution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/merge_resolution.clj
@@ -122,9 +122,19 @@
   "Spec §6.1 terminal: the resolution sub-workflow couldn't produce a
    clean merge within budget / before the curator declared the agent
    stuck. Carries enough context for an operator dashboard to surface
-   what was tried and what state the worktree was last in."
-  [{:keys [task-id strategy parents conflicts input-key
-           reason iterations last-attempt-ref]}]
+   what was tried and what state the worktree was last in.
+
+   Inputs from the upstream conflict-anomaly are read with their
+   namespaced keys (`:task/id`, `:merge/strategy`, `:merge/parents`,
+   `:merge/conflicts`, `:merge/input-key`); resolution-loop bookkeeping
+   uses unnamespaced keys (`:reason`, `:iterations`, `:last-attempt-ref`)
+   added by `terminal-result`."
+  [{task-id   :task/id
+    strategy  :merge/strategy
+    parents   :merge/parents
+    conflicts :merge/conflicts
+    input-key :merge/input-key
+    :keys     [reason iterations last-attempt-ref]}]
   {:anomaly/category :anomalies/dag-multi-parent-unresolvable
    :anomaly/message  (messages/t :dag.merge.resolution/unresolvable)
    :task/id          task-id

--- a/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
@@ -370,11 +370,12 @@
 
 (deftest sequential-merge-three-parent-disjoint-test
   (testing "Three parents touching disjoint files merge cleanly via the
-            :sequential-merge strategy: three pairwise `ort` merges in
-            plan-declaration order. Final HEAD is a chain of two merge
-            commits (p1 merged into p0-base, then p2 merged into the
-            result), each with two parents. All three files end up in
-            the tree."
+            :sequential-merge strategy: TWO pairwise `ort` merges
+            (N parents → N-1 merge invocations), each one a two-parent
+            merge against the running result, in plan-declaration order.
+            Final HEAD is a chain of two merge commits (p1 merged into
+            p0-base, then p2 merged into the result), each with two
+            parents. All three files end up in the tree."
     (create-parent-branch! "task-a" "src/a.txt" "from a\n")
     (create-parent-branch! "task-b" "src/b.txt" "from b\n")
     (create-parent-branch! "task-c" "src/c.txt" "from c\n")
@@ -405,14 +406,12 @@
         (is (= 3 (count parts))
             "final merge commit + 2 parents (sequential always 2-parent steps)")))))
 
-(deftest sequential-merge-conflict-on-second-step-test
-  (testing "When the second step in the sequential chain conflicts, the
-            anomaly surfaces with :merge/strategy :sequential-merge.
-            (The first parent merges cleanly, then the second parent
-            conflicts on the same file the first parent edited.) Tests
-            that the strategy keyword echoes through the conflict
-            anomaly so resolution-loop telemetry shows what was
-            attempted."
+(deftest sequential-merge-conflict-on-the-merge-step-test
+  (testing "Two parents conflicting on the same file produce a conflict
+            on the (single, since N=2 → N-1=1) merge step. The
+            unresolvable anomaly's :merge/strategy preserves
+            :sequential-merge so resolution-loop telemetry shows what
+            was attempted."
     (run-git! *repo* "checkout" "-b" "task-a" "main")
     (commit-file! *repo* "src/conflict.txt" "from a\n" "a edit")
     (run-git! *repo* "checkout" "-b" "task-b" "main")

--- a/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/merge_parent_branches_integration_test.clj
@@ -343,27 +343,95 @@
 ;------------------------------------------------------------------------------ Tests: unsupported strategy
 
 (deftest unsupported-strategy-anomaly-test
-  (testing "Strategies other than :git-merge fail fast with a typed
-            anomaly rather than silently falling through. :sequential-merge
-            ships in Stage 4; until then plans that explicitly request it
-            should see the unsupported-strategy anomaly so they don't
-            silently get :git-merge behavior under a different label."
+  (testing "Strategies not in supported-merge-strategies fail fast with
+            a typed anomaly. As of Stage 4a, :git-merge and
+            :sequential-merge are supported; any OTHER value still
+            surfaces :anomalies/dag-multi-parent-strategy-unsupported."
     (create-parent-branch! "task-a" "src/a.txt" "from a\n")
     (create-parent-branch! "task-b" "src/b.txt" "from b\n")
+    (let [task-def {:task/id "task-c"
+                    :task/deps [:a :b]
+                    ;; Bogus strategy keyword — never supported.
+                    :task/merge-strategy :pile-on-merge}
+          ctx (ctx-with-registry {:a {:branch "task-a"}
+                                  :b {:branch "task-b"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)]
+      (is (= :anomalies/dag-multi-parent-strategy-unsupported
+             (:anomaly/category result)))
+      (is (= :pile-on-merge (:merge/strategy result))
+          "the requested strategy is echoed back in the anomaly so the
+           operator/dashboard knows what was rejected")
+      (is (contains? (:merge/supported result) :git-merge)
+          "the anomaly carries the supported-strategies set")
+      (is (contains? (:merge/supported result) :sequential-merge)
+          ":sequential-merge is now in the supported set"))))
+
+;------------------------------------------------------------------------------ Tests: :sequential-merge
+
+(deftest sequential-merge-three-parent-disjoint-test
+  (testing "Three parents touching disjoint files merge cleanly via the
+            :sequential-merge strategy: three pairwise `ort` merges in
+            plan-declaration order. Final HEAD is a chain of two merge
+            commits (p1 merged into p0-base, then p2 merged into the
+            result), each with two parents. All three files end up in
+            the tree."
+    (create-parent-branch! "task-a" "src/a.txt" "from a\n")
+    (create-parent-branch! "task-b" "src/b.txt" "from b\n")
+    (create-parent-branch! "task-c" "src/c.txt" "from c\n")
+    (let [task-def {:task/id "task-d"
+                    :task/deps [:a :b :c]
+                    :task/merge-strategy :sequential-merge}
+          ctx (ctx-with-registry {:a {:branch "task-a"}
+                                  :b {:branch "task-b"}
+                                  :c {:branch "task-c"}})
+          result (dag-orch/merge-parent-branches! ctx task-def)
+          data (:data result)]
+      (is (dag/ok? result))
+      (is (= :sequential-merge (:strategy data)))
+      (is (str/starts-with? (:branch data) "refs/miniforge/dag-base/"))
+      (is (= 40 (count (:commit-sha data))))
+      (let [tree (run-git! *repo* "ls-tree" "-r" "--name-only" (:commit-sha data))
+            files (set (str/split-lines (str/trim (:out tree))))]
+        (is (contains? files "src/a.txt"))
+        (is (contains? files "src/b.txt"))
+        (is (contains? files "src/c.txt")))
+      ;; Final HEAD has two parents (the sequential-step before it +
+      ;; the last parent merged in). The previous step's commit has two
+      ;; parents too. Walking back two steps gets us to the original
+      ;; checked-out p0 SHA, single-parent root.
+      (let [parents-cmd (run-git! *repo* "rev-list" "--parents" "-n" "1"
+                                  (:commit-sha data))
+            parts (str/split (str/trim (:out parents-cmd)) #"\s+")]
+        (is (= 3 (count parts))
+            "final merge commit + 2 parents (sequential always 2-parent steps)")))))
+
+(deftest sequential-merge-conflict-on-second-step-test
+  (testing "When the second step in the sequential chain conflicts, the
+            anomaly surfaces with :merge/strategy :sequential-merge.
+            (The first parent merges cleanly, then the second parent
+            conflicts on the same file the first parent edited.) Tests
+            that the strategy keyword echoes through the conflict
+            anomaly so resolution-loop telemetry shows what was
+            attempted."
+    (run-git! *repo* "checkout" "-b" "task-a" "main")
+    (commit-file! *repo* "src/conflict.txt" "from a\n" "a edit")
+    (run-git! *repo* "checkout" "-b" "task-b" "main")
+    (commit-file! *repo* "src/conflict.txt" "from b\n" "b edit")
+    (run-git! *repo* "checkout" "main")
     (let [task-def {:task/id "task-c"
                     :task/deps [:a :b]
                     :task/merge-strategy :sequential-merge}
           ctx (ctx-with-registry {:a {:branch "task-a"}
                                   :b {:branch "task-b"}})
           result (dag-orch/merge-parent-branches! ctx task-def)]
-      (is (= :anomalies/dag-multi-parent-strategy-unsupported
+      ;; With the no-op stub agent (Stage 2B's default), the resolution
+      ;; loop hits recurring-conflict and terminates as unresolvable.
+      ;; The :merge/strategy on the underlying conflict-anomaly carries
+      ;; through into the unresolvable anomaly's :merge/strategy too.
+      (is (= :anomalies/dag-multi-parent-unresolvable
              (:anomaly/category result)))
       (is (= :sequential-merge (:merge/strategy result))
-          "the requested strategy is echoed back in the anomaly so the
-           operator/dashboard knows what was rejected")
-      (is (contains? (:merge/supported result) :git-merge)
-          "the anomaly carries the supported-strategies set so the user
-           can see what's available right now"))))
+          "strategy keyword preserved through resolution loop terminal"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment


### PR DESCRIPTION
## Summary

Stage 4a of v2 multi-parent merge per [I-DAG-MULTI-PARENT-MERGE.md §4.2 / §10.11](https://github.com/miniforge-ai/miniforge/blob/main/specs/informative/I-DAG-MULTI-PARENT-MERGE.md). Adds the alternate merge strategy to the supported set; plans can now opt in via `:task/merge-strategy :sequential-merge`. Default remains `:git-merge`.

## What's in this PR

**Strategy implementation**: pairwise `git merge -s ort` invocations in plan-declaration order. Each step is a robust two-parent merge; per-step conflict detection is easier to reason about than n-way octopus when conflicts do happen; handles parent branches that contain intermediate fan-in merge commits without `--mainline` plumbing.

Trade-offs vs. `:git-merge`:
- History reads as a chain of pairwise merges rather than a single fan-in.
- Slower than octopus on 3+ disjoint parents with no conflicts.
- Per-step conflict isolation makes the resolution loop's input clearer when one specific parent is the troublemaker.

**Code changes**:
- `run-merge!` now dispatches on strategy via `case`: `:git-merge` → existing `run-git-merge!`; `:sequential-merge` → new `run-sequential-merge!`; defensive default → strategy-unsupported anomaly.
- `run-sequential-merge!` walks `(rest parents)` doing one `git merge -s ort` per step with the spec §3.1 pinned flags. Per-step commit message names the step number, total, parent task-id, parent SHA so `git log` reads as a sequence of named integration steps.
- `head-sha-or-anomaly` extracted as a shared helper between the two strategy implementations.
- `supported-merge-strategies` now `#{:git-merge :sequential-merge}`.
- New catalog entries `:dag.merge/sequential-step-header` and `:dag.merge/sequential-step-body`.

**Bug fix discovered by new tests**: `unresolvable-anomaly` was destructuring unnamespaced keys (`strategy`, `parents`, etc) but `conflict-input` carries them under `:merge/strategy`, `:merge/parents`. Pre-Stage-4a no test asserted on these (all `:git-merge` unresolvables had no other strategies to compare against). Fixed the destructure to use the namespaced keys.

## Test plan

- [x] `sequential-merge-three-parent-disjoint-test`: 3 parents touching disjoint files; asserts `dag/ok` with `:strategy :sequential-merge`, namespaced ref written, all three files in the merged tree, final HEAD has 2 parents.
- [x] `sequential-merge-conflict-on-second-step-test`: 2 conflicting parents; asserts the unresolvable anomaly preserves `:merge/strategy :sequential-merge` through the resolution loop.
- [x] `unsupported-strategy-anomaly-test` updated (uses `:pile-on-merge` bogus keyword since `:sequential-merge` is now supported) and asserts both supported strategies appear in `:merge/supported`.
- [x] `bb test`: 5079 / 23165 / 0 / 0.

## Spec traceability

| Spec section | Implemented in this PR |
| ------------ | ---------------------- |
| §4.2 `:sequential-merge` algorithm | `run-sequential-merge!` |
| §3.1 pinned merge flags | reused `pinned-merge-flags` |
| §4.4 plan-annotated strategy | `:task/merge-strategy` already in schema (Stage 1A); guard now allows `:sequential-merge` |
| §10.11 strategy keyword set | `supported-merge-strategies` updated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)