### PR TITLE
refactor: exceptions-as-data cleanup of workflow (loader side)

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
@@ -24,6 +24,7 @@
    [clojure.java.io :as io]
    [clojure.edn :as edn]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response.interface :as response])
   (:import
    [java.util.jar JarFile]))
@@ -104,14 +105,22 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API
 
-(defn load-chain
-  "Load a chain definition from classpath resources.
+(defn try-load-chain
+  "Anomaly-returning chain loader.
 
    Arguments:
    - chain-id: Chain identifier (keyword, e.g. :reporting-chain)
    - version: Version string (e.g. \"1.0.0\" or \"latest\")
 
-   Returns chain definition map or throws if not found."
+   Returns:
+   - on success: `{:chain chain-def :source :resource :path resource-path}`
+   - on miss:    a `:not-found` anomaly carrying `:chain-id`, `:version`,
+                 `:looked-for` (vector of paths attempted)
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   site `load-chain` inlines a `response/throw-anomaly!` when an
+   anomaly is observed, preserving the legacy thrown-exception
+   contract for external callers that depend on it."
   [chain-id version]
   (let [versioned-path (str "chains/" (name chain-id) "-v" version ".edn")
         base-path (str "chains/" (name chain-id) ".edn")
@@ -123,10 +132,33 @@
         chain-def (when resource-path (load-chain-resource resource-path))]
     (if chain-def
       {:chain chain-def :source :resource :path resource-path}
+      (anomaly/anomaly :not-found
+                       (str "Chain '" (name chain-id) "' not found. "
+                            "Looked for: " versioned-path ", " base-path)
+                       {:chain-id chain-id
+                        :version version
+                        :looked-for [versioned-path base-path]}))))
+
+(defn load-chain
+  "Load a chain definition from classpath resources.
+
+   Arguments:
+   - chain-id: Chain identifier (keyword, e.g. :reporting-chain)
+   - version: Version string (e.g. \"1.0.0\" or \"latest\")
+
+   Returns the chain definition result map on success.
+   Throws via `response/throw-anomaly!` with category
+   `:anomalies/not-found` when no matching chain resource exists.
+
+   For an anomaly-returning equivalent that callers can branch on as
+   data, use `try-load-chain` directly."
+  [chain-id version]
+  (let [result (try-load-chain chain-id version)]
+    (if (anomaly/anomaly? result)
       (response/throw-anomaly! :anomalies/not-found
-                              (str "Chain '" (name chain-id) "' not found. "
-                                   "Looked for: " versioned-path ", " base-path)
-                              {:chain-id chain-id :version version}))))
+                               (:anomaly/message result)
+                               (:anomaly/data result))
+      result)))
 
 (defn list-chains
   "List all available chain definitions from classpath."

--- a/components/workflow/src/ai/miniforge/workflow/loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/loader.clj
@@ -23,6 +23,7 @@
    [clojure.java.io :as io]
    [clojure.edn :as edn]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.validator :as validator]
    [ai.miniforge.heuristic.interface :as heuristic])
@@ -115,7 +116,16 @@
    - workflow-id: Workflow identifier (keyword)
    - version: Version string (e.g., \"2.0.0\" or \"latest\")
 
-   Returns workflow config map or nil if not found."
+   Returns:
+   - workflow config map on success
+   - nil when no matching resource exists on the classpath
+   - a `:fault` anomaly when a candidate resource was found but EDN
+     parsing failed (carrying `:workflow-id`, `:resource-path`, `:error`)
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   site `load-workflow` inlines a `response/throw-anomaly!` when an
+   anomaly is observed, preserving the legacy thrown-exception contract
+   for external callers that depend on it."
   [workflow-id version]
   (let [;; Try versioned filename first: workflows/standard-sdlc-v2.0.0.edn
         versioned-path (str "workflows/" (name workflow-id) "-v" version ".edn")
@@ -133,11 +143,11 @@
         (with-open [rdr (io/reader resource)]
           (edn/read (java.io.PushbackReader. rdr)))
         (catch Exception e
-          (response/throw-anomaly! :anomalies/fault
-                                  "Failed to load workflow from resource"
-                                  {:workflow-id workflow-id
-                                   :resource-path resource-path
-                                   :error (.getMessage e)}))))))
+          (anomaly/anomaly :fault
+                           "Failed to load workflow from resource"
+                           {:workflow-id workflow-id
+                            :resource-path resource-path
+                            :error (.getMessage e)}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Heuristic store loading
@@ -174,33 +184,48 @@
 (defn try-load-from-sources
   "Try loading workflow from resource or store.
 
-   Returns workflow or nil if not found."
+   Returns:
+   - workflow config map on success
+   - nil if no matching resource or store entry was found
+   - a `:fault` anomaly when a resource was found but failed to parse
+     (propagates the anomaly from `load-from-resource`)"
   [workflow-id version opts]
-  (or (load-from-resource workflow-id version)
-      (load-from-store workflow-id version opts)))
+  (let [from-resource (load-from-resource workflow-id version)]
+    (cond
+      (anomaly/anomaly? from-resource) from-resource
+      (some? from-resource)            from-resource
+      :else                            (load-from-store workflow-id version opts))))
 
 (defn validate-and-cache-workflow
   "Validate workflow and add to cache.
 
-   Throws ex-info if validation fails.
-   Returns result map with workflow, source, and validation."
+   Returns:
+   - on success: a result map `{:workflow :source :validation}`
+   - on validation failure: an `:invalid-input` anomaly carrying
+     `:workflow-id`, `:version`, `:errors`
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   site `load-workflow` inlines a `response/throw-anomaly!` when an
+   anomaly is observed."
   [workflow workflow-id version skip-validation?]
   (let [validation (if skip-validation?
                     {:valid? true :errors []}
                     (validator/validate-workflow workflow))]
-    (when-not (:valid? validation)
-      (response/throw-anomaly! :anomalies.workflow/invalid-config
-                              "Workflow validation failed"
-                              {:workflow-id workflow-id
-                               :version version
-                               :errors (:errors validation)}))
-
-    ;; Cache the validated workflow
-    (swap! workflow-cache assoc [workflow-id version] workflow)
-
-    {:workflow workflow
-     :source (if (load-from-resource workflow-id version) :resource :store)
-     :validation validation}))
+    (if-not (:valid? validation)
+      (anomaly/anomaly :invalid-input
+                       "Workflow validation failed"
+                       {:workflow-id workflow-id
+                        :version version
+                        :errors (:errors validation)})
+      (do
+        ;; Cache the validated workflow
+        (swap! workflow-cache assoc [workflow-id version] workflow)
+        {:workflow workflow
+         :source (let [from-resource (load-from-resource workflow-id version)]
+                   (if (and from-resource (not (anomaly/anomaly? from-resource)))
+                     :resource
+                     :store))
+         :validation validation}))))
 
 (defn load-workflow
   "Load workflow config with caching.
@@ -219,7 +244,18 @@
     :source :resource | :store | :cache
     :validation validation-result}
 
-   Throws ex-info if workflow not found or validation fails."
+   This is the external-boundary entry point. It inlines
+   `response/throw-anomaly!` on:
+   - parse failures from `load-from-resource` (anomaly category
+     `:anomalies/fault`)
+   - validation failures from `validate-and-cache-workflow`
+     (anomaly category `:anomalies.workflow/invalid-config`)
+   - missing workflow on every source (anomaly category
+     `:anomalies/not-found`)
+
+   For anomaly-returning equivalents that callers can branch on as
+   data, use `load-from-resource` and `validate-and-cache-workflow`
+   directly."
   [workflow-id version opts]
   (let [cache-key [workflow-id version]
         skip-cache? (:skip-cache? opts false)
@@ -232,14 +268,29 @@
        :validation {:valid? true :errors []}}
 
       ;; Try loading from sources
-      (if-let [workflow (try-load-from-sources workflow-id version opts)]
-        (validate-and-cache-workflow workflow workflow-id version skip-validation?)
+      (let [from-sources (try-load-from-sources workflow-id version opts)]
+        (cond
+          ;; Source-level fault — escalate at this single boundary site.
+          (anomaly/anomaly? from-sources)
+          (response/throw-anomaly! :anomalies/fault
+                                   (:anomaly/message from-sources)
+                                   (:anomaly/data from-sources))
 
-        ;; Not found anywhere
-        (response/throw-anomaly! :anomalies/not-found
-                                "Workflow not found"
-                                {:workflow-id workflow-id
-                                 :version version})))))
+          ;; Found — validate-and-cache may itself return an anomaly.
+          (some? from-sources)
+          (let [result (validate-and-cache-workflow from-sources workflow-id version skip-validation?)]
+            (if (anomaly/anomaly? result)
+              (response/throw-anomaly! :anomalies.workflow/invalid-config
+                                       (:anomaly/message result)
+                                       (:anomaly/data result))
+              result))
+
+          ;; Not found anywhere
+          :else
+          (response/throw-anomaly! :anomalies/not-found
+                                   "Workflow not found"
+                                   {:workflow-id workflow-id
+                                    :version version}))))))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Workflow discovery

--- a/components/workflow/src/ai/miniforge/workflow/loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/loader.clj
@@ -185,29 +185,46 @@
   "Try loading workflow from resource or store.
 
    Returns:
-   - workflow config map on success
+   - `{:workflow w :source :resource}` when found via `load-from-resource`
+   - `{:workflow w :source :store}` when found via `load-from-store`
    - nil if no matching resource or store entry was found
    - a `:fault` anomaly when a resource was found but failed to parse
-     (propagates the anomaly from `load-from-resource`)"
+     (propagates the anomaly from `load-from-resource`)
+
+   The result includes `:source` so the caller can thread it through
+   `validate-and-cache-workflow` without re-reading the resource."
   [workflow-id version opts]
   (let [from-resource (load-from-resource workflow-id version)]
     (cond
       (anomaly/anomaly? from-resource) from-resource
-      (some? from-resource)            from-resource
-      :else                            (load-from-store workflow-id version opts))))
+      (some? from-resource)            {:workflow from-resource :source :resource}
+      :else                            (when-let [w (load-from-store workflow-id version opts)]
+                                         {:workflow w :source :store}))))
 
 (defn validate-and-cache-workflow
   "Validate workflow and add to cache.
 
+   Arguments:
+   - workflow         — the workflow config map
+   - workflow-id      — keyword id
+   - version          — version string
+   - source           — `:resource` | `:store` (where the workflow was
+                        loaded from). Threaded by callers that already
+                        know — e.g. `try-load-from-sources` returns it
+                        in its result map. Avoids a second
+                        `load-from-resource` round-trip just to compute
+                        `:source`.
+   - skip-validation? — bypass the validator (still caches)
+
    Returns:
-   - on success: a result map `{:workflow :source :validation}`
+   - on success: `{:workflow :source :validation}`
    - on validation failure: an `:invalid-input` anomaly carrying
      `:workflow-id`, `:version`, `:errors`
 
    This is the canonical, anomaly-returning entry point. The boundary
    site `load-workflow` inlines a `response/throw-anomaly!` when an
    anomaly is observed."
-  [workflow workflow-id version skip-validation?]
+  [workflow workflow-id version source skip-validation?]
   (let [validation (if skip-validation?
                     {:valid? true :errors []}
                     (validator/validate-workflow workflow))]
@@ -221,10 +238,7 @@
         ;; Cache the validated workflow
         (swap! workflow-cache assoc [workflow-id version] workflow)
         {:workflow workflow
-         :source (let [from-resource (load-from-resource workflow-id version)]
-                   (if (and from-resource (not (anomaly/anomaly? from-resource)))
-                     :resource
-                     :store))
+         :source source
          :validation validation}))))
 
 (defn load-workflow
@@ -277,8 +291,13 @@
                                    (:anomaly/data from-sources))
 
           ;; Found — validate-and-cache may itself return an anomaly.
+          ;; `from-sources` is `{:workflow :source}` per
+          ;; `try-load-from-sources`; pass `:source` through directly so
+          ;; we don't re-read the resource.
           (some? from-sources)
-          (let [result (validate-and-cache-workflow from-sources workflow-id version skip-validation?)]
+          (let [{:keys [workflow source]} from-sources
+                result (validate-and-cache-workflow workflow workflow-id version
+                                                    source skip-validation?)]
             (if (anomaly/anomaly? result)
               (response/throw-anomaly! :anomalies.workflow/invalid-config
                                        (:anomaly/message result)

--- a/components/workflow/src/ai/miniforge/workflow/registry.clj
+++ b/components/workflow/src/ai/miniforge/workflow/registry.clj
@@ -140,8 +140,12 @@
         phase-count (count phases)
         max-iterations (get-in workflow [:workflow/config :max-total-iterations] 20)
         task-types (:workflow/task-types workflow)
-        has-review? (some #(str/includes? (str (:phase/id %)) "review") phases)
-        has-testing? (some #(str/includes? (str (:phase/id %)) "test") phases)
+        ;; `some` returns true | nil; the WorkflowCharacteristics schema
+        ;; requires `boolean?`, so coerce the nil case to false. Without
+        ;; the wrap, workflows with no review/test phases would fail
+        ;; schema validation and emit a spurious :invalid-input anomaly.
+        has-review? (boolean (some #(str/includes? (str (:phase/id %)) "review") phases))
+        has-testing? (boolean (some #(str/includes? (str (:phase/id %)) "test") phases))
         complexity (cond
                      (< phase-count 4) :simple
                      (< phase-count 8) :medium

--- a/components/workflow/src/ai/miniforge/workflow/registry.clj
+++ b/components/workflow/src/ai/miniforge/workflow/registry.clj
@@ -30,6 +30,7 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.workflow.validator :as validator]
@@ -90,21 +91,34 @@
    Arguments:
      resource-path - Path to workflow EDN file
 
-   Returns: Workflow map or nil if not found"
+   Returns:
+   - workflow definition map on success
+   - nil when no resource exists at `resource-path`
+   - a `:fault` anomaly when the resource exists but failed to parse
+     (carrying `:resource-path` and `:error`)
+
+   This is the canonical, anomaly-returning entry point. The
+   in-component caller `discover-workflows-from-resources` filters
+   anomalies out of its sequence rather than letting one bad resource
+   abort discovery."
   [resource-path]
   (when-let [resource (io/resource resource-path)]
     (try
       (edn/read-string (slurp resource))
       (catch Exception e
-        (response/throw-anomaly! :anomalies/fault
-                                (str "Failed to load workflow from " resource-path)
-                                {:resource-path resource-path
-                                 :error (ex-message e)})))))
+        (anomaly/anomaly :fault
+                         (str "Failed to load workflow from " resource-path)
+                         {:resource-path resource-path
+                          :error (ex-message e)})))))
 
 (defn discover-workflows-from-resources
   "Discover workflows from classpath resources.
    The active workflow families are determined by whichever components contribute
    `workflows/*.edn` files to the classpath.
+
+   Filters out resources that failed to parse (anomaly results from
+   `load-workflow-from-resource`) so a single corrupt EDN file does
+   not mask all workflows.
 
    Returns: Sequence of workflow maps"
   []
@@ -112,10 +126,58 @@
        (filter #(str/ends-with? % ".edn"))
        (sort)
        (map #(str "workflows/" %))
-       (keep load-workflow-from-resource)))
+       (keep load-workflow-from-resource)
+       (remove anomaly/anomaly?)))
 
 ;;------------------------------------------------------------------------------ Layer 2
 ;; Workflow characteristics
+
+(defn- compute-characteristics
+  "Compute the raw characteristics map from a workflow definition,
+   without schema validation. Pure data shaping."
+  [workflow]
+  (let [phases (:workflow/phases workflow)
+        phase-count (count phases)
+        max-iterations (get-in workflow [:workflow/config :max-total-iterations] 20)
+        task-types (:workflow/task-types workflow)
+        has-review? (some #(str/includes? (str (:phase/id %)) "review") phases)
+        has-testing? (some #(str/includes? (str (:phase/id %)) "test") phases)
+        complexity (cond
+                     (< phase-count 4) :simple
+                     (< phase-count 8) :medium
+                     :else :complex)]
+    {:id (:workflow/id workflow)
+     :version (:workflow/version workflow)
+     :name (:workflow/name workflow)
+     :description (:workflow/description workflow)
+     :phases phase-count
+     :max-iterations max-iterations
+     :task-types (or task-types [])
+     :complexity complexity
+     :has-review has-review?
+     :has-testing has-testing?}))
+
+(defn try-workflow-characteristics
+  "Anomaly-returning variant of `workflow-characteristics`.
+
+   Returns:
+   - on success: characteristics map validated against
+     `WorkflowCharacteristics`
+   - on schema failure: an `:invalid-input` anomaly carrying
+     `:characteristics` and `:errors` (humanized malli explanation)
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   site `workflow-characteristics` inlines a `response/throw-anomaly!`
+   when an anomaly is observed, preserving the legacy thrown-exception
+   contract for external callers that depend on a plain map."
+  [workflow]
+  (let [characteristics (compute-characteristics workflow)]
+    (if (schemas/valid-characteristics? characteristics)
+      characteristics
+      (anomaly/anomaly :invalid-input
+                       "Invalid workflow characteristics"
+                       {:characteristics characteristics
+                        :errors (schemas/explain-characteristics characteristics)}))))
 
 (defn workflow-characteristics
   "Extract characteristics from workflow for selection.
@@ -133,35 +195,19 @@
       :task-types [keywords]
       :complexity :simple | :medium | :complex
       :has-review boolean
-      :has-testing boolean}"
+      :has-testing boolean}
+
+   Throws via `response/throw-anomaly!` with category
+   `:anomalies.workflow/invalid-config` when the computed
+   characteristics fail schema validation. Use
+   `try-workflow-characteristics` for an anomaly-returning equivalent."
   [workflow]
-  (let [phases (:workflow/phases workflow)
-        phase-count (count phases)
-        max-iterations (get-in workflow [:workflow/config :max-total-iterations] 20)
-        task-types (:workflow/task-types workflow)
-        has-review? (some #(str/includes? (str (:phase/id %)) "review") phases)
-        has-testing? (some #(str/includes? (str (:phase/id %)) "test") phases)
-        complexity (cond
-                     (< phase-count 4) :simple
-                     (< phase-count 8) :medium
-                     :else :complex)
-        characteristics {:id (:workflow/id workflow)
-                         :version (:workflow/version workflow)
-                         :name (:workflow/name workflow)
-                         :description (:workflow/description workflow)
-                         :phases phase-count
-                         :max-iterations max-iterations
-                         :task-types (or task-types [])
-                         :complexity complexity
-                         :has-review has-review?
-                         :has-testing has-testing?}]
-    ;; Validate against schema
-    (when-not (schemas/valid-characteristics? characteristics)
+  (let [result (try-workflow-characteristics workflow)]
+    (if (anomaly/anomaly? result)
       (response/throw-anomaly! :anomalies.workflow/invalid-config
-                              "Invalid workflow characteristics"
-                              {:characteristics characteristics
-                               :errors (schemas/explain-characteristics characteristics)}))
-    characteristics))
+                               (:anomaly/message result)
+                               (:anomaly/data result))
+      result)))
 
 ;;------------------------------------------------------------------------------ Layer 3
 ;; Registry operations
@@ -170,18 +216,40 @@
   [workflow]
   (:errors (validator/validate-workflow workflow)))
 
-(defn- validate-workflow-registration!
+(defn validate-workflow-registration
+  "Validate a workflow definition for registration.
+
+   Returns:
+   - the workflow itself when validation passes
+   - an `:invalid-input` anomaly carrying `:workflow-id` and
+     `:validation/errors` when the validator reports errors
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   site `register-workflow!` inlines a `response/throw-anomaly!` when
+   an anomaly is observed."
   [workflow]
   (let [workflow-id (:workflow/id workflow)
         errors (registration-errors workflow)]
-    (when (seq errors)
-      (response/throw-anomaly!
-       :anomalies.workflow/invalid-config
-       (messages/t :status/invalid-workflow-registration
-                   {:workflow-id workflow-id})
-       {:workflow-id workflow-id
-        :validation/errors errors}))
-    workflow))
+    (if (seq errors)
+      (anomaly/anomaly :invalid-input
+                       (messages/t :status/invalid-workflow-registration
+                                   {:workflow-id workflow-id})
+                       {:workflow-id workflow-id
+                        :validation/errors errors})
+      workflow)))
+
+(defn missing-workflow-id-anomaly
+  "Return an `:invalid-input` anomaly describing a workflow missing
+   `:workflow/id`, or nil when the id is present.
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   site `register-workflow!` inlines a `response/throw-anomaly!` on
+   anomaly."
+  [workflow]
+  (when-not (:workflow/id workflow)
+    (anomaly/anomaly :invalid-input
+                     (messages/t :status/missing-workflow-id)
+                     {:workflow workflow})))
 
 (defn register-workflow!
   "Register a workflow in the registry.
@@ -189,15 +257,26 @@
    Arguments:
      workflow - Workflow definition map
 
-  Returns: The registered workflow"
+   Returns: The registered workflow.
+
+   Throws via `response/throw-anomaly!` with category
+   `:anomalies/incorrect` when `:workflow/id` is missing, or
+   `:anomalies.workflow/invalid-config` when validator reports errors.
+
+   For anomaly-returning equivalents that callers can branch on as
+   data, use `missing-workflow-id-anomaly` and
+   `validate-workflow-registration`."
   [workflow]
-  (let [id (:workflow/id workflow)]
-    (when-not id
-      (response/throw-anomaly! :anomalies/incorrect
-                              (messages/t :status/missing-workflow-id)
-                              {:workflow workflow}))
-    (validate-workflow-registration! workflow)
-    (swap! registry assoc id workflow)
+  (when-let [a (missing-workflow-id-anomaly workflow)]
+    (response/throw-anomaly! :anomalies/incorrect
+                             (:anomaly/message a)
+                             (:anomaly/data a)))
+  (let [validated (validate-workflow-registration workflow)]
+    (when (anomaly/anomaly? validated)
+      (response/throw-anomaly! :anomalies.workflow/invalid-config
+                               (:anomaly/message validated)
+                               (:anomaly/data validated)))
+    (swap! registry assoc (:workflow/id workflow) workflow)
     workflow))
 
 (defn get-workflow

--- a/components/workflow/src/ai/miniforge/workflow/schemas.clj
+++ b/components/workflow/src/ai/miniforge/workflow/schemas.clj
@@ -18,7 +18,8 @@
 
 (ns ai.miniforge.workflow.schemas
   "Malli schemas for workflow-related data structures."
-  (:require [malli.core :as m]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [malli.core :as m]
             [malli.error :as me]))
 
 ;;------------------------------------------------------------------------------ Layer 0
@@ -155,11 +156,36 @@
   (when-let [explanation (m/explain CheckpointData value)]
     (me/humanize explanation)))
 
-(defn validate-checkpoint-data!
-  "Validate loaded or soon-to-be-persisted checkpoint data at the boundary."
+(defn validate-checkpoint-data
+  "Validate loaded or soon-to-be-persisted checkpoint data.
+
+   Returns:
+   - the input value when it satisfies `CheckpointData`
+   - an `:invalid-input` anomaly carrying `:value` and `:errors`
+     (humanized malli explanation) otherwise
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   helper `validate-checkpoint-data!` re-escalates the anomaly via a
+   thrown `ex-info` for callers (e.g. the checkpoint store) that
+   treat schema breakage as a programmer error rather than a runtime
+   condition to be carried forward as data."
   [value]
   (if (valid-checkpoint-data? value)
     value
-    (throw (ex-info "Invalid checkpoint data"
-                    {:value value
-                     :errors (explain-checkpoint-data value)}))))
+    (anomaly/anomaly :invalid-input
+                     "Invalid checkpoint data"
+                     {:value value
+                      :errors (explain-checkpoint-data value)})))
+
+(defn validate-checkpoint-data!
+  "Validate loaded or soon-to-be-persisted checkpoint data at the boundary.
+
+   Returns the input value when valid; throws `ex-info` carrying
+   `:value` and `:errors` when invalid. Use `validate-checkpoint-data`
+   for an anomaly-returning equivalent."
+  [value]
+  (let [result (validate-checkpoint-data value)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      (:anomaly/data result)))
+      result)))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/load_from_resource_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/load_from_resource_test.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.load-from-resource-test
+  "Coverage for `loader/load-from-resource` (anomaly-returning) and the
+   `loader/load-workflow` boundary that escalates anomalies to slingshot
+   throws.
+
+   The parse-failure path returns a `:fault` anomaly. The boundary
+   `load-workflow` inlines a `response/throw-anomaly!` with the
+   `:anomalies/fault` slingshot category so legacy try+ callers above
+   still observe the thrown shape they depend on."
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.loader :as loader])
+  (:import (clojure.lang ExceptionInfo)))
+
+;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
+
+(deftest load-from-resource-returns-workflow-on-success
+  (testing "valid workflow EDN parses to a map (no anomaly)"
+    (let [workflow (loader/load-from-resource :canonical-sdlc "2.0.0")]
+      (is (some? workflow))
+      (is (not (anomaly/anomaly? workflow)))
+      (is (map? workflow)))))
+
+(deftest load-from-resource-returns-nil-when-not-on-classpath
+  (testing "absent resource returns plain nil (not an anomaly)"
+    (let [result (loader/load-from-resource :no-such-workflow-9001 "1.0.0")]
+      (is (nil? result))
+      (is (not (anomaly/anomaly? result))))))
+
+;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
+
+(deftest load-from-resource-returns-anomaly-on-parse-failure
+  (testing "EDN parse failure yields a :fault anomaly with diagnostics"
+    ;; Simulate an exception path in load-from-resource by redef'ing a
+    ;; collaborator. We use a workflow id that does resolve on the
+    ;; classpath, then make the inner read explode.
+    (with-redefs [edn/read (fn [_] (throw (RuntimeException. "edn parse boom")))]
+      (let [result (loader/load-from-resource :canonical-sdlc "2.0.0")]
+        (is (anomaly/anomaly? result))
+        (is (= :fault (:anomaly/type result)))
+        (let [data (:anomaly/data result)]
+          (is (= :canonical-sdlc (:workflow-id data)))
+          (is (some? (:resource-path data)))
+          (is (= "edn parse boom" (:error data))))))))
+
+;------------------------------------------------------------------------------ Boundary escalation through load-workflow
+
+(deftest load-workflow-throws-on-load-from-resource-fault
+  (testing "load-workflow escalates a parse-failure anomaly to slingshot"
+    (loader/clear-cache!)
+    (with-redefs [loader/load-from-resource (fn [workflow-id _version]
+                                              (anomaly/anomaly :fault
+                                                               "boom"
+                                                               {:workflow-id workflow-id
+                                                                :resource-path "x"
+                                                                :error "parse error"}))
+                  loader/load-from-store (fn [_ _ _] nil)]
+      (try
+        (loader/load-workflow :anything "1.0.0" {})
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (let [data (ex-data e)]
+            (is (= :anomalies/fault (:anomaly/category data)))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/load_workflow_from_resource_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/load_workflow_from_resource_test.clj
@@ -1,0 +1,68 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.load-workflow-from-resource-test
+  "Coverage for `registry/load-workflow-from-resource` (anomaly-returning)
+   and the `discover-workflows-from-resources` consumer that filters
+   anomalies out of its sequence rather than letting one bad resource
+   abort discovery."
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.registry :as registry]))
+
+;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
+
+(deftest load-workflow-from-resource-returns-map-on-success
+  (testing "existing workflow EDN resource parses to a non-anomaly map"
+    (let [result (registry/load-workflow-from-resource "workflows/canonical-sdlc-v2.0.0.edn")]
+      (is (some? result))
+      (is (not (anomaly/anomaly? result)))
+      (is (map? result)))))
+
+(deftest load-workflow-from-resource-returns-nil-when-resource-absent
+  (testing "absent resource returns nil (no anomaly)"
+    (is (nil? (registry/load-workflow-from-resource "workflows/no-such-workflow-9001.edn")))))
+
+;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
+
+(deftest load-workflow-from-resource-returns-anomaly-on-parse-failure
+  (testing "EDN parse failure yields a :fault anomaly"
+    (with-redefs [edn/read-string (fn [_] (throw (RuntimeException. "edn boom")))]
+      (let [result (registry/load-workflow-from-resource "workflows/canonical-sdlc-v2.0.0.edn")]
+        (is (anomaly/anomaly? result))
+        (is (= :fault (:anomaly/type result)))
+        (let [data (:anomaly/data result)]
+          (is (= "workflows/canonical-sdlc-v2.0.0.edn" (:resource-path data)))
+          (is (= "edn boom" (:error data))))))))
+
+;------------------------------------------------------------------------------ Discovery filters out anomalies
+
+(deftest discover-workflows-skips-anomalies
+  (testing "discover-workflows-from-resources removes anomaly results from its seq"
+    (let [bad-anomaly (anomaly/anomaly :fault "broken" {:resource-path "x"})]
+      (with-redefs [registry/list-resource-names (fn [_] ["one.edn" "two.edn"])
+                    registry/load-workflow-from-resource
+                    (fn [path]
+                      (case path
+                        "workflows/one.edn" {:workflow/id :one}
+                        "workflows/two.edn" bad-anomaly))]
+        (let [result (registry/discover-workflows-from-resources)]
+          (is (= 1 (count result)))
+          (is (= :one (:workflow/id (first result))))
+          (is (every? (complement anomaly/anomaly?) result)))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/register_workflow_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/register_workflow_test.clj
@@ -1,0 +1,101 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.register-workflow-test
+  "Coverage for the registry registration anomaly-returning helpers
+   (`missing-workflow-id-anomaly`, `validate-workflow-registration`)
+   and the `register-workflow!` boundary that escalates them to
+   slingshot."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.registry :as registry]
+            [ai.miniforge.workflow.validator :as validator])
+  (:import (clojure.lang ExceptionInfo)))
+
+(def workflow-no-id
+  {:workflow/version "1.0.0"
+   :workflow/name "Anonymous"
+   :workflow/phases [{:phase/id :start}]})
+
+;------------------------------------------------------------------------------ missing-workflow-id-anomaly
+
+(deftest missing-workflow-id-anomaly-returns-nil-when-id-present
+  (testing "id present → nil (no anomaly)"
+    (is (nil? (registry/missing-workflow-id-anomaly {:workflow/id :ok})))))
+
+(deftest missing-workflow-id-anomaly-returns-anomaly-when-id-missing
+  (testing "id absent → :invalid-input anomaly carrying :workflow"
+    (let [result (registry/missing-workflow-id-anomaly workflow-no-id)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= workflow-no-id (get-in result [:anomaly/data :workflow]))))))
+
+;------------------------------------------------------------------------------ validate-workflow-registration
+
+(deftest validate-workflow-registration-returns-anomaly-on-invalid
+  (testing "validator errors → :invalid-input anomaly carrying :validation/errors"
+    (with-redefs [validator/validate-workflow
+                  (fn [_] {:valid? false :errors [{:msg "bad"}]})]
+      (let [result (registry/validate-workflow-registration {:workflow/id :x})]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= :x (get-in result [:anomaly/data :workflow-id])))
+        (is (seq (get-in result [:anomaly/data :validation/errors])))))))
+
+(deftest validate-workflow-registration-returns-workflow-on-valid
+  (testing "validator clean → returns the workflow itself (no anomaly)"
+    (with-redefs [validator/validate-workflow
+                  (fn [_] {:valid? true :errors []})]
+      (let [wf {:workflow/id :ok}
+            result (registry/validate-workflow-registration wf)]
+        (is (not (anomaly/anomaly? result)))
+        (is (= wf result))))))
+
+;------------------------------------------------------------------------------ Boundary escalation through register-workflow!
+
+(deftest register-workflow!-throws-on-missing-id
+  (registry/clear-registry!)
+  (testing "register-workflow! escalates missing-id anomaly under :anomalies/incorrect"
+    (try
+      (registry/register-workflow! workflow-no-id)
+      (is false "should have thrown")
+      (catch ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= :anomalies/incorrect (:anomaly/category data))))))))
+
+(deftest register-workflow!-throws-on-validator-failure
+  (registry/clear-registry!)
+  (testing "register-workflow! escalates validator anomaly under :anomalies.workflow/invalid-config"
+    (with-redefs [validator/validate-workflow
+                  (fn [_] {:valid? false :errors [{:msg "bad"}]})]
+      (try
+        (registry/register-workflow! {:workflow/id :bad})
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (let [data (ex-data e)]
+            (is (= :anomalies.workflow/invalid-config (:anomaly/category data)))))))))
+
+(deftest register-workflow!-happy-path
+  (registry/clear-registry!)
+  (testing "valid workflow is stored and returned unchanged"
+    (with-redefs [validator/validate-workflow
+                  (fn [_] {:valid? true :errors []})]
+      (let [wf {:workflow/id :ok-test :workflow/version "1.0.0"}
+            result (registry/register-workflow! wf)]
+        (is (= wf result))
+        (is (registry/workflow-exists? :ok-test))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/try_load_chain_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/try_load_chain_test.clj
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.try-load-chain-test
+  "Coverage for `chain-loader/try-load-chain` (anomaly-returning) and
+   the `chain-loader/load-chain` boundary that escalates a not-found
+   anomaly to slingshot under `:anomalies/not-found`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.chain-loader :as chain-loader])
+  (:import (clojure.lang ExceptionInfo)))
+
+;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
+
+(deftest try-load-chain-returns-result-on-success
+  (testing "existing chain resource yields a non-anomaly result map"
+    (let [result (chain-loader/try-load-chain :spec-to-pr "1.0.0")]
+      (is (not (anomaly/anomaly? result)))
+      (is (some? (:chain result)))
+      (is (= :resource (:source result))))))
+
+;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
+
+(deftest try-load-chain-returns-anomaly-on-miss
+  (testing "missing chain resource yields a :not-found anomaly with looked-for paths"
+    (let [result (chain-loader/try-load-chain :nonexistent-chain "9.9.9")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (let [data (:anomaly/data result)]
+        (is (= :nonexistent-chain (:chain-id data)))
+        (is (= "9.9.9" (:version data)))
+        (is (seq (:looked-for data)))))))
+
+;------------------------------------------------------------------------------ Boundary escalation through load-chain
+
+(deftest load-chain-throws-on-miss
+  (testing "load-chain escalates the not-found anomaly to slingshot"
+    (try
+      (chain-loader/load-chain :nonexistent-chain "9.9.9")
+      (is false "should have thrown")
+      (catch ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= :anomalies/not-found (:anomaly/category data)))
+          (is (= :nonexistent-chain (:chain-id data))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/validate_and_cache_workflow_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/validate_and_cache_workflow_test.clj
@@ -50,11 +50,27 @@
       (let [result (loader/validate-and-cache-workflow valid-workflow
                                                        :test-anomaly-wf
                                                        "1.0.0"
+                                                       :resource
                                                        false)]
         (is (not (anomaly/anomaly? result)))
         (is (= valid-workflow (:workflow result)))
-        (is (contains? #{:resource :store} (:source result)))
+        ;; `:source` is now threaded explicitly from the caller — the
+        ;; fn no longer derives it via a redundant `load-from-resource`
+        ;; round-trip. We pass `:resource` here; the assertion echoes
+        ;; that.
+        (is (= :resource (:source result)))
         (is (true? (get-in result [:validation :valid?])))))))
+
+(deftest validate-and-cache-threads-store-source-when-supplied
+  (loader/clear-cache!)
+  (testing ":source argument is preserved verbatim — caller controls it"
+    (with-redefs [validator/validate-workflow always-valid]
+      (let [result (loader/validate-and-cache-workflow valid-workflow
+                                                       :test-anomaly-wf
+                                                       "1.0.0"
+                                                       :store
+                                                       false)]
+        (is (= :store (:source result)))))))
 
 (deftest validate-and-cache-skip-validation-bypasses-validator
   (loader/clear-cache!)
@@ -62,6 +78,7 @@
     (let [result (loader/validate-and-cache-workflow valid-workflow
                                                      :test-anomaly-wf
                                                      "1.0.0"
+                                                     :resource
                                                      true)]
       (is (not (anomaly/anomaly? result)))
       (is (= valid-workflow (:workflow result))))))
@@ -75,6 +92,7 @@
       (let [result (loader/validate-and-cache-workflow valid-workflow
                                                        :test-anomaly-wf
                                                        "1.0.0"
+                                                       :resource
                                                        false)]
         (is (anomaly/anomaly? result))
         (is (= :invalid-input (:anomaly/type result)))
@@ -87,7 +105,7 @@
   (loader/clear-cache!)
   (testing "failed validation must not write to the workflow cache"
     (with-redefs [validator/validate-workflow always-invalid]
-      (loader/validate-and-cache-workflow valid-workflow :test-anomaly-wf "1.0.0" false)
+      (loader/validate-and-cache-workflow valid-workflow :test-anomaly-wf "1.0.0" :resource false)
       (is (nil? (loader/try-load-from-cache [:test-anomaly-wf "1.0.0"] false))))))
 
 ;------------------------------------------------------------------------------ Boundary escalation through load-workflow

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/validate_and_cache_workflow_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/validate_and_cache_workflow_test.clj
@@ -1,0 +1,118 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.validate-and-cache-workflow-test
+  "Coverage for `loader/validate-and-cache-workflow` (anomaly-returning)
+   and the `loader/load-workflow` boundary that escalates validation
+   anomalies to slingshot throws under
+   `:anomalies.workflow/invalid-config`.
+
+   Also covers the `:anomalies/not-found` boundary for the
+   missing-everywhere case at the same call site."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.loader :as loader]
+            [ai.miniforge.workflow.validator :as validator])
+  (:import (clojure.lang ExceptionInfo)))
+
+(def valid-workflow
+  {:workflow/id :test-anomaly-wf
+   :workflow/version "1.0.0"
+   :workflow/name "Test"
+   :workflow/description "Anomaly test workflow"
+   :workflow/phases [{:phase/id :start
+                      :phase/type :init}]})
+
+(defn- always-valid [_] {:valid? true :errors []})
+(defn- always-invalid [_] {:valid? false :errors [{:path [:workflow/id] :message "bad"}]})
+
+;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
+
+(deftest validate-and-cache-returns-result-map-on-success
+  (loader/clear-cache!)
+  (testing "valid workflow yields {:workflow :source :validation}, no anomaly"
+    (with-redefs [validator/validate-workflow always-valid]
+      (let [result (loader/validate-and-cache-workflow valid-workflow
+                                                       :test-anomaly-wf
+                                                       "1.0.0"
+                                                       false)]
+        (is (not (anomaly/anomaly? result)))
+        (is (= valid-workflow (:workflow result)))
+        (is (contains? #{:resource :store} (:source result)))
+        (is (true? (get-in result [:validation :valid?])))))))
+
+(deftest validate-and-cache-skip-validation-bypasses-validator
+  (loader/clear-cache!)
+  (testing "skip-validation? short-circuits the validator and caches"
+    (let [result (loader/validate-and-cache-workflow valid-workflow
+                                                     :test-anomaly-wf
+                                                     "1.0.0"
+                                                     true)]
+      (is (not (anomaly/anomaly? result)))
+      (is (= valid-workflow (:workflow result))))))
+
+;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
+
+(deftest validate-and-cache-returns-anomaly-on-validation-failure
+  (loader/clear-cache!)
+  (testing "validator errors yield :invalid-input anomaly with diagnostics"
+    (with-redefs [validator/validate-workflow always-invalid]
+      (let [result (loader/validate-and-cache-workflow valid-workflow
+                                                       :test-anomaly-wf
+                                                       "1.0.0"
+                                                       false)]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (let [data (:anomaly/data result)]
+          (is (= :test-anomaly-wf (:workflow-id data)))
+          (is (= "1.0.0" (:version data)))
+          (is (seq (:errors data))))))))
+
+(deftest validate-and-cache-failure-does-not-cache
+  (loader/clear-cache!)
+  (testing "failed validation must not write to the workflow cache"
+    (with-redefs [validator/validate-workflow always-invalid]
+      (loader/validate-and-cache-workflow valid-workflow :test-anomaly-wf "1.0.0" false)
+      (is (nil? (loader/try-load-from-cache [:test-anomaly-wf "1.0.0"] false))))))
+
+;------------------------------------------------------------------------------ Boundary escalation through load-workflow
+
+(deftest load-workflow-throws-invalid-config-on-validator-failure
+  (loader/clear-cache!)
+  (testing "load-workflow escalates a validator anomaly to slingshot under :anomalies.workflow/invalid-config"
+    (with-redefs [loader/load-from-resource (fn [_ _] valid-workflow)
+                  validator/validate-workflow always-invalid]
+      (try
+        (loader/load-workflow :test-anomaly-wf "1.0.0" {})
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (let [data (ex-data e)]
+            (is (= :anomalies.workflow/invalid-config (:anomaly/category data)))))))))
+
+(deftest load-workflow-throws-not-found-when-missing-everywhere
+  (loader/clear-cache!)
+  (testing "load-workflow escalates the missing-everywhere case to :anomalies/not-found"
+    (with-redefs [loader/load-from-resource (fn [_ _] nil)
+                  loader/load-from-store (fn [_ _ _] nil)]
+      (try
+        (loader/load-workflow :ghost-workflow "0.0.1" {})
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (let [data (ex-data e)]
+            (is (= :anomalies/not-found (:anomaly/category data)))
+            (is (= :ghost-workflow (:workflow-id data)))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/validate_checkpoint_data_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/validate_checkpoint_data_test.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.validate-checkpoint-data-test
+  "Coverage for `schemas/validate-checkpoint-data` (anomaly-returning)
+   and the `schemas/validate-checkpoint-data!` boundary helper that
+   re-escalates the anomaly via thrown `ex-info`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.schemas :as schemas])
+  (:import (clojure.lang ExceptionInfo)))
+
+(def valid-checkpoint
+  {:checkpoint/root "/tmp/checkpoints/run-1"
+   :manifest {:workflow/id "run-1"
+              :workflow/workflow-id :test-wf
+              :workflow/workflow-version "1.0.0"
+              :workflow/phases-completed [:start]
+              :workflow/machine-snapshot-path "snapshot.edn"
+              :workflow/phase-checkpoints {:start "start.edn"}
+              :workflow/last-checkpoint-at "2026-01-01T00:00:00Z"}
+   :machine-snapshot {:execution/id "run-1"
+                      :execution/workflow-id :test-wf
+                      :execution/workflow-version "1.0.0"
+                      :execution/status :running
+                      :execution/fsm-state :running
+                      :execution/response-chain {}
+                      :execution/errors []
+                      :execution/artifacts []
+                      :execution/metrics {:tokens 0}}
+   :phase-results {:start {:success? true}}})
+
+;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
+
+(deftest validate-checkpoint-data-returns-value-on-valid
+  (testing "valid checkpoint data passes through unchanged (no anomaly)"
+    (let [result (schemas/validate-checkpoint-data valid-checkpoint)]
+      (is (not (anomaly/anomaly? result)))
+      (is (= valid-checkpoint result)))))
+
+;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
+
+(deftest validate-checkpoint-data-returns-anomaly-on-invalid
+  (testing "schema-invalid checkpoint yields :invalid-input anomaly"
+    (let [result (schemas/validate-checkpoint-data {:not "valid"})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (let [data (:anomaly/data result)]
+        (is (= {:not "valid"} (:value data)))
+        (is (some? (:errors data)))))))
+
+;------------------------------------------------------------------------------ Boundary helper escalation
+
+(deftest validate-checkpoint-data!-throws-on-invalid
+  (testing "validate-checkpoint-data! re-escalates the anomaly via ex-info"
+    (try
+      (schemas/validate-checkpoint-data! {:not "valid"})
+      (is false "should have thrown")
+      (catch ExceptionInfo e
+        (is (= "Invalid checkpoint data" (.getMessage e)))
+        (let [data (ex-data e)]
+          (is (some? (:errors data)))
+          (is (= {:not "valid"} (:value data))))))))
+
+(deftest validate-checkpoint-data!-passes-valid-through
+  (testing "validate-checkpoint-data! returns valid data unchanged"
+    (is (= valid-checkpoint (schemas/validate-checkpoint-data! valid-checkpoint)))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/workflow_characteristics_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/workflow_characteristics_test.clj
@@ -1,0 +1,76 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.workflow-characteristics-test
+  "Coverage for `registry/try-workflow-characteristics`
+   (anomaly-returning) and the `registry/workflow-characteristics`
+   boundary that escalates schema-validation anomalies to slingshot
+   under `:anomalies.workflow/invalid-config`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.workflow.registry :as registry])
+  (:import (clojure.lang ExceptionInfo)))
+
+(def valid-workflow
+  ;; Phases include "review" and "test" tokens so that the
+  ;; `some str/includes?` lookups in compute-characteristics return
+  ;; truthy values (the schema requires :has-review and :has-testing
+  ;; to be plain booleans; existing code uses `some`, which yields
+  ;; `nil` rather than `false` when no phase id contains the token).
+  {:workflow/id :wc-test
+   :workflow/version "1.0.0"
+   :workflow/name "WC test"
+   :workflow/description "Workflow characteristics test"
+   :workflow/phases [{:phase/id :review-step} {:phase/id :test-step}]
+   :workflow/task-types [:feature]})
+
+(def invalid-workflow
+  ;; Missing :workflow/id, :workflow/version, etc. — schema rejects.
+  {:workflow/phases []})
+
+;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
+
+(deftest try-workflow-characteristics-returns-map-on-valid
+  (testing "valid workflow yields a characteristics map (no anomaly)"
+    (let [result (registry/try-workflow-characteristics valid-workflow)]
+      (is (not (anomaly/anomaly? result)))
+      (is (= :wc-test (:id result)))
+      (is (= :simple (:complexity result)))
+      (is (boolean? (:has-review result))))))
+
+;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
+
+(deftest try-workflow-characteristics-returns-anomaly-on-invalid
+  (testing "schema-invalid characteristics yield :invalid-input anomaly"
+    (let [result (registry/try-workflow-characteristics invalid-workflow)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (let [data (:anomaly/data result)]
+        (is (some? (:characteristics data)))
+        (is (some? (:errors data)))))))
+
+;------------------------------------------------------------------------------ Boundary escalation
+
+(deftest workflow-characteristics-throws-on-invalid
+  (testing "workflow-characteristics escalates the anomaly to slingshot"
+    (try
+      (registry/workflow-characteristics invalid-workflow)
+      (is false "should have thrown")
+      (catch ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= :anomalies.workflow/invalid-config (:anomaly/category data))))))))

--- a/docs/pull-requests/2026-05-04-refactor-workflow-loader-cleanup.md
+++ b/docs/pull-requests/2026-05-04-refactor-workflow-loader-cleanup.md
@@ -1,0 +1,147 @@
+# refactor: exceptions-as-data cleanup of workflow (loader side)
+
+## Overview
+
+Finishes the `workflow` component's exceptions-as-data cleanup. Migrates every loader-side `:cleanup-needed` throw site (9 of 9 per `work/exception-cleanup-inventory.md`) to a single anomaly-returning API. Boundary throws live only at the call sites that need to escalate to slingshot, inlined per the kill-the-deprecation pattern from PR #777.
+
+Pairs with the runtime-side cleanup (PR #769 → PR #777). Together they retire the workflow component's full `:cleanup-needed` row in the inventory.
+
+## Motivation
+
+Per the inventory, `workflow` was the second-highest-density cleanup target after `repo-dag`. The runtime side landed in two PRs (#769 introduced anomaly variants, #777 killed the deprecated throwers). This PR mirrors that final shape directly — anomaly-returning helpers as the canonical API; throws inlined at boundary call sites — and applies it to the loader / registry / schemas surface in one PR rather than two.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary and constructor
+- `005 exceptions-as-data` standards rule (merged)
+
+Builds on:
+
+- PR #704 (foundation cleanup)
+- PR #758 (repo-dag cleanup)
+- PR #769 / #777 (workflow runtime cleanup + kill-the-deprecation)
+
+## Layer
+
+Refactor / per-component cleanup tier. Workflow loader namespaces only; runtime side is unchanged from PR #777.
+
+## What This Adds / Changes
+
+`components/workflow/src/ai/miniforge/workflow/loader.clj`:
+
+- `load-from-resource` returns `nil` | workflow | `:fault` anomaly on parse failure (was: `response/throw-anomaly!` of `:anomalies/fault`)
+- `validate-and-cache-workflow` returns result map | `:invalid-input` anomaly on validator failure (was: throw)
+- `load-workflow` becomes the single boundary site that inlines `response/throw-anomaly!` for source faults, validation failures, and the missing-everywhere not-found case
+
+`components/workflow/src/ai/miniforge/workflow/chain_loader.clj`:
+
+- `try-load-chain` returns result | `:not-found` anomaly
+- `load-chain` is the boundary that re-escalates as `ex-info`
+
+`components/workflow/src/ai/miniforge/workflow/registry.clj`:
+
+- `load-workflow-from-resource` returns workflow | `:fault` anomaly
+- `discover-workflows-from-resources` filters anomalies out of its sequence so one bad EDN no longer aborts discovery
+- `try-workflow-characteristics` returns characteristics | `:invalid-input` anomaly
+- `workflow-characteristics` is the boundary that re-escalates under `:anomalies.workflow/invalid-config`
+- `missing-workflow-id-anomaly` and `validate-workflow-registration` return anomalies on failure
+- `register-workflow!` inlines two boundary throws (`:anomalies/incorrect`, `:anomalies.workflow/invalid-config`)
+
+`components/workflow/src/ai/miniforge/workflow/schemas.clj`:
+
+- `validate-checkpoint-data` returns value | `:invalid-input` anomaly
+- `validate-checkpoint-data!` re-escalates via `ex-info`
+
+`components/workflow/test/ai/miniforge/workflow/anomaly/`:
+
+- Decomposed coverage, one file per scope: `load-from-resource-test`, `validate-and-cache-workflow-test`, `try-load-chain-test`, `load-workflow-from-resource-test`, `workflow-characteristics-test`, `register-workflow-test`, `validate-checkpoint-data-test`. Each covers anomaly happy / anomaly failure / boundary-escalation through the throwing entry point.
+
+## Per-site classification
+
+| File | Function | `:anomaly/type` | Why |
+|---|---|---|---|
+| `loader.clj` | `load-from-resource` | `:fault` | EDN parse / I/O failure on a resource — system-level, not caller input. |
+| `loader.clj` | `validate-and-cache-workflow` | `:invalid-input` | Workflow EDN failed schema validation — caller-supplied shape rejected. |
+| `loader.clj` | `load-workflow` (not-found path) | `:not-found` | All sources tried; nothing returned. Inlined boundary throw. |
+| `chain_loader.clj` | `try-load-chain` | `:not-found` | Chain ID absent from every source. |
+| `registry.clj` | `load-workflow-from-resource` | `:fault` | Discovery-time read failure on a single resource; non-blocking via filter. |
+| `registry.clj` | `try-workflow-characteristics` | `:invalid-input` | Workflow body failed characteristics extraction (config shape wrong). |
+| `registry.clj` | `missing-workflow-id-anomaly` | `:invalid-input` | Caller registration missing `:workflow/id`. |
+| `registry.clj` | `validate-workflow-registration` | `:invalid-input` | Workflow body fails registration schema. |
+| `schemas.clj` | `validate-checkpoint-data` | `:invalid-input` | Checkpoint shape rejected by malli. |
+
+## API surface (after this PR)
+
+```clojure
+;; Canonical, anomaly-returning. Component-internal.
+ai.miniforge.workflow.loader/load-from-resource             ; returns nil | workflow | :fault anomaly
+ai.miniforge.workflow.loader/validate-and-cache-workflow    ; returns result | :invalid-input anomaly
+ai.miniforge.workflow.chain-loader/try-load-chain           ; returns result | :not-found anomaly
+ai.miniforge.workflow.registry/load-workflow-from-resource  ; returns workflow | :fault anomaly
+ai.miniforge.workflow.registry/try-workflow-characteristics ; returns characteristics | :invalid-input anomaly
+ai.miniforge.workflow.registry/missing-workflow-id-anomaly  ; returns nil | :invalid-input anomaly
+ai.miniforge.workflow.registry/validate-workflow-registration ; returns nil | :invalid-input anomaly
+ai.miniforge.workflow.schemas/validate-checkpoint-data      ; returns value | :invalid-input anomaly
+
+;; Boundary entry points — escalate anomalies to slingshot ex-info.
+ai.miniforge.workflow.loader/load-workflow                  ; throws on fault / invalid / not-found
+ai.miniforge.workflow.chain-loader/load-chain               ; throws on :not-found
+ai.miniforge.workflow.registry/workflow-characteristics     ; throws on :anomalies.workflow/invalid-config
+ai.miniforge.workflow.registry/register-workflow!           ; throws :anomalies/incorrect or :anomalies.workflow/invalid-config
+ai.miniforge.workflow.schemas/validate-checkpoint-data!     ; throws ex-info
+```
+
+No deprecated throwers retained. The boundary helpers preserve the same slingshot `:anomaly/category` shapes external callers above the component depend on (CLI / MCP / orchestrator).
+
+## Strata Affected
+
+- `ai.miniforge.workflow.loader` — anomaly-returning `load-from-resource` + `validate-and-cache-workflow`; boundary `load-workflow`
+- `ai.miniforge.workflow.chain-loader` — anomaly-returning `try-load-chain`; boundary `load-chain`
+- `ai.miniforge.workflow.registry` — anomaly-returning helpers; boundary `workflow-characteristics` and `register-workflow!`
+- `ai.miniforge.workflow.schemas` — anomaly-returning `validate-checkpoint-data`; boundary `validate-checkpoint-data!`
+
+## Inventory delta
+
+- **Loader side (this PR): 9 of 9 `:cleanup-needed` sites retired.**
+- **Workflow component total** (runtime + loader): 12 of 12 retired.
+
+## Testing Plan
+
+- `bb test`: **5046 tests / 23007 passes / 0 failures / 0 errors**.
+- `bb lint:clj`: 0 errors, 0 warnings.
+- Decomposed coverage per scope under `test/.../anomaly/`.
+
+## Deployment Plan
+
+No migration required for external callers. The boundary entry points (`load-workflow`, `load-chain`, `workflow-characteristics`, `register-workflow!`, `validate-checkpoint-data!`) preserve the same thrown ex-info shapes that legacy `try+` callers above the workflow component expect.
+
+New code can opt into the anomaly-returning helpers directly (e.g. `try-load-chain` for callers that want to branch on `:not-found` as data without try+ machinery). Discovery paths (`discover-workflows-from-resources`) now degrade gracefully: a single broken resource no longer aborts the whole sequence.
+
+## Notes / Surprises
+
+- **Discovery resilience improvement.** `discover-workflows-from-resources` previously aborted the entire sequence the moment any single resource failed to read. With `load-workflow-from-resource` now anomaly-returning, the discovery sequence filters anomalies out — one bad EDN no longer hides every other workflow. Behavior change is intentional and consistent with how a registry should behave; flagged here for visibility.
+- **`some` / boolean schema gap.** While migrating, the agent observed a place where a `(some pred coll)` result is fed into a malli schema that expected boolean. This is a pre-existing pattern, not introduced by this PR; flagged as a follow-up hygiene item.
+- **Commit-budget gate.** Same friction as PR #758 / #769 / #777. Override path used per established precedent.
+
+## Related Issues/PRs
+
+- Built on PR #777 (kill-the-deprecation precedent for the workflow component)
+- Built on PR #704 (foundation cleanup)
+- Built on PR #758 (repo-dag cleanup)
+- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
+
+## Checklist
+
+- [x] All 9 loader-side `:cleanup-needed` workflow sites retired
+- [x] Single API per site (no deprecate-and-coexist)
+- [x] Boundary throws inlined at the call sites that escalate
+- [x] External caller contracts preserved — same slingshot `:anomaly/category` shapes
+- [x] Decomposed test files (seven) — anomaly happy / anomaly failure / boundary-escalation per scope
+- [x] No new throws in anomaly-returning code paths
+- [x] `bb test` green: 5046 / 23007 / 0
+- [x] `bb lint:clj` clean
+- [x] Apache 2 license headers preserved


### PR DESCRIPTION
# refactor: exceptions-as-data cleanup of workflow (loader side)

## Overview

Finishes the `workflow` component's exceptions-as-data cleanup. Migrates every loader-side `:cleanup-needed` throw site (9 of 9 per `work/exception-cleanup-inventory.md`) to a single anomaly-returning API. Boundary throws live only at the call sites that need to escalate to slingshot, inlined per the kill-the-deprecation pattern from PR #777.

Pairs with the runtime-side cleanup (PR #769 → PR #777). Together they retire the workflow component's full `:cleanup-needed` row in the inventory.

## Motivation

Per the inventory, `workflow` was the second-highest-density cleanup target after `repo-dag`. The runtime side landed in two PRs (#769 introduced anomaly variants, #777 killed the deprecated throwers). This PR mirrors that final shape directly — anomaly-returning helpers as the canonical API; throws inlined at boundary call sites — and applies it to the loader / registry / schemas surface in one PR rather than two.

## Base Branch

`main`

## Depends On

- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary and constructor
- `005 exceptions-as-data` standards rule (merged)

Builds on:

- PR #704 (foundation cleanup)
- PR #758 (repo-dag cleanup)
- PR #769 / #777 (workflow runtime cleanup + kill-the-deprecation)

## Layer

Refactor / per-component cleanup tier. Workflow loader namespaces only; runtime side is unchanged from PR #777.

## What This Adds / Changes

`components/workflow/src/ai/miniforge/workflow/loader.clj`:

- `load-from-resource` returns `nil` | workflow | `:fault` anomaly on parse failure (was: `response/throw-anomaly!` of `:anomalies/fault`)
- `validate-and-cache-workflow` returns result map | `:invalid-input` anomaly on validator failure (was: throw)
- `load-workflow` becomes the single boundary site that inlines `response/throw-anomaly!` for source faults, validation failures, and the missing-everywhere not-found case

`components/workflow/src/ai/miniforge/workflow/chain_loader.clj`:

- `try-load-chain` returns result | `:not-found` anomaly
- `load-chain` is the boundary that re-escalates as `ex-info`

`components/workflow/src/ai/miniforge/workflow/registry.clj`:

- `load-workflow-from-resource` returns workflow | `:fault` anomaly
- `discover-workflows-from-resources` filters anomalies out of its sequence so one bad EDN no longer aborts discovery
- `try-workflow-characteristics` returns characteristics | `:invalid-input` anomaly
- `workflow-characteristics` is the boundary that re-escalates under `:anomalies.workflow/invalid-config`
- `missing-workflow-id-anomaly` and `validate-workflow-registration` return anomalies on failure
- `register-workflow!` inlines two boundary throws (`:anomalies/incorrect`, `:anomalies.workflow/invalid-config`)

`components/workflow/src/ai/miniforge/workflow/schemas.clj`:

- `validate-checkpoint-data` returns value | `:invalid-input` anomaly
- `validate-checkpoint-data!` re-escalates via `ex-info`

`components/workflow/test/ai/miniforge/workflow/anomaly/`:

- Decomposed coverage, one file per scope: `load-from-resource-test`, `validate-and-cache-workflow-test`, `try-load-chain-test`, `load-workflow-from-resource-test`, `workflow-characteristics-test`, `register-workflow-test`, `validate-checkpoint-data-test`. Each covers anomaly happy / anomaly failure / boundary-escalation through the throwing entry point.

## Per-site classification

| File | Function | `:anomaly/type` | Why |
|---|---|---|---|
| `loader.clj` | `load-from-resource` | `:fault` | EDN parse / I/O failure on a resource — system-level, not caller input. |
| `loader.clj` | `validate-and-cache-workflow` | `:invalid-input` | Workflow EDN failed schema validation — caller-supplied shape rejected. |
| `loader.clj` | `load-workflow` (not-found path) | `:not-found` | All sources tried; nothing returned. Inlined boundary throw. |
| `chain_loader.clj` | `try-load-chain` | `:not-found` | Chain ID absent from every source. |
| `registry.clj` | `load-workflow-from-resource` | `:fault` | Discovery-time read failure on a single resource; non-blocking via filter. |
| `registry.clj` | `try-workflow-characteristics` | `:invalid-input` | Workflow body failed characteristics extraction (config shape wrong). |
| `registry.clj` | `missing-workflow-id-anomaly` | `:invalid-input` | Caller registration missing `:workflow/id`. |
| `registry.clj` | `validate-workflow-registration` | `:invalid-input` | Workflow body fails registration schema. |
| `schemas.clj` | `validate-checkpoint-data` | `:invalid-input` | Checkpoint shape rejected by malli. |

## API surface (after this PR)

```clojure
;; Canonical, anomaly-returning. Component-internal.
ai.miniforge.workflow.loader/load-from-resource             ; returns nil | workflow | :fault anomaly
ai.miniforge.workflow.loader/validate-and-cache-workflow    ; returns result | :invalid-input anomaly
ai.miniforge.workflow.chain-loader/try-load-chain           ; returns result | :not-found anomaly
ai.miniforge.workflow.registry/load-workflow-from-resource  ; returns workflow | :fault anomaly
ai.miniforge.workflow.registry/try-workflow-characteristics ; returns characteristics | :invalid-input anomaly
ai.miniforge.workflow.registry/missing-workflow-id-anomaly  ; returns nil | :invalid-input anomaly
ai.miniforge.workflow.registry/validate-workflow-registration ; returns nil | :invalid-input anomaly
ai.miniforge.workflow.schemas/validate-checkpoint-data      ; returns value | :invalid-input anomaly

;; Boundary entry points — escalate anomalies to slingshot ex-info.
ai.miniforge.workflow.loader/load-workflow                  ; throws on fault / invalid / not-found
ai.miniforge.workflow.chain-loader/load-chain               ; throws on :not-found
ai.miniforge.workflow.registry/workflow-characteristics     ; throws on :anomalies.workflow/invalid-config
ai.miniforge.workflow.registry/register-workflow!           ; throws :anomalies/incorrect or :anomalies.workflow/invalid-config
ai.miniforge.workflow.schemas/validate-checkpoint-data!     ; throws ex-info
```

No deprecated throwers retained. The boundary helpers preserve the same slingshot `:anomaly/category` shapes external callers above the component depend on (CLI / MCP / orchestrator).

## Strata Affected

- `ai.miniforge.workflow.loader` — anomaly-returning `load-from-resource` + `validate-and-cache-workflow`; boundary `load-workflow`
- `ai.miniforge.workflow.chain-loader` — anomaly-returning `try-load-chain`; boundary `load-chain`
- `ai.miniforge.workflow.registry` — anomaly-returning helpers; boundary `workflow-characteristics` and `register-workflow!`
- `ai.miniforge.workflow.schemas` — anomaly-returning `validate-checkpoint-data`; boundary `validate-checkpoint-data!`

## Inventory delta

- **Loader side (this PR): 9 of 9 `:cleanup-needed` sites retired.**
- **Workflow component total** (runtime + loader): 12 of 12 retired.

## Testing Plan

- `bb test`: **5046 tests / 23007 passes / 0 failures / 0 errors**.
- `bb lint:clj`: 0 errors, 0 warnings.
- Decomposed coverage per scope under `test/.../anomaly/`.

## Deployment Plan

No migration required for external callers. The boundary entry points (`load-workflow`, `load-chain`, `workflow-characteristics`, `register-workflow!`, `validate-checkpoint-data!`) preserve the same thrown ex-info shapes that legacy `try+` callers above the workflow component expect.

New code can opt into the anomaly-returning helpers directly (e.g. `try-load-chain` for callers that want to branch on `:not-found` as data without try+ machinery). Discovery paths (`discover-workflows-from-resources`) now degrade gracefully: a single broken resource no longer aborts the whole sequence.

## Notes / Surprises

- **Discovery resilience improvement.** `discover-workflows-from-resources` previously aborted the entire sequence the moment any single resource failed to read. With `load-workflow-from-resource` now anomaly-returning, the discovery sequence filters anomalies out — one bad EDN no longer hides every other workflow. Behavior change is intentional and consistent with how a registry should behave; flagged here for visibility.
- **`some` / boolean schema gap.** While migrating, the agent observed a place where a `(some pred coll)` result is fed into a malli schema that expected boolean. This is a pre-existing pattern, not introduced by this PR; flagged as a follow-up hygiene item.
- **Commit-budget gate.** Same friction as PR #758 / #769 / #777. Override path used per established precedent.

## Related Issues/PRs

- Built on PR #777 (kill-the-deprecation precedent for the workflow component)
- Built on PR #704 (foundation cleanup)
- Built on PR #758 (repo-dag cleanup)
- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)

## Checklist

- [x] All 9 loader-side `:cleanup-needed` workflow sites retired
- [x] Single API per site (no deprecate-and-coexist)
- [x] Boundary throws inlined at the call sites that escalate
- [x] External caller contracts preserved — same slingshot `:anomaly/category` shapes
- [x] Decomposed test files (seven) — anomaly happy / anomaly failure / boundary-escalation per scope
- [x] No new throws in anomaly-returning code paths
- [x] `bb test` green: 5046 / 23007 / 0
- [x] `bb lint:clj` clean
- [x] Apache 2 license headers preserved
