### PR TITLE
fix(review): normalize timeout-only reviewer failures

### DIFF
--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -571,6 +571,41 @@
   [logger data]
   (log/info logger :reviewer :reviewer/phase-completed {:data data}))
 
+(defn- timeout-only-error-result
+  "Normalize the reviewer exit path when the LLM only reports its own timeout.
+
+   This preserves backend timeout metadata, emits the standard phase-completed
+   telemetry, and reports the deterministic gate outcome instead of converting
+   the backend failure into a bogus code-review rejection."
+  [logger normalized llm-review gate-result counts duration tokens cost-usd timeout-failure-message]
+  (log/warn logger :reviewer :reviewer/backend-timeout-only
+            {:data {:llm-decision (:review/decision llm-review)
+                    :gate-decision (:decision gate-result)
+                    :blocking-issues (:review/blocking-issues llm-review)
+                    :duration-ms duration}})
+  (leave-review logger {:review/decision (:decision gate-result)
+                        :duration-ms duration
+                        :gates-passed (:passed counts)
+                        :gates-failed (:failed counts)
+                        :llm? true
+                        :status :error
+                        :error-code :reviewer/backend-timeout})
+  (assoc
+   (result-boundary/error-response
+    normalized
+    timeout-failure-message
+    {:data (merge (or (some-> normalized :llm-error :data) {})
+                  {:code :reviewer/backend-timeout
+                   :blocking-issues (:review/blocking-issues llm-review)})})
+   :metrics
+   (cond-> {:decision (:decision gate-result)
+            :gates-passed (:passed counts)
+            :gates-failed (:failed counts)
+            :gates-total (:total counts)
+            :duration-ms duration
+            :tokens tokens}
+     cost-usd (assoc :cost-usd cost-usd))))
+
 ;------------------------------------------------------------------------------ Layer 5
 ;; Agent creation
 
@@ -709,34 +744,9 @@
                     duration (- (System/currentTimeMillis) start-time)]
 
                 (if timeout-only-review?
-                  (do
-                    (log/warn logger :reviewer :reviewer/backend-timeout-only
-                              {:data {:llm-decision (:review/decision llm-review)
-                                      :gate-decision (:decision gate-result)
-                                      :blocking-issues (:review/blocking-issues llm-review)
-                                      :duration-ms duration}})
-                    (leave-review logger {:review/decision (:decision gate-result)
-                                          :duration-ms duration
-                                          :gates-passed (:passed counts)
-                                          :gates-failed (:failed counts)
-                                          :llm? true
-                                          :status :error
-                                          :error-code :reviewer/backend-timeout})
-                    (assoc
-                     (result-boundary/error-response
-                      normalized
-                      timeout-failure-message
-                      {:data (merge (or (some-> normalized :llm-error :data) {})
-                                    {:code :reviewer/backend-timeout
-                                     :blocking-issues (:review/blocking-issues llm-review)})})
-                     :metrics
-                     (cond-> {:decision (:decision gate-result)
-                              :gates-passed (:passed counts)
-                              :gates-failed (:failed counts)
-                              :gates-total (:total counts)
-                              :duration-ms duration
-                              :tokens tokens}
-                       cost-usd (assoc :cost-usd cost-usd))))
+                  (timeout-only-error-result
+                   logger normalized llm-review gate-result counts duration tokens cost-usd
+                   timeout-failure-message)
                   (do
                     (log/info logger :reviewer :reviewer/review-complete
                               {:data {:decision final-decision

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -375,6 +375,40 @@
       (string? (:message llm-error)) (:message llm-error)
       :else "Reviewer LLM invocation failed before producing a review artifact")))
 
+(defn- backend-failure-message
+  "Derive the backend failure message when the reviewer LLM response parsed,
+   but the underlying invocation still failed."
+  [response llm-review]
+  (if-let [message (:message (llm/get-error response))]
+    message
+    (or (first (:review/blocking-issues llm-review))
+        "Reviewer LLM invocation failed after producing a review artifact")))
+
+(defn- backend-timeout-issue?
+  [message]
+  (boolean
+   (and (string? message)
+        (re-find #"(?i)(adaptive timeout|stagnation timeout|timed out|stream-idle|timeout)"
+                 message))))
+
+(defn- timeout-only-review?
+  "True when a parsed review artifact is just reflecting the reviewer backend's
+   own timeout rather than providing actionable code-review findings."
+  [_response llm-review]
+  (let [blocking-issues (vec (:review/blocking-issues llm-review))
+        recommendations (vec (:review/recommendations llm-review))
+        issues (vec (:review/issues llm-review))
+        gate-results (vec (:review/gate-results llm-review))
+        negative-decision? (contains? #{:rejected :changes-requested}
+                                      (:review/decision llm-review))
+        all-gates-passed? (every? :passed? gate-results)]
+    (and negative-decision?
+         (seq blocking-issues)
+         (empty? recommendations)
+         (empty? issues)
+         all-gates-passed?
+         (every? backend-timeout-issue? blocking-issues))))
+
 (defn llm-issues->recommendations
   "Extract suggestions from LLM issues as recommendations."
   [issues]
@@ -627,9 +661,12 @@
 
               (let [;; Parse LLM review
                     llm-review (:parsed-content normalized)
-                    failure-message (review-failure-message response content)
+                    parse-failure-message (review-failure-message response content)
+                    timeout-failure-message (backend-failure-message response llm-review)
                     parse-failed? (nil? llm-review)
+                    timeout-only-review? (timeout-only-review? response llm-review)
                     llm-decision (cond
+                                   timeout-only-review? nil
                                    parse-failed? :rejected
                                    llm-review (normalize-llm-decision (:review/decision llm-review)))
                     llm-issues (get llm-review :review/issues [])
@@ -650,7 +687,9 @@
                     all-blocking (cond-> (into (vec (:blocking-issues gate-result))
                                                (llm-issues->blocking-strings llm-issues))
                                    parse-failed?
-                                   (conj failure-message))
+                                   (conj parse-failure-message)
+                                   timeout-only-review?
+                                   (conj timeout-failure-message))
                     all-warnings (into (vec (:warnings gate-result))
                                        (llm-issues->warning-strings llm-issues))
 
@@ -672,23 +711,42 @@
 
                     duration (- (System/currentTimeMillis) start-time)]
 
-                (log/info logger :reviewer :reviewer/review-complete
-                          {:data {:decision final-decision
-                                  :llm-decision llm-decision
-                                  :llm-parse-failed? parse-failed?
-                                  :gates-passed (:passed counts)
-                                  :gates-failed (:failed counts)
-                                  :llm-issues (count llm-issues)
-                                  :duration-ms duration}})
-
-                ;; Phase lifecycle: mark review exit with decision
-                (leave-review logger {:review/decision final-decision
-                                      :duration-ms duration
+                (if timeout-only-review?
+                  (do
+                    (log/warn logger :reviewer :reviewer/backend-timeout-only
+                              {:data {:llm-decision (:review/decision llm-review)
+                                      :blocking-issues (:review/blocking-issues llm-review)
+                                      :duration-ms duration}})
+                    {:status :error
+                     :error {:message timeout-failure-message
+                             :data {:code :reviewer/backend-timeout
+                                    :blocking-issues (:review/blocking-issues llm-review)}}
+                     :metrics (cond-> {:decision (:decision gate-result)
+                                       :gates-passed (:passed counts)
+                                       :gates-failed (:failed counts)
+                                       :gates-total (:total counts)
+                                       :duration-ms duration
+                                       :tokens tokens}
+                                cost-usd (assoc :cost-usd cost-usd))})
+                  (do
+                    (log/info logger :reviewer :reviewer/review-complete
+                              {:data {:decision final-decision
+                                      :llm-decision llm-decision
+                                      :llm-parse-failed? parse-failed?
+                                      :timeout-only-review? timeout-only-review?
                                       :gates-passed (:passed counts)
                                       :gates-failed (:failed counts)
-                                      :llm? true})
+                                      :llm-issues (count llm-issues)
+                                      :duration-ms duration}})
 
-                (build-review-result review counts duration tokens :cost-usd cost-usd)))
+                    ;; Phase lifecycle: mark review exit with decision
+                    (leave-review logger {:review/decision final-decision
+                                          :duration-ms duration
+                                          :gates-passed (:passed counts)
+                                          :gates-failed (:failed counts)
+                                          :llm? true})
+
+                    (build-review-result review counts duration tokens :cost-usd cost-usd)))))
 
             ;; No LLM — gate-only fallback
             (let [gate-feedbacks (run-gates-on-artifact gates artifact context logger)

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -394,19 +394,17 @@
 (defn- timeout-only-review?
   "True when a parsed review artifact is just reflecting the reviewer backend's
    own timeout rather than providing actionable code-review findings."
-  [_response llm-review]
+  [llm-review gate-result]
   (let [blocking-issues (vec (:review/blocking-issues llm-review))
         recommendations (vec (:review/recommendations llm-review))
         issues (vec (:review/issues llm-review))
-        gate-results (vec (:review/gate-results llm-review))
         negative-decision? (contains? #{:rejected :changes-requested}
-                                      (:review/decision llm-review))
-        all-gates-passed? (every? :passed? gate-results)]
+                                      (:review/decision llm-review))]
     (and negative-decision?
+         (= :approved (:decision gate-result))
          (seq blocking-issues)
          (empty? recommendations)
          (empty? issues)
-         all-gates-passed?
          (every? backend-timeout-issue? blocking-issues))))
 
 (defn llm-issues->recommendations
@@ -662,9 +660,13 @@
               (let [;; Parse LLM review
                     llm-review (:parsed-content normalized)
                     parse-failure-message (review-failure-message response content)
-                    timeout-failure-message (backend-failure-message response llm-review)
                     parse-failed? (nil? llm-review)
-                    timeout-only-review? (timeout-only-review? response llm-review)
+                    ;; Run deterministic gates
+                    gate-feedbacks (run-gates-on-artifact gates artifact context logger)
+                    gate-result (make-review-decision gate-feedbacks config)
+                    counts (calculate-gate-counts gate-feedbacks)
+                    timeout-failure-message (backend-failure-message response llm-review)
+                    timeout-only-review? (timeout-only-review? llm-review gate-result)
                     llm-decision (cond
                                    timeout-only-review? nil
                                    parse-failed? :rejected
@@ -672,11 +674,6 @@
                     llm-issues (get llm-review :review/issues [])
                     llm-strengths (get llm-review :review/strengths [])
                     llm-summary (:review/summary llm-review)
-
-                    ;; Run deterministic gates
-                    gate-feedbacks (run-gates-on-artifact gates artifact context logger)
-                    gate-result (make-review-decision gate-feedbacks config)
-                    counts (calculate-gate-counts gate-feedbacks)
 
                     ;; Merge decisions: gates can override LLM
                     final-decision (if llm-decision
@@ -715,19 +712,31 @@
                   (do
                     (log/warn logger :reviewer :reviewer/backend-timeout-only
                               {:data {:llm-decision (:review/decision llm-review)
+                                      :gate-decision (:decision gate-result)
                                       :blocking-issues (:review/blocking-issues llm-review)
                                       :duration-ms duration}})
-                    {:status :error
-                     :error {:message timeout-failure-message
-                             :data {:code :reviewer/backend-timeout
-                                    :blocking-issues (:review/blocking-issues llm-review)}}
-                     :metrics (cond-> {:decision (:decision gate-result)
-                                       :gates-passed (:passed counts)
-                                       :gates-failed (:failed counts)
-                                       :gates-total (:total counts)
-                                       :duration-ms duration
-                                       :tokens tokens}
-                                cost-usd (assoc :cost-usd cost-usd))})
+                    (leave-review logger {:review/decision (:decision gate-result)
+                                          :duration-ms duration
+                                          :gates-passed (:passed counts)
+                                          :gates-failed (:failed counts)
+                                          :llm? true
+                                          :status :error
+                                          :error-code :reviewer/backend-timeout})
+                    (assoc
+                     (result-boundary/error-response
+                      normalized
+                      timeout-failure-message
+                      {:data (merge (or (some-> normalized :llm-error :data) {})
+                                    {:code :reviewer/backend-timeout
+                                     :blocking-issues (:review/blocking-issues llm-review)})})
+                     :metrics
+                     (cond-> {:decision (:decision gate-result)
+                              :gates-passed (:passed counts)
+                              :gates-failed (:failed counts)
+                              :gates-total (:total counts)
+                              :duration-ms duration
+                              :tokens tokens}
+                       cost-usd (assoc :cost-usd cost-usd))))
                   (do
                     (log/info logger :reviewer :reviewer/review-complete
                               {:data {:decision final-decision

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -44,6 +44,33 @@
    but legitimate reviews are killed mid-turn."
   600000)
 
+(def ^:private unparseable-output-token-count
+  42)
+
+(def ^:private parseable-backend-failure-token-count
+  7)
+
+(def ^:private timeout-review-token-count
+  9)
+
+(def ^:private timeout-success-wrapper-token-count
+  11)
+
+(def ^:private backend-timeout-elapsed-ms
+  120183)
+
+(def ^:private wrapped-timeout-elapsed-ms
+  120228)
+
+(def ^:private backend-timeout-stop-reason
+  "timeout")
+
+(def ^:private backend-timeout-num-turns
+  4)
+
+(def ^:private backend-timeout-type
+  "adaptive_timeout")
+
 ;------------------------------------------------------------------------------ Test fixtures
 
 (defn passing-gate
@@ -76,6 +103,53 @@
    :artifact/content {:code/files [{:path "src/example.clj"
                                     :content "(ns example)\n(defn hello [] \"world\")"
                                     :action :create}]}})
+
+(defn- review-gate-feedback
+  ([] (review-gate-feedback :unknown 0))
+  ([gate-id duration-ms]
+   {:gate-id gate-id
+    :gate-type :unknown
+    :passed? true
+    :errors []
+    :warnings []
+    :duration-ms duration-ms}))
+
+(defn- adaptive-timeout-message
+  [elapsed-ms]
+  (str "Adaptive timeout: Stagnation timeout: no progress for "
+       elapsed-ms
+       "ms"))
+
+(defn- wrapped-timeout-message
+  [elapsed-ms]
+  (str (adaptive-timeout-message elapsed-ms)
+       " (type: stagnation, elapsed: "
+       elapsed-ms
+       "ms)"))
+
+(defn- timeout-only-review-content
+  ([blocking-message]
+   (timeout-only-review-content blocking-message [(review-gate-feedback)]))
+  ([blocking-message gate-results]
+   (pr-str {:review/decision :rejected
+            :review/gate-results gate-results
+            :review/blocking-issues [blocking-message]
+            :review/recommendations []})))
+
+(defn- mock-llm-response
+  [content & {:as extra}]
+  (merge {:success? true
+          :content content
+          :tokens 1}
+         extra))
+
+(defn- backend-timeout-error
+  ([message]
+   (backend-timeout-error message nil))
+  ([message data]
+   (cond-> {:type backend-timeout-type
+            :message message}
+     data (assoc :data data))))
 
 ;------------------------------------------------------------------------------ Core functionality tests
 
@@ -202,9 +276,9 @@
   (testing "successful LLM calls that cannot be parsed fail closed"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
-                             {:success? true
-                              :content "not valid edn"
-                              :tokens 42})
+                             (mock-llm-response
+                              "not valid edn"
+                              :tokens unparseable-output-token-count))
                   llm/success? :success?
                   llm/get-content :content]
       (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
@@ -214,16 +288,18 @@
         (is (= :rejected (:review/decision review)))
         (is (= ["Reviewer LLM output could not be parsed into a review artifact"]
                (:review/blocking-issues review)))
-        (is (= 42 (get-in result [:metrics :tokens])))))))
+        (is (= unparseable-output-token-count
+               (get-in result [:metrics :tokens])))))))
 
 (deftest test-reviewer-uses-parseable-content-even-when-backend-flags-failure
   (testing "parseable review content still drives the decision when backend success? is false"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
-                             {:success? false
-                              :content "```clojure\n{:review/decision :changes-requested\n :review/issues [{:severity :blocking :description \"Needs changes\"}]}\n```"
-                              :tokens 7
-                              :error {:message "artifact file not found"}})
+                             (mock-llm-response
+                              "```clojure\n{:review/decision :changes-requested\n :review/issues [{:severity :blocking :description \"Needs changes\"}]}\n```"
+                              :success? false
+                              :tokens parseable-backend-failure-token-count
+                              :error {:message "artifact file not found"}))
                   llm/success? :success?
                   llm/get-content :content
                   llm/get-error :error]
@@ -233,19 +309,19 @@
             review (:artifact result)]
         (is (= :changes-requested (:review/decision review)))
         (is (some #{"Needs changes"} (:review/blocking-issues review)))
-        (is (= 7 (get-in result [:metrics :tokens])))))))
+        (is (= parseable-backend-failure-token-count
+               (get-in result [:metrics :tokens])))))))
 
 (deftest test-reviewer-timeout-only-parseable-failure-is-agent-error
   (testing "timeout-only parsed review failures do not become rejected code-review artifacts"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
-                             {:success? false
-                              :content "{:review/decision :rejected
-                                         :review/gate-results [{:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}]
-                                         :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120183ms\"]
-                                         :review/recommendations []}"
-                              :tokens 9
-                              :error {:message "Adaptive timeout: Stagnation timeout: no progress for 120183ms"}})
+                             (mock-llm-response
+                              (timeout-only-review-content
+                               (adaptive-timeout-message backend-timeout-elapsed-ms))
+                              :success? false
+                              :tokens timeout-review-token-count
+                              :error {:message (adaptive-timeout-message backend-timeout-elapsed-ms)}))
                   llm/success? :success?
                   llm/get-content :content
                   llm/get-error :error]
@@ -253,23 +329,24 @@
                                                 :gates []})
             result (core/invoke reviewer {} sample-artifact)]
         (is (= :error (:status result)))
-        (is (= "Adaptive timeout: Stagnation timeout: no progress for 120183ms"
+        (is (= (adaptive-timeout-message backend-timeout-elapsed-ms)
                (get-in result [:error :message])))
         (is (= :reviewer/backend-timeout
                (get-in result [:error :data :code])))
-        (is (= 9 (get-in result [:metrics :tokens])))))))
+        (is (= timeout-review-token-count
+               (get-in result [:metrics :tokens])))))))
 
 (deftest test-reviewer-timeout-only-parseable-success-wrapper-is-agent-error
   (testing "timeout-only parsed review failures are treated as backend errors even when the wrapper reports success"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
-                             {:success? true
-                              :content "{:review/decision :rejected
-                                         :review/gate-results [{:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}
-                                                                {:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}]
-                                         :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120228ms (type: stagnation, elapsed: 120228ms)\"]
-                                         :review/recommendations []}"
-                              :tokens 11})
+                             (mock-llm-response
+                              (timeout-only-review-content
+                               (wrapped-timeout-message wrapped-timeout-elapsed-ms)
+                               [(review-gate-feedback)
+                                (review-gate-feedback)])
+                              :success? true
+                              :tokens timeout-success-wrapper-token-count))
                   llm/success? :success?
                   llm/get-content :content
                   llm/get-error (constantly nil)]
@@ -277,24 +354,25 @@
                                                 :gates []})
             result (core/invoke reviewer {} sample-artifact)]
         (is (= :error (:status result)))
-        (is (= "Adaptive timeout: Stagnation timeout: no progress for 120228ms (type: stagnation, elapsed: 120228ms)"
+        (is (= (wrapped-timeout-message wrapped-timeout-elapsed-ms)
                (get-in result [:error :message])))
         (is (= :reviewer/backend-timeout
                (get-in result [:error :data :code])))
-        (is (= 11 (get-in result [:metrics :tokens])))))))
+        (is (= timeout-success-wrapper-token-count
+               (get-in result [:metrics :tokens])))))))
 
 (deftest test-reviewer-timeout-only-shape-does-not-hide-real-gate-failures
   (testing "timeout-only classification requires the deterministic gates to approve"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
-                             {:success? false
-                              :content "{:review/decision :rejected
-                                         :review/gate-results []
-                                         :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120183ms\"]
-                                         :review/recommendations []}"
-                              :tokens 9
-                              :error {:type "adaptive_timeout"
-                                      :message "Adaptive timeout: Stagnation timeout: no progress for 120183ms"}})
+                             (mock-llm-response
+                              (timeout-only-review-content
+                               (adaptive-timeout-message backend-timeout-elapsed-ms)
+                               [])
+                              :success? false
+                              :tokens timeout-review-token-count
+                              :error (backend-timeout-error
+                                      (adaptive-timeout-message backend-timeout-elapsed-ms))))
                   llm/success? :success?
                   llm/get-content :content
                   llm/get-error :error]
@@ -311,15 +389,14 @@
     (let [events (atom [])]
       (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                     llm/chat (fn [_client _prompt _opts]
-                               {:success? false
-                                :content "{:review/decision :rejected
-                                           :review/gate-results [{:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}]
-                                           :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120183ms\"]
-                                           :review/recommendations []}"
-                                :tokens 9
-                                :error {:type "adaptive_timeout"
-                                        :message "Adaptive timeout: Stagnation timeout: no progress for 120183ms"
-                                        :data {:elapsed-ms 120183}}})
+                               (mock-llm-response
+                                (timeout-only-review-content
+                                 (adaptive-timeout-message backend-timeout-elapsed-ms))
+                                :success? false
+                                :tokens timeout-review-token-count
+                                :error (backend-timeout-error
+                                        (adaptive-timeout-message backend-timeout-elapsed-ms)
+                                        {:elapsed-ms backend-timeout-elapsed-ms})))
                     llm/success? :success?
                     llm/get-content :content
                     llm/get-error :error
@@ -342,17 +419,16 @@
   (testing "timeout-only backend errors preserve normalized backend metadata for post-mortem"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
-                             {:success? false
-                              :content "{:review/decision :rejected
-                                         :review/gate-results [{:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}]
-                                         :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120183ms\"]
-                                         :review/recommendations []}"
-                              :tokens 9
-                              :stop-reason "timeout"
-                              :num-turns 4
-                              :error {:type "adaptive_timeout"
-                                      :message "Adaptive timeout: Stagnation timeout: no progress for 120183ms"
-                                      :data {:elapsed-ms 120183}}})
+                             (mock-llm-response
+                              (timeout-only-review-content
+                               (adaptive-timeout-message backend-timeout-elapsed-ms))
+                              :success? false
+                              :tokens timeout-review-token-count
+                              :stop-reason backend-timeout-stop-reason
+                              :num-turns backend-timeout-num-turns
+                              :error (backend-timeout-error
+                                      (adaptive-timeout-message backend-timeout-elapsed-ms)
+                                      {:elapsed-ms backend-timeout-elapsed-ms})))
                   llm/success? :success?
                   llm/get-content :content
                   llm/get-error :error]
@@ -362,13 +438,13 @@
         (is (= :error (:status result)))
         (is (= :reviewer/backend-timeout
                (get-in result [:error :data :code])))
-        (is (= "adaptive_timeout"
+        (is (= backend-timeout-type
                (get-in result [:error :data :type])))
-        (is (= 120183
+        (is (= backend-timeout-elapsed-ms
                (get-in result [:error :data :elapsed-ms])))
-        (is (= "timeout"
+        (is (= backend-timeout-stop-reason
                (get-in result [:error :data :stop-reason])))
-        (is (= 4
+        (is (= backend-timeout-num-turns
                (get-in result [:error :data :num-turns])))))))
 
 (deftest test-reviewer-rejects-degraded-implement-handoff

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -234,6 +234,54 @@
         (is (some #{"Needs changes"} (:review/blocking-issues review)))
         (is (= 7 (get-in result [:metrics :tokens])))))))
 
+(deftest test-reviewer-timeout-only-parseable-failure-is-agent-error
+  (testing "timeout-only parsed review failures do not become rejected code-review artifacts"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             {:success? false
+                              :content "{:review/decision :rejected
+                                         :review/gate-results [{:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}]
+                                         :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120183ms\"]
+                                         :review/recommendations []}"
+                              :tokens 9
+                              :error {:message "Adaptive timeout: Stagnation timeout: no progress for 120183ms"}})
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error :error]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates []})
+            result (core/invoke reviewer {} sample-artifact)]
+        (is (= :error (:status result)))
+        (is (= "Adaptive timeout: Stagnation timeout: no progress for 120183ms"
+               (get-in result [:error :message])))
+        (is (= :reviewer/backend-timeout
+               (get-in result [:error :data :code])))
+        (is (= 9 (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-timeout-only-parseable-success-wrapper-is-agent-error
+  (testing "timeout-only parsed review failures are treated as backend errors even when the wrapper reports success"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             {:success? true
+                              :content "{:review/decision :rejected
+                                         :review/gate-results [{:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}
+                                                                {:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}]
+                                         :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120228ms (type: stagnation, elapsed: 120228ms)\"]
+                                         :review/recommendations []}"
+                              :tokens 11})
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error (constantly nil)]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates []})
+            result (core/invoke reviewer {} sample-artifact)]
+        (is (= :error (:status result)))
+        (is (= "Adaptive timeout: Stagnation timeout: no progress for 120228ms (type: stagnation, elapsed: 120228ms)"
+               (get-in result [:error :message])))
+        (is (= :reviewer/backend-timeout
+               (get-in result [:error :data :code])))
+        (is (= 11 (get-in result [:metrics :tokens])))))))
+
 (deftest test-reviewer-rejects-degraded-implement-handoff
   (testing "default reviewer rejects curated artifacts marked as degraded handoffs"
     (let [reviewer (reviewer/create-reviewer {:llm-backend nil})

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -23,6 +23,7 @@
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.reviewer :as reviewer]
    [ai.miniforge.agent.core :as core]
+   [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.loop.interface :as loop]
    [ai.miniforge.response.interface :as response]))
@@ -281,6 +282,94 @@
         (is (= :reviewer/backend-timeout
                (get-in result [:error :data :code])))
         (is (= 11 (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-timeout-only-shape-does-not-hide-real-gate-failures
+  (testing "timeout-only classification requires the deterministic gates to approve"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             {:success? false
+                              :content "{:review/decision :rejected
+                                         :review/gate-results []
+                                         :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120183ms\"]
+                                         :review/recommendations []}"
+                              :tokens 9
+                              :error {:type "adaptive_timeout"
+                                      :message "Adaptive timeout: Stagnation timeout: no progress for 120183ms"}})
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error :error]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates [(failing-gate :gate1 "Gate failure")]})
+            result (core/invoke reviewer {} sample-artifact)]
+        (is (= :success (:status result)))
+        (is (not= :reviewer/backend-timeout
+                  (get-in result [:error :data :code])))
+        (is (= :rejected (get-in result [:artifact :review/decision])))))))
+
+(deftest test-reviewer-timeout-only-error-emits-phase-completed
+  (testing "timeout-only backend errors still emit review phase completion telemetry"
+    (let [events (atom [])]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                    llm/chat (fn [_client _prompt _opts]
+                               {:success? false
+                                :content "{:review/decision :rejected
+                                           :review/gate-results [{:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}]
+                                           :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120183ms\"]
+                                           :review/recommendations []}"
+                                :tokens 9
+                                :error {:type "adaptive_timeout"
+                                        :message "Adaptive timeout: Stagnation timeout: no progress for 120183ms"
+                                        :data {:elapsed-ms 120183}}})
+                    llm/success? :success?
+                    llm/get-content :content
+                    llm/get-error :error
+                    log/info (fn [_logger category event payload]
+                               (swap! events conj {:category category
+                                                   :event event
+                                                   :payload payload}))]
+        (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                  :gates []})
+              result (core/invoke reviewer {} sample-artifact)
+              completed-event (some #(when (= :reviewer/phase-completed (:event %)) %) @events)]
+          (is (= :error (:status result)))
+          (is completed-event)
+          (is (= :reviewer/backend-timeout
+                 (get-in completed-event [:payload :data :error-code])))
+          (is (= :error
+                 (get-in completed-event [:payload :data :status]))))))))
+
+(deftest test-reviewer-timeout-only-error-preserves-backend-metadata
+  (testing "timeout-only backend errors preserve normalized backend metadata for post-mortem"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             {:success? false
+                              :content "{:review/decision :rejected
+                                         :review/gate-results [{:gate-id :unknown :gate-type :unknown :passed? true :errors [] :warnings [] :duration-ms 0}]
+                                         :review/blocking-issues [\"Adaptive timeout: Stagnation timeout: no progress for 120183ms\"]
+                                         :review/recommendations []}"
+                              :tokens 9
+                              :stop-reason "timeout"
+                              :num-turns 4
+                              :error {:type "adaptive_timeout"
+                                      :message "Adaptive timeout: Stagnation timeout: no progress for 120183ms"
+                                      :data {:elapsed-ms 120183}}})
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error :error]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates []})
+            result (core/invoke reviewer {} sample-artifact)]
+        (is (= :error (:status result)))
+        (is (= :reviewer/backend-timeout
+               (get-in result [:error :data :code])))
+        (is (= "adaptive_timeout"
+               (get-in result [:error :data :type])))
+        (is (= 120183
+               (get-in result [:error :data :elapsed-ms])))
+        (is (= "timeout"
+               (get-in result [:error :data :stop-reason])))
+        (is (= 4
+               (get-in result [:error :data :num-turns])))))))
 
 (deftest test-reviewer-rejects-degraded-implement-handoff
   (testing "default reviewer rejects curated artifacts marked as degraded handoffs"

--- a/docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md
+++ b/docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md
@@ -1,0 +1,42 @@
+## Summary
+
+This PR packages the remaining Claude dogfood review-boundary fix from the `behavioral-verification-monitor` run on
+`main`.
+
+The remaining failure shape was narrower:
+
+1. the reviewer could return a parsed review artifact with all gates passing
+2. the only blocking issue could be an adaptive-timeout/stagnation message
+3. Miniforge could still treat that as a real rejected review and redirect implement
+
+## What Changed
+
+### Reviewer timeout-only failures now fail as backend errors
+
+- broaden the reviewer timeout-only classifier so it does not depend on the backend wrapper’s `success?` bit
+- when the parsed review artifact says:
+  - all gates passed
+  - no real findings or recommendations exist
+  - the only blocking issues are timeout/stagnation messages
+  - the decision is negative
+  then review now returns `:reviewer/backend-timeout` instead of a fake rejected review
+- preserve the timeout message itself as the phase error message
+- add regressions for both shapes:
+  - backend wrapper reports failure
+  - backend wrapper reports nominal success but the parsed review is still only a timeout echo
+
+## Validation
+
+- `clj-kondo` on touched files: clean
+- focused JVM regression run:
+  - `ai.miniforge.agent.reviewer-test`
+
+## Live Behavior
+
+- persisted dogfood review snapshot showed `4/4` gates passed, no real findings, and only an adaptive-timeout blocking
+  issue
+- that exact shape is now classified as a reviewer/backend failure instead of a code-review rejection
+
+## Follow-up
+
+- rerun the Claude dogfood workflow from the updated branch state so the new reviewer timeout fix is actually in play


### PR DESCRIPTION
## Summary

This PR packages the remaining Claude dogfood review-boundary fix from the `behavioral-verification-monitor` run on
`main`.

The remaining failure shape was narrower:

1. the reviewer could return a parsed review artifact with all gates passing
2. the only blocking issue could be an adaptive-timeout/stagnation message
3. Miniforge could still treat that as a real rejected review and redirect implement

## What Changed

### Reviewer timeout-only failures now fail as backend errors

- broaden the reviewer timeout-only classifier so it does not depend on the backend wrapper’s `success?` bit
- when the parsed review artifact says:
  - all gates passed
  - no real findings or recommendations exist
  - the only blocking issues are timeout/stagnation messages
  - the decision is negative
  then review now returns `:reviewer/backend-timeout` instead of a fake rejected review
- preserve the timeout message itself as the phase error message
- add regressions for both shapes:
  - backend wrapper reports failure
  - backend wrapper reports nominal success but the parsed review is still only a timeout echo

## Validation

- `clj-kondo` on touched files: clean
- focused JVM regression run:
  - `ai.miniforge.agent.reviewer-test`

## Live Behavior

- persisted dogfood review snapshot showed `4/4` gates passed, no real findings, and only an adaptive-timeout blocking
  issue
- that exact shape is now classified as a reviewer/backend failure instead of a code-review rejection

## Follow-up

- rerun the Claude dogfood workflow from the updated branch state so the new reviewer timeout fix is actually in play
