### PR TITLE
fix(cli): harden dogfood startup, no-op handoff, and resume

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -332,7 +332,9 @@
 
 (defn- await-stream
   [stream-future]
-  (deref stream-future 1000 ""))
+  (try
+    @stream-future
+    (catch Exception _ "")))
 
 (defn- run-cli-command
   [cmd timeout-ms & {:keys [workdir]}]

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -19,7 +19,6 @@
 (ns ai.miniforge.cli.workflow-runner
   (:require
    [babashka.fs :as fs]
-   [babashka.process :as p]
    [clojure.string :as str]
    [clojure.edn :as edn]
    [cheshire.core :as json]
@@ -306,32 +305,55 @@
   (when (System/getenv "CLAUDECODE")
     (into {} (remove (fn [[k _]] (= k "CLAUDECODE"))) (System/getenv))))
 
+(defn- start-cli-process
+  [cmd workdir]
+  (let [builder (ProcessBuilder. ^java.util.List cmd)]
+    (when-let [process-env (cli-process-env)]
+      (let [env (.environment builder)]
+        (.clear env)
+        (doseq [[k v] process-env]
+          (.put env k v))))
+    (when workdir
+      (.directory builder (java.io.File. workdir)))
+    (.start builder)))
+
+(defn- stream-reader
+  [stream]
+  (future
+    (with-open [stream stream]
+      (slurp stream))))
+
+(defn- destroy-cli-process!
+  [^Process process]
+  (try
+    (.destroyForcibly process)
+    (.waitFor process 1000 java.util.concurrent.TimeUnit/MILLISECONDS)
+    (catch Exception _ nil)))
+
+(defn- await-stream
+  [stream-future]
+  (deref stream-future 1000 ""))
+
 (defn- run-cli-command
   [cmd timeout-ms & {:keys [workdir]}]
-  (let [empty-stdin (java.io.ByteArrayInputStream. (byte-array 0))
-        process (apply p/process
-                       (cond-> {:out :string
-                                :err :string
-                                :continue true
-                                :in empty-stdin}
-                         (cli-process-env) (assoc :env (cli-process-env))
-                         workdir (assoc :dir workdir))
-                       cmd)
-        result (deref process timeout-ms ::timeout)]
-    (if (= ::timeout result)
+  (let [^Process process (start-cli-process cmd workdir)
+        _ (.close (.getOutputStream process))
+        out-future (stream-reader (.getInputStream process))
+        err-future (stream-reader (.getErrorStream process))
+        completed? (.waitFor process timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)]
+    (if-not completed?
       (do
-        (try
-          (when-let [^Process jp (:proc process)]
-            (.destroyForcibly jp))
-          (catch Exception _ nil))
+        (destroy-cli-process! process)
+        (future-cancel out-future)
+        (future-cancel err-future)
         {:out ""
          :err (messages/t :workflow-runner/cli-process-timeout
                           {:timeout-ms timeout-ms})
          :exit -1
          :timeout-ms timeout-ms})
-      {:out (:out result)
-       :err (:err result)
-       :exit (:exit result)})))
+      {:out (await-stream out-future)
+       :err (await-stream err-future)
+       :exit (.exitValue process)})))
 
 (defn- success-response
   [output]

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -30,6 +30,24 @@
     (fs/create-dirs (fs/path root ".git"))
     root))
 
+(defn- shell-path []
+  (or (some-> (fs/which "sh") str)
+      "/bin/sh"))
+
+(deftest run-cli-command-captures-short-lived-process-output-test
+  (testing "probe helper captures stdout, stderr, and exit code for short-lived commands"
+    (let [result (#'sut/run-cli-command [(shell-path) "-lc" "printf ok; printf warn >&2"] 5000)]
+      (is (= "ok" (:out result)))
+      (is (= "warn" (:err result)))
+      (is (= 0 (:exit result))))))
+
+(deftest run-cli-command-times-out-fast-test
+  (testing "probe helper returns a timeout result instead of hanging the caller"
+    (let [result (#'sut/run-cli-command [(shell-path) "-lc" "sleep 1"] 10)]
+      (is (= -1 (:exit result)))
+      (is (= 10 (:timeout-ms result)))
+      (is (str/includes? (:err result) "10")))))
+
 (deftest assert-runtime-alignment-rejects-worktree-mismatch-test
   (testing "explicit execution worktree must survive into runtime context"
     (let [source-root (temp-repo-root)

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -41,6 +41,16 @@
       (is (= "warn" (:err result)))
       (is (= 0 (:exit result))))))
 
+(deftest await-stream-waits-for-reader-completion-test
+  (testing "stream join waits for a completed reader instead of dropping late output"
+    (let [started-at (System/currentTimeMillis)
+          result (#'sut/await-stream (future
+                                       (Thread/sleep 1100)
+                                       "late-output"))
+          elapsed-ms (- (System/currentTimeMillis) started-at)]
+      (is (= "late-output" result))
+      (is (<= 1000 elapsed-ms)))))
+
 (deftest run-cli-command-times-out-fast-test
   (testing "probe helper returns a timeout result instead of hanging the caller"
     (let [result (#'sut/run-cli-command [(shell-path) "-lc" "sleep 1"] 10)]

--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -127,12 +127,16 @@ the file list from your Write/Edit tool calls.
 ## Already-Implemented Response
 
 If the task is already fully implemented in the existing files provided to you,
-do NOT generate new code. Instead, call `submit` with:
+do NOT generate new code. Prefer writing this EDN to
+`.miniforge/implement.edn` with `Write`:
 
 ```clojure
 {:status :already-implemented
  :summary \"Brief explanation: what exists, why no changes are needed\"}
 ```
+
+If `Write` is unavailable, the same EDN map in your final message is an
+acceptable fallback. The runtime normalizes both paths.
 
 Only use this when ALL acceptance criteria are already met by existing code.
 If even partial changes are needed, proceed with normal Write/Edit delivery.

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -506,6 +506,28 @@
                        (.getPath f) "—" (ex-message e)))
             nil))))))
 
+(defn read-capsule-worktree-artifact
+  "Read a role artifact from <workdir>/.miniforge/<role>.edn inside a capsule.
+
+   Returns the parsed artifact map or nil. Missing files and parse failures are
+   treated as non-fatal, matching host-mode read-worktree-artifact behavior."
+  [session role]
+  (when (and session role)
+    (let [path (str (:workdir session) "/.miniforge/" (name role) ".edn")
+          result ((:exec! session) (:executor session) (:environment-id session)
+                  (str "cat " path) {:workdir (:workdir session)})
+          content (get-in result [:data :stdout] "")]
+      (when (seq content)
+        (try
+          (-> content
+              edn/read-string
+              parse-uuid-strings)
+          (catch Exception e
+            (binding [*out* *err*]
+              (println "WARN: failed to parse capsule worktree artifact at"
+                       path "—" (ex-message e)))
+            nil))))))
+
 (defn read-artifact
   "Read the artifact EDN file from a session directory.
 
@@ -761,10 +783,14 @@
   (try
     (let [result (body-fn session)
           workdir (:workdir session)
-          worktree-artifacts (when (and (= :host mode) workdir)
+          read-role-artifact (case mode
+                               :capsule #(read-capsule-worktree-artifact session %)
+                               :host    #(read-worktree-artifact workdir %)
+                               (constantly nil))
+          worktree-artifacts (when workdir
                                (into {}
                                      (keep (fn [role]
-                                             (when-let [a (read-worktree-artifact workdir role)]
+                                             (when-let [a (read-role-artifact role)]
                                                [role a])))
                                      [:plan :implement :verify :review :release]))]
       {:llm-result result

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -48,6 +48,23 @@
    [:mcp-config-path [:string {:min 1}]]
    [:artifact-path [:string {:min 1}]]])
 
+(def ^:private system-message-templates
+  "System-localized stderr message templates for artifact-session I/O."
+  {:warn/worktree-artifact-parse
+   "WARN: failed to parse worktree artifact at %s — %s"
+
+   :warn/capsule-worktree-artifact-parse
+   "WARN: failed to parse capsule worktree artifact at %s — %s"
+
+   :error/artifact-file-missing
+   "ERROR: artifact file not found at %s — MCP tool was likely not called by the LLM"
+
+   :warn/artifact-parse
+   "WARN: failed to parse artifact at %s — %s"
+
+   :warn/context-misses-parse
+   "WARN: failed to parse context misses at %s — %s"})
+
 (defn validate-session
   "Validate a session map against the Session schema.
 
@@ -103,6 +120,37 @@
       ;; 4. Last-resort fallback
       :else
       ["bb" "miniforge"])))
+
+(defn- emit-system-message!
+  "Render a system-scoped stderr message from a shared template."
+  [message-key & args]
+  (binding [*out* *err*]
+    (println (apply format (get system-message-templates message-key) args))))
+
+(defn- artifact-filename
+  "Canonical filename for a role artifact in .miniforge/."
+  [role]
+  (str (name role) ".edn"))
+
+(defn- worktree-artifact-file
+  "Resolve the canonical .miniforge artifact file for a role."
+  [workdir role]
+  (io/file workdir ".miniforge" (artifact-filename role)))
+
+(defn- parse-edn-content
+  "Parse EDN content with a transform, logging failures as system messages."
+  [content transform warning-key path]
+  (try
+    (-> content
+        transform)
+    (catch Exception e
+      (emit-system-message! warning-key path (ex-message e))
+      nil)))
+
+(defn- parse-edn-file
+  "Read and parse an EDN file with a transform, logging failures consistently."
+  [f transform warning-key]
+  (parse-edn-content (slurp f) transform warning-key (.getPath f)))
 
 (def ^:private codex-artifact-table-pattern
   #"^\[mcp_servers\.artifact(?:\..+)?\]\s*$")
@@ -493,40 +541,28 @@
    unreadable, or parse failure — all logged to stderr, never thrown)."
   [workdir role]
   (when (and workdir role)
-    (let [filename (str (name role) ".edn")
-          f (io/file workdir ".miniforge" filename)]
+    (let [f (worktree-artifact-file workdir role)]
       (when (.exists f)
-        (try
-          (-> (slurp f)
-              edn/read-string
-              parse-uuid-strings)
-          (catch Exception e
-            (binding [*out* *err*]
-              (println "WARN: failed to parse worktree artifact at"
-                       (.getPath f) "—" (ex-message e)))
-            nil))))))
+        (parse-edn-file f
+                        (comp parse-uuid-strings edn/read-string)
+                        :warn/worktree-artifact-parse)))))
 
 (defn read-capsule-worktree-artifact
   "Read a role artifact from <workdir>/.miniforge/<role>.edn inside a capsule.
 
-   Returns the parsed artifact map or nil. Missing files and parse failures are
+  Returns the parsed artifact map or nil. Missing files and parse failures are
    treated as non-fatal, matching host-mode read-worktree-artifact behavior."
   [session role]
   (when (and session role)
-    (let [path (str (:workdir session) "/.miniforge/" (name role) ".edn")
+    (let [path (.getPath (worktree-artifact-file (:workdir session) role))
           result ((:exec! session) (:executor session) (:environment-id session)
                   (str "cat " path) {:workdir (:workdir session)})
           content (get-in result [:data :stdout] "")]
       (when (seq content)
-        (try
-          (-> content
-              edn/read-string
-              parse-uuid-strings)
-          (catch Exception e
-            (binding [*out* *err*]
-              (println "WARN: failed to parse capsule worktree artifact at"
-                       path "—" (ex-message e)))
-            nil))))))
+        (parse-edn-content content
+                           (comp parse-uuid-strings edn/read-string)
+                           :warn/capsule-worktree-artifact-parse
+                           path)))))
 
 (defn read-artifact
   "Read the artifact EDN file from a session directory.
@@ -534,26 +570,19 @@
    Arguments:
    - session - Session map from create-session!
 
-   Returns:
-   - Parsed artifact map with proper UUID types, or nil if not found.
+  Returns:
+  - Parsed artifact map with proper UUID types, or nil if not found.
      Logs warnings on missing file or parse failure instead of silently returning nil."
   [session]
   (let [f (io/file (:artifact-path session))]
     (if-not (.exists f)
       (do
-        (binding [*out* *err*]
-          (println "ERROR: artifact file not found at" (:artifact-path session)
-                   "— MCP tool was likely not called by the LLM"))
+        (emit-system-message! :error/artifact-file-missing
+                              (:artifact-path session))
         nil)
-      (try
-        (-> (slurp f)
-            edn/read-string
-            parse-uuid-strings)
-        (catch Exception e
-          (binding [*out* *err*]
-            (println "WARN: failed to parse artifact at" (:artifact-path session)
-                     "—" (ex-message e)))
-          nil)))))
+      (parse-edn-file f
+                      (comp parse-uuid-strings edn/read-string)
+                      :warn/artifact-parse))))
 
 (defn read-context-misses
   "Read context cache misses from the session directory.
@@ -566,12 +595,7 @@
   (let [path (str (:dir session) "/context-misses.edn")
         f (io/file path)]
     (when (.exists f)
-      (try
-        (edn/read-string (slurp f))
-        (catch Exception e
-          (binding [*out* *err*]
-            (println "WARN: failed to parse context misses:" (ex-message e)))
-          nil)))))
+      (parse-edn-file f edn/read-string :warn/context-misses-parse))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; High-level session helpers

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.patterns.interface :as patterns]
@@ -438,23 +439,14 @@
      :code/summary "Implementation from code blocks"
      :code/created-at (java.util.Date.)}))
 
-(defn- usable-llm-content?
-  "True when the LLM response content can still be normalized into an
-   implementer result even if the backend wrapper marked the turn unsuccessful."
-  [content]
-  (when (and (string? content)
-             (not (str/blank? content)))
-    (boolean
-     (or (parse-code-response content)
-         (code-from-blocks content)))))
-
 (defn- process-llm-response
   "Normalize structured implementer outputs from any submission channel:
    worktree metadata, MCP artifact, file fallback, or parseable stdout."
-  [response structured-artifact artifact-source context logger tokens cost-usd input]
-  (let [content (llm/get-content response)
-        parsed (or structured-artifact (parse-code-response content))]
-    (let [tools (get response :tools-called [])]
+  [{:keys [content structured-artifact parsed-content derived-artifact
+           artifact-source tokens cost-usd tools-called]}
+   context logger input]
+  (let [parsed (or structured-artifact parsed-content)]
+    (let [tools tools-called]
       (when (nil? artifact-source)
         (log/warn logger :implementer :implementer/mcp-tool-not-called
                   {:data {:content-length (count (or content ""))
@@ -470,7 +462,7 @@
         (build-already-implemented-response parsed tokens cost-usd))
 
       :else
-      (if-let [code (or parsed (code-from-blocks content))]
+      (if-let [code (or parsed derived-artifact)]
         (build-code-response code context tokens cost-usd)
         (response/error (messages/t :error/parse-failed) {:tokens tokens})))))
 
@@ -535,7 +527,6 @@
           #(invoke-implementer-session % llm-client user-prompt effective-system-prompt
                                        config context on-chunk existing-files working-dir))
         response llm-result
-        worktree-artifact (get worktree-artifacts :implement)
         file-artifact (when-not artifact
                         (if (= :capsule session-mode)
                           (file-artifacts/collect-written-files-via-executor
@@ -546,15 +537,14 @@
                            working-dir)
                           (file-artifacts/collect-written-files pre-session-snapshot
                                                                 working-dir)))
-        artifact-source (cond
-                          worktree-artifact :worktree-metadata
-                          artifact :mcp
-                          file-artifact :file-fallback
-                          :else nil)
-        structured-artifact (or worktree-artifact artifact file-artifact)
-        tokens (get response :tokens 0)
-        cost-usd (get response :cost-usd)
-        content (llm/get-content response)]
+        normalized (result-boundary/normalize-llm-result
+                    {:role :implement
+                     :response response
+                     :worktree-artifacts worktree-artifacts
+                     :artifact artifact
+                     :fallback-artifact file-artifact
+                     :parse-response parse-code-response
+                     :derive-artifact code-from-blocks})]
     (when (seq context-misses)
       (log/info logger :implementer :implementer/context-cache-misses
                 {:data {:miss-count (count context-misses)
@@ -565,10 +555,10 @@
                         :tools-called (get response :tools-called [])}}))
     (log/info logger :implementer :implementer/llm-called
               {:data (cond-> {:success (llm/success? response)
-                              :tokens tokens
+                              :tokens (:tokens normalized)
                               :streaming? (boolean on-chunk)
-                              :artifact-source (or artifact-source :none)
-                              :tools-called (get response :tools-called [])}
+                              :artifact-source (or (:artifact-source normalized) :none)
+                              :tools-called (:tools-called normalized)}
                        (:stop-reason response)
                        (assoc :stop-reason (:stop-reason response))
                        (:num-turns response)
@@ -581,26 +571,16 @@
     ;; successful stream of edits; the old path discarded a real
     ;; artifact because the LLM response was classified as failure.
     ;; Mirrors the planner fix in `(or worktree-plan (llm/success? …))`.
-    (if (or structured-artifact
-            (llm/success? response)
-            (usable-llm-content? content))
-      (process-llm-response response structured-artifact artifact-source
-                            context logger tokens cost-usd input)
+    (if (result-boundary/usable-content? normalized)
+      (process-llm-response normalized context logger input)
       ;; LLM call failed, no artifact — preserve the full llm-error
       ;; shape into :data so the phase-completed event carries
       ;; :type (e.g. "cli_error" / "adaptive_timeout"), :stderr /
       ;; :stdout / :timeout / :exit-code for post-mortem. Iters
       ;; 11-12 of planner-convergence lost this context and produced
       ;; undiagnosable "Unknown error" phase errors; same trap here.
-      (let [llm-err (llm/get-error response)
-            error-msg (or (:message llm-err)
-                          (messages/t :error/llm-failed))
-            stop-reason (:stop-reason response)
-            num-turns   (:num-turns response)]
-        (response/error error-msg
-                        {:data (cond-> (or llm-err {})
-                                 stop-reason (assoc :stop-reason stop-reason)
-                                 num-turns   (assoc :num-turns num-turns))})))))
+      (result-boundary/error-response normalized
+                                      (messages/t :error/llm-failed)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -422,6 +422,12 @@
                                  :tokens tokens
                                  :cost-usd cost-usd}})))
 
+(defn- code-artifact?
+  "True when the structured artifact is a code artifact payload."
+  [artifact]
+  (and (map? artifact)
+       (contains? artifact :code/files)))
+
 (defn- code-from-blocks
   "Build a code artifact map from extracted markdown code blocks."
   [content]
@@ -443,10 +449,11 @@
          (code-from-blocks content)))))
 
 (defn- process-llm-response
-  "Process a successful LLM response, returning the appropriate result."
-  [response artifact artifact-source context logger tokens cost-usd input]
+  "Normalize structured implementer outputs from any submission channel:
+   worktree metadata, MCP artifact, file fallback, or parseable stdout."
+  [response structured-artifact artifact-source context logger tokens cost-usd input]
   (let [content (llm/get-content response)
-        parsed (or artifact (parse-code-response content))]
+        parsed (or structured-artifact (parse-code-response content))]
     (let [tools (get response :tools-called [])]
       (when (nil? artifact-source)
         (log/warn logger :implementer :implementer/mcp-tool-not-called
@@ -454,8 +461,8 @@
                           :tools-called tools
                           :has-code-blocks? (boolean (re-find #"```" (or content "")))}})))
     (cond
-      artifact
-      (build-code-response artifact context tokens cost-usd)
+      (code-artifact? structured-artifact)
+      (build-code-response structured-artifact context tokens cost-usd)
 
       (= :already-implemented (:status parsed))
       (if (repair-attempt? input)
@@ -522,11 +529,13 @@
    existing-files input]
   (let [working-dir (or (:execution/worktree-path context)
                         (System/getProperty "user.dir"))
-        {:keys [llm-result artifact context-misses pre-session-snapshot session-mode]}
+        {:keys [llm-result artifact worktree-artifacts context-misses
+                pre-session-snapshot session-mode]}
         (artifact-session/with-session context
           #(invoke-implementer-session % llm-client user-prompt effective-system-prompt
                                        config context on-chunk existing-files working-dir))
         response llm-result
+        worktree-artifact (get worktree-artifacts :implement)
         file-artifact (when-not artifact
                         (if (= :capsule session-mode)
                           (file-artifacts/collect-written-files-via-executor
@@ -538,10 +547,11 @@
                           (file-artifacts/collect-written-files pre-session-snapshot
                                                                 working-dir)))
         artifact-source (cond
+                          worktree-artifact :worktree-metadata
                           artifact :mcp
                           file-artifact :file-fallback
                           :else nil)
-        effective-artifact (or artifact file-artifact)
+        structured-artifact (or worktree-artifact artifact file-artifact)
         tokens (get response :tokens 0)
         cost-usd (get response :cost-usd)
         content (llm/get-content response)]
@@ -571,10 +581,10 @@
     ;; successful stream of edits; the old path discarded a real
     ;; artifact because the LLM response was classified as failure.
     ;; Mirrors the planner fix in `(or worktree-plan (llm/success? …))`.
-    (if (or effective-artifact
+    (if (or structured-artifact
             (llm/success? response)
             (usable-llm-content? content))
-      (process-llm-response response effective-artifact artifact-source
+      (process-llm-response response structured-artifact artifact-source
                             context logger tokens cost-usd input)
       ;; LLM call failed, no artifact — preserve the full llm-error
       ;; shape into :data so the phase-completed event carries

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -432,6 +432,16 @@
      :code/summary "Implementation from code blocks"
      :code/created-at (java.util.Date.)}))
 
+(defn- usable-llm-content?
+  "True when the LLM response content can still be normalized into an
+   implementer result even if the backend wrapper marked the turn unsuccessful."
+  [content]
+  (when (and (string? content)
+             (not (str/blank? content)))
+    (boolean
+     (or (parse-code-response content)
+         (code-from-blocks content)))))
+
 (defn- process-llm-response
   "Process a successful LLM response, returning the appropriate result."
   [response artifact artifact-source context logger tokens cost-usd input]
@@ -533,7 +543,8 @@
                           :else nil)
         effective-artifact (or artifact file-artifact)
         tokens (get response :tokens 0)
-        cost-usd (get response :cost-usd)]
+        cost-usd (get response :cost-usd)
+        content (llm/get-content response)]
     (when (seq context-misses)
       (log/info logger :implementer :implementer/context-cache-misses
                 {:data {:miss-count (count context-misses)
@@ -560,7 +571,9 @@
     ;; successful stream of edits; the old path discarded a real
     ;; artifact because the LLM response was classified as failure.
     ;; Mirrors the planner fix in `(or worktree-plan (llm/success? …))`.
-    (if (or effective-artifact (llm/success? response))
+    (if (or effective-artifact
+            (llm/success? response)
+            (usable-llm-content? content))
       (process-llm-response response effective-artifact artifact-source
                             context logger tokens cost-usd input)
       ;; LLM call failed, no artifact — preserve the full llm-error

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -24,6 +24,7 @@
    [ai.miniforge.agent.budget :as budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
@@ -457,24 +458,23 @@
       (llm/chat llm-client user-prompt
                 (merge {:system @planner-system-prompt} mcp-opts)))))
 
-(defn- planner-plan-artifact
-  "Select the planner artifact authority for the session."
-  [worktree-artifacts artifact]
-  {:worktree-plan (get worktree-artifacts :plan)
-   :artifact artifact})
-
-(defn- effective-plan
-  "Return the authoritative submitted plan when one exists."
-  [{:keys [worktree-plan artifact]}]
-  (or worktree-plan artifact))
+(defn- normalize-planner-result
+  [response worktree-artifacts artifact]
+  (result-boundary/normalize-llm-result
+   {:role :plan
+    :response response
+    :worktree-artifacts worktree-artifacts
+    :artifact artifact
+    :content-fn planner-response-content
+    :parse-response parse-plan-response}))
 
 (defn- planner-log-data
   "Build planner invocation telemetry data."
-  [llm-response on-chunk plan-artifact]
-  (let [plan-source (cond
-                      (:worktree-plan plan-artifact) :worktree
-                      (:artifact plan-artifact) :mcp-artifact
-                      :else :final-message)]
+  [llm-response on-chunk normalized]
+  (let [plan-source (case (:artifact-source normalized)
+                      :worktree-metadata :worktree
+                      :mcp :mcp-artifact
+                      :final-message)]
     (cond-> {:success (llm/success? llm-response)
              :tokens (get llm-response :tokens 0)
              :streaming? (boolean on-chunk)
@@ -516,12 +516,12 @@
                           % llm-client retry-prompt config context on-chunk)
         {:keys [llm-result artifact worktree-artifacts]}
         (artifact-session/with-session context run-retry)
-        plan-artifact  (planner-plan-artifact worktree-artifacts artifact)
-        submitted-plan (effective-plan plan-artifact)
+        normalized     (normalize-planner-result llm-result worktree-artifacts artifact)
+        submitted-plan (:structured-artifact normalized)
         parsed-plan    (when-not submitted-plan
-                         (parse-plan-response (planner-response-content llm-result)))]
+                         (:parsed-content normalized))]
     {:llm-response   llm-result
-     :plan-artifact  plan-artifact
+     :normalized     normalized
      :submitted-plan submitted-plan
      :parsed-plan    parsed-plan}))
 
@@ -564,11 +564,11 @@
                     #(invoke-planner-session % llm-client user-prompt config context
                                              on-chunk existing-files))
                   llm-response llm-result
-                  plan-artifact (planner-plan-artifact worktree-artifacts artifact)
-                  submitted-plan (effective-plan plan-artifact)
-                  response-content (planner-response-content llm-response)
+                  normalized (normalize-planner-result llm-response worktree-artifacts artifact)
+                  submitted-plan (:structured-artifact normalized)
+                  response-content (:content normalized)
                   parsed-plan (when-not submitted-plan
-                                (parse-plan-response response-content))
+                                (:parsed-content normalized))
                   retry-result (when (planner-submission-retry? llm-response
                                                                 submitted-plan
                                                                 parsed-plan)
@@ -579,7 +579,7 @@
                                                          config context on-chunk
                                                          response-content))
                   final-llm-response   (or (:llm-response retry-result) llm-response)
-                  final-plan-artifact  (or (:plan-artifact retry-result) plan-artifact)
+                  final-normalized     (or (:normalized retry-result) normalized)
                   final-submitted-plan (or (:submitted-plan retry-result) submitted-plan)
                   final-parsed-plan    (or (:parsed-plan retry-result) parsed-plan)
                   retry-tokens         (if (identical? final-llm-response llm-response)
@@ -591,7 +591,7 @@
                           {:data {:miss-count (count context-misses)
                                   :misses context-misses}}))
               (log/info logger :planner :planner/llm-called
-                        {:data (planner-log-data final-llm-response on-chunk final-plan-artifact)})
+                        {:data (planner-log-data final-llm-response on-chunk final-normalized)})
               ;; Container-promotion preempts CLI error classification:
               ;; if the agent wrote a valid plan.edn into the worktree,
               ;; or submitted a plan through the MCP artifact path,
@@ -601,9 +601,7 @@
               ;; successful Write — the plan existed, but the old
               ;; success-branch-only logic ignored it because the LLM
               ;; response was classified as failure.
-              (if (or final-submitted-plan
-                      final-parsed-plan
-                      (llm/success? final-llm-response))
+              (if (result-boundary/usable-content? final-normalized)
                 (let [content (planner-response-content final-llm-response)
                       stop-reason (:stop-reason final-llm-response)
                       num-turns   (:num-turns final-llm-response)
@@ -651,14 +649,7 @@
                 ;; post-mortem. Iters 11-12 lost this context and
                 ;; produced undiagnosable \"Unknown error\" / bare
                 ;; \"Process timed out\" phase errors.
-                (let [llm-err (llm/get-error final-llm-response)
-                      error-msg (or (:message llm-err) "LLM call failed")
-                      stop-reason (:stop-reason final-llm-response)
-                      num-turns   (:num-turns final-llm-response)]
-                  (response/error error-msg
-                                  {:data (cond-> (or llm-err {})
-                                           stop-reason (assoc :stop-reason stop-reason)
-                                           num-turns   (assoc :num-turns num-turns))}))))
+                (result-boundary/error-response final-normalized "LLM call failed")))
                ;; No LLM client — hard failure
             (response/throw-anomaly! :anomalies.agent/llm-error
                                     "No LLM backend provided for planner agent"

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.agent.budget :as budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
@@ -241,30 +242,31 @@
               user-prompt (input->text input context)]
           (if llm-client
             ;; Use the real LLM with artifact session for MCP tool support
-            (let [{:keys [llm-result artifact]}
+            (let [{:keys [llm-result artifact worktree-artifacts]}
                   (artifact-session/with-session context
                     #(invoke-releaser-session % llm-client user-prompt config context on-chunk))
                   llm-response llm-result
-                  tokens (get llm-response :tokens 0)]
+                  normalized (result-boundary/normalize-llm-result
+                              {:role :release
+                               :response llm-response
+                               :worktree-artifacts worktree-artifacts
+                               :artifact artifact
+                               :parse-response parse-release-response})]
               (log/info logger :releaser :releaser/llm-called
                         {:data {:success (llm/success? llm-response)
-                                :tokens tokens
+                                :tokens (:tokens normalized)
                                 :streaming? (boolean on-chunk)}})
-              (if (llm/success? llm-response)
-                (let [content (llm/get-content llm-response)
-                      parsed (or artifact (parse-release-response content))]
+              (if (result-boundary/usable-content? normalized)
+                (let [parsed (result-boundary/authoritative-payload normalized)]
                   (if parsed
                     (let [release-with-meta (-> parsed
                                                 (update :release/id #(or % (random-uuid)))
                                                 (assoc :release/created-at (java.util.Date.)))]
-                      (response/success release-with-meta {:tokens tokens}))
+                      (response/success release-with-meta {:tokens (:tokens normalized)}))
                     ;; LLM returned content but no parseable release artifact — fail explicitly
                     (response/error "LLM response could not be parsed as release artifact"
-                                    {:tokens tokens})))
-                ;; LLM call failed — propagate error, no fallback
-                (let [error-msg (or (:message (llm/get-error llm-response))
-                                    "LLM call failed")]
-                  (response/error error-msg))))
+                                    {:tokens (:tokens normalized)})))
+                (result-boundary/error-response normalized "LLM call failed")))
             ;; No LLM client — fail explicitly
             (response/error "No LLM backend provided"))))
 

--- a/components/agent/src/ai/miniforge/agent/result_boundary.clj
+++ b/components/agent/src/ai/miniforge/agent/result_boundary.clj
@@ -1,0 +1,95 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.result-boundary
+  "Shared result-boundary helpers for agent roles that can receive structured
+   outcomes through multiple channels."
+  (:require
+   [ai.miniforge.llm.interface :as llm]
+   [ai.miniforge.response.interface :as response]
+   [clojure.string :as str]))
+
+(defn normalize-llm-result
+  "Fan in known result channels for an agent turn into one normalized map."
+  [{:keys [role response worktree-artifacts artifact fallback-artifact
+           parse-response derive-artifact content-fn]}]
+  (let [extract-content (or content-fn llm/get-content)
+        content (or (extract-content response) "")
+        worktree-artifact (when role
+                            (get worktree-artifacts role))
+        artifact-source (cond
+                          worktree-artifact :worktree-metadata
+                          artifact :mcp
+                          fallback-artifact :file-fallback
+                          :else nil)
+        structured-artifact (or worktree-artifact artifact fallback-artifact)
+        parsed-content (when parse-response
+                         (parse-response content))
+        derived-artifact (when derive-artifact
+                           (derive-artifact content))]
+    {:response response
+     :content content
+     :response-success? (llm/success? response)
+     :llm-error (llm/get-error response)
+     :artifact-source artifact-source
+     :structured-artifact structured-artifact
+     :parsed-content parsed-content
+     :derived-artifact derived-artifact
+     :tokens (get response :tokens 0)
+     :cost-usd (get response :cost-usd)
+     :stop-reason (:stop-reason response)
+     :num-turns (:num-turns response)
+     :tools-called (get response :tools-called [])
+     :usable? (boolean
+               (or structured-artifact
+                   parsed-content
+                   derived-artifact
+                   (llm/success? response)))}))
+
+(defn authoritative-payload
+  "Return the canonical payload chosen by the normalized boundary."
+  [{:keys [structured-artifact parsed-content derived-artifact]}]
+  (or structured-artifact parsed-content derived-artifact))
+
+(defn error-response
+  "Build a failure response that preserves the backend error shape plus
+   common response metadata for post-mortem."
+  ([normalized default-message]
+   (error-response normalized default-message {}))
+  ([{:keys [llm-error stop-reason num-turns tokens]} default-message extra]
+   (let [error-msg (or (:message llm-error) default-message)
+         data (cond-> (merge (or llm-error {}) (:data extra))
+                stop-reason (assoc :stop-reason stop-reason)
+                num-turns   (assoc :num-turns num-turns))]
+     (response/error error-msg
+                     (cond-> extra
+                       tokens (assoc :tokens tokens)
+                       (seq data) (assoc :data data))))))
+
+(defn usable-content?
+  "True when the boundary has any structured or parseable outcome."
+  [normalized]
+  (boolean (:usable? normalized)))
+
+(defn parse-failed?
+  "True when non-blank content produced no structured or parseable payload."
+  [{:keys [content structured-artifact parsed-content derived-artifact]}]
+  (and (not (str/blank? content))
+       (nil? structured-artifact)
+       (nil? parsed-content)
+       (nil? derived-artifact)))

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -23,6 +23,7 @@
   (:require
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
@@ -612,9 +613,12 @@
                              (llm/chat-stream llm-client user-prompt on-chunk
                                               base-opts)
                              (llm/chat llm-client user-prompt base-opts))
-                  content (or (llm/get-content response) "")
-                  tokens (get response :tokens 0)
-                  cost-usd (get response :cost-usd)]
+                  normalized (result-boundary/normalize-llm-result
+                              {:response response
+                               :parse-response parse-review-response})
+                  content (:content normalized)
+                  tokens (:tokens normalized)
+                  cost-usd (:cost-usd normalized)]
 
               (log/info logger :reviewer :reviewer/llm-called
                         {:data {:success (llm/success? response)
@@ -622,8 +626,7 @@
                                 :streaming? (boolean on-chunk)}})
 
               (let [;; Parse LLM review
-                    llm-review (when-not (str/blank? content)
-                                 (parse-review-response content))
+                    llm-review (:parsed-content normalized)
                     failure-message (review-failure-message response content)
                     parse-failed? (nil? llm-review)
                     llm-decision (cond

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -375,6 +375,38 @@
       (string? (:message llm-error)) (:message llm-error)
       :else "Reviewer LLM invocation failed before producing a review artifact")))
 
+(defn- backend-failure-message
+  "Derive the backend failure message when the reviewer LLM response parsed,
+   but the underlying invocation still failed."
+  [response llm-review]
+  (if-let [message (:message (llm/get-error response))]
+    message
+    (or (first (:review/blocking-issues llm-review))
+        "Reviewer LLM invocation failed after producing a review artifact")))
+
+(defn- backend-timeout-issue?
+  [message]
+  (boolean
+   (and (string? message)
+        (re-find #"(?i)(adaptive timeout|stagnation timeout|timed out|stream-idle|timeout)"
+                 message))))
+
+(defn- timeout-only-review?
+  "True when a parsed review artifact is just reflecting the reviewer backend's
+   own timeout rather than providing actionable code-review findings."
+  [llm-review gate-result]
+  (let [blocking-issues (vec (:review/blocking-issues llm-review))
+        recommendations (vec (:review/recommendations llm-review))
+        issues (vec (:review/issues llm-review))
+        negative-decision? (contains? #{:rejected :changes-requested}
+                                      (:review/decision llm-review))]
+    (and negative-decision?
+         (= :approved (:decision gate-result))
+         (seq blocking-issues)
+         (empty? recommendations)
+         (empty? issues)
+         (every? backend-timeout-issue? blocking-issues))))
+
 (defn llm-issues->recommendations
   "Extract suggestions from LLM issues as recommendations."
   [issues]
@@ -539,6 +571,41 @@
   [logger data]
   (log/info logger :reviewer :reviewer/phase-completed {:data data}))
 
+(defn- timeout-only-error-result
+  "Normalize the reviewer exit path when the LLM only reports its own timeout.
+
+   This preserves backend timeout metadata, emits the standard phase-completed
+   telemetry, and reports the deterministic gate outcome instead of converting
+   the backend failure into a bogus code-review rejection."
+  [logger normalized llm-review gate-result counts duration tokens cost-usd timeout-failure-message]
+  (log/warn logger :reviewer :reviewer/backend-timeout-only
+            {:data {:llm-decision (:review/decision llm-review)
+                    :gate-decision (:decision gate-result)
+                    :blocking-issues (:review/blocking-issues llm-review)
+                    :duration-ms duration}})
+  (leave-review logger {:review/decision (:decision gate-result)
+                        :duration-ms duration
+                        :gates-passed (:passed counts)
+                        :gates-failed (:failed counts)
+                        :llm? true
+                        :status :error
+                        :error-code :reviewer/backend-timeout})
+  (assoc
+   (result-boundary/error-response
+    normalized
+    timeout-failure-message
+    {:data (merge (or (some-> normalized :llm-error :data) {})
+                  {:code :reviewer/backend-timeout
+                   :blocking-issues (:review/blocking-issues llm-review)})})
+   :metrics
+   (cond-> {:decision (:decision gate-result)
+            :gates-passed (:passed counts)
+            :gates-failed (:failed counts)
+            :gates-total (:total counts)
+            :duration-ms duration
+            :tokens tokens}
+     cost-usd (assoc :cost-usd cost-usd))))
+
 ;------------------------------------------------------------------------------ Layer 5
 ;; Agent creation
 
@@ -627,19 +694,21 @@
 
               (let [;; Parse LLM review
                     llm-review (:parsed-content normalized)
-                    failure-message (review-failure-message response content)
+                    parse-failure-message (review-failure-message response content)
                     parse-failed? (nil? llm-review)
+                    ;; Run deterministic gates
+                    gate-feedbacks (run-gates-on-artifact gates artifact context logger)
+                    gate-result (make-review-decision gate-feedbacks config)
+                    counts (calculate-gate-counts gate-feedbacks)
+                    timeout-failure-message (backend-failure-message response llm-review)
+                    timeout-only-review? (timeout-only-review? llm-review gate-result)
                     llm-decision (cond
+                                   timeout-only-review? nil
                                    parse-failed? :rejected
                                    llm-review (normalize-llm-decision (:review/decision llm-review)))
                     llm-issues (get llm-review :review/issues [])
                     llm-strengths (get llm-review :review/strengths [])
                     llm-summary (:review/summary llm-review)
-
-                    ;; Run deterministic gates
-                    gate-feedbacks (run-gates-on-artifact gates artifact context logger)
-                    gate-result (make-review-decision gate-feedbacks config)
-                    counts (calculate-gate-counts gate-feedbacks)
 
                     ;; Merge decisions: gates can override LLM
                     final-decision (if llm-decision
@@ -650,7 +719,9 @@
                     all-blocking (cond-> (into (vec (:blocking-issues gate-result))
                                                (llm-issues->blocking-strings llm-issues))
                                    parse-failed?
-                                   (conj failure-message))
+                                   (conj parse-failure-message)
+                                   timeout-only-review?
+                                   (conj timeout-failure-message))
                     all-warnings (into (vec (:warnings gate-result))
                                        (llm-issues->warning-strings llm-issues))
 
@@ -672,23 +743,29 @@
 
                     duration (- (System/currentTimeMillis) start-time)]
 
-                (log/info logger :reviewer :reviewer/review-complete
-                          {:data {:decision final-decision
-                                  :llm-decision llm-decision
-                                  :llm-parse-failed? parse-failed?
-                                  :gates-passed (:passed counts)
-                                  :gates-failed (:failed counts)
-                                  :llm-issues (count llm-issues)
-                                  :duration-ms duration}})
-
-                ;; Phase lifecycle: mark review exit with decision
-                (leave-review logger {:review/decision final-decision
-                                      :duration-ms duration
+                (if timeout-only-review?
+                  (timeout-only-error-result
+                   logger normalized llm-review gate-result counts duration tokens cost-usd
+                   timeout-failure-message)
+                  (do
+                    (log/info logger :reviewer :reviewer/review-complete
+                              {:data {:decision final-decision
+                                      :llm-decision llm-decision
+                                      :llm-parse-failed? parse-failed?
+                                      :timeout-only-review? timeout-only-review?
                                       :gates-passed (:passed counts)
                                       :gates-failed (:failed counts)
-                                      :llm? true})
+                                      :llm-issues (count llm-issues)
+                                      :duration-ms duration}})
 
-                (build-review-result review counts duration tokens :cost-usd cost-usd)))
+                    ;; Phase lifecycle: mark review exit with decision
+                    (leave-review logger {:review/decision final-decision
+                                          :duration-ms duration
+                                          :gates-passed (:passed counts)
+                                          :gates-failed (:failed counts)
+                                          :llm? true})
+
+                    (build-review-result review counts duration tokens :cost-usd cost-usd)))))
 
             ;; No LLM — gate-only fallback
             (let [gate-feedbacks (run-gates-on-artifact gates artifact context logger)

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -24,6 +24,7 @@
    [ai.miniforge.agent.budget :as budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.response.interface :as response]
@@ -333,65 +334,61 @@
                                "\n\nWrite your tests directly to the appropriate test files. "
                                "Include complete test code, not placeholders.")]
           (if llm-client
-            ;; Use the real LLM with artifact session for MCP tool support
-            (let [{:keys [llm-result artifact context-misses]}
+            (let [{:keys [llm-result artifact worktree-artifacts context-misses]}
                   (artifact-session/with-session context
                     #(invoke-tester-session % llm-client user-prompt config context
                                            on-chunk code-artifact))
                   response llm-result
-                  tokens (get response :tokens 0)
-                  cost-usd (get response :cost-usd)]
+                  normalized (result-boundary/normalize-llm-result
+                              {:role :verify
+                               :response response
+                               :worktree-artifacts worktree-artifacts
+                               :artifact artifact
+                               :parse-response parse-test-response
+                               :derive-artifact (fn [content]
+                                                  (when-let [files (extract-test-code-blocks content)]
+                                                    {:test/id (random-uuid)
+                                                     :test/files files
+                                                     :test/type :unit
+                                                     :test/summary "Tests from code blocks"
+                                                     :test/created-at (java.util.Date.)}))})]
               (when (seq context-misses)
                 (log/info logger :tester :tester/context-cache-misses
                           {:data {:miss-count (count context-misses)
                                   :misses context-misses}}))
               (log/info logger :tester :tester/llm-called
                         {:data {:success (llm/success? response)
-                                :tokens tokens
+                                :tokens (:tokens normalized)
                                 :streaming? (boolean on-chunk)}})
-              (if (llm/success? response)
-                ;; Check for MCP artifact first, then fall back to text parsing
-                (let [content (llm/get-content response)
-                      parsed (or artifact (parse-test-response content))
-                      ;; Try multiple parsing strategies (no fallback — fail explicitly)
-                      tests (or parsed
-                                (when-let [files (extract-test-code-blocks content)]
-                                  {:test/id (random-uuid)
-                                   :test/files files
-                                   :test/type :unit
-                                   :test/summary "Tests from code blocks"
-                                   :test/created-at (java.util.Date.)}))]
-                  (if tests
-                    (let [tests-with-meta (-> tests
-                                          (update :test/id #(or % (random-uuid)))
-                                          (assoc :test/framework (extract-test-framework (:test/files tests) context))
-                                          (assoc :test/assertions-count
-                                                 (or (:test/assertions-count tests)
-                                                     (->> (:test/files tests)
-                                                          (map :content)
-                                                          (map count-assertions)
-                                                          (reduce +))))
-                                          (assoc :test/cases-count
-                                                 (or (:test/cases-count tests)
-                                                     (->> (:test/files tests)
-                                                          (map :content)
-                                                          (map count-test-cases)
-                                                          (reduce +))))
-                                          (assoc :test/created-at (java.util.Date.)))]
-                  (response/success tests-with-meta
-                                    {:tokens tokens
-                                     :metrics {:test-files (count (:test/files tests-with-meta))
-                                               :test-type (:test/type tests-with-meta)
-                                               :assertions (:test/assertions-count tests-with-meta)
-                                               :cases (:test/cases-count tests-with-meta)
-                                               :tokens tokens
-                                               :cost-usd cost-usd}}))
-                    ;; LLM returned content but no parseable tests — fail explicitly
-                    (response/error "LLM response could not be parsed as test artifact"
-                                    {:tokens tokens})))
-                ;; LLM call failed — propagate error, no fallback
-                (response/error (or (:message (llm/get-error response))
-                                    "LLM call failed"))))
+              (if (result-boundary/usable-content? normalized)
+                (if-let [tests (result-boundary/authoritative-payload normalized)]
+                  (let [tests-with-meta (-> tests
+                                            (update :test/id #(or % (random-uuid)))
+                                            (assoc :test/framework (extract-test-framework (:test/files tests) context))
+                                            (assoc :test/assertions-count
+                                                   (or (:test/assertions-count tests)
+                                                       (->> (:test/files tests)
+                                                            (map :content)
+                                                            (map count-assertions)
+                                                            (reduce +))))
+                                            (assoc :test/cases-count
+                                                   (or (:test/cases-count tests)
+                                                       (->> (:test/files tests)
+                                                            (map :content)
+                                                            (map count-test-cases)
+                                                            (reduce +))))
+                                            (assoc :test/created-at (java.util.Date.)))]
+                    (response/success tests-with-meta
+                                      {:tokens (:tokens normalized)
+                                       :metrics {:test-files (count (:test/files tests-with-meta))
+                                                 :test-type (:test/type tests-with-meta)
+                                                 :assertions (:test/assertions-count tests-with-meta)
+                                                 :cases (:test/cases-count tests-with-meta)
+                                                 :tokens (:tokens normalized)
+                                                 :cost-usd (:cost-usd normalized)}}))
+                  (response/error "LLM response could not be parsed as test artifact"
+                                  {:tokens (:tokens normalized)}))
+                (result-boundary/error-response normalized "LLM call failed")))
             ;; No LLM client — fail explicitly
             (response/error "No LLM backend provided"))))
 

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -202,6 +202,60 @@
                                :content (str/trim content)}))
                vec))))))
 
+(defn- code-block-test-artifact
+  "Derive a test artifact from markdown code blocks when structured EDN is absent."
+  [content]
+  (when-let [files (extract-test-code-blocks content)]
+    {:test/id (random-uuid)
+     :test/files files
+     :test/type :unit
+     :test/summary "Tests from code blocks"
+     :test/created-at (java.util.Date.)}))
+
+(defn- count-test-file-assertions
+  "Count assertions across all files in a test artifact."
+  [test-files]
+  (->> test-files
+       (map :content)
+       (map count-assertions)
+       (reduce + 0)))
+
+(defn- count-test-file-cases
+  "Count cases across all files in a test artifact."
+  [test-files]
+  (->> test-files
+       (map :content)
+       (map count-test-cases)
+       (reduce + 0)))
+
+(defn- enrich-test-artifact
+  "Attach normalized metadata to a parsed test artifact."
+  [tests context]
+  (let [test-files (:test/files tests)]
+    (-> tests
+        (update :test/id #(or % (random-uuid)))
+        (assoc :test/framework (extract-test-framework test-files context))
+        (assoc :test/assertions-count
+               (if (contains? tests :test/assertions-count)
+                 (:test/assertions-count tests)
+                 (count-test-file-assertions test-files)))
+        (assoc :test/cases-count
+               (if (contains? tests :test/cases-count)
+                 (:test/cases-count tests)
+                 (count-test-file-cases test-files)))
+        (assoc :test/created-at (or (:test/created-at tests)
+                                    (java.util.Date.))))))
+
+(defn- test-artifact-metrics
+  "Build the success metrics payload for a normalized test artifact."
+  [tests tokens cost-usd]
+  {:test-files (count (:test/files tests))
+   :test-type (:test/type tests)
+   :assertions (:test/assertions-count tests)
+   :cases (:test/cases-count tests)
+   :tokens tokens
+   :cost-usd cost-usd})
+
 ;; make-fallback-tests removed — silent fallback masks real failures,
 ;; prevents retry/repair from working, and short-circuits checkpoint resume.
 
@@ -345,13 +399,7 @@
                                :worktree-artifacts worktree-artifacts
                                :artifact artifact
                                :parse-response parse-test-response
-                               :derive-artifact (fn [content]
-                                                  (when-let [files (extract-test-code-blocks content)]
-                                                    {:test/id (random-uuid)
-                                                     :test/files files
-                                                     :test/type :unit
-                                                     :test/summary "Tests from code blocks"
-                                                     :test/created-at (java.util.Date.)}))})]
+                               :derive-artifact code-block-test-artifact})]
               (when (seq context-misses)
                 (log/info logger :tester :tester/context-cache-misses
                           {:data {:miss-count (count context-misses)
@@ -362,30 +410,12 @@
                                 :streaming? (boolean on-chunk)}})
               (if (result-boundary/usable-content? normalized)
                 (if-let [tests (result-boundary/authoritative-payload normalized)]
-                  (let [tests-with-meta (-> tests
-                                            (update :test/id #(or % (random-uuid)))
-                                            (assoc :test/framework (extract-test-framework (:test/files tests) context))
-                                            (assoc :test/assertions-count
-                                                   (or (:test/assertions-count tests)
-                                                       (->> (:test/files tests)
-                                                            (map :content)
-                                                            (map count-assertions)
-                                                            (reduce +))))
-                                            (assoc :test/cases-count
-                                                   (or (:test/cases-count tests)
-                                                       (->> (:test/files tests)
-                                                            (map :content)
-                                                            (map count-test-cases)
-                                                            (reduce +))))
-                                            (assoc :test/created-at (java.util.Date.)))]
+                  (let [tests-with-meta (enrich-test-artifact tests context)]
                     (response/success tests-with-meta
                                       {:tokens (:tokens normalized)
-                                       :metrics {:test-files (count (:test/files tests-with-meta))
-                                                 :test-type (:test/type tests-with-meta)
-                                                 :assertions (:test/assertions-count tests-with-meta)
-                                                 :cases (:test/cases-count tests-with-meta)
-                                                 :tokens (:tokens normalized)
-                                                 :cost-usd (:cost-usd normalized)}}))
+                                       :metrics (test-artifact-metrics tests-with-meta
+                                                                       (:tokens normalized)
+                                                                       (:cost-usd normalized))}))
                   (response/error "LLM response could not be parsed as test artifact"
                                   {:tokens (:tokens normalized)}))
                 (result-boundary/error-response normalized "LLM call failed")))

--- a/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
@@ -40,9 +40,16 @@
   [log]
   (fn [_executor _env-id command & [_opts]]
     (swap! log conj command)
-    (if (and (string? command) (str/starts-with? command "cat ") (str/includes? command "artifact.edn"))
+    (cond
+      (and (string? command) (str/starts-with? command "cat ") (str/includes? command "artifact.edn"))
       {:ok? true :data {:stdout "{:code/id \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\" :code/description \"test\"}"
                         :stderr "" :exit-code 0}}
+
+      (and (string? command) (str/starts-with? command "cat ") (str/includes? command "implement.edn"))
+      {:ok? true :data {:stdout "{:status :already-implemented :summary \"already there\"}"
+                        :stderr "" :exit-code 0}}
+
+      :else
       {:ok? true :data {:stdout "" :stderr "" :exit-code 0}})))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -157,6 +164,18 @@
           artifact (session/read-capsule-artifact s)]
       (is (some? artifact))
       (is (uuid? (:code/id artifact))))))
+
+(deftest read-capsule-worktree-artifact-test
+  (testing "reads .miniforge/<role>.edn from inside the capsule worktree"
+    (let [log (atom [])
+          s {:capsule? true
+             :exec! (mock-execute-with-artifact! log)
+             :executor :mock
+             :environment-id "env-role"
+             :workdir "/workspace"}
+          artifact (session/read-capsule-worktree-artifact s :implement)]
+      (is (= :already-implemented (:status artifact)))
+      (is (= "already there" (:summary artifact))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
@@ -23,17 +23,27 @@
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
    [ai.miniforge.agent.artifact-session :as session]
-   [ai.miniforge.dag-executor.executor :as executor]))
+   [ai.miniforge.dag-executor.executor :as executor]
+   [ai.miniforge.dag-executor.result :as result]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Mock executor infrastructure
+
+(def ^:private capsule-workdir
+  "/workspace")
+
+(def ^:private capsule-session-dir
+  (str capsule-workdir "/.miniforge-session"))
+
+(def ^:private capsule-cleanup-command
+  (str "rm -rf " capsule-session-dir))
 
 (defn- mock-execute!
   "Mock executor that records commands and returns success."
   [log]
   (fn [_executor _env-id command & [_opts]]
     (swap! log conj command)
-    {:ok? true :data {:stdout "" :stderr "" :exit-code 0}}))
+    (result/ok {:stdout "" :stderr "" :exit-code 0})))
 
 (defn- mock-execute-with-artifact!
   "Mock executor that records commands and returns artifact EDN for cat commands."
@@ -42,15 +52,17 @@
     (swap! log conj command)
     (cond
       (and (string? command) (str/starts-with? command "cat ") (str/includes? command "artifact.edn"))
-      {:ok? true :data {:stdout "{:code/id \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\" :code/description \"test\"}"
-                        :stderr "" :exit-code 0}}
+      (result/ok {:stdout "{:code/id \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\" :code/description \"test\"}"
+                  :stderr ""
+                  :exit-code 0})
 
       (and (string? command) (str/starts-with? command "cat ") (str/includes? command "implement.edn"))
-      {:ok? true :data {:stdout "{:status :already-implemented :summary \"already there\"}"
-                        :stderr "" :exit-code 0}}
+      (result/ok {:stdout "{:status :already-implemented :summary \"already there\"}"
+                  :stderr ""
+                  :exit-code 0})
 
       :else
-      {:ok? true :data {:stdout "" :stderr "" :exit-code 0}})))
+      (result/ok {:stdout "" :stderr "" :exit-code 0}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; with-session dispatch tests
@@ -83,11 +95,11 @@
         (let [context {:execution/mode :governed
                        :execution/executor :mock-executor
                        :execution/environment-id "env-123"
-                       :execution/worktree-path "/workspace"}
+                       :execution/worktree-path capsule-workdir}
               result (session/with-session context
                        (fn [session]
                          (is (true? (:capsule? session)))
-                         (is (= "/workspace/.miniforge-session" (:dir session)))
+                         (is (= capsule-session-dir (:dir session)))
                          (is (= :mock-executor (:executor session)))
                          :capsule-response))]
           (is (= :capsule-response (:llm-result result)))
@@ -104,7 +116,7 @@
         (let [context {:execution/mode :governed
                        :execution/executor :mock
                        :execution/environment-id "env-456"
-                       :execution/worktree-path "/workspace"}
+                       :execution/worktree-path capsule-workdir}
               result (session/with-session context
                        (fn [_session] :done))]
           (is (some? (:artifact result)))
@@ -116,14 +128,13 @@
           context {:execution/mode :governed
                    :execution/executor :mock
                    :execution/environment-id "env-789"
-                   :execution/worktree-path "/workspace"}]
+                   :execution/worktree-path capsule-workdir}]
       (with-redefs [executor/execute! (mock-execute! log)]
         (is (thrown? Exception
               (session/with-session context
                 (fn [_session]
-                  (throw (ex-info "test error" {})))))))
-      ;; Cleanup rm -rf should have been called
-      (is (some #(.contains (str %) "rm -rf") @log)))))
+                  (throw (ex-info "test error" {}))))))
+        (is (some #(= capsule-cleanup-command %) @log))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Context cache dispatch tests
@@ -145,7 +156,7 @@
              :exec! (mock-execute! log)
              :executor :mock
              :environment-id "env-test"
-             :workdir "/workspace"}]
+             :workdir capsule-workdir}]
       (session/write-context-cache-for-session! s {"src/foo.clj" "(ns foo)"})
       (is (some #(.contains (str %) "context-cache.edn") @log)))))
 
@@ -160,7 +171,7 @@
              :exec! (mock-execute-with-artifact! log)
              :executor :mock
              :environment-id "env-uuid"
-             :workdir "/workspace"}
+             :workdir capsule-workdir}
           artifact (session/read-capsule-artifact s)]
       (is (some? artifact))
       (is (uuid? (:code/id artifact))))))
@@ -172,7 +183,7 @@
              :exec! (mock-execute-with-artifact! log)
              :executor :mock
              :environment-id "env-role"
-             :workdir "/workspace"}
+             :workdir capsule-workdir}
           artifact (session/read-capsule-worktree-artifact s :implement)]
       (is (= :already-implemented (:status artifact)))
       (is (= "already there" (:summary artifact))))))

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -312,7 +312,7 @@
                     :tokens 9
                     :cost-usd 0.01
                     :error {:type "cli_error"
-                            :message "artifact file not found"}} 
+                            :message "artifact file not found"}}
           result (with-redefs [artifact-session/create-session!
                                (fn [& _] (session-map))
                                artifact-session/write-mcp-config!
@@ -330,10 +330,42 @@
                                file-artifacts/collect-written-files
                                (fn [_ _] nil)]
                    (@#'implementer/invoke-with-llm
-                    nil "prompt" "system" {} {} nil logger [] {}))]
+                   nil "prompt" "system" {} {} nil logger [] {}))]
       (is (= :already-implemented (:status result)))
       (is (= "done" (:summary result)))
       (is (= [] (get-in result [:output :code/files]))))))
+
+  (testing "worktree metadata artifact is canonical for already-implemented outcomes"
+    (let [[logger _] (log/collecting-logger {:min-level :trace})
+          response {:success false
+                    :content "Plan submitted but no final artifact text"
+                    :tokens 7
+                    :cost-usd 0.01
+                    :error {:type "cli_error"
+                            :message "artifact file not found"}}
+          result (with-redefs [artifact-session/with-session
+                               (fn [_context body-fn]
+                                 {:llm-result (body-fn {})
+                                  :artifact nil
+                                  :worktree-artifacts {:implement {:status :already-implemented
+                                                                   :summary "found in worktree metadata"}}
+                                  :context-misses nil
+                                  :pre-session-snapshot {:untracked #{}
+                                                         :modified #{}
+                                                         :deleted #{}
+                                                         :added #{}}
+                                  :session-mode :host})
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] response)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] nil)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger [] {}))]
+      (is (= :already-implemented (:status result)))
+      (is (= "found in worktree metadata" (:summary result)))
+      (is (= [] (get-in result [:output :code/files])))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -303,7 +303,37 @@
                     {:task/review-feedback ["Fix the blocking issues"]}))]
       (is (response/error? result))
       (is (= :implementer/unverified-already-implemented
-             (get-in result [:error :data :code]))))))
+             (get-in result [:error :data :code])))))
+
+  (testing "parseable already-implemented content survives an unsuccessful backend wrapper"
+    (let [[logger _] (log/collecting-logger {:min-level :trace})
+          response {:success false
+                    :content "{:status :already-implemented :summary \"done\"}"
+                    :tokens 9
+                    :cost-usd 0.01
+                    :error {:type "cli_error"
+                            :message "artifact file not found"}} 
+          result (with-redefs [artifact-session/create-session!
+                               (fn [& _] (session-map))
+                               artifact-session/write-mcp-config!
+                               identity
+                               artifact-session/read-artifact
+                               (constantly nil)
+                               artifact-session/read-context-misses
+                               (constantly nil)
+                               artifact-session/cleanup-session!
+                               (constantly nil)
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] response)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] nil)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger [] {}))]
+      (is (= :already-implemented (:status result)))
+      (is (= "done" (:summary result)))
+      (is (= [] (get-in result [:output :code/files]))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests

--- a/components/agent/test/ai/miniforge/agent/releaser_test.clj
+++ b/components/agent/test/ai/miniforge/agent/releaser_test.clj
@@ -20,8 +20,11 @@
   "Tests for the Releaser agent."
   (:require
    [clojure.test :as test :refer [deftest testing is]]
+   [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.releaser :as releaser]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]))
 
@@ -83,7 +86,34 @@
     (let [agent (releaser/create-releaser)
           result (core/invoke agent {} code-artifact-input)]
       (is (= :error (:status result)))
-      (is (some? (:error result))))))
+      (is (some? (:error result)))))
+
+  (testing "accepts parseable release content even when backend flags failure"
+    (let [fake-llm-client {:type :fake}
+          parsed-release {:release/id (random-uuid)
+                          :release/branch-name "feature/already-ready"
+                          :release/commit-message "feat: ship"
+                          :release/pr-title "feat: ship"
+                          :release/pr-description "## Summary\nReady"
+                          :release/files-summary "No file changes required"}
+          agent (releaser/create-releaser {:llm-backend fake-llm-client})]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role provided] provided)
+                    artifact-session/with-session
+                    (fn [_context _body-fn]
+                      {:llm-result {:success false
+                                    :content (pr-str parsed-release)
+                                    :error {:message "Adaptive timeout"}}
+                       :artifact nil
+                       :worktree-artifacts {}
+                       :session-mode :host})
+                    llm/success? :success
+                    llm/get-content :content
+                    llm/get-error :error]
+        (let [result (core/invoke agent {:llm-backend fake-llm-client}
+                                  code-artifact-input)]
+          (is (= :success (:status result)))
+          (is (= "feature/already-ready"
+                 (get-in result [:output :release/branch-name]))))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests

--- a/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
+++ b/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.result-boundary-test
+  (:require
+   [ai.miniforge.agent.result-boundary :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest normalize-llm-result-prefers-worktree-metadata
+  (testing "worktree metadata wins over MCP artifact, fallback artifact, and parsed stdout"
+    (let [normalized (sut/normalize-llm-result
+                      {:role :implement
+                       :response {:success false
+                                  :content "{:status :already-implemented :summary \"stdout\"}"
+                                  :error {:message "backend failed"}}
+                       :worktree-artifacts {:implement {:status :already-implemented
+                                                        :summary "worktree"}}
+                       :artifact {:status :already-implemented :summary "mcp"}
+                       :fallback-artifact {:status :already-implemented :summary "fallback"}
+                       :parse-response read-string})]
+      (is (= :worktree-metadata (:artifact-source normalized)))
+      (is (= "worktree" (:summary (sut/authoritative-payload normalized))))
+      (is (true? (sut/usable-content? normalized))))))
+
+(deftest normalize-llm-result-accepts-parseable-content-from-failure
+  (testing "parseable stdout still yields a usable boundary when backend success is false"
+    (let [normalized (sut/normalize-llm-result
+                      {:response {:success false
+                                  :content "{:status :already-implemented :summary \"done\"}"
+                                  :error {:message "Adaptive timeout"}}
+                       :parse-response read-string})]
+      (is (false? (:response-success? normalized)))
+      (is (= :already-implemented (:status (:parsed-content normalized))))
+      (is (true? (sut/usable-content? normalized))))))
+
+(deftest error-response-preserves-backend-error-shape
+  (testing "error-response carries raw backend data and response metadata through"
+    (let [normalized {:llm-error {:message "Adaptive timeout"
+                                  :type "adaptive_timeout"
+                                  :raw-stdout "stream"}
+                      :stop-reason :timeout
+                      :num-turns 3
+                      :tokens 17}
+          result (sut/error-response normalized "LLM call failed")]
+      (is (= :error (:status result)))
+      (is (= "Adaptive timeout" (get-in result [:error :message])))
+      (is (= "adaptive_timeout" (get-in result [:error :data :type])))
+      (is (= "stream" (get-in result [:error :data :raw-stdout])))
+      (is (= :timeout (get-in result [:error :data :stop-reason])))
+      (is (= 3 (get-in result [:error :data :num-turns])))
+      (is (= 17 (get-in result [:metrics :tokens]))))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -23,6 +23,7 @@
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.reviewer :as reviewer]
    [ai.miniforge.agent.core :as core]
+   [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.loop.interface :as loop]
    [ai.miniforge.response.interface :as response]))
@@ -42,6 +43,33 @@
   "Floor for the reviewer main-turn :max-total-ms. Below this, long
    but legitimate reviews are killed mid-turn."
   600000)
+
+(def ^:private unparseable-output-token-count
+  42)
+
+(def ^:private parseable-backend-failure-token-count
+  7)
+
+(def ^:private timeout-review-token-count
+  9)
+
+(def ^:private timeout-success-wrapper-token-count
+  11)
+
+(def ^:private backend-timeout-elapsed-ms
+  120183)
+
+(def ^:private wrapped-timeout-elapsed-ms
+  120228)
+
+(def ^:private backend-timeout-stop-reason
+  "timeout")
+
+(def ^:private backend-timeout-num-turns
+  4)
+
+(def ^:private backend-timeout-type
+  "adaptive_timeout")
 
 ;------------------------------------------------------------------------------ Test fixtures
 
@@ -75,6 +103,53 @@
    :artifact/content {:code/files [{:path "src/example.clj"
                                     :content "(ns example)\n(defn hello [] \"world\")"
                                     :action :create}]}})
+
+(defn- review-gate-feedback
+  ([] (review-gate-feedback :unknown 0))
+  ([gate-id duration-ms]
+   {:gate-id gate-id
+    :gate-type :unknown
+    :passed? true
+    :errors []
+    :warnings []
+    :duration-ms duration-ms}))
+
+(defn- adaptive-timeout-message
+  [elapsed-ms]
+  (str "Adaptive timeout: Stagnation timeout: no progress for "
+       elapsed-ms
+       "ms"))
+
+(defn- wrapped-timeout-message
+  [elapsed-ms]
+  (str (adaptive-timeout-message elapsed-ms)
+       " (type: stagnation, elapsed: "
+       elapsed-ms
+       "ms)"))
+
+(defn- timeout-only-review-content
+  ([blocking-message]
+   (timeout-only-review-content blocking-message [(review-gate-feedback)]))
+  ([blocking-message gate-results]
+   (pr-str {:review/decision :rejected
+            :review/gate-results gate-results
+            :review/blocking-issues [blocking-message]
+            :review/recommendations []})))
+
+(defn- mock-llm-response
+  [content & {:as extra}]
+  (merge {:success? true
+          :content content
+          :tokens 1}
+         extra))
+
+(defn- backend-timeout-error
+  ([message]
+   (backend-timeout-error message nil))
+  ([message data]
+   (cond-> {:type backend-timeout-type
+            :message message}
+     data (assoc :data data))))
 
 ;------------------------------------------------------------------------------ Core functionality tests
 
@@ -201,9 +276,9 @@
   (testing "successful LLM calls that cannot be parsed fail closed"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
-                             {:success? true
-                              :content "not valid edn"
-                              :tokens 42})
+                             (mock-llm-response
+                              "not valid edn"
+                              :tokens unparseable-output-token-count))
                   llm/success? :success?
                   llm/get-content :content]
       (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
@@ -213,16 +288,18 @@
         (is (= :rejected (:review/decision review)))
         (is (= ["Reviewer LLM output could not be parsed into a review artifact"]
                (:review/blocking-issues review)))
-        (is (= 42 (get-in result [:metrics :tokens])))))))
+        (is (= unparseable-output-token-count
+               (get-in result [:metrics :tokens])))))))
 
 (deftest test-reviewer-uses-parseable-content-even-when-backend-flags-failure
   (testing "parseable review content still drives the decision when backend success? is false"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
-                             {:success? false
-                              :content "```clojure\n{:review/decision :changes-requested\n :review/issues [{:severity :blocking :description \"Needs changes\"}]}\n```"
-                              :tokens 7
-                              :error {:message "artifact file not found"}})
+                             (mock-llm-response
+                              "```clojure\n{:review/decision :changes-requested\n :review/issues [{:severity :blocking :description \"Needs changes\"}]}\n```"
+                              :success? false
+                              :tokens parseable-backend-failure-token-count
+                              :error {:message "artifact file not found"}))
                   llm/success? :success?
                   llm/get-content :content
                   llm/get-error :error]
@@ -232,7 +309,143 @@
             review (:artifact result)]
         (is (= :changes-requested (:review/decision review)))
         (is (some #{"Needs changes"} (:review/blocking-issues review)))
-        (is (= 7 (get-in result [:metrics :tokens])))))))
+        (is (= parseable-backend-failure-token-count
+               (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-timeout-only-parseable-failure-is-agent-error
+  (testing "timeout-only parsed review failures do not become rejected code-review artifacts"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             (mock-llm-response
+                              (timeout-only-review-content
+                               (adaptive-timeout-message backend-timeout-elapsed-ms))
+                              :success? false
+                              :tokens timeout-review-token-count
+                              :error {:message (adaptive-timeout-message backend-timeout-elapsed-ms)}))
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error :error]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates []})
+            result (core/invoke reviewer {} sample-artifact)]
+        (is (= :error (:status result)))
+        (is (= (adaptive-timeout-message backend-timeout-elapsed-ms)
+               (get-in result [:error :message])))
+        (is (= :reviewer/backend-timeout
+               (get-in result [:error :data :code])))
+        (is (= timeout-review-token-count
+               (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-timeout-only-parseable-success-wrapper-is-agent-error
+  (testing "timeout-only parsed review failures are treated as backend errors even when the wrapper reports success"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             (mock-llm-response
+                              (timeout-only-review-content
+                               (wrapped-timeout-message wrapped-timeout-elapsed-ms)
+                               [(review-gate-feedback)
+                                (review-gate-feedback)])
+                              :success? true
+                              :tokens timeout-success-wrapper-token-count))
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error (constantly nil)]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates []})
+            result (core/invoke reviewer {} sample-artifact)]
+        (is (= :error (:status result)))
+        (is (= (wrapped-timeout-message wrapped-timeout-elapsed-ms)
+               (get-in result [:error :message])))
+        (is (= :reviewer/backend-timeout
+               (get-in result [:error :data :code])))
+        (is (= timeout-success-wrapper-token-count
+               (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-timeout-only-shape-does-not-hide-real-gate-failures
+  (testing "timeout-only classification requires the deterministic gates to approve"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             (mock-llm-response
+                              (timeout-only-review-content
+                               (adaptive-timeout-message backend-timeout-elapsed-ms)
+                               [])
+                              :success? false
+                              :tokens timeout-review-token-count
+                              :error (backend-timeout-error
+                                      (adaptive-timeout-message backend-timeout-elapsed-ms))))
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error :error]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates [(failing-gate :gate1 "Gate failure")]})
+            result (core/invoke reviewer {} sample-artifact)]
+        (is (= :success (:status result)))
+        (is (not= :reviewer/backend-timeout
+                  (get-in result [:error :data :code])))
+        (is (= :rejected (get-in result [:artifact :review/decision])))))))
+
+(deftest test-reviewer-timeout-only-error-emits-phase-completed
+  (testing "timeout-only backend errors still emit review phase completion telemetry"
+    (let [events (atom [])]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                    llm/chat (fn [_client _prompt _opts]
+                               (mock-llm-response
+                                (timeout-only-review-content
+                                 (adaptive-timeout-message backend-timeout-elapsed-ms))
+                                :success? false
+                                :tokens timeout-review-token-count
+                                :error (backend-timeout-error
+                                        (adaptive-timeout-message backend-timeout-elapsed-ms)
+                                        {:elapsed-ms backend-timeout-elapsed-ms})))
+                    llm/success? :success?
+                    llm/get-content :content
+                    llm/get-error :error
+                    log/info (fn [_logger category event payload]
+                               (swap! events conj {:category category
+                                                   :event event
+                                                   :payload payload}))]
+        (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                  :gates []})
+              result (core/invoke reviewer {} sample-artifact)
+              completed-event (some #(when (= :reviewer/phase-completed (:event %)) %) @events)]
+          (is (= :error (:status result)))
+          (is completed-event)
+          (is (= :reviewer/backend-timeout
+                 (get-in completed-event [:payload :data :error-code])))
+          (is (= :error
+                 (get-in completed-event [:payload :data :status]))))))))
+
+(deftest test-reviewer-timeout-only-error-preserves-backend-metadata
+  (testing "timeout-only backend errors preserve normalized backend metadata for post-mortem"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             (mock-llm-response
+                              (timeout-only-review-content
+                               (adaptive-timeout-message backend-timeout-elapsed-ms))
+                              :success? false
+                              :tokens timeout-review-token-count
+                              :stop-reason backend-timeout-stop-reason
+                              :num-turns backend-timeout-num-turns
+                              :error (backend-timeout-error
+                                      (adaptive-timeout-message backend-timeout-elapsed-ms)
+                                      {:elapsed-ms backend-timeout-elapsed-ms})))
+                  llm/success? :success?
+                  llm/get-content :content
+                  llm/get-error :error]
+      (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                :gates []})
+            result (core/invoke reviewer {} sample-artifact)]
+        (is (= :error (:status result)))
+        (is (= :reviewer/backend-timeout
+               (get-in result [:error :data :code])))
+        (is (= backend-timeout-type
+               (get-in result [:error :data :type])))
+        (is (= backend-timeout-elapsed-ms
+               (get-in result [:error :data :elapsed-ms])))
+        (is (= backend-timeout-stop-reason
+               (get-in result [:error :data :stop-reason])))
+        (is (= backend-timeout-num-turns
+               (get-in result [:error :data :num-turns])))))))
 
 (deftest test-reviewer-rejects-degraded-implement-handoff
   (testing "default reviewer rejects curated artifacts marked as degraded handoffs"

--- a/components/agent/test/ai/miniforge/agent/tester_test.clj
+++ b/components/agent/test/ai/miniforge/agent/tester_test.clj
@@ -20,8 +20,11 @@
   "Tests for the Tester agent."
   (:require
    [clojure.test :as test :refer [deftest testing is]]
+   [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.tester :as tester]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]))
 
@@ -80,7 +83,34 @@
     (let [agent (tester/create-tester)
           result (core/invoke agent {} {:code sample-code-artifact})]
       (is (= :error (:status result)))
-      (is (some? (:error result))))))
+      (is (some? (:error result)))))
+
+  (testing "accepts parseable test artifact content even when backend flags failure"
+    (let [fake-llm-client {:type :fake}
+          agent (tester/create-tester {:llm-backend fake-llm-client})
+          stdout-tests {:test/id (random-uuid)
+                        :test/files [{:path "test/auth/login_test.clj"
+                                      :content "(ns auth.login-test)\n(deftest login-test (is true))"}]
+                        :test/type :unit}]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role provided] provided)
+                    artifact-session/with-session
+                    (fn [_context _body-fn]
+                      {:llm-result {:success false
+                                    :content (pr-str stdout-tests)
+                                    :error {:message "Adaptive timeout"}}
+                       :artifact nil
+                       :worktree-artifacts {}
+                       :context-misses nil
+                       :pre-session-snapshot {}
+                       :session-mode :host})
+                    llm/success? :success
+                    llm/get-content :content
+                    llm/get-error :error]
+        (let [result (core/invoke agent {:llm-backend fake-llm-client}
+                                  {:code sample-code-artifact})]
+          (is (= :success (:status result)))
+          (is (= :unit (get-in result [:output :test/type])))
+          (is (= 1 (count (get-in result [:output :test/files])))))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests

--- a/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
+++ b/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
@@ -21,19 +21,14 @@
    read the same way across the umbrella and so tests can inspect
    exit/capture output uniformly.
 
-   Stratification (intra-namespace):
-   Layer 0 — pure data + helpers with no in-ns deps.
-   Layer 1 — composes Layer 0 (`command-candidates`, `run!`,
-             `run-bg!`, `sh`).
-   Layer 2 — `resolve-command` composes `command-candidates` + the L0
-             `first-resolved-command`.
-   Layer 3 — `clojure-command` (public single-purpose entry over L2)."
+   Layer 0: argument normalization and command-resolution planning (pure).
+   Layer 1: process invocations on top of Layer 0."
   (:refer-clojure :exclude [run!])
   (:require [babashka.fs :as fs]
             [babashka.process :as p]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; No in-namespace dependencies.
+;; Argument normalization and command planning (pure)
 
 (def ^:private windows-clojure-command
   "Fallback executable names for Clojure tooling on Windows runners."
@@ -47,6 +42,14 @@
     [(first args) (rest args)]
     [{} args]))
 
+(defn command-candidates
+  "Return candidate executable names for `cmd` on `os`."
+  [cmd os]
+  (let [candidates (if (and (= os :windows) (= cmd "clojure"))
+                     (into [cmd] windows-clojure-command)
+                     [cmd])]
+    (vec (distinct candidates))))
+
 (defn first-resolved-command
   "Return the first executable path found by `lookup-fn`, else the first
    candidate name unchanged."
@@ -55,6 +58,54 @@
               (some-> (lookup-fn candidate) str))
             candidates)
       (first candidates)))
+
+(defn resolve-command
+  "Resolve `cmd` to an executable path when possible."
+  [cmd]
+  (let [windows-os? (re-find #"(?i)windows" (System/getProperty "os.name" ""))
+        os          (if windows-os? :windows :unix)
+        candidates  (command-candidates cmd os)]
+    (first-resolved-command candidates fs/which)))
+
+(defn clojure-command
+  "Resolve the best Clojure executable for the current process."
+  []
+  (resolve-command "clojure"))
+
+(defn- resolved-cmd
+  "Resolve the executable token in `cmd`, preserving the remaining args."
+  [cmd]
+  (if (seq cmd)
+    (into [(resolve-command (first cmd))] (rest cmd))
+    []))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Process invocations
+
+(defn run!
+  "Run a command inheriting stdio. Throws ex-info on non-zero exit.
+   Accepts an optional opts map as the first arg."
+  [& args]
+  (let [[opts cmd] (split-opts args)
+        result     (apply p/sh (merge {:continue true} opts) (resolved-cmd cmd))]
+    (when-not (zero? (:exit result))
+      (throw (ex-info (str "Command failed: " (pr-str cmd))
+                      {:exit (:exit result) :cmd cmd})))
+    result))
+
+(defn run-bg!
+  "Start a command in the background. Returns the process handle.
+   Caller is responsible for destroying it via `destroy!`."
+  [& args]
+  (let [[opts cmd] (split-opts args)]
+    (apply p/process (merge {:out :inherit :err :inherit} opts) (resolved-cmd cmd))))
+
+(defn sh
+  "Run a command, capture stdout/stderr, return the result map.
+   Never throws — caller inspects `:exit`."
+  [& args]
+  (let [[opts cmd] (split-opts args)]
+    (apply p/sh opts (resolved-cmd cmd))))
 
 (defn installed?
   "True if `cmd` resolves on PATH. Uses `babashka.fs/which`, which is
@@ -68,61 +119,6 @@
   (when proc
     (p/destroy proc)
     (try (deref proc 5000 nil) (catch Exception _ nil))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Composes Layer 0.
-
-(defn command-candidates
-  "Return candidate executable names for `cmd` on `os`."
-  [cmd os]
-  (let [candidates (if (and (= os :windows) (= cmd "clojure"))
-                     (into [cmd] windows-clojure-command)
-                     [cmd])]
-    (vec (distinct candidates))))
-
-(defn run!
-  "Run a command inheriting stdio. Throws ex-info on non-zero exit.
-   Accepts an optional opts map as the first arg (like `p/shell`)."
-  [& args]
-  (let [[opts cmd] (split-opts args)
-        result     (apply p/shell (merge {:continue true} opts) cmd)]
-    (when-not (zero? (:exit result))
-      (throw (ex-info (str "Command failed: " (pr-str cmd))
-                      {:exit (:exit result) :cmd cmd})))
-    result))
-
-(defn run-bg!
-  "Start a command in the background. Returns the process handle.
-   Caller is responsible for destroying it via `destroy!`."
-  [& args]
-  (let [[opts cmd] (split-opts args)]
-    (apply p/process (merge {:out :inherit :err :inherit} opts) cmd)))
-
-(defn sh
-  "Run a command, capture stdout/stderr, return the result map.
-   Never throws — caller inspects `:exit`."
-  [& args]
-  (let [[opts cmd] (split-opts args)]
-    (apply p/sh opts cmd)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Composes Layer 1.
-
-(defn resolve-command
-  "Resolve `cmd` to an executable path when possible."
-  [cmd]
-  (let [windows-os? (re-find #"(?i)windows" (System/getProperty "os.name" ""))
-        os          (if windows-os? :windows :unix)
-        candidates  (command-candidates cmd os)]
-    (first-resolved-command candidates fs/which)))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Composes Layer 2.
-
-(defn clojure-command
-  "Resolve the best Clojure executable for the current process."
-  []
-  (resolve-command "clojure"))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -286,6 +286,8 @@
         curator-terminal?
         (= :curator/no-files-written
            (get-in curator-result [:error :data :code]))
+        already-implemented-noop?
+        (= :already-implemented (:status impl-result))
         ;; "Degraded handoff" means the implementer agent reported a hard
         ;; error but the curator recovered files anyway. :already-implemented
         ;; is a deliberate skip (work was completed in a prior turn) — the
@@ -314,6 +316,15 @@
                               :raw-error (:error impl-result)))
                      (dissoc :error)
                      (update :metrics merge (:metrics curator-result)))
+                 ;; A verified no-op is legitimate implement success-by-prior-work.
+                 ;; The curator only sees an empty diff, so its terminal
+                 ;; :curator/no-files-written verdict cannot distinguish
+                 ;; "task already satisfied" from "agent did nothing." Preserve
+                 ;; the implementer's normalized :already-implemented result here
+                 ;; and let the outer phase boundary apply the usual repair-loop
+                 ;; guards in leave-implement.
+                 (and already-implemented-noop? curator-terminal?)
+                 impl-result
                  ;; Curator said no-files (terminal). This wins over any
                  ;; implementer error — the implementer's error is the symptom,
                  ;; the empty diff is the root cause the phase runner needs.

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -29,7 +29,8 @@
             [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.knowledge.interface :as knowledge]
-            [ai.miniforge.response.interface :as response]))
+            [ai.miniforge.response.interface :as response]
+            [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
@@ -233,12 +234,12 @@
 
 (defn- compute-decision
   "Pick the post-review action: :stagnated | :repair | :exhausted | :complete."
-  [{:keys [reviewer-blocked? stagnated? within-budget? phase-status]}]
+  [{:keys [reviewer-blocked? stagnated? within-budget? phase-status actionable-feedback?]}]
   (cond
-    stagnated?                              :stagnated
-    (and reviewer-blocked? within-budget?)  :repair
-    (= :failed phase-status)                :exhausted
-    :else                                   :complete))
+    stagnated?                                               :stagnated
+    (and reviewer-blocked? within-budget? actionable-feedback?) :repair
+    (= :failed phase-status)                                 :exhausted
+    :else                                                    :complete))
 
 (defn- apply-decision
   "Apply the chosen post-review action to the updated context."
@@ -269,6 +270,14 @@
   [result]
   (or (get-in result [:output :review/feedback])
       (get-in result [:output :review/issues])))
+
+(defn- actionable-feedback?
+  "True when review feedback gives implement something concrete to repair."
+  [feedback]
+  (cond
+    (string? feedback)     (not (str/blank? feedback))
+    (sequential? feedback) (seq feedback)
+    :else                  (some? feedback)))
 
 (defn leave-review
   "Post-processing for review phase.
@@ -302,11 +311,12 @@
         stagnated?        (compute-stagnated? reviewer-blocked? prior-history current-fp)
         phase-status      (compute-phase-status reviewer-blocked? gate-failed?)
         within-budget?    (< iterations max-iterations)
-        decision          (compute-decision {:reviewer-blocked? reviewer-blocked?
-                                             :stagnated?        stagnated?
-                                             :within-budget?    within-budget?
-                                             :phase-status      phase-status})
         feedback          (review-feedback result)
+        decision          (compute-decision {:reviewer-blocked?    reviewer-blocked?
+                                             :stagnated?           stagnated?
+                                             :within-budget?       within-budget?
+                                             :phase-status         phase-status
+                                             :actionable-feedback? (actionable-feedback? feedback)})
         updated-ctx       (accumulate-base-ctx ctx end-time duration-ms phase-status
                                                metrics iterations current-fp)
         next-ctx          (apply-decision decision updated-ctx feedback

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -375,6 +375,30 @@
                (get-in final-result [:phase :error :message])))
         (is (empty? (get-in final-result [:execution :phases-completed] [])))))))
 
+(deftest leave-implement-preserves-verified-already-implemented-noop-test
+  (testing "already-implemented survives curator no-files when the task is already satisfied"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 {:status :already-implemented
+                                  :output {:code/id (random-uuid)
+                                           :code/files []
+                                           :code/summary "Behavioral harness already exists"}
+                                  :summary "Behavioral harness already exists"
+                                  :metrics {:tokens 25 :duration-ms 250}})
+                  agent/curate-implement-output mock-curator-error]
+      (let [ctx (create-base-context)
+            ctx-with-config (assoc ctx :phase-config {:phase :implement})
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) ctx-with-config)
+            final-result ((:leave interceptor) enter-result)]
+        (is (= :already-implemented (get-in enter-result [:phase :result :status])))
+        (is (= :already-implemented (get-in final-result [:phase :status])))
+        (is (= :already-implemented (get-in final-result [:phase :skipped-reason])))
+        (is (= "Behavioral harness already exists"
+               (get-in final-result [:phase :result :summary])))
+        (is (nil? (get-in final-result [:phase :error])))
+        (is (= [:implement] (get-in final-result [:execution :phases-completed])))))))
+
 ;------------------------------------------------------------------------------ Layer 3: Capsule File Loading
 
 (deftest load-files-from-capsule-reads-via-execute-fn-test

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -31,14 +31,18 @@
 ;; leave-review status tests
 ;; ============================================================================
 
+(def ^:private default-review-issues
+  [{:severity :blocking
+    :description "Missing require"}])
+
 (defn simulate-leave-review
   "Simulate the leave-review logic for a given decision and iteration state.
    Returns the phase map after leave-review processing."
-  [decision iterations max-iterations]
-  (let [result {:output {:review/decision decision
-                         :review/issues [{:severity :blocking
-                                          :description "Missing require"}]}
-                :metrics {:tokens 100 :duration-ms 5000}}
+  ([decision iterations max-iterations]
+   (simulate-leave-review decision iterations max-iterations {:review/issues default-review-issues}))
+  ([decision iterations max-iterations review-output]
+   (let [result {:output (merge {:review/decision decision} review-output)
+                 :metrics {:tokens 100 :duration-ms 5000}}
         ctx {:phase {:started-at (- (System/currentTimeMillis) 1000)
                      :iterations iterations
                      :budget {:iterations max-iterations}
@@ -51,7 +55,7 @@
         interceptor (phase/get-phase-interceptor {:phase :review})
         leave-fn (:leave interceptor)
         result-ctx (leave-fn ctx)]
-    (:phase result-ctx)))
+    (:phase result-ctx))))
 
 ;; ============================================================================
 ;; Core behavior tests
@@ -86,7 +90,7 @@
     (let [phase (simulate-leave-review :changes-requested 1 4)]
       (is (some? (:review-feedback phase))
           "Review feedback should be stored for implement to consume")
-      (is (= [{:severity :blocking :description "Missing require"}]
+      (is (= default-review-issues
              (:review-feedback phase))
           "Should contain the review issues"))))
 
@@ -103,6 +107,14 @@
     (let [phase (simulate-leave-review :rejected 4 4)]
       (is (phase/failed? phase))
       (is (not (phase/redirect-requested? phase))))))
+
+(deftest rejected-without-actionable-feedback-fails-closed
+  (testing "operational reviewer rejection with no repair feedback does not redirect"
+    (let [phase (simulate-leave-review :rejected 1 4 {})]
+      (is (phase/failed? phase))
+      (is (not (phase/redirect-requested? phase))
+          "No redirect when reviewer produced no actionable feedback for implement")
+      (is (nil? (:review-feedback phase))))))
 
 (deftest approved-sets-completed-status
   (testing "approved review sets :completed status"

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -38,7 +38,8 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.interface :as workflow]
-   [ai.miniforge.workflow-resume.schema :as schema]))
+   [ai.miniforge.workflow-resume.schema :as schema]
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure extractors over an event sequence
@@ -263,6 +264,13 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Identity resolution
 
+(defn- synthetic-dag-task-workflow-id?
+  "True when the recorded workflow id is an internal DAG task workflow key,
+   not a loadable top-level workflow type from the registry."
+  [workflow-id]
+  (and (keyword? workflow-id)
+       (str/starts-with? (name workflow-id) "dag-task-")))
+
 (defn resolve-workflow-identity
   "Resolve `{:workflow-type :workflow-version}` for a resume run.
 
@@ -279,11 +287,14 @@
                     {:message "Invalid resolve-workflow-identity input"})
   (let [workflow-spec (:workflow-spec reconstructed)
         machine-snapshot (:machine-snapshot reconstructed)
-        workflow-type (or (:execution/workflow-id machine-snapshot)
-                          (some-> workflow-spec :name keyword)
+        workflow-id-from-snapshot (:execution/workflow-id machine-snapshot)
+        workflow-type (or (some-> workflow-spec :name keyword)
+                          (when-not (synthetic-dag-task-workflow-id? workflow-id-from-snapshot)
+                            workflow-id-from-snapshot)
                           (fallback-fn))
-        workflow-version (or (:execution/workflow-version machine-snapshot)
-                             (get workflow-spec :version "latest"))]
+        workflow-version (or (get workflow-spec :version)
+                             (:execution/workflow-version machine-snapshot)
+                             "latest")]
     (when-not workflow-type
       (response/throw-anomaly! :anomalies/not-found
                               "Could not resolve a workflow type for resume"

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -158,6 +158,14 @@
                                 :execution/workflow-version "2.0.0"}}
             (constantly nil))))))
 
+(deftest resolve-workflow-identity-ignores-synthetic-dag-task-workflow-id-test
+  (testing "synthetic DAG task workflow ids fall back to a loadable top-level workflow type"
+    (is (= {:workflow-type :default-sdlc :workflow-version "2.0.0"}
+           (core/resolve-workflow-identity
+            {:machine-snapshot {:execution/workflow-id :dag-task-a0000001-0001-4000-8000-000000000001
+                                :execution/workflow-version "2.0.0"}}
+            (constantly :default-sdlc))))))
+
 (deftest resolve-workflow-identity-fallback-test
   (testing "no spec → fallback-fn result used as :workflow-type"
     (is (= {:workflow-type :default-sdlc :workflow-version "latest"}

--- a/docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md
+++ b/docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md
@@ -1,0 +1,42 @@
+## Summary
+
+This PR packages the remaining Claude dogfood review-boundary fix from the `behavioral-verification-monitor` run on
+`main`.
+
+The remaining failure shape was narrower:
+
+1. the reviewer could return a parsed review artifact with all gates passing
+2. the only blocking issue could be an adaptive-timeout/stagnation message
+3. Miniforge could still treat that as a real rejected review and redirect implement
+
+## What Changed
+
+### Reviewer timeout-only failures now fail as backend errors
+
+- broaden the reviewer timeout-only classifier so it does not depend on the backend wrapper’s `success?` bit
+- when the parsed review artifact says:
+  - all gates passed
+  - no real findings or recommendations exist
+  - the only blocking issues are timeout/stagnation messages
+  - the decision is negative
+  then review now returns `:reviewer/backend-timeout` instead of a fake rejected review
+- preserve the timeout message itself as the phase error message
+- add regressions for both shapes:
+  - backend wrapper reports failure
+  - backend wrapper reports nominal success but the parsed review is still only a timeout echo
+
+## Validation
+
+- `clj-kondo` on touched files: clean
+- focused JVM regression run:
+  - `ai.miniforge.agent.reviewer-test`
+
+## Live Behavior
+
+- persisted dogfood review snapshot showed `4/4` gates passed, no real findings, and only an adaptive-timeout blocking
+  issue
+- that exact shape is now classified as a reviewer/backend failure instead of a code-review rejection
+
+## Follow-up
+
+- rerun the Claude dogfood workflow from the updated branch state so the new reviewer timeout fix is actually in play

--- a/docs/pull-requests/2026-05-06-fix-dogfood-startup-implement-resume.md
+++ b/docs/pull-requests/2026-05-06-fix-dogfood-startup-implement-resume.md
@@ -1,0 +1,54 @@
+## Summary
+
+This PR packages the Claude dogfood fixes that are not review-policy specific:
+
+1. short backend/version probes in CLI startup could still behave differently from the real inherited Claude process
+2. a valid `:already-implemented` implement result could still be overwritten by curator `:no-files-written`
+3. workflow resume could still die when a checkpoint recorded a synthetic DAG task workflow id instead of a loadable
+  top-level workflow type
+
+## What Changed
+
+### CLI startup probes are supervised directly
+
+- replace the short probe path in `workflow_runner.clj` with direct `ProcessBuilder` execution
+- read stdout/stderr concurrently
+- close stdin explicitly
+- enforce timeout with forcible process teardown
+- add focused probe tests for:
+  - fast successful command capture
+  - bounded timeout behavior
+
+### Implement preserves verified no-op outcomes
+
+- in `enter-implement`, a normalized `:already-implemented` result now survives curator `:curator/no-files-written`
+- this keeps verified “task already satisfied” outcomes from being collapsed into terminal empty-diff failures
+- existing repair-loop hardening remains in place:
+  - unsupported `:already-implemented` after prior review/verify failures still fails closed
+- add a regression covering the full `enter`/`leave` path for a legitimate already-implemented no-op
+
+### Resume ignores synthetic DAG task workflow ids
+
+- `workflow-resume` now treats keywords like `:dag-task-...` as internal synthetic workflow ids, not loadable workflow
+  types
+- identity resolution now prefers:
+  - recorded workflow spec
+  - non-synthetic machine snapshot workflow id
+  - fallback selection profile
+- this fixes resume runs that previously died with `Workflow not found` while replaying task-subworkflow checkpoints
+- add a regression for the synthetic DAG-task id shape
+
+## Validation
+
+- `clj-kondo` on touched files: clean
+- focused JVM regression run:
+  - `ai.miniforge.phase-software-factory.implement-test`
+  - `ai.miniforge.workflow-resume.core-test`
+  - `ai.miniforge.cli.workflow-runner.preflight-test`
+
+## Live Behavior
+
+- Claude dogfood on this branch now stamps `/Users/chris/.local/bin/claude 2.1.129`
+- `:explore` passes
+- `:plan` passes
+- the first DAG implement/verify cycle gets past startup and no-op handoff issues


### PR DESCRIPTION
## Summary

This PR packages the Claude dogfood fixes that are not review-policy specific:

1. short backend/version probes in CLI startup could still behave differently from the real inherited Claude process
2. a valid `:already-implemented` implement result could still be overwritten by curator `:no-files-written`
3. workflow resume could still die when a checkpoint recorded a synthetic DAG task workflow id instead of a loadable
  top-level workflow type

## What Changed

### CLI startup probes are supervised directly

- replace the short probe path in `workflow_runner.clj` with direct `ProcessBuilder` execution
- read stdout/stderr concurrently
- close stdin explicitly
- enforce timeout with forcible process teardown
- add focused probe tests for:
  - fast successful command capture
  - bounded timeout behavior

### Implement preserves verified no-op outcomes

- in `enter-implement`, a normalized `:already-implemented` result now survives curator `:curator/no-files-written`
- this keeps verified “task already satisfied” outcomes from being collapsed into terminal empty-diff failures
- existing repair-loop hardening remains in place:
  - unsupported `:already-implemented` after prior review/verify failures still fails closed
- add a regression covering the full `enter`/`leave` path for a legitimate already-implemented no-op

### Resume ignores synthetic DAG task workflow ids

- `workflow-resume` now treats keywords like `:dag-task-...` as internal synthetic workflow ids, not loadable workflow
  types
- identity resolution now prefers:
  - recorded workflow spec
  - non-synthetic machine snapshot workflow id
  - fallback selection profile
- this fixes resume runs that previously died with `Workflow not found` while replaying task-subworkflow checkpoints
- add a regression for the synthetic DAG-task id shape

## Validation

- `clj-kondo` on touched files: clean
- focused JVM regression run:
  - `ai.miniforge.phase-software-factory.implement-test`
  - `ai.miniforge.workflow-resume.core-test`
  - `ai.miniforge.cli.workflow-runner.preflight-test`

## Live Behavior

- Claude dogfood on this branch now stamps `/Users/chris/.local/bin/claude 2.1.129`
- `:explore` passes
- `:plan` passes
- the first DAG implement/verify cycle gets past startup and no-op handoff issues
