### PR TITLE
fix: recover Claude result-event content

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -131,6 +131,7 @@
           "result"
           (let [usage (or (:usage data) (get-in data [:result :usage]))]
             (cond-> {:delta "" :done? true
+                     :final-content (:result data)
                      :usage {:input-tokens (:input_tokens usage)
                              :output-tokens (:output_tokens usage)}
                      :cost-usd (:total_cost_usd data)}
@@ -732,6 +733,14 @@
       ;; Claude surfaces num_turns as an absolute count on the result event.
       (when-let [nt (:num-turns parsed)]
         (reset! accumulated-turns nt))
+      ;; Claude may surface the final assistant text only on the terminal
+      ;; result event. Preserve previously streamed content when present,
+      ;; but recover result-only output when no assistant delta arrived.
+      (when-let [final-content (:final-content parsed)]
+        (when (and (string? final-content)
+                   (str/blank? @accumulated-content)
+                   (not (str/blank? final-content)))
+          (reset! accumulated-content final-content)))
       ;; Codex signals each completed turn via :increment-turns rather than
       ;; emitting an absolute count — bump the accumulator on each one.
       (when (:increment-turns parsed)

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -74,6 +74,15 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Stream parser functions
 
+(defn- parsed-usage
+  [usage]
+  (let [input-tokens (:input_tokens usage)
+        output-tokens (:output_tokens usage)]
+    (when (or (number? input-tokens)
+              (number? output-tokens))
+      {:input-tokens input-tokens
+       :output-tokens output-tokens})))
+
 (defn parse-claude-stream-line
   "Parse a line from Claude CLI streaming output.
 
@@ -129,12 +138,12 @@
             {:delta delta-text :done? false})
 
           "result"
-          (let [usage (or (:usage data) (get-in data [:result :usage]))]
+          (let [usage (parsed-usage (or (:usage data)
+                                        (get-in data [:result :usage])))]
             (cond-> {:delta "" :done? true
                      :final-content (:result data)
-                     :usage {:input-tokens (:input_tokens usage)
-                             :output-tokens (:output_tokens usage)}
                      :cost-usd (:total_cost_usd data)}
+              usage (assoc :usage usage)
               (:session_id data) (assoc :session-id (:session_id data))
               (:num_turns data)  (assoc :num-turns (:num_turns data))
               ;; Claude Code surfaces a top-level stop_reason on the

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -159,7 +159,16 @@
     (let [line (json/generate-string {:type "result" :result {}})
           parsed (impl/parse-claude-stream-line line)]
       (is (true? (:done? parsed)))
-      (is (nil? (get-in parsed [:usage :input-tokens])))))
+      (is (nil? (:usage parsed)))))
+
+  (testing "result event with usage map present but nil token fields omits :usage"
+    (let [line (json/generate-string
+                 {:type "result"
+                  :usage {:input_tokens nil
+                          :output_tokens nil}})
+          parsed (impl/parse-claude-stream-line line)]
+      (is (true? (:done? parsed)))
+      (is (nil? (:usage parsed)))))
 
   (testing "result event captures num_turns and top-level stop_reason"
     (let [line (json/generate-string

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -145,11 +145,13 @@
   (testing "result event extracts usage tokens"
     (let [line (json/generate-string
                  {:type "result"
-                  :result {:usage {:input_tokens 1234
-                                   :output_tokens 567}}})
+                  :result "final text"
+                  :usage {:input_tokens 1234
+                          :output_tokens 567}})
           parsed (impl/parse-claude-stream-line line)]
       (is (= "" (:delta parsed)))
       (is (true? (:done? parsed)))
+      (is (= "final text" (:final-content parsed)))
       (is (= 1234 (get-in parsed [:usage :input-tokens])))
       (is (= 567 (get-in parsed [:usage :output-tokens])))))
 
@@ -354,11 +356,36 @@
       ;; Feed a result event with usage (top-level format from Claude CLI)
       (handler (json/generate-string
                  {:type "result"
+                  :result "Hello"
                   :usage {:input_tokens 100
                           :output_tokens 50}
                   :total_cost_usd 0.0045}))
       (is (= {:input-tokens 100 :output-tokens 50} @usage))
       (is (= 0.0045 @cost)))))
+
+(deftest stream-parser-recovers-result-only-content-test
+  (testing "result-only content is recovered when no assistant delta arrived"
+    (let [content (atom "")
+          usage (atom nil)
+          cost (atom nil)
+          chunks (atom [])
+          tools (atom [])
+          session-id (atom nil)
+          stop-reason (atom nil)
+          turns (atom nil)
+          handler (impl/stream-with-parser
+                   #'impl/parse-claude-stream-line
+                   (fn [chunk] (swap! chunks conj chunk))
+                   content usage cost tools session-id stop-reason turns)]
+      (handler (json/generate-string
+                {:type "result"
+                 :result "{\"ok\":true}"
+                 :stop_reason "end_turn"
+                 :usage {:input_tokens 9 :output_tokens 3}}))
+      (is (= "{\"ok\":true}" @content))
+      (is (= {:input-tokens 9 :output-tokens 3} @usage))
+      (is (= "end_turn" @stop-reason))
+      (is (= "{\"ok\":true}" (:content (last @chunks)))))))
 
 (deftest stream-parser-accumulates-stop-reason-and-turns-test
   (testing "latest stop_reason wins, num_turns captured from result event"

--- a/docs/archive/pr-logs/2026-05-06-fix-claude-result-event-content-recovery.md
+++ b/docs/archive/pr-logs/2026-05-06-fix-claude-result-event-content-recovery.md
@@ -1,0 +1,48 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix Claude result-event content recovery
+
+## Summary
+
+Recover final assistant text from Claude CLI's terminal `result` event
+when no assistant text delta was emitted earlier in the stream.
+
+This closes a real failure mode for workflow-native Career profile
+synthesis, where Claude returned a successful `end_turn` response but
+Miniforge accumulated zero content and downstream JSON parsing failed.
+
+## Changes
+
+- `miniforge/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj`
+  - teach `parse-claude-stream-line` to surface `:final-content` from
+    the terminal `result` event
+  - teach `stream-with-parser` to seed accumulated content from
+    `:final-content` when no assistant delta arrived
+- `miniforge/components/llm/test/ai/miniforge/llm/interface_test.clj`
+  - cover `result` events that carry authoritative final text
+  - cover result-only content recovery in the stream accumulator
+
+## Why
+
+Recent Claude CLI output can place the actual final text in the
+terminal `result.result` field even when the assistant event stream
+does not emit a text delta. Miniforge was only harvesting usage from
+that event, so downstream workflow code saw `nil` or empty content even
+though the run had succeeded.
+
+## Verification
+
+- `git diff --check`
+- `clojure -M:test -e "(require 'ai.miniforge.llm.interface-test) (let [result (clojure.test/run-tests 'ai.miniforge.llm.interface-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
+- `clojure -M -e \"(require 'ai.miniforge.llm.protocols.impl.llm-client 'cheshire.core) (let [line (cheshire.core/generate-string {:type \\\"result\\\" :result \\\"{\\\\\\\"ok\\\\\\\":true}\\\" :stop_reason \\\"end_turn\\\" :usage {:input_tokens 9 :output_tokens 3}}) parsed (ai.miniforge.llm.protocols.impl.llm-client/parse-claude-stream-line line) content (atom \\\"\\\") usage (atom nil) cost (atom nil) tools (atom []) session-id (atom nil) stop-reason (atom nil) turns (atom nil) chunks (atom []) handler (ai.miniforge.llm.protocols.impl.llm-client/stream-with-parser #'ai.miniforge.llm.protocols.impl.llm-client/parse-claude-stream-line (fn [chunk] (swap! chunks conj chunk)) content usage cost tools session-id stop-reason turns)] (handler line) (when-not (= @content \\\"{\\\\\\\"ok\\\\\\\":true}\\\") (System/exit 1)))\"`
+
+## Result
+
+Workflow callers can now rely on Miniforge to recover Claude result
+content even when the assistant stream emitted no text delta. This
+restores the expected LLM contract for downstream structured-output
+parsers.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Fix Claude result-event content recovery

## Summary

Recover final assistant text from Claude CLI's terminal `result` event
when no assistant text delta was emitted earlier in the stream.

This closes a real failure mode for workflow-native Career profile
synthesis, where Claude returned a successful `end_turn` response but
Miniforge accumulated zero content and downstream JSON parsing failed.

## Changes

- `miniforge/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj`
  - teach `parse-claude-stream-line` to surface `:final-content` from
    the terminal `result` event
  - teach `stream-with-parser` to seed accumulated content from
    `:final-content` when no assistant delta arrived
- `miniforge/components/llm/test/ai/miniforge/llm/interface_test.clj`
  - cover `result` events that carry authoritative final text
  - cover result-only content recovery in the stream accumulator

## Why

Recent Claude CLI output can place the actual final text in the
terminal `result.result` field even when the assistant event stream
does not emit a text delta. Miniforge was only harvesting usage from
that event, so downstream workflow code saw `nil` or empty content even
though the run had succeeded.

## Verification

- `git diff --check`
- `clojure -M:test -e "(require 'ai.miniforge.llm.interface-test) (let [result (clojure.test/run-tests 'ai.miniforge.llm.interface-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
- `clojure -M -e \"(require 'ai.miniforge.llm.protocols.impl.llm-client 'cheshire.core) (let [line (cheshire.core/generate-string {:type \\\"result\\\" :result \\\"{\\\\\\\"ok\\\\\\\":true}\\\" :stop_reason \\\"end_turn\\\" :usage {:input_tokens 9 :output_tokens 3}}) parsed (ai.miniforge.llm.protocols.impl.llm-client/parse-claude-stream-line line) content (atom \\\"\\\") usage (atom nil) cost (atom nil) tools (atom []) session-id (atom nil) stop-reason (atom nil) turns (atom nil) chunks (atom []) handler (ai.miniforge.llm.protocols.impl.llm-client/stream-with-parser #'ai.miniforge.llm.protocols.impl.llm-client/parse-claude-stream-line (fn [chunk] (swap! chunks conj chunk)) content usage cost tools session-id stop-reason turns)] (handler line) (when-not (= @content \\\"{\\\\\\\"ok\\\\\\\":true}\\\") (System/exit 1)))\"`

## Result

Workflow callers can now rely on Miniforge to recover Claude result
content even when the assistant stream emitted no text delta. This
restores the expected LLM contract for downstream structured-output
parsers.
