### PR TITLE
feat(supervisory-state): add canonical spec identity to WorkflowRun (BD-1)

### DIFF
--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -439,7 +439,8 @@
 
 (deftest stream-parser-recovers-result-only-content-test
   (testing "result-only content is recovered when no assistant delta arrived"
-    (let [content (atom "")
+    (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+          content (atom "")
           usage (atom nil)
           cost (atom nil)
           chunks (atom [])
@@ -450,7 +451,7 @@
           handler (impl/stream-with-parser
                    #'impl/parse-claude-stream-line
                    (fn [chunk] (swap! chunks conj chunk))
-                   content usage cost tools session-id stop-reason turns)]
+                   monitor content usage cost tools session-id stop-reason turns)]
       (handler (json/generate-string
                 {:type "result"
                  :result "{\"ok\":true}"

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -155,8 +155,12 @@
    shape some emitters use when building a spec from raw input."
   [event]
   (let [spec        (:workflow/spec event)
-        title       (or (:spec/title spec) (:title spec))
-        description (or (:spec/description spec) (:description spec))
+        ;; Trim + not-empty so blank strings ("", "   ") are dropped rather
+        ;; than emitted as `{:spec/title ""}` — that shape would violate the
+        ;; `[:string {:min 1}]` schema constraint and is not useful identity.
+        clean       (fn [v] (when (string? v) (not-empty (str/trim v))))
+        title       (or (clean (:spec/title spec))       (clean (:title spec)))
+        description (or (clean (:spec/description spec)) (clean (:description spec)))
         intent      (:spec/intent spec)
         m (cond-> {}
             title       (assoc :spec/title title)

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -143,6 +143,27 @@
     :unreachable :unreachable
     :executing))
 
+(defn- extract-spec-identity
+  "Pull a canonical run-owned spec identity from a workflow event. Returns
+   nil when the event carries no identity-bearing fields, so callers can
+   omit `:workflow-run/spec` rather than emit an empty map.
+
+   Lifts the same identity the agent supervisory-bridge already carries
+   under `:workflow-spec` agent metadata (see N5-delta-1 §3.1 +
+   miniforge-control burndown BD-1) onto the run entity directly. Accepts
+   both parsed `:spec/*` keys and the bare `:title` / `:description`
+   shape some emitters use when building a spec from raw input."
+  [event]
+  (let [spec        (:workflow/spec event)
+        title       (or (:spec/title spec) (:title spec))
+        description (or (:spec/description spec) (:description spec))
+        intent      (:spec/intent spec)
+        m (cond-> {}
+            title       (assoc :spec/title title)
+            description (assoc :spec/description description)
+            intent      (assoc :spec/intent intent))]
+    (when (seq m) m)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; WorkflowRun handlers
 
@@ -157,20 +178,27 @@
         wf-key   (or (:workflow/key spec)
                      (some-> spec :workflow/spec name)
                      (workflow-key-fallback id))
-        run      (merge {:workflow-run/id              id
-                         :workflow-run/workflow-key    wf-key
-                         :workflow-run/intent          intent
-                         :workflow-run/status          :running
-                         :workflow-run/current-phase   :unknown
-                         :workflow-run/started-at      ts
-                         :workflow-run/updated-at      ts
-                         :workflow-run/trigger-source  :cli
-                         :workflow-run/correlation-id  id}
-                        ;; Preserve fields from a prior phase-* event that
-                        ;; arrived before workflow/started.
-                        (select-keys existing
-                                     [:workflow-run/current-phase
-                                      :workflow-run/workflow-key]))]
+        spec-identity (extract-spec-identity event)
+        run      (cond-> (merge {:workflow-run/id              id
+                                 :workflow-run/workflow-key    wf-key
+                                 :workflow-run/intent          intent
+                                 :workflow-run/status          :running
+                                 :workflow-run/current-phase   :unknown
+                                 :workflow-run/started-at      ts
+                                 :workflow-run/updated-at      ts
+                                 :workflow-run/trigger-source  :cli
+                                 :workflow-run/correlation-id  id}
+                                ;; Preserve fields from a prior phase-* event that
+                                ;; arrived before workflow/started. `:workflow-run/spec`
+                                ;; is preserved here too so a placeholder set by an
+                                ;; earlier spec-bearing event survives if this event
+                                ;; has none; an event-derived identity overrides it
+                                ;; below.
+                                (select-keys existing
+                                             [:workflow-run/current-phase
+                                              :workflow-run/workflow-key
+                                              :workflow-run/spec]))
+                   spec-identity (assoc :workflow-run/spec spec-identity))]
     (assoc-in table [:workflows id] run)))
 
 (defn- ensure-workflow

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -200,6 +200,15 @@
    [:workflow-run/correlation-id :id/uuid]
    [:workflow-run/artifact-ids {:optional true} [:vector :id/uuid]]
    [:workflow-run/evidence-bundle-id {:optional true} [:maybe :id/uuid]]
+   ;; BD-1: canonical run-owned spec identity. Lifted from `:workflow/spec`
+   ;; on the lifecycle event so consumers do not have to recover it from
+   ;; correlated agent metadata. Open: producers may add further `:spec/*`
+   ;; keys without a contract bump.
+   [:workflow-run/spec {:optional true}
+    [:map
+     [:spec/title       {:optional true} [:string {:min 1}]]
+     [:spec/description {:optional true} [:string {:min 1}]]
+     [:spec/intent      {:optional true} map?]]]
    [:workflow-run/prs {:optional true}
     [:vector
      [:map

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -75,6 +75,20 @@
     (is (nil? (:workflow-run/spec run))
         "no spec identity is set when the event carries none")))
 
+(deftest workflow-started-omits-blank-spec-fields
+  ;; Blank or whitespace-only title / description must not produce
+  ;; `{:spec/title ""}`, which would violate the `[:string {:min 1}]`
+  ;; schema and is not useful identity anyway.
+  (let [wf-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started
+                                   {:workflow/id   wf-id
+                                    :workflow/spec {:spec/title       "   "
+                                                    :spec/description ""}}))
+        run   (get-in table [:workflows wf-id])]
+    (is (nil? (:workflow-run/spec run))
+        "blank string fields are dropped, leaving no spec identity to emit")))
+
 (deftest workflow-started-normalizes-bare-title-and-description
   ;; Producers that build :workflow/spec from raw input may emit `:title` /
   ;; `:description` rather than the parsed `:spec/*` keys. Keep that path

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -52,6 +52,43 @@
     (is (string? (:workflow-run/workflow-key run))
         "synthesized key is a string when event carries no spec")))
 
+(deftest workflow-started-captures-spec-identity-when-present
+  (let [wf-id (random-uuid)
+        spec  {:spec/title       "Implement Feature"
+               :spec/description "wire the new feature"
+               :spec/intent      {:type :implement :scope ["app/core.clj"]}}
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started
+                                   {:workflow/id   wf-id
+                                    :workflow/spec spec}))
+        run   (get-in table [:workflows wf-id])]
+    (is (= "Implement Feature" (get-in run [:workflow-run/spec :spec/title])))
+    (is (= "wire the new feature" (get-in run [:workflow-run/spec :spec/description])))
+    (is (= {:type :implement :scope ["app/core.clj"]}
+           (get-in run [:workflow-run/spec :spec/intent])))))
+
+(deftest workflow-started-omits-spec-when-event-has-none
+  (let [wf-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started {:workflow/id wf-id}))
+        run   (get-in table [:workflows wf-id])]
+    (is (nil? (:workflow-run/spec run))
+        "no spec identity is set when the event carries none")))
+
+(deftest workflow-started-normalizes-bare-title-and-description
+  ;; Producers that build :workflow/spec from raw input may emit `:title` /
+  ;; `:description` rather than the parsed `:spec/*` keys. Keep that path
+  ;; working so old emitters do not silently drop spec identity.
+  (let [wf-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started
+                                   {:workflow/id   wf-id
+                                    :workflow/spec {:title       "Bare Title"
+                                                    :description "raw"}}))
+        run   (get-in table [:workflows wf-id])]
+    (is (= "Bare Title" (get-in run [:workflow-run/spec :spec/title])))
+    (is (= "raw" (get-in run [:workflow-run/spec :spec/description])))))
+
 (deftest workflow-phase-started-updates-phase
   (let [wf-id (random-uuid)
         table (-> schema/empty-table


### PR DESCRIPTION
## Summary

Adds an optional `:workflow-run/spec` field to the `supervisory-state` `WorkflowRun` entity, populated at `:workflow/started` time from the event's `:workflow/spec` payload. Lifts spec title / description / intent off correlated agent metadata and onto the run entity directly, where the control-plane TUI consumer can read it without alias-tolerant fallback paths.

This addresses **BD-1** in the `miniforge-control` upstream burndown (see `miniforge-control/work/in-progress/2026-04-25-console-ux-pass-dag.md`). Today the control-plane TUI ships alias-tolerant code that reaches into agent metadata under `workflow-spec`, `workflow-id`, `workflow_run_id`, `spec/id` to recover the human spec label. With this PR, that workaround is retired on the producer side; the consumer cutover happens in a follow-on `miniforge-control` PR that reads `WorkflowRun.spec.title` directly.

## Changes

- **`components/supervisory-state/src/.../schema.clj`** — Add optional `:workflow-run/spec` map to `WorkflowRun` with `:spec/title`, `:spec/description`, `:spec/intent`. Schema is open: producers may add further `:spec/*` keys without a contract bump.
- **`components/supervisory-state/src/.../accumulator.clj`** — New `extract-spec-identity` helper. Applied in `workflow-started`. Accepts both parsed `:spec/*` keys and the bare `:title` / `:description` shape some emitters use when building a spec from raw input, so older producers do not silently drop spec identity. Preserves `:workflow-run/spec` across the existing placeholder-merge logic so a spec set by an earlier event survives if `workflow/started` arrives without one; an event-derived identity overrides any preserved value.
- **Tests** — three new accumulator tests: spec-present, spec-absent, and bare-`title`/`description` normalization.

## Drive-by

- **`components/llm/test/.../interface_test.clj`** — `stream-with-parser` gained a `progress-monitor` parameter, but `stream-parser-recovers-result-only-content-test` (line 440) was not updated. The neighboring `stream-parser-accumulates-stop-reason-and-turns-test` already follows the new signature. This is a pre-commit-hook arity error on `main`. Bringing the result-only-content test in line.

## Why

The producer-side `workflow-started-event` (`components/tui-views/src/.../persistence.clj:37`) already emits `:workflow/spec`. Today that payload is dropped at the supervisory-state boundary and only re-discovered downstream via agent metadata — a lossy correlation path. This PR closes the gap.

## Validation

```
bb test
```

5208 tests, 23535 passes, 0 failures, 0 errors.
GraalVM/Babashka compatibility check passes.

## Follow-ups (in `miniforge-control`)

- Consumer-side cutover: read `WorkflowRun.spec.*` directly in the TUI run-row context resolver and reduce the alias-tolerant agent-metadata fallback in `tui/src/app/context.rs` and `tui/src/ui.rs`.

## Test plan

- [ ] reviewer confirms the schema addition is the right shape (open map under `:workflow-run/spec`, with `:spec/title` / `:spec/description` / `:spec/intent`)
- [ ] reviewer confirms the bare-`title`/`description` fallback in `extract-spec-identity` is acceptable (vs forcing producers to use `:spec/*` keys)
- [ ] reviewer agrees the LLM drive-by is appropriate to bundle here vs split

🤖 Generated with [Claude Code](https://claude.com/claude-code)