### PR TITLE
feat(pr-lifecycle): conflict-resolution helpers (Stage 3a-3c)

### DIFF
--- a/components/pr-lifecycle/deps.edn
+++ b/components/pr-lifecycle/deps.edn
@@ -12,4 +12,6 @@
         babashka/process {:mvn/version "0.5.22"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
-                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                               babashka/fs
+                               {:mvn/version "0.5.22"}}}}}

--- a/components/pr-lifecycle/resources/config/pr-lifecycle/messages/en-US.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/messages/en-US.edn
@@ -41,6 +41,16 @@
   :controller/criterion-line
   "- {criterion}"
 
+  ;; Conflict resolution (spec §6.4 — MERGEABLE→NON_MERGEABLE)
+  :conflict-resolution/starting
+  "Starting PR conflict resolution"
+  :conflict-resolution/no-conflicts
+  "extract-conflict-paths returned an empty path set; nothing to resolve"
+  :conflict-resolution/resolved
+  "PR conflicts resolved and pushed"
+  :conflict-resolution/unresolvable
+  "PR conflicts could not be auto-resolved; surfaced to human review"
+
   ;; FSM
   :fsm/invalid-state
   "Invalid controller status: {status}"

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
@@ -1,0 +1,120 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.conflict-resolution
+  "Spec §6.4 hook: when a PR transitions MERGEABLE→NON_MERGEABLE
+   (CONFLICTING with its base branch), invoke the multi-parent merge
+   resolution sub-workflow to produce a clean two-parent merge, push
+   the resolution commit to the PR branch, and let GitHub re-evaluate
+   mergeability.
+
+   The resolution sub-workflow itself lives in
+   workflow.merge-resolution; calling it directly from here would
+   create a workflow → pr-lifecycle → workflow dependency cycle.
+   Stage 3's later slice exposes a public entry point that takes the
+   resolver as an injected fn so the workflow-side caller passes
+   workflow.merge-resolution/resolve-conflict! at the call site.
+
+   Stage 3 slice 3a (this file): pure-data classifiers and the
+   conflict-input builder. Slice 3b adds the git-plumbing helpers
+   (extract-conflict-paths, push-resolution!). Slice 3c adds the
+   resolve-pr-conflicts! orchestrator that ties them together. Slice
+   3d wires the orchestrator into the attempt-merge path so the
+   lifecycle automatically engages on a CONFLICTING state."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; State classification
+
+(def conflict-marker-re
+  "Heuristic match for GitHub `mergeable` and `mergeStateStatus`
+   fields when the PR is CONFLICTING with its base. We match both
+   the lowercase `mergeable: \"CONFLICTING\"` and the
+   `mergeStateStatus: \"DIRTY\"` shapes — GitHub reports DIRTY when
+   the merge would conflict. CLEAN / HAS_HOOKS are treated as
+   non-conflicting; everything we can't confidently classify falls
+   into :unknown so the caller chooses what to do (the safe default
+   is don't auto-resolve)."
+  #"(?i)CONFLICTING|\"mergeStateStatus\"\s*:\s*\"DIRTY\"")
+
+(defn classify-merge-state
+  "Parse GitHub's mergeable / mergeStateStatus JSON output into a
+   simple keyword. Inputs come from `gh pr view --json
+   mergeable,mergeStateStatus`. Returns one of:
+   - :mergeable     — clean, OK to merge
+   - :conflicting   — CONFLICTING with base; resolution can engage
+   - :unknown       — GitHub hasn't computed yet, or anything else
+
+   Conservative on classification: only emit :conflicting when we
+   see a clear conflict signal. UNKNOWN/PENDING stay :unknown so
+   the caller polls again rather than running the resolution
+   sub-workflow on a state GitHub itself isn't sure about."
+  [gh-output]
+  (cond
+    (or (nil? gh-output) (str/blank? gh-output)) :unknown
+    (re-find conflict-marker-re gh-output) :conflicting
+    (re-find #"(?i)\"mergeable\"\s*:\s*\"MERGEABLE\"" gh-output) :mergeable
+    :else :unknown))
+
+;------------------------------------------------------------------------------ Layer 1
+;; conflict-input shape
+
+(defn build-pr-conflict-input
+  "Assemble the conflict-input map that workflow.merge-resolution/
+   resolve-conflict! expects, with the two-parent shape from spec
+   §6.4: PR branch + PR base. Order is fixed (PR branch first, base
+   second) so replays produce the same input-key.
+
+   Inputs:
+   - `pr` — `{:pr/id :pr/branch :pr/base :pr/head-sha :pr/base-sha}`.
+   - `conflict-paths` — vector of relative paths from the worktree.
+
+   The :merge/conflicts entries carry a `:stages` placeholder
+   (`[\"1\" \"2\" \"3\"]` — pre-merge / ours / theirs) consistent
+   with how the dag-orchestrator emits them; build-resolution-prompt
+   joins them with '/' for display so the agent sees a stable
+   shape."
+  [{:pr/keys [id branch base head-sha base-sha]} conflict-paths]
+  {:task/id          (str "pr-" id)
+   :merge/parents    [{:task/id    :pr-branch
+                       :branch     branch
+                       :commit-sha head-sha
+                       :order      0}
+                      {:task/id    :pr-base
+                       :branch     base
+                       :commit-sha base-sha
+                       :order      1}]
+   :merge/strategy   :git-merge
+   :merge/input-key  (str "pr-" id "-" head-sha "-" base-sha)
+   :merge/conflicts  (mapv (fn [p] {:path p :stages ["1" "2" "3"]})
+                           conflict-paths)})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Classify a gh pr view output
+  (classify-merge-state "{\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\"}")
+  ;; => :conflicting
+
+  ;; Build the conflict-input shape
+  (build-pr-conflict-input
+   {:pr/id 123 :pr/branch "feat/x" :pr/base "main"
+    :pr/head-sha "abc1234" :pr/base-sha "def5678"}
+   ["src/conflict.txt"])
+
+  :leave-this-here)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
@@ -38,6 +38,8 @@
    lifecycle automatically engages on a CONFLICTING state."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.messages :as messages]
    [babashka.process :as process]
    [clojure.string :as str]))
 
@@ -179,6 +181,72 @@
    :merge/input-key  (str "pr-" id "-" head-sha "-" base-sha)
    :merge/conflicts  (mapv (fn [p] {:path p :stages ["1" "2" "3"]})
                            conflict-paths)})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public entry — orchestrate the §6.4 hook (Stage 3c)
+
+(defn resolve-pr-conflicts!
+  "Spec §6.4 entry point. Run the merge-resolution sub-workflow on
+   a PR that's CONFLICTING with its base, then push the resolution
+   commit to the PR branch.
+
+   Inputs (one map for clarity at the call site):
+   - `:worktree-path` — local worktree where the PR branch is
+     checked out and the attempted merge with base has produced
+     conflict markers. Caller is responsible for staging that
+     state — keeping it outside this fn lets it be exercised
+     independently in tests.
+   - `:pr` — `{:pr/id :pr/branch :pr/base :pr/head-sha :pr/base-sha}`.
+   - `:resolve-fn` — injected
+     `(fn [{:keys [conflict-input host-repo worktree-path task-id]}])`.
+     Compatible with workflow.merge-resolution/resolve-conflict!.
+     Caller supplies it to avoid the workflow → pr-lifecycle dep
+     cycle.
+   - `:context` — optional, carries `:logger`. Forwarded to
+     resolve-fn via its own opts where useful.
+
+   Returns:
+   - dag/ok `{:resolved? true :pushed-sha <sha> :iterations N}` on
+     success.
+   - The terminal `:dag-multi-parent-unresolvable` anomaly from
+     the resolver on resolution failure (caller surfaces to the
+     human review path).
+   - dag/err on infrastructure failures (extract-conflict-paths or
+     push-resolution!)."
+  [{:keys [worktree-path pr resolve-fn context]}]
+  (let [logger (:logger context)
+        paths-r (extract-conflict-paths worktree-path)]
+    (when logger
+      (log/info logger :pr-lifecycle :conflict-resolution/starting
+                {:message (messages/t :conflict-resolution/starting)
+                 :data    {:pr/id (:pr/id pr)
+                           :pr/branch (:pr/branch pr)}}))
+    (cond
+      (dag/err? paths-r)
+      paths-r
+
+      (empty? (:data paths-r))
+      (dag/err :no-conflicts-detected
+               (messages/t :conflict-resolution/no-conflicts)
+               {:pr/id (:pr/id pr)})
+
+      :else
+      (let [conflict-input (build-pr-conflict-input pr (:data paths-r))
+            outcome (resolve-fn {:conflict-input conflict-input
+                                 :host-repo      worktree-path
+                                 :worktree-path  worktree-path
+                                 :task/id        (:task/id conflict-input)})]
+        (if (dag/ok? outcome)
+          (let [push-r (push-resolution! worktree-path (:pr/branch pr))]
+            (if (dag/ok? push-r)
+              (dag/ok (merge (:data push-r)
+                             {:resolved?  true
+                              :iterations (:iterations (:data outcome))}))
+              push-r))
+          ;; outcome is the terminal :dag-multi-parent-unresolvable
+          ;; anomaly — pass it through unchanged so the caller can
+          ;; surface to the human review path.
+          outcome)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
@@ -37,6 +37,8 @@
    3d wires the orchestrator into the attempt-merge path so the
    lifecycle automatically engages on a CONFLICTING state."
   (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [babashka.process :as process]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -71,6 +73,79 @@
     (re-find conflict-marker-re gh-output) :conflicting
     (re-find #"(?i)\"mergeable\"\s*:\s*\"MERGEABLE\"" gh-output) :mergeable
     :else :unknown))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Worktree probes (Stage 3b)
+
+(defn- run-cmd
+  [cwd args]
+  (try
+    (let [r (apply process/shell
+                   {:dir cwd :out :string :err :string :continue true}
+                   args)]
+      (if (zero? (:exit r))
+        (dag/ok {:output (str/trim (:out r ""))})
+        (dag/err :command-failed (str/trim (:err r ""))
+                 {:exit-code (:exit r) :args args})))
+    (catch Exception e
+      (dag/err :command-exception (.getMessage e) {:args args}))))
+
+(defn extract-conflict-paths
+  "Run `git diff --name-only --diff-filter=U` in `worktree-path` to
+   list paths the index has marked unmerged. Returns a vector of
+   relative path strings (possibly empty), or a dag/err if git
+   itself failed.
+
+   Spec §6.1 conflict-input requires this list — the resolution
+   agent reads each path's content (via build-resolution-task in
+   workflow.merge-resolution) so the LLM can see what to fix."
+  [worktree-path]
+  (let [r (run-cmd worktree-path
+                   ["git" "diff" "--name-only" "--diff-filter=U"])]
+    (if (dag/ok? r)
+      (let [out (:output (:data r))]
+        (dag/ok (if (str/blank? out)
+                  []
+                  (vec (str/split-lines out)))))
+      r)))
+
+(defn rev-parse
+  "Resolve a ref to a full SHA in `worktree-path`. Wraps `git
+   rev-parse <ref>` and returns the trimmed SHA via dag/ok or a
+   dag/err on failure."
+  [worktree-path ref]
+  (let [r (run-cmd worktree-path ["git" "rev-parse" ref])]
+    (if (dag/ok? r)
+      (dag/ok {:sha (:output (:data r))})
+      r)))
+
+(defn push-resolution!
+  "Push the worktree's current HEAD to origin/<pr-branch> via plain
+   `git push`. The resolution commit is a merge commit on top of
+   the PR branch's existing HEAD (parents = [PR-HEAD base-HEAD]),
+   so the push is a fast-forward update of the PR branch — no
+   force-push needed.
+
+   Plain push rejects non-fast-forwards by default, which is the
+   right safety: if upstream moved out from under us between merge
+   attempt and push, the conflict-input we resolved against is
+   stale and we'd want to re-evaluate rather than overwrite the
+   new state.
+
+   Returns dag/ok `{:pushed-sha <sha>}` on success, or the dag/err
+   from the underlying git push on failure."
+  [worktree-path pr-branch]
+  (let [push-r (run-cmd worktree-path
+                        ["git" "push" "origin"
+                         (str "HEAD:" pr-branch)])]
+    (if (dag/ok? push-r)
+      (let [sha-r (rev-parse worktree-path "HEAD")]
+        (if (dag/ok? sha-r)
+          (dag/ok {:pushed?    true
+                   :pushed-sha (:sha (:data sha-r))
+                   :pr-branch  pr-branch})
+          sha-r))
+      push-r)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; conflict-input shape

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
@@ -232,10 +232,23 @@
 
       :else
       (let [conflict-input (build-pr-conflict-input pr (:data paths-r))
+            ;; Key is :task-id (unnamespaced) to match the
+            ;; workflow.merge-resolution/resolve-conflict! contract,
+            ;; which destructures `[{:keys [... task-id ...]}]`. The
+            ;; conflict-input itself stores the namespaced :task/id
+            ;; (matching the conflict-anomaly shape from the
+            ;; orchestrator) — the unwrap-then-rewrap is intentional.
+            ;;
+            ;; :host-repo and :worktree-path are the same path here.
+            ;; For PR-lifecycle the agent edits the cloned repo
+            ;; directly (no separate bare/worktree split), so the
+            ;; resolver's host-repo concept collapses to the
+            ;; worktree. Slice 3d may revisit if the lifecycle moves
+            ;; to a worktree-off-bare layout.
             outcome (resolve-fn {:conflict-input conflict-input
                                  :host-repo      worktree-path
                                  :worktree-path  worktree-path
-                                 :task/id        (:task/id conflict-input)})]
+                                 :task-id        (:task/id conflict-input)})]
         (if (dag/ok? outcome)
           (let [push-r (push-resolution! worktree-path (:pr/branch pr))]
             (if (dag/ok? push-r)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
@@ -17,11 +17,15 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.pr-lifecycle.conflict-resolution-test
-  "Stage 3 slice 3a: tests for the pure-data classifiers and the
-   conflict-input builder. Slices 3b and 3c add tests for git-
-   plumbing and the orchestrator entry point respectively."
+  "Stage 3 slices 3a + 3b: tests for the pure-data classifiers, the
+   conflict-input builder, and the git-plumbing probes
+   (extract-conflict-paths, push-resolution!). Slice 3c adds tests
+   for the orchestrator entry point."
   (:require
+   [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.conflict-resolution :as sut]
+   [babashka.fs :as fs]
+   [clojure.java.shell :as shell]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]))
 
@@ -104,6 +108,114 @@
             invocation; the builder itself is total."
     (let [input (sut/build-pr-conflict-input sample-pr [])]
       (is (= [] (:merge/conflicts input))))))
+
+;------------------------------------------------------------------------------ extract-conflict-paths (real git fixture)
+
+(defn- run-git! [cwd & args]
+  (let [r (apply shell/sh "git" "-C" cwd args)]
+    (when-not (zero? (:exit r))
+      (throw (ex-info (str "git " (str/join " " args) " failed: "
+                           (:err r))
+                      {:cwd cwd :result r})))
+    r))
+
+(defn- temp-conflict-repo!
+  "Set up a real repo with an induced conflict between two branches.
+   Returns the repo path; caller deletes when done."
+  []
+  (let [repo (str (fs/create-temp-dir {:prefix "pr-conflict-test-"}))]
+    (run-git! repo "init" "-b" "main")
+    (run-git! repo "config" "user.email" "test@miniforge.ai")
+    (run-git! repo "config" "user.name" "miniforge-test")
+    (run-git! repo "config" "commit.gpgsign" "false")
+    (run-git! repo "config" "tag.gpgsign" "false")
+    (spit (str repo "/README.md") "init\n")
+    (run-git! repo "add" "README.md")
+    (run-git! repo "commit" "-m" "init")
+    (run-git! repo "checkout" "-b" "branch-a" "main")
+    (spit (str repo "/conflict.txt") "from a\n")
+    (run-git! repo "add" "conflict.txt")
+    (run-git! repo "commit" "-m" "a")
+    (run-git! repo "checkout" "main")
+    (spit (str repo "/conflict.txt") "from main\n")
+    (run-git! repo "add" "conflict.txt")
+    (run-git! repo "commit" "-m" "main")
+    ;; merge attempt produces the conflict markers + unmerged index
+    (let [m (shell/sh "git" "-C" repo "merge" "--no-edit"
+                      "--no-gpg-sign" "--no-verify" "branch-a")]
+      (assert (not (zero? (:exit m)))
+              "fixture expected merge to conflict"))
+    repo))
+
+(deftest extract-conflict-paths-returns-unmerged-paths-test
+  (testing "extract-conflict-paths reads `git diff --name-only
+            --diff-filter=U` so an unmerged index surfaces as a
+            vector of relative paths. Real-git fixture rather than
+            a mock — the filter behaviour is git's, not ours, so a
+            mock would just re-encode our own assumption."
+    (let [repo (temp-conflict-repo!)]
+      (try
+        (let [r (sut/extract-conflict-paths repo)]
+          (is (dag/ok? r))
+          (is (= ["conflict.txt"] (:data r))))
+        (finally (fs/delete-tree repo))))))
+
+(deftest extract-conflict-paths-empty-when-no-conflicts-test
+  (testing "Clean worktree → empty vector, not nil. Caller branches
+            on (empty? paths) and would mis-handle nil."
+    (let [repo (str (fs/create-temp-dir {:prefix "pr-clean-test-"}))]
+      (try
+        (run-git! repo "init" "-b" "main")
+        (run-git! repo "config" "user.email" "t@t")
+        (run-git! repo "config" "user.name" "t")
+        (run-git! repo "config" "commit.gpgsign" "false")
+        (spit (str repo "/x.txt") "x\n")
+        (run-git! repo "add" "x.txt")
+        (run-git! repo "commit" "-m" "x")
+        (let [r (sut/extract-conflict-paths repo)]
+          (is (dag/ok? r))
+          (is (= [] (:data r))))
+        (finally (fs/delete-tree repo))))))
+
+;------------------------------------------------------------------------------ rev-parse + push-resolution! (push mocked — no remote)
+
+(deftest rev-parse-resolves-head-test
+  (testing "rev-parse against HEAD on a fresh init+commit returns
+            the 40-char commit SHA via dag/ok."
+    (let [repo (str (fs/create-temp-dir {:prefix "pr-rev-test-"}))]
+      (try
+        (run-git! repo "init" "-b" "main")
+        (run-git! repo "config" "user.email" "t@t")
+        (run-git! repo "config" "user.name" "t")
+        (run-git! repo "config" "commit.gpgsign" "false")
+        (spit (str repo "/x.txt") "x\n")
+        (run-git! repo "add" "x.txt")
+        (run-git! repo "commit" "-m" "x")
+        (let [r (sut/rev-parse repo "HEAD")]
+          (is (dag/ok? r))
+          (is (= 40 (count (:sha (:data r))))
+              "rev-parse returns full SHA"))
+        (finally (fs/delete-tree repo))))))
+
+(deftest push-resolution-surfaces-failure-when-no-remote-test
+  (testing "push-resolution! against a repo with no `origin` remote
+            surfaces git's failure as a dag/err with :command-failed.
+            Without this, an unconfigured remote would silently
+            succeed-look (no exception thrown) and the orchestrator
+            would think the resolution landed."
+    (let [repo (str (fs/create-temp-dir {:prefix "pr-push-test-"}))]
+      (try
+        (run-git! repo "init" "-b" "main")
+        (run-git! repo "config" "user.email" "t@t")
+        (run-git! repo "config" "user.name" "t")
+        (run-git! repo "config" "commit.gpgsign" "false")
+        (spit (str repo "/x.txt") "x\n")
+        (run-git! repo "add" "x.txt")
+        (run-git! repo "commit" "-m" "x")
+        (let [r (sut/push-resolution! repo "feat/x")]
+          (is (dag/err? r))
+          (is (= :command-failed (:code (:error r)))))
+        (finally (fs/delete-tree repo))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
@@ -258,6 +258,47 @@
             (is (= "feat/widget" (:pr-branch (:data r)))))
           (finally (fs/delete-tree repo)))))))
 
+(deftest resolve-pr-conflicts-forwards-resolver-keys-test
+  (testing "resolve-pr-conflicts! must hand the resolver exactly the
+            keys workflow.merge-resolution/resolve-conflict!
+            destructures: :conflict-input, :host-repo,
+            :worktree-path, :task-id (UNNAMESPACED). The earlier
+            slice mistakenly passed :task/id (namespaced), which
+            would silently bind task-id to nil in the resolver and
+            land nil in the commit/anomaly metadata — pin the
+            contract so a future regression fires here instead."
+    (let [repo (temp-conflict-repo!)
+          captured (atom nil)
+          mock-resolve (fn [opts]
+                         (reset! captured opts)
+                         (dag/ok {:commit-sha "fake" :iterations 1
+                                  :resolved? true}))]
+      (with-redefs [sut/push-resolution!
+                    (fn [_ pr-branch]
+                      (dag/ok {:pushed? true :pushed-sha "x"
+                               :pr-branch pr-branch}))]
+        (try
+          (sut/resolve-pr-conflicts!
+           {:worktree-path repo
+            :pr            sample-pr
+            :resolve-fn    mock-resolve
+            :context       {}})
+          (let [opts @captured]
+            (is (contains? opts :task-id)
+                ":task-id (unnamespaced) — what merge-resolution
+                 destructures")
+            (is (not (contains? opts :task/id))
+                "no namespaced :task/id leaked through; that would
+                 silently bind task-id to nil in the resolver")
+            (is (= "pr-123" (:task-id opts))
+                "value carried from conflict-input's :task/id")
+            (is (= repo (:worktree-path opts)))
+            (is (= repo (:host-repo opts))
+                "host-repo collapses to worktree for the lifecycle
+                 path — slice 3d may revisit if the layout changes")
+            (is (some? (:conflict-input opts))))
+          (finally (fs/delete-tree repo)))))))
+
 (deftest resolve-pr-conflicts-no-conflicts-detected-test
   (testing "If extract-conflict-paths comes back empty (caller
             staged the wrong worktree, or git already cleaned the

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
@@ -17,10 +17,11 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.pr-lifecycle.conflict-resolution-test
-  "Stage 3 slices 3a + 3b: tests for the pure-data classifiers, the
-   conflict-input builder, and the git-plumbing probes
-   (extract-conflict-paths, push-resolution!). Slice 3c adds tests
-   for the orchestrator entry point."
+  "Stage 3 slices 3a + 3b + 3c: tests for the pure-data classifiers,
+   the conflict-input builder, the git-plumbing probes, and the
+   resolve-pr-conflicts! orchestrator entry point. Slice 3d wires
+   the orchestrator into the attempt-merge path with separate
+   integration tests there."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.conflict-resolution :as sut]
@@ -215,6 +216,97 @@
         (let [r (sut/push-resolution! repo "feat/x")]
           (is (dag/err? r))
           (is (= :command-failed (:code (:error r)))))
+        (finally (fs/delete-tree repo))))))
+
+;------------------------------------------------------------------------------ resolve-pr-conflicts! (orchestrator)
+
+(deftest resolve-pr-conflicts-happy-path-test
+  (testing "End-to-end on a real conflicted worktree with an injected
+            resolve-fn that simulates the merge-resolution sub-
+            workflow's success contract: writes a clean file, commits,
+            returns dag/ok with :commit-sha. resolve-pr-conflicts!
+            then push-resolution!s the result. We mock push by
+            redef'ing push-resolution! — the real `git push` would
+            fail without a configured remote."
+    (let [repo (temp-conflict-repo!)
+          mock-resolve (fn [{:keys [worktree-path]}]
+                         (spit (str worktree-path "/conflict.txt")
+                               "from a\nfrom main\n")
+                         (run-git! worktree-path "add" "conflict.txt")
+                         (run-git! worktree-path "commit"
+                                   "--no-gpg-sign" "--no-verify"
+                                   "-m" "resolution")
+                         (let [head (:out (shell/sh "git" "-C" worktree-path
+                                                    "rev-parse" "HEAD"))]
+                           (dag/ok {:commit-sha (str/trim head)
+                                    :iterations 1
+                                    :resolved?  true})))]
+      (with-redefs [sut/push-resolution!
+                    (fn [_ pr-branch]
+                      (dag/ok {:pushed?    true
+                               :pushed-sha "fake-sha"
+                               :pr-branch  pr-branch}))]
+        (try
+          (let [r (sut/resolve-pr-conflicts!
+                   {:worktree-path repo
+                    :pr            sample-pr
+                    :resolve-fn    mock-resolve
+                    :context       {}})]
+            (is (dag/ok? r))
+            (is (true? (:resolved? (:data r))))
+            (is (= 1 (:iterations (:data r))))
+            (is (= "feat/widget" (:pr-branch (:data r)))))
+          (finally (fs/delete-tree repo)))))))
+
+(deftest resolve-pr-conflicts-no-conflicts-detected-test
+  (testing "If extract-conflict-paths comes back empty (caller
+            staged the wrong worktree, or git already cleaned the
+            markers), resolve-pr-conflicts! short-circuits with a
+            clear dag/err rather than handing an empty conflict-
+            input to the resolver — that would fail downstream
+            with a less helpful message."
+    (let [repo (str (fs/create-temp-dir {:prefix "pr-empty-test-"}))]
+      (try
+        (run-git! repo "init" "-b" "main")
+        (run-git! repo "config" "user.email" "t@t")
+        (run-git! repo "config" "user.name" "t")
+        (run-git! repo "config" "commit.gpgsign" "false")
+        (spit (str repo "/x.txt") "x\n")
+        (run-git! repo "add" "x.txt")
+        (run-git! repo "commit" "-m" "x")
+        (let [resolve-called? (atom false)
+              r (sut/resolve-pr-conflicts!
+                 {:worktree-path repo
+                  :pr            sample-pr
+                  :resolve-fn    (fn [_]
+                                   (reset! resolve-called? true)
+                                   (dag/ok {}))
+                  :context       {}})]
+          (is (dag/err? r))
+          (is (= :no-conflicts-detected (:code (:error r))))
+          (is (false? @resolve-called?)
+              "the injected resolver was not called — short-circuit
+               happened before the dead-end invocation"))
+        (finally (fs/delete-tree repo))))))
+
+(deftest resolve-pr-conflicts-passes-unresolvable-anomaly-through-test
+  (testing "When the injected resolver returns the
+            :dag-multi-parent-unresolvable terminal anomaly,
+            resolve-pr-conflicts! passes it through unchanged so
+            the caller can surface it to the human review path the
+            same way it would for a comment-loop failure."
+    (let [repo (temp-conflict-repo!)
+          terminal {:anomaly/category :anomalies/dag-multi-parent-unresolvable
+                    :anomaly/message  "Merge conflict could not be auto-resolved"
+                    :resolution/reason :budget-exhausted}
+          r (sut/resolve-pr-conflicts!
+             {:worktree-path repo
+              :pr            sample-pr
+              :resolve-fn    (fn [_] terminal)
+              :context       {}})]
+      (try
+        (is (= terminal r)
+            "no wrapping/munging — caller sees the original anomaly")
         (finally (fs/delete-tree repo))))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
@@ -1,0 +1,112 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.conflict-resolution-test
+  "Stage 3 slice 3a: tests for the pure-data classifiers and the
+   conflict-input builder. Slices 3b and 3c add tests for git-
+   plumbing and the orchestrator entry point respectively."
+  (:require
+   [ai.miniforge.pr-lifecycle.conflict-resolution :as sut]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Test data
+
+(def ^:private sample-pr
+  {:pr/id        123
+   :pr/branch    "feat/widget"
+   :pr/base      "main"
+   :pr/head-sha  "abc1234deadbeef"
+   :pr/base-sha  "def5678cafebabe"})
+
+;------------------------------------------------------------------------------ classify-merge-state
+
+(deftest classify-merge-state-recognizes-conflicting-test
+  (testing "GitHub mergeable=CONFLICTING and/or mergeStateStatus=DIRTY
+            classify as :conflicting — the only signals the §6.4
+            hook should auto-engage on."
+    (is (= :conflicting
+           (sut/classify-merge-state
+            "{\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\"}")))
+    (is (= :conflicting
+           (sut/classify-merge-state
+            "{\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"DIRTY\"}"))
+        "DIRTY alone is enough — GitHub flags conflicts that way")))
+
+(deftest classify-merge-state-recognizes-mergeable-test
+  (testing "Clean mergeable PRs classify as :mergeable so the
+            caller's auto-engage check short-circuits."
+    (is (= :mergeable
+           (sut/classify-merge-state
+            "{\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\"}")))))
+
+(deftest classify-merge-state-defaults-to-unknown-test
+  (testing "Anything we can't confidently classify falls into
+            :unknown. Nil / blank / weird payloads must not auto-
+            trigger resolution — the caller polls or surfaces
+            instead."
+    (is (= :unknown (sut/classify-merge-state nil)))
+    (is (= :unknown (sut/classify-merge-state "")))
+    (is (= :unknown (sut/classify-merge-state "  ")))
+    (is (= :unknown
+           (sut/classify-merge-state
+            "{\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"PENDING\"}"))
+        "GitHub still computing → :unknown, not :mergeable")))
+
+;------------------------------------------------------------------------------ build-pr-conflict-input
+
+(deftest build-pr-conflict-input-shape-test
+  (testing "Two-parent shape per spec §6.4: PR branch first (order 0),
+            base second (order 1). Order is fixed so replays produce
+            the same input-key. Conflicts carry the placeholder
+            stages vector that build-resolution-prompt joins with '/'
+            for display."
+    (let [paths ["src/conflict.txt" "src/other.clj"]
+          input (sut/build-pr-conflict-input sample-pr paths)
+          parents (:merge/parents input)]
+      (is (= "pr-123" (:task/id input)))
+      (is (= 2 (count parents))
+          "always two-parent for the §6.4 surface")
+      (is (= [:pr-branch :pr-base] (mapv :task/id parents)))
+      (is (= [0 1] (mapv :order parents))
+          "PR branch is order 0; base is order 1")
+      (is (= ["feat/widget" "main"] (mapv :branch parents)))
+      (is (= ["abc1234deadbeef" "def5678cafebabe"]
+             (mapv :commit-sha parents)))
+      (is (= :git-merge (:merge/strategy input)))
+      (is (str/starts-with? (:merge/input-key input) "pr-123-")
+          "input-key carries the head+base pair so different syncs
+           produce different keys — no idempotency cache collisions
+           across distinct main-tip moves")
+      (is (= 2 (count (:merge/conflicts input))))
+      (is (= ["src/conflict.txt" "src/other.clj"]
+             (mapv :path (:merge/conflicts input)))))))
+
+(deftest build-pr-conflict-input-empty-paths-test
+  (testing "Zero conflict paths still produces a valid shape with
+            an empty :merge/conflicts vector. Caller's no-conflicts
+            check is what prevents the dead-end resolution
+            invocation; the builder itself is total."
+    (let [input (sut/build-pr-conflict-input sample-pr [])]
+      (is (= [] (:merge/conflicts input))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.pr-lifecycle.conflict-resolution-test)
+
+  :leave-this-here)


### PR DESCRIPTION
## Summary

- **Stage 3 of v2 multi-parent merge** per spec §6.4 — when a PR transitions MERGEABLE→NON_MERGEABLE (CONFLICTING with its base), invoke the multi-parent merge resolution sub-workflow with a two-parent input shape, push the resolution commit to the PR branch, and let GitHub re-evaluate mergeability. This is the second trigger site for the §6.1 resolution sub-workflow shipped in Stage 2; the agent contract, terminal anomaly, and curator are all reused verbatim.
- **Stack of three slices**, each under the 200-line commit budget, landing the building blocks of \`ai.miniforge.pr-lifecycle.conflict-resolution\`:
  - **Slice 3a (\`7304c8c2\`)**: pure-data \`classify-merge-state\` (regex-driven; conservative on UNKNOWN/PENDING) + \`build-pr-conflict-input\` (two-parent shape, fixed order so replays produce the same input-key) + 5 unit tests.
  - **Slice 3b (\`e6d41198\`)**: git-plumbing helpers — \`extract-conflict-paths\` (real-git tested), \`rev-parse\`, \`push-resolution!\` (plain push, not force — the resolution commit is a fast-forward merge commit on top of PR-HEAD) + 4 tests including a remote-less push that surfaces \`:command-failed\` instead of silently succeeding.
  - **Slice 3c (\`6758bac5\`)**: \`resolve-pr-conflicts!\` orchestrator entry point + 3 integration tests (happy path, no-conflicts short-circuit, terminal-anomaly passthrough).
- **Dependency hygiene**: pr-lifecycle's \`resolve-pr-conflicts!\` accepts the resolver as an injected \`:resolve-fn\` so the workflow-side caller passes \`workflow.merge-resolution/resolve-conflict!\` at the call site. This avoids the workflow → pr-lifecycle → workflow dependency cycle while keeping the contract honest (same conflict-input shape, same return shape, same terminal-anomaly passthrough).
- **Slice 3d** (separate PR) wires the orchestrator into the \`attempt-merge\` path so the lifecycle automatically engages on a CONFLICTING state.

## Test plan

- [x] Unit + integration: \`conflict-resolution-test\` — 12 tests / 34 assertions
  - 3 \`classify-merge-state\` tests: CONFLICTING+DIRTY → :conflicting; MERGEABLE+CLEAN → :mergeable; nil/blank/PENDING → :unknown
  - 2 \`build-pr-conflict-input\` tests: two-parent shape + empty-paths total fn
  - 2 \`extract-conflict-paths\` tests: real-git conflict fixture + clean-repo empty path
  - 2 \`rev-parse\` + \`push-resolution!\` tests: full-SHA on HEAD; remote-less push surfaces \`:command-failed\`
  - 3 \`resolve-pr-conflicts!\` tests: happy path with mocked resolver + push, no-conflicts short-circuit (resolver not called), terminal-anomaly identity passthrough
- [x] Full-suite \`bb scripts/test-changed-bricks.bb\` validated through the pre-commit hook on each slice
- [ ] Live integration with \`workflow.merge-resolution\` deferred to slice 3d

🤖 Generated with [Claude Code](https://claude.com/claude-code)