### PR TITLE
fix(llm): per-backend :prompt-via config; route claude prompt through stdin

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -903,6 +903,40 @@
     (exec-fn cmd opts)
     (exec-fn cmd)))
 
+(defn normalize-exec-fn
+  "Wrap an exec-fn so it accepts both 1-arity (cmd) and 2-arity
+   (cmd opts) call patterns.
+
+   `:exec-fn` on `create-client` is a documented public test hook.
+   Pre-:prompt-via callers supplied 1-arity functions; once the
+   :stdin path landed the impl started invoking exec-fn 2-arity for
+   the :claude backend. Without this wrapper a 1-arity user fn
+   would throw ArityException the first time the new code path
+   ran.
+
+   The wrapper probes 2-arity on first 2-arity call and caches the
+   decision in an atom so subsequent calls dispatch directly. The
+   probe only happens when the caller actually passes opts; pure
+   1-arity invocations stay one indirection.
+
+   Returns a fn equivalent to `f` for callers that already accept
+   both arities."
+  [f]
+  (let [arity (atom :unknown)]
+    (fn
+      ([cmd] (f cmd))
+      ([cmd opts]
+       (case @arity
+         :one (f cmd)
+         :two (f cmd opts)
+         (try
+           (let [r (f cmd opts)]
+             (reset! arity :two)
+             r)
+           (catch clojure.lang.ArityException _
+             (reset! arity :one)
+             (f cmd))))))))
+
 (defn log-prompt-sent [logger backend prompt]
   (when logger
     (log/debug logger :system :agent/prompt-sent

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -355,6 +355,17 @@
                    (str "mcp__" (name server) "__" (name tool))))))
        (str/join ",")))
 
+(def ^:private claude-input-format-flag
+  "Claude CLI flag that selects how the user prompt is delivered. Paired
+   with `claude-input-format-stdin` (the only value we use today), this
+   tells the CLI to read the prompt from stdin instead of argv."
+  "--input-format")
+
+(def ^:private claude-input-format-stdin
+  "Argument value for `claude-input-format-flag` that switches the CLI
+   to text-on-stdin input mode."
+  "text")
+
 (defn- claude-args
   "Build CLI arguments for the Claude backend.
 
@@ -386,7 +397,8 @@
     (cond-> ["-p"]
       streaming?                   (conj "--output-format" "stream-json")
       streaming?                   (conj "--verbose")
-      stdin?                       (conj "--input-format" "text")
+      stdin?                       (conj claude-input-format-flag
+                                         claude-input-format-stdin)
       mcp-config                   (into ["--mcp-config" mcp-config])
       (seq mcp-allowed-tools)      (into ["--allowedTools" (claude-mcp-allowlist-string mcp-allowed-tools)])
       (seq disallowed-tools)       (into ["--disallowedTools" (str/join "," disallowed-tools)])
@@ -860,6 +872,37 @@
   (or (:prompt request)
       (build-messages-prompt (:messages request))))
 
+(defn- resolve-prompt-via
+  "Read the backend's declared prompt-delivery mode. Defaults to :argv
+   so backends that pre-date the :prompt-via knob keep their legacy
+   behavior."
+  [backend-config]
+  (get backend-config :prompt-via :argv))
+
+(defn- exec-opts-for-prompt-via
+  "Build the exec-layer opts map for a given prompt-via + prompt.
+
+   :stdin → {:stdin prompt} so the exec layer pipes the prompt to the
+            subprocess's stdin.
+   :argv  → {} (prompt rides in argv via the args-fn).
+
+   Returning an empty map for :argv lets call sites use `(seq opts)`
+   to decide between the 1-arity and 2-arity exec-fn calls — preserves
+   back-compat with caller-supplied 1-arity exec-fns documented as a
+   public test hook on CLIClient."
+  [prompt-via prompt]
+  (cond-> {} (= prompt-via :stdin) (assoc :stdin prompt)))
+
+(defn- run-cli-exec
+  "Invoke a CLI exec-fn with cmd plus optional opts. The 1-arity
+   branch keeps caller-supplied exec-fns from the days before opts
+   existed working unchanged; the 2-arity branch threads opts in
+   when they carry signal (e.g. :stdin)."
+  [exec-fn cmd opts]
+  (if (seq opts)
+    (exec-fn cmd opts)
+    (exec-fn cmd)))
+
 (defn log-prompt-sent [logger backend prompt]
   (when logger
     (log/debug logger :system :agent/prompt-sent
@@ -893,18 +936,15 @@
             response)))
 
       ;; CLI backend
-      (let [prompt (build-request-prompt request)
-            prompt-via (get backend-config :prompt-via :argv)
+      (let [prompt     (build-request-prompt request)
+            prompt-via (resolve-prompt-via backend-config)
             request-with-model (cond-> request model (assoc :model model))
-            args (args-fn (assoc request-with-model
-                                 :prompt prompt
-                                 :prompt-via prompt-via))
+            args     (args-fn (assoc request-with-model
+                                     :prompt prompt
+                                     :prompt-via prompt-via))
             full-cmd (into [cmd] args)
-            exec-opts (cond-> {}
-                        (= prompt-via :stdin) (assoc :stdin prompt))
-            result (if (seq exec-opts)
-                     (exec-fn full-cmd exec-opts)
-                     (exec-fn full-cmd))
+            opts     (exec-opts-for-prompt-via prompt-via prompt)
+            result   (run-cli-exec exec-fn full-cmd opts)
             response (parse-cli-output (:out result) (:exit result) (:err result))]
         (log-response logger response)
         response))))
@@ -1062,13 +1102,13 @@
         stream-fn (or (:stream-exec-fn client) stream-exec-fn)
         {:keys [backend model]} config
         {:keys [cmd args-fn stream-parser]} backend-config
-        prompt (build-request-prompt request)
-        prompt-via (get backend-config :prompt-via :argv)
+        prompt     (build-request-prompt request)
+        prompt-via (resolve-prompt-via backend-config)
         request-with-model (cond-> request model (assoc :model model))
-        args (args-fn (assoc request-with-model
-                             :prompt prompt
-                             :streaming? true
-                             :prompt-via prompt-via))
+        args     (args-fn (assoc request-with-model
+                                 :prompt prompt
+                                 :streaming? true
+                                 :prompt-via prompt-via))
         full-cmd (into [cmd] args)
         accumulated-content (atom "")
         accumulated-usage (atom nil)
@@ -1081,16 +1121,18 @@
       (log/debug logger :system :agent/streaming-prompt-sent
                  {:data {:backend backend
                          :prompt-length (count prompt)}}))
-    (let [result (stream-fn
+    (let [base-opts {:progress-monitor progress-monitor
+                     :workdir (:workdir request)}
+          stream-opts (merge base-opts
+                             (exec-opts-for-prompt-via prompt-via prompt))
+          result (stream-fn
                   full-cmd
                   (stream-with-parser stream-parser on-chunk progress-monitor
                                       accumulated-content accumulated-usage
                                       accumulated-cost accumulated-tools
                                       accumulated-session-id
                                       accumulated-stop-reason accumulated-turns)
-                  (cond-> {:progress-monitor progress-monitor
-                           :workdir (:workdir request)}
-                    (= prompt-via :stdin) (assoc :stdin prompt)))
+                  stream-opts)
           exit-code (:exit result)
           timeout-info (:timeout result)
           final-content @accumulated-content

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -356,14 +356,37 @@
        (str/join ",")))
 
 (defn- claude-args
-  "Build CLI arguments for the Claude backend."
+  "Build CLI arguments for the Claude backend.
+
+   Prompt delivery is controlled by `:prompt-via` on the request map:
+
+     :argv  (default) — prompt is conjoined as a positional argv arg.
+                        Legacy behavior; kept for tests + backends that
+                        do not invoke the planner-sized prompt path.
+     :stdin           — prompt is omitted from argv; `--input-format text`
+                        tells claude to read the user prompt from stdin.
+                        Required for the planner / implementer path
+                        because system-prompt + spec text +
+                        existing-files context regularly exceeds POSIX
+                        ARG_MAX once combined into argv (observed
+                        2026-05-07 stage-3 dogfood: \"Argument list too
+                        long\" on plan phase).
+
+   Callers (handle-streaming / complete-impl) read `:prompt-via` from
+   the backend config and thread it into the request map before
+   invoking this fn; for :stdin they additionally pipe the prompt
+   string into the process via the exec layer's `:stdin` option."
   [{:keys [prompt system max-tokens streaming? mcp-config mcp-allowed-tools
-           disallowed-tools supervision budget-usd max-turns model resume]}]
+           disallowed-tools supervision budget-usd max-turns model resume
+           prompt-via]
+    :or   {prompt-via :argv}}]
   (let [budget (or budget-usd
-                   (when max-tokens (default-claude-cli-budget-usd)))]
+                   (when max-tokens (default-claude-cli-budget-usd)))
+        stdin? (= prompt-via :stdin)]
     (cond-> ["-p"]
       streaming?                   (conj "--output-format" "stream-json")
       streaming?                   (conj "--verbose")
+      stdin?                       (conj "--input-format" "text")
       mcp-config                   (into ["--mcp-config" mcp-config])
       (seq mcp-allowed-tools)      (into ["--allowedTools" (claude-mcp-allowlist-string mcp-allowed-tools)])
       (seq disallowed-tools)       (into ["--disallowedTools" (str/join "," disallowed-tools)])
@@ -373,7 +396,7 @@
       max-turns                    (into ["--max-turns" (str max-turns)])
       model                        (into ["--model" model])
       resume                       (into ["--resume" resume])
-      true                         (conj prompt))))
+      (not stdin?)                 (conj prompt))))
 
 (defn- codex-args
   "Build CLI arguments for the Codex backend."
@@ -409,7 +432,12 @@
             :requires-cli? true
             :api-key-var "ANTHROPIC_API_KEY"
             :stream-parser parse-claude-stream-line
-            :args-fn claude-args}
+            :args-fn claude-args
+            ;; Prompt delivery: stdin. The planner path's system-prompt +
+            ;; spec text + existing-files context regularly pushes argv
+            ;; past POSIX ARG_MAX. Claude CLI supports --input-format text
+            ;; to read the user prompt from stdin; we use that instead.
+            :prompt-via :stdin}
 
    :codex {:cmd "codex"
            :streaming? true
@@ -418,7 +446,10 @@
            :requires-cli? true
            :api-key-var nil
            :stream-parser parse-codex-stream-line
-           :args-fn codex-args}
+           :args-fn codex-args
+           ;; Prompt delivery: argv. Codex CLI takes a positional prompt;
+           ;; flip to :stdin if its prompt envelope grows past ARG_MAX.
+           :prompt-via :argv}
 
    :openai {:cmd "http"
             :streaming? true
@@ -446,7 +477,8 @@
             :provider "Cursor"
             :requires-cli? true
             :api-key-var nil
-            :args-fn cursor-args}
+            :args-fn cursor-args
+            :prompt-via :argv}
 
    :echo {:cmd "echo"
           :streaming? false
@@ -454,7 +486,8 @@
           :provider "Test"
           :requires-cli? false
           :api-key-var nil
-          :args-fn echo-args}})
+          :args-fn echo-args
+          :prompt-via :argv}})
 
 (defn build-messages-prompt [messages]
   (->> messages
@@ -783,13 +816,23 @@
   (when (System/getenv "CLAUDECODE")
     (into {} (remove (fn [[k _]] (= k "CLAUDECODE"))) (System/getenv))))
 
+(defn- ->stdin-stream
+  "Build the InputStream passed as the subprocess's stdin. A non-blank
+   :stdin string becomes a ByteArrayInputStream over its UTF-8 bytes;
+   absent or blank stdin maps to a zero-length stream so the
+   subprocess sees EOF immediately (legacy behavior for argv backends)."
+  [stdin-str]
+  (if (and (string? stdin-str) (not (.isEmpty ^String stdin-str)))
+    (ByteArrayInputStream. (.getBytes ^String stdin-str "UTF-8"))
+    (ByteArrayInputStream. (byte-array 0))))
+
 (defn stream-exec-fn
   ([cmd on-line]
    (stream-exec-fn cmd on-line {}))
-  ([cmd on-line {:keys [progress-monitor workdir]}]
+  ([cmd on-line {:keys [progress-monitor workdir stdin]}]
    (let [monitor (or progress-monitor (default-progress-monitor))
-         empty-stdin (ByteArrayInputStream. (byte-array 0))
-         process (apply p/process (cond-> {:err :string :in empty-stdin}
+         in-stream (->stdin-stream stdin)
+         process (apply p/process (cond-> {:err :string :in in-stream}
                                           (clean-env) (assoc :env (clean-env))
                                           workdir     (assoc :dir workdir)) cmd)
          out-reader (java.io.BufferedReader.
@@ -851,10 +894,17 @@
 
       ;; CLI backend
       (let [prompt (build-request-prompt request)
+            prompt-via (get backend-config :prompt-via :argv)
             request-with-model (cond-> request model (assoc :model model))
-            args (args-fn (assoc request-with-model :prompt prompt))
+            args (args-fn (assoc request-with-model
+                                 :prompt prompt
+                                 :prompt-via prompt-via))
             full-cmd (into [cmd] args)
-            result (exec-fn full-cmd)
+            exec-opts (cond-> {}
+                        (= prompt-via :stdin) (assoc :stdin prompt))
+            result (if (seq exec-opts)
+                     (exec-fn full-cmd exec-opts)
+                     (exec-fn full-cmd))
             response (parse-cli-output (:out result) (:exit result) (:err result))]
         (log-response logger response)
         response))))
@@ -1013,8 +1063,12 @@
         {:keys [backend model]} config
         {:keys [cmd args-fn stream-parser]} backend-config
         prompt (build-request-prompt request)
+        prompt-via (get backend-config :prompt-via :argv)
         request-with-model (cond-> request model (assoc :model model))
-        args (args-fn (assoc request-with-model :prompt prompt :streaming? true))
+        args (args-fn (assoc request-with-model
+                             :prompt prompt
+                             :streaming? true
+                             :prompt-via prompt-via))
         full-cmd (into [cmd] args)
         accumulated-content (atom "")
         accumulated-usage (atom nil)
@@ -1034,8 +1088,9 @@
                                       accumulated-cost accumulated-tools
                                       accumulated-session-id
                                       accumulated-stop-reason accumulated-turns)
-                  {:progress-monitor progress-monitor
-                   :workdir (:workdir request)})
+                  (cond-> {:progress-monitor progress-monitor
+                           :workdir (:workdir request)}
+                    (= prompt-via :stdin) (assoc :stdin prompt)))
           exit-code (:exit result)
           timeout-info (:timeout result)
           final-content @accumulated-content
@@ -1122,15 +1177,21 @@
 
 ;------------------------------------------------------------------------------ Layer 3
 
-(defn default-exec-fn [cmd]
-  (let [timeout-ms 600000
-        empty-stdin (ByteArrayInputStream. (byte-array 0))
-        result (apply p/shell (cond-> {:out :string :err :string :continue true
-                                       :in empty-stdin :timeout timeout-ms}
-                                (clean-env) (assoc :env (clean-env))) cmd)]
-    {:out (:out result)
-     :err (:err result)
-     :exit (:exit result)}))
+(defn default-exec-fn
+  "Run `cmd` with `p/shell`, capturing :out / :err / :exit.
+
+   2-arity opts map supports `:stdin` — a string piped to the
+   subprocess's stdin. Absent or blank => zero-length stdin (legacy)."
+  ([cmd] (default-exec-fn cmd {}))
+  ([cmd {:keys [stdin]}]
+   (let [timeout-ms 600000
+         in-stream  (->stdin-stream stdin)
+         result (apply p/shell (cond-> {:out :string :err :string :continue true
+                                        :in in-stream :timeout timeout-ms}
+                                 (clean-env) (assoc :env (clean-env))) cmd)]
+     {:out (:out result)
+      :err (:err result)
+      :exit (:exit result)})))
 
 (defn capsule-exec-fn
   "Returns an exec-fn that routes CLI commands through a task capsule executor.
@@ -1155,17 +1216,17 @@
          :exit 1}))))
 
 (defn mock-exec-fn [output & {:keys [exit] :or {exit 0}}]
-  (fn [_cmd]
-    {:out output
-     :err ""
-     :exit exit}))
+  (fn
+    ([_cmd]      {:out output :err "" :exit exit})
+    ([_cmd _opts] {:out output :err "" :exit exit})))
 
 (defn mock-exec-fn-multi [outputs]
-  (let [call-count (atom 0)]
-    (fn [_cmd]
-      (let [idx @call-count
-            output (get outputs idx (last outputs))]
-        (swap! call-count inc)
-        {:out output
-         :err ""
-         :exit 0}))))
+  (let [call-count (atom 0)
+        respond    (fn []
+                     (let [idx @call-count
+                           output (get outputs idx (last outputs))]
+                       (swap! call-count inc)
+                       {:out output :err "" :exit 0}))]
+    (fn
+      ([_cmd]       (respond))
+      ([_cmd _opts] (respond)))))

--- a/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
@@ -61,5 +61,8 @@
    (->CLIClient (cond-> {:backend backend}
                   model (assoc :model model))
                 logger
-                (or exec-fn impl/default-exec-fn)
+                ;; Normalize so 1-arity user-supplied exec-fns keep
+                ;; working when the impl invokes 2-arity (the
+                ;; :prompt-via :stdin path on the claude backend).
+                (impl/normalize-exec-fn (or exec-fn impl/default-exec-fn))
                 stream-exec-fn)))

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -801,8 +801,9 @@
                   {:backend :claude
                    :stream-exec-fn (fn [_cmd _on-line _opts]
                                      {:out "" :err "stream stderr" :exit 0})
-                   :exec-fn (fn [_cmd]
-                              {:out "fallback answer" :err "" :exit 0})})
+                   :exec-fn (fn
+                              ([_cmd]      {:out "fallback answer" :err "" :exit 0})
+                              ([_cmd _opts] {:out "fallback answer" :err "" :exit 0}))})
           resp (llm/complete-stream client {:prompt "test"} #(swap! chunks conj %))]
       (is (:success resp))
       (is (= "fallback answer" (:content resp)))
@@ -850,6 +851,92 @@
     (testing "max-turns flag omitted when not provided"
       (let [args (args-fn {:prompt "test" :budget-usd 1.0})]
         (is (not (some #{"--max-turns"} args)))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Claude backend prompt delivery (argv vs stdin) — argv-overflow guard
+;;
+;; The Stage 3 dogfood (2026-05-07) hit "Argument list too long" because
+;; the planner's system-prompt + spec text + existing-files context
+;; pushed the argv past POSIX ARG_MAX. The :claude backend now declares
+;; :prompt-via :stdin and the args-fn omits the positional prompt while
+;; adding --input-format text. These tests lock that contract.
+
+(def ^:private giant-prompt
+  "Synthetic prompt used to assert the prompt content is NOT placed in
+   the argv when :prompt-via :stdin. Same shape (string) as a real
+   planner prompt; size is small but the assertions hinge on
+   identity-of-content, not length."
+  "this should arrive on stdin not in argv")
+
+(deftest claude-args-fn-prompt-via-argv-default-test
+  (testing "prompt-via defaults to :argv — prompt is the last argv element"
+    (let [args-fn (:args-fn (get impl/backends :claude))
+          args (args-fn {:prompt giant-prompt})]
+      (is (= giant-prompt (last args))
+          "prompt is conjoined as positional argv arg")
+      (is (not (some #{"--input-format"} args))
+          "no --input-format flag in argv mode"))))
+
+(deftest claude-args-fn-prompt-via-argv-explicit-test
+  (testing "prompt-via :argv (explicit) keeps current argv shape"
+    (let [args-fn (:args-fn (get impl/backends :claude))
+          args (args-fn {:prompt giant-prompt :prompt-via :argv})]
+      (is (= giant-prompt (last args))
+          "prompt is conjoined as positional argv arg")
+      (is (not (some #{"--input-format"} args))))))
+
+(deftest claude-args-fn-prompt-via-stdin-omits-argv-test
+  (testing "prompt-via :stdin drops the positional prompt"
+    (let [args-fn (:args-fn (get impl/backends :claude))
+          args (args-fn {:prompt giant-prompt :prompt-via :stdin})]
+      (is (not (some #{giant-prompt} args))
+          "prompt content must NOT appear in argv when :prompt-via :stdin")
+      (is (some #{"--input-format"} args)
+          "--input-format text flag must be present so claude reads stdin")
+      (is (= "text" (nth args (inc (.indexOf args "--input-format"))))
+          "--input-format value is 'text'"))))
+
+(deftest claude-backend-declares-prompt-via-stdin-test
+  (testing ":claude backend config declares :prompt-via :stdin"
+    (is (= :stdin (:prompt-via (get impl/backends :claude)))
+        "claude must default to stdin to avoid POSIX ARG_MAX overflow")))
+
+(deftest non-claude-backends-default-to-argv-test
+  (testing "codex / cursor / echo backends keep :prompt-via :argv"
+    (is (= :argv (:prompt-via (get impl/backends :codex))))
+    (is (= :argv (:prompt-via (get impl/backends :cursor))))
+    (is (= :argv (:prompt-via (get impl/backends :echo))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; default-exec-fn / stream-exec-fn — :stdin opt is piped to the subprocess
+;;
+;; Use `cat` as the subprocess: stdin is echoed verbatim to stdout, so we
+;; can assert the bytes the exec layer wrote without depending on a
+;; real LLM CLI.
+
+(deftest default-exec-fn-pipes-stdin-test
+  (testing ":stdin opt is written to subprocess stdin"
+    (let [{:keys [out exit]} (impl/default-exec-fn ["cat"] {:stdin "hello stdin"})]
+      (is (zero? exit))
+      (is (= "hello stdin" out)))))
+
+(deftest default-exec-fn-no-stdin-default-test
+  (testing "no :stdin opt → empty stdin (legacy behavior)"
+    (let [{:keys [out exit]} (impl/default-exec-fn ["cat"])]
+      (is (zero? exit))
+      (is (= "" out)))))
+
+(deftest stream-exec-fn-pipes-stdin-test
+  (testing ":stdin opt is written to subprocess stdin in streaming path"
+    (let [seen (atom [])
+          handler (fn [line] (swap! seen conj line))
+          monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+          {:keys [exit]} (impl/stream-exec-fn ["cat"] handler
+                                              {:stdin "line1\nline2\n"
+                                               :progress-monitor monitor})]
+      (is (zero? exit))
+      (is (= ["line1" "line2"] @seen)
+          "subprocess saw stdin content split by line"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -926,6 +926,38 @@
       (is (zero? exit))
       (is (= "" out)))))
 
+(deftest legacy-1-arity-exec-fn-survives-stdin-path-test
+  (testing "1-arity user-supplied :exec-fn keeps working when impl invokes 2-arity"
+    ;; Backward-compat guard: PR #798 review pointed out that callers
+    ;; predating :prompt-via supplied 1-arity exec-fns. The :claude
+    ;; backend now invokes 2-arity (it declares :prompt-via :stdin).
+    ;; create-client wraps user fns through normalize-exec-fn so the
+    ;; legacy contract still works.
+    (let [seen (atom nil)
+          legacy-1-arity (fn [cmd]
+                           (reset! seen cmd)
+                           {:out "ok" :err "" :exit 0})
+          client (ai.miniforge.llm.protocols.records.llm-client/create-client
+                  {:backend :claude :exec-fn legacy-1-arity})
+          resp (llm/complete client {:prompt "hello"})]
+      (is (llm/success? resp)
+          "complete succeeds even though impl tried 2-arity first")
+      (is (some? @seen)
+          "legacy 1-arity fn was eventually invoked"))))
+
+(deftest normalize-exec-fn-passes-opts-to-2-arity-fn-test
+  (testing "2-arity user-supplied exec-fn receives opts unchanged"
+    (let [seen-opts (atom nil)
+          two-arity (fn
+                      ([cmd] {:out "" :err "" :exit 0 :seen-cmd cmd})
+                      ([cmd opts]
+                       (reset! seen-opts opts)
+                       {:out "ok" :err "" :exit 0}))
+          wrapped (impl/normalize-exec-fn two-arity)]
+      (wrapped ["claude" "-p"] {:stdin "the-prompt"})
+      (is (= {:stdin "the-prompt"} @seen-opts)
+          "opts must reach a 2-arity-capable fn unchanged"))))
+
 (deftest stream-exec-fn-pipes-stdin-test
   (testing ":stdin opt is written to subprocess stdin in streaming path"
     (let [seen (atom [])

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -861,18 +861,18 @@
 ;; :prompt-via :stdin and the args-fn omits the positional prompt while
 ;; adding --input-format text. These tests lock that contract.
 
-(def ^:private giant-prompt
-  "Synthetic prompt used to assert the prompt content is NOT placed in
-   the argv when :prompt-via :stdin. Same shape (string) as a real
-   planner prompt; size is small but the assertions hinge on
-   identity-of-content, not length."
+(def ^:private sample-prompt
+  "Synthetic prompt used to assert the prompt content's *placement*
+   (argv vs not-argv). Same shape (string) as a real planner prompt;
+   size is small because the assertions hinge on identity-of-content,
+   not length."
   "this should arrive on stdin not in argv")
 
 (deftest claude-args-fn-prompt-via-argv-default-test
   (testing "prompt-via defaults to :argv — prompt is the last argv element"
     (let [args-fn (:args-fn (get impl/backends :claude))
-          args (args-fn {:prompt giant-prompt})]
-      (is (= giant-prompt (last args))
+          args (args-fn {:prompt sample-prompt})]
+      (is (= sample-prompt (last args))
           "prompt is conjoined as positional argv arg")
       (is (not (some #{"--input-format"} args))
           "no --input-format flag in argv mode"))))
@@ -880,16 +880,16 @@
 (deftest claude-args-fn-prompt-via-argv-explicit-test
   (testing "prompt-via :argv (explicit) keeps current argv shape"
     (let [args-fn (:args-fn (get impl/backends :claude))
-          args (args-fn {:prompt giant-prompt :prompt-via :argv})]
-      (is (= giant-prompt (last args))
+          args (args-fn {:prompt sample-prompt :prompt-via :argv})]
+      (is (= sample-prompt (last args))
           "prompt is conjoined as positional argv arg")
       (is (not (some #{"--input-format"} args))))))
 
 (deftest claude-args-fn-prompt-via-stdin-omits-argv-test
   (testing "prompt-via :stdin drops the positional prompt"
     (let [args-fn (:args-fn (get impl/backends :claude))
-          args (args-fn {:prompt giant-prompt :prompt-via :stdin})]
-      (is (not (some #{giant-prompt} args))
+          args (args-fn {:prompt sample-prompt :prompt-via :stdin})]
+      (is (not (some #{sample-prompt} args))
           "prompt content must NOT appear in argv when :prompt-via :stdin")
       (is (some #{"--input-format"} args)
           "--input-format text flag must be present so claude reads stdin")


### PR DESCRIPTION
## Summary

The 2026-05-07 stage-3 dogfood failed at plan-phase with:

```
Cannot run program "claude" (in directory "..."): Exec failed,
error: 7 (Argument list too long)
```

Root cause: `claude-args` packed prompt + system-prompt + spec text + existing-files context all into argv. Once combined the argv exceeded POSIX `ARG_MAX`. Stage 2 dogfood squeaked by; Stage 3's incrementally larger context tipped over.

Fix is per-backend, not Claude-only. Each backend declares `:prompt-via :argv | :stdin`. Stdin-supporting backends omit prompt from argv and pipe it via the subprocess's stdin instead. CLI-only backends keep `:argv`.

## Changes

**Backend declarations:**
| backend | `:prompt-via` | rationale |
|---|---|---|
| `:claude`  | `:stdin` | overflow blocker; CLI supports `--input-format text` |
| `:codex`   | `:argv` | no overflow yet — flip when its envelope grows |
| `:cursor`  | `:argv` | unchanged |
| `:echo`    | `:argv` | unchanged |

**`claude-args`:**
- Reads `:prompt-via` from request (defaults `:argv` for back-compat)
- `:stdin` path drops trailing positional prompt + adds `--input-format text`
- `:argv` path unchanged

**Exec layer:**
- `default-exec-fn` and `stream-exec-fn` each gain a 2-arity that accepts `:stdin` (string). Missing/empty stdin maps to a zero-length stream (legacy behavior).
- 1-arity callers untouched. `mock-exec-fn` / `mock-exec-fn-multi` / test-side ad-hoc exec-fns gain matching 2-arities.

**Plumbing:**
- `complete-impl` + `handle-streaming` pull `:prompt-via` from backend-config, thread it into the args-fn invocation, and on `:stdin` pass `:stdin prompt` through to the exec layer.

## Known follow-up

`capsule-exec-fn` (governed-mode container path) does not yet forward stdin. The host path is the immediate dogfood blocker; capsule support lands separately when needed.

## Test plan

- [x] `bb test`: 5226 / 0 / 0 (was 5218 — 8 new)
  - `claude-args` `:argv` (default + explicit) shape locked
  - `claude-args` `:stdin` omits positional + adds `--input-format text`
  - backends declarations (claude→stdin, others→argv)
  - `default-exec-fn` pipes `:stdin` to subprocess (via `cat`)
  - `default-exec-fn` no-stdin → empty stdin (legacy)
  - `stream-exec-fn` pipes `:stdin` (via `cat`, line-by-line)
- [ ] Re-dogfood Stage 3 spec; verify plan phase no longer fails on argv overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)