### PR TITLE
refactor: exceptions-as-data cleanup of spec-parser

### DIFF
--- a/components/spec-parser/deps.edn
+++ b/components/spec-parser/deps.edn
@@ -1,5 +1,7 @@
 {:paths ["src" "resources"]
- :deps {metosin/malli {:mvn/version "0.16.4"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}    ; Canonical anomaly maps for exceptions-as-data
+        ai.miniforge/knowledge {:local/root "../knowledge"} ; YAML frontmatter parsing
+        metosin/malli {:mvn/version "0.16.4"}
         babashka/fs   {:mvn/version "0.5.22"}
         cheshire/cheshire {:mvn/version "5.13.0"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/spec-parser/src/ai/miniforge/spec_parser/core.clj
+++ b/components/spec-parser/src/ai/miniforge/spec_parser/core.clj
@@ -21,8 +21,15 @@
 
    Layer 0: File format detection
    Layer 1: Format-specific parsers (EDN, JSON, Markdown)
-   Layer 2: Spec normalization — canonical :spec/* only"
+   Layer 2: Spec normalization — canonical :spec/* only
+
+   Failure model: layer 0/1/2 fns return canonical anomaly maps
+   (`ai.miniforge.anomaly.interface/anomaly`) on caller-supplied input
+   problems. The single boundary fn `parse-spec-file` escalates anomalies
+   to `ex-info` so existing slingshot callers (CLI `run` command,
+   task-executor pre-flight) keep their exception-shaped contract."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.spec-parser.schema :as schema]
    [babashka.fs :as fs]
@@ -34,7 +41,10 @@
 ;; File format detection
 
 (defn detect-format
-  "Detect file format from extension."
+  "Detect file format from extension.
+
+   Returns the format keyword on success, or an `:invalid-input` anomaly
+   when the extension is not in the supported set."
   [path]
   (let [ext (fs/extension path)]
     (case ext
@@ -43,36 +53,52 @@
       "edn"  :edn
       "json" :json
       "md"   :markdown
-      (throw (ex-info (str "Unsupported file format: " ext)
-                      {:path path :extension ext})))))
+      (anomaly/anomaly :invalid-input
+                       (str "Unsupported file format: " ext)
+                       {:path path
+                        :extension ext
+                        :supported #{"yaml" "yml" "edn" "json" "md"}}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Format-specific parsers
 
 (defn parse-yaml
-  "Parse YAML file content."
+  "Parse YAML file content.
+
+   Returns an `:unsupported` anomaly — YAML support is not yet
+   implemented; callers should convert their spec to EDN, JSON, or
+   Markdown."
   [_content]
-  (throw (ex-info "YAML support coming soon - use EDN or JSON for now"
-                  {:format :yaml
-                   :workaround "Convert your YAML to EDN or JSON"})))
+  (anomaly/anomaly :unsupported
+                   "YAML support coming soon - use EDN or JSON for now"
+                   {:format :yaml
+                    :workaround "Convert your YAML to EDN or JSON"}))
 
 (defn parse-edn
-  "Parse EDN file content."
+  "Parse EDN file content.
+
+   Returns the parsed value on success, or an `:invalid-input` anomaly
+   when the content is malformed."
   [content]
   (try
     (edn/read-string content)
     (catch Exception e
-      (throw (ex-info "Failed to parse EDN file"
-                      {:error (ex-message e)} e)))))
+      (anomaly/anomaly :invalid-input
+                       "Failed to parse EDN file"
+                       {:error (ex-message e)}))))
 
 (defn parse-json
-  "Parse JSON file content."
+  "Parse JSON file content.
+
+   Returns the parsed value on success, or an `:invalid-input` anomaly
+   when the content is malformed."
   [content]
   (try
     (json/parse-string content true)
     (catch Exception e
-      (throw (ex-info "Failed to parse JSON file"
-                      {:error (ex-message e)} e)))))
+      (anomaly/anomaly :invalid-input
+                       "Failed to parse JSON file"
+                       {:error (ex-message e)}))))
 
 (def ^:private spec-key->ns
   "Map plain YAML keys to their :spec/* or :workflow/* namespace.
@@ -163,57 +189,102 @@
    :markdown parse-markdown})
 
 (defn parse-content
-  "Parse file content using the appropriate format parser."
+  "Parse file content using the appropriate format parser.
+
+   Returns the parser's result (which may itself be an anomaly when the
+   content is malformed), or a `:fault` anomaly when no parser is
+   registered for the requested format. The fault case is exhaustive —
+   `detect-format` only emits formats that have parsers — so reaching it
+   indicates a programmer error in the registry."
   [format content]
   (if-let [parser (get format-parsers format)]
     (parser content)
-    (throw (ex-info (str "No parser registered for format: " format)
-                    {:format format
-                     :available (keys format-parsers)}))))
+    (anomaly/anomaly :fault
+                     (str "No parser registered for format: " format)
+                     {:format format
+                      :available (keys format-parsers)})))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Spec normalization — canonical :spec/* only
 
+(defn- spec-shape-anomaly
+  "Return an `:invalid-input` anomaly when `spec` violates the minimum
+   shape required by `normalize-spec`, otherwise nil."
+  [spec]
+  (cond
+    (not (map? spec))
+    (anomaly/anomaly :invalid-input
+                     "Workflow spec must be a map"
+                     {:spec spec})
+
+    (not (:spec/title spec))
+    (anomaly/anomaly :invalid-input
+                     "Workflow spec must have :spec/title"
+                     {:spec spec})
+
+    (not (:spec/description spec))
+    (anomaly/anomaly :invalid-input
+                     "Workflow spec must have :spec/description"
+                     {:spec spec})))
+
+(defn- assemble-normalized-spec
+  "Build the normalized :spec/* payload. Caller is responsible for running
+   [[spec-shape-anomaly]] first; reaching this fn with a malformed spec is
+   a programmer error."
+  [spec]
+  (let [{:spec/keys [title description intent constraints tags
+                     acceptance-criteria code-artifact
+                     repo-url branch llm-backend sandbox plan-tasks]
+         :workflow/keys [type version]} spec]
+    (cond-> {:spec/title            title
+             :spec/description      description
+             :spec/intent           (or intent {:type :general})
+             :spec/constraints      (or constraints [])
+             :spec/tags             (or tags [])
+             :spec/workflow-type    (or (some-> type keyword) :canonical-sdlc)
+             :spec/workflow-version (or version "latest")
+             :spec/raw-data         spec}
+      acceptance-criteria (assoc :spec/acceptance-criteria acceptance-criteria)
+      code-artifact       (assoc :spec/code-artifact code-artifact)
+      repo-url            (assoc :spec/repo-url repo-url)
+      branch              (assoc :spec/branch branch)
+      llm-backend         (assoc :spec/llm-backend llm-backend)
+      (some? sandbox)     (assoc :spec/sandbox sandbox)
+      plan-tasks          (assoc :spec/plan-tasks plan-tasks))))
+
 (defn normalize-spec
   "Normalize parsed spec to canonical :spec/* workflow format.
 
-   Accepts canonical :spec/* input and applies defaults for missing optional fields.
-   Uses destructuring for clean extraction.
+   Accepts canonical :spec/* input and applies defaults for missing
+   optional fields. Returns the normalized payload on success, or an
+   `:invalid-input` anomaly when the input is not a map or is missing
+   :spec/title or :spec/description."
+  [spec]
+  (or (spec-shape-anomaly spec)
+      (assemble-normalized-spec spec)))
 
-   Output: normalized map with :spec/* namespace ready for workflow engine."
-  [{:spec/keys [title description intent constraints tags
-                acceptance-criteria code-artifact
-                repo-url branch llm-backend sandbox plan-tasks]
-    :workflow/keys [type version]
-    :as spec}]
-  (when-not (map? spec)
-    (throw (ex-info "Workflow spec must be a map"
-                    {:spec spec})))
+;------------------------------------------------------------------------------ Layer 3
+;; File loading + boundary escalation
 
-  (when-not title
-    (throw (ex-info "Workflow spec must have :spec/title"
-                    {:spec spec})))
+(defn- escalate!
+  "Boundary helper — translate a canonical anomaly into the legacy
+   ex-info shape so existing slingshot callers (CLI `run`, task-executor
+   pre-flight) keep their exception contract.
 
-  (when-not description
-    (throw (ex-info "Workflow spec must have :spec/description"
-                    {:spec spec})))
+   `parse-spec-file` is the single escalation point in this component;
+   layer 0/1/2 fns return anomalies."
+  [anom]
+  (throw (ex-info (:anomaly/message anom)
+                  (assoc (:anomaly/data anom)
+                         :anomaly/type (:anomaly/type anom)))))
 
-  ;; Build normalized payload with defaults
-  (cond-> {:spec/title            title
-           :spec/description      description
-           :spec/intent           (or intent {:type :general})
-           :spec/constraints      (or constraints [])
-           :spec/tags             (or tags [])
-           :spec/workflow-type    (or (some-> type keyword) :canonical-sdlc)
-           :spec/workflow-version (or version "latest")
-           :spec/raw-data         spec}
-    acceptance-criteria (assoc :spec/acceptance-criteria acceptance-criteria)
-    code-artifact       (assoc :spec/code-artifact code-artifact)
-    repo-url            (assoc :spec/repo-url repo-url)
-    branch              (assoc :spec/branch branch)
-    llm-backend         (assoc :spec/llm-backend llm-backend)
-    (some? sandbox)     (assoc :spec/sandbox sandbox)
-    plan-tasks          (assoc :spec/plan-tasks plan-tasks)))
+(defn- file-not-found-anomaly
+  "Return a `:not-found` anomaly when `path` does not resolve, otherwise nil."
+  [path]
+  (when-not (fs/exists? path)
+    (anomaly/anomaly :not-found
+                     (str "Spec file not found: " path)
+                     {:path path})))
 
 (defn parse-spec-file
   "Parse a workflow specification file and normalize to canonical format.
@@ -227,20 +298,28 @@
    Returns normalized spec map ready for workflow engine, decorated with:
    - :spec/provenance - Source file metadata
 
+   Boundary semantics: this is the public escalation point for the
+   component. Anomalies surfaced by `detect-format`, `parse-content`,
+   or `normalize-spec` are rethrown as ex-info so existing slingshot
+   callers (CLI `run`, task-executor pre-flight) keep their existing
+   exception-shaped contract.
+
    Throws ex-info on:
    - File not found
    - Unsupported format
    - Parse errors
    - Invalid spec schema"
   [path]
-  (when-not (fs/exists? path)
-    (throw (ex-info (str "Spec file not found: " path)
-                    {:path path})))
+  (when-let [anom (file-not-found-anomaly path)]
+    (escalate! anom))
 
-  (let [format     (detect-format path)
+  (let [format (detect-format path)
+        _      (when (anomaly/anomaly? format) (escalate! format))
         content    (slurp path)
         parsed     (parse-content format content)
-        normalized (normalize-spec parsed)]
+        _          (when (anomaly/anomaly? parsed) (escalate! parsed))
+        normalized (normalize-spec parsed)
+        _          (when (anomaly/anomaly? normalized) (escalate! normalized))]
 
     ;; Add provenance decoration
     (assoc normalized

--- a/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/detect_format_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/detect_format_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.spec-parser.anomaly.detect-format-test
+  "Coverage for `core/detect-format` (anomaly-returning) and its
+   boundary escalation through `parse-spec-file`.
+
+   `detect-format` classifies an extension to a parser keyword. An
+   unsupported extension is `:invalid-input` because the path is
+   caller-supplied. The boundary at `parse-spec-file` rethrows the
+   anomaly as ex-info so existing slingshot callers (CLI `run`,
+   task-executor pre-flight) keep their exception-shaped contract."
+  (:require [clojure.test :refer [deftest is testing]]
+            [babashka.fs :as fs]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.spec-parser.core :as core]))
+
+;------------------------------------------------------------------------------ Anomaly-returning happy path
+
+(deftest detect-format-known-extensions
+  (testing "supported extensions return their format keyword"
+    (is (= :edn      (core/detect-format "spec.edn")))
+    (is (= :json     (core/detect-format "spec.json")))
+    (is (= :markdown (core/detect-format "spec.md")))
+    (is (= :yaml     (core/detect-format "spec.yaml")))
+    (is (= :yaml     (core/detect-format "spec.yml")))))
+
+;------------------------------------------------------------------------------ Anomaly-returning failure path
+
+(deftest detect-format-unsupported-returns-anomaly
+  (testing "unknown extension yields :invalid-input anomaly"
+    (let [result (core/detect-format "spec.toml")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
+
+(deftest detect-format-anomaly-data-carries-triage-info
+  (testing "anomaly data carries path, extension, and supported set"
+    (let [result (core/detect-format "spec.toml")
+          data   (:anomaly/data result)]
+      (is (= "spec.toml" (:path data)))
+      (is (= "toml" (:extension data)))
+      (is (contains? (:supported data) "edn")))))
+
+;------------------------------------------------------------------------------ Boundary escalation
+;;
+;; `parse-spec-file` is the public escalation point. When given a path
+;; that exists on disk but has an unsupported extension, the
+;; `detect-format` anomaly is rethrown as ex-info carrying the
+;; `:anomaly/type` for downstream classification.
+
+(deftest parse-spec-file-escalates-unsupported-extension
+  (testing "unsupported extension surfaces as ex-info from parse-spec-file"
+    (let [tmp (fs/create-temp-file {:suffix ".toml"})]
+      (try
+        (spit (fs/file tmp) "title = \"x\"")
+        (let [thrown (try
+                       (core/parse-spec-file (str tmp))
+                       nil
+                       (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown) "expected ex-info to be thrown")
+          (is (= :invalid-input (:anomaly/type (ex-data thrown)))))
+        (finally
+          (fs/delete-if-exists tmp))))))

--- a/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/normalize_spec_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/normalize_spec_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.spec-parser.anomaly.normalize-spec-test
+  "Coverage for `core/normalize-spec` (anomaly-returning) and its
+   boundary escalation through `parse-spec-file`.
+
+   The three shape checks (must-be-map, must-have-:spec/title,
+   must-have-:spec/description) all classify as `:invalid-input` because
+   the spec is caller-supplied. The boundary at `parse-spec-file`
+   rethrows as ex-info."
+  (:require [clojure.test :refer [deftest is testing]]
+            [babashka.fs :as fs]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.spec-parser.core :as core]))
+
+;------------------------------------------------------------------------------ Anomaly-returning happy path
+
+(deftest normalize-spec-minimal-input
+  (testing "minimal valid input normalizes (not an anomaly)"
+    (let [result (core/normalize-spec {:spec/title "T" :spec/description "D"})]
+      (is (not (anomaly/anomaly? result)))
+      (is (= "T" (:spec/title result)))
+      (is (= "D" (:spec/description result))))))
+
+;------------------------------------------------------------------------------ Anomaly-returning failure paths
+
+(deftest normalize-spec-non-map-input
+  (testing "non-map input yields :invalid-input anomaly"
+    (let [result (core/normalize-spec "not a map")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "Workflow spec must be a map" (:anomaly/message result))))))
+
+(deftest normalize-spec-missing-title
+  (testing "map without :spec/title yields :invalid-input anomaly"
+    (let [result (core/normalize-spec {:spec/description "D"})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "Workflow spec must have :spec/title" (:anomaly/message result))))))
+
+(deftest normalize-spec-missing-description
+  (testing "map without :spec/description yields :invalid-input anomaly"
+    (let [result (core/normalize-spec {:spec/title "T"})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "Workflow spec must have :spec/description" (:anomaly/message result))))))
+
+;------------------------------------------------------------------------------ Boundary escalation
+
+(deftest parse-spec-file-escalates-missing-title
+  (testing "spec missing :spec/title surfaces as ex-info from parse-spec-file"
+    (let [tmp (fs/create-temp-file {:suffix ".edn"})]
+      (try
+        (spit (fs/file tmp) "{:spec/description \"only desc\"}")
+        (let [thrown (try
+                       (core/parse-spec-file (str tmp))
+                       nil
+                       (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown))
+          (is (= :invalid-input (:anomaly/type (ex-data thrown)))))
+        (finally
+          (fs/delete-if-exists tmp))))))

--- a/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_content_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_content_test.clj
@@ -1,0 +1,79 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.spec-parser.anomaly.parse-content-test
+  "Coverage for `core/parse-content` (anomaly-returning) and its
+   boundary escalation through `parse-spec-file`.
+
+   `parse-content` dispatches on a known format keyword. Reaching the
+   unknown-format branch is exhaustive — `detect-format` only emits
+   formats with parsers — so it is `:fault` (programmer error in the
+   registry), not `:invalid-input`. `parse-yaml` is a separate
+   `:unsupported` anomaly because YAML is reachable through the normal
+   detect-format path until YAML support lands."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.spec-parser.core :as core]))
+
+;------------------------------------------------------------------------------ Anomaly-returning happy path
+
+(deftest parse-content-known-format
+  (testing "known format dispatches to its parser"
+    (is (= {:a 1} (core/parse-content :edn "{:a 1}")))))
+
+;------------------------------------------------------------------------------ Anomaly-returning failure paths
+
+(deftest parse-content-unknown-format-returns-fault
+  (testing "unknown format yields :fault anomaly (registry-level programmer error)"
+    (let [result (core/parse-content :toml "[x]")]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (contains? (set (get-in result [:anomaly/data :available])) :edn)))))
+
+(deftest parse-content-yaml-returns-unsupported
+  (testing "YAML dispatches to parse-yaml which returns :unsupported anomaly"
+    (let [result (core/parse-content :yaml "title: T\n")]
+      (is (anomaly/anomaly? result))
+      (is (= :unsupported (:anomaly/type result))))))
+
+(deftest parse-content-malformed-edn-returns-anomaly
+  (testing "format-level dispatch surfaces parser anomalies (not wrapped)"
+    (let [result (core/parse-content :edn "{:a 1")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
+
+;------------------------------------------------------------------------------ Boundary escalation
+;;
+;; `parse-content`'s :fault branch is unreachable through `parse-spec-file`
+;; (every keyword `detect-format` emits has a registered parser), but
+;; `parse-yaml`'s :unsupported anomaly *is* reachable: a `.yaml` file
+;; on disk routes through detect-format → parse-content → parse-yaml.
+
+(deftest parse-spec-file-escalates-yaml-unsupported
+  (testing "yaml content surfaces as ex-info from parse-spec-file"
+    (let [tmp (babashka.fs/create-temp-file {:suffix ".yaml"})]
+      (try
+        (spit (babashka.fs/file tmp) "title: T\n")
+        (let [thrown (try
+                       (core/parse-spec-file (str tmp))
+                       nil
+                       (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown))
+          (is (= :unsupported (:anomaly/type (ex-data thrown)))))
+        (finally
+          (babashka.fs/delete-if-exists tmp))))))

--- a/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_content_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_content_test.clj
@@ -26,7 +26,8 @@
    registry), not `:invalid-input`. `parse-yaml` is a separate
    `:unsupported` anomaly because YAML is reachable through the normal
    detect-format path until YAML support lands."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [babashka.fs :as fs]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.spec-parser.core :as core]))
 
@@ -66,9 +67,9 @@
 
 (deftest parse-spec-file-escalates-yaml-unsupported
   (testing "yaml content surfaces as ex-info from parse-spec-file"
-    (let [tmp (babashka.fs/create-temp-file {:suffix ".yaml"})]
+    (let [tmp (fs/create-temp-file {:suffix ".yaml"})]
       (try
-        (spit (babashka.fs/file tmp) "title: T\n")
+        (spit (fs/file tmp) "title: T\n")
         (let [thrown (try
                        (core/parse-spec-file (str tmp))
                        nil
@@ -76,4 +77,4 @@
           (is (some? thrown))
           (is (= :unsupported (:anomaly/type (ex-data thrown)))))
         (finally
-          (babashka.fs/delete-if-exists tmp))))))
+          (fs/delete-if-exists tmp))))))

--- a/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_edn_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_edn_test.clj
@@ -1,0 +1,62 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.spec-parser.anomaly.parse-edn-test
+  "Coverage for `core/parse-edn` (anomaly-returning) and its boundary
+   escalation through `parse-spec-file`.
+
+   Malformed EDN is `:invalid-input` because the content is
+   caller-supplied. The boundary at `parse-spec-file` rethrows as
+   ex-info so existing slingshot callers keep their contract."
+  (:require [clojure.test :refer [deftest is testing]]
+            [babashka.fs :as fs]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.spec-parser.core :as core]))
+
+;------------------------------------------------------------------------------ Anomaly-returning happy path
+
+(deftest parse-edn-valid-content
+  (testing "valid EDN parses to data"
+    (is (= {:spec/title "T" :spec/description "D"}
+           (core/parse-edn "{:spec/title \"T\" :spec/description \"D\"}")))))
+
+;------------------------------------------------------------------------------ Anomaly-returning failure path
+
+(deftest parse-edn-malformed-returns-anomaly
+  (testing "unbalanced braces yield :invalid-input anomaly"
+    (let [result (core/parse-edn "{:a 1")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "Failed to parse EDN file" (:anomaly/message result)))
+      (is (string? (get-in result [:anomaly/data :error]))))))
+
+;------------------------------------------------------------------------------ Boundary escalation
+
+(deftest parse-spec-file-escalates-malformed-edn
+  (testing "malformed EDN surfaces as ex-info from parse-spec-file"
+    (let [tmp (fs/create-temp-file {:suffix ".edn"})]
+      (try
+        (spit (fs/file tmp) "{:spec/title \"unterminated")
+        (let [thrown (try
+                       (core/parse-spec-file (str tmp))
+                       nil
+                       (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown))
+          (is (= :invalid-input (:anomaly/type (ex-data thrown)))))
+        (finally
+          (fs/delete-if-exists tmp))))))

--- a/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_json_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_json_test.clj
@@ -1,0 +1,56 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.spec-parser.anomaly.parse-json-test
+  "Coverage for `core/parse-json` (anomaly-returning) and its boundary
+   escalation through `parse-spec-file`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [babashka.fs :as fs]
+            [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.spec-parser.core :as core]))
+
+;------------------------------------------------------------------------------ Anomaly-returning happy path
+
+(deftest parse-json-valid-content
+  (testing "valid JSON parses to keywordized map"
+    (is (= {:title "T"} (core/parse-json "{\"title\": \"T\"}")))))
+
+;------------------------------------------------------------------------------ Anomaly-returning failure path
+
+(deftest parse-json-malformed-returns-anomaly
+  (testing "malformed JSON yields :invalid-input anomaly"
+    (let [result (core/parse-json "{not json}")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "Failed to parse JSON file" (:anomaly/message result))))))
+
+;------------------------------------------------------------------------------ Boundary escalation
+
+(deftest parse-spec-file-escalates-malformed-json
+  (testing "malformed JSON surfaces as ex-info from parse-spec-file"
+    (let [tmp (fs/create-temp-file {:suffix ".json"})]
+      (try
+        (spit (fs/file tmp) "{not json}")
+        (let [thrown (try
+                       (core/parse-spec-file (str tmp))
+                       nil
+                       (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown))
+          (is (= :invalid-input (:anomaly/type (ex-data thrown)))))
+        (finally
+          (fs/delete-if-exists tmp))))))

--- a/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_spec_file_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_spec_file_test.clj
@@ -1,0 +1,69 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.spec-parser.anomaly.parse-spec-file-test
+  "Coverage for `core/parse-spec-file` (boundary fn) — file-not-found
+   path and the boundary escalation contract.
+
+   `parse-spec-file` is the public escalation point for the spec-parser
+   component. Layer 0/1/2 fns return anomalies; this fn rethrows them
+   as ex-info so existing slingshot callers (CLI `run`, task-executor
+   pre-flight) keep their exception-shaped contract.
+
+   File-not-found is `:not-found` (caller-supplied path that does not
+   resolve). All anomalies escalated by `parse-spec-file` carry the
+   original `:anomaly/type` in their ex-data for downstream
+   classification."
+  (:require [clojure.test :refer [deftest is testing]]
+            [babashka.fs :as fs]
+            [ai.miniforge.spec-parser.core :as core]))
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest parse-spec-file-valid-edn
+  (testing "valid EDN spec parses and normalizes"
+    (let [tmp (fs/create-temp-file {:suffix ".edn"})]
+      (try
+        (spit (fs/file tmp) "{:spec/title \"T\" :spec/description \"D\"}")
+        (let [result (core/parse-spec-file (str tmp))]
+          (is (= "T" (:spec/title result)))
+          (is (= "D" (:spec/description result)))
+          (is (= :edn (get-in result [:spec/provenance :source-format]))))
+        (finally
+          (fs/delete-if-exists tmp))))))
+
+;------------------------------------------------------------------------------ File-not-found anomaly + boundary escalation
+
+(deftest parse-spec-file-not-found-escalates
+  (testing "missing path surfaces as :not-found ex-info"
+    (let [thrown (try
+                   (core/parse-spec-file "/tmp/does-not-exist-spec-parser-test.edn")
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (= :not-found (:anomaly/type (ex-data thrown))))
+      (is (re-find #"Spec file not found" (ex-message thrown))))))
+
+(deftest parse-spec-file-ex-data-carries-anomaly-type
+  (testing "every escalated anomaly tags ex-data with :anomaly/type"
+    (let [thrown (try
+                   (core/parse-spec-file "/tmp/missing-1.edn")
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :not-found (:anomaly/type (ex-data thrown))))
+      (is (= "/tmp/missing-1.edn" (:path (ex-data thrown)))))))

--- a/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_spec_file_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/anomaly/parse_spec_file_test.clj
@@ -49,10 +49,19 @@
 
 ;------------------------------------------------------------------------------ File-not-found anomaly + boundary escalation
 
+(defn- nonexistent-path
+  "Generate a path under the system temp dir that is guaranteed not to
+   exist. Avoids `/tmp/...` hardcodes that can be flaky if the file
+   happens to be present on the test machine."
+  [suffix]
+  (str (fs/path (fs/temp-dir)
+                (str "spec-parser-anomaly-" (random-uuid) "-" suffix))))
+
 (deftest parse-spec-file-not-found-escalates
   (testing "missing path surfaces as :not-found ex-info"
-    (let [thrown (try
-                   (core/parse-spec-file "/tmp/does-not-exist-spec-parser-test.edn")
+    (let [path   (nonexistent-path "missing.edn")
+          thrown (try
+                   (core/parse-spec-file path)
                    nil
                    (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown))
@@ -61,9 +70,10 @@
 
 (deftest parse-spec-file-ex-data-carries-anomaly-type
   (testing "every escalated anomaly tags ex-data with :anomaly/type"
-    (let [thrown (try
-                   (core/parse-spec-file "/tmp/missing-1.edn")
+    (let [path   (nonexistent-path "ex-data.edn")
+          thrown (try
+                   (core/parse-spec-file path)
                    nil
                    (catch clojure.lang.ExceptionInfo e e))]
       (is (= :not-found (:anomaly/type (ex-data thrown))))
-      (is (= "/tmp/missing-1.edn" (:path (ex-data thrown)))))))
+      (is (= path (:path (ex-data thrown)))))))

--- a/components/spec-parser/test/ai/miniforge/spec_parser/interface_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/interface_test.clj
@@ -21,6 +21,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.spec-parser.interface :as spec-parser]
    [ai.miniforge.spec-parser.schema :as schema]
    [malli.core :as m]
@@ -174,17 +175,23 @@
 ;------------------------------------------------------------------------------ Layer 3: Validation Error Tests
 
 (deftest validation-errors-test
-  (testing "spec must be a map"
-    (is (thrown-with-msg? Exception #"must be a map"
-          (spec-parser/normalize-spec "not a map"))))
+  (testing "spec must be a map — returns :invalid-input anomaly"
+    (let [result (spec-parser/normalize-spec "not a map")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (str/includes? (:anomaly/message result) "must be a map"))))
 
-  (testing "spec must have :spec/title"
-    (is (thrown-with-msg? Exception #"must have :spec/title"
-          (spec-parser/normalize-spec {:spec/description "No title"}))))
+  (testing "spec must have :spec/title — returns :invalid-input anomaly"
+    (let [result (spec-parser/normalize-spec {:spec/description "No title"})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (str/includes? (:anomaly/message result) ":spec/title"))))
 
-  (testing "spec must have :spec/description"
-    (is (thrown-with-msg? Exception #"must have :spec/description"
-          (spec-parser/normalize-spec {:spec/title "No desc"})))))
+  (testing "spec must have :spec/description — returns :invalid-input anomaly"
+    (let [result (spec-parser/normalize-spec {:spec/title "No desc"})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (str/includes? (:anomaly/message result) ":spec/description")))))
 
 (deftest validate-spec-with-malli-test
   (testing "valid normalized spec passes Malli validation"

--- a/docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md
@@ -1,0 +1,94 @@
+# refactor: exceptions-as-data cleanup of spec-parser
+
+## Overview
+
+Migrates every throw site in `components/spec-parser/src/.../core.clj` (7 sites) to anomaly returns. Boundary escalation lives in `parse-spec-file` only — anomalies rethrown as `ex-info` with `:anomaly/type` tagged in `ex-data` so existing slingshot callers (CLI `run`, task-executor pre-flight) stay green.
+
+Mirrors the kill-the-deprecation pattern from PR #777. Single API per site.
+
+## Motivation
+
+Per `work/exception-cleanup-inventory.md`, `spec-parser` had 6 `:cleanup-needed` sites in `core.clj` plus 2 `:fatal-only` markers that got minimal cleanup pass-through (no new throw sites in anomaly-returning paths).
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary and constructor
+
+## Layer
+
+Refactor / per-component cleanup tier.
+
+## What This Adds / Changes
+
+`components/spec-parser/deps.edn`:
+
+- Adds `:local/root` deps on `ai.miniforge/anomaly` (and explicit `ai.miniforge/knowledge` since `core.clj` already required it but the dep was missing from the component's own deps.edn — pre-existing latent gap).
+
+`components/spec-parser/src/.../core.clj`:
+
+- Each thrower replaced with anomaly-returning logic.
+- Private helpers introduced: `escalate!`, `file-not-found-anomaly`, `spec-shape-anomaly`, `assemble-normalized-spec`.
+- `parse-spec-file` is the single boundary site that inlines `escalate!` to rethrow anomalies as `ex-info` with `:anomaly/type` tagged.
+
+`components/spec-parser/test/.../interface_test.clj`:
+
+- `validation-errors-test` updated to assert anomaly-returns (kill-the-deprecation: same interface name, new contract).
+
+`components/spec-parser/test/.../anomaly/` (new):
+
+- Six new decomposed test files, one per fn: `detect_format_test.clj`, `parse_edn_test.clj`, `parse_json_test.clj`, `normalize_spec_test.clj`, `parse_content_test.clj`, `parse_spec_file_test.clj`. Each covers happy path + failure path + boundary escalation through `parse-spec-file`.
+
+## Per-site classification
+
+| Site (line) | Fn | Anomaly type | Rationale |
+|------------:|----|--------------|-----------|
+| 46 | `detect-format` (unsupported ext) | `:invalid-input` | caller-supplied path |
+| 65 | `parse-edn` (malformed) | `:invalid-input` | caller-supplied content |
+| 74 | `parse-json` (malformed) | `:invalid-input` | caller-supplied content |
+| 190 | `normalize-spec` (non-map) | `:invalid-input` | caller-supplied shape |
+| 194 | `normalize-spec` (no `:spec/title`) | `:invalid-input` | caller-supplied shape |
+| 198 | `normalize-spec` (no `:spec/desc`) | `:invalid-input` | caller-supplied shape |
+| 237 | `parse-spec-file` (file-not-found) | `:not-found` | caller-supplied path |
+| 55 | `parse-yaml` (placeholder) | `:unsupported` | minimal cleanup |
+| 170 | `parse-content` (unknown format) | `:fault` | registry programmer error, exhaustive |
+
+## Strata Affected
+
+- `ai.miniforge.spec-parser.core` — every thrower migrated; private helpers added; `parse-spec-file` is the boundary.
+- `ai.miniforge.spec-parser.interface-test` — one assertion swap.
+
+## Testing Plan
+
+- `bb pre-commit` green: lint:clj clean, fmt:md clean, test **5129 tests / 23341 passes / 0 failures / 0 errors**, GraalVM compat clean.
+- One transient `bb_proc.core_test/test-run!-returns-result-on-zero-exit` flake on a non-final pre-commit run; cleared on the run that landed the commit. Unrelated to spec-parser.
+
+## Deployment Plan
+
+No migration. External slingshot callers continue to see the same `ex-info` shape via the `parse-spec-file` boundary; in-component anomaly returns are additive surface for new callers.
+
+## Notes
+
+- **`spec-parser/deps.edn` was implicitly relying on `ai.miniforge/knowledge`** via the polylith workspace — `core.clj` required it but the dep was missing from the component's own `deps.edn`. Added it explicitly. Pre-existing latent gap, not caused by this refactor.
+- **Commit budget**: tripped at 447 lines (ceiling 200). Override invoked per the precedent set by PRs #758 / #769 / #777 / #787 — cleanup is single-purpose with mandatory paired tests; slicing impl from tests violates the workstream's acceptance criteria.
+
+## Related Issues/PRs
+
+- Built on PR #777 (kill-the-deprecation precedent)
+- Built on PR #704 (foundation cleanup)
+- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
+- Companion to Wave 7 cleanup PRs — operator, agent component, task
+
+## Checklist
+
+- [x] All 6 `:cleanup-needed` spec-parser sites retired
+- [x] Single API per site (no deprecate-and-coexist)
+- [x] Boundary throw inlined in `parse-spec-file`
+- [x] External slingshot caller contracts preserved
+- [x] Decomposed test files (six)
+- [x] No new throws in anomaly-returning code paths
+- [x] `bb pre-commit` green
+- [x] Apache 2 license headers preserved

--- a/docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md
@@ -51,7 +51,7 @@ Refactor / per-component cleanup tier.
 | 74 | `parse-json` (malformed) | `:invalid-input` | caller-supplied content |
 | 190 | `normalize-spec` (non-map) | `:invalid-input` | caller-supplied shape |
 | 194 | `normalize-spec` (no `:spec/title`) | `:invalid-input` | caller-supplied shape |
-| 198 | `normalize-spec` (no `:spec/desc`) | `:invalid-input` | caller-supplied shape |
+| 198 | `normalize-spec` (no `:spec/description`) | `:invalid-input` | caller-supplied shape |
 | 237 | `parse-spec-file` (file-not-found) | `:not-found` | caller-supplied path |
 | 55 | `parse-yaml` (placeholder) | `:unsupported` | minimal cleanup |
 | 170 | `parse-content` (unknown format) | `:fault` | registry programmer error, exhaustive |


### PR DESCRIPTION
# refactor: exceptions-as-data cleanup of spec-parser

## Overview

Migrates every throw site in `components/spec-parser/src/.../core.clj` (7 sites) to anomaly returns. Boundary escalation lives in `parse-spec-file` only — anomalies rethrown as `ex-info` with `:anomaly/type` tagged in `ex-data` so existing slingshot callers (CLI `run`, task-executor pre-flight) stay green.

Mirrors the kill-the-deprecation pattern from PR #777. Single API per site.

## Motivation

Per `work/exception-cleanup-inventory.md`, `spec-parser` had 6 `:cleanup-needed` sites in `core.clj` plus 2 `:fatal-only` markers that got minimal cleanup pass-through (no new throw sites in anomaly-returning paths).

## Base Branch

`main`

## Depends On

- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary and constructor

## Layer

Refactor / per-component cleanup tier.

## What This Adds / Changes

`components/spec-parser/deps.edn`:

- Adds `:local/root` deps on `ai.miniforge/anomaly` (and explicit `ai.miniforge/knowledge` since `core.clj` already required it but the dep was missing from the component's own deps.edn — pre-existing latent gap).

`components/spec-parser/src/.../core.clj`:

- Each thrower replaced with anomaly-returning logic.
- Private helpers introduced: `escalate!`, `file-not-found-anomaly`, `spec-shape-anomaly`, `assemble-normalized-spec`.
- `parse-spec-file` is the single boundary site that inlines `escalate!` to rethrow anomalies as `ex-info` with `:anomaly/type` tagged.

`components/spec-parser/test/.../interface_test.clj`:

- `validation-errors-test` updated to assert anomaly-returns (kill-the-deprecation: same interface name, new contract).

`components/spec-parser/test/.../anomaly/` (new):

- Six new decomposed test files, one per fn: `detect_format_test.clj`, `parse_edn_test.clj`, `parse_json_test.clj`, `normalize_spec_test.clj`, `parse_content_test.clj`, `parse_spec_file_test.clj`. Each covers happy path + failure path + boundary escalation through `parse-spec-file`.

## Per-site classification

| Site (line) | Fn | Anomaly type | Rationale |
|------------:|----|--------------|-----------|
| 46 | `detect-format` (unsupported ext) | `:invalid-input` | caller-supplied path |
| 65 | `parse-edn` (malformed) | `:invalid-input` | caller-supplied content |
| 74 | `parse-json` (malformed) | `:invalid-input` | caller-supplied content |
| 190 | `normalize-spec` (non-map) | `:invalid-input` | caller-supplied shape |
| 194 | `normalize-spec` (no `:spec/title`) | `:invalid-input` | caller-supplied shape |
| 198 | `normalize-spec` (no `:spec/desc`) | `:invalid-input` | caller-supplied shape |
| 237 | `parse-spec-file` (file-not-found) | `:not-found` | caller-supplied path |
| 55 | `parse-yaml` (placeholder) | `:unsupported` | minimal cleanup |
| 170 | `parse-content` (unknown format) | `:fault` | registry programmer error, exhaustive |

## Strata Affected

- `ai.miniforge.spec-parser.core` — every thrower migrated; private helpers added; `parse-spec-file` is the boundary.
- `ai.miniforge.spec-parser.interface-test` — one assertion swap.

## Testing Plan

- `bb pre-commit` green: lint:clj clean, fmt:md clean, test **5129 tests / 23341 passes / 0 failures / 0 errors**, GraalVM compat clean.
- One transient `bb_proc.core_test/test-run!-returns-result-on-zero-exit` flake on a non-final pre-commit run; cleared on the run that landed the commit. Unrelated to spec-parser.

## Deployment Plan

No migration. External slingshot callers continue to see the same `ex-info` shape via the `parse-spec-file` boundary; in-component anomaly returns are additive surface for new callers.

## Notes

- **`spec-parser/deps.edn` was implicitly relying on `ai.miniforge/knowledge`** via the polylith workspace — `core.clj` required it but the dep was missing from the component's own `deps.edn`. Added it explicitly. Pre-existing latent gap, not caused by this refactor.
- **Commit budget**: tripped at 447 lines (ceiling 200). Override invoked per the precedent set by PRs #758 / #769 / #777 / #787 — cleanup is single-purpose with mandatory paired tests; slicing impl from tests violates the workstream's acceptance criteria.

## Related Issues/PRs

- Built on PR #777 (kill-the-deprecation precedent)
- Built on PR #704 (foundation cleanup)
- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
- Companion to Wave 7 cleanup PRs — operator, agent component, task

## Checklist

- [x] All 6 `:cleanup-needed` spec-parser sites retired
- [x] Single API per site (no deprecate-and-coexist)
- [x] Boundary throw inlined in `parse-spec-file`
- [x] External slingshot caller contracts preserved
- [x] Decomposed test files (six)
- [x] No new throws in anomaly-returning code paths
- [x] `bb pre-commit` green
- [x] Apache 2 license headers preserved
