### PR TITLE
fix(polylith): restore workspace verification gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Run Polylith workspace check
         run: |
+          set -o pipefail
           echo "::group::Polylith Structure"
           bb poly:check 2>&1 | tee poly-check.log
           echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,53 @@ permissions:
   contents: read
 
 jobs:
+  structure:
+    name: Structure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install Clojure
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: clojure-${{ runner.os }}-${{ hashFiles('deps.edn', '**/deps.edn') }}
+          restore-keys: |
+            clojure-${{ runner.os }}-
+
+      - name: Run Polylith workspace check
+        run: |
+          echo "::group::Polylith Structure"
+          bb poly:check 2>&1 | tee poly-check.log
+          echo "::endgroup::"
+
+      - name: Upload structure logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: structure-logs-${{ github.sha }}
+          path: poly-check.log
+          retention-days: 7
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: [structure]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -74,6 +118,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [structure]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/bases/etl/deps.edn
+++ b/bases/etl/deps.edn
@@ -1,5 +1,4 @@
 {:paths ["src" "resources"]
  :deps {cheshire/cheshire     {:mvn/version "5.13.0"}
-        org.babashka/cli      {:mvn/version "0.8.60"}
-        ai.miniforge/messages {:local/root "../../components/messages"}}
+        org.babashka/cli      {:mvn/version "0.8.60"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/bb.edn
+++ b/bb.edn
@@ -78,6 +78,16 @@
            (when-not (zero? exit)
              (System/exit exit)))}
 
+  poly:check
+  {:doc  "Run Polylith workspace structure checks"
+   :task (do
+           (println "🏗️  Running Polylith workspace check...")
+           (println "Command: clojure -M:poly check")
+           (let [exit (run-clojure-stream! "-M:poly" "check")]
+             (when-not (zero? exit)
+               (println "❌ Polylith workspace check failed with exit code:" exit)
+               (System/exit exit))))}
+
   test:poly
   {:doc  "Run unit (brick) tests via Polylith (full, serial)"
    :task (do
@@ -121,8 +131,8 @@
   ;; ──────────────────────────────────────────────────────────────────────────
 
   pre-commit
-  {:doc     "Run all pre-commit checks (commit budget first, then lint, format, test, graalvm)"
-   :depends [commit-budget lint:clj fmt:md test test:graalvm]
+  {:doc     "Run all pre-commit checks (commit budget, structure, lint, format, test, graalvm)"
+   :depends [commit-budget poly:check lint:clj fmt:md test test:graalvm]
    :task    (println "\n✅ ALL PRE-COMMIT CHECKS PASSED\n")}
 
   ;; ──────────────────────────────────────────────────────────────────────────

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/impl.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/impl.clj
@@ -1,0 +1,132 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.adapter-claude-code.impl
+  "Implementation for the Claude Code control-plane adapter."
+  (:require
+   [ai.miniforge.adapter-claude-code.discovery :as discovery]
+   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.control-plane.interface :as control-plane]
+   [ai.miniforge.control-plane-adapter.interface :as proto]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Internal helpers
+
+(def ^:const default-decisions-dir
+  "Default directory where decisions are dropped for Claude Code agents."
+  (str (config/miniforge-home) "/decisions"))
+
+(defn- adapter-decisions-dir
+  [{:keys [decisions-dir]}]
+  (or decisions-dir
+      default-decisions-dir))
+
+(defn- ensure-decisions-dir!
+  [config agent-id]
+  (let [dir (io/file (adapter-decisions-dir config) (str agent-id))]
+    (.mkdirs dir)
+    dir))
+
+(defn- pid-alive?
+  [pid]
+  (try
+    (let [proc (.start (ProcessBuilder. ["kill" "-0" (str pid)]))]
+      (.waitFor proc)
+      (zero? (.exitValue proc)))
+    (catch Exception _
+      false)))
+
+(defn- session-file-active-within-ms?
+  [session-file threshold-ms]
+  (and session-file
+       (.exists (io/file session-file))
+       (< (- (System/currentTimeMillis)
+             (.lastModified (io/file session-file)))
+          threshold-ms)))
+
+(defn- poll-status
+  [agent-record]
+  (let [pid (get-in agent-record [:agent/metadata :pid])
+        session-file (get-in agent-record [:agent/metadata :session-file])]
+    (cond
+      (and pid (pid-alive? pid))
+      {:status (if (session-file-active-within-ms? session-file (* 60 1000))
+                 :running
+                 :idle)}
+
+      (session-file-active-within-ms? session-file (* 5 60 1000))
+      {:status :running}
+
+      :else
+      nil)))
+
+(defn- deliver-decision!
+  [config agent-record decision-resolution]
+  (try
+    (let [agent-id (:agent/id agent-record)
+          decision-id (:decision/id decision-resolution)
+          dir (ensure-decisions-dir! config agent-id)
+          file (io/file dir (str decision-id ".edn"))]
+      (spit file (pr-str decision-resolution))
+      {:delivered? true})
+    (catch Exception e
+      {:delivered? false :error (ex-message e)})))
+
+(defn- send-signal!
+  [agent-record command]
+  (let [pid (get-in agent-record [:agent/metadata :pid])
+        signal-map {:pause "-TSTP" :resume "-CONT" :terminate "-TERM"}]
+    (if pid
+      (if-let [signal (get signal-map command)]
+        (try
+          (.start (ProcessBuilder. ["kill" signal (str pid)]))
+          {:success? true}
+          (catch Exception e
+            {:success? false :error (ex-message e)}))
+        {:success? false
+         :error (control-plane/t :adapter/unknown-command {:command command})})
+      {:success? false
+       :error (control-plane/t :adapter/no-pid)})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Protocol implementation
+
+(defrecord ClaudeCodeAdapter [config]
+  proto/ControlPlaneAdapter
+
+  (adapter-id [_] :claude-code)
+
+  (discover-agents [_ adapter-config]
+    (discovery/discover-sessions adapter-config))
+
+  (poll-agent-status [_ agent-record]
+    (poll-status agent-record))
+
+  (deliver-decision [_ agent-record decision-resolution]
+    (deliver-decision! config agent-record decision-resolution))
+
+  (send-command [_ agent-record command]
+    (send-signal! agent-record command)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Factory
+
+(defn create-adapter
+  [config]
+  (->ClaudeCodeAdapter config))

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/interface.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/interface.clj
@@ -22,95 +22,9 @@
    Discovers local Claude Code sessions, polls their status,
    and delivers decisions via file-drop mechanism.
 
-   Layer 0: Adapter creation
-   Layer 1: Protocol implementation"
+   Layer 0: Adapter creation"
   (:require
-   [ai.miniforge.adapter-claude-code.discovery :as discovery]
-   [ai.miniforge.config.interface :as config]
-   [ai.miniforge.control-plane.interface :as control-plane]
-   [ai.miniforge.control-plane-adapter.interface :as proto]
-   [clojure.java.io :as io]))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Decision file-drop directory
-
-(def ^:const decisions-dir
-  "Directory where decisions are dropped for Claude Code agents."
-  (str (config/miniforge-home) "/decisions"))
-
-(defn- adapter-decisions-dir
-  [{:keys [decisions-dir]}]
-  (or decisions-dir
-      (str (config/miniforge-home) "/decisions")))
-
-(defn- ensure-decisions-dir!
-  [config agent-id]
-  (let [dir (io/file (adapter-decisions-dir config) (str agent-id))]
-    (.mkdirs dir)
-    dir))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Protocol implementation
-
-(defrecord ClaudeCodeAdapter [config]
-  proto/ControlPlaneAdapter
-
-  (adapter-id [_] :claude-code)
-
-  (discover-agents [_ config]
-    (discovery/discover-sessions config))
-
-  (poll-agent-status [_ agent-record]
-    (let [pid (get-in agent-record [:agent/metadata :pid])
-          session-file (get-in agent-record [:agent/metadata :session-file])]
-      (cond
-        ;; Check PID first — most reliable
-        (and pid (try
-                   (let [proc (.start (ProcessBuilder. ["kill" "-0" (str pid)]))]
-                     (.waitFor proc)
-                     (zero? (.exitValue proc)))
-                   (catch Exception _ false)))
-        (let [recent? (and session-file
-                           (.exists (io/file session-file))
-                           (< (- (System/currentTimeMillis)
-                                  (.lastModified (io/file session-file)))
-                              (* 60 1000)))]
-          {:status (if recent? :running :idle)})
-
-        ;; No PID or process dead — check log recency
-        (and session-file
-             (.exists (io/file session-file))
-             (< (- (System/currentTimeMillis)
-                    (.lastModified (io/file session-file)))
-                (* 5 60 1000)))
-        {:status :running}
-
-        ;; Agent is gone
-        :else nil)))
-
-  (deliver-decision [_ agent-record decision-resolution]
-    (try
-      (let [agent-id (:agent/id agent-record)
-            decision-id (:decision/id decision-resolution)
-            dir (ensure-decisions-dir! config agent-id)
-            file (io/file dir (str decision-id ".edn"))]
-        (spit file (pr-str decision-resolution))
-        {:delivered? true})
-      (catch Exception e
-        {:delivered? false :error (ex-message e)})))
-
-  (send-command [_ agent-record command]
-    (let [pid (get-in agent-record [:agent/metadata :pid])
-          signal-map {:pause "-TSTP" :resume "-CONT" :terminate "-TERM"}]
-      (if pid
-        (if-let [signal (get signal-map command)]
-          (try
-            (.start (ProcessBuilder. ["kill" signal (str pid)]))
-            {:success? true}
-            (catch Exception e
-              {:success? false :error (ex-message e)}))
-          {:success? false :error (control-plane/t :adapter/unknown-command {:command command})})
-        {:success? false :error (control-plane/t :adapter/no-pid)}))))
+   [ai.miniforge.adapter-claude-code.impl :as impl]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Factory
@@ -124,11 +38,9 @@
    Example:
      (def adapter (create-adapter))"
   [& [config]]
-  (->ClaudeCodeAdapter (or config {})))
+  (impl/create-adapter (or config {})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (def adapter (create-adapter))
-  (proto/adapter-id adapter)
-  (proto/discover-agents adapter {})
   :end)

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/interface.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/interface.clj
@@ -38,8 +38,14 @@
   "Directory where decisions are dropped for Claude Code agents."
   (str (config/miniforge-home) "/decisions"))
 
-(defn- ensure-decisions-dir! [agent-id]
-  (let [dir (io/file decisions-dir (str agent-id))]
+(defn- adapter-decisions-dir
+  [{:keys [decisions-dir]}]
+  (or decisions-dir
+      (str (config/miniforge-home) "/decisions")))
+
+(defn- ensure-decisions-dir!
+  [config agent-id]
+  (let [dir (io/file (adapter-decisions-dir config) (str agent-id))]
     (.mkdirs dir)
     dir))
 
@@ -86,7 +92,7 @@
     (try
       (let [agent-id (:agent/id agent-record)
             decision-id (:decision/id decision-resolution)
-            dir (ensure-decisions-dir! agent-id)
+            dir (ensure-decisions-dir! config agent-id)
             file (io/file dir (str decision-id ".edn"))]
         (spit file (pr-str decision-resolution))
         {:delivered? true})

--- a/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/interface_test.clj
+++ b/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/interface_test.clj
@@ -151,22 +151,20 @@
 
 (deftest deliver-decision-writes-edn-file-test
   (testing "Decision is written as <decision-id>.edn under decisions-dir/<agent-id>/"
-    (let [adapter (sut/create-adapter)
+    (let [base (make-temp-dir)
+          adapter (sut/create-adapter {:decisions-dir (.getAbsolutePath base)})
           aid (random-uuid)
           did (random-uuid)
           rec (agent-record :agent/id aid)
           resolution {:decision/id did
                       :decision/resolution "approved"
                       :decision/comment    "looks good"}
-          ret (proto/deliver-decision adapter rec resolution)]
+          ret (proto/deliver-decision adapter rec resolution)
+          expected (io/file base (str aid) (str did ".edn"))]
       (is (true? (:delivered? ret)))
-      ;; File was written under the configured decisions-dir
-      (let [expected (io/file sut/decisions-dir (str aid) (str did ".edn"))]
-        (is (.exists expected))
-        (let [round-trip (read-string (slurp expected))]
-          (is (= resolution round-trip)))
-        ;; Cleanup so the temp file doesn't accumulate.
-        (.delete expected)))))
+      (is (.exists expected))
+      (let [round-trip (read-string (slurp expected))]
+        (is (= resolution round-trip))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; send-command

--- a/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/interface_test.clj
+++ b/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/interface_test.clj
@@ -74,9 +74,9 @@
 ;; create-adapter / adapter-id
 
 (deftest create-adapter-returns-record-test
-  (testing "create-adapter returns a ClaudeCodeAdapter record"
+  (testing "create-adapter returns a control-plane adapter"
     (let [a (sut/create-adapter)]
-      (is (instance? ai.miniforge.adapter_claude_code.interface.ClaudeCodeAdapter a))
+      (is (satisfies? proto/ControlPlaneAdapter a))
       (is (= :claude-code (proto/adapter-id a))))))
 
 (deftest create-adapter-stores-config-test

--- a/components/agent/src/ai/miniforge/agent/interface/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/specialized.clj
@@ -26,7 +26,7 @@
    [ai.miniforge.agent.reviewer :as reviewer]
    [ai.miniforge.agent.tester :as tester]
    [ai.miniforge.agent.protocols.records.specialized :as specialized-records]
-   [ai.miniforge.progress-detector.detectors.repair-loop :as repair-loop]))
+   [ai.miniforge.progress-detector.interface :as progress-detector]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Specialized agent support
@@ -93,7 +93,7 @@
 ;; components/progress-detector/.../detectors/repair-loop in Stage 2.
 ;; These re-exports stay for backward compatibility; phase-software-factory
 ;; reads them through this interface.
-(def review-fingerprint repair-loop/review-fingerprint)
-(def review-stagnated?  repair-loop/stagnated?)
+(def review-fingerprint progress-detector/review-fingerprint)
+(def review-stagnated?  progress-detector/stagnated?)
 (def release-summary releaser/release-summary)
 (def validate-release-artifact releaser/validate-release-artifact)

--- a/components/bb-dev-tools/src/ai/miniforge/bb_dev_tools/adapters/cloverage.clj
+++ b/components/bb-dev-tools/src/ai/miniforge/bb_dev_tools/adapters/cloverage.clj
@@ -20,7 +20,7 @@
   "Adapter for Cloverage-backed JVM coverage tasks."
   (:require
    [ai.miniforge.bb-dev-tools.adapter-registry :as registry]
-   [ai.miniforge.bb-test-runner.core :as bb-test-runner]
+   [ai.miniforge.bb-test-runner.interface :as bb-test-runner]
    [babashka.fs :as fs]))
 
 (defn- repo-cwd

--- a/components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj
+++ b/components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj
@@ -20,15 +20,25 @@
   "Unit tests for bb-proc. Exercises only on commands guaranteed to
    exist on any POSIX host (`true`, `false`, `echo`). No network, no
    filesystem writes, no sleeps beyond the tight `destroy!` deadline."
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [babashka.fs :as fs]
+            [clojure.test :refer [deftest testing is]]
             [clojure.string :as str]
             [ai.miniforge.bb-proc.core :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Factories
 
-(def ^:private ok-cmd   "true")
-(def ^:private fail-cmd "false")
+(defn- required-command
+  "Resolve a required POSIX command to an absolute path for deterministic tests."
+  [cmd]
+  (or (some-> (fs/which cmd) str)
+      cmd))
+
+(def ^:private ok-cmd
+  (required-command "true"))
+
+(def ^:private fail-cmd
+  (required-command "false"))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Unit tests

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
@@ -62,6 +62,16 @@
   [deps-config opts]
   (core/coverage-args deps-config opts))
 
+(defn load-deps-config
+  "Load the repo deps.edn config needed for coverage planning."
+  [repo-root]
+  (core/load-deps-config repo-root))
+
+(defn coverage-install-args
+  "Pure helper: build the argv needed to prefetch the coverage tool."
+  []
+  (core/coverage-install-args))
+
 (defn install-coverage-tool
   "Prefetch the Cloverage dependency into the repo's local Clojure cache.
    Accepts `{:repo-root \".\"}` and returns the process exit code."

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -62,27 +62,23 @@
 ;; event-file-path
 
 (deftest event-file-path-test
-  (testing "returns a File path ending in .json"
-    (let [wf-id (random-uuid)
-          path (sinks/event-file-path wf-id)]
-      (is (instance? java.io.File path))
-      (is (str/ends-with? (.getName path) ".json"))
-      (is (str/includes? (.getPath path) (str wf-id)))))
-
-  (testing "creates the workflow subdirectory"
-    (let [wf-id (random-uuid)
-          path (sinks/event-file-path wf-id)
-          parent (.getParentFile path)]
-      (is (.isDirectory parent))
-      (is (str/ends-with? (.getName parent) (str wf-id)))))
-
-  (testing "accepts an explicit base-dir"
+  (testing "returns a File path ending in .json under an explicit base-dir"
     (with-temp-dir
       (fn [dir]
         (let [wf-id (random-uuid)
               path (sinks/event-file-path dir wf-id)]
+          (is (instance? java.io.File path))
           (is (str/includes? (.getPath path) (.getPath dir)))
-          (is (str/ends-with? (.getName path) ".json")))))))
+          (is (str/ends-with? (.getName path) ".json"))))))
+
+  (testing "creates the workflow subdirectory under an explicit base-dir"
+    (with-temp-dir
+      (fn [dir]
+        (let [wf-id (random-uuid)
+              path (sinks/event-file-path dir wf-id)
+              parent (.getParentFile path)]
+          (is (.isDirectory parent))
+          (is (str/ends-with? (.getName parent) (str wf-id))))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; file-sink

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -451,7 +451,8 @@
           handler (impl/stream-with-parser
                    #'impl/parse-claude-stream-line
                    (fn [chunk] (swap! chunks conj chunk))
-                   monitor content usage cost tools session-id stop-reason turns)]
+                   monitor
+                   content usage cost tools session-id stop-reason turns)]
       (handler (json/generate-string
                 {:type "result"
                  :result "{\"ok\":true}"

--- a/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
@@ -59,6 +59,7 @@
      :inherit / :disable / :enable / :tune"
   (:require
    [ai.miniforge.anomaly.interface                    :as anomaly]
+   [ai.miniforge.progress-detector.detectors.repair-loop :as repair-loop]
    [ai.miniforge.progress-detector.event-envelope     :as envelope]
    [ai.miniforge.progress-detector.protocol           :as proto]
    [ai.miniforge.progress-detector.schema             :as schema]
@@ -313,6 +314,14 @@
   [state]
   (anomalies-by-severity state :fatal))
 
+(def review-fingerprint
+  "Stable fingerprint of the actionable content of a review artifact."
+  repair-loop/review-fingerprint)
+
+(def stagnated?
+  "True when the current review fingerprint has made no actionable progress."
+  repair-loop/stagnated?)
+
 ;------------------------------------------------------------------------------ Rich Comment
 
 (comment
@@ -321,7 +330,6 @@
         cfg  (resolve-config [{:config/params {:window-size 5}}
                               {:config/directive :tune
                                :config/params {:window-size 10}}])
-        st0  (init det (effective-config-params cfg))
         obs1 (make-observation :tool/Read 1 (java.time.Instant/now)
                                {:tool/duration-ms 120})
         stf  (reduce-observations det (effective-config-params cfg) [obs1])]

--- a/components/progress-detector/test/ai/miniforge/progress_detector/interface_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/interface_test.clj
@@ -30,6 +30,14 @@
   (anomaly/anomaly :fault "test failure" (apply detector-anomaly-data
                                                 (mapcat identity opts))))
 
+(defn- review-issue
+  "Build a reviewer issue entry."
+  [description]
+  {:severity :blocking
+   :file "src/example/core.clj"
+   :line 42
+   :description description})
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Detector lifecycle (init / observe / reduce-observations)
 
@@ -202,3 +210,11 @@
       (is (= 1 (count (pd/anomalies-by-severity state :fatal))))
       (is (= [{:anomaly/data {:anomaly/severity :fatal :x 4}}]
              (pd/fatal-anomalies state))))))
+
+(deftest repair-loop-reexports-test
+  (testing "review-fingerprint and stagnated? are available through the public interface"
+    (let [review {:review/issues [(review-issue "add guard clause")]}
+          fingerprint (pd/review-fingerprint review)]
+      (is (seq fingerprint))
+      (is (true? (pd/stagnated? fingerprint fingerprint)))
+      (is (false? (pd/stagnated? nil fingerprint))))))

--- a/components/response-chain/src/ai/miniforge/response_chain/contract.clj
+++ b/components/response-chain/src/ai/miniforge/response_chain/contract.clj
@@ -25,10 +25,10 @@
    was returned. The `Chain` is the accumulating envelope.
 
    Schemas are exposed so consumers can validate at their own
-   boundaries. The component itself only validates input where doing so
-   prevents corruption of the chain invariant."
+  boundaries. The component itself only validates input where doing so
+  prevents corruption of the chain invariant."
   (:require
-   [ai.miniforge.anomaly.contract :as anomaly-contract]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [malli.core :as m]
    [malli.error :as me]))
 
@@ -55,7 +55,7 @@
   [:map {:closed true}
    [:operation  :keyword]
    [:succeeded? :boolean]
-   [:anomaly    [:maybe anomaly-contract/Anomaly]]
+   [:anomaly    [:maybe anomaly/Anomaly]]
    [:response   :any]
    [:request    {:optional true} :any]])
 

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -326,6 +326,8 @@ $ git commit -m "feat: add new feature"
 **Guidelines:**
 
 - Pre-commit hooks are not suggestions
+- Structural workspace checks are part of pre-commit and CI: `bb poly:check`
+- `poly check` failures are blocking architecture regressions, not optional warnings
 - If check is broken, fix the check, don't disable it
 - "Just this once" becomes "just every time"
 - CI time is expensive - catch issues locally

--- a/docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md
+++ b/docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md
@@ -1,0 +1,64 @@
+# fix(polylith): restore workspace structure gate
+
+## Summary
+
+This PR restores Polylith workspace cleanliness as a blocking check instead of a best-effort convention, then fixes the
+fresh-`main` verification issues that the restored gate exposed.
+
+The result is that `poly check`, changed-bricks testing, and full `bb pre-commit` all run green again on a clean
+branch.
+
+## Problem
+
+`poly check` was not in the blocking path.
+
+That allowed:
+
+- internal component dependencies to drift past public interfaces
+- project dependency declarations to fall out of sync with actual usage
+- invalid workspace wiring to land without failing pre-commit or CI
+
+The repo was no longer structurally clean even though normal lint/test paths still passed.
+
+## Structural Changes
+
+- fixed illegal internal deps by routing through public interfaces
+- restored missing project deps for `data-foundry`, `miniforge`, `miniforge-core`, and `miniforge-tui`
+- removed the invalid `bases/etl` component dependency
+- re-exported the needed `bb-test-runner` and `progress-detector` interface functions
+- added `bb poly:check`
+- added `poly:check` to `bb pre-commit`
+- added a blocking CI `structure` job that runs `bb poly:check`
+- added regression coverage for the new `progress-detector` public interface surface
+- documented the structure gate in development guidance
+
+## Verification Path Stabilization
+
+Restoring the structure gate surfaced a second class of fresh-`main` issues in the real changed-bricks path.
+
+This PR also fixes those so the blocking verification path is deterministic again:
+
+- made Claude adapter decision delivery honor an adapter-provided `:decisions-dir`
+- updated the Claude adapter decision-delivery test to use a temp decisions root
+- removed the event-stream sink test's dependency on the ambient default events home
+- resolved `true` / `false` to absolute paths in `bb-proc` tests
+- updated the `llm` stream parser test to use the current progress-monitor-aware arity
+- removed the stale unused binding from the touched `progress-detector` interface file
+- updated `scripts/test-changed-bricks.bb` so native-store bricks can run in isolated JVMs instead of the aggregate
+  runner
+
+## Validation
+
+- `bb poly:check`
+- focused interface regressions for:
+  - `ai.miniforge.progress-detector.interface-test`
+  - `ai.miniforge.bb-dev-tools.core-test`
+  - `ai.miniforge.response-chain.interface.malli-validation-test`
+- focused fresh-`main` verification regressions for:
+  - `ai.miniforge.adapter-claude-code.interface-test`
+  - `ai.miniforge.event-stream.sinks-test`
+  - `ai.miniforge.bb-proc.core-test`
+  - `ai.miniforge.llm.interface-test`
+  - `ai.miniforge.pipeline-pack-store.interface-test`
+- escalated `bb scripts/test-changed-bricks.bb`
+- escalated `bb pre-commit`

--- a/projects/data-foundry/deps.edn
+++ b/projects/data-foundry/deps.edn
@@ -26,12 +26,16 @@
         ai.miniforge/connector-jira            {:local/root "../../components/connector-jira"}
         ai.miniforge/connector-pipeline-output {:local/root "../../components/connector-pipeline-output"}
         ai.miniforge/connector-sarif           {:local/root "../../components/connector-sarif"}
+        ai.miniforge/anomaly                   {:local/root "../../components/anomaly"}
+        ai.miniforge/coerce                    {:local/root "../../components/coerce"}
         ai.miniforge/config                    {:local/root "../../components/config"}
         ai.miniforge/dag-executor              {:local/root "../../components/dag-executor"}
         ai.miniforge/dag-primitives            {:local/root "../../components/dag-primitives"}
         ai.miniforge/data-quality              {:local/root "../../components/data-quality"}
+        ai.miniforge/event-stream              {:local/root "../../components/event-stream"}
         ai.miniforge/logging                   {:local/root "../../components/logging"}
         ai.miniforge/messages                  {:local/root "../../components/messages"}
+        ai.miniforge/phase                     {:local/root "../../components/phase"}
         ai.miniforge/response                  {:local/root "../../components/response"}
         ai.miniforge/schema                    {:local/root "../../components/schema"}}
 

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -57,6 +57,8 @@ ai.miniforge/messages {:local/root "../../components/messages"}
         ai.miniforge/control-plane-adapter {:local/root "../../components/control-plane-adapter"}
         ai.miniforge/dag-primitives {:local/root "../../components/dag-primitives"}
         ai.miniforge/decision {:local/root "../../components/decision"}
+        ai.miniforge/failure-classifier {:local/root "../../components/failure-classifier"}
+        ai.miniforge/progress-detector {:local/root "../../components/progress-detector"}
         ai.miniforge/reporting {:local/root "../../components/reporting"}
         ai.miniforge/release-executor {:local/root "../../components/release-executor"}
         ai.miniforge/pr-lifecycle {:local/root "../../components/pr-lifecycle"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -68,10 +68,13 @@
         ai.miniforge/dag-primitives {:local/root "../../components/dag-primitives"}
         ai.miniforge/decision {:local/root "../../components/decision"}
         ai.miniforge/diagnosis {:local/root "../../components/diagnosis"}
+        ai.miniforge/failure-classifier {:local/root "../../components/failure-classifier"}
         ai.miniforge/improvement {:local/root "../../components/improvement"}
+        ai.miniforge/progress-detector {:local/root "../../components/progress-detector"}
         ai.miniforge/reliability {:local/root "../../components/reliability"}
         ai.miniforge/repo-index {:local/root "../../components/repo-index"}
         ai.miniforge/semantic-analyzer {:local/root "../../components/semantic-analyzer"}
+        ai.miniforge/workflow-resume {:local/root "../../components/workflow-resume"}
         ai.miniforge/lsp-mcp-bridge {:local/root "../../bases/lsp-mcp-bridge"}
         ai.miniforge/mcp-context-server {:local/root "../../bases/mcp-context-server"}}
 

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -87,6 +87,7 @@
         ai.miniforge/dag-primitives {:local/root "../../components/dag-primitives"}
         ;; Decision component (control plane decisions)
         ai.miniforge/decision {:local/root "../../components/decision"}
+        ai.miniforge/progress-detector {:local/root "../../components/progress-detector"}
         ;; Semantic analysis for code understanding
         ai.miniforge/semantic-analyzer {:local/root "../../components/semantic-analyzer"}
         ;; Context packing for agent prompts

--- a/scripts/test-changed-bricks.bb
+++ b/scripts/test-changed-bricks.bb
@@ -25,6 +25,16 @@
    index, causing empty or wrong-tree commits."
   (dissoc (into {} (System/getenv)) "GIT_INDEX_FILE"))
 
+(def ^:private test-env
+  "Environment for the test JVM with git worktree vars stripped.
+   Test namespaces shell out to git against temp repos and worktrees, so the
+   caller's worktree-specific git vars must not leak into child JVMs."
+  (dissoc (into {} (System/getenv))
+          "GIT_INDEX_FILE"
+          "GIT_DIR"
+          "GIT_WORK_TREE"
+          "GIT_COMMON_DIR"))
+
 (defn poly-changed-names
   "Query poly for changed brick names since main. Returns a vector of strings."
   [key]
@@ -53,25 +63,33 @@
 
 ;; --------------------------------------------------------------------------- Brick-parallel test execution
 
+(def ^:private isolated-bricks
+  "Bricks that should run in their own test JVM.
+   Some native-backed stores are reliable in isolation but can fail inside the
+   large aggregate JVM used for changed-brick testing."
+  #{"pipeline-pack-store"})
+
 (defn build-test-expr
-  "Build a Clojure expression that runs bricks in parallel, but namespaces
-   within each brick sequentially.
+  "Build a Clojure expression that runs brick groups in a single test JVM.
+   Namespaces within a brick always run sequentially.
 
    with-redefs (used heavily in phase/agent tests) mutates global var roots,
    so namespaces sharing the same with-redefs targets must not run concurrently.
    Brick boundaries are the natural isolation unit — different bricks don't
    share mocked vars."
-  [brick-groups]
+  [brick-groups parallel?]
   (let [quote-ns (fn [n] (str "'" n))
         all-nses (mapcat val brick-groups)
         require-expr (str/join " " (map quote-ns all-nses))
-        ;; Build a vector of vectors: [[ns1 ns2] [ns3] ...]
         groups-expr (str "["
                          (str/join " "
-                           (map (fn [[_brick nses]]
-                                  (str "[" (str/join " " (map quote-ns nses)) "]"))
-                                brick-groups))
-                         "]")]
+                                   (map (fn [[_brick nses]]
+                                          (str "[" (str/join " " (map quote-ns nses)) "]"))
+                                        brick-groups))
+                         "]")
+        results-expr (if parallel?
+                       "(doall (pmap run-group groups))"
+                       "(mapv run-group groups)")]
     (str "(require 'clojure.test " require-expr ") "
          "(let [groups " groups-expr
          "      run-group (fn [nses] "
@@ -80,7 +98,7 @@
          "                              (select-keys (clojure.test/run-tests ns) "
          "                                           [:test :pass :fail :error]))) "
          "                          {:test 0 :pass 0 :fail 0 :error 0} nses))"
-         "      results (doall (pmap run-group groups))"
+         "      results " results-expr
          "      summary (reduce (fn [acc r] (merge-with + acc r)) "
          "                      {:test 0 :pass 0 :fail 0 :error 0} results)]"
          "  (println) "
@@ -120,6 +138,25 @@
       brick-groups
       affinity-groups)))
 
+(defn partition-isolated-bricks
+  "Split brick-groups into {:isolated ... :parallel ...} by brick name."
+  [brick-groups]
+  (reduce-kv
+   (fn [acc brick nses]
+     (update acc (if (isolated-bricks brick) :isolated :parallel) assoc brick nses))
+   {:isolated {} :parallel {}}
+   brick-groups))
+
+(defn run-test-jvm!
+  "Run the given brick groups in a dedicated Clojure test JVM.
+   Returns the process exit code."
+  [brick-groups parallel?]
+  (let [expr (build-test-expr brick-groups parallel?)
+        {:keys [exit]} (deref (p/process {:out :inherit :err :inherit
+                                          :env test-env}
+                                         "clojure" "-M:dev:test" "-e" expr))]
+    exit))
+
 
 ;; --------------------------------------------------------------------------- Main
 
@@ -130,42 +167,38 @@
         ;; Group namespaces by brick so we can parallelize across bricks
         ;; but run sequentially within each brick
         brick-groups (-> (into {}
-                           (concat
-                             (for [c components
-                                   :let [nses (find-test-nses "components" c)]
-                                   :when (seq nses)]
-                               [c nses])
-                             (for [b bases
-                                   :let [nses (find-test-nses "bases" b)]
-                                   :when (seq nses)]
-                               [b nses])))
+                              (concat
+                               (for [c components
+                                     :let [nses (find-test-nses "components" c)]
+                                     :when (seq nses)]
+                                 [c nses])
+                               (for [b bases
+                                     :let [nses (find-test-nses "bases" b)]
+                                     :when (seq nses)]
+                                 [b nses])))
                          coalesce-by-affinity)
+        {:keys [isolated parallel]} (partition-isolated-bricks brick-groups)
         total-nses (reduce + 0 (map count (vals brick-groups)))]
     (if (empty? brick-groups)
       (println "✓ No changed bricks — nothing to test")
       (do
         (println (str "  Changed bricks: " (str/join ", " (keys brick-groups))))
+        (when (seq isolated)
+          (println (str "  Isolated bricks: " (str/join ", " (keys isolated)))))
         (println (str "  Test namespaces (" total-nses " across " (count brick-groups) " bricks):"))
         (doseq [[brick nses] brick-groups]
           (println (str "    " brick " (" (count nses) " namespaces)"))
           (doseq [ns nses] (println (str "      " ns))))
-        (let [expr (build-test-expr brick-groups)
-              ;; Strip git worktree vars from the test JVM's environment.
-              ;; Changed-brick detection may need the caller's GIT_DIR /
-              ;; GIT_WORK_TREE, but test namespaces shell out to git against
-              ;; temp repos and worktrees. If those vars leak into the test
-              ;; JVM, git commands inside tests resolve against the committing
-              ;; repo instead of the test fixture repo, causing false failures.
-              test-env (dissoc (into {} (System/getenv))
-                               "GIT_INDEX_FILE"
-                               "GIT_DIR"
-                               "GIT_WORK_TREE"
-                               "GIT_COMMON_DIR")
-              {:keys [exit]} (deref (p/process {:out :inherit :err :inherit
-                                                :env test-env}
-                                               "clojure" "-M:dev:test" "-e" expr))]
-          (when-not (zero? exit)
-            (println "❌ Tests failed with exit code:" exit)
-            (System/exit exit)))))))
+        (doseq [[brick nses] isolated]
+          (println (str "▶ Running isolated brick: " brick))
+          (let [exit (run-test-jvm! {brick nses} false)]
+            (when-not (zero? exit)
+              (println "❌ Tests failed with exit code:" exit)
+              (System/exit exit))))
+        (when (seq parallel)
+          (let [exit (run-test-jvm! parallel true)]
+            (when-not (zero? exit)
+              (println "❌ Tests failed with exit code:" exit)
+              (System/exit exit))))))))
 
 (-main)

--- a/scripts/test-changed-bricks.bb
+++ b/scripts/test-changed-bricks.bb
@@ -63,11 +63,28 @@
 
 ;; --------------------------------------------------------------------------- Brick-parallel test execution
 
-(def ^:private isolated-bricks
+(def ^:private isolated-bricks-env-var
+  "Environment variable that overrides the isolated brick set.
+   Value should be a comma-separated list such as:
+   MINIFORGE_TEST_ISOLATED_BRICKS=pipeline-pack-store,artifact"
+  "MINIFORGE_TEST_ISOLATED_BRICKS")
+
+(def ^:private default-isolated-bricks
   "Bricks that should run in their own test JVM.
    Some native-backed stores are reliable in isolation but can fail inside the
    large aggregate JVM used for changed-brick testing."
   #{"pipeline-pack-store"})
+
+(defn configured-isolated-bricks
+  "Return the configured isolated brick set.
+   A comma-separated MINIFORGE_TEST_ISOLATED_BRICKS overrides the defaults."
+  []
+  (if-let [raw (some-> (System/getenv isolated-bricks-env-var) str/trim seq)]
+    (->> (str/split raw #",")
+         (map str/trim)
+         (remove str/blank?)
+         set)
+    default-isolated-bricks))
 
 (defn build-test-expr
   "Build a Clojure expression that runs brick groups in a single test JVM.
@@ -141,11 +158,12 @@
 (defn partition-isolated-bricks
   "Split brick-groups into {:isolated ... :parallel ...} by brick name."
   [brick-groups]
-  (reduce-kv
-   (fn [acc brick nses]
-     (update acc (if (isolated-bricks brick) :isolated :parallel) assoc brick nses))
-   {:isolated {} :parallel {}}
-   brick-groups))
+  (let [isolated-bricks (configured-isolated-bricks)]
+    (reduce-kv
+     (fn [acc brick nses]
+       (update acc (if (isolated-bricks brick) :isolated :parallel) assoc brick nses))
+     {:isolated {} :parallel {}}
+     brick-groups)))
 
 (defn run-test-jvm!
   "Run the given brick groups in a dedicated Clojure test JVM.


### PR DESCRIPTION
## Summary
- restore `poly check` as a blocking local and CI gate
- fix the existing workspace dependency drift on `main`
- stabilize the changed-bricks verification path that the restored gate exposed

## Validation
- `bb poly:check`
- focused regressions for interface and fresh-main verification fixes
- escalated `bb scripts/test-changed-bricks.bb`
- escalated `bb pre-commit`

## PR Doc
- docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md