### PR TITLE
feat(progress-detector): supervisor 3-arity + runtime :on-anomaly (stage 3 partial salvage)

### DIFF
--- a/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
@@ -59,11 +59,13 @@
      :inherit / :disable / :enable / :tune"
   (:require
    [ai.miniforge.anomaly.interface                    :as anomaly]
+   [ai.miniforge.progress-detector.config             :as cfg]
    [ai.miniforge.progress-detector.event-envelope     :as envelope]
    [ai.miniforge.progress-detector.protocol           :as proto]
+   [ai.miniforge.progress-detector.runtime            :as runtime]
    [ai.miniforge.progress-detector.schema             :as schema]
-   [ai.miniforge.progress-detector.tool-profile       :as tp]
-   [ai.miniforge.progress-detector.config             :as cfg]))
+   [ai.miniforge.progress-detector.supervisor         :as sup]
+   [ai.miniforge.progress-detector.tool-profile       :as tp]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Detector protocol (re-exported)
@@ -259,6 +261,93 @@
   "Overlay child config onto parent config.
    Shorthand for (resolve-config [parent child])."
   cfg/overlay)
+
+;------------------------------------------------------------------------------ Layer 3
+;; Supervisor re-exports
+
+(def default-policy
+  "Stage 2 class-default policy map: {:mechanical :terminate :heuristic :warn}.
+   Pass as the policy arg to handle when you want no overrides."
+  sup/default-policy)
+
+(def select-controlling
+  "Choose the controlling anomaly from a seq using severity→class→seq ranking.
+   Re-exported from supervisor for callers that need the selection logic
+   without a full handle decision."
+  sup/select-controlling)
+
+(defn handle
+  "Supervisor decision over a vector of anomalies.
+
+   Arities:
+
+     (handle anomalies)
+       Uses default-policy and no category overrides.
+
+     (handle policy anomalies)
+       Uses caller-supplied class-default policy, no category overrides.
+
+     (handle policy on-anomaly anomalies)
+       Full 3-arity form. Resolution order for action:
+         1. (get on-anomaly (anomaly-category controlling))
+         2. (get policy     (anomaly-class    controlling))
+         3. :continue
+
+   Returns:
+     {:action     :continue | :terminate | :warn
+      :anomalies  all anomalies
+      :anomaly    controlling anomaly map (absent when input is empty)
+      :reason     termination reason string (present only when :terminate)}"
+  ([anomalies]                    (sup/handle anomalies))
+  ([policy anomalies]             (sup/handle policy anomalies))
+  ([policy on-anomaly anomalies]  (sup/handle policy on-anomaly anomalies)))
+
+(def supervisor-terminate?
+  "Convenience predicate over a `handle` decision map — true iff :action is :terminate."
+  sup/terminate?)
+
+;------------------------------------------------------------------------------ Layer 3
+;; Runtime re-exports
+
+(defn make-runtime
+  "Build a per-agent-run detector runtime.
+
+   Arguments:
+     opts - map with:
+       :detectors  - seq of Detector implementations (may be empty)
+       :config     - (optional) detector config map
+       :policy     - (optional) class-default supervisor policy map
+       :on-anomaly - (optional) per-category action override map.
+                     Consulted before :policy in supervisor/handle.
+                     Example: {:anomalies.agent/tool-loop :terminate
+                               :anomalies.review/stagnation :continue}
+
+   Returns: runtime atom. Drive it with observe! / check."
+  [opts]
+  (runtime/make-runtime opts))
+
+(def observe!
+  "Feed one event into the runtime's detector pipeline. Returns the atom."
+  runtime/observe!)
+
+(defn check
+  "Run the supervisor over unseen anomalies; mark them as seen.
+   Returns a handle decision map.
+   Threads both :policy and :on-anomaly through to supervisor/handle."
+  [rt]
+  (runtime/check rt))
+
+(def runtime-terminate?
+  "Peek at the supervisor decision without consuming the unseen window."
+  runtime/terminate?)
+
+(def current-anomalies-rt
+  "Vector of every anomaly emitted so far on this runtime."
+  runtime/current-anomalies)
+
+(def new-anomalies
+  "Anomalies emitted since the last check call."
+  runtime/new-anomalies)
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Convenience constructors and helpers

--- a/components/progress-detector/src/ai/miniforge/progress_detector/runtime.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/runtime.clj
@@ -28,7 +28,9 @@
    The runtime owns:
      - a single MultiDetector composing the configured detector set
      - the running detector state (one map; pure-reducer threading)
-     - the supervisor policy
+     - the supervisor policy (class-default decisions)
+     - the on-anomaly map (per-category action overrides, consulted
+       before the class-default policy)
      - bookkeeping for which anomalies have already been seen by
        the supervisor (so we don't re-fire termination on the same
        anomaly across observe! calls)
@@ -50,14 +52,17 @@
    Keys:
      :detector       - the composed (Multi)Detector
      :detector-state - the threaded reducer state
-     :policy         - supervisor policy map
+     :policy         - supervisor class-default policy map
+     :on-anomaly     - per-category action override map; consulted
+                       before :policy in the 3-arity supervisor/handle
      :seen-count     - number of anomalies the supervisor has been
                        shown so far; new-anomalies = drop seen-count
                        from current-anomalies"
-  [detector detector-state policy]
+  [detector detector-state policy on-anomaly]
   {:detector       detector
    :detector-state detector-state
    :policy         policy
+   :on-anomaly     on-anomaly
    :seen-count     0})
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -78,24 +83,29 @@
 
    Arguments:
      opts - map with:
-       :detectors - seq of Detector implementations. May be empty —
-                    an empty list is replaced with a single
-                    null-detector so the runtime stays usable when
-                    detectors are disabled (Stage 2 spec acceptance:
-                    'removing all detectors leaves the agent runtime
-                    functional and bounded by Layer 1 caps').
-       :config    - (optional) detector config map passed to init
-                    on each detector
-       :policy    - (optional) supervisor policy map
-                    (defaults to sup/default-policy)
+       :detectors  - seq of Detector implementations. May be empty —
+                     an empty list is replaced with a single
+                     null-detector so the runtime stays usable when
+                     detectors are disabled (Stage 2 spec acceptance:
+                     'removing all detectors leaves the agent runtime
+                     functional and bounded by Layer 1 caps').
+       :config     - (optional) detector config map passed to init
+                     on each detector
+       :policy     - (optional) supervisor class-default policy map
+                     (defaults to sup/default-policy)
+       :on-anomaly - (optional) per-category action override map.
+                     Consulted before :policy in supervisor/handle.
+                     Example: {:anomalies.agent/tool-loop :terminate
+                               :anomalies.review/stagnation :continue}
+                     Defaults to {} (no category overrides).
 
    Returns: atom holding runtime state. Pass to observe! / check
    to drive it."
-  [{:keys [detectors config policy]
-    :or   {config {} policy sup/default-policy}}]
+  [{:keys [detectors config policy on-anomaly]
+    :or   {config {} policy sup/default-policy on-anomaly {}}}]
   (let [composed (proto/multi-detector (effective-detectors detectors))
         d-state  (proto/init composed config)]
-    (atom (initial-state composed d-state policy))))
+    (atom (initial-state composed d-state policy on-anomaly))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Observation
@@ -138,15 +148,20 @@
   "Run the supervisor over anomalies emitted since the last check
    and return its decision map (see supervisor/handle).
 
+   Threads both :policy (class-default) and :on-anomaly (per-category
+   overrides) from the runtime config through to supervisor/handle
+   3-arity, so category-specific actions take precedence over the
+   class-default.
+
    Side effect: marks those anomalies as seen so the next check
    only considers anomalies that arrived after this one. This
    guards against repeatedly returning :terminate for the same
    already-acted-on anomaly while the runtime is still draining."
   [runtime]
-  (let [{:keys [detector-state policy seen-count]} @runtime
+  (let [{:keys [detector-state policy on-anomaly seen-count]} @runtime
         all       (get detector-state :anomalies [])
         unseen    (subvec all (min seen-count (count all)))
-        decision  (sup/handle policy unseen)]
+        decision  (sup/handle policy on-anomaly unseen)]
     (swap! runtime assoc :seen-count (count all))
     decision))
 
@@ -155,10 +170,10 @@
    the unseen-anomaly window. Use `check` when you want to mark
    anomalies as acted-on."
   [runtime]
-  (let [{:keys [detector-state policy seen-count]} @runtime
+  (let [{:keys [detector-state policy on-anomaly seen-count]} @runtime
         all    (get detector-state :anomalies [])
         unseen (subvec all (min seen-count (count all)))]
-    (sup/terminate? (sup/handle policy unseen))))
+    (sup/terminate? (sup/handle policy on-anomaly unseen))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 
@@ -174,10 +189,19 @@
                  :determinism :stable-with-resource-version
                  :anomaly/categories #{:anomalies.agent/tool-loop}})
 
+  ;; Default runtime — mechanical anomaly terminates
   (def rt (make-runtime
             {:detectors [(tl/make-tool-loop-detector reg)
                          (rl/make-repair-loop-detector)]
              :config    {:config/params {:threshold-n 3}}}))
+
+  ;; Runtime with on-anomaly: tool-loop → :continue (suppressed)
+  ;; but stagnation → :terminate (default policy)
+  (def rt2 (make-runtime
+             {:detectors [(tl/make-tool-loop-detector reg)
+                          (rl/make-repair-loop-detector)]
+              :config    {:config/params {:threshold-n 3}}
+              :on-anomaly {:anomalies.agent/tool-loop :continue}}))
 
   ;; Hammer Read with the same args 3× — should fire mechanical
   (let [obs {:tool/id   :tool/Read

--- a/components/progress-detector/src/ai/miniforge/progress_detector/supervisor.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/supervisor.clj
@@ -25,10 +25,12 @@
      :anomaly/class :mechanical → :terminate
      :anomaly/class :heuristic  → :warn (logged, no action)
 
-   Stage 3 will replace this with a per-category :on-anomaly policy
-   map plus composite-rules for promoting combined heuristics to
-   mechanical anomalies. The Stage 2 surface is intentionally tiny
-   — just enough to make the detectors *do* something.
+   Stage 3 adds a per-category on-anomaly map for finer-grained control.
+   Resolution order in the 3-arity handle:
+
+     1. category lookup in on-anomaly  (e.g. {:tool-loop :terminate})
+     2. class-default from policy       (e.g. {:mechanical :terminate})
+     3. :continue                       (catch-all safe default)
 
    Controlling-anomaly selection (when multiple anomalies fire in
    the same observe step):
@@ -65,6 +67,7 @@
 
 (defn- anomaly-severity [a] (get-in a [:anomaly/data :anomaly/severity]))
 (defn- anomaly-class    [a] (get-in a [:anomaly/data :anomaly/class]))
+(defn- anomaly-category [a] (get-in a [:anomaly/data :anomaly/category]))
 
 (defn- anomaly-event-seq
   "First :seq from :anomaly/data :anomaly/evidence :event-ids — used as
@@ -103,11 +106,29 @@
 (defn handle
   "Decide what to do given a vector of anomalies.
 
-   Arguments:
-     policy    - map of :anomaly/class → action keyword
-                 (default: default-policy = mechanical→:terminate,
-                                            heuristic→:warn)
-     anomalies - vector of anomaly maps emitted by the detector pipeline
+   Arities:
+
+     (handle anomalies)
+       1-arity convenience — uses default-policy and empty on-anomaly.
+
+     (handle policy anomalies)
+       2-arity back-compat — delegates to (handle policy {} anomalies).
+
+     (handle policy on-anomaly anomalies)
+       3-arity canonical form. Arguments:
+         policy     - map of :anomaly/class → action keyword
+                      (default: default-policy = mechanical→:terminate,
+                                                 heuristic→:warn)
+         on-anomaly - map of :anomaly/category → action keyword,
+                      consulted BEFORE the class-default policy.
+                      Example: {:anomalies.agent/tool-loop :terminate
+                                :anomalies.review/stagnation :continue}
+         anomalies  - vector of anomaly maps emitted by the detector pipeline
+
+   Resolution order for action:
+     1. (get on-anomaly (anomaly-category controlling))
+     2. (get policy     (anomaly-class    controlling))
+     3. :continue
 
    Returns:
      {:action     :continue | :terminate | :warn
@@ -117,13 +138,17 @@
 
    The result is data — no side effects. The caller (typically
    runtime.clj wired into agent.invoke) drives any actual cancellation."
-  ([anomalies] (handle default-policy anomalies))
-  ([policy anomalies]
+  ([anomalies]           (handle default-policy {} anomalies))
+  ([policy anomalies]    (handle policy {} anomalies))
+  ([policy on-anomaly anomalies]
    (if (empty? anomalies)
      {:action    :continue
       :anomalies anomalies}
      (let [controlling (select-controlling anomalies)
-           action      (get policy (anomaly-class controlling) :continue)
+           category    (anomaly-category controlling)
+           action      (or (get on-anomaly category)
+                           (get policy (anomaly-class controlling))
+                           :continue)
            summary     (get-in controlling
                                [:anomaly/data :anomaly/evidence :summary]
                                (msg/t :supervisor/no-summary))
@@ -146,16 +171,25 @@
   (handle [])
   ;; => {:action :continue :anomalies []}
 
-  ;; A mechanical error → terminate
+  ;; A mechanical error → terminate (1-arity, uses default-policy)
   (def err-anomaly
     {:anomaly/type :fault
      :anomaly/data {:detector/kind    :detector/tool-loop
                     :anomaly/class    :mechanical
+                    :anomaly/category :anomalies.agent/tool-loop
                     :anomaly/severity :error
                     :anomaly/evidence {:summary "Read foo.clj 6 times"
                                        :event-ids [1]}}})
   (handle [err-anomaly])
   ;; => {:action :terminate :anomaly {...} :reason "Terminating run: ..."}
+
+  ;; 3-arity: category overrides class-default
+  ;; on-anomaly says :tool-loop → :continue → no termination even though
+  ;; the class-default policy would say :terminate
+  (handle default-policy
+          {:anomalies.agent/tool-loop :continue}
+          [err-anomaly])
+  ;; => {:action :continue ...}
 
   ;; Heuristic warn → don't terminate
   (def warn-anomaly

--- a/components/progress-detector/src/ai/miniforge/progress_detector/supervisor.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/supervisor.clj
@@ -28,16 +28,30 @@
    Stage 3 adds a per-category on-anomaly map for finer-grained control.
    Resolution order in the 3-arity handle:
 
-     1. category lookup in on-anomaly  (e.g. {:tool-loop :terminate})
-     2. class-default from policy       (e.g. {:mechanical :terminate})
-     3. :continue                       (catch-all safe default)
+     1. category lookup in on-anomaly
+        (e.g. {:anomalies.agent/tool-loop :terminate})
+     2. class-default from policy
+        (e.g. {:mechanical :terminate})
+     3. :continue
+        (catch-all safe default)
 
    Controlling-anomaly selection (when multiple anomalies fire in
    the same observe step):
 
-     :fatal > :error > :warn > :info        (severity rank)
-     ties broken: :mechanical > :heuristic  (class rank)
-     further ties: earliest :event/seq      (deterministic)
+     1. compute the effective action per anomaly under
+        on-anomaly + policy
+     2. pick by strongest effective action:
+        :terminate > :warn > :continue   (action rank)
+     3. tie-break by severity rank:
+        :fatal > :error > :warn > :info
+     4. then class rank:
+        :mechanical > :heuristic
+     5. then earliest :event/seq         (deterministic)
+
+   Action-first ordering matters: a controlling anomaly chosen by
+   severity/class alone would let an on-anomaly :continue
+   suppression on the strongest-by-severity anomaly mask a weaker
+   anomaly that the policy / on-anomaly would otherwise terminate.
 
    All anomalies (controlling and not) are surfaced to the caller;
    the supervisor names which one drives the decision."
@@ -55,6 +69,13 @@
 (def ^:private class-rank
   "Mechanical > heuristic when severities tie."
   {:mechanical 2 :heuristic 1})
+
+(def ^:private action-rank
+  "Strongest action wins when controlling-anomaly selection happens
+   AFTER applying on-anomaly + policy. Used in handle's selection
+   tuple so that a suppressed-to-:continue anomaly never masks a
+   sibling that policy / on-anomaly would otherwise terminate."
+  {:terminate 3 :warn 2 :continue 1})
 
 (def default-policy
   "Stage 2 class-default policy. Stage 3 layers a per-category map
@@ -91,17 +112,44 @@
 ;; Public API
 
 (defn select-controlling
-  "Choose one controlling anomaly from a non-empty seq.
+  "Choose one controlling anomaly from a non-empty seq using the
+   severity/class/seq rank only — does NOT consider effective action.
 
-   Selection rule (Stage 1 spec, lifted verbatim):
-     :fatal > :error > :warn > :info,
-     ties broken :mechanical > :heuristic,
-     further ties broken by earliest :event/seq.
+   Kept for Stage 1 callers that don't have policy/on-anomaly
+   context. Stage 3's `handle` uses an action-aware variant
+   internally (see select-controlling-by-action) so on-anomaly
+   suppressions don't mask sibling anomalies that should terminate.
 
    Returns nil for an empty input."
   [anomalies]
   (when (seq anomalies)
     (first (sort-by ranking-tuple anomalies))))
+
+(defn- effective-action
+  "Compute the effective action for ONE anomaly under on-anomaly
+   then policy then catch-all :continue."
+  [policy on-anomaly anomaly]
+  (or (get on-anomaly (anomaly-category anomaly))
+      (get policy     (anomaly-class    anomaly))
+      :continue))
+
+(defn- action-aware-tuple
+  "Selection tuple that orders by effective action first, then
+   severity / class / seq. Strongest action wins so that an
+   on-anomaly :continue on a severity-strongest anomaly cannot
+   mask a sibling that policy / on-anomaly would terminate."
+  [policy on-anomaly anomaly]
+  [(- (get action-rank (effective-action policy on-anomaly anomaly) 0))
+   (- (get severity-rank (anomaly-severity anomaly) 0))
+   (- (get class-rank    (anomaly-class    anomaly) 0))
+   (anomaly-event-seq anomaly)])
+
+(defn- select-controlling-by-action
+  "Action-aware controlling-anomaly selection used by `handle`.
+   Returns nil for an empty input."
+  [policy on-anomaly anomalies]
+  (when (seq anomalies)
+    (first (sort-by #(action-aware-tuple policy on-anomaly %) anomalies))))
 
 (defn handle
   "Decide what to do given a vector of anomalies.
@@ -144,11 +192,9 @@
    (if (empty? anomalies)
      {:action    :continue
       :anomalies anomalies}
-     (let [controlling (select-controlling anomalies)
-           category    (anomaly-category controlling)
-           action      (or (get on-anomaly category)
-                           (get policy (anomaly-class controlling))
-                           :continue)
+     (let [controlling (select-controlling-by-action
+                        policy on-anomaly anomalies)
+           action      (effective-action policy on-anomaly controlling)
            summary     (get-in controlling
                                [:anomaly/data :anomaly/evidence :summary]
                                (msg/t :supervisor/no-summary))

--- a/components/progress-detector/test/ai/miniforge/progress_detector/runtime_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/runtime_test.clj
@@ -17,7 +17,7 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.progress-detector.runtime-test
-  "Tests for the agent-run detector runtime."
+  "Tests for the agent-run detector runtime — includes on-anomaly threading."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.progress-detector.detectors.repair-loop :as repair]
@@ -84,6 +84,20 @@
       (is (= [] (sut/current-anomalies rt)))
       (is (= [] (sut/new-anomalies rt)))
       (is (false? (sut/terminate? rt))))))
+
+(deftest make-runtime-on-anomaly-stored-in-state-test
+  (testing "make-runtime stores :on-anomaly in the runtime atom"
+    (let [on-anomaly {:anomalies.agent/tool-loop :continue}
+          rt         (sut/make-runtime {:detectors  []
+                                        :on-anomaly on-anomaly})]
+      (is (= on-anomaly (:on-anomaly @rt))
+          ":on-anomaly is persisted in the runtime state"))))
+
+(deftest make-runtime-default-on-anomaly-is-empty-test
+  (testing "make-runtime defaults :on-anomaly to {} when not supplied"
+    (let [rt (sut/make-runtime {:detectors []})]
+      (is (= {} (:on-anomaly @rt))
+          "no :on-anomaly key ⇒ defaults to empty map"))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Tool-loop end-to-end
@@ -210,3 +224,70 @@
         (sut/observe! rt (read-event i)))
       (is (= :warn (:action (sut/check rt)))
           "custom policy treats mechanical as :warn"))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; on-anomaly threading through check and terminate?
+
+(deftest on-anomaly-suppresses-tool-loop-termination-test
+  (testing "on-anomaly :continue for tool-loop category prevents :terminate"
+    (let [reg (registry-with-read-stable)
+          rt  (sut/make-runtime
+               {:detectors  [(tloop/make-tool-loop-detector reg)]
+                :config     {:config/params {:threshold-n 5}}
+                ;; tool-loop anomalies are :mechanical → default :terminate,
+                ;; but on-anomaly overrides the category to :continue
+                :on-anomaly {:anomalies.agent/tool-loop :continue}})]
+      (doseq [i (range 1 7)]
+        (sut/observe! rt (read-event i)))
+      (let [decision (sut/check rt)]
+        (is (= :continue (:action decision))
+            "on-anomaly suppresses the tool-loop termination")
+        (is (some? (:anomaly decision))
+            "controlling anomaly still surfaced even when action is :continue")))))
+
+(deftest on-anomaly-escalates-stagnation-when-policy-would-warn-test
+  (testing "on-anomaly can escalate repair-loop stagnation beyond class-default"
+    (let [;; Override policy so heuristic → :warn (default already), but
+          ;; on-anomaly escalates stagnation category to :terminate
+          rt (sut/make-runtime
+              {:detectors  [(repair/make-repair-loop-detector)]
+               :on-anomaly {:anomalies.review/stagnation :terminate}})]
+      (sut/observe! rt (review-event 1 [blocking-issue]))
+      (sut/observe! rt (review-event 2 [blocking-issue]))
+      (let [decision (sut/check rt)]
+        (is (= :terminate (:action decision))
+            "on-anomaly escalates stagnation to :terminate")
+        (is (string? (:reason decision)))))))
+
+(deftest on-anomaly-does-not-affect-other-categories-test
+  (testing "on-anomaly suppression is scoped — other categories still use policy"
+    (let [reg (registry-with-read-stable)
+          rt  (sut/make-runtime
+               {:detectors  [(tloop/make-tool-loop-detector reg)
+                             (repair/make-repair-loop-detector)]
+                :config     {:config/params {:threshold-n 5}}
+                ;; Only suppress tool-loop; stagnation remains at policy default
+                :on-anomaly {:anomalies.agent/tool-loop :continue}})]
+      ;; Trigger tool-loop (suppressed)
+      (doseq [i (range 1 7)]
+        (sut/observe! rt (read-event i)))
+      ;; Trigger repair-loop stagnation (not suppressed)
+      (sut/observe! rt (review-event 100 [blocking-issue]))
+      (sut/observe! rt (review-event 101 [blocking-issue]))
+      (let [decision (sut/check rt)]
+        ;; The controlling anomaly will be whichever is stronger, but
+        ;; the stagnation anomaly is not suppressed by on-anomaly
+        (is (some? (:anomaly decision))
+            "at least one anomaly fires")))))
+
+(deftest terminate?-respects-on-anomaly-test
+  (testing "terminate? peek also honours on-anomaly override"
+    (let [reg (registry-with-read-stable)
+          rt  (sut/make-runtime
+               {:detectors  [(tloop/make-tool-loop-detector reg)]
+                :config     {:config/params {:threshold-n 5}}
+                :on-anomaly {:anomalies.agent/tool-loop :continue}})]
+      (doseq [i (range 1 7)]
+        (sut/observe! rt (read-event i)))
+      (is (false? (sut/terminate? rt))
+          "terminate? returns false when on-anomaly suppresses the category"))))

--- a/components/progress-detector/test/ai/miniforge/progress_detector/runtime_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/runtime_test.clj
@@ -246,39 +246,74 @@
             "controlling anomaly still surfaced even when action is :continue")))))
 
 (deftest on-anomaly-escalates-stagnation-when-policy-would-warn-test
-  (testing "on-anomaly can escalate repair-loop stagnation beyond class-default"
-    (let [;; Override policy so heuristic → :warn (default already), but
-          ;; on-anomaly escalates stagnation category to :terminate
-          rt (sut/make-runtime
-              {:detectors  [(repair/make-repair-loop-detector)]
-               :on-anomaly {:anomalies.review/stagnation :terminate}})]
-      (sut/observe! rt (review-event 1 [blocking-issue]))
-      (sut/observe! rt (review-event 2 [blocking-issue]))
-      (let [decision (sut/check rt)]
+  (testing "PR #803 review fix: on-anomaly :terminate must actually
+            ESCALATE beyond what policy would do — the previous
+            version of this test left the default policy in place,
+            and repair-loop emits :mechanical :error which already
+            terminates via the default policy. The assertion
+            therefore passed even when on-anomaly was ignored.
+
+            Override policy so mechanical → :warn so the only path
+            to :terminate is via on-anomaly. Sanity-check that the
+            policy override alone (without on-anomaly) yields :warn,
+            then confirm on-anomaly flips it to :terminate."
+    (let [warn-policy {:mechanical :warn :heuristic :warn}
+          ;; Without on-anomaly: policy says :warn → expect :warn.
+          baseline-rt (sut/make-runtime
+                       {:detectors [(repair/make-repair-loop-detector)]
+                        :policy    warn-policy})
+          ;; With on-anomaly :terminate: must escalate to :terminate.
+          escalating-rt (sut/make-runtime
+                         {:detectors  [(repair/make-repair-loop-detector)]
+                          :policy     warn-policy
+                          :on-anomaly {:anomalies.review/stagnation :terminate}})]
+      (sut/observe! baseline-rt (review-event 1 [blocking-issue]))
+      (sut/observe! baseline-rt (review-event 2 [blocking-issue]))
+      (sut/observe! escalating-rt (review-event 1 [blocking-issue]))
+      (sut/observe! escalating-rt (review-event 2 [blocking-issue]))
+      (is (= :warn (:action (sut/check baseline-rt)))
+          "policy override sanity check — without on-anomaly, action is :warn")
+      (let [decision (sut/check escalating-rt)]
         (is (= :terminate (:action decision))
-            "on-anomaly escalates stagnation to :terminate")
+            "on-anomaly genuinely escalates stagnation beyond policy :warn")
         (is (string? (:reason decision)))))))
 
 (deftest on-anomaly-does-not-affect-other-categories-test
-  (testing "on-anomaly suppression is scoped — other categories still use policy"
+  (testing "PR #803 review fix: scope isolation must demonstrate
+            that the un-suppressed anomaly drives the decision —
+            the previous version asserted only that ‘some anomaly
+            fires’, which was true even when the suppressed-to-
+            :continue anomaly remained controlling. With the
+            action-aware controlling-anomaly selection (PR #803 fix
+            #1), the un-suppressed stagnation must be the
+            controlling anomaly AND :action must be :terminate.
+
+            Setup: tool-loop fires (mechanical → would terminate)
+            but on-anomaly suppresses it to :continue. Stagnation
+            fires (mechanical, default :terminate) and is NOT
+            suppressed. The decision must terminate, with
+            stagnation as controlling."
     (let [reg (registry-with-read-stable)
           rt  (sut/make-runtime
                {:detectors  [(tloop/make-tool-loop-detector reg)
                              (repair/make-repair-loop-detector)]
                 :config     {:config/params {:threshold-n 5}}
-                ;; Only suppress tool-loop; stagnation remains at policy default
                 :on-anomaly {:anomalies.agent/tool-loop :continue}})]
-      ;; Trigger tool-loop (suppressed)
+      ;; Trigger tool-loop (suppressed by on-anomaly)
       (doseq [i (range 1 7)]
         (sut/observe! rt (read-event i)))
       ;; Trigger repair-loop stagnation (not suppressed)
       (sut/observe! rt (review-event 100 [blocking-issue]))
       (sut/observe! rt (review-event 101 [blocking-issue]))
-      (let [decision (sut/check rt)]
-        ;; The controlling anomaly will be whichever is stronger, but
-        ;; the stagnation anomaly is not suppressed by on-anomaly
-        (is (some? (:anomaly decision))
-            "at least one anomaly fires")))))
+      (let [decision (sut/check rt)
+            controlling-cat (get-in decision
+                                    [:anomaly :anomaly/data :anomaly/category])]
+        (is (= :terminate (:action decision))
+            "un-suppressed stagnation drives the decision to :terminate
+             — proves the suppressed tool-loop did NOT mask termination")
+        (is (= :anomalies.review/stagnation controlling-cat)
+            "controlling anomaly is the stagnation, not the suppressed
+             tool-loop — action-aware selection works as advertised")))))
 
 (deftest terminate?-respects-on-anomaly-test
   (testing "terminate? peek also honours on-anomaly override"

--- a/components/progress-detector/test/ai/miniforge/progress_detector/supervisor_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/supervisor_test.clj
@@ -17,7 +17,8 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.progress-detector.supervisor-test
-  "Tests for the Stage 2 minimal supervisor."
+  "Tests for the supervisor — covers Stage 2 class-default policy and
+   Stage 3 per-category on-anomaly overrides."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.progress-detector.supervisor :as sut]))
@@ -27,18 +28,21 @@
 
 (defn- mk-anomaly
   "Construct a minimal anomaly map under :anomaly/data — the supervisor
-   only reads :anomaly/class, :anomaly/severity, and the
+   only reads :anomaly/class, :anomaly/category, :anomaly/severity, and the
    :anomaly/evidence :event-ids vector for tie-breaking."
   ([anomaly-class severity]
-   (mk-anomaly anomaly-class severity nil))
+   (mk-anomaly anomaly-class severity nil nil))
   ([anomaly-class severity event-seq]
+   (mk-anomaly anomaly-class severity event-seq nil))
+  ([anomaly-class severity event-seq category]
    {:anomaly/type :fault
     :anomaly/data
-    {:detector/kind    :detector/test
-     :anomaly/class    anomaly-class
-     :anomaly/severity severity
-     :anomaly/evidence {:summary    (str (name anomaly-class) " " (name severity))
-                        :event-ids  (cond-> [] event-seq (conj event-seq))}}}))
+    (cond-> {:detector/kind    :detector/test
+             :anomaly/class    anomaly-class
+             :anomaly/severity severity
+             :anomaly/evidence {:summary    (str (name anomaly-class) " " (name severity))
+                                :event-ids  (cond-> [] event-seq (conj event-seq))}}
+      category (assoc :anomaly/category category))}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Empty + class-default policy
@@ -137,3 +141,99 @@
       (is (contains? terminate-decision :reason))
       (is (not (contains? warn-decision :reason)))
       (is (not (contains? continue-decision :reason))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; 3-arity handle — on-anomaly category overrides
+
+(deftest on-anomaly-category-overrides-class-default-test
+  (testing "category lookup in on-anomaly takes precedence over class-default policy"
+    (let [category :anomalies.agent/tool-loop
+          ;; mechanical error would normally :terminate per default-policy
+          a        (mk-anomaly :mechanical :error 1 category)
+          ;; but on-anomaly says :continue for this category
+          decision (sut/handle sut/default-policy
+                               {category :continue}
+                               [a])]
+      (is (= :continue (:action decision))
+          "on-anomaly category override suppresses class-default :terminate"))))
+
+(deftest on-anomaly-terminate-overrides-class-warn-test
+  (testing "category lookup can escalate action beyond class-default"
+    (let [category :anomalies.review/stagnation
+          ;; heuristic warn would normally :warn per default-policy
+          a        (mk-anomaly :heuristic :warn 1 category)
+          ;; on-anomaly escalates this category to :terminate
+          decision (sut/handle sut/default-policy
+                               {category :terminate}
+                               [a])]
+      (is (= :terminate (:action decision))
+          "on-anomaly can escalate a heuristic to :terminate")
+      (is (string? (:reason decision))
+          ":reason present when action is :terminate"))))
+
+(deftest on-anomaly-empty-falls-back-to-policy-test
+  (testing "empty on-anomaly map falls back to class-default policy"
+    (let [a        (mk-anomaly :mechanical :error 1 :anomalies.agent/tool-loop)
+          decision (sut/handle sut/default-policy {} [a])]
+      (is (= :terminate (:action decision))
+          "empty on-anomaly map ⇒ class-default :terminate"))))
+
+(deftest on-anomaly-missing-category-falls-back-to-policy-test
+  (testing "category not in on-anomaly falls back to class-default policy"
+    (let [a        (mk-anomaly :mechanical :error 1 :anomalies.agent/tool-loop)
+          ;; on-anomaly only covers a different category
+          decision (sut/handle sut/default-policy
+                               {:anomalies.review/stagnation :continue}
+                               [a])]
+      (is (= :terminate (:action decision))
+          "unmatched category falls through to class-default policy"))))
+
+(deftest on-anomaly-nil-category-falls-back-to-policy-test
+  (testing "anomaly with no category key falls back to class-default policy"
+    (let [;; mk-anomaly with nil category omits :anomaly/category from data
+          a        (mk-anomaly :mechanical :error 1)
+          decision (sut/handle sut/default-policy
+                               {:anomalies.agent/tool-loop :continue}
+                               [a])]
+      (is (= :terminate (:action decision))
+          "nil category does not match any on-anomaly key; policy used"))))
+
+(deftest on-anomaly-resolution-order-category-first-test
+  (testing "full resolution chain: category → policy → :continue"
+    (let [category :anomalies.agent/tool-loop
+          ;; anomaly whose class is not in policy at all (:exotic)
+          ;; but category IS in on-anomaly
+          a        {:anomaly/type :fault
+                    :anomaly/data {:anomaly/class    :exotic
+                                   :anomaly/category category
+                                   :anomaly/severity :error
+                                   :anomaly/evidence {:summary "test" :event-ids [1]}}}]
+      ;; Step 1: category found → :terminate
+      (is (= :terminate
+             (:action (sut/handle {} {category :terminate} [a])))
+          "category hit → returned directly")
+      ;; Step 2: category miss, class found → :warn
+      (is (= :warn
+             (:action (sut/handle {:exotic :warn} {} [a])))
+          "class-default hit when category misses")
+      ;; Step 3: both miss → :continue
+      (is (= :continue
+             (:action (sut/handle {} {} [a])))
+          "nothing matches → :continue"))))
+
+(deftest two-arity-delegates-to-three-arity-test
+  (testing "2-arity (handle policy anomalies) is back-compat delegate to 3-arity"
+    ;; The 2-arity and 3-arity with empty on-anomaly must produce identical decisions.
+    (let [a        (mk-anomaly :mechanical :error 1 :anomalies.agent/tool-loop)
+          via-two  (sut/handle sut/default-policy [a])
+          via-three (sut/handle sut/default-policy {} [a])]
+      (is (= (:action via-two) (:action via-three)))
+      (is (= (:anomaly via-two) (:anomaly via-three))))))
+
+(deftest three-arity-empty-input-continues-test
+  (testing "3-arity handle with empty anomalies always returns :continue"
+    (let [decision (sut/handle sut/default-policy
+                               {:anomalies.agent/tool-loop :terminate}
+                               [])]
+      (is (= :continue (:action decision)))
+      (is (= [] (:anomalies decision))))))

--- a/components/progress-detector/test/ai/miniforge/progress_detector/supervisor_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/supervisor_test.clj
@@ -237,3 +237,57 @@
                                [])]
       (is (= :continue (:action decision)))
       (is (= [] (:anomalies decision))))))
+
+;------------------------------------------------------------------------------ PR #803 fix: action-aware controlling-anomaly selection
+
+(deftest suppressed-strong-does-not-mask-terminating-weak-test
+  (testing "PR #803 Copilot fix — controlling-anomaly selection
+            must consider the EFFECTIVE action (after on-anomaly +
+            policy), not just severity/class. Otherwise an
+            on-anomaly :continue suppression on a severity-strong
+            anomaly silently masks a sibling that policy /
+            on-anomaly would terminate.
+
+            Setup: tool-loop is mechanical :error (severity-
+            strongest under default-policy → would terminate).
+            on-anomaly suppresses it to :continue. A second anomaly,
+            heuristic :warn, has on-anomaly :terminate. Without
+            action-aware selection, tool-loop wins controlling →
+            :continue → bug. With the fix, the heuristic anomaly
+            is selected as controlling because its effective action
+            (:terminate) outranks tool-loop's :continue."
+    (let [tool-loop (mk-anomaly :mechanical :error 1
+                                :anomalies.agent/tool-loop)
+          stagnation (mk-anomaly :heuristic :warn 2
+                                 :anomalies.review/stagnation)
+          on-anomaly {:anomalies.agent/tool-loop :continue
+                      :anomalies.review/stagnation :terminate}
+          decision (sut/handle sut/default-policy on-anomaly
+                               [tool-loop stagnation])]
+      (is (= :terminate (:action decision))
+          "the un-suppressed stagnation anomaly drives the
+           decision — termination is not silently masked by the
+           suppressed tool-loop")
+      (is (= :anomalies.review/stagnation
+             (get-in decision [:anomaly :anomaly/data :anomaly/category]))
+          "the controlling anomaly is the one whose effective action
+           is strongest, not the one whose severity/class is strongest")
+      (is (string? (:reason decision))
+          ":reason populated when terminating, even though the
+           severity-strongest anomaly was suppressed"))))
+
+(deftest action-rank-tiebreak-uses-severity-test
+  (testing "When two anomalies have the SAME effective action, the
+            existing severity / class / seq tie-break still applies.
+            Two mechanicals both at default :terminate → controlling
+            is the one with stronger severity, mirroring Stage 1
+            behaviour."
+    (let [error-a (mk-anomaly :mechanical :error 1
+                              :anomalies.agent/tool-loop)
+          fatal-a (mk-anomaly :mechanical :fatal 2
+                              :anomalies.agent/runaway)
+          decision (sut/handle [error-a fatal-a])]
+      (is (= :terminate (:action decision)))
+      (is (= :anomalies.agent/runaway
+             (get-in decision [:anomaly :anomaly/data :anomaly/category]))
+          "fatal beats error within the same :terminate action tier"))))


### PR DESCRIPTION
## Summary

Partial Stage 3 salvage. The 2026-05-07 stage-3 dogfood (workflow `82c5742b`) drove the supervisor + runtime task end-to-end through plan → implement before hitting the MCP artifact-handoff failure mode (same one we saw on stage-2). The workspace bundle preserves a complete, well-shaped artifact for one of seven planner-decomposed tasks; salvaged here verbatim from `refs/dogfood/stage3-task-dacf1806`.

## What lands

### `supervisor.clj` — `handle` 3-arity
Resolution order for action:
1. `(get on-anomaly (anomaly-category controlling))` — per-category override
2. `(get policy     (anomaly-class    controlling))` — class-default
3. `:continue` — safe fallback

Existing 1- and 2-arity stay; both delegate to 3-arity for back-compat. New private `anomaly-category` accessor reads `[:anomaly/data :anomaly/category]`.

### `runtime.clj` — `:on-anomaly` threading
`make-runtime` accepts `:on-anomaly` opt (defaults `{}`). Stored on the runtime atom alongside `:policy`. Both `check` and `terminate?` thread `:policy` and `:on-anomaly` through to `sup/handle` 3-arity.

### `interface.clj` — Re-exports
`handle` (multi-arity), `default-policy`, `select-controlling`, `make-runtime`, `observe!`, `check`, `runtime-terminate?`, `current-anomalies-rt`, `new-anomalies`. The `-rt` suffix on `terminate?` / `current-anomalies` avoids collision with the state-map versions documented for Stage 1.

### Tests — 14 new
- 8 supervisor 3-arity: category override suppresses, category override escalates, fallback to class policy when category absent, fallback to `:continue` when both absent, 2-arity back-compat parity, full 3-step resolution, empty input with non-empty `on-anomaly`, etc.
- 6 runtime: `:on-anomaly` stored in atom, default `{}`, end-to-end suppression of tool-loop via category override, end-to-end escalation of stagnation, category scope isolation, `terminate?` honours override.

## Stage 3 still owes

Planner-decomposed tasks 2-7, none of which the dogfood reached:
- LLM stream tool-event surfacing (`parse-claude-stream-line` + codex extensions)
- `agent.detector-wiring` component (per-call runtime lifecycle)
- `agent.invoke` wrapping across all six roles
- Per-agent prompt EDN `:prompt/detectors` knobs
- Termination semantics (cancel in-flight stream, throw `:anomalies.agent/terminated`)

These will need either another dogfood pass (now that argv overflow is fixed) or manual burn-down on the DAG.

## Test plan

- [x] `bb test`: 5346 / 0 / 0
- [x] PR #762 + Stage 2 regression tests preserved
- [ ] Land remaining Stage 3 tasks before re-dogfooding

🤖 Generated with [Claude Code](https://claude.com/claude-code)