### PR TITLE
feat(event-stream): quiesce + drain shutdown ordering (BD-2a)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -802,6 +802,45 @@
           (when-not (:quiet opts)
             (println (display/colorize :yellow (messages/t :workflow-runner/sandbox-released)))))))))
 
+(defn- best-effort-shutdown?
+  "Honor `MINIFORGE_BEST_EFFORT_SHUTDOWN` as the documented escape hatch
+   for local/dev loops that don't care about event durability. Default
+   off — normal headless mode treats drain failures as errors."
+  []
+  (let [v (System/getenv "MINIFORGE_BEST_EFFORT_SHUTDOWN")]
+    (boolean (and v (contains? #{"1" "true" "yes" "on"} (str/lower-case v))))))
+
+(defn- event-stream-shutdown!
+  "Run the BD-2a shutdown sequence on `es`: quiesce publishers for
+   `workflow-id`, then drain sinks. Returns the structured drain result
+   for inclusion in the run result map, or `nil` when no event stream
+   exists (dashboard-url runs).
+
+   On a non-OK drain in normal mode (best-effort off), throws an
+   ex-info carrying the drain result so the caller's catch path renders
+   the failure and the CLI exits non-zero. Best-effort mode logs the
+   degradation to stderr and returns the result without throwing."
+  [es workflow-id {:keys [quiet]}]
+  (when es
+    (es/quiesce! es {:workflow-id workflow-id :timeout-ms 5000})
+    (let [drain-result (es/drain! es {:timeout-ms 5000})]
+      (when-not (:ok? drain-result)
+        (let [best-effort? (best-effort-shutdown?)
+              msg (str "Event-stream drain incomplete on shutdown: "
+                       (name (:reason drain-result :unknown))
+                       (when-let [pending (:pending-count drain-result)]
+                         (str " (pending=" pending ")"))
+                       (when-let [failed (:failed-sinks drain-result)]
+                         (str " (failed-sinks=" (count failed) ")")))]
+          (binding [*out* *err*]
+            (println (cond-> msg
+                       (not quiet) (->> (display/colorize :yellow))
+                       best-effort? (str " [MINIFORGE_BEST_EFFORT_SHUTDOWN=1, continuing]"))))
+          (when-not best-effort?
+            (throw (ex-info msg {:reason :event-stream-drain-failed
+                                 :drain-result drain-result})))))
+      drain-result)))
+
 (defn run-workflow! [workflow-id {:keys [version output quiet event-stream dashboard-url]
                                     :or {version "latest" output :pretty quiet false}
                                     :as opts}]
@@ -828,8 +867,17 @@
         (try
           (let [result (execute-workflow-pipeline run-pipeline workflow workflow-input callbacks-with-url artifact-store es)]
             (close-artifact-store artifact-store)
-            (display/print-result result opts)
-            result)
+            ;; BD-2a shutdown ordering: fence late publishers for this
+            ;; workflow, then drain sinks before returning. quiesce!
+            ;; rejects any post-terminal `publish!` for this workflow
+            ;; (heartbeat / cleanup background threads); drain! waits
+            ;; for in-flight publishes to settle and asks each sink to
+            ;; flush. Without this, headless exits could land before the
+            ;; producer-side completion event was durable.
+            (let [shutdown (event-stream-shutdown! es workflow-id opts)]
+              (display/print-result result opts)
+              (cond-> result
+                (some? shutdown) (assoc :event-durability shutdown))))
           (finally
             (progress-cleanup)))))
     (catch Exception e

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -99,47 +99,77 @@
            :filters {}
            :sequence-numbers {}
            :logger (:logger opts)
-           :sinks event-sinks})))
+           :sinks event-sinks
+           ;; BD-2a: workflow-scoped publisher fence. Once a workflow id
+           ;; is in this set, `publish!` rejects further events for that
+           ;; workflow rather than running sinks/subscribers.
+           :quiesced-workflows #{}
+           ;; BD-2a: in-flight publish counter. `drain!` waits on this
+           ;; reaching zero before draining sinks. `publish!` increments
+           ;; on entry (after the quiesce check) and decrements in a
+           ;; finally so a sink exception still releases the slot.
+           :in-flight 0})))
 
 (defn publish! [stream event]
-  (let [{:keys [subscribers filters logger sinks]} @stream
-        workflow-id (:workflow/id event)]
-    ;; Persist event to configured sinks
-    (doseq [sink sinks]
-      (try
-        (sink event)
-        (catch Exception e
-          (when logger
-            (let [anomaly (response/from-exception e)]
-              (log/warn logger :event-stream :sink-error
-                       {:message "Event sink failed"
-                        :data {:event-type (:event/type event)
-                               :anomaly anomaly}}))))))
+  (let [workflow-id (:workflow/id event)
+        ;; BD-2a: snapshot the quiesced set once and check before incrementing
+        ;; in-flight, so a quiesced workflow's publish never enters the body
+        ;; and a concurrent `quiesce!` waiter sees a true at-rest in-flight.
+        quiesced? (and workflow-id
+                       (contains? (:quiesced-workflows @stream) workflow-id))]
+    (if quiesced?
+      (let [{:keys [logger]} @stream]
+        (when logger
+          (log/warn logger :event-stream :event/rejected-after-quiesce
+                    {:message "publish! rejected: workflow quiesced"
+                     :data {:event-type (:event/type event)
+                            :workflow-id workflow-id}}))
+        {:rejected? true
+         :reason :workflow-quiesced
+         :workflow-id workflow-id
+         :event-type (:event/type event)})
+      (do
+        (swap! stream update :in-flight inc)
+        (try
+          (let [{:keys [subscribers filters logger sinks]} @stream]
+            ;; Persist event to configured sinks
+            (doseq [sink sinks]
+              (try
+                (sink event)
+                (catch Exception e
+                  (when logger
+                    (let [anomaly (response/from-exception e)]
+                      (log/warn logger :event-stream :sink-error
+                                {:message "Event sink failed"
+                                 :data {:event-type (:event/type event)
+                                        :anomaly anomaly}}))))))
 
-    ;; In-memory event log
-    (swap! stream update :events conj event)
+            ;; In-memory event log
+            (swap! stream update :events conj event)
 
-    ;; Notify subscribers
-    (doseq [[sub-id callback] subscribers]
-      (let [filter-fn (get filters sub-id (constantly true))]
-        (when (filter-fn event)
-          (try
-            (callback event)
-            (catch Exception e
-              (when logger
-                (let [anomaly (response/from-exception e)]
-                  (log/error logger :event-stream :event/callback-error
-                             {:message "Event callback failed"
-                              :data {:subscriber-id sub-id
-                                     :event-type (:event/type event)
-                                     :anomaly anomaly}}))))))))
-    (when logger
-      (log/debug logger :event-stream :event/published
-                 {:message "Event published"
-                  :data {:event-type (:event/type event)
-                         :workflow-id workflow-id
-                         :sequence (:event/sequence-number event)}}))
-    event))
+            ;; Notify subscribers
+            (doseq [[sub-id callback] subscribers]
+              (let [filter-fn (get filters sub-id (constantly true))]
+                (when (filter-fn event)
+                  (try
+                    (callback event)
+                    (catch Exception e
+                      (when logger
+                        (let [anomaly (response/from-exception e)]
+                          (log/error logger :event-stream :event/callback-error
+                                     {:message "Event callback failed"
+                                      :data {:subscriber-id sub-id
+                                             :event-type (:event/type event)
+                                             :anomaly anomaly}}))))))))
+            (when logger
+              (log/debug logger :event-stream :event/published
+                         {:message "Event published"
+                          :data {:event-type (:event/type event)
+                                 :workflow-id workflow-id
+                                 :sequence (:event/sequence-number event)}}))
+            event)
+          (finally
+            (swap! stream update :in-flight dec)))))))
 
 (defn subscribe!
   ([stream subscriber-id callback]
@@ -159,6 +189,113 @@
                (update :subscribers dissoc subscriber-id)
                (update :filters dissoc subscriber-id))))
   nil)
+
+;------------------------------------------------------------------------------ Layer 1
+;; BD-2a: workflow-scoped publisher quiesce + sink drain barrier.
+;;
+;; `quiesce!` fences future publishes for a workflow so the terminal event
+;; for that workflow is genuinely the last. `drain!` waits for in-flight
+;; publishes to complete and then asks each sink that exposes a drain hook
+;; (under the sink's metadata) to flush. Together they replace the
+;; pre-BD-2a race where headless exits could land before background
+;; producers finished publishing or sinks finished writing.
+
+(defn- wait-for-condition
+  "Spin-wait until `pred` returns truthy or the deadline passes. Returns
+   the final pred value (truthy = condition met before deadline)."
+  [pred deadline-ms]
+  (loop []
+    (let [v (pred)]
+      (cond
+        v v
+        (>= (System/currentTimeMillis) deadline-ms) nil
+        :else (do (Thread/sleep 10) (recur))))))
+
+(defn quiesce!
+  "Fence publishers for `workflow-id` and wait for any in-flight publishes
+   to settle. After return, `publish!` for that workflow returns
+   `{:rejected? true :reason :workflow-quiesced ...}` instead of running
+   sinks or subscribers.
+
+   Without `:workflow-id`, no fence is added — the call only waits for
+   currently in-flight publishes across all workflows to complete. Useful
+   as a barrier before `drain!` when the caller does not care to fence a
+   specific workflow.
+
+   Options:
+     :workflow-id  fence target. Optional.
+     :timeout-ms   wait budget for in-flight publishes (default 5000).
+
+   Returns:
+     {:ok? true  :pending-publishers 0}
+     {:ok? false :pending-publishers N :reason :timeout}"
+  ([stream] (quiesce! stream {}))
+  ([stream {:keys [workflow-id timeout-ms]
+            :or   {timeout-ms 5000}}]
+   (when workflow-id
+     (swap! stream update :quiesced-workflows conj workflow-id))
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)
+         settled? (wait-for-condition #(zero? (:in-flight @stream)) deadline)
+         pending  (:in-flight @stream)]
+     (if settled?
+       {:ok? true :pending-publishers 0}
+       {:ok? false :reason :timeout :pending-publishers pending}))))
+
+(defn drain!
+  "Wait until every event accepted by `publish!` before this call has
+   reached all configured sinks, including any sink-specific flush hook.
+
+   Sinks may declare a drain hook by carrying it under metadata:
+
+     (with-meta sink-fn {:drain (fn [opts] {:ok? true})})
+
+   Sinks without a drain hook are assumed already-drained on `publish!`
+   return — the file/stdout/stderr sinks are synchronous, so this is the
+   common case. The fleet sink with its internal batching is the
+   motivating exception.
+
+   `drain!` first waits for in-flight publishes to settle (so the
+   sink-list snapshot it operates on covers the full pre-call set), then
+   invokes each sink's drain hook with a shared timeout.
+
+   Options:
+     :timeout-ms  total wait budget across in-flight settle + sink drain
+                  (default 5000).
+
+   Returns one of:
+     {:ok? true  :drained-count N}
+     {:ok? false :reason :timeout       :pending-count N}
+     {:ok? false :reason :sink-error    :failed-sinks [{...}]}
+
+   The result is structured so the caller (e.g. `run-workflow!`) can map
+   it to a non-zero exit unless `MINIFORGE_BEST_EFFORT_SHUTDOWN` is set,
+   per the BD-2a contract."
+  ([stream] (drain! stream {}))
+  ([stream {:keys [timeout-ms] :or {timeout-ms 5000}}]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)
+         settled? (wait-for-condition #(zero? (:in-flight @stream)) deadline)]
+     (if-not settled?
+       {:ok? false :reason :timeout :pending-count (:in-flight @stream)}
+       (let [{:keys [sinks]} @stream
+             results (mapv
+                      (fn [sink]
+                        (if-let [drain-fn (:drain (meta sink))]
+                          (let [remaining (max 100 (- deadline (System/currentTimeMillis)))]
+                            (try
+                              {:sink sink :result (drain-fn {:timeout-ms remaining})}
+                              (catch Exception e
+                                {:sink sink :result {:ok? false
+                                                     :reason :sink-error
+                                                     :error (ex-message e)}})))
+                          ;; No drain hook: sink is assumed synchronous.
+                          {:sink sink :result {:ok? true}}))
+                      sinks)
+             failed (filterv (comp not :ok? :result) results)]
+         (if (seq failed)
+           {:ok? false
+            :reason :sink-error
+            :failed-sinks (mapv :result failed)}
+           {:ok? true :drained-count (count results)}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Query API

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -236,9 +236,17 @@
      (swap! stream update :quiesced-workflows conj workflow-id))
    (let [deadline (+ (System/currentTimeMillis) timeout-ms)
          settled? (wait-for-condition #(zero? (:in-flight @stream)) deadline)
-         pending  (:in-flight @stream)]
+         ;; Read in-flight once at return time and report it honestly in
+         ;; both branches. In no-workflow-id mode there is no fence, so a
+         ;; concurrent publisher can land between the wait observing zero
+         ;; and us reading. With a fence in place that workflow's future
+         ;; publishes are rejected (no in-flight increment), but other
+         ;; workflows can still increment. The observational contract is:
+         ;; "ok=true means in-flight reached zero at some point during
+         ;; the wait; pending is the value at return."
+         pending (:in-flight @stream)]
      (if settled?
-       {:ok? true :pending-publishers 0}
+       {:ok? true :pending-publishers pending}
        {:ok? false :reason :timeout :pending-publishers pending}))))
 
 (defn drain!
@@ -277,18 +285,32 @@
      (if-not settled?
        {:ok? false :reason :timeout :pending-count (:in-flight @stream)}
        (let [{:keys [sinks]} @stream
-             results (mapv
-                      (fn [sink]
-                        (if-let [drain-fn (:drain (meta sink))]
-                          (let [remaining (max 100 (- deadline (System/currentTimeMillis)))]
-                            (try
-                              {:sink sink :result (drain-fn {:timeout-ms remaining})}
-                              (catch Exception e
-                                {:sink sink :result {:ok? false
-                                                     :reason :sink-error
-                                                     :error (ex-message e)}})))
-                          ;; No drain hook: sink is assumed synchronous.
-                          {:sink sink :result {:ok? true}}))
+             ;; Process sinks in order, honoring the total budget. If the
+             ;; deadline is already past, mark the remaining sinks as
+             ;; timed out without calling them — this prevents a slow
+             ;; first sink from granting later sinks "extra" wall time
+             ;; just because of a per-sink minimum, which would violate
+             ;; the docstring's total-budget contract.
+             results (reduce
+                      (fn [acc sink]
+                        (let [remaining (- deadline (System/currentTimeMillis))]
+                          (conj acc
+                                (cond
+                                  (<= remaining 0)
+                                  {:sink sink :result {:ok? false :reason :timeout}}
+
+                                  (some? (:drain (meta sink)))
+                                  (try
+                                    {:sink sink
+                                     :result ((:drain (meta sink)) {:timeout-ms remaining})}
+                                    (catch Exception e
+                                      {:sink sink :result {:ok? false
+                                                           :reason :sink-error
+                                                           :error (ex-message e)}}))
+
+                                  ;; No drain hook: sink is assumed synchronous.
+                                  :else {:sink sink :result {:ok? true}}))))
+                      []
                       sinks)
              failed (filterv (comp not :ok? :result) results)]
          (if (seq failed)

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -110,66 +110,137 @@
            ;; finally so a sink exception still releases the slot.
            :in-flight 0})))
 
-(defn publish! [stream event]
-  (let [workflow-id (:workflow/id event)
-        ;; BD-2a: snapshot the quiesced set once and check before incrementing
-        ;; in-flight, so a quiesced workflow's publish never enters the body
-        ;; and a concurrent `quiesce!` waiter sees a true at-rest in-flight.
-        quiesced? (and workflow-id
-                       (contains? (:quiesced-workflows @stream) workflow-id))]
-    (if quiesced?
-      (let [{:keys [logger]} @stream]
+;------------------------------------------------------------------------------ Layer 0
+;; publish! helpers — small, single-purpose pieces composed by publish!
+;; itself. Each helper is testable in isolation; tests live in
+;; `publish_helpers_test.clj`.
+
+(defn- workflow-quiesced?
+  "True when `event`'s workflow id has been fenced via `quiesce!`."
+  [stream event]
+  (when-let [wid (:workflow/id event)]
+    (contains? (:quiesced-workflows @stream) wid)))
+
+(defn- rejection-result
+  "Build the structured rejection map returned to a publisher whose
+   workflow has been quiesced. Stable shape so callers can pattern-match."
+  [event reason]
+  {:rejected?   true
+   :reason      reason
+   :workflow-id (:workflow/id event)
+   :event-type  (:event/type event)})
+
+(defn- log-rejection!
+  "Surface a quiesce rejection at warn level if a logger is configured."
+  [logger event]
+  (when logger
+    (log/warn logger :event-stream :event/rejected-after-quiesce
+              {:message "publish! rejected: workflow quiesced"
+               :data    {:event-type  (:event/type event)
+                         :workflow-id (:workflow/id event)}})))
+
+(defn- rejection-if-quiesced
+  "Return the structured rejection map when `event`'s workflow is fenced,
+   else nil. Logs the rejection as a side effect so callers don't have
+   to do it twice."
+  [stream event]
+  (when (workflow-quiesced? stream event)
+    (log-rejection! (:logger @stream) event)
+    (rejection-result event :workflow-quiesced)))
+
+(defn- with-in-flight
+  "Run `body-fn` while incrementing the stream's in-flight publish
+   counter, decrementing in a finally so an exception still releases the
+   slot. Returns body-fn's result. Cross-cutting concern that lets
+   `quiesce!` / `drain!` observe an at-rest stream when no publishes
+   are mid-flight."
+  [stream body-fn]
+  (swap! stream update :in-flight inc)
+  (try
+    (body-fn)
+    (finally
+      (swap! stream update :in-flight dec))))
+
+(defn- record-event!
+  "Append `event` to the in-memory event log."
+  [stream event]
+  (swap! stream update :events conj event))
+
+(defn- deliver-to-sink!
+  "Invoke `sink` with `event`, swallowing exceptions and logging them.
+   A failing sink must not break others or the publish path."
+  [sink event logger]
+  (try
+    (sink event)
+    (catch Exception e
+      (when logger
+        (log/warn logger :event-stream :sink-error
+                  {:message "Event sink failed"
+                   :data    {:event-type (:event/type event)
+                             :anomaly    (response/from-exception e)}})))))
+
+(defn- deliver-to-sinks!
+  "Fan `event` out to every configured sink. Each sink runs in
+   isolation via `deliver-to-sink!`."
+  [sinks event logger]
+  (doseq [sink sinks]
+    (deliver-to-sink! sink event logger)))
+
+(defn- deliver-to-subscriber!
+  "Invoke `callback` for `event` when `filter-fn` accepts it,
+   swallowing exceptions and logging them."
+  [sub-id callback filter-fn event logger]
+  (when (filter-fn event)
+    (try
+      (callback event)
+      (catch Exception e
         (when logger
-          (log/warn logger :event-stream :event/rejected-after-quiesce
-                    {:message "publish! rejected: workflow quiesced"
-                     :data {:event-type (:event/type event)
-                            :workflow-id workflow-id}}))
-        {:rejected? true
-         :reason :workflow-quiesced
-         :workflow-id workflow-id
-         :event-type (:event/type event)})
-      (do
-        (swap! stream update :in-flight inc)
-        (try
-          (let [{:keys [subscribers filters logger sinks]} @stream]
-            ;; Persist event to configured sinks
-            (doseq [sink sinks]
-              (try
-                (sink event)
-                (catch Exception e
-                  (when logger
-                    (let [anomaly (response/from-exception e)]
-                      (log/warn logger :event-stream :sink-error
-                                {:message "Event sink failed"
-                                 :data {:event-type (:event/type event)
-                                        :anomaly anomaly}}))))))
+          (log/error logger :event-stream :event/callback-error
+                     {:message "Event callback failed"
+                      :data    {:subscriber-id sub-id
+                                :event-type    (:event/type event)
+                                :anomaly       (response/from-exception e)}}))))))
 
-            ;; In-memory event log
-            (swap! stream update :events conj event)
+(defn- deliver-to-subscribers!
+  "Fan `event` out to every subscriber that accepts it via its filter."
+  [subscribers filters event logger]
+  (doseq [[sub-id callback] subscribers]
+    (let [filter-fn (get filters sub-id (constantly true))]
+      (deliver-to-subscriber! sub-id callback filter-fn event logger))))
 
-            ;; Notify subscribers
-            (doseq [[sub-id callback] subscribers]
-              (let [filter-fn (get filters sub-id (constantly true))]
-                (when (filter-fn event)
-                  (try
-                    (callback event)
-                    (catch Exception e
-                      (when logger
-                        (let [anomaly (response/from-exception e)]
-                          (log/error logger :event-stream :event/callback-error
-                                     {:message "Event callback failed"
-                                      :data {:subscriber-id sub-id
-                                             :event-type (:event/type event)
-                                             :anomaly anomaly}}))))))))
-            (when logger
-              (log/debug logger :event-stream :event/published
-                         {:message "Event published"
-                          :data {:event-type (:event/type event)
-                                 :workflow-id workflow-id
-                                 :sequence (:event/sequence-number event)}}))
-            event)
-          (finally
-            (swap! stream update :in-flight dec)))))))
+(defn- log-published!
+  "Debug-log that `event` reached the subscribers."
+  [logger event]
+  (when logger
+    (log/debug logger :event-stream :event/published
+               {:message "Event published"
+                :data    {:event-type  (:event/type event)
+                          :workflow-id (:workflow/id event)
+                          :sequence    (:event/sequence-number event)}})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; publish! orchestrates the helpers above as a small pipeline.
+
+(defn publish!
+  "Publish `event` to the stream.
+
+   When the event's workflow has been quiesced (BD-2a), short-circuits
+   with a structured `{:rejected? true ...}` map and runs no sinks or
+   subscribers. Otherwise: fan out to sinks, append to the in-memory
+   log, fan out to subscribers, log, and return `event`.
+
+   In-flight publishes are tracked so `quiesce!` / `drain!` can wait
+   for the stream to settle before reporting at-rest."
+  [stream event]
+  (or (rejection-if-quiesced stream event)
+      (with-in-flight stream
+        (fn []
+          (let [{:keys [sinks subscribers filters logger]} @stream]
+            (deliver-to-sinks! sinks event logger)
+            (record-event! stream event)
+            (deliver-to-subscribers! subscribers filters event logger)
+            (log-published! logger event)
+            event)))))
 
 (defn subscribe!
   ([stream subscriber-id callback]

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -48,6 +48,10 @@
 (def get-events stream/get-events)
 (def get-latest-status stream/get-latest-status)
 
+;; BD-2a shutdown-ordering primitives.
+(def quiesce! stream/quiesce!)
+(def drain! stream/drain!)
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Event constructors
 

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/stream.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/stream.clj
@@ -31,3 +31,8 @@
 (def unsubscribe! core/unsubscribe!)
 (def get-events core/get-events)
 (def get-latest-status core/get-latest-status)
+
+;; BD-2a: shutdown ordering primitives. See `core/quiesce!` and
+;; `core/drain!` for the contract.
+(def quiesce! core/quiesce!)
+(def drain! core/drain!)

--- a/components/event-stream/test/ai/miniforge/event_stream/publish_helpers_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/publish_helpers_test.clj
@@ -1,0 +1,174 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.publish-helpers-test
+  "Stratum-by-stratum tests for the helpers `publish!` composes. The
+   helpers are private (`defn-`) so tests reach them via `#'`-vars.
+   Each helper is single-purpose; the existing `publish!` integration
+   coverage in `core_test.clj` and `quiesce_drain_test.clj` exercises
+   them composed."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.event-stream.core :as core]))
+
+(def ^:private workflow-quiesced?     #'core/workflow-quiesced?)
+(def ^:private rejection-result       #'core/rejection-result)
+(def ^:private rejection-if-quiesced  #'core/rejection-if-quiesced)
+(def ^:private with-in-flight         #'core/with-in-flight)
+(def ^:private record-event!          #'core/record-event!)
+(def ^:private deliver-to-sink!       #'core/deliver-to-sink!)
+(def ^:private deliver-to-sinks!      #'core/deliver-to-sinks!)
+(def ^:private deliver-to-subscriber! #'core/deliver-to-subscriber!)
+(def ^:private deliver-to-subscribers! #'core/deliver-to-subscribers!)
+
+(defn- evt
+  ([] (evt :test/event (random-uuid)))
+  ([event-type wid]
+   {:event/type event-type
+    :event/id (random-uuid)
+    :workflow/id wid
+    :event/sequence-number 0
+    :message "test"}))
+
+;------------------------------------------------------------------------------ workflow-quiesced?
+
+(deftest workflow-quiesced?-tracks-quiesced-set
+  (let [wid-a (random-uuid)
+        wid-b (random-uuid)
+        stream (atom {:quiesced-workflows #{wid-a}})]
+    (is (true?  (workflow-quiesced? stream (evt :x wid-a))))
+    (is (false? (boolean (workflow-quiesced? stream (evt :x wid-b)))))
+    (is (false? (boolean (workflow-quiesced? stream {:event/type :x}))))
+        "missing :workflow/id is treated as not-quiesced — there's nothing to fence"))
+
+;------------------------------------------------------------------------------ rejection-result
+
+(deftest rejection-result-shape-is-stable
+  (let [wid (random-uuid)
+        result (rejection-result {:event/type :test/event :workflow/id wid} :workflow-quiesced)]
+    (is (true? (:rejected? result)))
+    (is (= :workflow-quiesced (:reason result)))
+    (is (= wid (:workflow-id result)))
+    (is (= :test/event (:event-type result)))))
+
+;------------------------------------------------------------------------------ rejection-if-quiesced
+
+(deftest rejection-if-quiesced-returns-nil-when-not-fenced
+  (let [stream (atom {:quiesced-workflows #{} :logger nil})]
+    (is (nil? (rejection-if-quiesced stream (evt))))))
+
+(deftest rejection-if-quiesced-returns-result-when-fenced
+  (let [wid (random-uuid)
+        stream (atom {:quiesced-workflows #{wid} :logger nil})
+        result (rejection-if-quiesced stream (evt :test/event wid))]
+    (is (true? (:rejected? result)))
+    (is (= :workflow-quiesced (:reason result)))))
+
+;------------------------------------------------------------------------------ with-in-flight
+
+(deftest with-in-flight-increments-and-decrements-around-body
+  (let [stream (atom {:in-flight 0})
+        observed (atom nil)]
+    (with-in-flight stream
+      (fn []
+        (reset! observed (:in-flight @stream))
+        :body-result))
+    (is (= 1 @observed) "body sees the incremented counter")
+    (is (= 0 (:in-flight @stream)) "post-call counter is decremented back to zero")))
+
+(deftest with-in-flight-decrements-on-body-exception
+  (let [stream (atom {:in-flight 0})]
+    (is (thrown? Exception
+                 (with-in-flight stream (fn [] (throw (RuntimeException. "boom"))))))
+    (is (= 0 (:in-flight @stream))
+        "decrement runs in finally so a body exception doesn't leak the slot")))
+
+(deftest with-in-flight-returns-body-value
+  (let [stream (atom {:in-flight 0})]
+    (is (= :result (with-in-flight stream (constantly :result))))))
+
+;------------------------------------------------------------------------------ record-event!
+
+(deftest record-event!-appends-to-events-vector
+  (let [stream (atom {:events []})
+        e1 (evt) e2 (evt)]
+    (record-event! stream e1)
+    (record-event! stream e2)
+    (is (= [e1 e2] (:events @stream)))))
+
+;------------------------------------------------------------------------------ deliver-to-sink!
+
+(deftest deliver-to-sink!-calls-the-sink
+  (let [calls (atom [])
+        sink (fn [e] (swap! calls conj e))
+        e (evt)]
+    (deliver-to-sink! sink e nil)
+    (is (= [e] @calls))))
+
+(deftest deliver-to-sink!-swallows-and-logs-exceptions
+  (let [throwing-sink (fn [_] (throw (RuntimeException. "sink failed")))]
+    ;; Logger nil — must not throw on the swallow path.
+    (is (nil? (deliver-to-sink! throwing-sink (evt) nil))
+        "exception from sink must not propagate; nil return is fine")))
+
+;------------------------------------------------------------------------------ deliver-to-sinks!
+
+(deftest deliver-to-sinks!-runs-all-sinks-even-when-one-throws
+  (let [calls (atom [])
+        good-sink (fn [e] (swap! calls conj [:good e]))
+        bad-sink (fn [_] (throw (RuntimeException. "boom")))
+        another-good-sink (fn [e] (swap! calls conj [:other e]))
+        e (evt)]
+    (deliver-to-sinks! [good-sink bad-sink another-good-sink] e nil)
+    (is (= 2 (count @calls))
+        "the bad sink does not stop the others")
+    (is (= [:good e] (first @calls)))
+    (is (= [:other e] (second @calls)))))
+
+;------------------------------------------------------------------------------ deliver-to-subscriber!
+
+(deftest deliver-to-subscriber!-respects-filter
+  (let [calls (atom [])
+        callback (fn [e] (swap! calls conj e))
+        accept-fn (constantly true)
+        reject-fn (constantly false)
+        e (evt)]
+    (deliver-to-subscriber! :sub-1 callback reject-fn e nil)
+    (is (empty? @calls) "filter rejected — callback must not run")
+    (deliver-to-subscriber! :sub-1 callback accept-fn e nil)
+    (is (= [e] @calls))))
+
+(deftest deliver-to-subscriber!-swallows-callback-exceptions
+  (let [throwing-cb (fn [_] (throw (RuntimeException. "cb failed")))]
+    (is (nil? (deliver-to-subscriber! :sub-1 throwing-cb (constantly true) (evt) nil))
+        "callback exception must not propagate")))
+
+;------------------------------------------------------------------------------ deliver-to-subscribers!
+
+(deftest deliver-to-subscribers!-applies-filters-and-isolates-failures
+  (let [calls (atom [])
+        cb-a (fn [e] (swap! calls conj [:a e]))
+        cb-b (fn [_] (throw (RuntimeException. "b boom")))
+        cb-c (fn [e] (swap! calls conj [:c e]))
+        subscribers {:sub-a cb-a :sub-b cb-b :sub-c cb-c}
+        ;; sub-c gets a filter that rejects every event.
+        filters {:sub-c (constantly false)}
+        e (evt)]
+    (deliver-to-subscribers! subscribers filters e nil)
+    (is (= [[:a e]] @calls)
+        "a runs (no filter, accept by default), b throws (swallowed), c is filtered out")))

--- a/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
@@ -1,0 +1,197 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.quiesce-drain-test
+  "Contract tests for the BD-2a shutdown ordering primitives.
+
+   `quiesce!` fences future publishers for a workflow id; `drain!` waits
+   for in-flight publishes to settle and asks each sink that exposes a
+   drain hook (under metadata) to flush. Together they replace the
+   pre-BD-2a race where headless exits could land before background
+   producers finished publishing or sinks finished writing."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.event-stream.core :as core]))
+
+(defn- recording-sink
+  "Return [sink record] where `sink` collects events into `record` so
+   tests can assert sink reach-through."
+  []
+  (let [record (atom [])
+        sink (fn [event] (swap! record conj event))]
+    [sink record]))
+
+(defn- workflow-event
+  "Build a minimal event with `:workflow/id` for publish! tests. The
+   envelope shape is what `create-envelope` would have produced; tests
+   here construct it directly to avoid mutating sequence numbers."
+  [workflow-id event-type]
+  {:event/type event-type
+   :event/id (random-uuid)
+   :event/timestamp (java.util.Date.)
+   :event/version core/event-version
+   :workflow/id workflow-id
+   :message "test"})
+
+;------------------------------------------------------------------------------ quiesce!
+
+(deftest quiesce-rejects-future-publishes-for-target-workflow
+  (let [[sink record] (recording-sink)
+        stream (core/create-event-stream {:sinks [sink]})
+        wid (random-uuid)
+        result-pre (core/publish! stream (workflow-event wid :test/event))
+        _quiesce (core/quiesce! stream {:workflow-id wid})
+        result-post (core/publish! stream (workflow-event wid :test/event))]
+    (is (= 1 (count @record))
+        "the sink should observe the pre-quiesce event but not the post-quiesce one")
+    (is (not (:rejected? result-pre)))
+    (is (true? (:rejected? result-post)))
+    (is (= :workflow-quiesced (:reason result-post)))
+    (is (= wid (:workflow-id result-post)))))
+
+(deftest quiesce-only-fences-named-workflow
+  (let [[sink record] (recording-sink)
+        stream (core/create-event-stream {:sinks [sink]})
+        wid-a (random-uuid)
+        wid-b (random-uuid)]
+    (core/quiesce! stream {:workflow-id wid-a})
+    (let [a-result (core/publish! stream (workflow-event wid-a :test/event))
+          b-result (core/publish! stream (workflow-event wid-b :test/event))]
+      (is (true? (:rejected? a-result))
+          "workflow A is quiesced and must reject")
+      (is (not (:rejected? b-result))
+          "workflow B is independent and must still publish")
+      (is (= 1 (count @record))
+          "only B's event reached the sink"))))
+
+(deftest quiesce-without-workflow-id-just-waits
+  ;; Without a target workflow, quiesce! adds no fence — it only waits
+  ;; for any currently in-flight publish to settle. Useful as a global
+  ;; barrier before drain! when no specific workflow is being torn down.
+  (let [stream (core/create-event-stream {:sinks []})]
+    (let [result (core/quiesce! stream {})]
+      (is (true? (:ok? result)))
+      (is (= 0 (:pending-publishers result))))
+    (let [wid (random-uuid)
+          ;; And publish still works after a no-target quiesce.
+          publish-result (core/publish! stream (workflow-event wid :test/event))]
+      (is (not (:rejected? publish-result))))))
+
+(deftest quiesce-returns-ok-when-stream-is-quiet
+  (let [stream (core/create-event-stream {:sinks []})
+        result (core/quiesce! stream {:workflow-id (random-uuid) :timeout-ms 500})]
+    (is (true? (:ok? result)))
+    (is (= 0 (:pending-publishers result)))))
+
+;------------------------------------------------------------------------------ drain!
+
+(deftest drain-default-sinks-return-ok-immediately
+  ;; File / stdout / stderr sinks are synchronous in the publish! body, so
+  ;; once publish! returns there is nothing to drain. Sinks without a
+  ;; metadata `:drain` hook are assumed already-drained.
+  (let [[sink _record] (recording-sink)
+        stream (core/create-event-stream {:sinks [sink]})
+        wid (random-uuid)]
+    (dotimes [_ 5]
+      (core/publish! stream (workflow-event wid :test/event)))
+    (let [result (core/drain! stream {:timeout-ms 500})]
+      (is (true? (:ok? result)))
+      (is (= 1 (:drained-count result))))))
+
+(deftest drain-invokes-sink-drain-hook-when-present
+  ;; A sink that carries a drain hook under metadata (e.g. fleet-sink with
+  ;; an internal batch) must receive the drain call and report status.
+  (let [drain-called? (atom false)
+        sink (with-meta
+               (fn [_event] nil)
+               {:drain (fn [_opts]
+                         (reset! drain-called? true)
+                         {:ok? true})})
+        stream (core/create-event-stream {:sinks [sink]})
+        result (core/drain! stream {:timeout-ms 500})]
+    (is (true? @drain-called?))
+    (is (true? (:ok? result)))))
+
+(deftest drain-reports-sink-error-with-structured-result
+  (let [bad-sink (with-meta
+                   (fn [_event] nil)
+                   {:drain (fn [_opts] {:ok? false :reason :sink-error :error "boom"})})
+        good-sink (with-meta
+                    (fn [_event] nil)
+                    {:drain (fn [_opts] {:ok? true})})
+        stream (core/create-event-stream {:sinks [good-sink bad-sink]})
+        result (core/drain! stream {:timeout-ms 500})]
+    (is (false? (:ok? result)))
+    (is (= :sink-error (:reason result)))
+    (is (= 1 (count (:failed-sinks result))))
+    (is (= "boom" (-> result :failed-sinks first :error)))))
+
+(deftest drain-reports-timeout-when-sink-hook-hangs
+  (let [hanging-sink (with-meta
+                       (fn [_event] nil)
+                       {:drain (fn [_opts]
+                                 ;; Sink itself reports timeout when its budget runs out.
+                                 (Thread/sleep 200)
+                                 {:ok? false :reason :timeout})})
+        stream (core/create-event-stream {:sinks [hanging-sink]})
+        result (core/drain! stream {:timeout-ms 250})]
+    (is (false? (:ok? result)))
+    (is (= :sink-error (:reason result))
+        "sink-reported timeout surfaces as a sink-error in the aggregate result")))
+
+(deftest drain-catches-sink-drain-exceptions
+  (let [throwing-sink (with-meta
+                        (fn [_event] nil)
+                        {:drain (fn [_opts] (throw (ex-info "kaboom" {})))})
+        stream (core/create-event-stream {:sinks [throwing-sink]})
+        result (core/drain! stream {:timeout-ms 500})]
+    (is (false? (:ok? result)))
+    (is (= :sink-error (:reason result)))
+    (is (= "kaboom" (-> result :failed-sinks first :error)))))
+
+;------------------------------------------------------------------------------ ordering invariants
+
+(deftest publish-during-drain-does-not-bypass-quiesce
+  ;; Pin the contract that quiesce! prevents publishers from sneaking in
+  ;; between quiesce! and drain!. Without the quiesce step, drain! cannot
+  ;; cover late publishers — that's the v1 race the BD-2a primitives are
+  ;; meant to close.
+  (let [[sink record] (recording-sink)
+        stream (core/create-event-stream {:sinks [sink]})
+        wid (random-uuid)]
+    ;; Pre-quiesce publish lands.
+    (core/publish! stream (workflow-event wid :test/event))
+    (core/quiesce! stream {:workflow-id wid})
+    ;; A publisher that races with shutdown attempts to publish *after*
+    ;; quiesce. Drain runs immediately after.
+    (core/publish! stream (workflow-event wid :test/event))
+    (core/drain! stream {:timeout-ms 500})
+    (is (= 1 (count @record))
+        "exactly one event reached the sink — the pre-quiesce one")))
+
+(deftest in-flight-tracking-decrements-on-sink-exception
+  ;; A sink that throws must still release the in-flight slot, otherwise
+  ;; quiesce! and drain! would wait forever on a stuck counter.
+  (let [throwing-sink (fn [_event] (throw (RuntimeException. "sink boom")))
+        stream (core/create-event-stream {:sinks [throwing-sink]})
+        wid (random-uuid)]
+    ;; publish! catches sink exceptions and continues.
+    (core/publish! stream (workflow-event wid :test/event))
+    (let [result (core/drain! stream {:timeout-ms 500})]
+      (is (true? (:ok? result))
+          "in-flight counter must release even when the sink throws"))))

--- a/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
@@ -154,6 +154,30 @@
     (is (= :sink-error (:reason result))
         "sink-reported timeout surfaces as a sink-error in the aggregate result")))
 
+(deftest drain-budget-short-circuits-remaining-sinks-when-deadline-passes
+  ;; If an earlier sink consumes the entire drain budget, subsequent
+  ;; sinks must not be granted "extra" wall time (which would happen
+  ;; under a `(max 100 remaining)` floor). They are marked as timed out
+  ;; without their drain hook being called.
+  (let [budget-burner (with-meta
+                        (fn [_event] nil)
+                        {:drain (fn [{:keys [timeout-ms]}]
+                                  (Thread/sleep timeout-ms)
+                                  {:ok? false :reason :timeout})})
+        called? (atom false)
+        later-sink (with-meta
+                     (fn [_event] nil)
+                     {:drain (fn [_opts]
+                               (reset! called? true)
+                               {:ok? true})})
+        stream (core/create-event-stream {:sinks [budget-burner later-sink]})
+        result (core/drain! stream {:timeout-ms 100})]
+    (is (false? (:ok? result)))
+    (is (false? @called?)
+        "later sink's drain hook must not be invoked once budget is exhausted")
+    (is (= 2 (count (:failed-sinks result)))
+        "both sinks contribute failure entries — the burner timed out, the later one was short-circuited")))
+
 (deftest drain-catches-sink-drain-exceptions
   (let [throwing-sink (with-meta
                         (fn [_event] nil)


### PR DESCRIPTION
## Summary

First implementation PR off the BD-2 design RFC (#795). Adds the two shutdown-ordering primitives the headless-exit race requires:

- **`quiesce!`** fences future publishers for a workflow id. After return, `publish!` for that workflow returns `{:rejected? true :reason :workflow-quiesced ...}` instead of running sinks or subscribers. The terminal `:workflow/completed` / `:workflow/failed` event becomes the genuine last publish for that workflow.
- **`drain!`** waits for in-flight publishes to settle, then asks each sink that exposes a `:drain` hook under metadata to flush. Synchronous sinks (file, stdout, stderr) need no hook; the fleet sink's batched HTTP path is the motivating exception. Returns a structured result so callers can map to a non-zero exit.

## Wire-up

`bases/cli/workflow_runner.clj` `run-workflow!`:

- After `execute-workflow-pipeline` returns and `close-artifact-store` has run, call `quiesce!` for the workflow then `drain!`. On non-OK drain in normal mode, throw an `ex-info` carrying the drain result so the existing catch path renders the failure and the CLI exits non-zero.
- `MINIFORGE_BEST_EFFORT_SHUTDOWN=1` is the documented escape hatch for local/dev loops: drain failures still log a structured warning to stderr but the run continues. Per the BD-2 RFC v4 commitment, this mode is explicit and noisy — never silent.
- Drain result is attached to the run result as `:event-durability` so downstream callers can detect a degraded shutdown.

## Internal change to `publish!`

- Snapshot `:quiesced-workflows` once on entry; reject before any side effect, so a quiesced workflow's publish never runs sinks or subscribers.
- Increment `:in-flight` after the quiesce check, decrement in a finally so a sink exception still releases the slot.

## Tests

`components/event-stream/test/.../quiesce_drain_test.clj` pins the contract:

- quiesce rejects future publishes for the named workflow;
- quiesce only fences the named workflow (independent workflows continue);
- quiesce without a workflow id is a global in-flight barrier only;
- drain returns ok immediately when all sinks are synchronous;
- drain invokes the `:drain` metadata hook when present;
- drain reports structured `:sink-error` when a sink fails or throws;
- the explicit "publish-during-drain does not bypass quiesce" test pins the v1 race the primitives are meant to close;
- in-flight tracking decrements on sink exception so drain can't hang on a stuck counter.

## Out of scope (tracked for follow-on)

- **File-sink atomic write + fsync hardening** (BD-2a test #8 in the RFC). Current file sink uses `spit`, which closes the writer but does not fsync. Bigger contained change; lands separately so this PR stays focused on the publisher-fence + sink-drain contract surface.
- **CLI exit-code wiring beyond `throw`**. The current PR throws on non-OK drain; whatever calls `run-workflow!` exits non-zero on the rethrown exception. A more structured `event_durability` field in the run result is in place; richer CLI exit-code handling is a small follow-on.

## Validation

```
bb pre-commit
```

All checks passed. 5208 tests, 0 failures (the 1 flaky failure observed during the BD-2 RFC commit was unrelated and didn't reproduce here).

## Test plan

- [ ] reviewer agrees the metadata-based drain hook is the right opt-in for sinks that need flushing (vs an explicit protocol).
- [ ] reviewer agrees throwing-on-non-OK-drain is the right wiring vs returning a structured result and trusting the caller.
- [ ] reviewer confirms the file-sink fsync hardening is appropriate to defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)