### PR TITLE
feat(workflow): wire MERGEABLE→NON_MERGEABLE hook end-to-end (Stage 3d)

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -145,6 +145,12 @@
    - :ci-poll-interval-ms - CI poll interval (default 30000)
    - :review-poll-interval-ms - Review poll interval (default 30000)
    - :auto-resolve-comments - Auto-resolve conversation threads after fixes (default true)
+   - :resolve-fn - Spec §6.4 resolution callback. When set, attempt-merge!
+     forwards it to merge/attempt-merge via context, where the
+     conflict-resolution dispatch picks it up on a CONFLICTING branch
+     state. Workflow-side caller passes
+     workflow.merge-resolution/resolve-conflict! here so pr-lifecycle
+     stays free of a workflow dependency.
 
    Returns controller state atom."
   [dag-id run-id task-id task
@@ -170,6 +176,7 @@
            :event-bus (:event-bus non-nil-opts)
            :logger (:logger non-nil-opts)
            :generate-fn (:generate-fn non-nil-opts)
+           :resolve-fn (:resolve-fn non-nil-opts)
 
            ;; State
            :status controller-fsm/initial-status
@@ -440,7 +447,7 @@
   "Attempt to merge the PR."
   [controller]
   (let [{dag-id :dag/id run-id :run/id task-id :task/id
-         :keys [pr config event-bus logger]} @controller
+         :keys [pr config event-bus logger resolve-fn]} @controller
         {:keys [worktree-path merge-policy]} config]
 
     (update-status! controller :ready-to-merge)
@@ -453,12 +460,18 @@
 
     (let [merge-result (merge/attempt-merge
                         worktree-path (:pr/id pr) merge-policy
-                        {:dag-id dag-id
-                         :run-id run-id
-                         :task-id task-id
-                         :pr-id (:pr/id pr)
-                         :event-bus event-bus
-                         :logger logger})]
+                        ;; Spec §6.4: when caller injected
+                        ;; :resolve-fn at create-controller time,
+                        ;; thread it into the merge context so
+                        ;; merge.clj's conflict-resolution dispatch
+                        ;; picks it up on a CONFLICTING branch state.
+                        (cond-> {:dag-id dag-id
+                                 :run-id run-id
+                                 :task-id task-id
+                                 :pr-id (:pr/id pr)
+                                 :event-bus event-bus
+                                 :logger logger}
+                          resolve-fn (assoc :resolve-fn resolve-fn)))]
       (if (and (dag/ok? merge-result) (:merged? (:data merge-result)))
         (do
           (update-status! controller :merged)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -23,6 +23,7 @@
    a PR is ready to merge and executing the merge."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
    [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.logging.interface :as log]
    [babashka.process :as process]
@@ -46,7 +47,13 @@
    :require-no-unresolved-threads? true
    :require-branch-up-to-date? true
    :delete-branch-after-merge? true
-   :auto-rebase-on-stale? true})
+   :auto-rebase-on-stale? true
+   ;; Spec §6.4 hook: when GitHub reports the PR as CONFLICTING with
+   ;; its base, run the multi-parent merge resolution sub-workflow
+   ;; via conflict-resolution/resolve-pr-conflicts!. Engages only if
+   ;; the caller also supplied :resolve-fn on context (workflow side
+   ;; injects workflow.merge-resolution/resolve-conflict! there).
+   :auto-resolve-conflicts? true})
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; GitHub CLI helpers
@@ -256,6 +263,66 @@
               (dag/err :push-failed (:error push-result))))
           (dag/err :rebase-failed (:error rebase-result)))))))
 
+;------------------------------------------------------------------------------ Layer 1
+;; Conflict-resolution dispatch (Stage 3d, spec §6.4)
+
+(defn- pr-info-from-gh
+  "Fetch the fields conflict-resolution/resolve-pr-conflicts! needs
+   from `gh pr view`: PR number, branch (headRefName), base
+   (baseRefName), head SHA (headRefOid), base SHA (baseRefOid).
+   Returns dag/ok with the `{:pr/* ...}` shape on success or the
+   underlying gh failure as dag/err."
+  [worktree-path pr-number]
+  (let [r (run-gh-command
+           ["gh" "pr" "view" (str pr-number) "--json"
+            "number,headRefName,baseRefName,headRefOid,baseRefOid"]
+           worktree-path)]
+    (if (dag/err? r)
+      r
+      (let [out (:output (:data r))
+            field (fn [k]
+                    (second (re-find (re-pattern
+                                      (str "\"" k "\"\\s*:\\s*\"([^\"]+)\""))
+                                     out)))
+            head-branch (field "headRefName")
+            base-branch (field "baseRefName")
+            head-sha (field "headRefOid")
+            base-sha (field "baseRefOid")]
+        (if (and head-branch base-branch head-sha base-sha)
+          (dag/ok {:pr/id        pr-number
+                   :pr/branch    head-branch
+                   :pr/base      base-branch
+                   :pr/head-sha  head-sha
+                   :pr/base-sha  base-sha})
+          (dag/err :pr-info-incomplete
+                   "Could not parse PR head/base from gh output"
+                   {:gh-output out}))))))
+
+(defn- attempt-conflict-resolution!
+  "Spec §6.4 dispatch: when `branch-check` raw output classifies as
+   :conflicting AND policy enables auto-resolve AND context carries
+   `:resolve-fn`, run conflict-resolution/resolve-pr-conflicts! and
+   return its outcome. Otherwise return nil so the caller falls
+   back to the existing rebase/not-ready path.
+
+   The resolve-fn comes from context (workflow side injects
+   workflow.merge-resolution/resolve-conflict! at lifecycle ctor
+   time) so pr-lifecycle stays free of a workflow dependency."
+  [worktree-path pr-number policy context branch-raw]
+  (let [resolve-fn (:resolve-fn context)
+        state      (conflict-resolution/classify-merge-state branch-raw)]
+    (when (and (= :conflicting state)
+               (:auto-resolve-conflicts? policy)
+               resolve-fn)
+      (let [pr-r (pr-info-from-gh worktree-path pr-number)]
+        (if (dag/err? pr-r)
+          pr-r
+          (conflict-resolution/resolve-pr-conflicts!
+           {:worktree-path worktree-path
+            :pr            (:data pr-r)
+            :resolve-fn    resolve-fn
+            :context       context}))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Merge orchestration
 
@@ -308,8 +375,27 @@
                      "Merge command failed"
                      {:gh-error (:error merge-result)})))
 
-        ;; Not ready - check if we should auto-rebase
-        (if (and (contains? (set (:blocking readiness)) :branch-not-up-to-date)
+        ;; Not ready — branch-not-up-to-date may mean either
+        ;; CONFLICTING (Stage 3 §6.4 hook engages) or BEHIND (auto-
+        ;; rebase). Attempt conflict-resolution first; only if it
+        ;; declines (state isn't :conflicting, or policy/resolver
+        ;; absent) fall through to the rebase path.
+        (let [branch-raw (get-in (:branch (:checks readiness))
+                                 [:data :raw])
+              cr-result  (when (contains? (set (:blocking readiness))
+                                          :branch-not-up-to-date)
+                           (attempt-conflict-resolution!
+                            worktree-path pr-number policy context
+                            branch-raw))]
+          (cond
+            ;; conflict-resolution engaged — return its outcome
+            ;; (success, dag/err, or terminal anomaly) directly. The
+            ;; lifecycle's outer loop re-evaluates merge readiness
+            ;; on the next cycle once GitHub re-classifies the PR.
+            (some? cr-result)
+            cr-result
+
+            (and (contains? (set (:blocking readiness)) :branch-not-up-to-date)
                  (:auto-rebase-on-stale? policy))
           ;; Try to rebase
           (do
@@ -339,10 +425,11 @@
                     rebase-result))
                 (dag/err :branch-not-found "Could not determine PR branch"))))
 
-          ;; Can't merge and won't auto-rebase
-          (dag/err :not-ready
-                   "PR is not ready to merge"
-                   {:blocking (:blocking readiness)}))))))
+            :else
+            ;; Can't merge and won't auto-rebase
+            (dag/err :not-ready
+                     "PR is not ready to merge"
+                     {:blocking (:blocking readiness)})))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.logging.interface :as log]
    [babashka.process :as process]
+   [cheshire.core :as json]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -266,6 +267,16 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Conflict-resolution dispatch (Stage 3d, spec §6.4)
 
+(defn- parse-gh-json
+  "Parse `gh --json` output as JSON via Cheshire. Returns the parsed
+   map (keywordized keys) on success or nil if the body isn't valid
+   JSON. Cheshire matches what github.clj / pr_poller.clj already
+   use; the prior regex-based parse here was brittle to formatting
+   and escaping changes in gh's output."
+  [body]
+  (try (json/parse-string body true)
+       (catch Exception _ nil)))
+
 (defn- pr-info-from-gh
   "Fetch the fields conflict-resolution/resolve-pr-conflicts! needs
    from `gh pr view`: PR number, branch (headRefName), base
@@ -280,30 +291,67 @@
     (if (dag/err? r)
       r
       (let [out (:output (:data r))
-            field (fn [k]
-                    (second (re-find (re-pattern
-                                      (str "\"" k "\"\\s*:\\s*\"([^\"]+)\""))
-                                     out)))
-            head-branch (field "headRefName")
-            base-branch (field "baseRefName")
-            head-sha (field "headRefOid")
-            base-sha (field "baseRefOid")]
-        (if (and head-branch base-branch head-sha base-sha)
+            parsed (parse-gh-json out)
+            head-branch (:headRefName parsed)
+            base-branch (:baseRefName parsed)
+            head-sha (:headRefOid parsed)
+            base-sha (:baseRefOid parsed)]
+        (cond
+          (nil? parsed)
+          (dag/err :pr-info-invalid-json
+                   "Could not parse gh JSON output"
+                   {:gh-output out})
+
+          (and head-branch base-branch head-sha base-sha)
           (dag/ok {:pr/id        pr-number
                    :pr/branch    head-branch
                    :pr/base      base-branch
                    :pr/head-sha  head-sha
                    :pr/base-sha  base-sha})
+
+          :else
           (dag/err :pr-info-incomplete
-                   "Could not parse PR head/base from gh output"
-                   {:gh-output out}))))))
+                   "gh JSON missing one or more PR head/base fields"
+                   {:gh-output out
+                    :missing (cond-> []
+                               (not head-branch) (conj :headRefName)
+                               (not base-branch) (conj :baseRefName)
+                               (not head-sha)    (conj :headRefOid)
+                               (not base-sha)    (conj :baseRefOid))}))))))
+
+(defn- normalize-resolution-outcome
+  "conflict-resolution/resolve-pr-conflicts! can return:
+   - dag/ok on success;
+   - dag/err on infrastructure failure; or
+   - the bare `:dag-multi-parent-unresolvable` anomaly map (a
+     terminal failure of the resolution sub-workflow itself).
+
+   Bare anomaly maps break attempt-merge's implicit
+   dag/ok-or-dag/err contract — callers that branch on
+   dag/err?/dag/ok? would treat the anomaly as a generic blocked
+   merge and could retry indefinitely. Wrap the anomaly into a
+   dag/err with the distinct :code :conflict-unresolvable so the
+   controller / train monitor can transition the PR to :failed
+   instead of looping. The original anomaly is preserved under
+   :data :anomaly for diagnostic surfacing."
+  [outcome]
+  (if (and (map? outcome)
+           (contains? outcome :anomaly/category)
+           (not (dag/ok? outcome))
+           (not (dag/err? outcome)))
+    (dag/err :conflict-unresolvable
+             (or (:anomaly/message outcome)
+                 "Conflict resolution sub-workflow declared the merge unresolvable")
+             {:anomaly outcome})
+    outcome))
 
 (defn- attempt-conflict-resolution!
   "Spec §6.4 dispatch: when `branch-check` raw output classifies as
    :conflicting AND policy enables auto-resolve AND context carries
    `:resolve-fn`, run conflict-resolution/resolve-pr-conflicts! and
-   return its outcome. Otherwise return nil so the caller falls
-   back to the existing rebase/not-ready path.
+   return its outcome (normalized into dag/ok or dag/err — see
+   normalize-resolution-outcome). Otherwise return nil so the
+   caller falls back to the existing rebase/not-ready path.
 
    The resolve-fn comes from context (workflow side injects
    workflow.merge-resolution/resolve-conflict! at lifecycle ctor
@@ -317,11 +365,12 @@
       (let [pr-r (pr-info-from-gh worktree-path pr-number)]
         (if (dag/err? pr-r)
           pr-r
-          (conflict-resolution/resolve-pr-conflicts!
-           {:worktree-path worktree-path
-            :pr            (:data pr-r)
-            :resolve-fn    resolve-fn
-            :context       context}))))))
+          (normalize-resolution-outcome
+           (conflict-resolution/resolve-pr-conflicts!
+            {:worktree-path worktree-path
+             :pr            (:data pr-r)
+             :resolve-fn    resolve-fn
+             :context       context})))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Merge orchestration

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
@@ -248,6 +248,80 @@
         (is (= :not-ready (:code (:error result)))
             "fell through to the not-ready path")))))
 
+(deftest attempt-merge-conflicting-unresolvable-anomaly-becomes-dag-err-test
+  (testing "PR #805 review fix: conflict-resolution can return a
+            terminal `:dag-multi-parent-unresolvable` anomaly map.
+            Letting that bubble out of attempt-merge breaks the
+            implicit dag/ok-or-dag/err contract — callers branching
+            on dag/err? would treat the anomaly as a generic blocked
+            merge and could retry indefinitely. attempt-merge must
+            normalize the anomaly into a dag/err with the distinct
+            :code :conflict-unresolvable so the controller / train
+            monitor transitions the PR to :failed instead of looping.
+            The original anomaly is preserved under :data :anomaly
+            for diagnostic surfacing."
+    (let [terminal-anomaly {:anomaly/category :anomalies/dag-multi-parent-unresolvable
+                            :anomaly/message  "Merge conflict could not be auto-resolved"
+                            :resolution/reason :budget-exhausted}]
+      (with-redefs [merge/evaluate-merge-readiness
+                    (fn [_ _ _] conflicting-readiness)
+                    conflict-resolution/resolve-pr-conflicts!
+                    (fn [_] terminal-anomaly)
+                    merge/run-gh-command
+                    (fn [_ _]
+                      (dag/ok {:output (str "{\"number\":123,"
+                                            "\"headRefName\":\"feat/x\","
+                                            "\"baseRefName\":\"main\","
+                                            "\"headRefOid\":\"abc1234\","
+                                            "\"baseRefOid\":\"def5678\"}")}))]
+        (let [context {:dag-id (random-uuid) :run-id (random-uuid)
+                       :task-id (random-uuid) :pr-id 123
+                       :resolve-fn (fn [_] (dag/ok {}))}
+              result (merge/attempt-merge "/tmp" 123
+                                          merge/default-merge-policy
+                                          context)]
+          (is (dag/err? result)
+              "anomaly normalized into dag/err so callers' dag/err?
+               check fires correctly")
+          (is (= :conflict-unresolvable (:code (:error result)))
+              "distinct code lets controller/monitor transition to
+               :failed instead of treating as a generic retry")
+          (is (= terminal-anomaly (get-in result [:error :data :anomaly]))
+              "original anomaly preserved for diagnostic surfacing"))))))
+
+(deftest pr-info-from-gh-rejects-malformed-json-test
+  (testing "PR #805 review fix: pr-info-from-gh now parses gh's
+            JSON output via Cheshire (the same parser
+            github.clj / pr_poller.clj already use). When gh's
+            output isn't valid JSON, return a structured
+            :pr-info-invalid-json dag/err instead of silently
+            returning nils. The previous regex parser would have
+            quietly succeeded on partial matches and broken
+            downstream — Cheshire fails loud."
+    (with-redefs [merge/run-gh-command
+                  (fn [_ _]
+                    (dag/ok {:output "not actually json {{{"}))]
+      (let [r (#'merge/pr-info-from-gh "/tmp" 123)]
+        (is (dag/err? r))
+        (is (= :pr-info-invalid-json (:code (:error r))))))))
+
+(deftest pr-info-from-gh-parses-valid-json-test
+  (testing "Happy path: well-formed gh JSON output parses into
+            the {:pr/* ...} shape via Cheshire."
+    (with-redefs [merge/run-gh-command
+                  (fn [_ _]
+                    (dag/ok {:output (str "{\"number\":42,"
+                                          "\"headRefName\":\"feat/y\","
+                                          "\"baseRefName\":\"develop\","
+                                          "\"headRefOid\":\"sha-head\","
+                                          "\"baseRefOid\":\"sha-base\"}")}))]
+      (let [r (#'merge/pr-info-from-gh "/tmp" 42)]
+        (is (dag/ok? r))
+        (is (= "feat/y" (:pr/branch (:data r))))
+        (is (= "develop" (:pr/base (:data r))))
+        (is (= "sha-head" (:pr/head-sha (:data r))))
+        (is (= "sha-base" (:pr/base-sha (:data r))))))))
+
 (deftest attempt-merge-conflicting-with-policy-disabled-falls-through-test
   (testing "Even with a :resolve-fn on context, if policy's
             :auto-resolve-conflicts? is false, the dispatch

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
@@ -24,6 +24,7 @@
   (:require
    [clojure.test :refer [deftest testing is are]]
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
    [ai.miniforge.pr-lifecycle.merge :as merge]))
 
 ;------------------------------------------------------------------------------ Merge Methods
@@ -179,3 +180,96 @@
                      :task-id (random-uuid) :pr-id 123}
             result (merge/attempt-merge "/tmp" 123 policy context)]
         (is (dag/err? result))))))
+
+;------------------------------------------------------------------------------ Stage 3d: conflict-resolution dispatch
+
+(def ^:private conflicting-readiness
+  "Readiness map shaped like evaluate-merge-readiness output where
+   the branch check failed via CONFLICTING (DIRTY mergeStateStatus)."
+  {:ready? false
+   :checks {:branch (dag/ok {:up-to-date? false
+                             :raw "{\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\"}"})}
+   :blocking [:branch-not-up-to-date]})
+
+(deftest attempt-merge-conflicting-engages-resolver-test
+  (testing "When branch-check raw classifies as :conflicting AND
+            policy enables auto-resolve AND context carries
+            :resolve-fn, attempt-merge dispatches to
+            conflict-resolution/resolve-pr-conflicts! and returns
+            its outcome directly. The lifecycle's outer loop
+            re-evaluates merge readiness on the next cycle once
+            GitHub re-classifies the PR after the resolution
+            commit lands."
+    (let [resolver-called? (atom false)
+          fake-success (dag/ok {:resolved? true :iterations 1
+                                :pushed-sha "fake-sha"
+                                :pr-branch "feat/x"})]
+      (with-redefs [merge/evaluate-merge-readiness
+                    (fn [_ _ _] conflicting-readiness)
+                    conflict-resolution/resolve-pr-conflicts!
+                    (fn [_]
+                      (reset! resolver-called? true)
+                      fake-success)
+                    merge/run-gh-command
+                    (fn [_ _]
+                      (dag/ok {:output (str "{\"number\":123,"
+                                            "\"headRefName\":\"feat/x\","
+                                            "\"baseRefName\":\"main\","
+                                            "\"headRefOid\":\"abc1234\","
+                                            "\"baseRefOid\":\"def5678\"}")}))]
+        (let [context {:dag-id (random-uuid) :run-id (random-uuid)
+                       :task-id (random-uuid) :pr-id 123
+                       :resolve-fn (fn [_] (dag/ok {}))}
+              result (merge/attempt-merge "/tmp" 123
+                                          merge/default-merge-policy
+                                          context)]
+          (is (true? @resolver-called?)
+              "resolver was invoked for the :conflicting branch state")
+          (is (= fake-success result)
+              "attempt-merge returns the resolution outcome directly
+               — no rebase fallback when conflict-resolution engaged"))))))
+
+(deftest attempt-merge-conflicting-without-resolver-falls-through-test
+  (testing "When the branch is :conflicting but context has no
+            :resolve-fn (workflow side didn't inject one), the
+            conflict-resolution dispatch declines (returns nil)
+            and attempt-merge falls through to the existing
+            rebase / not-ready logic. With auto-rebase off, ends
+            up as :not-ready."
+    (with-redefs [merge/evaluate-merge-readiness
+                  (fn [_ _ _] conflicting-readiness)]
+      (let [policy (assoc merge/default-merge-policy
+                          :auto-rebase-on-stale? false)
+            context {:dag-id (random-uuid) :run-id (random-uuid)
+                     :task-id (random-uuid) :pr-id 123}
+            ;; no :resolve-fn on context
+            result (merge/attempt-merge "/tmp" 123 policy context)]
+        (is (dag/err? result))
+        (is (= :not-ready (:code (:error result)))
+            "fell through to the not-ready path")))))
+
+(deftest attempt-merge-conflicting-with-policy-disabled-falls-through-test
+  (testing "Even with a :resolve-fn on context, if policy's
+            :auto-resolve-conflicts? is false, the dispatch
+            declines and we fall through to rebase/not-ready.
+            Lets operators turn off auto-resolution per-PR
+            (e.g. for a PR known to need human attention) without
+            removing the wiring globally."
+    (let [resolver-called? (atom false)]
+      (with-redefs [merge/evaluate-merge-readiness
+                    (fn [_ _ _] conflicting-readiness)
+                    conflict-resolution/resolve-pr-conflicts!
+                    (fn [_]
+                      (reset! resolver-called? true)
+                      (dag/ok {}))]
+        (let [policy (assoc merge/default-merge-policy
+                            :auto-resolve-conflicts? false
+                            :auto-rebase-on-stale? false)
+              context {:dag-id (random-uuid) :run-id (random-uuid)
+                       :task-id (random-uuid) :pr-id 123
+                       :resolve-fn (fn [_] (dag/ok {}))}
+              result (merge/attempt-merge "/tmp" 123 policy context)]
+          (is (false? @resolver-called?)
+              "policy disabled — resolver never called")
+          (is (dag/err? result))
+          (is (= :not-ready (:code (:error result)))))))))

--- a/components/workflow/src/ai/miniforge/workflow/dag_monitor.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_monitor.clj
@@ -30,7 +30,8 @@
   (:require
    [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
    [ai.miniforge.pr-train.interface :as pr-train]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.workflow.merge-resolution :as merge-resolution]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Result constructors & predicates
@@ -72,7 +73,24 @@
   (let [dag-id (or (:dag-id context) (random-uuid))
         run-id (or (:run-id context) (random-uuid))
         event-bus (or (:event-bus context)
-                      (pr-lifecycle/create-event-bus))]
+                      (pr-lifecycle/create-event-bus))
+        ;; Spec §6.4 hook: when the PR-lifecycle merge step finds a
+        ;; CONFLICTING branch, dispatch into merge-resolution/
+        ;; resolve-conflict!. The auto-default agent-edit-fn uses the
+        ;; context's :llm-backend (matching dag_orchestrator's
+        ;; derive-resolution-overrides plumbing for the multi-parent
+        ;; merge case) so the same LLM-driven implementer resolves
+        ;; conflicts on both surfaces.
+        llm-backend (:llm-backend context)
+        logger      (:logger context)
+        agent-edit-fn (when llm-backend
+                        (merge-resolution/agent-driven-edit-fn
+                         (cond-> {:llm-backend llm-backend}
+                           logger (assoc :logger logger))))
+        resolve-fn (fn [opts]
+                     (merge-resolution/resolve-conflict!
+                      (cond-> opts
+                        agent-edit-fn (assoc :agent-edit-fn agent-edit-fn))))]
     (->> pr-infos
          (map (fn [{:keys [pr-number task-id]}]
                 [pr-number
@@ -85,6 +103,7 @@
                    :logger (:logger context)
                    :generate-fn (:generate-fn context)
                    :merge-policy (:merge-policy context)
+                   :resolve-fn resolve-fn
                    :max-fix-iterations (get context :max-fix-iterations 5))]))
          (into {}))))
 

--- a/components/workflow/src/ai/miniforge/workflow/dag_monitor.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_monitor.clj
@@ -76,21 +76,29 @@
                       (pr-lifecycle/create-event-bus))
         ;; Spec §6.4 hook: when the PR-lifecycle merge step finds a
         ;; CONFLICTING branch, dispatch into merge-resolution/
-        ;; resolve-conflict!. The auto-default agent-edit-fn uses the
-        ;; context's :llm-backend (matching dag_orchestrator's
-        ;; derive-resolution-overrides plumbing for the multi-parent
-        ;; merge case) so the same LLM-driven implementer resolves
-        ;; conflicts on both surfaces.
+        ;; resolve-conflict! with an LLM-driven agent-edit-fn.
+        ;;
+        ;; Only construct/inject :resolve-fn when context carries
+        ;; :llm-backend. Without a backend, merge-resolution would
+        ;; fall back to its no-op stub agent and deterministically
+        ;; return an unresolvable anomaly — the lifecycle would
+        ;; then attempt resolution every cycle for no benefit.
+        ;; Skipping injection lets the conflict-resolution dispatch
+        ;; decline cleanly and the existing rebase / not-ready path
+        ;; handles the PR. Callers that DO have a backend
+        ;; (workflow's dag-orchestrator path) get the auto-engage
+        ;; behaviour; callers that don't (e.g. phase-software-
+        ;; factory's pr_monitor) keep the existing semantics.
         llm-backend (:llm-backend context)
         logger      (:logger context)
-        agent-edit-fn (when llm-backend
-                        (merge-resolution/agent-driven-edit-fn
-                         (cond-> {:llm-backend llm-backend}
-                           logger (assoc :logger logger))))
-        resolve-fn (fn [opts]
-                     (merge-resolution/resolve-conflict!
-                      (cond-> opts
-                        agent-edit-fn (assoc :agent-edit-fn agent-edit-fn))))]
+        resolve-fn  (when llm-backend
+                      (let [agent-edit-fn
+                            (merge-resolution/agent-driven-edit-fn
+                             (cond-> {:llm-backend llm-backend}
+                               logger (assoc :logger logger)))]
+                        (fn [opts]
+                          (merge-resolution/resolve-conflict!
+                           (assoc opts :agent-edit-fn agent-edit-fn)))))]
     (->> pr-infos
          (map (fn [{:keys [pr-number task-id]}]
                 [pr-number

--- a/components/workflow/test/ai/miniforge/workflow/dag_monitor_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_monitor_test.clj
@@ -1,0 +1,69 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.dag-monitor-test
+  "Tests for ai.miniforge.workflow.dag-monitor — currently focused on
+   the spec §6.4 :resolve-fn injection gate added in Stage 3d. Other
+   monitor-cycle behaviour is exercised through the broader
+   monitoring-test integration suite."
+  (:require
+   [ai.miniforge.workflow.dag-monitor :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(def ^:private create-pr-controllers
+  (var-get #'sut/create-pr-controllers))
+
+(deftest resolve-fn-only-injected-when-llm-backend-present-test
+  (testing "PR #805 review fix: dag-monitor must NOT inject a
+            resolve-fn when context lacks :llm-backend. With no
+            backend, merge-resolution would fall back to its no-op
+            stub agent and deterministically return an unresolvable
+            anomaly — the lifecycle would attempt resolution every
+            cycle for no benefit. Skipping injection lets the
+            conflict-resolution dispatch decline cleanly and the
+            existing rebase / not-ready path handles the PR.
+            (e.g. phase-software-factory's pr_monitor calls
+            monitor-dag-prs without :llm-backend.)"
+    (let [pr-infos [{:pr-number 1 :task-id (random-uuid)}]
+          controllers (create-pr-controllers
+                       pr-infos
+                       {:worktree-path "/tmp"})]
+      (is (nil? (:resolve-fn @(get controllers 1)))
+          ":resolve-fn must be absent when :llm-backend is absent"))))
+
+(deftest resolve-fn-injected-when-llm-backend-present-test
+  (testing "Companion to the above: when :llm-backend IS on context,
+            dag-monitor wires the resolve-fn closure so the §6.4
+            hook fires end-to-end. Closure construction itself
+            doesn't validate the backend, so we just confirm the
+            controller carries a callable :resolve-fn."
+    (let [pr-infos [{:pr-number 2 :task-id (random-uuid)}]
+          controllers (create-pr-controllers
+                       pr-infos
+                       {:worktree-path "/tmp"
+                        :llm-backend ::mock-backend})]
+      (is (fn? (:resolve-fn @(get controllers 2)))
+          "controller carries the resolve-fn closure when backend
+           was supplied — closure body invokes merge-resolution/
+           resolve-conflict! at call time"))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.workflow.dag-monitor-test)
+
+  :leave-this-here)


### PR DESCRIPTION
## Summary

- **Stage 3 of v2 multi-parent merge** per spec §6.4 — final wiring slice. Slices 3a-3c (PR #796) landed the building blocks (\`classify-merge-state\`, \`build-pr-conflict-input\`, \`extract-conflict-paths\`, \`push-resolution!\`, \`resolve-pr-conflicts!\`). This PR completes the end-to-end path so a PR transitioning MERGEABLE→NON_MERGEABLE auto-engages the multi-parent merge resolution sub-workflow.
- **Three commits, each under the 200-line budget**:
  - \`c20be728\` (\`merge.clj\`): \`pr-info-from-gh\` helper + \`attempt-conflict-resolution!\` private dispatcher + restructured \`attempt-merge\`'s not-ready branch into a \`cond\` that fires conflict-resolution before falling through to rebase/not-ready. \`:auto-resolve-conflicts? true\` added to \`default-merge-policy\`. 3 new tests.
  - \`961a6564\` (\`controller.clj\`): \`create-controller\` accepts \`:resolve-fn\` opt; \`attempt-merge!\` threads it into the context map handed to \`merge/attempt-merge\` via \`cond->\` (absent \`:resolve-fn\` keeps the existing minimal context shape).
  - \`2201929f\` (\`dag_monitor.clj\`): \`create-pr-controllers\` builds a \`resolve-fn\` closure that calls \`merge-resolution/resolve-conflict!\` with an auto-defaulted \`:agent-edit-fn\` from context's \`:llm-backend\`. Mirrors how \`dag_orchestrator/derive-resolution-overrides\` wires the multi-parent merge case — same LLM-driven implementer resolves conflicts on both surfaces.
- **End-to-end path on a CONFLICTING PR**: dag-monitor builds controller with \`:resolve-fn\` → controller stores it → \`attempt-merge!\` threads it into context → \`merge/attempt-merge\`'s conflict-resolution dispatch fires → \`conflict-resolution/resolve-pr-conflicts!\` invokes the resolver → resolution commit pushed → GitHub re-evaluates → lifecycle re-runs the merge step.
- **Backwards-compat**: when no \`:llm-backend\` in context (tests, non-LLM contexts), \`agent-edit-fn\` falls back to the namespace-default no-op stub. When no \`:resolve-fn\` on the controller (older callers, non-workflow harnesses), conflict-resolution dispatch declines and falls through to the existing rebase / not-ready logic unchanged.

## Test plan

- [x] Unit + integration: 79 tests / 207 assertions across pr-lifecycle's controller, merge, and conflict-resolution namespaces — 0 failures, 0 errors.
- [x] New tests in \`merge-test\`:
  - \`attempt-merge-conflicting-engages-resolver-test\` — :conflicting + policy on + \`:resolve-fn\` present → resolver fires, result propagates verbatim.
  - \`attempt-merge-conflicting-without-resolver-falls-through-test\` — :conflicting but no \`:resolve-fn\` → falls through to not-ready (auto-rebase off).
  - \`attempt-merge-conflicting-with-policy-disabled-falls-through-test\` — \`:resolve-fn\` present but \`:auto-resolve-conflicts? false\` → resolver never called.
- [x] Smoke-load: \`(require 'ai.miniforge.workflow.dag-monitor)\` parses; \`create-pr-controllers\` populates \`:resolve-fn\` on the controller atom.
- [x] Full pre-commit suite passed on all three commits (5097+ tests, no regressions).
- [ ] Live PR-conflict smoke test deferred to Stage 4c (dogfood re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)