### PR TITLE
fix(llm): runtime keepalive for progress-monitor — decouple stagnation from CLI emission cadence

### DIFF
--- a/components/llm/src/ai/miniforge/llm/progress_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/progress_monitor.clj
@@ -159,13 +159,19 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Keepalive — decouples stagnation from CLI emission cadence
 
+(def ^:private keepalive-stop-join-ms
+  "How long stop! waits for the keepalive thread to exit after
+   interrupting it. 100ms is generous — the worker only needs to
+   wake from Thread/sleep, see the running? flag, and exit."
+  100)
+
 (defn start-keepalive!
   "Spawn a daemon thread that calls record-activity! on `monitor` every
    `interval-ms` until the returned 0-arity stop-fn is invoked.
 
    ## Why
 
-   Stage-2 dogfood (2026-05-07) failed at the planner with
+   Stage-3 dogfood (2026-05-07) failed at the planner with
    'Stagnation timeout: no progress for 180047ms'. Diagnosis: the
    claude CLI in `--input-format text` mode does not emit
    `rate_limit_event` during the model's think phase. Without
@@ -184,22 +190,38 @@
 
    ## Arguments
      monitor     - a progress monitor atom (from create-progress-monitor)
-     interval-ms - how often to refresh; should be < stagnation-threshold-ms
+     interval-ms - positive integer; how often to refresh. Must be
+                   strictly less than stagnation-threshold-ms or the
+                   keepalive will fire too late to prevent stagnation.
 
    ## Returns
-     0-arity stop-fn that stops the keepalive thread."
+     0-arity stop-fn. Calling it interrupts the worker thread and
+     waits up to `keepalive-stop-join-ms` for it to exit, so callers
+     can rely on no further `record-activity!` calls landing once
+     stop! has returned (modulo a single in-flight tick that already
+     started before the interrupt — kept harmless by the running?
+     check guarding record-activity!)."
   [monitor interval-ms]
+  (assert (and (integer? interval-ms) (pos? interval-ms))
+          "keepalive interval-ms must be a positive integer")
   (let [running? (atom true)
-        thread (Thread.
-                 (fn []
-                   (while @running?
-                     (Thread/sleep ^long interval-ms)
-                     (when @running?
-                       (record-activity! monitor :keepalive))))
-                 "llm-progress-monitor-keepalive")]
+        thread   (Thread.
+                   (fn []
+                     (try
+                       (while @running?
+                         (Thread/sleep ^long interval-ms)
+                         (when @running?
+                           (record-activity! monitor :keepalive)))
+                       (catch InterruptedException _
+                         ;; stop! interrupted us mid-sleep; exit cleanly.
+                         nil)))
+                   "llm-progress-monitor-keepalive")]
     (.setDaemon thread true)
     (.start thread)
-    (fn stop! [] (reset! running? false))))
+    (fn stop! []
+      (reset! running? false)
+      (.interrupt thread)
+      (.join thread keepalive-stop-join-ms))))
 
 (defn get-stats
   "Get current statistics from the monitor."

--- a/components/llm/src/ai/miniforge/llm/progress_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/progress_monitor.clj
@@ -156,6 +156,51 @@
       ;; Still making progress
       :else nil)))
 
+;------------------------------------------------------------------------------ Layer 1
+;; Keepalive — decouples stagnation from CLI emission cadence
+
+(defn start-keepalive!
+  "Spawn a daemon thread that calls record-activity! on `monitor` every
+   `interval-ms` until the returned 0-arity stop-fn is invoked.
+
+   ## Why
+
+   Stage-2 dogfood (2026-05-07) failed at the planner with
+   'Stagnation timeout: no progress for 180047ms'. Diagnosis: the
+   claude CLI in `--input-format text` mode does not emit
+   `rate_limit_event` during the model's think phase. Without
+   those heartbeats our stream-heartbeat-based stagnation guard has
+   no signal during legitimate model thinking on heavy prompts.
+
+   Keepalive decouples the per-run liveness check from the CLI's
+   own emission cadence — as long as the LLM-client's reader thread
+   is alive (i.e., this JVM is alive and the subprocess hasn't
+   wedged the JVM), the monitor's stagnation timer keeps refreshing.
+   `max-total-ms` remains the OS-wedge backstop.
+
+   This is the pragmatic stopgap until the Stage 3 progress-detector
+   wiring (semantic loop detection) replaces the wallclock approach
+   wholesale.
+
+   ## Arguments
+     monitor     - a progress monitor atom (from create-progress-monitor)
+     interval-ms - how often to refresh; should be < stagnation-threshold-ms
+
+   ## Returns
+     0-arity stop-fn that stops the keepalive thread."
+  [monitor interval-ms]
+  (let [running? (atom true)
+        thread (Thread.
+                 (fn []
+                   (while @running?
+                     (Thread/sleep ^long interval-ms)
+                     (when @running?
+                       (record-activity! monitor :keepalive))))
+                 "llm-progress-monitor-keepalive")]
+    (.setDaemon thread true)
+    (.start thread)
+    (fn stop! [] (reset! running? false))))
+
 (defn get-stats
   "Get current statistics from the monitor."
   [monitor]

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -838,6 +838,18 @@
     (ByteArrayInputStream. (.getBytes ^String stdin-str "UTF-8"))
     (ByteArrayInputStream. (byte-array 0))))
 
+(defn- keepalive-interval-ms
+  "Refresh interval for the stream-side keepalive thread.
+
+   Tied to the configured stagnation threshold so the keepalive fires
+   well within the window — at one-third of the threshold we get three
+   refreshes per stagnation-window, so a brief reader stall never
+   races the timer."
+  [monitor]
+  (let [stagnation (get @monitor :stagnation-threshold-ms
+                        (default-stagnation-threshold-ms))]
+    (max 1000 (long (/ stagnation 3)))))
+
 (defn stream-exec-fn
   ([cmd on-line]
    (stream-exec-fn cmd on-line {}))
@@ -849,7 +861,22 @@
                                           workdir     (assoc :dir workdir)) cmd)
          out-reader (java.io.BufferedReader.
                      (java.io.InputStreamReader. (:out process)))
-         {:keys [lines timeout]} (process-stream-lines out-reader monitor on-line)
+         ;; Decouple stagnation from the CLI's emission cadence.
+         ;; claude in --input-format text mode does not emit
+         ;; rate_limit_event during the model's think phase, so the
+         ;; stream-heartbeat-based stagnation guard has no signal
+         ;; during legitimate thinking on heavy prompts (2026-05-07
+         ;; stage-3 dogfood: stagnation timeout at 180s with 6
+         ;; init-time chunks then nothing for the model's full
+         ;; think). Keepalive refreshes the monitor while the JVM-side
+         ;; reader is alive; max-total-ms remains the wedge backstop.
+         stop-keepalive! (pm/start-keepalive! monitor
+                                              (keepalive-interval-ms monitor))
+         {:keys [lines timeout]}
+         (try
+           (process-stream-lines out-reader monitor on-line)
+           (finally
+             (stop-keepalive!)))
          ;; Stream ended with a timeout reason (stream-idle,
          ;; stagnation, or total-max) — the subprocess is hung or
          ;; silent. Kill it so `deref` returns immediately instead of

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -838,17 +838,34 @@
     (ByteArrayInputStream. (.getBytes ^String stdin-str "UTF-8"))
     (ByteArrayInputStream. (byte-array 0))))
 
+(def ^:private keepalive-min-interval-ms
+  "Floor on the keepalive interval so the worker doesn't burn cycles
+   pinging the monitor in a tight loop on production-sized thresholds.
+   1s is plenty fine-grained for a 180+ second stagnation window."
+  1000)
+
 (defn- keepalive-interval-ms
   "Refresh interval for the stream-side keepalive thread.
 
    Tied to the configured stagnation threshold so the keepalive fires
-   well within the window — at one-third of the threshold we get three
-   refreshes per stagnation-window, so a brief reader stall never
-   races the timer."
+   well within the window — at one-third of the threshold we get
+   three refreshes per stagnation-window, so a brief reader stall
+   never races the timer.
+
+   Two clamps:
+   - lower: `keepalive-min-interval-ms` to avoid a hot-loop on
+     production stagnation values.
+   - upper: strictly less than the stagnation threshold so the
+     keepalive always fires before stagnation can. The min wins
+     when the configured threshold is small (e.g. tests using
+     80ms) so the lower-bound floor doesn't push the interval
+     past the threshold."
   [monitor]
   (let [stagnation (get @monitor :stagnation-threshold-ms
-                        (default-stagnation-threshold-ms))]
-    (max 1000 (long (/ stagnation 3)))))
+                        (default-stagnation-threshold-ms))
+        target     (long (/ stagnation 3))
+        ceiling    (max 1 (dec stagnation))]
+    (min ceiling (max keepalive-min-interval-ms target))))
 
 (defn stream-exec-fn
   ([cmd on-line]

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -1017,6 +1017,42 @@
       (is (= :stagnation (:type (pm/check-timeout monitor)))
           "after stop!, silence stagnates as expected"))))
 
+(deftest keepalive-rejects-non-positive-interval-test
+  (testing "start-keepalive! refuses non-positive interval-ms"
+    ;; Without validation Thread/sleep would throw IllegalArgumentException
+    ;; deep in the worker thread; assert + AssertionError fails fast at the
+    ;; call site (PR #806 Copilot review).
+    (let [monitor (pm/create-progress-monitor {:stagnation-threshold-ms 1000})]
+      (is (thrown? AssertionError (pm/start-keepalive! monitor 0))
+          "0 interval rejected")
+      (is (thrown? AssertionError (pm/start-keepalive! monitor -10))
+          "negative interval rejected")
+      (is (thrown? AssertionError (pm/start-keepalive! monitor 1.5))
+          "non-integer interval rejected"))))
+
+(deftest keepalive-stop-is-definitive-test
+  (testing "after stop!, no further activity ticks land"
+    ;; Race-window guard: stop! interrupts the thread + joins so the
+    ;; worker has exited (or is about to exit on the running? check)
+    ;; before stop! returns. PR #806 Copilot review.
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms 5000
+                    :max-total-ms            60000
+                    :min-activity-interval-ms 1})
+          stop! (pm/start-keepalive! monitor 5)]
+      ;; Let several ticks land
+      (Thread/sleep 50)
+      (let [chunks-before-stop (:chunk-count @monitor)]
+        (stop!)
+        ;; Sleep long enough that further ticks WOULD land if the
+        ;; worker were still running (~10× the interval).
+        (Thread/sleep 100)
+        (let [chunks-after-stop (:chunk-count @monitor)
+              extra-ticks       (- chunks-after-stop chunks-before-stop)]
+          (is (<= extra-ticks 1)
+              (str "at most one in-flight tick may land after stop!, got "
+                   extra-ticks)))))))
+
 (deftest keepalive-does-not-mask-hard-limit-test
   (testing "keepalive only refreshes stagnation; max-total-ms still fires"
     ;; Wedge backstop: the keepalive is a per-tick refresh of

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -959,6 +959,84 @@
       (is (= {:stdin "the-prompt"} @seen-opts)
           "opts must reach a 2-arity-capable fn unchanged"))))
 
+;------------------------------------------------------------------------------ Layer 5
+;; Keepalive — decouples stagnation from the CLI's emission cadence
+;;
+;; Stage-3 dogfood (2026-05-07) failed at the planner with
+;; "Stagnation timeout: no progress for 180047ms". Diagnosis: claude
+;; CLI in `--input-format text` mode does not emit rate_limit_event
+;; during the model's think phase, so the stream-heartbeat-based
+;; stagnation guard has no signal during legitimate thinking.
+;;
+;; Fix: pm/start-keepalive! daemon thread that pings the monitor while
+;; the JVM-side reader is alive. These tests lock both halves of the
+;; contract — the bug pattern (silence => stagnation) and the fix
+;; (keepalive masks silence).
+
+(deftest stagnation-fires-on-silence-without-keepalive-test
+  (testing "without keepalive, a silent monitor stagnates after the threshold"
+    ;; Bug demonstration: this is the dogfood failure mode in unit form.
+    ;; record-activity! once at start, then silence — the timer expires.
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms 80
+                    :max-total-ms            5000
+                    :min-activity-interval-ms 1})]
+      (pm/record-activity! monitor :stream-init)
+      (Thread/sleep 200)
+      (let [timeout (pm/check-timeout monitor)]
+        (is (= :stagnation (:type timeout))
+            "silence beyond stagnation-threshold-ms ⇒ stagnation fires")))))
+
+(deftest keepalive-prevents-stagnation-during-silence-test
+  (testing "keepalive thread refreshes the monitor across silent periods"
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms 80
+                    :max-total-ms            5000
+                    :min-activity-interval-ms 1})
+          stop! (pm/start-keepalive! monitor 20)]
+      (try
+        (pm/record-activity! monitor :stream-init)
+        (Thread/sleep 200)
+        (is (nil? (pm/check-timeout monitor))
+            "keepalive refreshes ⇒ stagnation timer never expires")
+        (finally
+          (stop!))))))
+
+(deftest keepalive-stop-fn-halts-the-thread-test
+  (testing "stop! returned by start-keepalive! halts further refreshes"
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms 80
+                    :max-total-ms            5000
+                    :min-activity-interval-ms 1})
+          stop! (pm/start-keepalive! monitor 20)]
+      (pm/record-activity! monitor :stream-init)
+      (Thread/sleep 50)
+      (stop!)
+      ;; Allow any in-flight tick to settle, then sleep past the threshold.
+      (Thread/sleep 200)
+      (is (= :stagnation (:type (pm/check-timeout monitor)))
+          "after stop!, silence stagnates as expected"))))
+
+(deftest keepalive-does-not-mask-hard-limit-test
+  (testing "keepalive only refreshes stagnation; max-total-ms still fires"
+    ;; Wedge backstop: the keepalive is a per-tick refresh of
+    ;; last-activity-at, but :max-total-ms tracks elapsed-since-start
+    ;; independently. A run that legitimately exceeds max-total-ms
+    ;; must still time out — the keepalive cannot mask it.
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms 50000
+                    :max-total-ms            120
+                    :min-activity-interval-ms 1})
+          stop! (pm/start-keepalive! monitor 20)]
+      (try
+        (pm/record-activity! monitor :stream-init)
+        (Thread/sleep 200)
+        (let [timeout (pm/check-timeout monitor)]
+          (is (= :hard-limit (:type timeout))
+              "max-total-ms fires even with keepalive active"))
+        (finally
+          (stop!))))))
+
 (deftest stream-exec-fn-pipes-stdin-test
   (testing ":stdin opt is written to subprocess stdin in streaming path"
     (let [seen (atom [])


### PR DESCRIPTION
## Summary

The 2026-05-07 stage-3 dogfood failed at the planner phase with:

```
Stagnation timeout: no progress for 180047ms
  :chunks 6 :unique-chunks 1
```

Root cause: `claude --input-format text` (the stdin mode that PR #798 enabled) does **not** emit `rate_limit_event` during the model's think phase. With argv input the CLI produces those heartbeats throughout the call; with stdin input only the system-init event fires, then silence until the first assistant chunk. On heavy prompts the model think can exceed the 180s stagnation threshold and our heartbeat-based guard kills an actively-working subprocess.

A controlled probe confirmed: small prompt + stdin mode → 49.5s before first text line, with **zero** heartbeats in between. The planner-sized prompt scales beyond the 180s window.

## Fix

`pm/start-keepalive!` — a daemon thread that calls `record-activity!` on the monitor every `interval-ms` (defaults to one third of the configured stagnation threshold). `stream-exec-fn` starts it before the read loop and stops it in `finally`.

This decouples per-run liveness from claude's emission cadence — as long as the JVM-side reader is alive, stagnation stays masked. `:max-total-ms` remains the OS-wedge backstop; **the keepalive cannot mask hard-limit**.

This is the pragmatic stopgap until Stage 3 progress-detector wiring (semantic loop detection) replaces the wallclock approach wholesale. Future claude CLI version changes can no longer reintroduce this class of failure — the liveness check no longer depends on what claude chooses to emit.

## Test plan

Four new tests (5348 / 0 / 0):

- [x] `stagnation-fires-on-silence-without-keepalive-test` — Bug demo: one activity + silence ⇒ stagnation fires.
- [x] `keepalive-prevents-stagnation-during-silence-test` — Fix: same pattern with keepalive ⇒ no stagnation.
- [x] `keepalive-stop-fn-halts-the-thread-test` — `stop!` halts refreshes; subsequent silence stagnates again.
- [x] `keepalive-does-not-mask-hard-limit-test` — Wedge backstop preserved: `max-total-ms` still fires under keepalive.
- [ ] Re-dogfood Stage 3 with this on main.

## Files

- `components/llm/src/ai/miniforge/llm/progress_monitor.clj` — `start-keepalive!`
- `components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj` — wire keepalive into `stream-exec-fn`
- `components/llm/test/ai/miniforge/llm/interface_test.clj` — 4 regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)