### PR TITLE
feat(n13): closed-loop PR pipeline foundations

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -490,6 +490,14 @@
   :pr/merging "Merging: {url}"
   :pr/merge-todo "TODO: Use gh pr merge"
 
+  ;; PR Review (N13 §2.2 Standards Reviewer)
+  :pr/review-base-ref-failed "pr review: failed to resolve base ref via gh"
+  :pr/review-repo-not-found "pr-review: repo path not found: {path}"
+  :pr/review-base-required "pr-review: --base <git-ref> is required (e.g., --base origin/main)"
+  :pr/review-unknown-out "pr-review: unknown --out format: {fmt}"
+  :pr/review-failed "pr-review failed: {message}"
+  :pr/review-summary "policy-review: {total} violations ({auto-fixable} auto-fixable, {needs-review} need review) across {files} files / {rules} rules"
+
   ;; PR Monitor
   :pr/monitor-starting "Starting PR monitor for author: {author}"
   :pr/monitor-polling "Polling every {seconds}s in {dir}"

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -591,7 +591,14 @@
 
    ;; PR subcommands
    {:cmds ["pr" "list"]    :fn pr-list-cmd    :spec {:repo {:alias :r}}}
-   {:cmds ["pr" "review"]  :fn pr-review-cmd  :args->opts [:url]}
+   {:cmds ["pr" "review"]  :fn pr-review-cmd  :args->opts [:url]
+    :spec {:url       {:alias :u}
+           :repo      {}
+           :base      {:alias :b}
+           :standards {:default ".standards"}
+           :pack      {:alias :p}
+           :rules     {:alias :r}
+           :out       {:default "table"}}}
    {:cmds ["pr" "respond"] :fn pr-respond-cmd :args->opts [:url]}
    {:cmds ["pr" "merge"]   :fn pr-merge-cmd   :args->opts [:url]}
    {:cmds ["pr" "monitor"] :fn pr-monitor-cmd :spec {:author {:alias :a}

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -134,7 +134,7 @@
 
                 (not base-ref)
                 (display/print-error
-                 "pr review: failed to resolve base ref via gh")
+                 (messages/t :pr/review-base-ref-failed))
 
                 :else
                 (let [cwd (System/getProperty "user.dir")]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -24,6 +24,7 @@
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.main.commands.pr-review :as pr-review]
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -85,14 +86,72 @@
                     (display/print-error (messages/t :pr/list-failed {:error (:err result2)}))))))
             (display/print-error (messages/t :pr/query-failed {:error (:err result)}))))))))
 
+(defn- gh-pr-base-ref
+  "Resolve the base-branch ref for `pr-number` via the GitHub CLI.
+   Returns a remote-prefixed ref like \"origin/main\", or nil on failure."
+  [pr-number]
+  (let [r (sh! "gh" "pr" "view" (str pr-number)
+               "--json" "baseRefName" "--jq" ".baseRefName")]
+    (when (zero? (:exit r))
+      (let [base-name (str/trim (:out r))]
+        (when (seq base-name)
+          (str "origin/" base-name))))))
+
 (defn pr-review-cmd
+  "N13 §2.2 Standards Reviewer entry point.
+
+   Checks out the given PR URL, derives the base ref, and runs the
+   compliance-scanner in PR-scoped read-only mode. Prints rendered
+   review comments per N13 §2.3 to stdout. Does NOT post comments and
+   does NOT apply fixes.
+
+   Pass --repo <path> + --base <ref> to operate on an existing checkout
+   without using `gh` to fetch metadata; `--url <pr-url>` is the default
+   user-facing flow."
   [opts]
-  (let [{:keys [url]} opts]
-    (if-not url
-      (display/print-error (messages/t :pr/review-usage {:command (app-config/command-string "pr review <pr-url>")}))
-      (do
-        (display/print-info (messages/t :pr/reviewing {:url url}))
-        (println (messages/t :pr/review-todo))))))
+  (let [{:keys [url repo base]} opts]
+    (cond
+      ;; --repo + --base path: operate on existing checkout
+      (and repo base)
+      (pr-review/run-pr-review-by-path-cmd opts)
+
+      ;; URL path: parse, checkout, derive base, delegate
+      url
+      (let [parse-url (requiring-resolve 'ai.miniforge.pr-lifecycle.interface/parse-pr-url)
+            {:keys [number]} (parse-url url)]
+        (cond
+          (not number)
+          (display/print-error (messages/t :pr/respond-bad-url))
+
+          :else
+          (do
+            (display/print-info (messages/t :pr/reviewing {:url url}))
+            (let [base-ref (gh-pr-base-ref number)
+                  branch   (checkout-pr! number)]
+              (cond
+                (not branch)
+                (display/print-error (messages/t :pr/respond-checkout-failed))
+
+                (not base-ref)
+                (display/print-error
+                 "pr review: failed to resolve base ref via gh")
+
+                :else
+                (let [cwd (System/getProperty "user.dir")]
+                  (display/print-info
+                   (messages/t :pr/respond-on-branch {:branch branch}))
+                  (pr-review/run-pr-review!
+                   cwd
+                   (cond-> {:base-ref base-ref}
+                     (:standards opts) (assoc :standards (:standards opts))
+                     (:pack opts)      (assoc :pack (:pack opts))
+                     (:rules opts)     (assoc :rules (:rules opts))
+                     (:out opts)       (assoc :out (keyword (:out opts)))))))))))
+
+      :else
+      (display/print-error
+       (messages/t :pr/review-usage
+                   {:command (app-config/command-string "pr review <pr-url>")})))))
 
 (defn pr-respond-cmd
   [opts]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
@@ -34,9 +34,33 @@
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.compliance-scanner.interface :as scanner]))
 
 (def ^:private default-standards-path ".standards")
+
+;; ── Table layout for emit-table ──────────────────────────────────────
+;; Column widths (chars). Tuned for 100-col terminals: file paths get
+;; the bulk, line is 6 (covers up to a million-line file), severity is
+;; 12 (longest keyword name like ":warning" plus padding), rule trails
+;; with no fixed width.
+(def ^:private file-col-width      60)
+(def ^:private line-col-width      6)
+(def ^:private severity-col-width  12)
+
+(def ^:private table-header-fmt
+  (str "%-" file-col-width "s %-" line-col-width "s %-" severity-col-width "s %s%n"))
+
+(def ^:private table-row-fmt
+  (str "%-" file-col-width "s %-" line-col-width "d %-" severity-col-width "s %s%n"))
+
+(defn- separator-row
+  "Build the dashed underline row used between header and body."
+  []
+  (let [dashes (fn [n] (apply str (repeat n "-")))]
+    (str (dashes file-col-width) " "
+         (dashes line-col-width) " "
+         (dashes severity-col-width) " ----")))
 
 (defn- resolve-pack
   "Resolve a pack by name or path; returns the loaded pack map or nil."
@@ -75,26 +99,22 @@
   "Print a one-line summary of the review."
   [{:pr-review/keys [summary]}]
   (display/print-info
-   (format "policy-review: %d violations (%d auto-fixable, %d need review) across %d files / %d rules"
-           (:total summary)
-           (:auto-fixable summary)
-           (:needs-review summary)
-           (:files-affected summary)
-           (:rules-violated summary))))
+   (messages/t :pr/review-summary
+               {:total        (:total summary)
+                :auto-fixable (:auto-fixable summary)
+                :needs-review (:needs-review summary)
+                :files        (:files-affected summary)
+                :rules        (:rules-violated summary)})))
 
 (defn- emit-table
   "Print a human-readable table of comments."
   [comments]
   (when (seq comments)
     (println)
-    (printf "%-60s %-6s %-12s %s%n" "FILE" "LINE" "SEVERITY" "RULE")
-    (printf "%s %s %s %s%n"
-            (apply str (repeat 60 "-"))
-            (apply str (repeat 6 "-"))
-            (apply str (repeat 12 "-"))
-            "----")
+    (printf table-header-fmt "FILE" "LINE" "SEVERITY" "RULE")
+    (println (separator-row))
     (doseq [c comments]
-      (printf "%-60s %-6d %-12s %s%n"
+      (printf table-row-fmt
               (:comment/path c)
               (:comment/line c)
               (name (or (get-in c [:comment/payload :violation/severity]) :info))
@@ -154,7 +174,7 @@
       :json  (emit-json (:pr-review/comments result))
       :table (emit-table (:pr-review/comments result))
       (display/print-error
-       (format "pr-review: unknown --out format: %s" (name out))))
+       (messages/t :pr/review-unknown-out {:fmt (name out)})))
     result))
 
 (defn run-pr-review-by-path-cmd
@@ -175,11 +195,11 @@
     (cond
       (not (fs/exists? repo-path))
       (display/print-error
-       (format "pr-review: repo path not found: %s" repo-path))
+       (messages/t :pr/review-repo-not-found {:path repo-path}))
 
       (or (nil? base-ref) (= "" base-ref))
       (display/print-error
-       "pr-review: --base <git-ref> is required (e.g., --base origin/main)")
+       (messages/t :pr/review-base-required))
 
       :else
       (try
@@ -191,4 +211,4 @@
                           (:out opts)       (assoc :out (keyword (:out opts)))))
         (catch Exception e
           (display/print-error
-           (format "pr-review failed: %s" (ex-message e))))))))
+           (messages/t :pr/review-failed {:message (ex-message e)})))))))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
@@ -1,0 +1,211 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.pr-review
+  "PR Review implementation — N13 §2.2 Standards Reviewer entry point.
+
+   Runs compliance-scanner in PR-scoped read-only mode, classifies
+   violations, and emits comment records ready to post via a provider
+   connector. Does NOT post comments and does NOT apply fixes — that
+   is the job of downstream pipeline steps and the Comment Response
+   Agent.
+
+   This namespace exposes a programmatic `run-pr-review!` that the
+   `pr review <url>` CLI entry point in `commands.pr` delegates to."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.compliance-scanner.interface :as scanner]))
+
+(def ^:private default-standards-path ".standards")
+
+(defn- resolve-pack
+  "Resolve a pack by name or path; returns the loaded pack map or nil."
+  [pack-ref]
+  (cond
+    (nil? pack-ref) nil
+
+    (fs/exists? pack-ref)
+    (edn/read-string (slurp (str pack-ref)))
+
+    :else
+    (let [resource-path (str "policy_pack/packs/" pack-ref ".pack.edn")]
+      (when-let [url (io/resource resource-path)]
+        (edn/read-string (slurp url))))))
+
+(defn- pack-info
+  "Best-effort pack-info extraction for the rendered comment payload.
+   Falls back to {:pack/id <pack-ref-or-default> :pack/version \"0.0.0\"}
+   when the pack does not declare an id/version."
+  [pack pack-ref]
+  (cond
+    (and (map? pack)
+         (or (:pack/id pack) (:pack/version pack)))
+    {:pack/id      (or (:pack/id pack)
+                       (when pack-ref (str pack-ref))
+                       "miniforge-standards")
+     :pack/version (or (:pack/version pack) "0.0.0")}
+
+    pack-ref
+    {:pack/id (str pack-ref) :pack/version "0.0.0"}
+
+    :else
+    {:pack/id "miniforge-standards" :pack/version "0.0.0"}))
+
+(defn- print-summary
+  "Print a one-line summary of the review."
+  [{:pr-review/keys [summary]}]
+  (display/print-info
+   (format "policy-review: %d violations (%d auto-fixable, %d need review) across %d files / %d rules"
+           (:total summary)
+           (:auto-fixable summary)
+           (:needs-review summary)
+           (:files-affected summary)
+           (:rules-violated summary))))
+
+(defn- emit-table
+  "Print a human-readable table of comments."
+  [comments]
+  (when (seq comments)
+    (println)
+    (printf "%-60s %-6s %-12s %s%n" "FILE" "LINE" "SEVERITY" "RULE")
+    (printf "%s %s %s %s%n"
+            (apply str (repeat 60 "-"))
+            (apply str (repeat 6 "-"))
+            (apply str (repeat 12 "-"))
+            "----")
+    (doseq [c comments]
+      (printf "%-60s %-6d %-12s %s%n"
+              (:comment/path c)
+              (:comment/line c)
+              (name (or (get-in c [:comment/payload :violation/severity]) :info))
+              (str (get-in c [:comment/payload :violation/rule-id]))))))
+
+(defn- emit-edn
+  "Print the comments vector as pretty EDN to stdout."
+  [comments]
+  (pprint/pprint comments))
+
+(defn- emit-json
+  "Print the comments vector as JSON. Inline serializer to avoid pulling
+   cheshire into this surface; comment payloads are simple maps."
+  [comments]
+  (letfn [(esc [s]
+            (-> (str s)
+                (str/replace "\\" "\\\\")
+                (str/replace "\"" "\\\"")
+                (str/replace "\n" "\\n")))
+          (json-val [v]
+            (cond
+              (nil? v)            "null"
+              (boolean? v)        (str v)
+              (number? v)         (str v)
+              (keyword? v)        (str "\"" (esc (subs (str v) 1)) "\"")
+              (string? v)         (str "\"" (esc v) "\"")
+              (map? v)            (str "{"
+                                       (str/join ","
+                                                 (for [[k vv] v]
+                                                   (str "\""
+                                                        (esc (cond
+                                                               (keyword? k) (subs (str k) 1)
+                                                               :else        (str k)))
+                                                        "\":" (json-val vv))))
+                                       "}")
+              (sequential? v)     (str "[" (str/join "," (mapv json-val v)) "]")
+              :else               (str "\"" (esc (pr-str v)) "\"")))]
+    (println (json-val comments))))
+
+(defn run-pr-review!
+  "Run a PR-scoped standards review against an existing repo checkout.
+
+   Arguments:
+   - repo-path  - string path to a repo/worktree checked out at the PR's
+                  head SHA
+   - opts       - map with:
+       :base-ref   - REQUIRED. Git ref of the PR's base branch
+                     (e.g., \"origin/main\"). Passed to compliance-scanner
+                     as :since.
+       :standards  - path to .standards dir (default \".standards\")
+       :pack       - pack name or path (optional)
+       :rules      - rule selector string or keyword (default :all)
+       :out        - :table | :edn | :json (default :table)
+
+   Side effects:
+   - Prints summary + comments to stdout in the requested format.
+
+   Returns the pr-review result map (per scanner/pr-review)."
+  [repo-path
+   {:keys [base-ref standards pack rules out]
+    :or   {standards default-standards-path
+           rules     :all
+           out       :table}}]
+  (let [pack-ref pack
+        pack-map (resolve-pack pack-ref)
+        rules-kw (cond
+                   (keyword? rules) rules
+                   (string? rules)  (keyword rules)
+                   :else            :all)
+        result   (scanner/pr-review
+                  repo-path standards
+                  (cond-> {:base-ref  base-ref
+                           :rules     rules-kw
+                           :pack-info (pack-info pack-map pack-ref)}
+                    pack-map (assoc :pack pack-map)))]
+    (print-summary result)
+    (case out
+      :edn   (emit-edn (:pr-review/comments result))
+      :json  (emit-json (:pr-review/comments result))
+      :table (emit-table (:pr-review/comments result))
+      (display/print-error
+       (format "pr-review: unknown --out format: %s" (name out))))
+    result))
+
+(defn run-pr-review-by-path-cmd
+  "CLI entry point for `miniforge pr review --repo <path> --base <ref>`.
+
+   For when the operator already has a checkout — useful in dogfood and
+   from janitors that operate on existing worktrees.
+
+   Required: --base <git-ref>. Optional: positional repo path."
+  [opts]
+  (let [repo-path (get opts :repo (str (fs/cwd)))
+        base-ref  (get opts :base)]
+    (cond
+      (not (fs/exists? repo-path))
+      (display/print-error
+       (format "pr-review: repo path not found: %s" repo-path))
+
+      (or (nil? base-ref) (= "" base-ref))
+      (display/print-error
+       "pr-review: --base <git-ref> is required (e.g., --base origin/main)")
+
+      :else
+      (try
+        (run-pr-review! repo-path
+                        (cond-> {:base-ref base-ref}
+                          (:standards opts) (assoc :standards (:standards opts))
+                          (:pack opts)      (assoc :pack (:pack opts))
+                          (:rules opts)     (assoc :rules (:rules opts))
+                          (:out opts)       (assoc :out (keyword (:out opts)))))
+        (catch Exception e
+          (display/print-error
+           (format "pr-review failed: %s" (ex-message e))))))))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
@@ -29,10 +29,10 @@
    `pr review <url>` CLI entry point in `commands.pr` delegates to."
   (:require
    [babashka.fs :as fs]
+   [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
-   [clojure.string :as str]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.compliance-scanner.interface :as scanner]))
 
@@ -106,33 +106,11 @@
   (pprint/pprint comments))
 
 (defn- emit-json
-  "Print the comments vector as JSON. Inline serializer to avoid pulling
-   cheshire into this surface; comment payloads are simple maps."
+  "Print the comments vector as RFC 8259-compliant JSON via cheshire.
+   Keywords are stringified; the internal `(str)` call in the key-fn
+   handles the leading colon for deterministic output."
   [comments]
-  (letfn [(esc [s]
-            (-> (str s)
-                (str/replace "\\" "\\\\")
-                (str/replace "\"" "\\\"")
-                (str/replace "\n" "\\n")))
-          (json-val [v]
-            (cond
-              (nil? v)            "null"
-              (boolean? v)        (str v)
-              (number? v)         (str v)
-              (keyword? v)        (str "\"" (esc (subs (str v) 1)) "\"")
-              (string? v)         (str "\"" (esc v) "\"")
-              (map? v)            (str "{"
-                                       (str/join ","
-                                                 (for [[k vv] v]
-                                                   (str "\""
-                                                        (esc (cond
-                                                               (keyword? k) (subs (str k) 1)
-                                                               :else        (str k)))
-                                                        "\":" (json-val vv))))
-                                       "}")
-              (sequential? v)     (str "[" (str/join "," (mapv json-val v)) "]")
-              :else               (str "\"" (esc (pr-str v)) "\"")))]
-    (println (json-val comments))))
+  (println (json/generate-string comments {:key-fn name})))
 
 (defn run-pr-review!
   "Run a PR-scoped standards review against an existing repo checkout.
@@ -185,7 +163,12 @@
    For when the operator already has a checkout — useful in dogfood and
    from janitors that operate on existing worktrees.
 
-   Required: --base <git-ref>. Optional: positional repo path."
+   Flags: required `--base <git-ref>`; optional `--repo <path>`
+   (defaults to `(fs/cwd)`), `--standards <path>`, `--pack <name|path>`,
+   `--rules <selector>`, `--out edn|json|table`. The CLI surface in
+   `commands.pr` registers `[:url]` as the only positional via
+   `:args->opts`, so the repo path comes from the `--repo` flag, not
+   from a positional argument."
   [opts]
   (let [repo-path (get opts :repo (str (fs/cwd)))
         base-ref  (get opts :base)]

--- a/components/agent/resources/prompts/reviewer-planner.edn
+++ b/components/agent/resources/prompts/reviewer-planner.edn
@@ -1,0 +1,221 @@
+;; Reviewer-Planner Agent System Prompt
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Configures the Reviewer-Planner agent which determines which files
+;; must be loaded into the MCP context cache for a thorough policy
+;; review of a pull request. Produces a single-task plan whose
+;; :task/exclusive-files vector becomes the cache file set.
+;;
+;; This is the cache-curation step that runs BEFORE the Standards
+;; Reviewer (compliance-scanner) and BEFORE any downstream janitor
+;; agent (Comment Response, Conflict Resolution, CI Failure Handler)
+;; per N13 §2.1 / §2.4.
+;;
+;; Distinct from:
+;; - planner.edn (decomposes implementation specs into multi-task DAGs)
+;; - reviewer.edn (performs the semantic review itself)
+
+{:prompt/id :reviewer-planner
+ :prompt/version "0.1.0"
+ :prompt/agent :reviewer-planner
+
+ ;; Turn cap. Reviewer-planner has a narrow job: read the diff,
+ ;; identify imports/callers/standards-anchored files, emit one plan.
+ ;; Empirically tighter than implementation planning (80) — most
+ ;; runs converge under 20 turns. Cap at 30 for headroom on large
+ ;; multi-component diffs.
+ :prompt/max-turns 30
+
+ ;; Main-turn progress monitor. The reviewer-planner sees a PR diff
+ ;; (typically 200–2000 lines) plus the standards pack manifest.
+ ;; First-chunk latency is small relative to planner.edn because the
+ ;; input is bounded by diff size, not full-spec embedding. 90s
+ ;; stagnation, 240s overall covers the 95th-percentile run.
+ :prompt/progress-monitor
+ {:stagnation-threshold-ms     90000
+  :max-total-ms                240000
+  :min-activity-interval-ms    3000}
+
+ ;; Submission-retry parameters mirror planner.edn's tight retry budget.
+ :prompt/submission-retry-max-turns 3
+ :prompt/submission-retry-monitor
+ {:stagnation-threshold-ms     30000
+  :max-total-ms                90000
+  :min-activity-interval-ms    2000}
+
+ ;; User-turn template wrapped around every PR review request.
+ ;; Substitution keys: {{pr-url}} {{base-ref}} {{head-ref}}
+ ;; {{diff-text}} {{standards-summary}} {{repo-context}}.
+ :prompt/user-template
+ "Determine the file set required to thoroughly review the following
+pull request against the Miniforge standards pack(s) below.
+
+## Pull Request
+
+URL:  {{pr-url}}
+Base: {{base-ref}}
+Head: {{head-ref}}
+
+## Diff
+
+```diff
+{{diff-text}}
+```
+
+## Active Standards Pack(s)
+
+{{standards-summary}}
+
+## Repository Context
+
+{{repo-context}}
+
+## REQUIRED Output
+
+Primary submission path: use Write to create `.miniforge/plan.edn` in the
+working directory. That file IS the plan submission authority.
+
+Fallback only if Write fails or is unavailable: end your FINAL assistant
+message with the plan EDN wrapped in a ```clojure code fence.
+
+The plan MUST be a SINGLE-TASK plan whose `:task/exclusive-files` vector
+is the cache set. No multi-task decomposition. Use #uuid \"<placeholder>\"
+for IDs."
+
+ ;; Submission retry template (model has explored, must now emit).
+ :prompt/submission-retry-template
+ "You already completed the cache-curation analysis for this PR review.
+
+Do NOT explore further. Do NOT call context_read/context_grep/context_glob.
+Your only job is to submit the finished single-task plan NOW.
+
+Primary submission path:
+  Write `.miniforge/plan.edn` in the working directory using the Write tool.
+
+Fallback only if Write fails or is unavailable:
+  End your turn with ONLY the plan EDN in a ```clojure code fence.
+
+No narration. No explanation. No bullets. No markdown beyond the fallback
+code fence.
+
+PR under review:
+
+  URL:  {{pr-url}}
+  Base: {{base-ref}}
+  Head: {{head-ref}}
+
+Prior reviewer-planner output to convert into the final plan submission:
+
+{{prior-content}}"
+
+ :prompt/system
+ "You are a Reviewer-Planner Agent for the Miniforge Closed-Loop PR
+Pipeline (N13 §2.1).
+
+## Your Role
+
+Given a PR diff and the active standards pack(s), determine the minimal
+file set that must be loaded into the MCP context cache so that the
+downstream Standards Reviewer can evaluate the diff thoroughly.
+
+You do NOT review the diff yourself. You do NOT propose fixes. You do
+NOT decompose the work into implementation tasks. Your only output is a
+single-task Plan whose `:task/exclusive-files` vector enumerates the
+file set to cache.
+
+## Input
+
+You receive:
+1. A PR URL, base ref, and head ref.
+2. The full PR diff.
+3. A summary of the active standards pack(s) — rule IDs, descriptions,
+   file globs each rule applies to.
+4. Brief repository context (Polylith component names, top-level layout).
+
+You may use the MCP context tools to inspect specific files when
+deciding inclusion:
+- `context_read`  — peek at a candidate file
+- `context_grep`  — find callers, imports, references to symbols in the
+                    diff
+- `context_glob`  — find sibling files (tests, schema, fixtures)
+
+Use them sparingly. The goal is a curated cache, not exhaustive
+exploration.
+
+## Output Format
+
+You MUST output a single-task Plan as a Clojure map:
+
+```clojure
+{:plan/id    #uuid \"...\"
+ :plan/name  \"reviewer-cache-<pr-number>\"
+ :plan/tasks [{:task/id          #uuid \"...\"
+               :task/description \"Cache curation for PR #<n> review.\"
+               :task/type        :review-cache-prime
+               :task/dependencies []
+               :task/exclusive-files [<file-paths>...]
+               :task/acceptance-criteria
+               [\"Cache contains every file referenced by the diff\"
+                \"Cache contains files matching standards-pack globs that the diff touches\"
+                \"Cache contains direct callers/usages of changed public APIs\"]
+               :task/estimated-effort :small
+               :task/stratum 0}]
+ :plan/estimated-complexity :low|:medium|:high
+ :plan/risks       [\"...\"]
+ :plan/assumptions [\"...\"]}
+```
+
+## File-Set Selection Rules
+
+Include in `:task/exclusive-files`:
+
+1. **Every file changed by the diff.** Always.
+
+2. **Direct callers of changed public APIs.** When a function/var
+   exported from an `interface.clj` is modified, include callers found
+   via `context_grep`. Stop at one hop — do not recursively expand.
+
+3. **Files matching standards-pack rule globs that overlap the diff.**
+   If a rule applies to `components/**/*.clj` and the diff touches
+   `components/agent/src/.../foo.clj`, include adjacent rule-relevant
+   files in the same component (e.g., `interface.clj`, schema files).
+
+4. **Sibling test files** for each changed source file
+   (`<path>/test/.../test.clj` mirroring `<path>/src/.../source.clj`).
+
+5. **Pack manifest and rule definitions** when standards rules are
+   non-trivial — the reviewer needs the rule text accessible.
+
+Exclude:
+
+- Generated files (`target/`, `*.cpcache`, `node_modules/`, etc.).
+- Files unrelated to the diff or the pack scope.
+- Files larger than 200 KB unless they are directly diff-touched.
+
+## Sizing
+
+Aim for a cache size that lets a downstream agent load the entire
+working set within ~50k tokens. Trim aggressively. If the diff is
+large, prefer cohesive component slices over breadth.
+
+## Self-check Before Submission
+
+Before writing `.miniforge/plan.edn`, verify:
+
+- The plan has exactly ONE task with `:task/type :review-cache-prime`.
+- `:task/exclusive-files` includes every diff-touched file.
+- `:task/exclusive-files` is a vector of strings, each a path relative
+  to repo root.
+- No paths point to `target/`, `.cpcache`, or other generated dirs.
+- `:plan/risks` flags any rule whose evaluation may need files not
+  loaded (so the reviewer can request them lazily).
+
+## Failure Modes to Avoid
+
+- Multi-task decomposition. The downstream reviewer is a single agent
+  call, not a DAG.
+- Ignoring standards-pack globs. The reviewer needs rule-relevant
+  context, not just diff context.
+- Including the entire repo. The cache has a token budget; respect it.
+- Emitting prose instead of a Plan EDN. Silent narration is rejected
+  by the runtime."}

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
@@ -1,0 +1,206 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.comments
+  "Render classified Violations into PR review comment payloads per
+   N13 §2.3 (Closed-Loop PR Pipeline — Violation Comment Renderer).
+
+   Pure functions only. Consumers (e.g., `connector-github`) take the
+   structured comment maps emitted here and post them via the provider's
+   review-comment API.
+
+   Layer 0: payload helpers
+   Layer 1: comment-record builders
+   Layer 2: bulk renderer + severity inference"
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Severity inference
+
+(defn- infer-severity
+  "Map a classified Violation to a :violation/severity keyword.
+
+   Heuristic: auto-fixable? true → :warning; false with security/safety
+   category → :error; otherwise :warning. Callers may override by
+   providing :severity-override on the violation map."
+  [violation]
+  (or (:severity-override violation)
+      (let [auto-fix? (:auto-fixable? violation)
+            category  (some-> (:rule/category violation) str/lower-case)
+            critical-cat? (and category
+                               (or (str/includes? category "security")
+                                   (str/includes? category "safety")
+                                   (str/includes? category "critical")))]
+        (cond
+          critical-cat?      :error
+          (false? auto-fix?) :error
+          :else              :warning))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Payload construction
+
+(defn violation->payload
+  "Build the :comment/payload map for a single classified Violation.
+
+   Arguments:
+   - violation    - classified Violation (must have :auto-fixable? and :rationale)
+   - pack-info    - {:pack/id <string> :pack/version <string>}
+
+   Returns the inner payload map shape per N13 §2.3:
+
+     {:violation/rule-id       :keyword
+      :violation/severity      :error|:warning|:info
+      :violation/auto-fixable? boolean
+      :violation/suggested-fix string-or-nil
+      :violation/rationale     string
+      :violation/pack-id       string
+      :violation/pack-version  string}"
+  [violation pack-info]
+  {:violation/rule-id        (:rule/id violation)
+   :violation/severity       (infer-severity violation)
+   :violation/auto-fixable?  (boolean (:auto-fixable? violation))
+   :violation/suggested-fix  (:suggested violation)
+   :violation/rationale      (or (:rationale violation) "")
+   :violation/pack-id        (:pack/id pack-info)
+   :violation/pack-version   (:pack/version pack-info)})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Body rendering
+
+(defn- pr-edn
+  "Pretty-print an EDN value for embedding in a comment body. Stable
+   key ordering keeps comment diffs minimal across re-renders."
+  [v]
+  (if (map? v)
+    (let [ordered-keys [:violation/rule-id
+                        :violation/severity
+                        :violation/auto-fixable?
+                        :violation/suggested-fix
+                        :violation/rationale
+                        :violation/pack-id
+                        :violation/pack-version]
+          present      (filter #(contains? v %) ordered-keys)
+          extras       (sort (remove (set ordered-keys) (keys v)))
+          all-keys     (concat present extras)
+          lines        (for [k all-keys]
+                         (str " " (pr-str k) " " (pr-str (get v k))))]
+      (str "{" (str/triml (str/join "\n" lines)) "}"))
+    (pr-str v)))
+
+(defn- render-body
+  "Build the human-readable comment body with the embedded EDN payload
+   block."
+  [violation payload]
+  (str "**" (or (:rule/title violation) (name (:rule/id violation))) "**\n"
+       "\n"
+       (when-let [r (:rationale violation)] (str r "\n\n"))
+       (when-let [s (:suggested violation)]
+         (str "Suggested fix:\n```\n" s "\n```\n\n"))
+       "```edn\n"
+       ":comment/payload\n"
+       (pr-edn payload) "\n"
+       "```\n"
+       "<sub>Posted by `miniforge-policy-evaluator[bot]` — see N13 §2.3</sub>"))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Single-comment builder
+
+(defn violation->comment
+  "Render a single classified Violation to the comment record per
+   N13 §2.3.
+
+   Arguments:
+   - violation   - classified Violation
+   - pack-info   - {:pack/id ... :pack/version ...}
+
+   Returns:
+
+     {:comment/author  \"miniforge-policy-evaluator[bot]\"
+      :comment/path    string
+      :comment/line    int
+      :comment/body    string  ; markdown w/ embedded :comment/payload EDN
+      :comment/payload {:violation/...}}"
+  [violation pack-info]
+  (let [payload (violation->payload violation pack-info)
+        body    (render-body violation payload)]
+    {:comment/author  "miniforge-policy-evaluator[bot]"
+     :comment/path    (:file violation)
+     :comment/line    (:line violation)
+     :comment/body    body
+     :comment/payload payload}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Bulk renderer
+
+(defn violations->comments
+  "Render a vector of classified Violations to a vector of comment
+   records.
+
+   Arguments:
+   - violations  - vector of classified Violation maps
+   - pack-info   - {:pack/id ... :pack/version ...}
+
+   Stable output order: by (file, line, rule-id) ascending."
+  [violations pack-info]
+  (->> violations
+       (mapv #(violation->comment % pack-info))
+       (sort-by (juxt :comment/path :comment/line
+                      (comp str :violation/rule-id :comment/payload)))
+       vec))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Parser (round-trip helper)
+
+(defn extract-payload
+  "Extract a `:comment/payload` map from a comment body produced by
+   `render-body`. Returns nil if no payload block is found.
+
+   Used by the Comment Response Agent's bot-comment-table parser
+   (per `pr-monitoring-workflow.md` Bot Comment Handling) to recover
+   the structured payload from a posted comment."
+  [body]
+  (when (string? body)
+    (let [block-re #"(?s)```edn\s*:comment/payload\s*(\{.*?\})\s*```"]
+      (when-let [[_ edn-str] (re-find block-re body)]
+        (try
+          (binding [*read-eval* false]
+            (read-string edn-str))
+          (catch Exception _ nil))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Single violation
+  (def v {:rule/id        :ai.miniforge.standards/exceptions-as-data
+          :rule/category  "code-quality"
+          :rule/title     "Exceptions must be data, not exceptions"
+          :file           "components/agent/src/ai/miniforge/agent/foo.clj"
+          :line           42
+          :current        "(throw (ex-info ...))"
+          :suggested      "(anomaly/throw-anomaly ...)"
+          :auto-fixable?  true
+          :rationale      "Throwing exceptions breaks effect-as-data."})
+
+  (violation->comment v {:pack/id "miniforge-standards"
+                         :pack/version "1.4.0"})
+
+  ;; Round-trip the payload
+  (-> (violation->comment v {:pack/id "miniforge-standards" :pack/version "1.4.0"})
+      :comment/body
+      extract-payload)
+
+  :leave-this-here)

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
@@ -27,7 +27,8 @@
    Layer 0: payload helpers
    Layer 1: comment-record builders
    Layer 2: bulk renderer + severity inference"
-  (:require [clojure.string :as str]))
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Severity inference
@@ -35,21 +36,18 @@
 (defn- infer-severity
   "Map a classified Violation to a :violation/severity keyword.
 
-   Heuristic: auto-fixable? true → :warning; false with security/safety
-   category → :error; otherwise :warning. Callers may override by
-   providing :severity-override on the violation map."
+   Heuristic: violations whose `:rule/category` matches
+   security/safety/critical → :error. Everything else → :warning,
+   regardless of auto-fixability. Callers may override by providing
+   `:severity-override` on the violation map."
   [violation]
   (or (:severity-override violation)
-      (let [auto-fix? (:auto-fixable? violation)
-            category  (some-> (:rule/category violation) str/lower-case)
+      (let [category      (some-> (:rule/category violation) str/lower-case)
             critical-cat? (and category
                                (or (str/includes? category "security")
                                    (str/includes? category "safety")
                                    (str/includes? category "critical")))]
-        (cond
-          critical-cat?      :error
-          (false? auto-fix?) :error
-          :else              :warning))))
+        (if critical-cat? :error :warning))))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Payload construction
@@ -178,8 +176,11 @@
     (let [block-re #"(?s)```edn\s*:comment/payload\s*(\{.*?\})\s*```"]
       (when-let [[_ edn-str] (re-find block-re body)]
         (try
-          (binding [*read-eval* false]
-            (read-string edn-str))
+          ;; clojure.edn/read-string is strictly EDN — no reader macros,
+          ;; no #=, no eval. Comment bodies are untrusted input once
+          ;; posted/retrieved from a PR. {:default identity} swallows
+          ;; unknown tagged literals safely.
+          (edn/read-string {:default (fn [_tag value] value)} edn-str)
           (catch Exception _ nil))))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -31,6 +31,7 @@
             [ai.miniforge.compliance-scanner.plan               :as plan]
             [ai.miniforge.compliance-scanner.report             :as report]
             [ai.miniforge.compliance-scanner.execute            :as execute]
+            [ai.miniforge.compliance-scanner.comments           :as comments]
             [ai.miniforge.compliance-scanner.exceptions-as-data :as exc-data]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -153,6 +154,87 @@
    Returns map with :prs (vector of per-rule results), :violations-fixed, :files-changed."
   [plan repo-path]
   (execute/execute! plan repo-path))
+
+;------------------------------------------------------------------------------ Layer 1
+;; PR-scoped review entry point (N13 §2.2)
+
+(def violation->comment
+  "Render a single classified Violation to a PR review comment per
+   N13 §2.3."
+  comments/violation->comment)
+
+(def violations->comments
+  "Render a vector of classified Violations to a vector of PR review
+   comment records per N13 §2.3."
+  comments/violations->comments)
+
+(def extract-comment-payload
+  "Recover the embedded `:comment/payload` map from a comment body.
+   Used by the Comment Response Agent to parse posted policy
+   violations."
+  comments/extract-payload)
+
+(defn pr-review
+  "PR-scoped read-only standards review per N13 §2.2.
+
+   Runs scan with `:since base-ref` (incremental + diff-analysis modes),
+   classifies the resulting violations, and renders them to the comment
+   record shape defined in N13 §2.3 — without applying any fixes.
+
+   Arguments:
+   - repo-path      - string path to repo root (a checkout of the PR's
+                      head SHA)
+   - standards-path - string path to .standards dir
+   - opts           - map with:
+       :base-ref     - REQUIRED. Git ref of the PR's base branch (e.g.,
+                       \"origin/main\"). Passed through to scan as :since.
+       :rules        - rule selector, default :all
+       :pack-info    - {:pack/id <string> :pack/version <string>}.
+                       Embedded in every rendered comment payload.
+                       Defaults to {:pack/id \"unknown\" :pack/version \"0.0.0\"}
+                       if not supplied — callers SHOULD provide real values.
+       :pack         - pre-compiled PackManifest (optional)
+
+   Returns:
+
+     {:pr-review/scan-result <ScanResult>
+      :pr-review/classified  <vector of classified Violations>
+      :pr-review/comments    <vector of comment records, ready to post>
+      :pr-review/summary     {:total <int>
+                              :auto-fixable <int>
+                              :needs-review <int>
+                              :files-affected <int>
+                              :rules-violated <int>}}
+
+   This function does NOT post comments and does NOT apply fixes. The
+   caller (a step workflow / CLI / janitor) consumes the
+   :pr-review/comments vector and posts via `connector-github` (or the
+   appropriate provider connector).
+
+   See N13 §2.2 — Standards Reviewer (reuse compliance-scanner)."
+  [repo-path standards-path
+   {:keys [base-ref rules pack pack-info]
+    :or   {rules :all}
+    :as   _opts}]
+  (when-not (and (string? base-ref) (seq base-ref))
+    (throw (ex-info "pr-review requires :base-ref (e.g., \"origin/main\")"
+                    {:opts _opts :anomaly :pr-review/missing-base-ref})))
+  (let [scan-opts    (cond-> {:rules rules :since base-ref}
+                       pack (assoc :pack pack))
+        scan-result  (scan repo-path standards-path scan-opts)
+        classified   (classify (:violations scan-result))
+        pi           (or pack-info {:pack/id "unknown" :pack/version "0.0.0"})
+        comment-recs (violations->comments classified pi)
+        total        (count classified)
+        auto-fix     (count (filter :auto-fixable? classified))]
+    {:pr-review/scan-result scan-result
+     :pr-review/classified  classified
+     :pr-review/comments    comment-recs
+     :pr-review/summary     {:total          total
+                             :auto-fixable   auto-fix
+                             :needs-review   (- total auto-fix)
+                             :files-affected (count (distinct (mapv :file classified)))
+                             :rules-violated (count (distinct (mapv :rule/id classified)))}}))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Convenience orchestrator

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
@@ -67,6 +67,17 @@
     (is (= :error
            (:violation/severity
             (comments/violation->payload non-fixable-violation base-pack-info)))))
+  (testing "non-fixable + non-critical → :warning (not :error)"
+    (let [v (assoc auto-fixable-violation :auto-fixable? false)]
+      (is (= :warning
+             (:violation/severity
+              (comments/violation->payload v base-pack-info))))))
+  (testing "auto-fixable + critical category → :error (critical wins)"
+    (let [v (assoc auto-fixable-violation
+                   :rule/category "security")]
+      (is (= :error
+             (:violation/severity
+              (comments/violation->payload v base-pack-info))))))
   (testing ":severity-override wins"
     (is (= :info
            (:violation/severity

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
@@ -1,0 +1,136 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.comments-test
+  "Tests for the violation comment renderer (N13 §2.3)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [ai.miniforge.compliance-scanner.comments :as comments]))
+
+(def ^:private base-pack-info
+  {:pack/id "miniforge-standards" :pack/version "1.4.0"})
+
+(def ^:private auto-fixable-violation
+  {:rule/id        :ai.miniforge.standards/exceptions-as-data
+   :rule/category  "code-quality"
+   :rule/title     "Exceptions must be data, not exceptions"
+   :file           "components/agent/src/ai/miniforge/agent/foo.clj"
+   :line           42
+   :current        "(throw (ex-info \"bad\" {}))"
+   :suggested      "(anomaly/throw-anomaly :foo/bad-state {})"
+   :auto-fixable?  true
+   :rationale      "Throwing exceptions breaks effect-as-data."})
+
+(def ^:private non-fixable-violation
+  {:rule/id        :ai.miniforge.standards/no-credentials-in-source
+   :rule/category  "security"
+   :rule/title     "Hardcoded credentials"
+   :file           "bases/cli/src/ai/miniforge/cli/main.clj"
+   :line           17
+   :current        "(def api-key \"sk-XXXX\")"
+   :suggested      nil
+   :auto-fixable?  false
+   :rationale      "Manual review required for credential rotation."})
+
+(deftest payload-shape-required-keys
+  (testing "payload contains all N13 §2.3 keys"
+    (let [p (comments/violation->payload auto-fixable-violation base-pack-info)]
+      (is (= :ai.miniforge.standards/exceptions-as-data (:violation/rule-id p)))
+      (is (true?  (:violation/auto-fixable? p)))
+      (is (= "(anomaly/throw-anomaly :foo/bad-state {})" (:violation/suggested-fix p)))
+      (is (= "Throwing exceptions breaks effect-as-data." (:violation/rationale p)))
+      (is (= "miniforge-standards" (:violation/pack-id p)))
+      (is (= "1.4.0" (:violation/pack-version p)))
+      (is (#{:error :warning :info} (:violation/severity p))))))
+
+(deftest payload-severity-inference
+  (testing "auto-fixable + non-critical → :warning"
+    (is (= :warning
+           (:violation/severity
+            (comments/violation->payload auto-fixable-violation base-pack-info)))))
+  (testing "non-fixable + security category → :error"
+    (is (= :error
+           (:violation/severity
+            (comments/violation->payload non-fixable-violation base-pack-info)))))
+  (testing ":severity-override wins"
+    (is (= :info
+           (:violation/severity
+            (comments/violation->payload
+             (assoc auto-fixable-violation :severity-override :info)
+             base-pack-info))))))
+
+(deftest comment-record-shape
+  (testing "comment record has the four required keys + payload"
+    (let [c (comments/violation->comment auto-fixable-violation base-pack-info)]
+      (is (= "miniforge-policy-evaluator[bot]" (:comment/author c)))
+      (is (= (:file auto-fixable-violation) (:comment/path c)))
+      (is (= (:line auto-fixable-violation) (:comment/line c)))
+      (is (string? (:comment/body c)))
+      (is (map? (:comment/payload c))))))
+
+(deftest comment-body-embeds-edn-payload
+  (testing "comment body contains a parseable :comment/payload EDN block"
+    (let [c (comments/violation->comment auto-fixable-violation base-pack-info)
+          body (:comment/body c)]
+      (is (str/includes? body "```edn"))
+      (is (str/includes? body ":comment/payload"))
+      (is (str/includes? body ":violation/rule-id"))
+      (is (str/includes? body "miniforge-policy-evaluator[bot]")))))
+
+(deftest extract-payload-roundtrips
+  (testing "rendered → extracted yields the same payload"
+    (let [c   (comments/violation->comment auto-fixable-violation base-pack-info)
+          got (comments/extract-payload (:comment/body c))]
+      (is (= (:comment/payload c) got)))))
+
+(deftest extract-payload-missing-returns-nil
+  (testing "no payload block → nil"
+    (is (nil? (comments/extract-payload "no payload here")))
+    (is (nil? (comments/extract-payload nil)))))
+
+(deftest bulk-render-stable-order
+  (testing "violations are sorted by (path, line, rule-id) ascending"
+    (let [vs [(assoc auto-fixable-violation :line 50)
+              non-fixable-violation
+              auto-fixable-violation]
+          cs (comments/violations->comments vs base-pack-info)]
+      (is (= 3 (count cs)))
+      ;; bases/* sorts before components/*
+      (is (str/starts-with? (:comment/path (first cs)) "bases/"))
+      (let [components-comments (filter #(str/starts-with? (:comment/path %) "components/") cs)
+            lines               (mapv :comment/line components-comments)]
+        (is (= [42 50] lines))))))
+
+(deftest auto-fixable-flag-preserved
+  (testing "auto-fixable? boolean flows through to payload"
+    (is (true?  (-> auto-fixable-violation
+                    (comments/violation->comment base-pack-info)
+                    :comment/payload
+                    :violation/auto-fixable?)))
+    (is (false? (-> non-fixable-violation
+                    (comments/violation->comment base-pack-info)
+                    :comment/payload
+                    :violation/auto-fixable?)))))
+
+(deftest pack-info-injected
+  (testing "pack-id and pack-version are passed through"
+    (let [p (comments/violation->payload auto-fixable-violation
+                                          {:pack/id "custom-pack"
+                                           :pack/version "9.9.9"})]
+      (is (= "custom-pack" (:violation/pack-id p)))
+      (is (= "9.9.9" (:violation/pack-version p))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/pr_review_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/pr_review_test.clj
@@ -1,0 +1,139 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.pr-review-test
+  "Tests for the `pr-review` Layer 1 entry point (N13 §2.2).
+
+   Locks in the read-only contract: `pr-review`
+   - requires `:base-ref`,
+   - delegates to `scan` with `:since` populated from `:base-ref`,
+   - never invokes `execute!` (the auto-fix path),
+   - returns the rendered comment vector + summary."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.compliance-scanner.interface :as scanner]
+            [ai.miniforge.compliance-scanner.classify  :as classify-impl]
+            [ai.miniforge.compliance-scanner.scan      :as scan-impl]
+            [ai.miniforge.compliance-scanner.execute   :as execute-impl]))
+
+(def ^:private one-violation
+  {:rule/id        :ai.miniforge.standards/example-rule
+   :rule/category  "code-quality"
+   :rule/title     "Example rule"
+   :file           "components/example/src/foo.clj"
+   :line           7
+   :current        "(throw (ex-info \"x\" {}))"
+   :suggested      "(anomaly/throw-anomaly :foo/x {})"
+   :auto-fixable?  true
+   :rationale      "test fixture"})
+
+(def ^:private fake-scan-result
+  {:violations       [one-violation]
+   :rules-scanned    [:ai.miniforge.standards/example-rule]
+   :files-scanned    1
+   :scan-duration-ms 1})
+
+(deftest base-ref-required
+  (testing "missing :base-ref throws with anomaly tag"
+    (let [thrown (try
+                   (scanner/pr-review "/nonexistent" ".standards" {})
+                   nil
+                   (catch Exception e e))]
+      (is (some? thrown))
+      (is (= :pr-review/missing-base-ref
+             (:anomaly (ex-data thrown))))))
+  (testing "blank :base-ref also rejected"
+    (is (thrown? Exception
+                 (scanner/pr-review "/nonexistent" ".standards"
+                                    {:base-ref ""})))))
+
+(deftest scan-invoked-with-since
+  (testing "pr-review forwards :base-ref to scan as :since and never to execute!"
+    (let [scan-calls    (atom [])
+          execute-calls (atom 0)]
+      (with-redefs [scan-impl/scan-repo
+                    (fn [repo standards opts]
+                      (swap! scan-calls conj
+                             {:repo repo :standards standards :opts opts})
+                      fake-scan-result)
+                    execute-impl/execute!
+                    (fn [& args]
+                      (swap! execute-calls inc)
+                      args)]
+        (let [result (scanner/pr-review
+                      "/some/repo" ".standards"
+                      {:base-ref  "origin/main"
+                       :rules     :all
+                       :pack-info {:pack/id "test-pack" :pack/version "1.0.0"}})]
+          (is (= 1 (count @scan-calls)))
+          (is (= "origin/main" (get-in @scan-calls [0 :opts :since]))
+              ":since opt is populated from :base-ref")
+          (is (= :all (get-in @scan-calls [0 :opts :rules])))
+          (is (zero? @execute-calls)
+              "pr-review must not invoke execute! — read-only contract")
+          (is (= fake-scan-result (:pr-review/scan-result result)))
+          (is (= 1 (count (:pr-review/classified result))))
+          (is (= 1 (count (:pr-review/comments result))))
+          (is (= "test-pack"
+                 (get-in result [:pr-review/comments 0
+                                 :comment/payload :violation/pack-id])))
+          (is (= 1 (get-in result [:pr-review/summary :total]))))))))
+
+(deftest pack-info-default
+  (testing "no :pack-info supplied → default pack-id/version filled in"
+    (with-redefs [scan-impl/scan-repo (fn [_ _ _] fake-scan-result)
+                  execute-impl/execute! (fn [& _] (throw (ex-info "should not be called" {})))]
+      (let [result (scanner/pr-review
+                    "/some/repo" ".standards"
+                    {:base-ref "origin/main"})]
+        (is (= "unknown" (get-in result [:pr-review/comments 0
+                                         :comment/payload :violation/pack-id])))
+        (is (= "0.0.0"   (get-in result [:pr-review/comments 0
+                                         :comment/payload :violation/pack-version])))))))
+
+(deftest summary-counts
+  (testing "summary aggregates total / auto-fixable / needs-review / files / rules"
+    (let [v1 (assoc one-violation :file "a.clj" :rule/id :rule/a :auto-fixable? true)
+          v2 (assoc one-violation :file "b.clj" :rule/id :rule/b :auto-fixable? false)
+          v3 (assoc one-violation :file "a.clj" :rule/id :rule/a :auto-fixable? true)]
+      (with-redefs [scan-impl/scan-repo (fn [_ _ _] {:violations       [v1 v2 v3]
+                                                     :rules-scanned    [:rule/a :rule/b]
+                                                     :files-scanned    2
+                                                     :scan-duration-ms 1})
+                    classify-impl/classify-violations identity
+                    execute-impl/execute! (fn [& _] (throw (ex-info "should not be called" {})))]
+        (let [{:pr-review/keys [summary]}
+              (scanner/pr-review "/some/repo" ".standards"
+                                 {:base-ref "origin/main"})]
+          (is (= 3 (:total summary)))
+          (is (= 2 (:auto-fixable summary)))
+          (is (= 1 (:needs-review summary)))
+          (is (= 2 (:files-affected summary)))
+          (is (= 2 (:rules-violated summary))))))))
+
+(deftest empty-scan-returns-empty-comments
+  (testing "no violations → empty comments vector + zeroed summary"
+    (with-redefs [scan-impl/scan-repo (fn [_ _ _] {:violations       []
+                                                   :rules-scanned    []
+                                                   :files-scanned    0
+                                                   :scan-duration-ms 1})
+                  execute-impl/execute! (fn [& _] (throw (ex-info "should not be called" {})))]
+      (let [{:pr-review/keys [comments summary]}
+            (scanner/pr-review "/some/repo" ".standards"
+                               {:base-ref "origin/main"})]
+        (is (= [] comments))
+        (is (zero? (:total summary)))))))

--- a/docs/pull-requests/2026-05-07-feat-n13-pipeline-foundations.md
+++ b/docs/pull-requests/2026-05-07-feat-n13-pipeline-foundations.md
@@ -1,0 +1,182 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# feat: N13 closed-loop PR pipeline foundations
+
+## Overview
+
+Lay down the foundation pieces for the Closed-Loop PR Pipeline (N13):
+PR-scoped policy review using the existing `compliance-scanner`,
+violation-comment renderer keyed for the Comment Response Agent's
+bot-comment table, the listener-registry data model for the Resume
+Signal Dispatcher, the reviewer-planner prompt that primes the MCP
+context cache, and the seam in `pr-monitoring-workflow.md` that
+references all of the above.
+
+This PR is **paper + scaffolding only**. No webhook subscriber. No
+janitor dispatcher. No comment poster. The wiring this PR adds is
+sufficient to run the Standards Reviewer step end-to-end against a
+local checkout via `bb miniforge pr review`.
+
+## Motivation
+
+Operator-behavior mining over recent Claude + Codex sessions surfaces
+PR-lifecycle drudgery as the dominant typed operator turn:
+
+- ~448 manual `merged` confirmations
+- ~80 `respond-to-comments` directives
+- ~77 `resolve-conflicts` directives
+- ~130 plan-approval confirmations
+- ~30 idle-state probes
+
+The N13 spec (drafted in the companion `Spec Additions/` worktree)
+defines the closed loop that erases most of this. This PR lands the
+smallest viable foundation against the existing components — every new
+file references existing infrastructure rather than introducing new
+runtime surface.
+
+## Changes In Detail
+
+### Spec — `specs/informative/`
+
+- `pr-monitoring-workflow.md`
+  - Bot-comment table extended with `miniforge-policy-evaluator[bot]`
+    row pointing at N13 §2.5.
+  - New section: **Component: Plan-Driven Context Cache (per N13 §2.4)**
+    documenting the `reviewer-planner → context-cache → janitor` flow,
+    the elision threshold, and the SHA-keyed cache reuse rule.
+  - New section: **Component: Resume Signal Dispatcher (per N13 §2.7)**
+    summarizing the listener-registry handoff and the three resume
+    channels, with a forward reference to the listener-registry doc.
+- `n13-listener-registry.md` (new)
+  - Canonical schema for listener entries (PR URL → agents waiting on
+    merge), the four state transitions, the three registration moments
+    (authoring-agent emit, operator binding, workflow declaration),
+    storage at `.miniforge/listener-registry.edn`, dispatch contracts
+    per channel kind (`:pty`, `:miniforge-ipc`, `:webhook`), evidence
+    artifacts, and N11 operator surface requirements.
+
+### Agent prompt — `components/agent/resources/prompts/`
+
+- `reviewer-planner.edn` (new)
+  - Variant of `planner.edn` tuned for cache-curation in PR review
+    context.
+  - Output is a single-task Plan whose `:task/exclusive-files` becomes
+    the file set loaded into the MCP context cache for the downstream
+    Standards Reviewer (and any janitor that follows).
+  - Tighter turn budget (30 vs 80) and progress monitor (90s/240s vs
+    180s/600s) — the input is bounded by diff size, not full-spec
+    embedding.
+  - File-set selection rules cover diff-touched files, one-hop callers
+    of changed public APIs, standards-pack rule globs that overlap the
+    diff, sibling tests, and pack manifests.
+
+### Code — `components/compliance-scanner/`
+
+- `src/.../comments.clj` (new)
+  - Pure rendering layer for classified Violations → PR comment
+    records per N13 §2.3.
+  - `violation->payload` builds the inner `:violation/...` map.
+  - `violation->comment` builds the full comment record with the
+    embedded EDN payload block.
+  - `violations->comments` is the bulk renderer with stable sort
+    (path, line, rule-id).
+  - `extract-payload` is the round-trip helper used by the Comment
+    Response Agent's bot-comment-table parser.
+  - Severity inference: auto-fixable + non-critical → `:warning`,
+    non-fixable + security/safety/critical category → `:error`,
+    `:severity-override` wins.
+- `src/.../interface.clj` (modified)
+  - New Layer 1 entry point `pr-review` runs scan + classify + comment
+    rendering as one composed call. Required `:base-ref`. Optional
+    `:pack`, `:pack-info`, `:rules`. Read-only — does not call
+    `execute!`.
+  - Public re-exports: `violation->comment`, `violations->comments`,
+    `extract-comment-payload`.
+- `test/.../comments_test.clj` (new)
+  - 9 tests / 29 assertions covering payload shape, severity
+    inference, comment record shape, embedded-EDN block format,
+    round-trip via `extract-payload`, bulk renderer stable order,
+    auto-fixable flag passthrough, and pack-info injection.
+
+### CLI — `bases/cli/`
+
+- `src/.../commands/pr_review.clj` (new)
+  - `run-pr-review!` — programmatic entry point operating on an
+    existing repo checkout.
+  - Output formatters: `:table` (default), `:edn`, `:json`. JSON uses
+    a small inline serializer to avoid pulling cheshire into the
+    surface.
+  - `run-pr-review-by-path-cmd` — CLI entry for the `--repo + --base`
+    flow used by janitors operating on existing worktrees.
+- `src/.../commands/pr.clj` (modified)
+  - `pr-review-cmd` was a TODO stub — now delegates to
+    `pr-review/run-pr-review!`. Two flows:
+    1. `bb miniforge pr review <pr-url>` — checks out the PR via
+       `gh pr checkout`, derives base ref via `gh pr view --json
+       baseRefName`, then invokes the impl.
+    2. `bb miniforge pr review --repo <path> --base <ref>` —
+       no-checkout path for janitors and dogfood.
+- `src/.../main.clj` (modified)
+  - `pr review` flag spec extended: `--url --repo --base --standards
+    --pack --rules --out` with sensible defaults.
+
+## Reuse anchors
+
+Every new piece references existing infrastructure rather than
+inventing new runtime surface:
+
+| New surface                   | Reuses                                                          |
+| ----------------------------- | --------------------------------------------------------------- |
+| `pr-review` entry point       | `compliance-scanner.scan` `:since`, `classify`                  |
+| Reviewer-planner prompt       | Existing `planner.edn` template + planner runtime               |
+| Plan-driven cache for janitors| `bases/mcp-context-server` `context-cache.clj` `load-cache!`    |
+| `pr review <url>` CLI         | Existing `parse-pr-url`, `checkout-pr!`, `gh pr view --json`    |
+| Comment payload schema        | N9 read-only policy evaluation contract                         |
+
+## Verification
+
+- **Lint**: `clj-kondo` on all touched files — clean (0 errors, 0
+  warnings).
+- **Test**: `clojure -M:test` on the new
+  `comments_test` namespace — 9 tests / 29 assertions pass.
+- **Load**: `clojure -A:dev -e "(require 'ai.miniforge.cli.main)"` —
+  full CLI namespace tree loads with the new require chain.
+
+Manual smoke test path (not yet exercised in CI):
+
+```bash
+# Existing checkout, scan against base
+bb miniforge pr review --repo . --base origin/main --out edn
+
+# PR URL flow
+bb miniforge pr review https://github.com/<org>/<repo>/pull/<n>
+```
+
+## What's NOT in this PR
+
+These pieces are deliberately deferred — they belong in follow-up PRs
+once the foundation lands:
+
+- Webhook subscriber for `pull_request*` / `check_suite.completed`.
+- Janitor dispatcher that fans out to Conflict Resolution / Comment
+  Response / CI Failure Handler (those agents already exist as
+  designs in `pr-monitoring-workflow.md`).
+- Comment poster — `connector-github` integration that takes the
+  rendered comment vector and posts via the GitHub Reviews API. The
+  rendering side is complete; the posting side stays a TODO until the
+  webhook trigger lands.
+- Listener registry implementation (the schema is defined; the
+  read/write/dispatch code lives in a follow-up).
+- Closed-loop pipeline runtime composition (steps wired into a single
+  `:closed-loop-pr` workflow type per N13 §3).
+
+## References
+
+- N13 spec — drafted in companion `Spec Additions/` worktree, branch
+  `claude/angry-goodall-3e65e9`, commit `1187ef9`.
+- `specs/informative/pr-monitoring-workflow.md` (extended in this PR).
+- N9 — External PR Read-Only Policy Evaluation
+  (`work/n09-external-pr-read-only-eval.spec.edn`).

--- a/specs/informative/n13-listener-registry.md
+++ b/specs/informative/n13-listener-registry.md
@@ -1,0 +1,222 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Listener Registry — Resume Signal Dispatcher Data Model
+
+**Date:** 2026-05-07
+**Status:** Informative (N13 supporting spec)
+**Informs:** N13 §2.7, `pr-monitoring-workflow.md` Resume Signal Dispatcher
+
+---
+
+## Overview
+
+The Closed-Loop PR Pipeline (N13) needs a registry of agents that have
+declared they are waiting on a specific PR's merge. When the PR merges,
+each registered listener receives a structured resume primer through its
+declared channel.
+
+This document specifies the registry schema, lifecycle, and the
+canonical registration moments.
+
+---
+
+## Schema
+
+```clojure
+{:registry/version "1.0.0"
+
+ ;; Listener entry — keyed by PR URL.
+ :listener/entry
+ {:listener/id          #uuid "..."          ; stable per registration
+  :pr/url               "https://github.com/<org>/<repo>/pull/<n>"
+  :pr/repo-id           "<org>/<repo>"
+  :pr/number            123
+  :agent/id             "<runtime-stable-agent-id>"
+  :session/id           "<session-uuid>"     ; agent's current session, if any
+  :runtime              :claude-cli|:codex|:miniforge|:webhook
+  :resume-channel       {:channel/kind   :pty|:miniforge-ipc|:webhook
+                         :channel/target "<pty-id|topic|url>"
+                         :channel/auth   {...}}             ; optional, per-kind
+  :registered-at        #inst "..."
+  :registered-by        :authoring-agent|:operator|:workflow
+  :ttl-seconds          604800                              ; default 7 days
+  :status               :active|:dispatched|:expired|:cancelled
+  :resume/dispatched-at #inst "..."                         ; nil until merge
+  :resume/dispatch-id   #uuid "..."                         ; correlates to evidence
+  :notes                "<optional human note>"}}
+```
+
+---
+
+## Lifecycle
+
+### States
+
+```text
+        register
+   ─────────────────▶  :active
+                         │
+                         ├── pr.closed.merged ──▶ :dispatched
+                         │
+                         ├── ttl-elapsed ──────▶ :expired
+                         │
+                         └── unregister ───────▶ :cancelled
+```
+
+A listener entry MUST exist in exactly one state at a time. Transitions
+are append-only events on the registry's event log; the current state
+is a fold over those events.
+
+### Registration moments
+
+A listener MUST be registered at one of these moments:
+
+1. **Authoring-agent emit** — when an agent emits a PR-open event via
+   release phase (or equivalent), it MAY include a
+   `:listener/register` clause naming itself as the listener. This is
+   the default for Miniforge-authored PRs.
+2. **Operator binding** — via the N11 Native Control Console, the
+   operator binds a non-authoring agent (e.g., a parallel driving
+   session) to a PR's merge.
+3. **Workflow declaration** — a multi-step workflow that depends on a
+   PR landing MAY register itself as a listener; the workflow's resume
+   handler is invoked instead of an agent's.
+
+Registration outside these three moments MUST be rejected.
+
+### Deregistration
+
+A listener SHOULD be deregistered when:
+
+- The agent exits cleanly and is no longer waiting on the PR.
+- The operator cancels the binding.
+- The PR is closed without merging (registry MAY mark the listener
+  `:cancelled` automatically on `pull_request.closed` with
+  `merged: false`).
+
+A listener MUST be auto-expired when `:ttl-seconds` elapses without
+merge or dispatch.
+
+---
+
+## Storage
+
+The registry is a Miniforge artifact (per N6) stored at:
+
+```text
+.miniforge/listener-registry.edn
+```
+
+Schema:
+
+```clojure
+{:registry/version "1.0.0"
+ :registry/listeners {<pr-url-string> [<listener-entry> ...]}
+ :registry/last-updated #inst "..."}
+```
+
+Updates MUST be transactional (write-rename) to avoid partial reads.
+
+### Multi-tenant note
+
+For Miniforge Enterprise (per N12), the registry MAY be backed by a
+shared store keyed by tenant. The single-tenant artifact path remains
+the default.
+
+---
+
+## Dispatch
+
+When `pull_request.closed.merged` arrives for `<pr-url>`:
+
+1. Read all entries with `:status :active` for that PR URL.
+2. For each, build the resume primer per N13 §2.7:
+
+   ```clojure
+   {:resume/pr-url      "..."
+    :resume/merge-sha   "..."
+    :resume/merged-at   #inst "..."
+    :resume/diff-summary "..."
+    :resume/listener    {:agent/id ... :session/id ...}}
+   ```
+
+3. Send via the listener's `:resume-channel`. Per-kind contracts:
+   - `:pty` — write the primer (rendered as a structured prompt) to the
+     PTY's input fd via the N11 Native Control Console.
+   - `:miniforge-ipc` — emit the primer as a typed event on the topic
+     declared in `:channel/target`; the agent's runtime subscribes to
+     that topic.
+   - `:webhook` — POST the primer JSON to `:channel/target` with
+     optional auth from `:channel/auth`. Standard HTTP retry rules
+     apply (3 attempts, exponential backoff).
+4. On successful send, transition the entry to `:dispatched` and record
+   `:resume/dispatched-at` + `:resume/dispatch-id`.
+5. On failed send after retries, emit a `:listener/dispatch-failed`
+   event and surface to N11 attention queue. Entry remains `:active`
+   until the next attempt or operator action.
+
+---
+
+## Evidence
+
+Each dispatch MUST append to the PR's evidence bundle (per N6):
+
+```clojure
+{:evidence/listener-dispatch
+ {:dispatch/id        #uuid "..."
+  :listener/id        #uuid "..."
+  :pr/url             "..."
+  :merge/sha          "..."
+  :channel/kind       :pty|:miniforge-ipc|:webhook
+  :dispatched-at      #inst "..."
+  :outcome            :delivered|:failed
+  :failure-reason     "..."}} ; nil on :delivered
+```
+
+---
+
+## Operator surface (N11)
+
+The N11 Native Control Console MUST surface:
+
+- A "PR listeners" view per agent — which PRs the agent is waiting on,
+  with current registry status and TTL remaining.
+- A "Listeners on PR" view per PR — which agents are waiting, useful
+  when triaging a stalled PR.
+- A "Cancel binding" action per listener entry.
+- An attention item on `:listener/dispatch-failed`.
+
+---
+
+## Conformance
+
+A conforming Miniforge implementation MUST:
+
+1. Implement the listener entry schema as specified.
+2. Implement the four state transitions.
+3. Persist the registry at `.miniforge/listener-registry.edn` (or the
+   tenant-scoped equivalent for Enterprise).
+4. Honor the three registration moments and reject other registrations.
+5. Implement at least the `:pty` and `:miniforge-ipc` channels.
+6. Append evidence per the §Evidence section.
+
+A conforming implementation SHOULD:
+
+- Surface registry state in N11 per §Operator surface.
+- Auto-cancel listeners on `pull_request.closed` with `merged: false`.
+- Auto-expire on TTL elapse.
+
+A conforming implementation MAY:
+
+- Add additional channel kinds beyond the three specified.
+- Coalesce identical primers when multiple listeners share an
+  `:agent/id` (rare).
+
+---
+
+**Version:** 0.1.0-draft
+**Last Updated:** 2026-05-07

--- a/specs/informative/n13-listener-registry.md
+++ b/specs/informative/n13-listener-registry.md
@@ -27,7 +27,7 @@ canonical registration moments.
 ## Schema
 
 ```clojure
-{:registry/version "1.0.0"
+{:registry/version "0.1.0"
 
  ;; Listener entry — keyed by PR URL.
  :listener/entry
@@ -114,10 +114,15 @@ The registry is a Miniforge artifact (per N6) stored at:
 Schema:
 
 ```clojure
-{:registry/version "1.0.0"
+{:registry/version "0.1.0"
  :registry/listeners {<pr-url-string> [<listener-entry> ...]}
  :registry/last-updated #inst "..."}
 ```
+
+The `:registry/version` field tracks the on-disk artifact format and
+moves on the same cadence as this spec document; both currently sit at
+`0.1.0` (`-draft` in this document's footer denotes status, not a
+distinct version).
 
 Updates MUST be transactional (write-rename) to avoid partial reads.
 

--- a/specs/informative/pr-monitoring-workflow.md
+++ b/specs/informative/pr-monitoring-workflow.md
@@ -148,12 +148,18 @@ Handles comments on PRs from bots and humans.
 
 ### Bot Comment Handling
 
-| Bot        | Comment Pattern          | Action                           |
-| ---------- | ------------------------ | -------------------------------- |
-| Dependabot | Version update available | Evaluate and update if safe      |
-| CodeQL     | Security finding         | Assess severity, fix if critical |
-| Codecov    | Coverage decreased       | Add tests or justify             |
-| Renovate   | Dependency update        | Same as Dependabot               |
+| Bot                              | Comment Pattern                       | Action                                                                                                                 |
+| -------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Dependabot                       | Version update available              | Evaluate and update if safe                                                                                            |
+| CodeQL                           | Security finding                      | Assess severity, fix if critical                                                                                       |
+| Codecov                          | Coverage decreased                    | Add tests or justify                                                                                                   |
+| Renovate                         | Dependency update                     | Same as Dependabot                                                                                                     |
+| `miniforge-policy-evaluator[bot]` | Embedded `:comment/payload` EDN block | Apply `:violation/suggested-fix` if present; else dispatch a fix sub-task scoped to the rule-id and file. Per N13 §2.5. |
+
+When the embedded `:comment/payload` block reports
+`:violation/auto-fixable? false`, the agent MUST escalate to an N11
+attention item rather than attempt a fix. See N13 §2.6 for convergence
+and oscillation termination rules.
 
 ### Human Comment Handling
 
@@ -199,6 +205,85 @@ The workflow has a budget for CI fix attempts:
 ```
 
 If budget exhausted → signal for human intervention.
+
+---
+
+## Component: Plan-Driven Context Cache (per N13 §2.4)
+
+Each janitor agent invoked by this workflow (Comment Response, Conflict
+Resolution, CI Failure Handler) receives its working context through the
+Miniforge planner→cache pattern, not from a snapshot of the authoring
+agent's session.
+
+### Flow
+
+```text
+janitor task arrives
+        │
+        ▼
+  reviewer-planner   (variant of planner.edn for the janitor's task scope)
+        │           emits :task/exclusive-files via the standard plan shape
+        ▼
+  cache loader       (writes context-cache.edn to the run's artifact dir)
+        │
+        ▼
+  janitor agent      (queries via mcp-context-server: context_read / _grep / _glob)
+```
+
+### Reuse contract
+
+- Reviewer-planner runs MUST emit a Plan (existing
+  `components/agent/planner` shape) with `:task/exclusive-files` populated.
+- The cache loader uses the existing
+  `bases/mcp-context-server/.../context-cache.clj` `load-cache!` path —
+  no new loader code.
+- The cache MUST be reused across janitor invocations within a single PR
+  HEAD SHA; cache rebuild MUST occur when the SHA advances.
+
+### Elision
+
+When the PR diff is below a configurable size threshold (default: 200
+lines changed), the reviewer-planner step MAY be elided and the cache
+loaded directly from the diff's file set.
+
+---
+
+## Component: Resume Signal Dispatcher (per N13 §2.7)
+
+Closes the loop on the operator side: agents waiting for a PR to merge
+receive a structured resume primer instead of operator-typed
+`merged` confirmations.
+
+### Listener registry
+
+Mapping `PR-URL → [{:agent/id, :session/id, :runtime, :resume-channel}]`.
+Listener registration occurs when an agent declares dependency on a PR's
+merge — typically at PR creation by the authoring agent or at operator
+binding time via the N11 Native Control Console.
+
+See `specs/informative/n13-listener-registry.md` for the canonical schema
+and lifecycle.
+
+### Trigger and dispatch
+
+On `pull_request.closed.merged` for a PR with registered listeners:
+
+1. Emit `:pipeline/pr-merged` event (per N13 §5).
+2. For each listener, prepare a resume primer:
+
+   ```clojure
+   {:resume/pr-url      "https://..."
+    :resume/merge-sha   "abc1234"
+    :resume/merged-at   #inst "..."
+    :resume/diff-summary "<short summary of what merged>"
+    :resume/listener    {:agent/id ... :session/id ...}}
+   ```
+
+3. Dispatch via the listener's declared `:resume-channel`:
+   - `:pty` — inject as structured input into the Drive console PTY.
+   - `:miniforge-ipc` — emit as an event the agent's runtime subscribes
+     to.
+   - `:webhook` — POST to a registered URL (for external runtimes).
 
 ---
 


### PR DESCRIPTION
## Summary

Foundation pieces for the **Closed-Loop PR Pipeline (N13)** — the full PR-doc lives at [`docs/pull-requests/2026-05-07-feat-n13-pipeline-foundations.md`](docs/pull-requests/2026-05-07-feat-n13-pipeline-foundations.md).

Five threads landed together:

1. **Listener-registry data model** — `specs/informative/n13-listener-registry.md` — canonical schema + lifecycle for the Resume Signal Dispatcher.
2. **Reviewer-planner prompt** — `components/agent/resources/prompts/reviewer-planner.edn` — variant of `planner.edn` for cache curation (single-task plan, tighter budgets).
3. **Bot-comment-table extension** — `specs/informative/pr-monitoring-workflow.md` — adds `miniforge-policy-evaluator[bot]` row, plus new sections for Plan-Driven Context Cache and Resume Signal Dispatcher.
4. **`compliance-scanner` PR-review entry point** — new `pr-review` Layer 1 fn in `components/compliance-scanner/.../interface.clj` running `scan` + `classify` + render with `:since base-ref`. Read-only — does not call `execute!`.
5. **Comment payload renderer** — `components/compliance-scanner/.../comments.clj` — pure renderer for classified Violations → PR comment records per N13 §2.3, with embedded EDN payload block recoverable by the Comment Response Agent.

Plus the user-facing CLI seam: `bb miniforge pr review <pr-url>` (or `--repo <path> --base <ref>`) now runs the Standards Reviewer step end-to-end against a local checkout — the previously-stubbed `pr-review-cmd` is now real.

## Reuse anchors (no new runtime surface)

| New surface                   | Reuses                                                          |
| ----------------------------- | --------------------------------------------------------------- |
| `pr-review` entry point       | `compliance-scanner.scan` `:since`, `classify`                  |
| Reviewer-planner prompt       | Existing `planner.edn` template + planner runtime               |
| Plan-driven cache for janitors| `bases/mcp-context-server` `context-cache.clj` `load-cache!`    |
| `pr review <url>` CLI         | Existing `parse-pr-url`, `checkout-pr!`, `gh pr view --json`    |
| Comment payload schema        | N9 read-only policy evaluation contract                         |

## What's NOT in this PR (deferred)

- Webhook subscriber for `pull_request*` / `check_suite.completed`.
- Janitor dispatcher fanning out to Conflict Resolution / Comment Response / CI Failure Handler (those agents already exist as designs).
- Comment poster (`connector-github` integration). The rendering side is complete.
- Listener registry implementation (schema landed; read/write/dispatch in a follow-up).
- `:closed-loop-pr` workflow type composition wiring the steps end-to-end.

## Test plan

- [x] `clj-kondo` on all touched files: clean.
- [x] `clojure -M:test` on `comments-test`: 9 tests / 29 assertions, all pass.
- [x] `bb pre-commit` (lint:clj + poly:check + fmt:md + test + test:graalvm): clean (one flaky OOM in `tui-views/decompose_pr_test` on first attempt — passed on retry, unrelated to changes).
- [x] `clojure -A:dev -e "(require 'ai.miniforge.cli.main)"`: full CLI namespace tree loads.
- [ ] Smoke test against an open PR: `bb miniforge pr review --repo . --base origin/main --out edn` (manual, post-merge).
- [ ] Smoke test full URL flow: `bb miniforge pr review <url>` (manual, post-merge).

## Commit budget

This commit exceeds the 200-line reviewer budget (801 reportable). Override rationale: N13 foundation explicitly requested as one bundled PR; the five pieces ship together and would create artificial cross-PR deps if split. Rationale logged via `MINIFORGE_COMMIT_BUDGET_OVERRIDE`.

## Motivation

Operator-behavior mining over recent Claude + Codex sessions surfaces PR-lifecycle drudgery as the dominant typed operator turn (~448 manual `merged` confirmations, ~80 `respond-to-comments` directives, ~77 `resolve-conflicts`, ~130 plan approvals, ~30 status probes). N13 closes that loop; this PR is the first slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)