### PR TITLE
feat(event-stream): Snowflake event-id generator + filename grammar (BD-2b sub-1)

### DIFF
--- a/components/event-stream/resources/config/event-stream/messages/en-US.edn
+++ b/components/event-stream/resources/config/event-stream/messages/en-US.edn
@@ -17,4 +17,17 @@
   :stream/tool-use-line       "\n[tool] {names}\n"
 
   ;; Status payload published when the agent calls one or more tools.
-  :stream/agent-calling-tool  "Agent calling tool"}}
+  :stream/agent-calling-tool  "Agent calling tool"
+
+  ;; Snowflake event-id generator (BD-2b). All emitted at process
+  ;; boundaries — generator startup is the only place these can be
+  ;; raised, so an exception is the right shape rather than a data
+  ;; anomaly.
+  :snowflake/workers-exhausted
+  "All snowflake worker-id slots taken on this host (max {max}); refusing to start"
+
+  :snowflake/lease-io-failure
+  "Snowflake worker-lease acquire failed for slot {worker-id} at {lease-path}"
+
+  :snowflake/pre-epoch-clock
+  "Snowflake generator: wall clock {now-ms} is before the miniforge epoch {epoch-ms}"}}

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -20,6 +20,7 @@
   "Event bus and event constructors for workflow observability."
   (:require
    [ai.miniforge.event-stream.messages :as messages]
+   [ai.miniforge.event-stream.snowflake :as snowflake]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
@@ -54,12 +55,22 @@
 ;; Event envelope constructor
 
 (defn create-envelope
-  "Create an event envelope with sequence numbering."
+  "Create an event envelope with sequence numbering.
+
+   When the stream carries a `:snowflake-generator` (BD-2b), the
+   envelope's `:event/id` is a snowflake-encoded UUID — the
+   most-significant 64 bits encode (epoch-ms timestamp, worker id,
+   per-ms sequence) per the RFC, so events sort lexically by creation
+   order. Streams without a generator fall back to a random UUID;
+   `:event/id` stays a `uuid?` either way for downstream compatibility."
   [stream event-type workflow-id message]
-  (let [seq-num (get-in @stream [:sequence-numbers workflow-id] 0)]
+  (let [seq-num (get-in @stream [:sequence-numbers workflow-id] 0)
+        generator (:snowflake-generator @stream)]
     (swap! stream assoc-in [:sequence-numbers workflow-id] (inc seq-num))
     {:event/type event-type
-     :event/id (random-uuid)
+     :event/id (if generator
+                 (snowflake/next-id! generator)
+                 (random-uuid))
      :event/timestamp (java.util.Date.)
      :event/version event-version
      :event/sequence-number seq-num
@@ -87,7 +98,10 @@
      (create-event-stream {:sinks [(sinks/file-sink) (sinks/stdout-sink)]})
 
      ;; From config
-     (create-event-stream {:config user-config})"
+     (create-event-stream {:config user-config})
+
+     ;; With a Snowflake event-id generator (BD-2b)
+     (create-event-stream {:snowflake-generator (snowflake/create-generator)})"
   [& [opts]]
   (let [;; Create sinks from config or use provided sinks or default
         event-sinks (cond
@@ -108,7 +122,11 @@
            ;; reaching zero before draining sinks. `publish!` increments
            ;; on entry (after the quiesce check) and decrements in a
            ;; finally so a sink exception still releases the slot.
-           :in-flight 0})))
+           :in-flight 0
+           ;; BD-2b: optional Snowflake event-id generator. When present,
+           ;; `create-envelope` calls it for `:event/id` so events sort
+           ;; lexically by creation order. nil = random-uuid fallback.
+           :snowflake-generator (:snowflake-generator opts)})))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; publish! helpers — small, single-purpose pieces composed by publish!

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -84,9 +84,16 @@
   "Create an event stream with configurable sinks.
 
    Options:
-     :logger - Optional logger instance
-     :sinks - Vector of sink functions (default: file sink)
-     :config - Config map to create sinks from
+     :logger              - Optional logger instance
+     :sinks               - Vector of sink functions (default: file sink)
+     :config              - Config map to create sinks from
+     :snowflake-generator - Optional snowflake event-id generator
+                            (BD-2b). When supplied, `create-envelope`
+                            uses it for `:event/id` so events sort
+                            lexically by creation order. Without it,
+                            `:event/id` falls back to `random-uuid`
+                            and the file sink uses the legacy
+                            `{timestamp}-{uuid}.json` filename.
 
    Returns: Event stream atom
 

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -20,13 +20,18 @@
   "Configurable event sinks for different deployment scenarios.
 
    Supported sinks:
-   - :file   - Write to ~/.miniforge/events/<workflow-id>/<timestamp>-<uuid>.json (local dev)
+   - :file   - Write to ~/.miniforge/events/<workflow-id>/<eventid>__<seq>.transit.json
+               (local dev). When the event's :event/id is a Snowflake-encoded UUID,
+               the leading hex of the filename sorts by creation order. Legacy
+               files written before BD-2b retain the {timestamp}-{uuid}.json
+               name and are still readable.
    - :stdout - Print to stdout (container/Docker/K8s)
    - :stderr - Print to stderr (error-only events)
    - :fleet  - Send to fleet command (org-level ops)
    - :multi  - Combine multiple sinks"
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.event-stream.snowflake :as snowflake]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.pprint :as pprint]
@@ -70,14 +75,41 @@
     (transit/write writer event)
     (.toString out "UTF-8")))
 
+(defn- snowflake-uuid?
+  "True when `id` is a UUID whose low 64 bits are zero — the shape that
+   `snowflake/long->uuid` produces. Random UUIDs collide on this with
+   probability ~1 in 2^64, which is negligible."
+  [id]
+  (and (uuid? id)
+       (zero? (.getLeastSignificantBits ^java.util.UUID id))))
+
+(defn- event-filename
+  "Pick a filename for `event`.
+
+   New (BD-2b): when `:event/id` is a snowflake UUID,
+     `{event-id-hex16}__{workflow-seq-dec12}.transit.json`
+   sorts lex-by-creation across all workflows on this host.
+
+   Legacy: `{timestamp}-{uuid}.json` for streams without a snowflake
+   generator. Sort-by-creation still works via the timestamp prefix."
+  [event]
+  (let [id (:event/id event)
+        seq-num (long (or (:event/sequence-number event) 0))]
+    (if (snowflake-uuid? id)
+      (str (snowflake/uuid->hex id)
+           "__"
+           (format "%012d" seq-num)
+           ".transit.json")
+      (str (now-sortable-str) "-" (or id (random-uuid)) ".json"))))
+
 (defn- new-event-file-path
-  "Return a java.io.File for a new event file in `parent-dir`.
-   The filename is {timestamp}-{uuid}.json, sortable by creation time.
-   Creates `parent-dir` if it does not already exist."
-  [parent-dir]
+  "Return a java.io.File for `event` inside `parent-dir`. Creates the
+   directory if needed. The filename is derived from the event itself
+   (BD-2b filename grammar — see `event-filename`)."
+  [parent-dir event]
   (let [dir (io/file parent-dir)]
     (.mkdirs dir)
-    (io/file dir (str (now-sortable-str) "-" (random-uuid) ".json"))))
+    (io/file dir (event-filename event))))
 
 (defn- ensure-parent-dir!
   [file-path]
@@ -87,30 +119,35 @@
 
 (defn event-file-path
   "Return a java.io.File for a new event file in the per-workflow subdirectory.
-   Creates the subdirectory if needed.
+   Creates the subdirectory if needed. Filename derives from `event`'s
+   `:event/id` and `:event/sequence-number` (BD-2b filename grammar).
 
-   File layout: {base-dir}/{workflow-id}/{timestamp}-{uuid}.json
+   File layout: {base-dir}/{workflow-id}/{event-id-hex16}__{seq:012d}.transit.json
+                (or legacy {timestamp}-{uuid}.json for non-snowflake streams).
 
    Arguments:
+     base-dir    - Base directory (default: ~/.miniforge/events)
      workflow-id - UUID or string workflow identifier
-     base-dir    - Optional base directory (default: ~/.miniforge/events)"
-  ([workflow-id]
-   (event-file-path (default-events-dir) workflow-id))
-  ([base-dir workflow-id]
-   (new-event-file-path (io/file base-dir (str workflow-id)))))
+     event       - The event whose envelope provides the filename fields"
+  ([workflow-id event]
+   (event-file-path (default-events-dir) workflow-id event))
+  ([base-dir workflow-id event]
+   (new-event-file-path (io/file base-dir (str workflow-id)) event)))
 
 (defn operator-event-file-path
   "Return a java.io.File for a new event file in the operator subdirectory.
    Used by meta-loop, reliability, and degradation events (no :workflow/id).
 
-   File layout: {base-dir}/operator/{timestamp}-{uuid}.json
+   File layout: {base-dir}/operator/{event-id-hex16}__{seq:012d}.transit.json
+                (or legacy {timestamp}-{uuid}.json for non-snowflake streams).
 
    Arguments:
-     base-dir - Optional base directory (default: ~/.miniforge/events)"
-  ([]
-   (operator-event-file-path (default-events-dir)))
-  ([base-dir]
-   (new-event-file-path (io/file base-dir "operator"))))
+     base-dir - Base directory (default: ~/.miniforge/events)
+     event    - The event whose envelope provides the filename fields"
+  ([event]
+   (operator-event-file-path (default-events-dir) event))
+  ([base-dir event]
+   (new-event-file-path (io/file base-dir "operator") event)))
 
 (defn cleanup-stale-events!
   "Delete event files older than TTL from the events directory.
@@ -140,11 +177,16 @@
   "Create a file sink that writes each event as a Transit-JSON file.
 
    File layout:
-     per-workflow:  {base-dir}/{workflow-id}/{timestamp}-{uuid}.json
-     cross-workflow: {base-dir}/operator/{timestamp}-{uuid}.json
+     per-workflow:   {base-dir}/{workflow-id}/{event-id-hex16}__{seq:012d}.transit.json
+     cross-workflow: {base-dir}/operator/{event-id-hex16}__{seq:012d}.transit.json
 
-   Each event gets its own file (no append). Files are sortable by creation
-   time via the timestamp prefix.
+   The leading hex sorts by creation order when the event's :event/id is a
+   snowflake-encoded UUID (BD-2b). For events whose :event/id is a random
+   UUID (e.g. streams without a snowflake generator), the filename falls
+   back to the legacy {timestamp}-{uuid}.json shape so sort-by-creation
+   still works via the timestamp prefix.
+
+   Each event gets its own file (no append).
 
    Performs lazy cleanup of stale event files (older than 7 days) on creation.
 
@@ -161,8 +203,8 @@
     (try
       (let [base-dir (or (:base-dir opts) (default-events-dir))
             file-path (if-let [workflow-id (:workflow/id event)]
-                        (event-file-path base-dir workflow-id)
-                        (operator-event-file-path base-dir))]
+                        (event-file-path base-dir workflow-id event)
+                        (operator-event-file-path base-dir event))]
         (ensure-parent-dir! file-path)
         (spit file-path (write-transit-json event)))
       (catch Exception e

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -20,11 +20,16 @@
   "Configurable event sinks for different deployment scenarios.
 
    Supported sinks:
-   - :file   - Write to ~/.miniforge/events/<workflow-id>/<eventid>__<seq>.transit.json
-               (local dev). When the event's :event/id is a Snowflake-encoded UUID,
-               the leading hex of the filename sorts by creation order. Legacy
-               files written before BD-2b retain the {timestamp}-{uuid}.json
-               name and are still readable.
+   - :file   - Write to ~/.miniforge/events/<workflow-id>/<filename>
+               (local dev). The filename grammar is conditional on the
+               envelope's :event/id:
+                 * Snowflake-encoded UUID (low 64 bits zero, BD-2b) →
+                   {event-id-hex16}__{workflow-seq-dec12}.transit.json,
+                   sortable lex by creation order across workflows;
+                 * any other UUID (no snowflake generator wired into the
+                   stream, or legacy files on disk) →
+                   {timestamp}-{uuid}.json, sortable by the ts prefix.
+               Both shapes coexist; the reader accepts either.
    - :stdout - Print to stdout (container/Docker/K8s)
    - :stderr - Print to stderr (error-only events)
    - :fleet  - Send to fleet command (org-level ops)

--- a/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
@@ -55,6 +55,7 @@
    millisecond + same sequence slot, which is narrow."
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.event-stream.messages :as messages]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.logging.interface :as log]))
@@ -209,7 +210,14 @@
           nil
           ;; Real IO/permission failure. Wrap with context and propagate
           ;; rather than silently masking as :workers-exhausted later.
-          (throw (ex-info "Snowflake worker-lease acquire failed"
+          ;; Localized via messages/t. acquire-worker-lease! and its
+          ;; sole caller (create-generator at process startup) are at
+          ;; the edge — an exception is the right shape vs a data
+          ;; anomaly that callers would have to convert back to a
+          ;; failure signal.
+          (throw (ex-info (messages/t :snowflake/lease-io-failure
+                                      {:worker-id id
+                                       :lease-path (.getAbsolutePath lease-path)})
                           {:reason :lease-io-failure
                            :worker-id id
                            :lease-path (.getAbsolutePath lease-path)
@@ -218,16 +226,35 @@
 
 (defn acquire-worker-lease!
   "Walk slots 0..1023 and acquire the first whose lease file is
-   unlocked. The OS releases the lock on JVM exit, so stale leases
-   from dead processes are reclaimed automatically.
+   unlocked.
 
-   Throws ex-info when all slots are held — typical only when 1024+
-   miniforge processes coexist on the same host."
+   Why FileLock vs Clojure refs / STM
+   ----------------------------------
+   The lease has to coordinate across *operating-system processes*,
+   not just threads inside one JVM. Multiple miniforge CLI invocations
+   on the same host run as independent processes — they share the
+   `~/.miniforge/events/.workers/` directory but no JVM-level state.
+   Refs (`dosync`, `alter`, `commute`) are STM coordinated only within
+   a single JVM, so two concurrent processes both running
+   `(dosync (alter ref ...))` would hand each one the same worker id
+   and produce colliding event-id streams downstream. OS-level file
+   locks (`FileChannel/tryLock`) are the only primitive that gives
+   cross-process exclusion on a vanilla single-machine setup. As a
+   bonus the OS releases the lock automatically on JVM exit (graceful
+   or crash), so stale leases reclaim themselves without explicit
+   teardown.
+
+   Throws ex-info (localized) when all slots are held — typical only
+   when 1024+ miniforge processes coexist on the same host. This is
+   an edge condition raised at generator construction; an exception
+   is the right shape vs a data anomaly per the project's
+   exceptions-as-data conventions."
   [workers-dir]
   (loop [id 0]
     (cond
       (>= id max-workers)
-      (throw (ex-info "All snowflake worker-id slots taken on this host"
+      (throw (ex-info (messages/t :snowflake/workers-exhausted
+                                  {:max max-workers})
                       {:reason :workers-exhausted
                        :max    max-workers
                        :workers-dir (.getAbsolutePath workers-dir)}))
@@ -289,41 +316,86 @@
               {:message "Snowflake generator detected clock rollback; stalling"
                :data    details})))
 
+(def ^:private ^:const ^long park-budget-nanos
+  "Park budget for the wait loop on clock-rollback / sequence-exhausted.
+   100µs is short enough to wake well before the next ms tick (so the
+   loop spins ~10× per ms in the worst case) but long enough to avoid
+   a CPU-burning busy-spin. `parkNanos` may wake earlier on signal —
+   that's fine, the outer loop simply re-checks the wall clock."
+  100000)
+
+(def ^:private park-nanos-method
+  "Lazily-resolved `java.util.concurrent.locks.LockSupport/parkNanos`
+   via `Class/forName` + reflection. The id-generation path only
+   executes on the JVM, but this namespace is transitively loaded
+   from Babashka-runtime bricks and BB does not ship
+   `java.util.concurrent.locks`. A static method call would force
+   compile-time class resolution and break BB load; this delay
+   defers it to the first JVM invocation."
+  (delay
+    (.getMethod (Class/forName "java.util.concurrent.locks.LockSupport")
+                "parkNanos"
+                (into-array Class [Long/TYPE]))))
+
+(defn- park-briefly!
+  "Park the calling thread for up to `park-budget-nanos`. Used by the
+   id-generation loop in place of `Thread/sleep` so there's no
+   millisecond-rounded delay and the call surface stays
+   `LockSupport`-style rather than the deprecated sleep idiom. The
+   thread can wake earlier on spurious signal; callers must re-check
+   their condition."
+  []
+  (.invoke @park-nanos-method
+           nil
+           (into-array Object [(Long/valueOf park-budget-nanos)])))
+
+(defn- pre-epoch-error
+  [now-ms worker-id]
+  (ex-info (messages/t :snowflake/pre-epoch-clock
+                       {:now-ms now-ms :epoch-ms miniforge-epoch-ms})
+           {:reason     :pre-epoch-clock
+            :now-ms     now-ms
+            :epoch-ms   miniforge-epoch-ms
+            :worker-id  worker-id}))
+
+(defn- handle-rollback!
+  "Side-effect: warn once on first rollback observation. Park before
+   the outer loop retries. Returns the new `warned?` value."
+  [{:keys [logger ^long worker-id]} now-ms last-ts warned?]
+  (when (not warned?)
+    (log-rollback! logger {:now-ms    now-ms
+                           :last-ts   last-ts
+                           :worker-id worker-id}))
+  (park-briefly!)
+  true)
+
+(defn- emit-id
+  "CAS the new state and return the composed id long. nil on CAS loss
+   (caller retries the outer loop)."
+  [state old new-state ^long worker-id]
+  (when (compare-and-set! state old new-state)
+    (compose-id (- ^long (:last-ts new-state) miniforge-epoch-ms)
+                worker-id
+                ^long (:last-seq new-state))))
+
 (defn next-id-long!
-  "Internal: generate the next snowflake as a primitive long. Spins on
-   clock rollback or sequence exhaustion (1ms sleep per retry).
+  "Internal: generate the next snowflake as a primitive long. Parks on
+   clock rollback or sequence exhaustion (≤100µs per retry via
+   `LockSupport/parkNanos` rather than `Thread/sleep`).
    Public id functions (`next-id!`, `next-id-hex!`) wrap this."
-  ^long [{:keys [state now-fn logger ^long worker-id]}]
+  ^long [{:keys [state now-fn ^long worker-id] :as gen}]
   (loop [warned? false]
     (let [now-ms (long (now-fn))
           old    @state
           r      (next-state old now-ms)]
       (cond
-        (= r ::pre-epoch)
-        (throw (ex-info "Snowflake generator: wall clock is before the miniforge epoch"
-                        {:now-ms     now-ms
-                         :epoch-ms   miniforge-epoch-ms
-                         :worker-id  worker-id}))
-
-        (= r ::clock-rollback)
-        (do (when (not warned?)
-              (log-rollback! logger {:now-ms    now-ms
-                                     :last-ts   (:last-ts old)
-                                     :worker-id worker-id}))
-            (Thread/sleep 1)
-            (recur true))
-
-        (= r ::seq-exhausted)
-        (do (Thread/sleep 1)
-            (recur warned?))
-
-        (compare-and-set! state old r)
-        (compose-id (- (:last-ts r) miniforge-epoch-ms)
-                    worker-id
-                    (:last-seq r))
-
-        :else ;; Lost CAS race; retry with fresh state.
-        (recur warned?)))))
+        (= r ::pre-epoch)        (throw (pre-epoch-error now-ms worker-id))
+        (= r ::clock-rollback)   (recur (handle-rollback! gen now-ms (:last-ts old) warned?))
+        (= r ::seq-exhausted)    (do (park-briefly!) (recur warned?))
+        :else
+        (or (emit-id state old r worker-id)
+            ;; Lost CAS race against another thread — retry with fresh state.
+            (recur warned?))))))
 
 (defn next-id!
   "Generate the next snowflake event id as a `java.util.UUID`. The

--- a/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
@@ -59,14 +59,13 @@
    [clojure.string :as str]
    [ai.miniforge.logging.interface :as log]))
 
-;; NOTE: Class references for the worker-id lease path
-;; (java.io.RandomAccessFile, java.nio.ByteBuffer, java.nio.channels.FileChannel,
-;; java.nio.channels.FileLock, java.lang.management.ManagementFactory,
-;; java.net.InetAddress, java.io.File) are used via fully-qualified names inside
-;; fn bodies rather than imported at the top, so the namespace loads in
-;; Babashka (which doesn't ship java.nio.channels.FileLock). Functions that
-;; touch those classes only run on the JVM; the BB-runtime test loads the
-;; namespace but never calls them, which keeps event-stream BB-compatible.
+;; NOTE: The worker-id lease path constructs java.io.RandomAccessFile,
+;; calls .getChannel (FileChannel), .tryLock (returning FileLock), and
+;; wraps bytes via java.nio.ByteBuffer. Those references appear FQN
+;; inside fn bodies rather than imported at the top, so the namespace
+;; loads in Babashka (which doesn't ship java.nio.channels.FileLock).
+;; Worker-id leasing is JVM-only — the BB-runtime test loads the
+;; namespace but never calls it, keeping event-stream BB-compatible.
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants
@@ -173,12 +172,28 @@
 (defn- try-acquire-slot
   "Try to acquire an exclusive FileLock on `{workers-dir}/{id}.lease`.
    Returns a map `{:channel ... :lock ... :worker-id id}` on success,
-   `nil` if the slot is held. Does not retry."
+   `nil` if the slot is held by another holder. Does not retry.
+
+   Treats only lock-contention as a slot-held signal:
+     - `.tryLock` returning nil → another process / JVM holds it.
+     - `OverlappingFileLockException` → this JVM already holds an
+       overlapping lock on the same file (e.g. a sibling generator
+       in the same process).
+
+   IO/permission failures (failed to create the lease file, no write
+   permission on the workers dir) are real problems and propagate
+   with workers-dir/id context attached, rather than silently moving
+   to the next slot — which would otherwise misleadingly throw
+   `:workers-exhausted` even when no slots are actually contended."
   [workers-dir ^long id]
   (.mkdirs workers-dir)
   (let [lease-path (io/file workers-dir (str id ".lease"))
         raf       (java.io.RandomAccessFile. lease-path "rw")
         channel   (.getChannel raf)]
+    ;; Resolve OverlappingFileLockException lazily via Class/forName so
+    ;; this namespace stays loadable in Babashka (which doesn't ship
+    ;; java.nio.channels). A typed `(catch java.nio.channels...)` would
+    ;; force compile-time class resolution and break BB load.
     (try
       (let [lock (.tryLock channel)]
         (if lock
@@ -186,9 +201,20 @@
             (write-lease-metadata! channel id)
             {:channel channel :lock lock :worker-id id :raf raf})
           (do (.close raf) nil)))
-      (catch Exception _
-        (.close raf)
-        nil))))
+      (catch Exception e
+        (try (.close raf) (catch Exception _))
+        (if (instance? (Class/forName "java.nio.channels.OverlappingFileLockException") e)
+          ;; This JVM already holds an overlapping lock on the same
+          ;; file. Treat as "slot held" and let the caller advance.
+          nil
+          ;; Real IO/permission failure. Wrap with context and propagate
+          ;; rather than silently masking as :workers-exhausted later.
+          (throw (ex-info "Snowflake worker-lease acquire failed"
+                          {:reason :lease-io-failure
+                           :worker-id id
+                           :lease-path (.getAbsolutePath lease-path)
+                           :workers-dir (.getAbsolutePath workers-dir)}
+                          e)))))))
 
 (defn acquire-worker-lease!
   "Walk slots 0..1023 and acquire the first whose lease file is

--- a/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
@@ -1,0 +1,315 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.snowflake
+  "Twitter-Snowflake-style sortable event-id generator (BD-2b RFC v3/v4).
+
+   Layout (64-bit):
+     - 41-bit UTC ms timestamp from a fixed miniforge epoch
+       (2026-01-01T00:00:00Z),
+     - 10-bit local worker id (0..1023),
+     - 12-bit per-ms sequence (0..4095).
+
+   Two surface forms:
+
+     (next-id! generator)        ;; -> java.util.UUID
+     (next-id-hex! generator)    ;; -> 16-char lowercase hex string
+
+   The UUID encodes the snowflake into its most-significant 64 bits
+   and leaves the low 64 bits zero. This keeps `:event/id` a uuid?
+   for downstream code (schemas, accumulators, existing tests) while
+   the leading hex of the UUID's string form is the sortable
+   snowflake. Filenames carry just the hex form for compactness.
+
+   UUID hex form sorts lexically by creation order across all workflows
+   on a single host.
+
+   Worker-id allocation is lease-based under
+   `~/.miniforge/events/.workers/{id}.lease` using a Java FileLock.
+   The OS releases the lock automatically on JVM exit (graceful or
+   crash), so stale leases are reclaimed without explicit teardown.
+   The lease *file* persists with old metadata between processes; only
+   the lock state matters.
+
+   Clock rollback is handled in-memory: the generator refuses to emit
+   an id whose composed value would sort before the last-emitted id,
+   and stalls until the wall clock catches up. A logged warning surfaces
+   the rollback. Persisting a high-water mark to disk for cross-restart
+   safety is deferred — the cost is a write-per-id, and the actual
+   collision risk requires a JVM crash + restart inside the same
+   millisecond + same sequence slot, which is narrow."
+  (:require
+   [ai.miniforge.config.interface :as config]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [ai.miniforge.logging.interface :as log]))
+
+;; NOTE: Class references for the worker-id lease path
+;; (java.io.RandomAccessFile, java.nio.ByteBuffer, java.nio.channels.FileChannel,
+;; java.nio.channels.FileLock, java.lang.management.ManagementFactory,
+;; java.net.InetAddress, java.io.File) are used via fully-qualified names inside
+;; fn bodies rather than imported at the top, so the namespace loads in
+;; Babashka (which doesn't ship java.nio.channels.FileLock). Functions that
+;; touch those classes only run on the JVM; the BB-runtime test loads the
+;; namespace but never calls them, which keeps event-stream BB-compatible.
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants
+
+(def ^:const ^long miniforge-epoch-ms
+  "ms since unix epoch for 2026-01-01T00:00:00Z. The 41-bit timestamp
+   field is computed as (now - epoch). 41 bits ≈ 69.7 years from this
+   epoch — comfortable headroom."
+  1767225600000)
+
+(def ^:const ^long max-seq
+  "12-bit sequence — 4096 distinct ids per (ms × worker)."
+  4095)
+
+(def ^:const ^long max-workers
+  "10-bit worker space — 1024 concurrent workers per host."
+  1024)
+
+(def ^:const ^long worker-shift 12)
+(def ^:const ^long ts-shift 22)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pure id-composition
+
+(defn compose-id
+  "Compose a 64-bit snowflake from (ts-since-epoch-ms, worker-id, seq).
+   Pure: no clock or state."
+  ^long [^long ts-since-epoch ^long worker ^long sequence]
+  (bit-or (bit-shift-left ts-since-epoch ts-shift)
+          (bit-shift-left worker worker-shift)
+          sequence))
+
+(defn format-hex
+  "Render a 64-bit id as a 16-char lowercase hex string."
+  ^String [^long id]
+  (format "%016x" id))
+
+(defn long->uuid
+  "Embed a 64-bit snowflake id into a `java.util.UUID` as the
+   most-significant bits, with the low 64 bits zero. Keeps `:event/id`
+   typed as uuid for existing consumers while making the leading hex
+   the sortable snowflake."
+  ^java.util.UUID [^long id]
+  (java.util.UUID. id 0))
+
+(defn uuid->hex
+  "Extract the 16-char lowercase hex of the snowflake bits from a UUID
+   created by `long->uuid`. Inverse of long->uuid for filename use."
+  ^String [^java.util.UUID uuid]
+  (format-hex (.getMostSignificantBits uuid)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Generator state
+
+(defn- initial-state
+  [worker-id]
+  {:last-ts -1
+   :last-seq -1
+   :worker-id worker-id})
+
+(defn- next-state
+  "Pure: compute the next state from `state` and the current wall ms.
+   Returns either a new state (advanced) or one of the sentinels:
+     ::pre-epoch        wall ms is before the miniforge epoch — the
+                        timestamp field would be negative and the bit
+                        layout would corrupt
+     ::clock-rollback   wall ms is before last-ts → caller must stall
+     ::seq-exhausted    same ms but seq already at max → caller must stall
+
+   Time is encoded relative to `miniforge-epoch-ms`."
+  [{:keys [^long last-ts ^long last-seq] :as state} ^long now-ms]
+  (cond
+    (< now-ms miniforge-epoch-ms) ::pre-epoch
+    (< now-ms last-ts)            ::clock-rollback
+    (== now-ms last-ts)
+    (if (< last-seq max-seq)
+      (assoc state :last-seq (inc last-seq))
+      ::seq-exhausted)
+    :else
+    (assoc state :last-ts now-ms :last-seq 0)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Worker-id leasing (FileLock-based)
+
+(defn- default-workers-dir
+  []
+  (io/file (config/miniforge-home) "events" ".workers"))
+
+(defn- write-lease-metadata!
+  "Truncate `channel` and write the worker-id + acquire timestamp as
+   EDN. Force to disk. Metadata is informational only — the OS-level
+   FileLock release on JVM exit is what guarantees correctness, so
+   pid/host fields are not load-bearing and are deliberately omitted
+   to keep this namespace Babashka-loadable
+   (java.lang.management is not in BB)."
+  [channel worker-id]
+  (.truncate channel 0)
+  (let [meta  {:worker-id   worker-id
+               :acquired-at (System/currentTimeMillis)}
+        bytes (.getBytes (str (pr-str meta) "\n") "UTF-8")]
+    (.write channel (java.nio.ByteBuffer/wrap bytes))
+    (.force channel false)))
+
+(defn- try-acquire-slot
+  "Try to acquire an exclusive FileLock on `{workers-dir}/{id}.lease`.
+   Returns a map `{:channel ... :lock ... :worker-id id}` on success,
+   `nil` if the slot is held. Does not retry."
+  [workers-dir ^long id]
+  (.mkdirs workers-dir)
+  (let [lease-path (io/file workers-dir (str id ".lease"))
+        raf       (java.io.RandomAccessFile. lease-path "rw")
+        channel   (.getChannel raf)]
+    (try
+      (let [lock (.tryLock channel)]
+        (if lock
+          (do
+            (write-lease-metadata! channel id)
+            {:channel channel :lock lock :worker-id id :raf raf})
+          (do (.close raf) nil)))
+      (catch Exception _
+        (.close raf)
+        nil))))
+
+(defn acquire-worker-lease!
+  "Walk slots 0..1023 and acquire the first whose lease file is
+   unlocked. The OS releases the lock on JVM exit, so stale leases
+   from dead processes are reclaimed automatically.
+
+   Throws ex-info when all slots are held — typical only when 1024+
+   miniforge processes coexist on the same host."
+  [workers-dir]
+  (loop [id 0]
+    (cond
+      (>= id max-workers)
+      (throw (ex-info "All snowflake worker-id slots taken on this host"
+                      {:reason :workers-exhausted
+                       :max    max-workers
+                       :workers-dir (.getAbsolutePath workers-dir)}))
+      :else
+      (if-let [lease (try-acquire-slot workers-dir id)]
+        lease
+        (recur (inc id))))))
+
+(defn release-lease!
+  "Release a worker-id lease. Idempotent. The OS would release on JVM
+   exit anyway; this is for explicit teardown (tests, shutdown hooks)."
+  [{:keys [lock channel raf]}]
+  (when lock
+    (try (.release lock) (catch Exception _)))
+  (when channel
+    (try (.close channel) (catch Exception _)))
+  (when raf
+    (try (.close raf) (catch Exception _))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Generator handle
+
+(defn create-generator
+  "Allocate a new snowflake generator. Acquires a worker-id lease under
+   `:workers-dir` (default `~/.miniforge/events/.workers/`).
+
+   Returns a map carrying:
+     :state      atom with {:last-ts :last-seq :worker-id}
+     :worker-id  long, 0..1023
+     :lease      lease handle (release on close!)
+     :now-fn     0-arg fn returning wall ms (override for tests)
+     :logger     optional logger for clock-rollback warnings
+
+   Tests can pass `:now-fn` and `:lease` directly to avoid filesystem
+   side effects."
+  [& [{:keys [workers-dir now-fn logger lease]
+       :or   {now-fn (fn ^long [] (System/currentTimeMillis))}}]]
+  (let [lease (or lease (acquire-worker-lease! (or workers-dir (default-workers-dir))))
+        worker-id (:worker-id lease)]
+    {:state     (atom (initial-state worker-id))
+     :worker-id worker-id
+     :lease     lease
+     :now-fn    now-fn
+     :logger    logger}))
+
+(defn close!
+  "Release the generator's worker-id lease. Idempotent."
+  [generator]
+  (when-let [lease (:lease generator)]
+    (release-lease! lease)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Id generation
+
+(defn- log-rollback!
+  [logger details]
+  (when logger
+    (log/warn logger :event-stream :snowflake/clock-rollback
+              {:message "Snowflake generator detected clock rollback; stalling"
+               :data    details})))
+
+(defn next-id-long!
+  "Internal: generate the next snowflake as a primitive long. Spins on
+   clock rollback or sequence exhaustion (1ms sleep per retry).
+   Public id functions (`next-id!`, `next-id-hex!`) wrap this."
+  ^long [{:keys [state now-fn logger ^long worker-id]}]
+  (loop [warned? false]
+    (let [now-ms (long (now-fn))
+          old    @state
+          r      (next-state old now-ms)]
+      (cond
+        (= r ::pre-epoch)
+        (throw (ex-info "Snowflake generator: wall clock is before the miniforge epoch"
+                        {:now-ms     now-ms
+                         :epoch-ms   miniforge-epoch-ms
+                         :worker-id  worker-id}))
+
+        (= r ::clock-rollback)
+        (do (when (not warned?)
+              (log-rollback! logger {:now-ms    now-ms
+                                     :last-ts   (:last-ts old)
+                                     :worker-id worker-id}))
+            (Thread/sleep 1)
+            (recur true))
+
+        (= r ::seq-exhausted)
+        (do (Thread/sleep 1)
+            (recur warned?))
+
+        (compare-and-set! state old r)
+        (compose-id (- (:last-ts r) miniforge-epoch-ms)
+                    worker-id
+                    (:last-seq r))
+
+        :else ;; Lost CAS race; retry with fresh state.
+        (recur warned?)))))
+
+(defn next-id!
+  "Generate the next snowflake event id as a `java.util.UUID`. The
+   snowflake bits live in the UUID's most-significant 64 bits; low 64
+   bits are zero. The UUID's string form sorts lexically by creation
+   order on a single host."
+  ^java.util.UUID [generator]
+  (long->uuid (next-id-long! generator)))
+
+(defn next-id-hex!
+  "Generate the next snowflake event id as a 16-char lowercase hex
+   string. Use this for filenames and other places where the UUID's
+   hyphens are inconvenient."
+  ^String [generator]
+  (format-hex (next-id-long! generator)))

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -66,7 +66,8 @@
     (with-temp-dir
       (fn [dir]
         (let [wf-id (random-uuid)
-              path (sinks/event-file-path dir wf-id)]
+              event (sample-event {:workflow/id wf-id})
+              path (sinks/event-file-path dir wf-id event)]
           (is (instance? java.io.File path))
           (is (str/includes? (.getPath path) (.getPath dir)))
           (is (str/ends-with? (.getName path) ".json"))))))
@@ -75,10 +76,37 @@
     (with-temp-dir
       (fn [dir]
         (let [wf-id (random-uuid)
-              path (sinks/event-file-path dir wf-id)
+              event (sample-event {:workflow/id wf-id})
+              path (sinks/event-file-path dir wf-id event)
               parent (.getParentFile path)]
           (is (.isDirectory parent))
-          (is (str/ends-with? (.getName parent) (str wf-id))))))))
+          (is (str/ends-with? (.getName parent) (str wf-id)))))))
+
+  (testing "snowflake-encoded :event/id produces the new filename grammar"
+    (with-temp-dir
+      (fn [dir]
+        ;; A snowflake-encoded UUID has zero least-significant bits.
+        (let [wf-id (random-uuid)
+              snowflake-uuid (java.util.UUID. 0x018f3a9c8e4b12d0 0)
+              event (sample-event {:workflow/id wf-id
+                                   :event/id snowflake-uuid
+                                   :event/sequence-number 12345})
+              path (sinks/event-file-path dir wf-id event)
+              filename (.getName path)]
+          (is (str/ends-with? filename ".transit.json"))
+          (is (str/starts-with? filename "018f3a9c8e4b12d0__"))
+          (is (str/includes? filename "__000000012345.transit.json"))))))
+
+  (testing "random :event/id falls back to legacy timestamp-leading filename"
+    (with-temp-dir
+      (fn [dir]
+        (let [wf-id (random-uuid)
+              event (sample-event {:workflow/id wf-id})
+              path (sinks/event-file-path dir wf-id event)
+              filename (.getName path)]
+          ;; Legacy pattern: 20YYMMDDTHHMMSSsss-{uuid}.json
+          (is (re-matches #"\d{8}T\d{9}Z-[0-9a-f-]+\.json" filename)
+              (str "expected legacy timestamp-leading filename, got: " filename)))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; file-sink
@@ -160,7 +188,7 @@
         (let [sink (sinks/file-sink {:base-dir dir})
               wf-id (random-uuid)
               event (sample-event {:workflow/id wf-id})]
-          (with-redefs [sinks/event-file-path (fn [_ _]
+          (with-redefs [sinks/event-file-path (fn [_ _ _]
                                                 (io/file dir "nested" "workflow" "event.json"))]
             (sink event))
           (let [event-file (io/file dir "nested" "workflow" "event.json")]

--- a/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
@@ -1,0 +1,240 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.snowflake-test
+  "Tests for the BD-2b Snowflake event-id generator."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.java.io :as io]
+   [ai.miniforge.event-stream.snowflake :as sf])
+  (:import
+   [java.util UUID]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- with-temp-workers-dir [f]
+  (let [dir (java.nio.file.Files/createTempDirectory
+             "snowflake-test-workers-"
+             (into-array java.nio.file.attribute.FileAttribute []))]
+    (try
+      (f (.toFile dir))
+      (finally
+        (doseq [file (reverse (file-seq (.toFile dir)))]
+          (.delete ^java.io.File file))))))
+
+(defn- fixed-clock
+  "Return a 0-arg fn that returns successive values from `times`. Once
+   exhausted, repeats the last value (so the generator can spin without
+   running off the end)."
+  [times]
+  (let [counter (atom 0)
+        ts (vec times)]
+    (fn []
+      (let [i @counter
+            v (nth ts (min i (dec (count ts))))]
+        (swap! counter inc)
+        v))))
+
+(defn- generator-with-fixed-clock [times]
+  ;; No real lease — pass a fake lease handle to bypass file-locking.
+  {:state     (atom {:last-ts -1 :last-seq -1 :worker-id 0})
+   :worker-id 0
+   :lease     {:worker-id 0}
+   :now-fn    (fixed-clock times)})
+
+;------------------------------------------------------------------------------ Pure id-composition
+
+(deftest compose-id-packs-bits-correctly
+  ;; Verify the bit layout: 41-bit ts << 22 | 10-bit worker << 12 | 12-bit seq.
+  (let [id (sf/compose-id 0 0 0)]
+    (is (zero? id)))
+  (let [id (sf/compose-id 1 0 0)]
+    (is (= (bit-shift-left 1 22) id)))
+  (let [id (sf/compose-id 0 1 0)]
+    (is (= (bit-shift-left 1 12) id)))
+  (let [id (sf/compose-id 0 0 1)]
+    (is (= 1 id)))
+  (let [id (sf/compose-id 0xff 0x3ff 0xfff)]
+    (is (= (bit-or (bit-shift-left 0xff 22)
+                   (bit-shift-left 0x3ff 12)
+                   0xfff)
+           id))))
+
+(deftest format-hex-produces-16-char-lowercase
+  (is (= "0000000000000000" (sf/format-hex 0)))
+  (is (= "0000000000000001" (sf/format-hex 1)))
+  (is (= "ffffffffffffffff" (sf/format-hex -1)))) ; all-ones long
+
+(deftest long->uuid-zeros-low-bits
+  (let [u (sf/long->uuid 0x018f3a9c8e4b12d0)]
+    (is (instance? UUID u))
+    (is (= 0x018f3a9c8e4b12d0 (.getMostSignificantBits ^UUID u)))
+    (is (zero? (.getLeastSignificantBits ^UUID u))))
+  ;; Zero round-trips.
+  (is (= "00000000-0000-0000-0000-000000000000"
+         (str (sf/long->uuid 0)))))
+
+(deftest uuid->hex-extracts-msb
+  (let [u (sf/long->uuid 0x018f3a9c8e4b12d0)]
+    (is (= "018f3a9c8e4b12d0" (sf/uuid->hex u)))))
+
+;------------------------------------------------------------------------------ next-id! semantics
+
+(deftest next-id!-monotonic-within-same-ms
+  (let [base-ts sf/miniforge-epoch-ms
+        gen (generator-with-fixed-clock (repeat 10 base-ts))
+        ids (vec (repeatedly 5 #(sf/next-id-long! gen)))]
+    (is (= 5 (count (set ids))) "ids are unique")
+    (is (= ids (sort ids)) "ids are monotonic in same-ms (sequence increments)")
+    (let [seqs (map #(bit-and % sf/max-seq) ids)]
+      (is (= [0 1 2 3 4] seqs)
+          "sequence increments deterministically inside the same millisecond"))))
+
+(deftest next-id!-resets-sequence-on-ms-advance
+  (let [base-ts sf/miniforge-epoch-ms
+        ;; First call at base-ts, second call at base-ts + 1ms.
+        gen (generator-with-fixed-clock [base-ts (inc base-ts)])
+        id1 (sf/next-id-long! gen)
+        id2 (sf/next-id-long! gen)]
+    (is (zero? (bit-and id1 sf/max-seq)) "first id at new ms has seq=0")
+    (is (zero? (bit-and id2 sf/max-seq)) "second id at next ms also resets to seq=0")))
+
+(deftest next-id!-advances-ms-on-sequence-exhaustion
+  ;; Force seq to 4095 manually, then call next-id! at the same ms.
+  ;; The generator must spin — but with a fixed-clock that returns
+  ;; the same ms, it would spin forever. We simulate the wall clock
+  ;; advancing on the second call.
+  (let [base-ts sf/miniforge-epoch-ms
+        gen (generator-with-fixed-clock (concat (repeat 10 base-ts)
+                                                (repeat 10 (inc base-ts))))]
+    ;; Pre-seed state so seq is at max.
+    (reset! (:state gen) {:last-ts base-ts :last-seq sf/max-seq :worker-id 0})
+    (let [id (sf/next-id-long! gen)]
+      ;; The id should be at base-ts + 1, seq = 0.
+      (is (= (- (inc base-ts) sf/miniforge-epoch-ms)
+             (bit-shift-right id sf/ts-shift))
+          "exhaustion at base-ts forces advance to base-ts+1")
+      (is (zero? (bit-and id sf/max-seq))
+          "sequence resets at the new ms"))))
+
+(deftest next-id!-throws-on-pre-epoch-clock
+  ;; If the wall clock is somehow before the miniforge epoch, the bit
+  ;; layout would corrupt (negative ts shifts into worker bits). Throw
+  ;; loudly rather than silently emit garbage.
+  (let [gen (generator-with-fixed-clock [(- sf/miniforge-epoch-ms 1)])]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"before the miniforge epoch"
+                          (sf/next-id-long! gen)))))
+
+(deftest next-id!-stalls-on-clock-rollback
+  (let [base-ts (+ sf/miniforge-epoch-ms 1000)
+        ;; Call 1: time goes BACKWARD by 100ms. Generator must stall.
+        ;; Once enough retries land back at base-ts, it succeeds.
+        gen (generator-with-fixed-clock
+             (concat [base-ts]                       ; first emission sets last-ts
+                     (repeat 5 (- base-ts 100))      ; rollback - generator stalls
+                     (repeat 10 (inc base-ts))))]    ; clock recovers
+    ;; First call establishes last-ts.
+    (sf/next-id-long! gen)
+    ;; Second call sees rollback, retries; eventually succeeds at inc base-ts.
+    (let [id (sf/next-id-long! gen)
+          ts-component (- (bit-shift-right id sf/ts-shift) 0)
+          expected-ts (- (inc base-ts) sf/miniforge-epoch-ms)]
+      (is (= expected-ts ts-component)
+          "rollback resolves once wall clock surpasses last-ts"))))
+
+(deftest next-id!-returns-uuid-with-zero-low-bits
+  (let [base-ts sf/miniforge-epoch-ms
+        gen (generator-with-fixed-clock (repeat 5 base-ts))
+        u (sf/next-id! gen)]
+    (is (instance? UUID u))
+    (is (zero? (.getLeastSignificantBits ^UUID u))
+        "snowflake UUIDs always have zero low 64 bits — that's the discriminator")))
+
+(deftest next-id-hex!-is-16-lowercase-hex
+  (let [base-ts sf/miniforge-epoch-ms
+        gen (generator-with-fixed-clock (repeat 5 base-ts))
+        h (sf/next-id-hex! gen)]
+    (is (= 16 (count h)))
+    (is (re-matches #"[0-9a-f]{16}" h))))
+
+(deftest next-id-hex!-sorts-by-creation-order
+  ;; Three ids generated 100ms apart should sort lex.
+  (let [base-ts sf/miniforge-epoch-ms
+        gen (generator-with-fixed-clock [base-ts
+                                         (+ base-ts 100)
+                                         (+ base-ts 200)])
+        a (sf/next-id-hex! gen)
+        b (sf/next-id-hex! gen)
+        c (sf/next-id-hex! gen)]
+    (is (< (compare a b) 0))
+    (is (< (compare b c) 0))))
+
+;------------------------------------------------------------------------------ worker-id leasing
+
+(deftest acquire-worker-lease!-takes-id-zero-when-empty
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [lease (sf/acquire-worker-lease! dir)]
+        (try
+          (is (= 0 (:worker-id lease)))
+          (is (.exists (io/file dir "0.lease")))
+          (finally (sf/release-lease! lease)))))))
+
+(deftest acquire-worker-lease!-skips-locked-slot
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [first-lease (sf/acquire-worker-lease! dir)]
+        (try
+          (let [second-lease (sf/acquire-worker-lease! dir)]
+            (try
+              (is (= 0 (:worker-id first-lease)))
+              (is (= 1 (:worker-id second-lease))
+                  "a second concurrent acquire takes the next free slot")
+              (finally (sf/release-lease! second-lease))))
+          (finally (sf/release-lease! first-lease)))))))
+
+(deftest acquire-worker-lease!-reclaims-released-slot
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [lease-a (sf/acquire-worker-lease! dir)]
+        (sf/release-lease! lease-a))
+      (let [lease-b (sf/acquire-worker-lease! dir)]
+        (try
+          (is (= 0 (:worker-id lease-b))
+              "after release, slot 0 becomes acquirable again")
+          (finally (sf/release-lease! lease-b)))))))
+
+(deftest release-lease!-is-idempotent
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [lease (sf/acquire-worker-lease! dir)]
+        (sf/release-lease! lease)
+        (is (nil? (sf/release-lease! lease))
+            "second release is a no-op, not an error")))))
+
+(deftest create-generator-acquires-worker-lease
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [gen (sf/create-generator {:workers-dir dir})]
+        (try
+          (is (some? (:lease gen)))
+          (is (= 0 (:worker-id gen)))
+          (let [u (sf/next-id! gen)]
+            (is (instance? UUID u)))
+          (finally (sf/close! gen)))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
@@ -50,11 +50,37 @@
         (swap! counter inc)
         v))))
 
+;; ─── Test fixture constants ─────────────────────────────────────────
+;; The generator state initialises `last-ts` and `last-seq` to a sentinel
+;; meaning "no id has been emitted yet". `next-state` interprets this as
+;; "any wall ms ≥ epoch advances state and resets seq to 0", so the
+;; first emission goes through the third (forward-time) branch. The
+;; sentinel must be < any valid (ms, seq) pair the generator could
+;; observe; -1 is the conventional Java/Clojure sentinel for unset.
+(def ^:private ^:const ^long unset-timestamp-sentinel -1)
+(def ^:private ^:const ^long unset-sequence-sentinel  -1)
+
+;; Bypass the FileLock-based worker-id lease in unit tests by pinning a
+;; deterministic worker id and providing a fake lease handle. `0` is
+;; chosen for readability; any 0..max-workers-1 value works.
+(def ^:private ^:const ^long test-worker-id 0)
+
+(def ^:private fresh-test-state
+  "A fresh-but-quiesced generator state — what the production
+   `initial-state` factory would produce for the test worker-id, but
+   defined locally so tests don't reach into a private fn."
+  {:last-ts   unset-timestamp-sentinel
+   :last-seq  unset-sequence-sentinel
+   :worker-id test-worker-id})
+
+(def ^:private fake-test-lease
+  "Sentinel lease handle for tests that bypass the file-lock path."
+  {:worker-id test-worker-id})
+
 (defn- generator-with-fixed-clock [times]
-  ;; No real lease — pass a fake lease handle to bypass file-locking.
-  {:state     (atom {:last-ts -1 :last-seq -1 :worker-id 0})
-   :worker-id 0
-   :lease     {:worker-id 0}
+  {:state     (atom fresh-test-state)
+   :worker-id test-worker-id
+   :lease     fake-test-lease
    :now-fn    (fixed-clock times)})
 
 ;------------------------------------------------------------------------------ Pure id-composition
@@ -123,7 +149,9 @@
         gen (generator-with-fixed-clock (concat (repeat 10 base-ts)
                                                 (repeat 10 (inc base-ts))))]
     ;; Pre-seed state so seq is at max.
-    (reset! (:state gen) {:last-ts base-ts :last-seq sf/max-seq :worker-id 0})
+    (reset! (:state gen) {:last-ts   base-ts
+                          :last-seq  sf/max-seq
+                          :worker-id test-worker-id})
     (let [id (sf/next-id-long! gen)]
       ;; The id should be at base-ts + 1, seq = 0.
       (is (= (- (inc base-ts) sf/miniforge-epoch-ms)

--- a/scripts/test-changed-bricks.bb
+++ b/scripts/test-changed-bricks.bb
@@ -71,9 +71,22 @@
 
 (def ^:private default-isolated-bricks
   "Bricks that should run in their own test JVM.
-   Some native-backed stores are reliable in isolation but can fail inside the
-   large aggregate JVM used for changed-brick testing."
-  #{"pipeline-pack-store"})
+
+   - `pipeline-pack-store`: native-backed store; reliable in isolation
+     but can fail inside the large aggregate JVM.
+   - `pr-sync` and `agent`: tests `with-redefs` `clojure.java.shell/sh`
+     to local mocks (e.g. `make-sh-router` returning
+     `{:err \"no route matched\"}` for unmatched calls; or
+     `{:err \"fatal: not a git repo\"}` in agent's
+     snapshot-working-dir tests). `with-redefs` mutates the var
+     globally for the duration of the body, and parallel bricks share
+     a single JVM, so the mocked `sh` bleeds into other bricks' real
+     git/gh subprocess calls (notably `workflow/merge-resolution-test`
+     which legitimately needs to run `git init`). Isolating these
+     bricks contains the mock to its own JVM so the redef can't leak.
+     The deeper fix is to mock through private wrappers instead of
+     vendor namespaces; isolation is a workaround until that lands."
+  #{"pipeline-pack-store" "pr-sync" "agent"})
 
 (defn configured-isolated-bricks
   "Return the configured isolated brick set.


### PR DESCRIPTION
## Summary

First implementation slice off the [BD-2 design RFC (#795)](https://github.com/miniforge-ai/miniforge/pull/795). Establishes the on-disk shape that BD-2b sub-2/sub-3 and BD-2c build on, kept tight enough to land on its own.

- **Snowflake generator** (new `event-stream.snowflake` namespace): 41-bit ms ts from a fixed miniforge epoch + 10-bit worker + 12-bit per-ms sequence. Encoded into a `java.util.UUID`'s most-significant 64 bits with low 64 zero — `:event/id` stays `uuid?` for downstream code while the leading hex sorts lexically by creation order. Worker-id lease via `FileLock` (auto-released on JVM exit). Clock-rollback stall + pre-epoch guard.
- **Integration in `event-stream.core`**: `create-event-stream` accepts `:snowflake-generator`; `create-envelope` calls it for `:event/id` when present, falls back to `random-uuid` otherwise. No contract change for downstream — `(uuid? :event/id)` continues to hold.
- **Filename grammar in `event-stream.sinks`**: `{event-id-hex16}__{workflow-seq-dec12}.transit.json` for snowflake-encoded events; legacy `{timestamp}-{uuid}.json` fallback for non-snowflake streams. Reader filter (`.endsWith ".json"`) accepts both.
- **16 new snowflake tests** + 2 new sinks tests pin the contract.

## Drive-by fixes (surfaced by this PR)

1. **Test-runner brick isolation.** `pr-sync` and `agent` tests `with-redefs` `clojure.java.shell/sh` to local mocks. The runner runs bricks in parallel within a single JVM, so those mocks bleed into other bricks' real subprocess calls — notably `workflow/merge-resolution-test`'s `git init`, where the mock returns `{:err "no route matched"}` or `{:err "fatal: not a git repo"}` depending on which mock is active. Added `pr-sync` and `agent` to `default-isolated-bricks` so each gets its own JVM. Deeper fix (mocking through private wrappers instead of vendor namespaces) is a multi-file refactor, deferred.
2. **Babashka compatibility.** `event-stream` is transitively loaded from BB-runtime bricks. `java.nio.channels.FileLock` and `java.lang.management` aren't in BB. Replaced top-level `:import` with FQN class references inside fn bodies so the namespace loads in BB; worker-id leasing only ever runs on the JVM. Dropped `pid`/`host` from lease metadata (informational; FileLock OS-release on JVM exit is what guarantees correctness).

## Out of scope (tracked for follow-on sub-PRs)

- BD-2b sub-2: Manifest schema + lease liveness model.
- BD-2b sub-3: Atomic archive + scheduled cleanup with budgets.
- BD-2c: Active checkpoints + snapshots + consumer hydration.
- CLI wiring of the generator into the production stream startup. `create-event-stream` accepts a generator but the CLI doesn't yet pass one — production events still use random-uuid `:event/id` and the legacy filename until the wiring lands. Migration is producer-opt-in via the `create-event-stream` seam.

## Validation

```
bb pre-commit
```

5388 tests, 23980 passes, 0 failures, 0 errors. GraalVM/Babashka compatibility green.

## Test plan

- [ ] reviewer agrees with the `:event/id`-as-snowflake-encoded-UUID design (preserves `uuid?` for downstream)
- [ ] reviewer agrees the brick-isolation drive-by is the right interim until the deeper private-wrapper refactor
- [ ] reviewer agrees BB compat via FQN class references is reasonable vs marking the brick `:jvm-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)