### PR TITLE
feat(knowledge-pack): new component — content-addressed Zettelkasten packs

### DIFF
--- a/components/knowledge-pack/deps.edn
+++ b/components/knowledge-pack/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "resources"]
+ :deps  {ai.miniforge/knowledge    {:local/root "../knowledge"}
+         ;; SHA-256 over canonical EDN — same primitive zettel/digest
+         ;; uses, so pack digests are comparable across components.
+         ai.miniforge/content-hash {:local/root "../content-hash"}
+         metosin/malli             {:mvn/version "0.16.4"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/knowledge-pack/deps.edn
+++ b/components/knowledge-pack/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "resources"]
+{:paths ["src"]
  :deps  {ai.miniforge/knowledge    {:local/root "../knowledge"}
          ;; SHA-256 over canonical EDN — same primitive zettel/digest
          ;; uses, so pack digests are comparable across components.

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/interface.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/interface.clj
@@ -1,0 +1,71 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.knowledge-pack.interface
+  "Public API for the knowledge-pack component (Zettelkasten
+   distribution layer).
+
+   Implements the pack half of miniforge-fleet's Phase E Decision 6:
+   zettels are the wire format, packs are the curation /
+   distribution layer, content-addressed end-to-end so trust
+   attaches to immutable revisions.
+
+   Public surface:
+     `ZettelRef`   — Malli schema for the `(zettel/id,
+                     zettel/revision-id, zettel/digest)` triple
+                     packs use to reference zettel revisions.
+     `KnowledgePack` — Malli schema for the manifest itself.
+     `build-pack`  — fresh pack constructor; stamps `:pack/digest`
+                     + `:pack/revision-id` automatically.
+     `update-pack` — strips caller-supplied derived fields and
+                     re-stamps; idempotent on unchanged content.
+     `add-zettel`  — append a zettel reference; rotates revision.
+     `remove-zettel` — remove every reference to a zettel-id; rotates.
+     `zettel->ref` — pure projection from a zettel map to its
+                     content-addressed reference triple.
+     `compute-digest`        — pure SHA-256 hex of the pack's
+                                content projection.
+     `revision-id-from-digest` — pure UUID derivation from a digest.
+     `verify-pack` — verify a pack against a zettel store. Returns
+                     `{:valid? :pack/discrepancy :ref/discrepancies}`.
+
+   Two strata:
+     Layer 0 — schema re-exports.
+     Layer 1 — operation re-exports."
+  (:require
+   [ai.miniforge.knowledge-pack.pack   :as pack-impl]
+   [ai.miniforge.knowledge-pack.schema :as schema-impl]
+   [ai.miniforge.knowledge-pack.verify :as verify-impl]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema re-exports.
+
+(def ZettelRef     schema-impl/ZettelRef)
+(def KnowledgePack schema-impl/KnowledgePack)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Operation re-exports.
+
+(def build-pack             pack-impl/build-pack)
+(def update-pack            pack-impl/update-pack)
+(def add-zettel             pack-impl/add-zettel)
+(def remove-zettel          pack-impl/remove-zettel)
+(def zettel->ref            pack-impl/zettel->ref)
+(def compute-digest         pack-impl/compute-digest)
+(def revision-id-from-digest pack-impl/revision-id-from-digest)
+(def verify-pack            verify-impl/verify-pack)

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/pack.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/pack.clj
@@ -1,0 +1,210 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.knowledge-pack.pack
+  "Knowledge pack operations: build, update, project to a content-
+   addressed reference triple, derive the manifest digest +
+   revision-id.
+
+   Two strata mirror the zettel module:
+     Layer 0 — content-bearing subset + digest / revision-id
+               derivation. Pure; no I/O.
+     Layer 1 — public constructors: `build-pack`, `update-pack`,
+               plus the `zettel->ref` projection callers use to
+               build the `:pack/zettels` triples from existing
+               zettel maps."
+  (:require
+   [ai.miniforge.content-hash.interface :as content-hash])
+  (:import
+   [java.util UUID]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Content-bearing subset + revision identity.
+
+(def ^:private content-bearing-fields
+  "Fields whose value affects a pack's revision identity. Operational
+   metadata (`:pack/id`, `:pack/created`, `:pack/modified`,
+   `:pack/author`, `:fleet/*`, `:privacy/*`) is excluded — same
+   shape as zettel's content-bearing-fields so a privacy
+   reclassification or oss-version bump does NOT silently mint a
+   new revision."
+  [:pack/uid
+   :pack/title
+   :pack/version
+   :pack/description
+   :pack/zettels
+   :pack/dependencies])
+
+(defn- content-projection
+  "Pure: project a pack down to the content-bearing subset that feeds
+   the digest. Stable across additions of operational metadata."
+  [pack]
+  (select-keys pack content-bearing-fields))
+
+(defn compute-digest
+  "Pure: SHA-256 hex of the pack's canonical-EDN content-projection.
+   Stable across map-key reorderings and across non-content metadata
+   changes; rotates whenever a content-bearing field changes."
+  [pack]
+  (content-hash/content-hash (content-projection pack)))
+
+(defn revision-id-from-digest
+  "Pure: derive a stable UUID from a digest hex string. Two packs
+   with identical content-projections land on the same
+   `:pack/revision-id`."
+  ^UUID [^String digest]
+  (UUID/nameUUIDFromBytes (.getBytes digest "UTF-8")))
+
+(defn- stamp-revision
+  "Pure: stamp a pack with `:pack/digest` + `:pack/revision-id`
+   derived from its current content projection. Idempotent for an
+   already-stamped pack whose content has not changed."
+  [pack]
+  (let [d (compute-digest pack)]
+    (assoc pack
+           :pack/digest      d
+           :pack/revision-id (revision-id-from-digest d))))
+
+(def ^:private derived-fields
+  "Fields the constructor / updater own — callers cannot override
+   them via `update-pack`. Ensures the relationship between content
+   and revision identity stays tamper-evident, mirroring the
+   zettel-side spoof guard."
+  #{:pack/digest :pack/revision-id})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Public constructors + projection.
+
+(defn zettel->ref
+  "Pure: project a zettel map down to the `(zettel/id,
+   zettel/revision-id, zettel/digest)` triple a pack manifest holds.
+
+   Throws `ex-info` if any of the three fields is missing — packs
+   MUST reference content-addressable zettels per Decision 6, and
+   the constructor refuses to silently emit a malformed triple. A
+   legacy zettel without `:zettel/revision-id` / `:zettel/digest`
+   should be passed through `knowledge.zettel/update-zettel` first
+   to backfill those fields, after which the projection succeeds."
+  [zettel]
+  (let [{:zettel/keys [id revision-id digest]} zettel]
+    (when (or (nil? id) (nil? revision-id) (nil? digest))
+      (throw (ex-info "knowledge-pack: zettel missing one of [:zettel/id :zettel/revision-id :zettel/digest] — pack manifests require revision-keyed references"
+                      {:zettel/id          id
+                       :zettel/revision-id revision-id
+                       :zettel/digest      digest})))
+    {:zettel/id          id
+     :zettel/revision-id revision-id
+     :zettel/digest      digest}))
+
+(defn build-pack
+  "Construct a fresh content-addressed pack manifest.
+
+   Required arguments:
+   - uid     — human-readable pack id (e.g. \"rds-import-runbook\").
+   - title   — short display name.
+   - version — opaque version string (semver / dateversion / etc.).
+   - zettels — sequence of zettel maps (NOT triples). Each is
+                projected via `zettel->ref` so callers can pass the
+                same map shape they get from `knowledge/get-zettel`.
+
+   Options:
+   - :description           — markdown body.
+   - :author                — string (default: \"user\").
+   - :dependencies          — vector of `(pack-id, pack-revision-id,
+                              pack-digest)` triples.
+   - :fleet/shareable       — boolean.
+   - :fleet/share-scope     — :org / :team / :repo / :workflow.
+   - :privacy/classification — :public-org / :internal / :restricted /
+                               :secret.
+   - :fleet/oss-version     — version string.
+
+   The constructor stamps `:pack/digest` + `:pack/revision-id`
+   automatically, so two packs built from identical content land on
+   the same revision id.
+
+   Example:
+     (build-pack \"rds-import-runbook\" \"RDS Import Runbook\" \"1.0.0\"
+                 [zettel-1 zettel-2]
+                 :description \"...\"
+                 :fleet/share-scope :org
+                 :privacy/classification :internal)"
+  [uid title version zettels
+   & {:keys [description author dependencies
+             fleet/shareable fleet/share-scope privacy/classification
+             fleet/oss-version]
+      :or   {author "user"}}]
+  (let [now  (java.util.Date.)
+        pack (cond-> {:pack/id      (random-uuid)
+                      :pack/uid     uid
+                      :pack/title   title
+                      :pack/version version
+                      :pack/zettels (mapv zettel->ref zettels)
+                      :pack/created now
+                      :pack/author  author}
+               description    (assoc :pack/description description)
+               (seq dependencies)
+               (assoc :pack/dependencies (vec dependencies))
+               (some? shareable)      (assoc :fleet/shareable shareable)
+               share-scope            (assoc :fleet/share-scope share-scope)
+               classification         (assoc :privacy/classification classification)
+               oss-version            (assoc :fleet/oss-version oss-version))]
+    (stamp-revision pack)))
+
+(defn update-pack
+  "Update a pack with new values, setting the modified timestamp.
+
+   `:pack/digest` and `:pack/revision-id` are DERIVED — any value
+   the caller supplies for either is dropped before the merge.
+   `update-pack` always re-stamps the result via `stamp-revision`,
+   which is idempotent on unchanged content (same content → same
+   digest → same revision-id) and rotates the revision when a
+   content-bearing field changes (`:pack/uid` / `:pack/title` /
+   `:pack/version` / `:pack/description` / `:pack/zettels` /
+   `:pack/dependencies`).
+
+   Operational-metadata-only changes (`:fleet/*` / `:privacy/*` /
+   author) leave the revision identity intact, mirroring zettel
+   semantics — Decision 6 attaches trust to the immutable pack
+   revision, so changing a privacy classification must NOT silently
+   migrate trust onto a new revision.
+
+   A legacy pack without `:pack/digest` / `:pack/revision-id`
+   receives the stamped fields on its first update."
+  [pack changes]
+  (let [sanitised (apply dissoc changes derived-fields)
+        merged    (-> pack
+                      (merge sanitised)
+                      (assoc :pack/modified (java.util.Date.)))]
+    (stamp-revision merged)))
+
+(defn add-zettel
+  "Add a zettel reference to a pack's manifest. The zettel is
+   projected via `zettel->ref` (so callers can pass the zettel map
+   directly) and the pack revision rotates via `update-pack`."
+  [pack zettel]
+  (let [ref      (zettel->ref zettel)
+        existing (vec (:pack/zettels pack))]
+    (update-pack pack {:pack/zettels (conj existing ref)})))
+
+(defn remove-zettel
+  "Remove every reference to `zettel-id` from the pack's manifest.
+   Pack revision rotates if any reference was actually removed."
+  [pack zettel-id]
+  (let [filtered (vec (remove #(= zettel-id (:zettel/id %))
+                              (:pack/zettels pack)))]
+    (update-pack pack {:pack/zettels filtered})))

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/schema.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/schema.clj
@@ -1,0 +1,139 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.knowledge-pack.schema
+  "Malli schemas for Zettelkasten knowledge packs.
+
+   miniforge-fleet's Phase E Decision 6 makes packs the curation +
+   distribution layer for zettels. Two invariants the schema pins:
+
+     1. **Content-addressed references**, never 'latest in pack'
+        semantics. Each entry in `:pack/zettels` is an exact
+        `(zettel/id, zettel/revision-id, zettel/digest)` triple. A
+        pack manifest that loaded would have surfaced a different
+        revision or a tampered digest fails verification at the
+        boundary, never silently propagates.
+
+     2. **Revision-keyed identity** (mirroring the zettel pattern
+        landed in PR #807). Trust attaches to `:pack/revision-id`,
+        not to the mutable `:pack/id`. A change to the pack manifest
+        (adding / removing a zettel triple, retitling, etc.)
+        produces a new revision that does NOT inherit the prior
+        revision's trust automatically.
+
+   Schemas are layered:
+     Layer 0 — `ZettelRef`: the canonical content-addressed triple
+               packs and other content-addressed surfaces use to
+               reference a specific zettel revision.
+     Layer 1 — `KnowledgePack`: the manifest itself, plus its
+               revision-keyed identity + Fleet-share fields."
+  (:require
+   [ai.miniforge.knowledge.interface :as knowledge]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Content-addressed reference triple.
+
+(def ZettelRef
+  "The canonical Decision-6 reference to a zettel revision. Pack
+   manifests + future content-addressed surfaces reference zettels
+   only via this triple; no surface is permitted to substitute the
+   logical `:zettel/id` for a revision-keyed reference, since that
+   would silently re-target trust on every content edit."
+  [:map {:closed false}
+   [:zettel/id          uuid?]
+   [:zettel/revision-id uuid?]
+   [:zettel/digest      [:re #"^[0-9a-f]{64}$"]]])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pack manifest.
+
+(def KnowledgePack
+  "A curated collection of zettel revisions distributed as a
+   content-addressed manifest.
+
+   Required fields:
+     `:pack/id`            — UUID. Stable logical identity across
+                              pack revisions.
+     `:pack/uid`           — human-readable id (e.g. \"rds-import-runbook\").
+     `:pack/title`         — short display name.
+     `:pack/version`       — opaque version string. Pack authors
+                              choose semver / dateversion / whatever
+                              suits their distribution cadence;
+                              the schema only requires non-empty.
+     `:pack/zettels`       — vector of `ZettelRef` triples. The
+                              schema permits an empty pack so
+                              authors can stage a manifest before
+                              populating it.
+     `:pack/created`       — inst.
+     `:pack/author`        — string.
+
+   Revision-keyed identity (mirrors zettel; populated by
+   `knowledge-pack/build-pack` + rotated by
+   `knowledge-pack/update-pack`):
+     `:pack/revision-id`   — UUID derived from the digest.
+     `:pack/digest`        — SHA-256 hex of canonical-EDN of the
+                              pack's content-bearing subset.
+
+   Fleet-share intent (Decision 8 + 13 + 14; populated when the
+   pack is destined for the Fleet event log):
+     `:pack/description`           — markdown body.
+     `:pack/dependencies`          — vector of `(pack-id,
+                                      pack-revision-id, pack-digest)`
+                                      triples this pack composes.
+     `:fleet/shareable`            — boolean.
+     `:fleet/share-scope`          — `:org` / `:team` / `:repo` /
+                                      `:workflow`.
+     `:privacy/classification`     — `:public-org` / `:internal` /
+                                      `:restricted` / `:secret`.
+     `:fleet/oss-version`          — string.
+     `:pack/modified`              — inst, stamped on update."
+  [:map {:closed false}
+   ;; Identity.
+   [:pack/id      uuid?]
+   [:pack/uid     [:string {:min 1}]]
+   [:pack/title   [:string {:min 1 :max 200}]]
+   [:pack/version [:string {:min 1}]]
+
+   ;; Manifest body.
+   [:pack/zettels [:vector ZettelRef]]
+
+   ;; Operational metadata.
+   [:pack/created  inst?]
+   [:pack/author   [:string {:min 1}]]
+   [:pack/modified {:optional true} inst?]
+
+   ;; Optional content-bearing extras.
+   [:pack/description  {:optional true} :string]
+   [:pack/dependencies {:optional true}
+    [:vector [:map
+              [:pack/id          uuid?]
+              [:pack/revision-id uuid?]
+              [:pack/digest      [:re #"^[0-9a-f]{64}$"]]]]]
+
+   ;; Revision-keyed identity (Decision 6). Optional in the schema
+   ;; so legacy packs round-trip; new packs stamp these via
+   ;; `knowledge-pack/build-pack` and rotate via
+   ;; `knowledge-pack/update-pack`.
+   [:pack/revision-id {:optional true} uuid?]
+   [:pack/digest      {:optional true} [:re #"^[0-9a-f]{64}$"]]
+
+   ;; Fleet-share intent.
+   [:fleet/shareable        {:optional true} boolean?]
+   [:fleet/share-scope      {:optional true} knowledge/ShareScope]
+   [:privacy/classification {:optional true} knowledge/Classification]
+   [:fleet/oss-version      {:optional true} [:string {:min 1}]]])

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
@@ -1,0 +1,128 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.knowledge-pack.verify
+  "Pack manifest verification — the boundary that turns a stored
+   pack back into a trusted citation.
+
+   Decision 6 of miniforge-fleet's Phase E plan is structural: each
+   `:pack/zettels` entry carries an exact `(zettel-id, revision-id,
+   digest)` triple, so a pack loaded against a zettel store can be
+   verified end-to-end:
+
+     - The pack's own `:pack/digest` recomputes to the value stamped
+       on the manifest. A drift means the manifest body was edited
+       without going through `update-pack` — surfaces as
+       `:pack/digest-mismatch`.
+
+     - For each zettel ref, the store contains a zettel with the
+       same `:zettel/id` AND `:zettel/revision-id` AND
+       `:zettel/digest`. Any divergence — missing zettel, wrong
+       revision, mutated content — surfaces as a structured per-ref
+       discrepancy and the verification fails fast (no silent
+       'latest in pack' fallback).
+
+   The verifier is pure over its inputs: it takes a pack map and a
+   `lookup-fn` that resolves `(zettel-id, revision-id) → zettel
+   map`. Production wiring closes over a real
+   `knowledge.store/get-zettel-revision`; tests pass an in-memory
+   map without depending on the store machinery."
+  (:require
+   [ai.miniforge.knowledge-pack.pack :as pack]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Per-ref verification.
+
+(defn- verify-ref
+  "Pure: compare a single `:pack/zettels` entry against what the
+   store currently holds. Returns nil on success or a structured
+   discrepancy map on failure."
+  [{:zettel/keys [id revision-id digest] :as ref} lookup-fn]
+  (let [stored (lookup-fn id revision-id)]
+    (cond
+      (nil? stored)
+      {:ref ref
+       :reason :zettel-not-found
+       :detail "lookup returned nil for (zettel-id, revision-id)"}
+
+      (not= digest (:zettel/digest stored))
+      {:ref ref
+       :reason :digest-mismatch
+       :detail "stored zettel's :zettel/digest differs — content was rewritten without rotating the revision-id"
+       :stored-digest (:zettel/digest stored)}
+
+      (not= id (:zettel/id stored))
+      {:ref ref
+       :reason :id-mismatch
+       :detail "lookup returned a zettel with a different :zettel/id (lookup-fn invariant violation)"}
+
+      (not= revision-id (:zettel/revision-id stored))
+      {:ref ref
+       :reason :revision-id-mismatch
+       :detail "lookup returned a zettel with a different :zettel/revision-id (lookup-fn invariant violation)"})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Manifest-level verification.
+
+(defn- verify-manifest-digest
+  "Pure: recompute the pack's digest from the current content
+   projection and compare against the stamped value. Returns nil on
+   success or a discrepancy map on failure."
+  [pack]
+  (let [stamped     (:pack/digest pack)
+        recomputed  (pack/compute-digest pack)]
+    (cond
+      (nil? stamped)
+      {:reason :pack/digest-missing
+       :detail "pack manifest carries no :pack/digest — was it built via knowledge-pack/build-pack?"}
+
+      (not= stamped recomputed)
+      {:reason :pack/digest-mismatch
+       :detail "manifest body was edited without going through update-pack"
+       :stamped-digest stamped
+       :recomputed-digest recomputed})))
+
+(defn verify-pack
+  "Verify a pack against a zettel store.
+
+   Arguments:
+     pack       — the pack map (must carry `:pack/zettels` triples
+                  and `:pack/digest`).
+     lookup-fn  — `(fn [zettel-id revision-id] -> zettel-map | nil)`.
+                  Production callers close over the real zettel
+                  store; tests pass an in-memory shim.
+
+   Returns:
+     {:valid?       boolean
+      :pack/discrepancy   map | nil   ; manifest-level digest
+                                       ;   mismatch, if any
+      :ref/discrepancies  vector       ; per-ref problems, may be
+                                       ;   empty}
+
+   `:valid?` is true iff `:pack/discrepancy` is nil AND
+   `:ref/discrepancies` is empty. Callers wanting to fail closed on
+   any divergence can branch on `:valid?` directly; callers wanting
+   to surface every problem at once read both fields."
+  [pack lookup-fn]
+  (let [pack-disc (verify-manifest-digest pack)
+        ref-discs (->> (:pack/zettels pack)
+                       (keep #(verify-ref % lookup-fn))
+                       vec)]
+    {:valid?             (and (nil? pack-disc) (empty? ref-discs))
+     :pack/discrepancy   pack-disc
+     :ref/discrepancies  ref-discs}))

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
@@ -34,8 +34,11 @@
        same `:zettel/id` AND `:zettel/revision-id` AND
        `:zettel/digest`. Any divergence — missing zettel, wrong
        revision, mutated content — surfaces as a structured per-ref
-       discrepancy and the verification fails fast (no silent
-       'latest in pack' fallback).
+       discrepancy. The verifier ACCUMULATES every per-ref problem
+       it finds rather than short-circuiting, so an operator
+       diagnosing a partial-failure can see the full set in one
+       result map. There is no silent 'latest in pack' fallback —
+       any divergence is reported.
 
    The verifier is pure over its inputs: it takes a pack map and a
    `lookup-fn` that resolves `(zettel-id, revision-id) → zettel
@@ -81,21 +84,43 @@
 
 (defn- verify-manifest-digest
   "Pure: recompute the pack's digest from the current content
-   projection and compare against the stamped value. Returns nil on
-   success or a discrepancy map on failure."
+   projection, compare against the stamped digest, AND verify the
+   stamped `:pack/revision-id` is the UUID derived from that
+   recomputed digest. Returns nil on success or a discrepancy map
+   on failure.
+
+   Both checks matter: an attacker who tampers with manifest body
+   AND re-stamps `:pack/digest` would still trip the revision-id
+   check, because revision-id is `nameUUIDFromBytes(digest)`. A
+   tamper that goes through `update-pack` is not really tampering
+   — the revision rotates by design — but a bypass attempt that
+   forges either field independently is caught here."
   [pack]
-  (let [stamped     (:pack/digest pack)
-        recomputed  (pack/compute-digest pack)]
+  (let [stamped-digest (:pack/digest pack)
+        recomputed     (pack/compute-digest pack)
+        stamped-rev    (:pack/revision-id pack)
+        derived-rev    (when recomputed
+                         (pack/revision-id-from-digest recomputed))]
     (cond
-      (nil? stamped)
+      (nil? stamped-digest)
       {:reason :pack/digest-missing
        :detail "pack manifest carries no :pack/digest — was it built via knowledge-pack/build-pack?"}
 
-      (not= stamped recomputed)
+      (not= stamped-digest recomputed)
       {:reason :pack/digest-mismatch
        :detail "manifest body was edited without going through update-pack"
-       :stamped-digest stamped
-       :recomputed-digest recomputed})))
+       :stamped-digest stamped-digest
+       :recomputed-digest recomputed}
+
+      (nil? stamped-rev)
+      {:reason :pack/revision-id-missing
+       :detail "pack manifest carries :pack/digest but no :pack/revision-id — partial stamping should never happen via the constructors"}
+
+      (not= stamped-rev derived-rev)
+      {:reason :pack/revision-id-mismatch
+       :detail "manifest's :pack/revision-id does not match the UUID derived from :pack/digest — someone forged one without the other"
+       :stamped-revision-id stamped-rev
+       :derived-revision-id derived-rev})))
 
 (defn verify-pack
   "Verify a pack against a zettel store.

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
@@ -49,7 +49,17 @@
    [ai.miniforge.knowledge-pack.pack :as pack]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Per-ref verification.
+;; Discrepancy factory + per-ref verification.
+
+(defn- discrepancy
+  "Pure factory: build a discrepancy map. `extras` is an optional
+   map merged onto the `{:reason :detail}` base; per-ref callers
+   pass `{:ref ref :stored-digest ...}` and manifest-level callers
+   pass the stamped-vs-computed values an operator needs to triage."
+  ([reason detail]
+   {:reason reason :detail detail})
+  ([reason detail extras]
+   (merge {:reason reason :detail detail} extras)))
 
 (defn- verify-ref
   "Pure: compare a single `:pack/zettels` entry against what the
@@ -59,25 +69,24 @@
   (let [stored (lookup-fn id revision-id)]
     (cond
       (nil? stored)
-      {:ref ref
-       :reason :zettel-not-found
-       :detail "lookup returned nil for (zettel-id, revision-id)"}
+      (discrepancy :zettel-not-found
+                   "lookup returned nil for (zettel-id, revision-id)"
+                   {:ref ref})
 
       (not= digest (:zettel/digest stored))
-      {:ref ref
-       :reason :digest-mismatch
-       :detail "stored zettel's :zettel/digest differs — content was rewritten without rotating the revision-id"
-       :stored-digest (:zettel/digest stored)}
+      (discrepancy :digest-mismatch
+                   "stored zettel's :zettel/digest differs — content was rewritten without rotating the revision-id"
+                   {:ref ref :stored-digest (:zettel/digest stored)})
 
       (not= id (:zettel/id stored))
-      {:ref ref
-       :reason :id-mismatch
-       :detail "lookup returned a zettel with a different :zettel/id (lookup-fn invariant violation)"}
+      (discrepancy :id-mismatch
+                   "lookup returned a zettel with a different :zettel/id (lookup-fn invariant violation)"
+                   {:ref ref})
 
       (not= revision-id (:zettel/revision-id stored))
-      {:ref ref
-       :reason :revision-id-mismatch
-       :detail "lookup returned a zettel with a different :zettel/revision-id (lookup-fn invariant violation)"})))
+      (discrepancy :revision-id-mismatch
+                   "lookup returned a zettel with a different :zettel/revision-id (lookup-fn invariant violation)"
+                   {:ref ref}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Manifest-level verification.
@@ -103,24 +112,24 @@
                          (pack/revision-id-from-digest recomputed))]
     (cond
       (nil? stamped-digest)
-      {:reason :pack/digest-missing
-       :detail "pack manifest carries no :pack/digest — was it built via knowledge-pack/build-pack?"}
+      (discrepancy :pack/digest-missing
+                   "pack manifest carries no :pack/digest — was it built via knowledge-pack/build-pack?")
 
       (not= stamped-digest recomputed)
-      {:reason :pack/digest-mismatch
-       :detail "manifest body was edited without going through update-pack"
-       :stamped-digest stamped-digest
-       :recomputed-digest recomputed}
+      (discrepancy :pack/digest-mismatch
+                   "manifest body was edited without going through update-pack"
+                   {:stamped-digest    stamped-digest
+                    :recomputed-digest recomputed})
 
       (nil? stamped-rev)
-      {:reason :pack/revision-id-missing
-       :detail "pack manifest carries :pack/digest but no :pack/revision-id — partial stamping should never happen via the constructors"}
+      (discrepancy :pack/revision-id-missing
+                   "pack manifest carries :pack/digest but no :pack/revision-id — partial stamping should never happen via the constructors")
 
       (not= stamped-rev derived-rev)
-      {:reason :pack/revision-id-mismatch
-       :detail "manifest's :pack/revision-id does not match the UUID derived from :pack/digest — someone forged one without the other"
-       :stamped-revision-id stamped-rev
-       :derived-revision-id derived-rev})))
+      (discrepancy :pack/revision-id-mismatch
+                   "manifest's :pack/revision-id does not match the UUID derived from :pack/digest — someone forged one without the other"
+                   {:stamped-revision-id stamped-rev
+                    :derived-revision-id derived-rev}))))
 
 (defn verify-pack
   "Verify a pack against a zettel store.

--- a/components/knowledge-pack/test/ai/miniforge/knowledge_pack/pack_test.clj
+++ b/components/knowledge-pack/test/ai/miniforge/knowledge_pack/pack_test.clj
@@ -56,10 +56,15 @@
       (is (instance? UUID (:pack/revision-id p))))))
 
 (deftest test-pack-revision-id-is-deterministic-over-content
-  (testing "two packs with identical content land on the same revision-id and digest"
-    ;; Pin the inner zettel content via fresh constructions so digests
-    ;; align — different create-zettel calls with same content emit
-    ;; identical revision-id + digest.
+  (testing "two packs that reference the same zettel triples land on the same revision-id and digest"
+    ;; The pack's content-projection includes :pack/zettels (the
+    ;; vector of (zettel-id, revision-id, digest) triples), so
+    ;; pack determinism is against the SAME REFERENCED ZETTELS,
+    ;; not against \"two zettels that happen to have identical
+    ;; content\". `create-zettel` mints a fresh `:zettel/id` per
+    ;; call, so two zettels with identical content have different
+    ;; ids and would change the pack triple. The fixture binds
+    ;; `shared` once so both packs reference the same zettel id.
     (let [shared (z)
           p1 (pack-of [shared])
           p2 (pack-of [shared])]

--- a/components/knowledge-pack/test/ai/miniforge/knowledge_pack/pack_test.clj
+++ b/components/knowledge-pack/test/ai/miniforge/knowledge_pack/pack_test.clj
@@ -1,0 +1,185 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+
+(ns ai.miniforge.knowledge-pack.pack-test
+  "Tests for `knowledge-pack/build-pack` + `update-pack` + projection
+   helpers. Covers the same revision-keyed identity invariants the
+   zettel-side tests pin (deterministic over content; rotates on
+   content change; stable on operational-metadata change; spoof
+   guard on derived fields; legacy backfill)."
+  (:require
+   [ai.miniforge.knowledge-pack.interface :as kp]
+   [ai.miniforge.knowledge-pack.schema :as kp-schema]
+   [ai.miniforge.knowledge.interface :as knowledge]
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as m])
+  (:import
+   [java.util UUID]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers.
+
+(defn- z
+  "Build a fresh stamped zettel via the OSS knowledge constructor.
+   Each call produces a different :zettel/id but the same
+   :zettel/revision-id when the content is identical."
+  [& {:keys [uid title content]
+      :or {uid     "test-z"
+           title   "Test Zettel"
+           content "# Body of the test zettel."}}]
+  (knowledge/create-zettel uid title content :rule))
+
+(defn- pack-of
+  "Build a pack with sensible defaults around the supplied zettels."
+  [zettels & overrides]
+  (apply kp/build-pack
+         "test-pack" "Test Pack" "1.0.0" zettels
+         overrides))
+
+;------------------------------------------------------------------------------ Layer 1
+;; build-pack stamps revision + digest deterministically.
+
+(deftest test-build-pack-stamps-revision-and-digest
+  (testing "every fresh pack carries a 64-char hex digest + a UUID revision-id"
+    (let [p (pack-of [(z) (z :uid "second" :content "different content")])]
+      (is (string? (:pack/digest p)))
+      (is (re-matches #"^[0-9a-f]{64}$" (:pack/digest p)))
+      (is (instance? UUID (:pack/revision-id p))))))
+
+(deftest test-pack-revision-id-is-deterministic-over-content
+  (testing "two packs with identical content land on the same revision-id and digest"
+    ;; Pin the inner zettel content via fresh constructions so digests
+    ;; align — different create-zettel calls with same content emit
+    ;; identical revision-id + digest.
+    (let [shared (z)
+          p1 (pack-of [shared])
+          p2 (pack-of [shared])]
+      (is (not= (:pack/id p1) (:pack/id p2))
+          "logical :pack/id is fresh per call")
+      (is (= (:pack/digest p1)      (:pack/digest p2)))
+      (is (= (:pack/revision-id p1) (:pack/revision-id p2))))))
+
+(deftest test-distinct-content-produces-distinct-revision
+  (testing "any change to a content-bearing field produces a different revision-id"
+    (let [shared (z)
+          p1 (pack-of [shared])
+          p2 (pack-of [shared] :description "extra desc")]
+      (is (not= (:pack/digest p1)      (:pack/digest p2)))
+      (is (not= (:pack/revision-id p1) (:pack/revision-id p2))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; update-pack semantics.
+
+(deftest test-update-content-rotates-revision
+  (testing "changing :pack/title rotates the revision"
+    (let [p1 (pack-of [(z)])
+          p2 (kp/update-pack p1 {:pack/title "Renamed"})]
+      (is (not= (:pack/revision-id p1) (:pack/revision-id p2))))))
+
+(deftest test-update-zettels-rotates-revision
+  (testing "adding a zettel ref rotates the revision"
+    (let [p1 (pack-of [(z)])
+          p2 (kp/add-zettel p1 (z :uid "second" :content "different content"))]
+      (is (not= (:pack/revision-id p1) (:pack/revision-id p2)))
+      (is (= 1 (count (:pack/zettels p1))))
+      (is (= 2 (count (:pack/zettels p2)))))))
+
+(deftest test-remove-zettel-rotates-revision
+  (testing "removing a zettel ref rotates the revision"
+    (let [zettel (z)
+          p1 (pack-of [zettel])
+          p2 (kp/remove-zettel p1 (:zettel/id zettel))]
+      (is (not= (:pack/revision-id p1) (:pack/revision-id p2)))
+      (is (empty? (:pack/zettels p2))))))
+
+(deftest test-update-operational-metadata-leaves-revision-intact
+  (testing "operational-only changes (privacy, share scope, oss-version) preserve revision"
+    (let [p1 (pack-of [(z)] :privacy/classification :internal :fleet/oss-version "1.0.0")
+          p2 (kp/update-pack p1 {:privacy/classification :restricted})
+          p3 (kp/update-pack p2 {:fleet/share-scope :team})
+          p4 (kp/update-pack p3 {:fleet/oss-version "1.0.1"})]
+      (is (= (:pack/revision-id p1) (:pack/revision-id p2)))
+      (is (= (:pack/revision-id p2) (:pack/revision-id p3)))
+      (is (= (:pack/revision-id p3) (:pack/revision-id p4)))
+      (is (= (:pack/digest p1) (:pack/digest p4))))))
+
+(deftest test-update-ignores-caller-supplied-derived-fields
+  (testing "callers cannot spoof :pack/digest or :pack/revision-id via update-pack"
+    (let [p1 (pack-of [(z)])
+          forged-digest "0000000000000000000000000000000000000000000000000000000000000000"
+          forged-rev    (UUID/randomUUID)
+          p2 (kp/update-pack p1 {:pack/digest      forged-digest
+                                 :pack/revision-id forged-rev})]
+      (is (not= forged-digest (:pack/digest p2)))
+      (is (not= forged-rev (:pack/revision-id p2)))
+      (is (= (:pack/digest p1) (:pack/digest p2))
+          "digest stays equal to p1's because content didn't change"))))
+
+(deftest test-update-backfills-derived-fields-on-legacy-pack
+  (testing "a legacy pack without derived fields gets them stamped on first update"
+    (let [legacy {:pack/id      (UUID/randomUUID)
+                  :pack/uid     "legacy-pack"
+                  :pack/title   "Legacy"
+                  :pack/version "0.0.1"
+                  :pack/zettels []
+                  :pack/created (java.util.Date.)
+                  :pack/author  "user"}
+          updated (kp/update-pack legacy {:fleet/oss-version "1.0.0"})]
+      (is (string? (:pack/digest updated)))
+      (is (= 64 (count (:pack/digest updated))))
+      (is (instance? UUID (:pack/revision-id updated))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; zettel->ref projection.
+
+(deftest test-zettel-ref-projects-canonical-triple
+  (testing "zettel->ref returns a closed (id, revision-id, digest) map"
+    (let [zettel (z)
+          ref    (kp/zettel->ref zettel)]
+      (is (= (set [:zettel/id :zettel/revision-id :zettel/digest])
+             (set (keys ref))))
+      (is (= (:zettel/id zettel)          (:zettel/id ref)))
+      (is (= (:zettel/revision-id zettel) (:zettel/revision-id ref)))
+      (is (= (:zettel/digest zettel)      (:zettel/digest ref))))))
+
+(deftest test-zettel-ref-throws-on-missing-fields
+  (testing "a zettel missing revision-id / digest cannot be projected to a pack triple"
+    ;; The constructor refuses to silently emit a malformed triple —
+    ;; per Decision 6, packs reference content-addressable zettels
+    ;; only.
+    (let [legacy {:zettel/id (UUID/randomUUID)
+                  :zettel/uid "legacy"
+                  :zettel/title "Legacy"
+                  :zettel/content "Body."
+                  :zettel/type :rule
+                  :zettel/created (java.util.Date.)
+                  :zettel/author "user"}]
+      (is (thrown? clojure.lang.ExceptionInfo (kp/zettel->ref legacy))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Schema acceptance.
+
+(deftest test-built-pack-validates-against-schema
+  (testing "the constructor stamps a pack that round-trips through Malli"
+    (let [p (pack-of [(z)] :description "A test pack."
+                     :fleet/shareable true
+                     :fleet/share-scope :org
+                     :privacy/classification :internal
+                     :fleet/oss-version "1.0.0")]
+      (is (m/validate kp/KnowledgePack p)))))
+
+(deftest test-zettelref-schema-rejects-uppercase-digest
+  (testing ":zettel/digest must be lowercase hex per the shared regex"
+    (let [bad {:zettel/id          (UUID/randomUUID)
+               :zettel/revision-id (UUID/randomUUID)
+               :zettel/digest      "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"}]
+      (is (false? (m/validate kp-schema/ZettelRef bad))))))

--- a/components/knowledge-pack/test/ai/miniforge/knowledge_pack/verify_test.clj
+++ b/components/knowledge-pack/test/ai/miniforge/knowledge_pack/verify_test.clj
@@ -141,3 +141,32 @@
       (is (false? (:valid? result)))
       (is (= :pack/digest-missing
              (-> result :pack/discrepancy :reason))))))
+
+(deftest test-verify-pack-detects-missing-revision-id
+  (testing "a pack with :pack/digest but no :pack/revision-id surfaces :pack/revision-id-missing"
+    ;; Partial stamping should never happen via the constructors
+    ;; (build-pack / update-pack always stamp both), but a forged
+    ;; pack manifest could carry digest-only — pin the boundary.
+    (let [z1   (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
+          pack (kp/build-pack "p" "Pack" "1.0.0" [z1])
+          partial (dissoc pack :pack/revision-id)
+          result (kp/verify-pack partial (lookup-from (store-of [z1])))]
+      (is (false? (:valid? result)))
+      (is (= :pack/revision-id-missing
+             (-> result :pack/discrepancy :reason))))))
+
+(deftest test-verify-pack-detects-forged-revision-id
+  (testing ":pack/revision-id forged independent of :pack/digest fails with :pack/revision-id-mismatch"
+    ;; An attacker-rotated `:pack/revision-id` (e.g. attempting to
+    ;; ride existing trust onto new content by stamping a forged
+    ;; revision id) is caught because revision-id is derived from
+    ;; the digest.
+    (let [z1   (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
+          pack (kp/build-pack "p" "Pack" "1.0.0" [z1])
+          forged-rev (UUID/randomUUID)
+          tampered (assoc pack :pack/revision-id forged-rev)
+          result (kp/verify-pack tampered (lookup-from (store-of [z1])))]
+      (is (false? (:valid? result)))
+      (is (= :pack/revision-id-mismatch
+             (-> result :pack/discrepancy :reason)))
+      (is (= forged-rev (-> result :pack/discrepancy :stamped-revision-id))))))

--- a/components/knowledge-pack/test/ai/miniforge/knowledge_pack/verify_test.clj
+++ b/components/knowledge-pack/test/ai/miniforge/knowledge_pack/verify_test.clj
@@ -1,0 +1,143 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+
+(ns ai.miniforge.knowledge-pack.verify-test
+  "Tests for `verify-pack` — the boundary that turns a stored pack
+   manifest back into a trusted citation. Covers each named outcome:
+     - happy path: every triple resolves, digests match
+     - missing zettel
+     - digest drift on a stored zettel (content rewritten)
+     - lookup-fn invariant violations (id / revision-id mismatch)
+     - manifest-level digest drift (pack body edited bypassing
+       update-pack)"
+  (:require
+   [ai.miniforge.knowledge-pack.interface :as kp]
+   [ai.miniforge.knowledge.interface :as knowledge]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.util UUID]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers — build a tiny in-memory zettel store + a lookup-fn.
+
+(defn- store-of
+  "Build a `(zettel-id, revision-id) → zettel` map from a sequence
+   of zettels. The lookup-fn closes over this map."
+  [zettels]
+  (into {}
+        (map (fn [z] [[(:zettel/id z) (:zettel/revision-id z)] z]))
+        zettels))
+
+(defn- lookup-from
+  "Build a lookup-fn over an in-memory store map."
+  [store]
+  (fn [id revision-id]
+    (get store [id revision-id])))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Happy path.
+
+(deftest test-verify-pack-happy-path
+  (testing "every triple resolves + digests match → :valid? true"
+    (let [z1 (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
+          z2 (knowledge/create-zettel "z-2" "Z2" "Body 2." :rule)
+          pack   (kp/build-pack "p" "Pack" "1.0.0" [z1 z2])
+          result (kp/verify-pack pack (lookup-from (store-of [z1 z2])))]
+      (is (true? (:valid? result)))
+      (is (nil? (:pack/discrepancy result)))
+      (is (empty? (:ref/discrepancies result))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Per-ref discrepancies.
+
+(deftest test-verify-pack-missing-zettel
+  (testing "a triple that doesn't resolve in the store surfaces :zettel-not-found"
+    (let [z1   (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
+          pack (kp/build-pack "p" "Pack" "1.0.0" [z1])
+          ;; Empty store — z1 isn't there.
+          result (kp/verify-pack pack (lookup-from {}))]
+      (is (false? (:valid? result)))
+      (is (= 1 (count (:ref/discrepancies result))))
+      (is (= :zettel-not-found
+             (-> result :ref/discrepancies first :reason))))))
+
+(deftest test-verify-pack-digest-drift
+  (testing "a stored zettel's digest differing from the pack triple surfaces :digest-mismatch"
+    ;; The pack references z1 with its original digest; the store
+    ;; has the SAME id+revision but a tampered digest. Real-world
+    ;; analog: someone edited the stored content WITHOUT going
+    ;; through update-zettel, so revision-id stayed but content
+    ;; drifted.
+    (let [z1     (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
+          pack   (kp/build-pack "p" "Pack" "1.0.0" [z1])
+          tampered (assoc z1 :zettel/digest
+                          "0000000000000000000000000000000000000000000000000000000000000000")
+          result (kp/verify-pack pack (lookup-from (store-of [tampered])))]
+      (is (false? (:valid? result)))
+      (is (= :digest-mismatch
+             (-> result :ref/discrepancies first :reason))))))
+
+(deftest test-verify-pack-lookup-fn-invariant-violation
+  (testing "lookup-fn returning a zettel with mismatched :zettel/id surfaces :id-mismatch"
+    (let [z1     (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
+          pack   (kp/build-pack "p" "Pack" "1.0.0" [z1])
+          ;; Lookup-fn returns a zettel, but with a DIFFERENT :zettel/id —
+          ;; should never happen in production but pin the boundary.
+          bad-store {[(:zettel/id z1) (:zettel/revision-id z1)]
+                     (assoc z1 :zettel/id (UUID/randomUUID))}
+          result (kp/verify-pack pack (lookup-from bad-store))]
+      (is (false? (:valid? result)))
+      (is (= :id-mismatch
+             (-> result :ref/discrepancies first :reason))))))
+
+(deftest test-verify-pack-multiple-discrepancies
+  (testing "verify accumulates every per-ref problem, not just the first"
+    (let [z1   (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
+          z2   (knowledge/create-zettel "z-2" "Z2" "Body 2." :rule)
+          pack (kp/build-pack "p" "Pack" "1.0.0" [z1 z2])
+          ;; z1 missing; z2 digest tampered.
+          tampered-z2 (assoc z2 :zettel/digest
+                              "0000000000000000000000000000000000000000000000000000000000000000")
+          result (kp/verify-pack pack (lookup-from (store-of [tampered-z2])))]
+      (is (false? (:valid? result)))
+      (is (= 2 (count (:ref/discrepancies result))))
+      (is (= #{:zettel-not-found :digest-mismatch}
+             (set (map :reason (:ref/discrepancies result))))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Manifest-level discrepancies.
+
+(deftest test-verify-pack-detects-tampered-manifest
+  (testing "a pack whose body was edited without going through update-pack surfaces :pack/digest-mismatch"
+    ;; Forge a pack: build, then mutate :pack/title directly without
+    ;; update-pack — :pack/digest stays at the old content's digest.
+    (let [z1     (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
+          pack   (kp/build-pack "p" "Pack" "1.0.0" [z1])
+          tampered (assoc pack :pack/title "Tampered")  ; bypasses update-pack
+          result (kp/verify-pack tampered (lookup-from (store-of [z1])))]
+      (is (false? (:valid? result)))
+      (is (= :pack/digest-mismatch
+             (-> result :pack/discrepancy :reason))))))
+
+(deftest test-verify-pack-detects-missing-manifest-digest
+  (testing "a legacy pack without :pack/digest fails verification with :pack/digest-missing"
+    (let [legacy {:pack/id      (UUID/randomUUID)
+                  :pack/uid     "legacy"
+                  :pack/title   "Legacy"
+                  :pack/version "0.0.1"
+                  :pack/zettels []
+                  :pack/created (java.util.Date.)
+                  :pack/author  "user"}
+          result (kp/verify-pack legacy (lookup-from {}))]
+      (is (false? (:valid? result)))
+      (is (= :pack/digest-missing
+             (-> result :pack/discrepancy :reason))))))

--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -53,6 +53,11 @@
 (def KnowledgeQuery schema/KnowledgeQuery)
 (def AgentManifest schema/AgentManifest)
 (def LearningCapture schema/LearningCapture)
+;; Fleet-share enums (added in #807). Surfaced through the interface
+;; so downstream components reference them without reaching into
+;; `knowledge.schema` directly (Polylith dependency rule).
+(def ShareScope     schema/ShareScope)
+(def Classification schema/Classification)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Store creation

--- a/deps.edn
+++ b/deps.edn
@@ -38,7 +38,6 @@
                        "components/knowledge/src"
                        "components/knowledge/resources"
                        "components/knowledge-pack/src"
-                       "components/knowledge-pack/resources"
                        "components/policy/src"
                        "components/heuristic/src"
                        "components/heuristic/resources"

--- a/deps.edn
+++ b/deps.edn
@@ -37,6 +37,8 @@
                        "components/loop/resources"
                        "components/knowledge/src"
                        "components/knowledge/resources"
+                       "components/knowledge-pack/src"
+                       "components/knowledge-pack/resources"
                        "components/policy/src"
                        "components/heuristic/src"
                        "components/heuristic/resources"
@@ -209,6 +211,7 @@
                       ai.miniforge/decision {:local/root "components/decision"}
                       ai.miniforge/loop {:local/root "components/loop"}
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
+                      ai.miniforge/knowledge-pack {:local/root "components/knowledge-pack"}
                       ai.miniforge/policy {:local/root "components/policy"}
                       ai.miniforge/heuristic {:local/root "components/heuristic"}
                       ai.miniforge/response {:local/root "components/response"}
@@ -326,6 +329,7 @@
                        "components/decision/test"
                        "components/loop/test"
                        "components/knowledge/test"
+                       "components/knowledge-pack/test"
                        "components/policy/test"
                        "components/heuristic/test"
                        "components/phase/test"
@@ -447,6 +451,7 @@
                       ai.miniforge/decision {:local/root "components/decision"}
                       ai.miniforge/loop {:local/root "components/loop"}
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
+                      ai.miniforge/knowledge-pack {:local/root "components/knowledge-pack"}
                       ai.miniforge/policy {:local/root "components/policy"}
                       ai.miniforge/heuristic {:local/root "components/heuristic"}
                       ai.miniforge/response {:local/root "components/response"}
@@ -536,6 +541,8 @@
                               "components/loop/test"
                               "components/knowledge/src"
                               "components/knowledge/test"
+                              "components/knowledge-pack/src"
+                              "components/knowledge-pack/test"
                               "components/policy/src"
                               "components/policy/test"
                               "components/heuristic/src"

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -29,6 +29,13 @@
         ai.miniforge/loop {:local/root "../../components/loop"}
         ai.miniforge/observer {:local/root "../../components/observer"}
         ai.miniforge/knowledge {:local/root "../../components/knowledge"}
+        ;; Wired so `poly test brick:knowledge-pack` runs in this
+        ;; project's context. miniforge-fleet is the operational
+        ;; consumer (`pack` is the curation layer for the cross-
+        ;; instance event log Decision 6 commits to); this project
+        ;; carries no callers yet, so a Polylith warning 207 is
+        ;; expected until a downstream feature lands here.
+        ai.miniforge/knowledge-pack {:local/root "../../components/knowledge-pack"}
         ai.miniforge/spec-parser {:local/root "../../components/spec-parser"}
         ai.miniforge/policy {:local/root "../../components/policy"}
         ai.miniforge/heuristic {:local/root "../../components/heuristic"}


### PR DESCRIPTION
## Summary

Foundation for [miniforge-fleet's Phase E.3 distribution layer](https://github.com/miniforge-ai/miniforge-fleet/blob/main/docs/pull-requests/2026-05-04-chris-phase-e-planning.md). Closes the OSS-side prerequisite item #6 from the fleet planning doc — pack manifests as content-addressed `(zettel-id, revision-id, digest)` triples per Decision 6.

## What's new

A new `knowledge-pack` component, three strata:

- **`schema.clj`** — `ZettelRef` (the canonical Decision-6 reference triple every content-addressed surface uses) and `KnowledgePack` (the manifest, with revision-keyed identity + Fleet-share fields mirroring the zettel pattern from #807).
- **`pack.clj`** — `build-pack` / `update-pack` / `add-zettel` / `remove-zettel` constructors, plus the `zettel->ref` projection that turns a zettel map into a content-addressed reference. Same content-bearing-vs-operational split as zettel: privacy reclassification or oss-version bump preserves the revision id; manifest body changes rotate it. Spoof guard drops caller-supplied `:pack/digest` / `:pack/revision-id` from `update-pack`'s `changes`. Legacy packs without the derived fields backfill on first update.
- **`verify.clj`** — `verify-pack` boundary: takes a pack + a `(zettel-id, revision-id) → zettel` lookup-fn, returns `{:valid? :pack/discrepancy :ref/discrepancies}`. Catches manifest-body tampering (digest drift from the stamped value), missing zettels, stored-zettel digest drift, and lookup-fn invariant violations. **No silent 'latest in pack' fallback** — any divergence surfaces.

## Interface

```clojure
(ai.miniforge.knowledge-pack.interface/build-pack
  "rds-import-runbook" "RDS Import Runbook" "1.0.0"
  [zettel-1 zettel-2]
  :description "..."
  :fleet/share-scope :org
  :privacy/classification :internal)
```

Re-exports: `ZettelRef`, `KnowledgePack`, `build-pack`, `update-pack`, `add-zettel`, `remove-zettel`, `zettel->ref`, `compute-digest`, `revision-id-from-digest`, `verify-pack`.

## Drive-by on the `knowledge` interface

`knowledge` interface gained two re-exports — `ShareScope` and `Classification` — so this component (and any future Polylith consumer) references them through the canonical interface rather than reaching into `knowledge.schema` directly.

## Test plan

- [x] `clj-kondo --lint components/knowledge-pack components/knowledge` → 0 errors, 0 warnings
- [x] `clj -M:poly test brick:knowledge-pack` → 20 tests, 48 assertions, 0 failures
- [x] `clj -M:poly test brick:knowledge` → still all green (verified the interface re-exports don't break existing knowledge tests)
- [ ] CI green

## Out of scope (queued)

- **Outbox event emission** (`:zettel.promoted`, `:pack.published`, etc.). Separate PR.
- **`:org/id` / `:workspace/id` / `:auth/context` propagation in agent-runtime events.** Separate PR.
- **Knowledge-pack `:store` integration** — `verify-pack` takes a lookup-fn so production wiring can close over `knowledge.store/get-zettel-revision` once that surface lands; today's tests use an in-memory shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)