### PR TITLE
feat(event-stream): identity propagation — :org/id, :workspace/id, :repo/id, :auth/context

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -62,20 +62,46 @@
    most-significant 64 bits encode (epoch-ms timestamp, worker id,
    per-ms sequence) per the RFC, so events sort lexically by creation
    order. Streams without a generator fall back to a random UUID;
-   `:event/id` stays a `uuid?` either way for downstream compatibility."
-  [stream event-type workflow-id message]
-  (let [seq-num (get-in @stream [:sequence-numbers workflow-id] 0)
-        generator (:snowflake-generator @stream)]
-    (swap! stream assoc-in [:sequence-numbers workflow-id] (inc seq-num))
-    {:event/type event-type
-     :event/id (if generator
-                 (snowflake/next-id! generator)
-                 (random-uuid))
-     :event/timestamp (java.util.Date.)
-     :event/version event-version
-     :event/sequence-number seq-num
-     :workflow/id workflow-id
-     :message message}))
+   `:event/id` stays a `uuid?` either way for downstream compatibility.
+
+   Identity propagation (Decision 14 of miniforge-fleet's Phase E
+   plan): every envelope can carry org / workspace / repo / auth
+   context so subscribers can scope authorization without
+   retrofitting the event log later. Fields default off; pass any
+   subset via the options map. The OPTIONS arity is the
+   recommended call shape; the legacy 4-arg arity stays for
+   in-tree callers that don't have identity context yet.
+
+   Options:
+     :org/id        — UUID. Org tenancy boundary.
+     :workspace/id  — UUID. Workspace tenancy boundary.
+     :repo/id       — string. Slug-style repo id when applicable.
+     :auth/context  — map. Caller-shaped auth context.
+     :event/parent-id — UUID. Parent event id for causality.
+     :agent/id        — keyword. Agent that emitted the event.
+     :agent/instance-id — UUID. Specific agent instance."
+  ([stream event-type workflow-id message]
+   (create-envelope stream event-type workflow-id message {}))
+  ([stream event-type workflow-id message opts]
+   (let [seq-num   (get-in @stream [:sequence-numbers workflow-id] 0)
+         generator (:snowflake-generator @stream)]
+     (swap! stream assoc-in [:sequence-numbers workflow-id] (inc seq-num))
+     (cond-> {:event/type event-type
+              :event/id (if generator
+                          (snowflake/next-id! generator)
+                          (random-uuid))
+              :event/timestamp (java.util.Date.)
+              :event/version event-version
+              :event/sequence-number seq-num
+              :workflow/id workflow-id
+              :message message}
+       (:org/id opts)            (assoc :org/id (:org/id opts))
+       (:workspace/id opts)      (assoc :workspace/id (:workspace/id opts))
+       (:repo/id opts)           (assoc :repo/id (:repo/id opts))
+       (:auth/context opts)      (assoc :auth/context (:auth/context opts))
+       (:event/parent-id opts)   (assoc :event/parent-id (:event/parent-id opts))
+       (:agent/id opts)          (assoc :agent/id (:agent/id opts))
+       (:agent/instance-id opts) (assoc :agent/instance-id (:agent/instance-id opts))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Event bus operations

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -83,9 +83,17 @@
   ([stream event-type workflow-id message]
    (create-envelope stream event-type workflow-id message {}))
   ([stream event-type workflow-id message opts]
-   (let [seq-num   (get-in @stream [:sequence-numbers workflow-id] 0)
-         generator (:snowflake-generator @stream)]
-     (swap! stream assoc-in [:sequence-numbers workflow-id] (inc seq-num))
+   ;; `swap-vals!` returns [old-state new-state] atomically, so we
+   ;; pull the seq value and increment it in a single CAS — no
+   ;; window where two concurrent producers see the same number.
+   ;; The previous read-then-swap pattern WAS racey; reviewers
+   ;; flagged it on PR #814.
+   (let [[old _new] (swap-vals! stream
+                                update-in
+                                [:sequence-numbers workflow-id]
+                                (fnil inc 0))
+         seq-num    (get-in old [:sequence-numbers workflow-id] 0)
+         generator  (:snowflake-generator @stream)]
      (cond-> {:event/type event-type
               :event/id (if generator
                           (snowflake/next-id! generator)

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -19,7 +19,18 @@
 (ns ai.miniforge.event-stream.schema
   "N3-compliant event schemas for workflow observability.
 
-   See specs/normative/N3-event-stream.md for the full specification.")
+   See specs/normative/N3-event-stream.md for the full specification.
+
+   Identity propagation (added for miniforge-fleet's Phase E.1
+   planning prerequisite #10, Decision 14): every event schema
+   carries an optional `:org/id` / `:workspace/id` / `:repo/id` /
+   `:auth/context` quartet so subscribers can scope authorization
+   without retrofitting the event log later. All four are optional
+   for backward compatibility — single-org single-workspace
+   deployments populate them with stable singleton values; multi-
+   tenant deployments populate per-request. The `core/create-envelope`
+   constructor accepts them as optional kwargs and stamps them onto
+   the envelope when present.")
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Shared payload schemas
@@ -46,6 +57,10 @@
    [:agent/id {:optional true} keyword?]           ; OPTIONAL: agent that emitted event
    [:agent/instance-id {:optional true} uuid?]     ; OPTIONAL: specific agent instance
    [:event/parent-id {:optional true} uuid?]       ; OPTIONAL: parent event ID (for causality)
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])                ; REQUIRED: human-readable message
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -62,6 +77,10 @@
    [:workflow/id uuid?]
    [:workflow/spec {:optional true} map?]
    [:workflow/intent {:optional true} map?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def PhaseStarted
@@ -76,6 +95,10 @@
    [:workflow/phase keyword?]
    [:phase/expected-agent {:optional true} keyword?]
    [:phase/context {:optional true} map?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def PhaseCompleted
@@ -96,6 +119,10 @@
    [:phase/error {:optional true} map?]
    [:phase/tokens {:optional true} int?]
    [:phase/cost-usd {:optional true} number?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def WorkspacePersisted
@@ -117,6 +144,10 @@
    [:workspace/commit-sha {:optional true} string?]
    [:workspace/bundle-path {:optional true} string?]
    [:workspace/tier {:optional true} [:enum :worktree :remote]]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def WorkflowCompleted
@@ -133,6 +164,10 @@
    [:workflow/evidence-bundle-id {:optional true} uuid?]
    [:workflow/tokens {:optional true} int?]
    [:workflow/cost-usd {:optional true} number?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def WorkflowFailed
@@ -147,6 +182,10 @@
    [:workflow/failure-phase {:optional true} keyword?]
    [:workflow/failure-reason {:optional true} string?]
    [:workflow/error-details {:optional true} map?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 ;------------------------------------------------------------------------------ Layer 1.5
@@ -172,6 +211,10 @@
    [:pr/title {:optional true} string?]
    [:pr/author {:optional true} string?]
    [:pr/merge-order {:optional true} int?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -190,6 +233,10 @@
    [:agent/id keyword?]
    [:agent/instance-id {:optional true} uuid?]
    [:agent/context {:optional true} map?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def AgentCompleted
@@ -207,6 +254,10 @@
    [:agent/outcome {:optional true} [:enum :success :failure]]
    [:agent/output {:optional true} map?]
    [:agent/artifacts {:optional true} [:vector uuid?]]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def AgentChunk
@@ -221,6 +272,10 @@
    [:agent/id keyword?]
    [:chunk/delta string?]              ; The chunk of text
    [:chunk/done? {:optional true} boolean?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def AgentStatus
@@ -238,6 +293,10 @@
    [:status/type [:enum :reading :thinking :generating :validating :repairing :running :waiting :communicating]]
    [:status/detail {:optional true} string?]
    [:status/progress-percent {:optional true} int?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 ;------------------------------------------------------------------------------ Layer 3
@@ -255,6 +314,10 @@
    [:workaround-id {:optional true} keyword?]
    [:pattern-id keyword?]
    [:success? boolean?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def BackendSwitched
@@ -270,6 +333,10 @@
    [:to keyword?]
    [:reason string?]
    [:cooldown-until inst?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 ;------------------------------------------------------------------------------ Layer 4
@@ -289,6 +356,10 @@
    [:llm/model string?]
    [:llm/prompt-tokens {:optional true} int?]
    [:llm/request-id uuid?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def LLMResponse
@@ -308,6 +379,10 @@
    [:llm/total-tokens {:optional true} int?]
    [:llm/duration-ms {:optional true} int?]
    [:llm/cost-usd {:optional true} number?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 ;------------------------------------------------------------------------------ Layer 4.5
@@ -336,6 +411,10 @@
    [:dependency/previous-status {:optional true} keyword?]
    [:dependency/last-observed-at {:optional true} inst?]
    [:dependency/last-recovered-at {:optional true} inst?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def DependencyRecovered
@@ -361,6 +440,10 @@
    [:dependency/previous-status {:optional true} keyword?]
    [:dependency/last-observed-at {:optional true} inst?]
    [:dependency/last-recovered-at {:optional true} inst?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 ;------------------------------------------------------------------------------ Layer 5
@@ -456,6 +539,10 @@
    [:supervision/meta-eval? {:optional true} boolean?]
    [:supervision/confidence {:optional true} number?]
    [:workflow/phase {:optional true} keyword?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def InterventionRequested
@@ -479,6 +566,10 @@
    [:intervention/approval-required? {:optional true} boolean?]
    [:intervention/requested-at inst?]
    [:intervention/updated-at inst?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def InterventionStateChanged
@@ -505,6 +596,10 @@
    [:intervention/approval-required? {:optional true} boolean?]
    [:intervention/requested-at {:optional true} inst?]
    [:intervention/updated-at {:optional true} inst?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 ;; OCI container event schemas
@@ -521,6 +616,10 @@
    [:oci/container-id string?]
    [:oci/image-digest {:optional true} string?]
    [:oci/trust-level {:optional true} [:enum :untrusted :trusted :privileged]]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 (def ContainerCompleted
@@ -535,6 +634,10 @@
    [:oci/container-id string?]
    [:oci/exit-code int?]
    [:oci/duration-ms {:optional true} int?]
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
    [:message string?]])
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -29,8 +29,8 @@
    for backward compatibility — single-org single-workspace
    deployments populate them with stable singleton values; multi-
    tenant deployments populate per-request. The `core/create-envelope`
-   constructor accepts them as optional kwargs and stamps them onto
-   the envelope when present.")
+   constructor accepts them via an optional options map (5-arg
+   arity) and stamps them onto the envelope when present.")
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Shared payload schemas
@@ -41,89 +41,100 @@
    [:transition/type keyword?]
    [:transition/target keyword?]])
 
+;; ----------------------------------------------------------------------------
+;; Decision-14 identity quartet (added for miniforge-fleet's Phase E.1
+;; planning prerequisite #10). Defined ONCE here as a vector of Malli
+;; `:map` entries; every event schema below uses `with-identity` to
+;; append the same set. A single edit here propagates through every
+;; event without missing one.
+
+(def ^:private identity-entries
+  "Four optional fields every event schema accepts so subscribers
+   can scope authorization without retrofitting the wire format."
+  [[:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]])
+
+(defn with-identity
+  "Pure: append the Decision-14 identity quartet to `base-schema`'s
+   `:map` entries. Order in Malli `:map` is irrelevant for validation;
+   the helper keeps the per-event schemas focused on their own
+   payload while every event accepts the same identity set."
+  [base-schema]
+  (into base-schema identity-entries))
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event envelope (base schema all events must conform to)
 
 (def EventEnvelope
   "Base envelope schema for all events per N3 spec section 2."
-  [:map
-   [:event/type keyword?]              ; REQUIRED: event type identifier
-   [:event/id uuid?]                   ; REQUIRED: unique event ID
-   [:event/timestamp inst?]            ; REQUIRED: ISO-8601 timestamp
-   [:event/version string?]            ; REQUIRED: event schema version
-   [:event/sequence-number int?]       ; REQUIRED: monotonic sequence within workflow
-   [:workflow/id uuid?]                ; REQUIRED: workflow this event belongs to
-   [:workflow/phase {:optional true} keyword?]     ; OPTIONAL: current phase
-   [:agent/id {:optional true} keyword?]           ; OPTIONAL: agent that emitted event
-   [:agent/instance-id {:optional true} uuid?]     ; OPTIONAL: specific agent instance
-   [:event/parent-id {:optional true} uuid?]       ; OPTIONAL: parent event ID (for causality)
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])                ; REQUIRED: human-readable message
+  (with-identity
+   [:map
+    [:event/type keyword?]              ; REQUIRED: event type identifier
+    [:event/id uuid?]                   ; REQUIRED: unique event ID
+    [:event/timestamp inst?]            ; REQUIRED: ISO-8601 timestamp
+    [:event/version string?]            ; REQUIRED: event schema version
+    [:event/sequence-number int?]       ; REQUIRED: monotonic sequence within workflow
+    [:workflow/id uuid?]                ; REQUIRED: workflow this event belongs to
+    [:workflow/phase {:optional true} keyword?]     ; OPTIONAL: current phase
+    [:agent/id {:optional true} keyword?]           ; OPTIONAL: agent that emitted event
+    [:agent/instance-id {:optional true} uuid?]     ; OPTIONAL: specific agent instance
+    [:event/parent-id {:optional true} uuid?]       ; OPTIONAL: parent event ID (for causality)
+    [:message string?]]))               ; REQUIRED: human-readable message
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Workflow lifecycle event schemas
 
 (def WorkflowStarted
   "Schema for workflow/started event."
-  [:map
-   [:event/type [:= :workflow/started]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workflow/spec {:optional true} map?]
-   [:workflow/intent {:optional true} map?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/started]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/spec {:optional true} map?]
+    [:workflow/intent {:optional true} map?]
+    [:message string?]]))
 
 (def PhaseStarted
   "Schema for workflow/phase-started event."
-  [:map
-   [:event/type [:= :workflow/phase-started]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workflow/phase keyword?]
-   [:phase/expected-agent {:optional true} keyword?]
-   [:phase/context {:optional true} map?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/phase-started]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase keyword?]
+    [:phase/expected-agent {:optional true} keyword?]
+    [:phase/context {:optional true} map?]
+    [:message string?]]))
 
 (def PhaseCompleted
   "Schema for workflow/phase-completed event."
-  [:map
-   [:event/type [:= :workflow/phase-completed]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workflow/phase keyword?]
-   [:phase/duration-ms {:optional true} int?]
-   [:phase/outcome {:optional true} [:enum :success :failure :skipped]]
-   [:phase/artifacts {:optional true} [:vector uuid?]]
-   [:phase/transition-request {:optional true} TransitionRequest]
-   [:phase/redirect-to {:optional true} keyword?]
-   [:phase/error {:optional true} map?]
-   [:phase/tokens {:optional true} int?]
-   [:phase/cost-usd {:optional true} number?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/phase-completed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase keyword?]
+    [:phase/duration-ms {:optional true} int?]
+    [:phase/outcome {:optional true} [:enum :success :failure :skipped]]
+    [:phase/artifacts {:optional true} [:vector uuid?]]
+    [:phase/transition-request {:optional true} TransitionRequest]
+    [:phase/redirect-to {:optional true} keyword?]
+    [:phase/error {:optional true} map?]
+    [:phase/tokens {:optional true} int?]
+    [:phase/cost-usd {:optional true} number?]
+    [:message string?]]))
 
 (def WorkspacePersisted
   "Schema for workspace/persisted event.
@@ -131,62 +142,53 @@
    Emitted at phase boundaries when persist-workspace! has captured a
    checkpoint. Carries enough provenance for the dashboard / evidence
    bundle to surface 'inspect or resume from this archive'."
-  [:map
-   [:event/type [:= :workspace/persisted]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workspace/phase {:optional true} keyword?]
-   [:workspace/env-id {:optional true} string?]
-   [:workspace/branch {:optional true} string?]
-   [:workspace/commit-sha {:optional true} string?]
-   [:workspace/bundle-path {:optional true} string?]
-   [:workspace/tier {:optional true} [:enum :worktree :remote]]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :workspace/persisted]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workspace/phase {:optional true} keyword?]
+    [:workspace/env-id {:optional true} string?]
+    [:workspace/branch {:optional true} string?]
+    [:workspace/commit-sha {:optional true} string?]
+    [:workspace/bundle-path {:optional true} string?]
+    [:workspace/tier {:optional true} [:enum :worktree :remote]]
+    [:message string?]]))
 
 (def WorkflowCompleted
   "Schema for workflow/completed event."
-  [:map
-   [:event/type [:= :workflow/completed]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workflow/status [:enum :success :failure :cancelled]]
-   [:workflow/duration-ms {:optional true} int?]
-   [:workflow/evidence-bundle-id {:optional true} uuid?]
-   [:workflow/tokens {:optional true} int?]
-   [:workflow/cost-usd {:optional true} number?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/completed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/status [:enum :success :failure :cancelled]]
+    [:workflow/duration-ms {:optional true} int?]
+    [:workflow/evidence-bundle-id {:optional true} uuid?]
+    [:workflow/tokens {:optional true} int?]
+    [:workflow/cost-usd {:optional true} number?]
+    [:message string?]]))
 
 (def WorkflowFailed
   "Schema for workflow/failed event."
-  [:map
-   [:event/type [:= :workflow/failed]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workflow/failure-phase {:optional true} keyword?]
-   [:workflow/failure-reason {:optional true} string?]
-   [:workflow/error-details {:optional true} map?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/failed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/failure-phase {:optional true} keyword?]
+    [:workflow/failure-reason {:optional true} string?]
+    [:workflow/error-details {:optional true} map?]
+    [:message string?]]))
 
 ;------------------------------------------------------------------------------ Layer 1.5
 ;; PR lifecycle event schemas
@@ -197,254 +199,221 @@
    Emitted when a workflow creates a PR that should appear in the
    supervisory PR fleet. `:workflow/id` is the owning workflow run, which
    lets downstream consumers correlate the PR back to the run/spec dossier."
-  [:map
-   [:event/type [:= :pr/created]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:pr/repo string?]
-   [:pr/number int?]
-   [:pr/url string?]
-   [:pr/branch string?]
-   [:pr/title {:optional true} string?]
-   [:pr/author {:optional true} string?]
-   [:pr/merge-order {:optional true} int?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :pr/created]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:pr/repo string?]
+    [:pr/number int?]
+    [:pr/url string?]
+    [:pr/branch string?]
+    [:pr/title {:optional true} string?]
+    [:pr/author {:optional true} string?]
+    [:pr/merge-order {:optional true} int?]
+    [:message string?]]))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Agent lifecycle event schemas
 
 (def AgentStarted
   "Schema for agent/started event."
-  [:map
-   [:event/type [:= :agent/started]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workflow/phase {:optional true} keyword?]
-   [:agent/id keyword?]
-   [:agent/instance-id {:optional true} uuid?]
-   [:agent/context {:optional true} map?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :agent/started]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase {:optional true} keyword?]
+    [:agent/id keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:agent/context {:optional true} map?]
+    [:message string?]]))
 
 (def AgentCompleted
   "Schema for agent/completed event."
-  [:map
-   [:event/type [:= :agent/completed]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:agent/id keyword?]
-   [:agent/instance-id {:optional true} uuid?]
-   [:agent/duration-ms {:optional true} int?]
-   [:agent/outcome {:optional true} [:enum :success :failure]]
-   [:agent/output {:optional true} map?]
-   [:agent/artifacts {:optional true} [:vector uuid?]]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :agent/completed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:agent/id keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:agent/duration-ms {:optional true} int?]
+    [:agent/outcome {:optional true} [:enum :success :failure]]
+    [:agent/output {:optional true} map?]
+    [:agent/artifacts {:optional true} [:vector uuid?]]
+    [:message string?]]))
 
 (def AgentChunk
   "Schema for agent/chunk event (streaming output)."
-  [:map
-   [:event/type [:= :agent/chunk]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:agent/id keyword?]
-   [:chunk/delta string?]              ; The chunk of text
-   [:chunk/done? {:optional true} boolean?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :agent/chunk]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:agent/id keyword?]
+    [:chunk/delta string?]              ; The chunk of text
+    [:chunk/done? {:optional true} boolean?]
+    [:message string?]]))
 
 (def AgentStatus
   "Schema for agent/status event (real-time progress)."
-  [:map
-   [:event/type [:= :agent/status]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workflow/phase {:optional true} keyword?]
-   [:agent/id keyword?]
-   [:agent/instance-id {:optional true} uuid?]
-   [:status/type [:enum :reading :thinking :generating :validating :repairing :running :waiting :communicating]]
-   [:status/detail {:optional true} string?]
-   [:status/progress-percent {:optional true} int?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :agent/status]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase {:optional true} keyword?]
+    [:agent/id keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:status/type [:enum :reading :thinking :generating :validating :repairing :running :waiting :communicating]]
+    [:status/detail {:optional true} string?]
+    [:status/progress-percent {:optional true} int?]
+    [:message string?]]))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Self-healing event schemas
 
 (def WorkaroundApplied
   "Schema for self-healing/workaround-applied event."
-  [:map
-   [:event/type [:= :self-healing/workaround-applied]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:workaround-id {:optional true} keyword?]
-   [:pattern-id keyword?]
-   [:success? boolean?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :self-healing/workaround-applied]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workaround-id {:optional true} keyword?]
+    [:pattern-id keyword?]
+    [:success? boolean?]
+    [:message string?]]))
 
 (def BackendSwitched
   "Schema for self-healing/backend-switched event."
-  [:map
-   [:event/type [:= :self-healing/backend-switched]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:from keyword?]
-   [:to keyword?]
-   [:reason string?]
-   [:cooldown-until inst?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :self-healing/backend-switched]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:from keyword?]
+    [:to keyword?]
+    [:reason string?]
+    [:cooldown-until inst?]
+    [:message string?]]))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; LLM event schemas
 
 (def LLMRequest
   "Schema for llm/request event."
-  [:map
-   [:event/type [:= :llm/request]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:agent/id {:optional true} keyword?]
-   [:agent/instance-id {:optional true} uuid?]
-   [:llm/model string?]
-   [:llm/prompt-tokens {:optional true} int?]
-   [:llm/request-id uuid?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :llm/request]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:agent/id {:optional true} keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:llm/model string?]
+    [:llm/prompt-tokens {:optional true} int?]
+    [:llm/request-id uuid?]
+    [:message string?]]))
 
 (def LLMResponse
   "Schema for llm/response event."
-  [:map
-   [:event/type [:= :llm/response]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:agent/id {:optional true} keyword?]
-   [:agent/instance-id {:optional true} uuid?]
-   [:llm/model string?]
-   [:llm/request-id uuid?]
-   [:llm/completion-tokens {:optional true} int?]
-   [:llm/total-tokens {:optional true} int?]
-   [:llm/duration-ms {:optional true} int?]
-   [:llm/cost-usd {:optional true} number?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :llm/response]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:agent/id {:optional true} keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:llm/model string?]
+    [:llm/request-id uuid?]
+    [:llm/completion-tokens {:optional true} int?]
+    [:llm/total-tokens {:optional true} int?]
+    [:llm/duration-ms {:optional true} int?]
+    [:llm/cost-usd {:optional true} number?]
+    [:message string?]]))
 
 ;------------------------------------------------------------------------------ Layer 4.5
 ;; Dependency health event schemas
 
 (def DependencyHealthUpdated
   "Schema for dependency/health-updated event."
-  [:map
-   [:event/type [:= :dependency/health-updated]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id {:optional true} [:maybe uuid?]]
-   [:dependency/id keyword?]
-   [:dependency/source keyword?]
-   [:dependency/kind keyword?]
-   [:dependency/status keyword?]
-   [:dependency/failure-count int?]
-   [:dependency/window-size int?]
-   [:dependency/incident-counts map?]
-   [:dependency/vendor {:optional true} keyword?]
-   [:dependency/class {:optional true} keyword?]
-   [:dependency/retryability {:optional true} keyword?]
-   [:failure/class {:optional true} keyword?]
-   [:dependency/previous-status {:optional true} keyword?]
-   [:dependency/last-observed-at {:optional true} inst?]
-   [:dependency/last-recovered-at {:optional true} inst?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :dependency/health-updated]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:dependency/id keyword?]
+    [:dependency/source keyword?]
+    [:dependency/kind keyword?]
+    [:dependency/status keyword?]
+    [:dependency/failure-count int?]
+    [:dependency/window-size int?]
+    [:dependency/incident-counts map?]
+    [:dependency/vendor {:optional true} keyword?]
+    [:dependency/class {:optional true} keyword?]
+    [:dependency/retryability {:optional true} keyword?]
+    [:failure/class {:optional true} keyword?]
+    [:dependency/previous-status {:optional true} keyword?]
+    [:dependency/last-observed-at {:optional true} inst?]
+    [:dependency/last-recovered-at {:optional true} inst?]
+    [:message string?]]))
 
 (def DependencyRecovered
   "Schema for dependency/recovered event."
-  [:map
-   [:event/type [:= :dependency/recovered]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id {:optional true} [:maybe uuid?]]
-   [:dependency/id keyword?]
-   [:dependency/source keyword?]
-   [:dependency/kind keyword?]
-   [:dependency/status [:= :healthy]]
-   [:dependency/failure-count int?]
-   [:dependency/window-size int?]
-   [:dependency/incident-counts map?]
-   [:dependency/vendor {:optional true} keyword?]
-   [:dependency/class {:optional true} keyword?]
-   [:dependency/retryability {:optional true} keyword?]
-   [:failure/class {:optional true} keyword?]
-   [:dependency/previous-status {:optional true} keyword?]
-   [:dependency/last-observed-at {:optional true} inst?]
-   [:dependency/last-recovered-at {:optional true} inst?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :dependency/recovered]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:dependency/id keyword?]
+    [:dependency/source keyword?]
+    [:dependency/kind keyword?]
+    [:dependency/status [:= :healthy]]
+    [:dependency/failure-count int?]
+    [:dependency/window-size int?]
+    [:dependency/incident-counts map?]
+    [:dependency/vendor {:optional true} keyword?]
+    [:dependency/class {:optional true} keyword?]
+    [:dependency/retryability {:optional true} keyword?]
+    [:failure/class {:optional true} keyword?]
+    [:dependency/previous-status {:optional true} keyword?]
+    [:dependency/last-observed-at {:optional true} inst?]
+    [:dependency/last-recovered-at {:optional true} inst?]
+    [:message string?]]))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Privacy levels and OCI event schemas (N8)
@@ -526,119 +495,104 @@
 
 (def ToolUseEvaluated
   "Schema for supervision/tool-use-evaluated event."
-  [:map
-   [:event/type [:= :supervision/tool-use-evaluated]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:tool/name string?]
-   [:supervision/decision string?]
-   [:supervision/reasoning {:optional true} string?]
-   [:supervision/meta-eval? {:optional true} boolean?]
-   [:supervision/confidence {:optional true} number?]
-   [:workflow/phase {:optional true} keyword?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :supervision/tool-use-evaluated]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:tool/name string?]
+    [:supervision/decision string?]
+    [:supervision/reasoning {:optional true} string?]
+    [:supervision/meta-eval? {:optional true} boolean?]
+    [:supervision/confidence {:optional true} number?]
+    [:workflow/phase {:optional true} keyword?]
+    [:message string?]]))
 
 (def InterventionRequested
   "Schema for supervisory/intervention-requested event."
-  [:map
-   [:event/type [:= :supervisory/intervention-requested]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id {:optional true} [:maybe uuid?]]
-   [:intervention/id uuid?]
-   [:intervention/type keyword?]
-   [:intervention/target-type keyword?]
-   [:intervention/target-id any?]
-   [:intervention/requested-by string?]
-   [:intervention/request-source keyword?]
-   [:intervention/state keyword?]
-   [:intervention/justification {:optional true} string?]
-   [:intervention/details {:optional true} map?]
-   [:intervention/approval-required? {:optional true} boolean?]
-   [:intervention/requested-at inst?]
-   [:intervention/updated-at inst?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :supervisory/intervention-requested]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:intervention/id uuid?]
+    [:intervention/type keyword?]
+    [:intervention/target-type keyword?]
+    [:intervention/target-id any?]
+    [:intervention/requested-by string?]
+    [:intervention/request-source keyword?]
+    [:intervention/state keyword?]
+    [:intervention/justification {:optional true} string?]
+    [:intervention/details {:optional true} map?]
+    [:intervention/approval-required? {:optional true} boolean?]
+    [:intervention/requested-at inst?]
+    [:intervention/updated-at inst?]
+    [:message string?]]))
 
 (def InterventionStateChanged
   "Schema for supervisory/intervention-state-changed event."
-  [:map
-   [:event/type [:= :supervisory/intervention-state-changed]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id {:optional true} [:maybe uuid?]]
-   [:intervention/id uuid?]
-   [:intervention/state keyword?]
-   [:intervention/from-state {:optional true} keyword?]
-   [:intervention/type {:optional true} keyword?]
-   [:intervention/target-type {:optional true} keyword?]
-   [:intervention/target-id {:optional true} any?]
-   [:intervention/requested-by {:optional true} string?]
-   [:intervention/request-source {:optional true} keyword?]
-   [:intervention/justification {:optional true} string?]
-   [:intervention/details {:optional true} map?]
-   [:intervention/reason {:optional true} string?]
-   [:intervention/outcome {:optional true} any?]
-   [:intervention/approval-required? {:optional true} boolean?]
-   [:intervention/requested-at {:optional true} inst?]
-   [:intervention/updated-at {:optional true} inst?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :supervisory/intervention-state-changed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:intervention/id uuid?]
+    [:intervention/state keyword?]
+    [:intervention/from-state {:optional true} keyword?]
+    [:intervention/type {:optional true} keyword?]
+    [:intervention/target-type {:optional true} keyword?]
+    [:intervention/target-id {:optional true} any?]
+    [:intervention/requested-by {:optional true} string?]
+    [:intervention/request-source {:optional true} keyword?]
+    [:intervention/justification {:optional true} string?]
+    [:intervention/details {:optional true} map?]
+    [:intervention/reason {:optional true} string?]
+    [:intervention/outcome {:optional true} any?]
+    [:intervention/approval-required? {:optional true} boolean?]
+    [:intervention/requested-at {:optional true} inst?]
+    [:intervention/updated-at {:optional true} inst?]
+    [:message string?]]))
 
 ;; OCI container event schemas
 
 (def ContainerStarted
   "Schema for oci/container-started event."
-  [:map
-   [:event/type [:= :oci/container-started]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:oci/container-id string?]
-   [:oci/image-digest {:optional true} string?]
-   [:oci/trust-level {:optional true} [:enum :untrusted :trusted :privileged]]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :oci/container-started]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:oci/container-id string?]
+    [:oci/image-digest {:optional true} string?]
+    [:oci/trust-level {:optional true} [:enum :untrusted :trusted :privileged]]
+    [:message string?]]))
 
 (def ContainerCompleted
   "Schema for oci/container-completed event."
-  [:map
-   [:event/type [:= :oci/container-completed]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-   [:oci/container-id string?]
-   [:oci/exit-code int?]
-   [:oci/duration-ms {:optional true} int?]
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
+  (with-identity
+   [:map
+      [:event/type [:= :oci/container-completed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:oci/container-id string?]
+    [:oci/exit-code int?]
+    [:oci/duration-ms {:optional true} int?]
+    [:message string?]]))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/event-stream/test/ai/miniforge/event_stream/identity_propagation_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/identity_propagation_test.clj
@@ -1,0 +1,171 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+
+(ns ai.miniforge.event-stream.identity-propagation-test
+  "Tests for the Decision-14 identity-propagation fields landed for
+   miniforge-fleet's Phase E.1 prerequisite #10. Three areas:
+
+     1. `core/create-envelope` accepts the optional org / workspace /
+        repo / auth / parent / agent identity kwargs and stamps them
+        onto the envelope when present.
+     2. The legacy 4-arg arity still works (backward compatibility for
+        every in-tree caller that doesn't have identity context yet).
+     3. The new fields validate against `EventEnvelope` AND every
+        downstream event schema (so a producer adding the fields
+        doesn't trip the closed-map check)."
+  (:require
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.event-stream.schema :as schema]
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as m])
+  (:import
+   [java.util UUID]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers.
+
+(defn- fresh-stream []
+  (atom {:events [] :sequence-numbers {}}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; create-envelope: legacy 4-arg arity.
+
+(deftest test-legacy-arity-still-works
+  (testing "the 4-arg arity produces an envelope with no identity fields and validates"
+    (let [stream (fresh-stream)
+          wid (UUID/randomUUID)
+          ev (core/create-envelope stream :workflow/started wid "Started")]
+      (is (false? (contains? ev :org/id)))
+      (is (false? (contains? ev :workspace/id)))
+      (is (false? (contains? ev :repo/id)))
+      (is (false? (contains? ev :auth/context)))
+      (is (= :workflow/started (:event/type ev)))
+      (is (= wid (:workflow/id ev))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; create-envelope: identity kwargs.
+
+(deftest test-org-id-stamped-when-supplied
+  (testing ":org/id rides through to the envelope"
+    (let [stream (fresh-stream)
+          oid (UUID/randomUUID)
+          ev  (core/create-envelope stream :workflow/started (UUID/randomUUID) "msg"
+                                    {:org/id oid})]
+      (is (= oid (:org/id ev))))))
+
+(deftest test-workspace-id-stamped-when-supplied
+  (testing ":workspace/id rides through to the envelope"
+    (let [stream (fresh-stream)
+          wsid (UUID/randomUUID)
+          ev   (core/create-envelope stream :workflow/started (UUID/randomUUID) "msg"
+                                     {:workspace/id wsid})]
+      (is (= wsid (:workspace/id ev))))))
+
+(deftest test-repo-id-stamped-when-supplied
+  (testing ":repo/id rides through (string slug shape)"
+    (let [stream (fresh-stream)
+          ev (core/create-envelope stream :workflow/started (UUID/randomUUID) "msg"
+                                   {:repo/id "miniforge-ai/miniforge"})]
+      (is (= "miniforge-ai/miniforge" (:repo/id ev))))))
+
+(deftest test-auth-context-stamped-when-supplied
+  (testing ":auth/context rides through as an opaque map"
+    (let [stream (fresh-stream)
+          ctx {:auth/principal "alice" :auth/scopes #{:read :write}}
+          ev (core/create-envelope stream :workflow/started (UUID/randomUUID) "msg"
+                                   {:auth/context ctx})]
+      (is (= ctx (:auth/context ev))))))
+
+(deftest test-all-identity-fields-together
+  (testing "every identity field stamped together — full multi-tenant shape"
+    (let [stream (fresh-stream)
+          oid    (UUID/randomUUID)
+          wsid   (UUID/randomUUID)
+          parent (UUID/randomUUID)
+          aid    (UUID/randomUUID)
+          ev (core/create-envelope stream :workflow/started (UUID/randomUUID) "msg"
+                                   {:org/id            oid
+                                    :workspace/id      wsid
+                                    :repo/id           "owner/repo"
+                                    :auth/context      {:auth/principal "alice"}
+                                    :event/parent-id   parent
+                                    :agent/id          :planner
+                                    :agent/instance-id aid})]
+      (is (= oid (:org/id ev)))
+      (is (= wsid (:workspace/id ev)))
+      (is (= "owner/repo" (:repo/id ev)))
+      (is (= {:auth/principal "alice"} (:auth/context ev)))
+      (is (= parent (:event/parent-id ev)))
+      (is (= :planner (:agent/id ev)))
+      (is (= aid (:agent/instance-id ev))))))
+
+(deftest test-empty-opts-equivalent-to-legacy-arity
+  (testing "passing {} as opts is identical to the 4-arg arity"
+    (let [stream (fresh-stream)
+          wid (UUID/randomUUID)
+          a (core/create-envelope stream :workflow/started wid "m")
+          b (core/create-envelope stream :workflow/started wid "m" {})]
+      (is (= (dissoc a :event/id :event/timestamp :event/sequence-number)
+             (dissoc b :event/id :event/timestamp :event/sequence-number))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Schema acceptance — events with identity fields validate.
+
+(defn- envelope-shape
+  "Build a minimal EventEnvelope-compatible map with the identity fields populated."
+  [type-kw extra]
+  (merge {:event/type             type-kw
+          :event/id               (UUID/randomUUID)
+          :event/timestamp        (java.util.Date.)
+          :event/version          "1.0"
+          :event/sequence-number  0
+          :workflow/id            (UUID/randomUUID)
+          :org/id                 (UUID/randomUUID)
+          :workspace/id           (UUID/randomUUID)
+          :repo/id                "owner/repo"
+          :auth/context           {:auth/principal "alice"}
+          :message                "test"}
+         extra))
+
+(deftest test-envelope-with-identity-validates
+  (testing "EventEnvelope accepts the four identity fields"
+    (let [ev (envelope-shape :test/anything {})]
+      (is (m/validate schema/EventEnvelope ev)))))
+
+(deftest test-workflow-started-with-identity-validates
+  (testing "WorkflowStarted accepts the four identity fields (closed-map check passes)"
+    (let [ev (envelope-shape :workflow/started {})]
+      (is (m/validate schema/WorkflowStarted ev)))))
+
+(deftest test-phase-completed-with-identity-validates
+  (testing "PhaseCompleted accepts the four identity fields"
+    (let [ev (envelope-shape :workflow/phase-completed
+                             {:workflow/phase :plan})]
+      (is (m/validate schema/PhaseCompleted ev)))))
+
+(deftest test-tool-use-evaluated-with-identity-validates
+  (testing "ToolUseEvaluated accepts the four identity fields (later-added schema)"
+    (let [ev (envelope-shape :supervision/tool-use-evaluated
+                             {:tool/name "bash"
+                              :supervision/decision "approved"})]
+      (is (m/validate schema/ToolUseEvaluated ev)))))
+
+(deftest test-events-without-identity-still-validate
+  (testing "events without any identity fields still validate (backward compat)"
+    (let [ev {:event/type :workflow/started
+              :event/id (UUID/randomUUID)
+              :event/timestamp (java.util.Date.)
+              :event/version "1.0"
+              :event/sequence-number 0
+              :workflow/id (UUID/randomUUID)
+              :message "test"}]
+      (is (m/validate schema/WorkflowStarted ev)))))

--- a/components/event-stream/test/ai/miniforge/event_stream/identity_propagation_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/identity_propagation_test.clj
@@ -169,3 +169,29 @@
               :workflow/id (UUID/randomUUID)
               :message "test"}]
       (is (m/validate schema/WorkflowStarted ev)))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Sequence numbering — atomic increment under concurrency.
+
+(deftest test-sequence-numbers-are-unique-under-concurrency
+  (testing "concurrent create-envelope calls for the same workflow get distinct :event/sequence-number values"
+    ;; Reviewer flagged the original read-then-swap pattern as racey
+    ;; — concurrent producers could observe the same seq number.
+    ;; The fix uses `swap-vals!` for an atomic capture-and-increment.
+    ;; This test fans out N futures hitting the same workflow id and
+    ;; asserts that every emitted event got a distinct seq number.
+    (let [stream      (fresh-stream)
+          workflow-id (UUID/randomUUID)
+          n           500
+          futures     (doall
+                        (for [_ (range n)]
+                          (future
+                            (:event/sequence-number
+                              (core/create-envelope stream
+                                                    :workflow/started
+                                                    workflow-id
+                                                    "concurrency probe")))))
+          seqs        (mapv deref futures)]
+      (is (= n (count (distinct seqs)))
+          (str "expected " n " distinct seq numbers, got "
+               (count (distinct seqs)))))))


### PR DESCRIPTION
## Summary

Closes the OSS-side prerequisite captured in [miniforge-fleet's Phase E planning doc](https://github.com/miniforge-ai/miniforge-fleet/blob/main/docs/pull-requests/2026-05-04-chris-phase-e-planning.md) as item #10 (Decision 14): every event schema can carry an org / workspace / repo / auth quartet so subscribers scope authorization against the event log without retrofitting the wire format later.

## Schema additions

`EventEnvelope` and all 23 individual event schemas (closed-map validation requires each schema to enumerate the fields it accepts). All four are OPTIONAL so existing in-tree callers keep working unchanged:

| Field | Type | Notes |
|---|---|---|
| `:org/id` | UUID | Org tenancy boundary. |
| `:workspace/id` | UUID | Workspace tenancy boundary. |
| `:repo/id` | string | Slug-style repo id when applicable. |
| `:auth/context` | map | Caller-shaped auth context. |

Single-org single-workspace deployments populate the fields with stable singleton values; multi-tenant deployments populate per-request. Either way, **Phase F multi-tenant retrofit across the event log + subscribers + filters is a one-line schema move later instead of unbounded work** — exactly the trade Decision 14 makes.

## `core/create-envelope`

Gained a 5-arg arity that takes an opts map. Recognised keys cover the four identity fields plus `:event/parent-id`, `:agent/id`, `:agent/instance-id` (the latter three were already on the envelope schema but had no constructor path beyond direct map manipulation).

```clojure
(create-envelope stream :workflow/started workflow-id "Started"
                 {:org/id            org-id
                  :workspace/id      workspace-id
                  :repo/id           "owner/repo"
                  :auth/context      {:auth/principal "alice"}})
```

The legacy 4-arg arity delegates with empty opts so every existing caller stays unchanged.

## Test plan

- [x] `clj-kondo --lint components/event-stream` → 0 errors, 2 pre-existing warnings (unrelated unused-`testing` requires)
- [x] `clj -M:poly test brick:event-stream project:miniforge` → all event-stream tests pass; 12 new identity-propagation tests / 23 assertions
- [ ] CI green

## Out of scope (queued)

- **Wire-up at every emit site** — agent-runtime / workflow / phase code still calls the legacy 4-arg arity. A follow-up adopts the opts shape at producer level, keyed off whatever org/workspace context the agent runtime has at request time. This PR only puts the rail in place.
- **Outbox event emission** (`:zettel.promoted` etc.) lives in the next PR.

## Note on commit message

The commit body has a `[BYPASS-HOOKS: ...]` tag because the local pre-commit `bb test` step fails on a pre-existing `merge-resolution-test` issue (`git init -b main failed: no route matched` from `bb-proc` dispatch on this Mac) — verified by stashing this branch's changes and reproducing on origin/main. CI runs in a different environment and is expected green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)