### PR TITLE
fix: omit nil-valued chain bindings

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -77,7 +77,12 @@
     (keyword? binding) (get chain-input binding)))
 
 (defn resolve-bindings
-  "Resolve all input bindings for a step."
+  "Resolve all input bindings for a step.
+
+   Bindings that resolve to nil are omitted from the returned map
+   instead of being materialized as present-with-nil keys. This
+   preserves the semantic difference between an absent optional input
+   and an explicit nil value."
   [input-bindings prev-output chain-input]
   (reduce-kv
     (fn [acc k binding]

--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -81,7 +81,10 @@
   [input-bindings prev-output chain-input]
   (reduce-kv
     (fn [acc k binding]
-      (assoc acc k (resolve-binding binding prev-output chain-input)))
+      (let [resolved (resolve-binding binding prev-output chain-input)]
+        (if (nil? resolved)
+          acc
+          (assoc acc k resolved))))
     {}
     input-bindings))
 

--- a/components/workflow/test/ai/miniforge/workflow/chain_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_test.clj
@@ -78,6 +78,18 @@
       (is (= "static-label" (:label result)))
       (is (= "bonus" (:extra result))))))
 
+(deftest resolve-bindings-omits-missing-values-test
+  (testing "bindings that resolve to nil are omitted instead of materialized as nil-valued keys"
+    (let [bindings {:task :chain/input.task
+                    :notes :chain/input.notes
+                    :plan [:prev/last-phase-result :plan]}
+          prev-output {:last-phase-result {:plan "the plan"}}
+          chain-input {:task "build feature"}
+          result (chain/resolve-bindings bindings prev-output chain-input)]
+      (is (= "build feature" (:task result)))
+      (is (= "the plan" (:plan result)))
+      (is (not (contains? result :notes))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; run-chain tests
 

--- a/docs/archive/pr-logs/2026-05-08-fix-chain-bindings-omit-nil-values.md
+++ b/docs/archive/pr-logs/2026-05-08-fix-chain-bindings-omit-nil-values.md
@@ -1,0 +1,50 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix chain bindings omit nil values
+
+## Summary
+
+Stop Miniforge workflow chains from materializing missing optional
+inputs as present-with-`nil` keys during step handoff.
+
+This surfaced in Thesium Career on the JD/rank path: Career correctly
+omitted `:career/bootstrap-company-notes` when no company notes were
+provided, but Miniforge's chain runner reintroduced the key with a
+`nil` value while resolving `:step/input-bindings`. The downstream
+workflow schema treats that field as optional-string, so the presence
+of `nil` caused rank-step validation failure.
+
+## Changes
+
+- `components/workflow/src/ai/miniforge/workflow/chain.clj`
+  - change `resolve-bindings` to skip bindings that resolve to `nil`
+    instead of associating `key -> nil`
+- `components/workflow/test/ai/miniforge/workflow/chain_test.clj`
+  - add a regression test that proves missing optional bindings are
+    omitted from the resolved step input
+
+## Why
+
+Chain bindings should preserve the semantic difference between:
+
+- key absent
+- key present with a concrete value
+
+For optional workflow inputs, converting "absent" into
+"present-with-nil" breaks boundary validation and leaks transport
+mechanics into application contracts.
+
+## Verification
+
+- `clojure -M:test -e "(require 'ai.miniforge.workflow.chain-test) (let [result (clojure.test/run-tests 'ai.miniforge.workflow.chain-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
+
+## Result
+
+Workflow chains now preserve omitted optional inputs correctly across
+step handoff, which fixes the generic nil-materialization bug for
+Career and any other workflow family depending on optional chain input
+bindings.

--- a/docs/archive/pr-logs/2026-05-08-fix-chain-bindings-omit-nil-values.md
+++ b/docs/archive/pr-logs/2026-05-08-fix-chain-bindings-omit-nil-values.md
@@ -4,7 +4,7 @@
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
 
-# Fix chain bindings omit nil values
+# Fix chain bindings to omit nil values
 
 ## Summary
 


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Fix chain bindings omit nil values

## Summary

Stop Miniforge workflow chains from materializing missing optional
inputs as present-with-`nil` keys during step handoff.

This surfaced in Thesium Career on the JD/rank path: Career correctly
omitted `:career/bootstrap-company-notes` when no company notes were
provided, but Miniforge's chain runner reintroduced the key with a
`nil` value while resolving `:step/input-bindings`. The downstream
workflow schema treats that field as optional-string, so the presence
of `nil` caused rank-step validation failure.

## Changes

- `components/workflow/src/ai/miniforge/workflow/chain.clj`
  - change `resolve-bindings` to skip bindings that resolve to `nil`
    instead of associating `key -> nil`
- `components/workflow/test/ai/miniforge/workflow/chain_test.clj`
  - add a regression test that proves missing optional bindings are
    omitted from the resolved step input

## Why

Chain bindings should preserve the semantic difference between:

- key absent
- key present with a concrete value

For optional workflow inputs, converting "absent" into
"present-with-nil" breaks boundary validation and leaks transport
mechanics into application contracts.

## Verification

- `clojure -M:test -e "(require 'ai.miniforge.workflow.chain-test) (let [result (clojure.test/run-tests 'ai.miniforge.workflow.chain-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`

## Result

Workflow chains now preserve omitted optional inputs correctly across
step handoff, which fixes the generic nil-materialization bug for
Career and any other workflow family depending on optional chain input
bindings.
