### PR TITLE
fix(curator): fall back to worktree snapshot when impl-result has no :code/files

### DIFF
--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -198,11 +198,21 @@
          :code/files)))
 
 (defn- files-via-local-snapshot
-  "Collect files via local git status (non-capsule fallback)."
+  "Collect files via local git status (non-capsule fallback).
+
+   When `pre-session-snapshot` is missing (the implementer threw before
+   propagating it — e.g. supervisor termination in the middle of a stream),
+   fall back to an empty snapshot. Task worktrees start clean, so 'every
+   dirty file is implementer work' is the right interpretation. Without
+   this fallback, the curator emits :curator/no-files-written even when
+   the implementer wrote substantive files before the throw — observed
+   in the 2026-05-08 dogfood (Run 7 produced 285 LOC that the curator
+   rejected because the snapshot path short-circuited)."
   [{:keys [pre-session-snapshot worktree-path]}]
-  (when (and pre-session-snapshot worktree-path)
+  (when worktree-path
     (get (file-artifacts/collect-written-files
-          pre-session-snapshot worktree-path)
+          (or pre-session-snapshot (file-artifacts/empty-snapshot))
+          worktree-path)
          :code/files)))
 
 (def non-substantive-paths

--- a/components/agent/test/ai/miniforge/agent/curator_test.clj
+++ b/components/agent/test/ai/miniforge/agent/curator_test.clj
@@ -23,6 +23,9 @@
   (:require
    [ai.miniforge.agent.curator :as sut]
    [ai.miniforge.response.interface :as response]
+   [babashka.fs :as fs]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -234,6 +237,75 @@
                    :worktree-path "/tmp/ignored"
                    :llm-client nil})]
       (is (= :deterministic (get-in result [:output :code/curator-source]))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Local-snapshot fallback — recovers implementer work when impl-result
+;; never propagated :code/files (e.g. supervisor-terminated agent throw).
+
+(defn- git!
+  "Run git in `cwd`; throw on non-zero exit."
+  [cwd & args]
+  (let [r (apply shell/sh "git" "-C" (str cwd) args)]
+    (when-not (zero? (:exit r))
+      (throw (ex-info (str "git " (str/join " " args) " failed: " (:err r))
+                      {:cwd cwd :args args :result r})))
+    r))
+
+(defn- init-clean-worktree!
+  "Create a fresh git worktree with one committed file (clean HEAD)."
+  [worktree]
+  (git! worktree "init" "-b" "main")
+  (git! worktree "config" "user.email" "test@miniforge.ai")
+  (git! worktree "config" "user.name" "miniforge-test")
+  (git! worktree "config" "commit.gpgsign" "false")
+  (spit (fs/file worktree "README.md") "initial\n")
+  (git! worktree "add" "README.md")
+  (git! worktree "commit" "-m" "init"))
+
+(deftest curate-falls-back-to-worktree-snapshot-when-impl-result-missing-files
+  (testing "Run-7 dogfood regression: impl-result with no :code/files but a
+            dirty worktree must still surface implementer work via the local
+            snapshot fallback. Reproduces the case where the agent threw
+            mid-stream (e.g. supervisor termination) so invoke-with-llm
+            never reached collect-written-files, yet the writes are sitting
+            on disk waiting to be picked up."
+    (let [worktree (str (fs/create-temp-dir {:prefix "curator-fallback-"}))]
+      (try
+        (init-clean-worktree! worktree)
+        ;; Implementer-style writes that landed on disk before the throw.
+        (fs/create-dirs (fs/file worktree "src"))
+        (spit (fs/file worktree "src/added.clj") "(ns added)\n")
+        (spit (fs/file worktree "README.md") "modified\n")
+        (let [;; impl-result shape that response/failure produces — no :output map.
+              failure-result {:status :failed :success false
+                              :error {:message "agent terminated mid-stream"}}
+              result (sut/curate-implement-output
+                      {:implementer-result failure-result
+                       :worktree-path      worktree})]
+          (is (response/success? result)
+              "curator should fall back to the worktree snapshot and find the dirty files")
+          (let [files (get-in result [:output :code/files])
+                paths (set (map :path files))]
+            (is (contains? paths "src/added.clj"))
+            (is (contains? paths "README.md")
+                "modified-but-tracked file must also be picked up")))
+        (finally
+          (try (fs/delete-tree worktree) (catch Throwable _ nil)))))))
+
+(deftest curate-snapshot-fallback-still-fails-when-worktree-clean
+  (testing "fallback must NOT mask a genuinely empty diff — clean worktree
+            with no impl-result files still terminates with no-files-written"
+    (let [worktree (str (fs/create-temp-dir {:prefix "curator-clean-"}))]
+      (try
+        (init-clean-worktree! worktree)
+        (let [result (sut/curate-implement-output
+                      {:implementer-result {:status :failed :success false}
+                       :worktree-path      worktree})]
+          (is (= :curator/no-files-written
+                 (get-in result [:error :data :code])))
+          (is (= worktree (get-in result [:error :data :worktree-path]))))
+        (finally
+          (try (fs/delete-tree worktree) (catch Throwable _ nil)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment


### PR DESCRIPTION
## Summary
- `curator.files-via-local-snapshot` now uses an empty snapshot when `:pre-session-snapshot` is absent from the curator input. Task worktrees start clean, so "every dirty file is implementer work" is the right interpretation when no prior snapshot is available.
- Genuine empty-diff still terminates with `:curator/no-files-written` (locked by regression test).

## Why
Run-7 of the Stage 3 dogfood (workflow `c1598619`, 2026-05-08): implementer produced 285 LOC of valid work but the curator returned `:curator/no-files-written`, blocking the implement phase.

Root cause: when `agent/invoke` throws mid-stream (e.g. supervisor termination from PR #803), `invoke-with-llm`'s `collect-written-files` never runs, so `impl-result` becomes a `response/failure` with no `:output` map. The curator's `collect-files` chain then had nothing in `:implementer-result`, no `:pre-session-snapshot` on the input (no caller sets `:execution/pre-session-snapshot` in context), and short-circuited on the local-snapshot fallback. The implementer's writes were sitting on disk waiting to be picked up.

## Tests
- `curate-falls-back-to-worktree-snapshot-when-impl-result-missing-files` reproduces the Run-7 case: dirty worktree + failed `impl-result` + no `pre-session-snapshot` → curator surfaces files via the fallback.
- `curate-snapshot-fallback-still-fails-when-worktree-clean` locks the converse: clean worktree must still terminate.

## Test plan
- [ ] CI green
- [ ] Re-dogfood Stage 3 — implement should no longer fail with `:curator/no-files-written` when the agent terminates mid-stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)