### PR TITLE
feat(n13): batched review poster + `pr review --post`

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -497,6 +497,10 @@
   :pr/review-unknown-out "pr-review: unknown --out format: {fmt}"
   :pr/review-failed "pr-review failed: {message}"
   :pr/review-summary "policy-review: {total} violations ({auto-fixable} auto-fixable, {needs-review} need review) across {files} files / {rules} rules"
+  :pr/review-posted "Posted review with {count} inline comment(s): {url}"
+  :pr/review-post-failed "pr-review post failed: [{code}] {message}"
+  :pr/review-post-skipped-empty "No violations to post — skipping review post."
+  :pr/review-post-pr-required "pr-review --post requires a PR number (use the URL flow or pass --pr-number)."
 
   ;; PR Monitor
   :pr/monitor-starting "Starting PR monitor for author: {author}"

--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -501,6 +501,7 @@
   :pr/review-post-failed "pr-review post failed: [{code}] {message}"
   :pr/review-post-skipped-empty "No violations to post — skipping review post."
   :pr/review-post-pr-required "pr-review --post requires a PR number (use the URL flow or pass --pr-number)."
+  :pr/review-post-commit-id-required "pr-review --post requires a PR head SHA. The URL flow derives it from the worktree HEAD after `gh pr checkout` — pass --commit-id explicitly if calling the by-path flow on a worktree that isn't at the PR head."
 
   ;; PR Monitor
   :pr/monitor-starting "Starting PR monitor for author: {author}"

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -598,7 +598,9 @@
            :standards {:default ".standards"}
            :pack      {:alias :p}
            :rules     {:alias :r}
-           :out       {:default "table"}}}
+           :out       {:default "table"}
+           :post      {:coerce :boolean}
+           :pr-number {:coerce :long}}}
    {:cmds ["pr" "respond"] :fn pr-respond-cmd :args->opts [:url]}
    {:cmds ["pr" "merge"]   :fn pr-merge-cmd   :args->opts [:url]}
    {:cmds ["pr" "monitor"] :fn pr-monitor-cmd :spec {:author {:alias :a}

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -146,7 +146,8 @@
                      (:standards opts) (assoc :standards (:standards opts))
                      (:pack opts)      (assoc :pack (:pack opts))
                      (:rules opts)     (assoc :rules (:rules opts))
-                     (:out opts)       (assoc :out (keyword (:out opts)))))))))))
+                     (:out opts)       (assoc :out (keyword (:out opts)))
+                     (:post opts)      (assoc :post? true :pr-number number)))))))))
 
       :else
       (display/print-error

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -102,8 +102,13 @@
 
    Checks out the given PR URL, derives the base ref, and runs the
    compliance-scanner in PR-scoped read-only mode. Prints rendered
-   review comments per N13 §2.3 to stdout. Does NOT post comments and
-   does NOT apply fixes.
+   review comments per N13 §2.3 to stdout.
+
+   With `--post`, additionally batch-posts the rendered comments as a
+   single PR review (event=COMMENT) via `pr-lifecycle/post-review!`.
+   The PR head SHA needed for the create-review API is derived from
+   the worktree HEAD after `gh pr checkout`. Does NOT apply fixes —
+   that remains the Comment Response Agent's job.
 
    Pass --repo <path> + --base <ref> to operate on an existing checkout
    without using `gh` to fetch metadata; `--url <pr-url>` is the default

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
@@ -20,19 +20,30 @@
   "PR Review implementation — N13 §2.2 Standards Reviewer entry point.
 
    Runs compliance-scanner in PR-scoped read-only mode, classifies
-   violations, and emits comment records ready to post via a provider
-   connector. Does NOT post comments and does NOT apply fixes — that
-   is the job of downstream pipeline steps and the Comment Response
-   Agent.
+   violations, and emits comment records (the renderer shape from
+   `compliance-scanner.comments`).
 
-   This namespace exposes a programmatic `run-pr-review!` that the
-   `pr review <url>` CLI entry point in `commands.pr` delegates to."
+   By default this namespace only renders to stdout — the operator
+   can pipe / inspect / forward the output. When invoked with the
+   `--post` flag (URL flow) or `:post? true` programmatically, it
+   additionally batch-posts the comments as a single PR review via
+   `pr-lifecycle/post-review!` (N13 §2.2 Standards Reviewer end-cap).
+   Posting requires a PR number and the PR head SHA (`commit-id`);
+   the URL flow derives both automatically.
+
+   This namespace does NOT apply fixes — that remains the Comment
+   Response Agent's job per the pr-monitoring-workflow informative
+   spec.
+
+   The programmatic entry point is `run-pr-review!`, called from
+   `commands.pr`'s `pr-review-cmd`."
   (:require
    [babashka.fs :as fs]
    [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
+   [clojure.string :as str]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.compliance-scanner.interface :as scanner]
@@ -147,9 +158,18 @@
 
 (defn- maybe-post-review!
   "When the operator opted in via `--post`, batch-post the rendered
-   comments to the PR via `pr-lifecycle.interface/post-review!`. Skips
-   silently when there are zero comments to post."
-  [repo-path pr-number result]
+   comments to the PR via `pr-lifecycle.interface/post-review!`.
+
+   Surfaces three operator-facing outcomes:
+   - zero violations  → prints the `:pr/review-post-skipped-empty`
+                        info line so the operator sees that the post
+                        step ran and intentionally did nothing
+   - PR number missing → prints `:pr/review-post-pr-required` error
+   - missing commit-id → prints `:pr/review-post-commit-id-required` error
+   - otherwise        → posts via `post-review!` and prints either
+                        `:pr/review-posted` (with comment count + URL)
+                        or `:pr/review-post-failed` (typed code + msg)."
+  [repo-path pr-number commit-id result]
   (let [comments (:pr-review/comments result)]
     (cond
       (not (pos? (count comments)))
@@ -159,9 +179,13 @@
       (display/print-error
        (messages/t :pr/review-post-pr-required))
 
+      (or (nil? commit-id) (and (string? commit-id) (str/blank? commit-id)))
+      (display/print-error
+       (messages/t :pr/review-post-commit-id-required))
+
       :else
       (let [body (review-summary-body result)
-            r    (pr-lifecycle/post-review! repo-path pr-number body comments)]
+            r    (pr-lifecycle/post-review! repo-path pr-number commit-id body comments)]
         (if (dag/ok? r)
           (display/print-info
            (messages/t :pr/review-posted
@@ -188,8 +212,12 @@
        :out        - :table | :edn | :json (default :table)
        :post?      - when truthy, batch-post the rendered comments to
                      the PR as a single review (event=COMMENT). Requires
-                     :pr-number.
+                     :pr-number AND :commit-id.
        :pr-number  - integer PR number, required when :post? is truthy.
+       :commit-id  - full SHA of the PR's head commit. Required when
+                     :post? is truthy. Falls back to
+                     `(pr-lifecycle/git-head-sha repo-path)` when
+                     omitted, on the assumption the PR is checked out.
 
    Side effects:
    - Prints summary + comments to stdout in the requested format.
@@ -198,7 +226,7 @@
 
    Returns the pr-review result map (per scanner/pr-review)."
   [repo-path
-   {:keys [base-ref standards pack rules out post? pr-number]
+   {:keys [base-ref standards pack rules out post? pr-number commit-id]
     :or   {standards default-standards-path
            rules     :all
            out       :table}}]
@@ -222,7 +250,10 @@
       (display/print-error
        (messages/t :pr/review-unknown-out {:fmt (name out)})))
     (when post?
-      (maybe-post-review! repo-path pr-number result))
+      (maybe-post-review! repo-path
+                          pr-number
+                          (or commit-id (pr-lifecycle/git-head-sha repo-path))
+                          result))
     result))
 
 (defn run-pr-review-by-path-cmd
@@ -262,7 +293,8 @@
                                                    (cond
                                                      (integer? (:pr-number opts)) (:pr-number opts)
                                                      :else (try (Long/parseLong (str (:pr-number opts)))
-                                                                (catch Exception _ nil))))))
+                                                                (catch Exception _ nil))))
+                          (:commit-id opts) (assoc :commit-id (:commit-id opts))))
         (catch Exception e
           (display/print-error
            (messages/t :pr/review-failed {:message (ex-message e)})))))))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
@@ -35,7 +35,9 @@
    [clojure.pprint :as pprint]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]
-   [ai.miniforge.compliance-scanner.interface :as scanner]))
+   [ai.miniforge.compliance-scanner.interface :as scanner]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
 
 (def ^:private default-standards-path ".standards")
 
@@ -132,6 +134,44 @@
   [comments]
   (println (json/generate-string comments {:key-fn name})))
 
+(defn- review-summary-body
+  "Build the markdown body for the posted PR review from the
+   pr-review result's summary."
+  [{:pr-review/keys [summary]}]
+  (messages/t :pr/review-summary
+              {:total        (:total summary)
+               :auto-fixable (:auto-fixable summary)
+               :needs-review (:needs-review summary)
+               :files        (:files-affected summary)
+               :rules        (:rules-violated summary)}))
+
+(defn- maybe-post-review!
+  "When the operator opted in via `--post`, batch-post the rendered
+   comments to the PR via `pr-lifecycle.interface/post-review!`. Skips
+   silently when there are zero comments to post."
+  [repo-path pr-number result]
+  (let [comments (:pr-review/comments result)]
+    (cond
+      (not (pos? (count comments)))
+      (display/print-info (messages/t :pr/review-post-skipped-empty))
+
+      (not (pos-int? pr-number))
+      (display/print-error
+       (messages/t :pr/review-post-pr-required))
+
+      :else
+      (let [body (review-summary-body result)
+            r    (pr-lifecycle/post-review! repo-path pr-number body comments)]
+        (if (dag/ok? r)
+          (display/print-info
+           (messages/t :pr/review-posted
+                       {:count (:comment-count (:data r))
+                        :url   (:url (:data r))}))
+          (display/print-error
+           (messages/t :pr/review-post-failed
+                       {:code    (str (get-in r [:error :code]))
+                        :message (get-in r [:error :message])})))))))
+
 (defn run-pr-review!
   "Run a PR-scoped standards review against an existing repo checkout.
 
@@ -146,13 +186,19 @@
        :pack       - pack name or path (optional)
        :rules      - rule selector string or keyword (default :all)
        :out        - :table | :edn | :json (default :table)
+       :post?      - when truthy, batch-post the rendered comments to
+                     the PR as a single review (event=COMMENT). Requires
+                     :pr-number.
+       :pr-number  - integer PR number, required when :post? is truthy.
 
    Side effects:
    - Prints summary + comments to stdout in the requested format.
+   - When :post? is set: posts a single review batching all comments
+     via `pr-lifecycle.interface/post-review!`.
 
    Returns the pr-review result map (per scanner/pr-review)."
   [repo-path
-   {:keys [base-ref standards pack rules out]
+   {:keys [base-ref standards pack rules out post? pr-number]
     :or   {standards default-standards-path
            rules     :all
            out       :table}}]
@@ -175,6 +221,8 @@
       :table (emit-table (:pr-review/comments result))
       (display/print-error
        (messages/t :pr/review-unknown-out {:fmt (name out)})))
+    (when post?
+      (maybe-post-review! repo-path pr-number result))
     result))
 
 (defn run-pr-review-by-path-cmd
@@ -208,7 +256,13 @@
                           (:standards opts) (assoc :standards (:standards opts))
                           (:pack opts)      (assoc :pack (:pack opts))
                           (:rules opts)     (assoc :rules (:rules opts))
-                          (:out opts)       (assoc :out (keyword (:out opts)))))
+                          (:out opts)       (assoc :out (keyword (:out opts)))
+                          (:post opts)      (assoc :post? true)
+                          (:pr-number opts) (assoc :pr-number
+                                                   (cond
+                                                     (integer? (:pr-number opts)) (:pr-number opts)
+                                                     :else (try (Long/parseLong (str (:pr-number opts)))
+                                                                (catch Exception _ nil))))))
         (catch Exception e
           (display/print-error
            (messages/t :pr/review-failed {:message (ex-message e)})))))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -221,6 +221,89 @@
                    {:thread-id thread-id :thread thread})))
       result)))
 
+;------------------------------------------------------------------------------ Layer 1.5
+;; Batched review posting (N13 §2.2 Standards Reviewer)
+
+(defn- run-gh-with-stdin
+  "Run a `gh` command piping `stdin-body` over stdin. Returns the
+   same DAG-shaped result as `run-gh-command`. Used for `gh api ...
+   --input -` invocations where the JSON body is too large or too
+   nested to fit `-f`/`-F` field-pair encoding."
+  [args worktree-path stdin-body]
+  (try
+    (let [result (apply process/shell
+                        {:dir (str worktree-path)
+                         :in stdin-body
+                         :out :string
+                         :err :string
+                         :continue true}
+                        args)]
+      (if (zero? (:exit result))
+        (dag/ok {:output (str/trim (:out result ""))})
+        (dag/err :gh-command-failed
+                 (str/trim (:err result ""))
+                 {:exit-code (:exit result)
+                  :command args})))
+    (catch Exception e
+      (dag/err :gh-exception (.getMessage e)))))
+
+(defn- review-comment->github-comment
+  "Translate one comment record from `compliance-scanner.comments`
+   (`{:comment/path :comment/line :comment/body ...}`) to the inline-
+   comment shape GitHub's create-review API expects."
+  [c]
+  (let [path (or (:comment/path c) (:path c))
+        line (or (:comment/line c) (:line c))
+        body (or (:comment/body c) (:body c))]
+    {:path path
+     :line line
+     :side "RIGHT"
+     :body body}))
+
+(defn post-review!
+  "Post a single PR review batching multiple inline comments.
+
+   Uses the create-a-review REST endpoint
+   (`POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews`) so all
+   violations land as one expandable review on the PR rather than as
+   N separate top-level comments. The review is posted with
+   `event: \"COMMENT\"` — non-blocking, no approval/changes-requested
+   semantics. The `{owner}/{repo}` template is resolved by `gh` from
+   the worktree's git remote.
+
+   Arguments:
+   - worktree-path: path to a checkout of the PR's repo (gh resolves
+                    `{owner}/{repo}` from this worktree's remote)
+   - pr-number:     pull request number
+   - body:          review summary string (markdown)
+   - comments:      vector of comment records. Either the renderer
+                    shape (`:comment/path`/`:comment/line`/`:comment/body`)
+                    or a flatter `{:path :line :body}` shape; both
+                    accepted.
+
+   Returns DAG result with `{:review-id :url :state}` on success or
+   typed error on failure."
+  [worktree-path pr-number body comments]
+  (let [payload   {:body     body
+                   :event    "COMMENT"
+                   :comments (mapv review-comment->github-comment comments)}
+        json-body (json/generate-string payload)
+        endpoint  (str "repos/{owner}/{repo}/pulls/" pr-number "/reviews")
+        result    (run-gh-with-stdin
+                   ["gh" "api" endpoint "-X" "POST" "--input" "-"]
+                   worktree-path
+                   json-body)]
+    (if (dag/ok? result)
+      (try
+        (let [parsed (json/parse-string (:output (:data result)) true)]
+          (dag/ok {:review-id (:id parsed)
+                   :url       (:html_url parsed)
+                   :state     (:state parsed)
+                   :comment-count (count (:comments payload))}))
+        (catch Exception e
+          (dag/err :json-parse-error (.getMessage e))))
+      result)))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; High-level conversation operations
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -260,6 +260,22 @@
      :side "RIGHT"
      :body body}))
 
+(defn git-head-sha
+  "Return the full HEAD SHA of `worktree-path`, or nil if `git
+   rev-parse` fails. Used to populate `commit_id` for the create-review
+   API, which 422s on inline `comments[]` payloads without it."
+  [worktree-path]
+  (try
+    (let [r (process/shell {:dir (str worktree-path)
+                            :out :string
+                            :err :string
+                            :continue true}
+                           "git" "rev-parse" "HEAD")]
+      (when (zero? (:exit r))
+        (let [sha (str/trim (:out r ""))]
+          (when (seq sha) sha))))
+    (catch Throwable _ nil)))
+
 (defn post-review!
   "Post a single PR review batching multiple inline comments.
 
@@ -275,34 +291,44 @@
    - worktree-path: path to a checkout of the PR's repo (gh resolves
                     `{owner}/{repo}` from this worktree's remote)
    - pr-number:     pull request number
+   - commit-id:     full SHA of the PR's head commit. REQUIRED — the
+                    create-review API returns 422 on inline
+                    `comments[]` payloads without it. Callers can use
+                    `(git-head-sha worktree-path)` after a
+                    `gh pr checkout` to derive this.
    - body:          review summary string (markdown)
    - comments:      vector of comment records. Either the renderer
                     shape (`:comment/path`/`:comment/line`/`:comment/body`)
                     or a flatter `{:path :line :body}` shape; both
                     accepted.
 
-   Returns DAG result with `{:review-id :url :state}` on success or
-   typed error on failure."
-  [worktree-path pr-number body comments]
-  (let [payload   {:body     body
-                   :event    "COMMENT"
-                   :comments (mapv review-comment->github-comment comments)}
-        json-body (json/generate-string payload)
-        endpoint  (str "repos/{owner}/{repo}/pulls/" pr-number "/reviews")
-        result    (run-gh-with-stdin
-                   ["gh" "api" endpoint "-X" "POST" "--input" "-"]
-                   worktree-path
-                   json-body)]
-    (if (dag/ok? result)
-      (try
-        (let [parsed (json/parse-string (:output (:data result)) true)]
-          (dag/ok {:review-id (:id parsed)
-                   :url       (:html_url parsed)
-                   :state     (:state parsed)
-                   :comment-count (count (:comments payload))}))
-        (catch Exception e
-          (dag/err :json-parse-error (.getMessage e))))
-      result)))
+   Returns DAG result with `{:review-id :url :state :comment-count}`
+   on success or typed error on failure."
+  [worktree-path pr-number commit-id body comments]
+  (if (or (nil? commit-id) (and (string? commit-id) (str/blank? commit-id)))
+    (dag/err :missing-commit-id
+             "post-review! requires a non-blank commit-id (PR head SHA)"
+             {:pr-number pr-number})
+    (let [payload   {:body      body
+                     :event     "COMMENT"
+                     :commit_id commit-id
+                     :comments  (mapv review-comment->github-comment comments)}
+          json-body (json/generate-string payload)
+          endpoint  (str "repos/{owner}/{repo}/pulls/" pr-number "/reviews")
+          result    (run-gh-with-stdin
+                     ["gh" "api" endpoint "-X" "POST" "--input" "-"]
+                     worktree-path
+                     json-body)]
+      (if (dag/ok? result)
+        (try
+          (let [parsed (json/parse-string (:output (:data result)) true)]
+            (dag/ok {:review-id (:id parsed)
+                     :url       (:html_url parsed)
+                     :state     (:state parsed)
+                     :comment-count (count (:comments payload))}))
+          (catch Exception e
+            (dag/err :json-parse-error (.getMessage e))))
+        result))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; High-level conversation operations

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -314,6 +314,12 @@
      ; => {:success true :data {:reply-posted true :resolved true :thread-id \"PRRT_...\"}}"
   github/link-fix-pr-to-comment)
 
+(def git-head-sha
+  "Return the full HEAD SHA of `worktree-path`, or nil. Convenience
+   helper for callers of `post-review!` that need a `commit-id` after
+   a `gh pr checkout`."
+  github/git-head-sha)
+
 (def post-review!
   "Post a single PR review batching multiple inline comments
    (N13 §2.2 Standards Reviewer end-cap).
@@ -327,6 +333,10 @@
    Arguments:
    - worktree-path: path to a checkout of the PR's repo
    - pr-number:     pull request number
+   - commit-id:     full SHA of the PR's head commit. REQUIRED — the
+                    create-review API returns 422 on inline
+                    `comments[]` payloads without it. Use
+                    `git-head-sha` after a `gh pr checkout`.
    - body:          review summary string (markdown)
    - comments:      vector of comment records — accepts either the
                     `compliance-scanner.comments` shape
@@ -337,11 +347,12 @@
    on success or typed error on failure.
 
    Example:
-     (post-review! \"/path/to/repo\" 808 \"Standards review (3 findings)\"
-                   [{:comment/path \"src/foo.clj\"
-                     :comment/line 42
-                     :comment/body \"...payload edn block...\"}])
-     ; => {:success true :data {:review-id ... :url \"https://...\" ...}}"
+     (let [sha (git-head-sha \"/path/to/repo\")]
+       (post-review! \"/path/to/repo\" 808 sha \"Standards review (3 findings)\"
+                     [{:comment/path \"src/foo.clj\"
+                       :comment/line 42
+                       :comment/body \"...payload edn block...\"}]))
+     ; => {:ok? true :data {:review-id ... :url \"https://...\" ...}}"
   github/post-review!)
 
 ;------------------------------------------------------------------------------ Layer 3

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -314,6 +314,36 @@
      ; => {:success true :data {:reply-posted true :resolved true :thread-id \"PRRT_...\"}}"
   github/link-fix-pr-to-comment)
 
+(def post-review!
+  "Post a single PR review batching multiple inline comments
+   (N13 §2.2 Standards Reviewer end-cap).
+
+   Bundles N violations into one review via the create-a-review REST
+   endpoint so the PR shows a single expandable review instead of N
+   top-level comments. Posted with `event: \"COMMENT\"` (non-blocking
+   — no approval / changes-requested semantics). The `{owner}/{repo}`
+   API template is resolved by `gh` from the worktree's git remote.
+
+   Arguments:
+   - worktree-path: path to a checkout of the PR's repo
+   - pr-number:     pull request number
+   - body:          review summary string (markdown)
+   - comments:      vector of comment records — accepts either the
+                    `compliance-scanner.comments` shape
+                    (`:comment/path`/`:comment/line`/`:comment/body`)
+                    or a flatter `{:path :line :body}` shape.
+
+   Returns DAG result with `{:review-id :url :state :comment-count}`
+   on success or typed error on failure.
+
+   Example:
+     (post-review! \"/path/to/repo\" 808 \"Standards review (3 findings)\"
+                   [{:comment/path \"src/foo.clj\"
+                     :comment/line 42
+                     :comment/body \"...payload edn block...\"}])
+     ; => {:success true :data {:review-id ... :url \"https://...\" ...}}"
+  github/post-review!)
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Fix loop
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
@@ -1,0 +1,139 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.github-test
+  "Tests for the github.clj batched-review posting (N13 §2.2)."
+  (:require [babashka.process :as process]
+            [cheshire.core :as json]
+            [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.dag-executor.interface :as dag]
+            [ai.miniforge.pr-lifecycle.github :as github]))
+
+;; ── helpers ──────────────────────────────────────────────────────────
+
+(defn- capture-shell
+  "Replace `process/shell` with a stub that records every invocation
+   (args + stdin) into `calls-atom` and returns `result`. Returns a
+   no-arg fn suitable for `with-redefs`."
+  [calls-atom result]
+  (fn [opts & args]
+    (swap! calls-atom conj {:opts opts :args (vec args)})
+    result))
+
+(def ^:private fake-review-success
+  (json/generate-string
+   {:id 999001 :html_url "https://github.com/o/r/pull/42#pullrequestreview-999001"
+    :state "COMMENTED"}))
+
+(def ^:private comment-renderer-shape
+  [{:comment/author "miniforge-policy-evaluator[bot]"
+    :comment/path   "components/agent/src/foo.clj"
+    :comment/line   42
+    :comment/body   "**Rule X**\n\n```edn\n:comment/payload\n{:violation/rule-id :x}\n```"}
+   {:comment/author "miniforge-policy-evaluator[bot]"
+    :comment/path   "components/agent/src/bar.clj"
+    :comment/line   7
+    :comment/body   "**Rule Y**"}])
+
+(def ^:private flat-shape
+  [{:path "src/baz.clj" :line 1 :body "flat-shape body"}])
+
+;; ── tests ────────────────────────────────────────────────────────────
+
+(deftest post-review-uses-create-review-endpoint-via-stdin
+  (testing "post-review! shells out to the right gh api endpoint with --input -"
+    (let [calls (atom [])
+          stub  (capture-shell calls
+                               {:exit 0 :out fake-review-success :err ""})]
+      (with-redefs [process/shell stub]
+        (let [_ (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape)
+              call (first @calls)]
+          (is (= 1 (count @calls)))
+          (is (= ["gh" "api"
+                  "repos/{owner}/{repo}/pulls/42/reviews"
+                  "-X" "POST" "--input" "-"]
+                 (:args call)))
+          (is (= "/some/repo" (str (get-in call [:opts :dir])))
+              "gh runs in the worktree dir so {owner}/{repo} resolves")
+          (is (= :string (get-in call [:opts :out])))
+          (is (= true (get-in call [:opts :continue]))
+              "exit codes returned, not thrown"))))))
+
+(deftest post-review-translates-renderer-shape-to-github-comments
+  (testing "stdin JSON has comments[] with path/line/side/body keys per render record"
+    (let [calls (atom [])
+          stub  (capture-shell calls
+                               {:exit 0 :out fake-review-success :err ""})]
+      (with-redefs [process/shell stub]
+        (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape))
+      (let [stdin (get-in (first @calls) [:opts :in])
+            payload (json/parse-string stdin true)]
+        (is (= "summary" (:body payload)))
+        (is (= "COMMENT" (:event payload)))
+        (is (= 2 (count (:comments payload))))
+        (is (= {:path "components/agent/src/foo.clj"
+                :line 42
+                :side "RIGHT"
+                :body (-> comment-renderer-shape first :comment/body)}
+               (first (:comments payload))))))))
+
+(deftest post-review-accepts-flat-shape-too
+  (testing "{:path :line :body} also flows through unchanged"
+    (let [calls (atom [])
+          stub  (capture-shell calls
+                               {:exit 0 :out fake-review-success :err ""})]
+      (with-redefs [process/shell stub]
+        (github/post-review! "/some/repo" 42 "summary" flat-shape))
+      (let [stdin (get-in (first @calls) [:opts :in])
+            payload (json/parse-string stdin true)]
+        (is (= 1 (count (:comments payload))))
+        (is (= {:path "src/baz.clj" :line 1 :side "RIGHT" :body "flat-shape body"}
+               (first (:comments payload))))))))
+
+(deftest post-review-success-shape
+  (testing "successful gh response is parsed into {:review-id :url :state :comment-count}"
+    (let [calls (atom [])
+          stub  (capture-shell calls
+                               {:exit 0 :out fake-review-success :err ""})]
+      (with-redefs [process/shell stub]
+        (let [r (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape)]
+          (is (dag/ok? r))
+          (is (= 999001 (-> r :data :review-id)))
+          (is (= "COMMENTED" (-> r :data :state)))
+          (is (= 2 (-> r :data :comment-count)))
+          (is (re-find #"#pullrequestreview-999001" (-> r :data :url))))))))
+
+(deftest post-review-gh-failure-returns-typed-error
+  (testing "non-zero gh exit yields :gh-command-failed with stderr + exit code"
+    (let [calls (atom [])
+          stub  (capture-shell calls
+                               {:exit 1 :out "" :err "HTTP 422: Unprocessable Entity"})]
+      (with-redefs [process/shell stub]
+        (let [r (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape)]
+          (is (not (dag/ok? r)))
+          (is (= :gh-command-failed (get-in r [:error :code])))
+          (is (re-find #"422" (get-in r [:error :message])))
+          (is (= 1 (get-in r [:error :data :exit-code]))))))))
+
+(deftest post-review-shell-exception-returns-typed-error
+  (testing "process/shell throwing yields :gh-exception"
+    (let [stub (fn [& _] (throw (ex-info "boom" {})))]
+      (with-redefs [process/shell stub]
+        (let [r (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape)]
+          (is (not (dag/ok? r)))
+          (is (= :gh-exception (get-in r [:error :code]))))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
@@ -40,6 +40,8 @@
    {:id 999001 :html_url "https://github.com/o/r/pull/42#pullrequestreview-999001"
     :state "COMMENTED"}))
 
+(def ^:private fixture-sha "deadbeefcafef00ddeadbeefcafef00ddeadbeef")
+
 (def ^:private comment-renderer-shape
   [{:comment/author "miniforge-policy-evaluator[bot]"
     :comment/path   "components/agent/src/foo.clj"
@@ -61,7 +63,7 @@
           stub  (capture-shell calls
                                {:exit 0 :out fake-review-success :err ""})]
       (with-redefs [process/shell stub]
-        (let [_ (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape)
+        (let [_ (github/post-review! "/some/repo" 42 fixture-sha "summary" comment-renderer-shape)
               call (first @calls)]
           (is (= 1 (count @calls)))
           (is (= ["gh" "api"
@@ -75,16 +77,18 @@
               "exit codes returned, not thrown"))))))
 
 (deftest post-review-translates-renderer-shape-to-github-comments
-  (testing "stdin JSON has comments[] with path/line/side/body keys per render record"
+  (testing "stdin JSON has comments[] with path/line/side/body keys per render record + commit_id"
     (let [calls (atom [])
           stub  (capture-shell calls
                                {:exit 0 :out fake-review-success :err ""})]
       (with-redefs [process/shell stub]
-        (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape))
+        (github/post-review! "/some/repo" 42 fixture-sha "summary" comment-renderer-shape))
       (let [stdin (get-in (first @calls) [:opts :in])
             payload (json/parse-string stdin true)]
         (is (= "summary" (:body payload)))
         (is (= "COMMENT" (:event payload)))
+        (is (= fixture-sha (:commit_id payload))
+            "commit_id (PR head SHA) MUST be present — GitHub 422s without it on inline comments[]")
         (is (= 2 (count (:comments payload))))
         (is (= {:path "components/agent/src/foo.clj"
                 :line 42
@@ -92,13 +96,26 @@
                 :body (-> comment-renderer-shape first :comment/body)}
                (first (:comments payload))))))))
 
+(deftest post-review-rejects-missing-commit-id
+  (testing "missing/blank commit-id short-circuits with :missing-commit-id, never shells out"
+    (let [calls (atom [])
+          stub  (capture-shell calls {:exit 0 :out "" :err ""})]
+      (doseq [bad [nil "" "   "]]
+        (with-redefs [process/shell stub]
+          (let [r (github/post-review! "/some/repo" 42 bad "summary" comment-renderer-shape)]
+            (is (not (dag/ok? r)))
+            (is (= :missing-commit-id (get-in r [:error :code]))
+                (str "input was " (pr-str bad))))))
+      (is (zero? (count @calls))
+          "no shell invocation when commit-id missing — fail fast"))))
+
 (deftest post-review-accepts-flat-shape-too
   (testing "{:path :line :body} also flows through unchanged"
     (let [calls (atom [])
           stub  (capture-shell calls
                                {:exit 0 :out fake-review-success :err ""})]
       (with-redefs [process/shell stub]
-        (github/post-review! "/some/repo" 42 "summary" flat-shape))
+        (github/post-review! "/some/repo" 42 fixture-sha "summary" flat-shape))
       (let [stdin (get-in (first @calls) [:opts :in])
             payload (json/parse-string stdin true)]
         (is (= 1 (count (:comments payload))))
@@ -111,7 +128,7 @@
           stub  (capture-shell calls
                                {:exit 0 :out fake-review-success :err ""})]
       (with-redefs [process/shell stub]
-        (let [r (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape)]
+        (let [r (github/post-review! "/some/repo" 42 fixture-sha "summary" comment-renderer-shape)]
           (is (dag/ok? r))
           (is (= 999001 (-> r :data :review-id)))
           (is (= "COMMENTED" (-> r :data :state)))
@@ -124,7 +141,7 @@
           stub  (capture-shell calls
                                {:exit 1 :out "" :err "HTTP 422: Unprocessable Entity"})]
       (with-redefs [process/shell stub]
-        (let [r (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape)]
+        (let [r (github/post-review! "/some/repo" 42 fixture-sha "summary" comment-renderer-shape)]
           (is (not (dag/ok? r)))
           (is (= :gh-command-failed (get-in r [:error :code])))
           (is (re-find #"422" (get-in r [:error :message])))
@@ -134,6 +151,6 @@
   (testing "process/shell throwing yields :gh-exception"
     (let [stub (fn [& _] (throw (ex-info "boom" {})))]
       (with-redefs [process/shell stub]
-        (let [r (github/post-review! "/some/repo" 42 "summary" comment-renderer-shape)]
+        (let [r (github/post-review! "/some/repo" 42 fixture-sha "summary" comment-renderer-shape)]
           (is (not (dag/ok? r)))
           (is (= :gh-exception (get-in r [:error :code]))))))))

--- a/docs/pull-requests/2026-05-08-feat-n13-batched-review-poster.md
+++ b/docs/pull-requests/2026-05-08-feat-n13-batched-review-poster.md
@@ -1,0 +1,104 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# feat(n13): batched review poster + `pr review --post`
+
+## Overview
+
+Make the N13 Standards Reviewer pipeline run end-to-end against a real
+PR. The renderer landed with #808; this PR adds the **comment poster**
+on top — `bb miniforge pr review <pr-url> --post` now executes the full
+loop: scan → classify → render → post a single batched review on the PR.
+
+This is the first half of the deferred N13 implementation work called
+out in the #808 PR doc. The other half (webhook subscriber so it
+auto-fires on `pull_request.opened`) lands in a follow-up.
+
+## What's new
+
+### `components/pr-lifecycle`
+
+- `github.clj` `post-review!` (Layer 1.5) — bundles N inline comments
+  into one PR review via the create-a-review REST endpoint
+  (`POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews`) with
+  `event: "COMMENT"` (non-blocking — no approval / changes-requested
+  semantics). Single API call instead of N top-level comments;
+  reviewers see one expandable review on the PR.
+- `github.clj` `run-gh-with-stdin` (Layer 0 helper) — `gh api ... --input -`
+  invocation with stdin piping. Needed because `gh api -f`/`-F` can't
+  cleanly encode the nested `comments[]` array.
+- `github.clj` `review-comment->github-comment` (Layer 1.5 helper) —
+  translates the renderer's `:comment/path` / `:comment/line` /
+  `:comment/body` shape (or a flatter `{:path :line :body}`) to the
+  `{path,line,side,body}` shape the GitHub API expects.
+- `interface.clj` `post-review!` re-export with full docstring.
+- `test/.../github_test.clj` — 6 tests / 22 assertions covering:
+  endpoint + stdin wiring, payload shape from both renderer + flat
+  shapes, success parsing into `{:review-id :url :state :comment-count}`,
+  non-zero exit → typed `:gh-command-failed` error with stderr,
+  `process/shell` exception → typed `:gh-exception`. Mocks via
+  `with-redefs` on `babashka.process/shell`.
+
+### `bases/cli`
+
+- `pr_review.clj` — `run-pr-review!` learns `:post?` and `:pr-number`
+  options. New `maybe-post-review!` private helper handles the post
+  call: skips silently on zero violations, errors out if `--post` was
+  set without a resolvable PR number, otherwise builds a markdown
+  body from the review summary and dispatches to
+  `pr-lifecycle/post-review!`.
+- `pr.clj` — URL flow plumbs `--post` through and supplies the
+  `:pr-number` parsed from the URL automatically.
+- `main.clj` — `pr review` flag spec gains `:post {:coerce :boolean}`
+  and `:pr-number {:coerce :long}`.
+- `messages/en-US.edn` — four new keys under `:pr/review-`:
+  `posted`, `post-failed`, `post-skipped-empty`, `post-pr-required`.
+
+## Operator surface
+
+```bash
+# Render only (existing behavior — unchanged)
+bb miniforge pr review https://github.com/<org>/<repo>/pull/<n>
+
+# Render + post one batched review on the PR
+bb miniforge pr review https://github.com/<org>/<repo>/pull/<n> --post
+
+# By-path flow (operator already has the checkout)
+bb miniforge pr review --repo . --base origin/main --post --pr-number 808
+```
+
+## Reuse anchors
+
+| New surface         | Reuses                                                   |
+| ------------------- | -------------------------------------------------------- |
+| `post-review!`      | Existing `pr-lifecycle/github.clj` patterns (`process/shell`, `dag/ok`/`dag/err`, `cheshire`) |
+| Renderer payload    | `compliance-scanner/comments` from #808 — unchanged      |
+| URL flow            | Existing `parse-pr-url`, `checkout-pr!`, `gh-pr-base-ref` |
+| Auth                | `gh` CLI's existing user token — no new auth surface     |
+
+## What's NOT in this PR (deferred)
+
+- Webhook subscriber for `pull_request.opened` / `synchronize` (so the
+  pipeline auto-fires, no operator hand needed).
+- Listener registry implementation (schema is in N13 §2.7; read/write/
+  dispatch is a follow-up).
+- Resume Signal Dispatcher.
+- `:closed-loop-pr` workflow type composing all eight step workflows
+  from N13 §3.
+
+## Test plan
+
+- [x] `clj-kondo` on touched files: clean.
+- [x] `github_test`: 6 tests / 22 assertions pass under `:dev:test`.
+- [x] Full namespace tree loads under `:dev:test`.
+- [ ] `bb pre-commit`: pending (will run on commit).
+- [ ] Live smoke test against an open miniforge PR with 1+ standards
+      violations (manual, post-merge).
+
+## References
+
+- Spec: N13 §2.2 (Standards Reviewer step), §2.3 (Comment payload schema).
+- Renderer: shipped in #808 (`components/compliance-scanner/.../comments.clj`).
+- Companion to upcoming webhook PR.


### PR DESCRIPTION
## Summary

Make the N13 Standards Reviewer pipeline run end-to-end against a real PR. The renderer landed in [#808](https://github.com/miniforge-ai/miniforge/pull/808); this PR adds the **comment poster** on top — `bb miniforge pr review <pr-url> --post` now executes the full loop: scan → classify → render → post a single batched review on the PR.

Full PR doc: [`docs/pull-requests/2026-05-08-feat-n13-batched-review-poster.md`](docs/pull-requests/2026-05-08-feat-n13-batched-review-poster.md).

## What's new

- `pr-lifecycle/github.clj` `post-review!` (Layer 1.5) — bundles N inline comments into one PR review via the create-a-review REST endpoint with `event: "COMMENT"` (non-blocking). One API call, one expandable review on the PR.
- `pr-lifecycle/github.clj` `run-gh-with-stdin` helper — `gh api ... --input -` invocation with stdin piping (the nested `comments[]` array doesn't fit `-f`/`-F` field encoding).
- `pr-lifecycle/interface.clj` re-export with full docstring.
- `bases/cli/.../pr_review.clj` — `run-pr-review!` learns `:post?` + `:pr-number`. New `maybe-post-review!` private helper handles the post call.
- `bases/cli/.../pr.clj` URL flow plumbs `--post` through and supplies `:pr-number` from the parsed URL automatically.
- `main.clj` flag spec + four new `:pr/review-*` i18n keys.
- 6 tests / 22 assertions in `github_test.clj` covering endpoint wiring, payload shape (renderer + flat), success parsing, typed `:gh-command-failed` on non-zero exit, typed `:gh-exception` on shell throw.

## Operator surface

```bash
bb miniforge pr review <pr-url>          # render only (existing)
bb miniforge pr review <pr-url> --post   # render + post one batched review
bb miniforge pr review --repo . --base origin/main --post --pr-number 808
```

## Test plan

- [x] `clj-kondo` on touched files: clean.
- [x] `github_test`: 6 / 22 pass.
- [x] Full namespace tree loads under `:dev:test`.
- [x] `bb pre-commit`: ✅ ALL PRE-COMMIT CHECKS PASSED.
- [ ] Live smoke test against an open miniforge PR with 1+ standards violations (manual, post-merge).

## Commit budget

422 insertions across 8 files. Override rationale: cohesive feature slice — impl + tests + CLI wiring + i18n + docs landed together so the operator's first end-to-end run works against a real PR. Splitting would create artificial cross-PR deps. Logged via `MINIFORGE_COMMIT_BUDGET_OVERRIDE`.

## What's NOT in this PR (deferred)

- Webhook subscriber for `pull_request.opened` / `synchronize` (so the loop auto-fires) — next PR.
- Listener registry implementation.
- Resume Signal Dispatcher.
- `:closed-loop-pr` workflow type composing all eight step workflows from N13 §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)