### PR TITLE
fix: harden workflow step failure observability

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -381,7 +381,6 @@
   (cond-> ["exec"
            "--json"
            "--sandbox=workspace-write"
-           "--ask-for-approval=never"
            "--skip-git-repo-check"]
     true   (into ["-c" "approval_policy=never"])
     true   (into ["-c" "mcp_servers.artifact.required=true"])

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -161,9 +161,10 @@
     (let [args ((private-fn 'codex-args) {:prompt "fix bug"})]
       (is (= "exec" (first args)))
       (is (some #(= "--json" %) args))
-      ;; Explicit sandbox + approval replaces the deprecated --full-auto alias.
+      ;; Explicit sandbox + approval-policy config replaces the deprecated
+      ;; --full-auto alias.
       (is (some #(= "--sandbox=workspace-write" %) args))
-      (is (some #(= "--ask-for-approval=never" %) args))
+      (is (some #(re-matches #"approval_policy=\"?never\"?" %) args))
       (is (some #(= "--skip-git-repo-check" %) args))
       (is (= "fix bug" (last args))))))
 
@@ -173,10 +174,8 @@
       ;; mcp_servers.artifact.required=true makes Codex fail loudly if our
       ;; MCP server doesn't initialize, instead of running without it.
       (is (some #(= "mcp_servers.artifact.required=true" %) args))
-      ;; --ask-for-approval=never sets the policy via the CLI flag, and
-      ;; approval_policy=never sets it via -c so any config.toml default
-      ;; cannot relax it. Two different knobs, both pinned to never.
-      (is (some #(= "--ask-for-approval=never" %) args))
+      ;; approval_policy=never is set via -c so any config.toml default
+      ;; cannot relax it.
       (is (some #(re-matches #"approval_policy=\"?never\"?" %) args)))))
 
 (deftest codex-args-model-test

--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -157,6 +157,7 @@
               output (:execution/output result)
               step-result {:step/id step-id
                            :step/workflow-id workflow-id
+                           :step/execution-id (:execution/id result)
                            :step/status (:execution/status result)
                            :step/output output
                            :step/chain-id chain-id

--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -77,7 +77,12 @@
     (keyword? binding) (get chain-input binding)))
 
 (defn resolve-bindings
-  "Resolve all input bindings for a step."
+  "Resolve all input bindings for a step.
+
+   Bindings that resolve to nil are omitted from the returned map
+   instead of being materialized as present-with-nil keys. This
+   preserves the semantic difference between an absent optional input
+   and an explicit nil value."
   [input-bindings prev-output chain-input]
   (reduce-kv
     (fn [acc k binding]

--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -81,7 +81,10 @@
   [input-bindings prev-output chain-input]
   (reduce-kv
     (fn [acc k binding]
-      (assoc acc k (resolve-binding binding prev-output chain-input)))
+      (let [resolved (resolve-binding binding prev-output chain-input)]
+        (if (nil? resolved)
+          acc
+          (assoc acc k resolved))))
     {}
     input-bindings))
 

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -89,6 +89,18 @@
                         {:error (ex-message ex)})))))
       ctx)))
 
+(defn- entered-phase-context?
+  "True when the phase enter step established the standard phase context.
+
+   Enter-path exceptions are normalized by the interceptor error handler into
+   `{:phase {:status :failed :error ...}}`, but that path does not populate the
+   normal enter-context keys like `:started-at` or `:result`. In that state the
+   corresponding `:leave` function has no valid phase context to finalize."
+  [phase-result]
+  (and (map? phase-result)
+       (contains? phase-result :started-at)
+       (contains? phase-result :result)))
+
 (defn extract-phase-result
   "Extract phase result from context."
   [ctx]
@@ -226,7 +238,9 @@
         ctx-entered (execute-enter interceptor ctx-clean)
         phase-result (extract-phase-result ctx-entered)
         phase-result-gated (apply-gate-validation interceptor phase-result ctx-entered)
-        ctx-left (execute-leave interceptor (assoc ctx-entered :phase phase-result-gated))]
+        ctx-left (if (entered-phase-context? phase-result-gated)
+                   (execute-leave interceptor (assoc ctx-entered :phase phase-result-gated))
+                   (assoc ctx-entered :phase phase-result-gated))]
     [ctx-left (extract-phase-result ctx-left)]))
 
 (defn process-phase-result

--- a/components/workflow/test/ai/miniforge/workflow/chain_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_events_test.clj
@@ -47,7 +47,8 @@
 (defn mock-pipeline-success
   "Mock run-pipeline that always succeeds."
   [_workflow _input _opts]
-  {:execution/status :completed
+  {:execution/id (random-uuid)
+   :execution/status :completed
    :execution/output {:artifacts []
                       :phase-results {}
                       :last-phase-result {:plan "the-plan"}
@@ -56,7 +57,8 @@
 (defn mock-pipeline-failure
   "Mock run-pipeline that always fails."
   [_workflow _input _opts]
-  {:execution/status :failed
+  {:execution/id (random-uuid)
+   :execution/status :failed
    :execution/output {:artifacts []
                       :phase-results {}
                       :last-phase-result {:success? false}
@@ -104,6 +106,8 @@
             (is (= :step-1 (:step/id step-started)))
             (is (= 0 (:step/index step-started)))
             (is (= :workflow-a (:step/workflow-id step-started))))
+          (let [first-step (first (:chain/step-results result))]
+            (is (uuid? (:step/execution-id first-step))))
           (let [completed (last (:events @stream))]
             (is (= :test-chain (:chain/id completed)))
             (is (= 2 (:chain/step-count completed)))
@@ -138,6 +142,8 @@
             (is (= :step-1 (:step/id step-failed)))
             (is (= 0 (:step/index step-failed)))
             (is (= "LLM timeout" (:chain/error step-failed))))
+          (let [failed-step (first (:chain/step-results result))]
+            (is (uuid? (:step/execution-id failed-step))))
           (let [chain-failed (last (:events @stream))]
             (is (= :step-1 (:chain/failed-step chain-failed)))
             (is (= "LLM timeout" (:chain/error chain-failed)))))))))

--- a/components/workflow/test/ai/miniforge/workflow/chain_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_test.clj
@@ -78,6 +78,18 @@
       (is (= "static-label" (:label result)))
       (is (= "bonus" (:extra result))))))
 
+(deftest resolve-bindings-omits-missing-values-test
+  (testing "bindings that resolve to nil are omitted instead of materialized as nil-valued keys"
+    (let [bindings {:task :chain/input.task
+                    :notes :chain/input.notes
+                    :plan [:prev/last-phase-result :plan]}
+          prev-output {:last-phase-result {:plan "the plan"}}
+          chain-input {:task "build feature"}
+          result (chain/resolve-bindings bindings prev-output chain-input)]
+      (is (= "build feature" (:task result)))
+      (is (= "the plan" (:plan result)))
+      (is (not (contains? result :notes))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; run-chain tests
 

--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -163,6 +163,34 @@
       (is (nil? (get-in ctx-after [:phase :phase/transition-request]))
           "Stale phase transition request must not leak"))))
 
+(deftest enter-failure-skips-leave-test
+  (testing "execute-phase-lifecycle does not invoke leave when enter fails before phase context exists"
+    (let [leave-called? (atom false)
+          interceptor {:config {:phase :failing-phase}
+                       :enter (fn [_]
+                                (throw (ex-info "enter failed" {:phase :failing-phase})))
+                       :leave (fn [ctx]
+                                (reset! leave-called? true)
+                                ctx)
+                       :error (fn [ctx ex]
+                                (-> ctx
+                                    (assoc-in [:phase :status] :failed)
+                                    (assoc-in [:phase :error]
+                                              {:message (ex-message ex)
+                                               :data (ex-data ex)})))}
+          ctx {:execution/input {}
+               :execution/phase-results {}
+               :execution/errors []
+               :execution/response-chain {:operation :test :succeeded? true}
+               :execution/artifacts []
+               :execution/files-written []
+               :execution/metrics {:tokens 0 :duration-ms 0}}
+          [ctx-after phase-result] (exec/execute-phase-lifecycle interceptor ctx)]
+      (is (false? @leave-called?)
+          "Leave must not run when enter failed before establishing phase context")
+      (is (= :failed (:status phase-result)))
+      (is (= "enter failed" (get-in ctx-after [:phase :error :message]))))))
+
 ;; ============================================================================
 ;; Fix 5: Review feedback survives :phase clearing (Run 9 bug)
 ;;

--- a/docs/archive/pr-logs/2026-05-08-fix-chain-bindings-omit-nil-values.md
+++ b/docs/archive/pr-logs/2026-05-08-fix-chain-bindings-omit-nil-values.md
@@ -1,0 +1,50 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix chain bindings omit nil values
+
+## Summary
+
+Stop Miniforge workflow chains from materializing missing optional
+inputs as present-with-`nil` keys during step handoff.
+
+This surfaced in Thesium Career on the JD/rank path: Career correctly
+omitted `:career/bootstrap-company-notes` when no company notes were
+provided, but Miniforge's chain runner reintroduced the key with a
+`nil` value while resolving `:step/input-bindings`. The downstream
+workflow schema treats that field as optional-string, so the presence
+of `nil` caused rank-step validation failure.
+
+## Changes
+
+- `components/workflow/src/ai/miniforge/workflow/chain.clj`
+  - change `resolve-bindings` to skip bindings that resolve to `nil`
+    instead of associating `key -> nil`
+- `components/workflow/test/ai/miniforge/workflow/chain_test.clj`
+  - add a regression test that proves missing optional bindings are
+    omitted from the resolved step input
+
+## Why
+
+Chain bindings should preserve the semantic difference between:
+
+- key absent
+- key present with a concrete value
+
+For optional workflow inputs, converting "absent" into
+"present-with-nil" breaks boundary validation and leaks transport
+mechanics into application contracts.
+
+## Verification
+
+- `clojure -M:test -e "(require 'ai.miniforge.workflow.chain-test) (let [result (clojure.test/run-tests 'ai.miniforge.workflow.chain-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
+
+## Result
+
+Workflow chains now preserve omitted optional inputs correctly across
+step handoff, which fixes the generic nil-materialization bug for
+Career and any other workflow family depending on optional chain input
+bindings.

--- a/docs/archive/pr-logs/2026-05-08-fix-chain-bindings-omit-nil-values.md
+++ b/docs/archive/pr-logs/2026-05-08-fix-chain-bindings-omit-nil-values.md
@@ -4,7 +4,7 @@
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
 
-# Fix chain bindings omit nil values
+# Fix chain bindings to omit nil values
 
 ## Summary
 

--- a/docs/archive/pr-logs/2026-05-09-fix-workflow-leave-skip-and-chain-execution-observability.md
+++ b/docs/archive/pr-logs/2026-05-09-fix-workflow-leave-skip-and-chain-execution-observability.md
@@ -1,0 +1,57 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix workflow leave-after-enter-failure and chain step observability
+
+## Summary
+
+Fix two generic Miniforge workflow runtime issues exposed by the
+Thesium Career JD fixture path:
+
+1. chain step results now retain the underlying workflow execution id
+2. workflow execution no longer invokes a phase `:leave` function when
+   the phase `:enter` step failed before phase context was established
+
+Together these changes stop opaque follow-on failures and make chained
+workflow failures inspectable at the exact step execution boundary.
+
+## Changes
+
+- `components/workflow/src/ai/miniforge/workflow/chain.clj`
+  - retain `:step/execution-id` on each chain step result
+- `components/workflow/src/ai/miniforge/workflow/execution.clj`
+  - add `entered-phase-context?`
+  - skip `execute-leave` when enter-phase failure produced only a
+    failed error map and never established `:started-at` / `:result`
+- `components/workflow/test/ai/miniforge/workflow/chain_events_test.clj`
+  - assert step execution ids are retained on success and failure
+- `components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj`
+  - add regression coverage proving leave is not called after an
+    enter-phase exception that occurred before phase context existed
+
+## Why
+
+Before this fix, an enter-phase exception in a workflow step could be
+followed by an unrelated `NullPointerException` from the phase's leave
+handler, because leave tried to finalize a phase that had never
+initialized `:started-at` or `:result`.
+
+That turned the real failure into a misleading secondary crash.
+
+Separately, chain results lacked the workflow execution ids needed to
+inspect the exact failing step in Miniforge event streams.
+
+## Verification
+
+- `git diff --check`
+- `bb test`
+
+## Result
+
+Miniforge now preserves the original enter-phase failure and exposes
+the exact workflow execution id for each chained step, which gives
+product CLIs enough information to point operators directly at the
+right event stream for diagnosis.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Fix workflow leave-after-enter-failure and Codex workflow observability

## Summary

Fix three generic Miniforge workflow runtime issues exposed by the
Thesium Career JD fixture path:

1. chain step results now retain the underlying workflow execution id
2. workflow execution no longer invokes a phase `:leave` function when
   the phase `:enter` step failed before phase context was established
3. sandboxed Codex library runs now seed a writable runtime
   `CODEX_HOME` instead of assuming `~/.codex` is writable

Together these changes stop opaque follow-on failures and make chained
workflow failures inspectable at the exact step execution boundary.

## Changes

- `components/workflow/src/ai/miniforge/workflow/chain.clj`
  - retain `:step/execution-id` on each chain step result
- `components/workflow/src/ai/miniforge/workflow/execution.clj`
  - add `entered-phase-context?`
  - skip `execute-leave` when enter-phase failure produced only a
    failed error map and never established `:started-at` / `:result`
- `components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj`
  - seed a writable runtime `CODEX_HOME` under `java.io.tmpdir`
  - copy auth/config seed files from the user's configured Codex home
  - pass backend-specific process env through both streaming and
    non-streaming CLI execution
- `components/workflow/test/ai/miniforge/workflow/chain_events_test.clj`
  - assert step execution ids are retained on success and failure
- `components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj`
  - add regression coverage proving leave is not called after an
    enter-phase exception that occurred before phase context existed
- `components/llm/test/ai/miniforge/llm/args_fn_test.clj`
  - cover runtime `CODEX_HOME` seeding

## Why

Before this fix, an enter-phase exception in a workflow step could be
followed by an unrelated `NullPointerException` from the phase's leave
handler, because leave tried to finalize a phase that had never
initialized `:started-at` or `:result`.

That turned the real failure into a misleading secondary crash.

Separately, chain results lacked the workflow execution ids needed to
inspect the exact failing step in Miniforge event streams.

And once the Thesium workflow boundary was correctly selecting Codex as
an injected backend, Miniforge's library execution path still failed in
sandboxed runs because the Codex CLI tried to write under `~/.codex`.

## Verification

- `git diff --check`
- `clojure -M:test -e "(require 'ai.miniforge.llm.args-fn-test 'ai.miniforge.workflow.chain-events-test 'ai.miniforge.workflow.run7-regression-test) (let [result (clojure.test/run-tests 'ai.miniforge.llm.args-fn-test 'ai.miniforge.workflow.chain-events-test 'ai.miniforge.workflow.run7-regression-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`

## Result

Miniforge now preserves the original enter-phase failure, exposes the
exact workflow execution id for each chained step, and lets Codex run
as a real injected library backend under sandboxed workflow execution
instead of failing on local session-state writes.
