### PR TITLE
fix(test): add explicit phase loader support

### DIFF
--- a/components/phase/resources/config/phase/test-support-namespaces.edn
+++ b/components/phase/resources/config/phase/test-support-namespaces.edn
@@ -1,0 +1,2 @@
+{:phase/namespaces
+ [ai.miniforge.phase.loader-support]}

--- a/components/phase/src/ai/miniforge/phase/loader.clj
+++ b/components/phase/src/ai/miniforge/phase/loader.clj
@@ -24,7 +24,7 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Configuration
 
-(def phase-loader-config-resource
+(def ^:dynamic phase-loader-config-resource
   "Classpath resource path for phase implementation namespace declarations."
   "config/phase/namespaces.edn")
 

--- a/components/phase/test/ai/miniforge/phase/interface_test.clj
+++ b/components/phase/test/ai/miniforge/phase/interface_test.clj
@@ -21,7 +21,18 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.phase.registry :as registry]))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(clojure.test/use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))
 
 (defmethod registry/get-phase-interceptor :test-phase
   [config]

--- a/components/phase/test/ai/miniforge/phase/interface_test.clj
+++ b/components/phase/test/ai/miniforge/phase/interface_test.clj
@@ -30,7 +30,7 @@
 (clojure.test/use-fixtures :each
   (fn [f]
     (phase/reset-phase-loader!)
-    (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+    (binding [loader/phase-loader-config-resource phase-test-config-resource]
       (f))
     (phase/reset-phase-loader!)))
 

--- a/components/phase/test/ai/miniforge/phase/loader_support.clj
+++ b/components/phase/test/ai/miniforge/phase/loader_support.clj
@@ -1,0 +1,41 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.loader-support
+  (:require
+   [ai.miniforge.phase.registry :as registry]))
+
+(def loader-support-phase
+  :loader-test-phase)
+
+(defmethod registry/get-phase-interceptor loader-support-phase
+  [config]
+  {:name ::loader-test-phase
+   :config (registry/merge-with-defaults config)
+   :enter identity
+   :leave identity
+   :error (fn [ctx _ex] ctx)})
+
+(registry/register-phase-defaults!
+ loader-support-phase
+ {:phase loader-support-phase
+  :agent :loader-tester
+  :gates [:loader-synthetic-gate]
+  :budget {:tokens 1
+           :iterations 1
+           :time-seconds 1}})

--- a/components/phase/test/ai/miniforge/phase/loader_test.clj
+++ b/components/phase/test/ai/miniforge/phase/loader_test.clj
@@ -22,6 +22,15 @@
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]))
 
+(def loader-support-namespace
+  'ai.miniforge.phase.loader-support)
+
+(def loader-support-phase
+  :loader-test-phase)
+
+(def loader-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
 (use-fixtures :each
   (fn [f]
     (phase/reset-phase-loader!)
@@ -30,19 +39,16 @@
 
 (deftest configured-phase-namespaces-test
   (testing "phase implementation namespaces are discovered from composed resources"
-    (let [phase-namespaces (set (loader/configured-phase-namespaces))]
-      (is (contains? phase-namespaces 'ai.miniforge.phase-software-factory.explore))
-      (is (contains? phase-namespaces 'ai.miniforge.phase-software-factory.plan))
-      (is (contains? phase-namespaces 'ai.miniforge.phase-software-factory.release)))))
+    (with-redefs [loader/phase-loader-config-resource loader-test-config-resource]
+      (let [phase-namespaces (loader/configured-phase-namespaces)]
+        (is (some #{loader-support-namespace} phase-namespaces))
+        (is (every? symbol? phase-namespaces))
+        (is (= (count phase-namespaces)
+               (count (distinct phase-namespaces))))))))
 
 (deftest ensure-phase-implementations-loaded-test
   (testing "loading configured phase implementations registers their phase defaults"
-    (phase/ensure-phase-implementations-loaded!)
-    (let [phases (phase/list-phases)]
-      (is (contains? phases :explore))
-      (is (contains? phases :plan))
-      (is (contains? phases :implement))
-      (is (contains? phases :verify))
-      (is (contains? phases :review))
-      (is (contains? phases :release))
-      (is (contains? phases :done)))))
+    (with-redefs [loader/phase-loader-config-resource loader-test-config-resource]
+      (phase/ensure-phase-implementations-loaded!)
+      (let [phases (phase/list-phases)]
+        (is (contains? phases loader-support-phase))))))

--- a/components/phase/test/ai/miniforge/phase/loader_test.clj
+++ b/components/phase/test/ai/miniforge/phase/loader_test.clj
@@ -39,7 +39,7 @@
 
 (deftest configured-phase-namespaces-test
   (testing "phase implementation namespaces are discovered from composed resources"
-    (with-redefs [loader/phase-loader-config-resource loader-test-config-resource]
+    (binding [loader/phase-loader-config-resource loader-test-config-resource]
       (let [phase-namespaces (loader/configured-phase-namespaces)]
         (is (some #{loader-support-namespace} phase-namespaces))
         (is (every? symbol? phase-namespaces))
@@ -48,7 +48,7 @@
 
 (deftest ensure-phase-implementations-loaded-test
   (testing "loading configured phase implementations registers their phase defaults"
-    (with-redefs [loader/phase-loader-config-resource loader-test-config-resource]
+    (binding [loader/phase-loader-config-resource loader-test-config-resource]
       (phase/ensure-phase-implementations-loaded!)
       (let [phases (phase/list-phases)]
         (is (contains? phases loader-support-phase))))))

--- a/docs/pull-requests/2026-05-09-fix-test-phase-loader-support.md
+++ b/docs/pull-requests/2026-05-09-fix-test-phase-loader-support.md
@@ -1,0 +1,26 @@
+# fix(test): add explicit phase loader support
+
+## Summary
+
+This PR makes phase loader tests use explicit test-support resources instead of
+assuming product phase namespaces are ambient on every narrowed project
+classpath.
+
+## Problem
+
+The restored stable-derived Polylith test path exposed that `phase` tests were
+passing only because wider repo classpaths happened to include product phase
+resources. Under project-scoped execution that assumption breaks.
+
+## Changes
+
+- add `config/phase/test-support-namespaces.edn`
+- add `phase/loader_support.clj` with dedicated test-support phase namespaces
+- update `phase.loader-test` to bind the explicit test-support loader config
+- update `phase.interface-test` to exercise the explicit phase test-support path
+
+## Validation
+
+- `ai.miniforge.phase.loader-test`
+- `ai.miniforge.phase.interface-test`
+- full `bb pre-commit` via the normal commit hook path


### PR DESCRIPTION
# fix(test): add explicit phase loader support

## Summary

This PR makes phase loader tests use explicit test-support resources instead of
assuming product phase namespaces are ambient on every narrowed project
classpath.

## Problem

The restored stable-derived Polylith test path exposed that `phase` tests were
passing only because wider repo classpaths happened to include product phase
resources. Under project-scoped execution that assumption breaks.

## Changes

- add `config/phase/test-support-namespaces.edn`
- add `phase/loader_support.clj` with dedicated test-support phase namespaces
- update `phase.loader-test` to bind the explicit test-support loader config
- update `phase.interface-test` to exercise the explicit phase test-support path

## Validation

- `ai.miniforge.phase.loader-test`
- `ai.miniforge.phase.interface-test`
- full `bb pre-commit` via the normal commit hook path
