### PR TITLE
fix(test): isolate workflow runner phase loading

### DIFF
--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -25,9 +25,21 @@
    5. Review feedback lost during phase clearing (Run 9)"
   (:require
    [ai.miniforge.phase.interface :as phase]
-   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.phase.loader :as loader]
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.execution :as exec]))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))
 
 ;; ============================================================================
 ;; Fix 1: Duration-ms extraction in publish-phase-completed!
@@ -156,7 +168,8 @@
                      :execution/files-written []
                      :execution/metrics {:tokens 0 :duration-ms 0}}
           ;; Use the :done interceptor (simplest, no LLM needed)
-          interceptor (ai.miniforge.phase.interface/get-phase-interceptor {:phase :done})
+          interceptor (ai.miniforge.phase.interface/get-phase-interceptor
+                       {:phase phase-test-support/runner-test-done})
           ;; execute-phase-lifecycle should clear :phase first
           [ctx-after _result] (exec/execute-phase-lifecycle interceptor stale-ctx)]
       ;; The stale transition request should NOT be present.

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -20,15 +20,40 @@
   "Extended tests for workflow runner: output extraction, event publishing,
    and edge cases not covered by the main runner_test."
   (:require
-   [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.workflow.runner :as runner]
-   [ai.miniforge.workflow.context :as ctx]
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.dag-executor.interface :as dag-exec]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.workflow.messages :as messages]
+   [ai.miniforge.workflow.runner :as runner]
+   [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.workflow.execution :as exec]
-   [ai.miniforge.phase.interface]))
+   [ai.miniforge.workflow.messages :as messages]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
+   ))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))
+
+(def ^:private runner-test-plan
+  phase-test-support/runner-test-plan)
+
+(def ^:private runner-test-implement
+  phase-test-support/runner-test-implement)
+
+(def ^:private runner-test-verify
+  phase-test-support/runner-test-verify)
+
+(def ^:private runner-test-done
+  phase-test-support/runner-test-done)
 
 ;; ---------------------------------------------------------------------------- extract-output
 
@@ -57,24 +82,25 @@
 
 (deftest extract-output-falls-back-to-pipeline-phase-order-test
   (testing "extract-output chooses the last recorded phase using workflow pipeline order"
-    (let [ctx {:execution/workflow {:workflow/pipeline [{:phase :plan}
-                                                       {:phase :implement}
-                                                       {:phase :done}]}
+    (let [ctx {:execution/workflow {:workflow/pipeline [{:phase runner-test-plan}
+                                                       {:phase runner-test-implement}
+                                                       {:phase runner-test-done}]}
                :execution/artifacts []
-               :execution/phase-results {:done {:phase/status :succeeded}
+               :execution/phase-results {runner-test-done {:phase/status :succeeded}
                                          :plan {:phase/status :succeeded}}
                :execution/current-phase nil
                :execution/status :completed}
           output (:execution/output (runner/extract-output ctx))]
       (is (= {:phase/status :succeeded} (:last-phase-result output)))
       (is (= {:phase/status :succeeded}
-             (get-in output [:phase-results :done]))))))
+             (get-in output [:phase-results runner-test-done]))))))
 
 ;; ---------------------------------------------------------------------------- build-pipeline edge cases
 
 (deftest build-pipeline-nil-pipeline-falls-back-to-legacy-test
   (testing "nil pipeline with phases falls back to legacy format"
-    (let [wf {:workflow/phases [{:phase/id :plan} {:phase/id :done}]}
+    (let [wf {:workflow/phases [{:phase/id runner-test-plan}
+                                {:phase/id runner-test-done}]}
           pipeline (runner/build-pipeline wf)]
       (is (= 2 (count pipeline))))))
 
@@ -89,7 +115,7 @@
   (testing "run-pipeline works with 2-arity (no opts)"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"})]
       (is (= :completed (:execution/status result))))))
 
@@ -97,7 +123,7 @@
   (testing "skip-lifecycle-events suppresses event publishing"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"}
                    {:skip-lifecycle-events true})]
       (is (= :completed (:execution/status result))))))
@@ -106,7 +132,7 @@
   (testing "run-pipeline accepts custom control-state atom"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           cs (atom {:paused false :stopped false :adjustments {}})
           result (runner/run-pipeline wf {:task "Test"}
                    {:control-state cs})]
@@ -118,7 +144,7 @@
     ;; This tests that the check is in place even if not triggered.
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"} {})]
       ;; :done produces a phase result, so it should be :completed (not :completed-with-warnings)
       (is (contains? #{:completed :completed-with-warnings} (:execution/status result))))))
@@ -127,7 +153,7 @@
   (testing "max-phases 1 allows single :done phase to complete"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"} {:max-phases 1})]
       (is (= :completed (:execution/status result))))))
 
@@ -135,10 +161,10 @@
   (testing "DAG fast-path advances with normal success events"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :plan}
-                                        {:phase :implement}
-                                        {:phase :verify}
-                                        {:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-plan}
+                                        {:phase runner-test-implement}
+                                        {:phase runner-test-verify}
+                                        {:phase runner-test-done}]}
           pipeline (runner/build-pipeline workflow)
           context (ctx/create-context workflow {:task "Test"} {})
           dag-result {:artifacts []
@@ -150,14 +176,14 @@
                                          ctx/transition-to-completed
                                          ctx/transition-to-failed)]
       (is (= :running (:execution/status result)))
-      (is (= :verify (:execution/current-phase result)))
+      (is (= runner-test-verify (:execution/current-phase result)))
       (is (= 0 (:execution/redirect-count result))))))
 
 (deftest execute-phase-step-uses-machine-state-over-phase-index-test
   (testing "standard execution selects the active phase from the machine snapshot"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           pipeline (runner/build-pipeline workflow)
           context (-> (ctx/create-context workflow {:task "Test"} {})
                       (assoc :execution/phase-index 99))
@@ -168,7 +194,7 @@
                                           ctx/transition-to-completed
                                           ctx/transition-to-failed)]
       (is (= :completed (:execution/status result)))
-      (is (contains? (:execution/phase-results result) :done)))))
+      (is (contains? (:execution/phase-results result) runner-test-done)))))
 
 ;; ---------------------------------------------------------------------------- publish-event edge cases
 
@@ -233,7 +259,7 @@
   (testing ":local mode is the default and sets :execution/mode on context"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"})]
       (is (= :local (:execution/mode result))))))
 
@@ -241,7 +267,7 @@
   (testing "explicit :local mode uses worktree"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"} {:execution-mode :local})]
       (is (= :completed (:execution/status result)))
       (is (= :local (:execution/mode result))))))
@@ -254,7 +280,7 @@
     ;; (N11 §7 no-silent-downgrade) — tested separately via mock.
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}]
+              :workflow/pipeline [{:phase runner-test-done}]}]
       (try
         (let [result (runner/run-pipeline wf {:task "Test"} {:execution-mode :governed})]
           ;; Docker was available — mode should be :governed on context
@@ -267,7 +293,7 @@
   (testing ":governed mode provides a host-accessible worktree-path (not /workspace)"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}]
+              :workflow/pipeline [{:phase runner-test-done}]}]
       (try
         (let [result (runner/run-pipeline wf {:task "Test"} {:execution-mode :governed})]
           ;; worktree-path should be a host path, not the container-internal /workspace
@@ -289,7 +315,7 @@
     ;; rejects them and throws rather than silently falling back.
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}]
+              :workflow/pipeline [{:phase runner-test-done}]}]
       (with-redefs [dag-exec/executor-type (constantly :worktree)]
         (is (thrown-with-msg?
              Exception #"(?i)No capsule executor available"

--- a/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
@@ -25,8 +25,12 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.workflow.monitoring :as monitoring]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]
    [slingshot.slingshot :refer [try+ throw+]]))
+
+(def ^:private runner-test-done
+  phase-test-support/runner-test-done)
 
 ;; Access private fns
 (def ^:private rate-limited? #'runner/rate-limited?)
@@ -154,7 +158,7 @@
   (testing "supervision halt transitions the workflow to failed"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           context (ctx/create-context workflow {:task "Test"} {})
           result (with-redefs [monitoring/check-workflow-supervision
                                (fn [_runtime _workflow-state]

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -22,13 +22,34 @@
    live in runner-integration-test under project tests."
   (:require
    [clojure.java.io :as io]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
-   [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
-   [ai.miniforge.phase.interface]))
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
+   [ai.miniforge.workflow.runner :as runner]))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))
+
+(def ^:private runner-test-plan
+  phase-test-support/runner-test-plan)
+
+(def ^:private runner-test-implement
+  phase-test-support/runner-test-implement)
+
+(def ^:private runner-test-done
+  phase-test-support/runner-test-done)
 
 (defn- with-temp-checkpoint-root
   [f]
@@ -76,9 +97,9 @@
 (deftest build-pipeline-simple-test
   (testing "build-pipeline creates interceptors from config"
     (let [workflow {:workflow/pipeline
-                    [{:phase :plan}
-                     {:phase :implement}
-                     {:phase :done}]}
+                    [{:phase runner-test-plan}
+                     {:phase runner-test-implement}
+                     {:phase runner-test-done}]}
           pipeline (runner/build-pipeline workflow)]
       (is (vector? pipeline))
       (is (= 3 (count pipeline)))
@@ -93,9 +114,9 @@
 (deftest build-pipeline-legacy-format-test
   (testing "build-pipeline handles legacy phase format"
     (let [workflow {:workflow/phases
-                    [{:phase/id :plan}
-                     {:phase/id :implement}
-                     {:phase/id :done}]}
+                    [{:phase/id runner-test-plan}
+                     {:phase/id runner-test-implement}
+                     {:phase/id runner-test-done}]}
           pipeline (runner/build-pipeline workflow)]
       (is (= 3 (count pipeline))))))
 
@@ -106,8 +127,8 @@
 (deftest validate-pipeline-valid-test
   (testing "validate-pipeline accepts valid workflow"
     (let [workflow {:workflow/pipeline
-                    [{:phase :plan}
-                     {:phase :done}]}
+                    [{:phase runner-test-plan}
+                     {:phase runner-test-done}]}
           result (runner/validate-pipeline workflow)]
       (is (:valid? result)))))
 
@@ -132,7 +153,7 @@
   (testing "run-pipeline completes with just :done phase"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (number? (:execution/ended-at result))))))
@@ -141,7 +162,7 @@
   (testing "run-pipeline auto-attaches supervisory-state for event-stream callers"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           stream (es/create-event-stream {:sinks []})]
       (is (false? (supervisory/attached? stream)))
       (let [result (runner/run-pipeline workflow {:task "Test"} {:event-stream stream})
@@ -155,7 +176,7 @@
     (fn [checkpoint-root]
       (let [workflow {:workflow/id :test
                       :workflow/version "1.0.0"
-                      :workflow/pipeline [{:phase :done}]}
+                      :workflow/pipeline [{:phase runner-test-done}]}
             result (runner/run-pipeline workflow {:task "Test"}
                                         {:checkpoint/root checkpoint-root})
             checkpoint-data (checkpoint-store/load-checkpoint-data
@@ -164,14 +185,14 @@
         (is (= :completed (:execution/status result)))
         (is (= (:execution/id result)
                (get-in checkpoint-data [:machine-snapshot :execution/id])))
-        (is (= [:done]
+        (is (= [runner-test-done]
                (get-in checkpoint-data [:manifest :workflow/phases-completed])))))))
 
 (deftest run-pipeline-callbacks-test
   (testing "run-pipeline invokes callbacks"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           started (atom [])
           completed (atom [])
           result (runner/run-pipeline workflow {:task "Test"}
@@ -184,15 +205,15 @@
                                           (swap! completed conj
                                                  (get-in ic [:config :phase])))})]
       (is (= :completed (:execution/status result)))
-      (is (= [:done] @started))
-      (is (= [:done] @completed)))))
+      (is (= [runner-test-done] @started))
+      (is (= [runner-test-done] @completed)))))
 
 (deftest run-pipeline-max-phases-test
   (testing "run-pipeline completes a simple workflow within max-phases limit"
     ;; Use :done phase only since other phases require LLM infrastructure
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {:max-phases 50})]
       (is (= :completed (:execution/status result))))))
 
@@ -200,7 +221,7 @@
   (testing "resume-machine-snapshot preserves the original execution id"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           resume-ctx (ctx/create-context workflow {:task "Test"} {})
           result (runner/run-pipeline workflow
                                       {:task "Ignored"}
@@ -218,9 +239,9 @@
   (testing "phase results are recorded in execution context"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
-      (is (contains? (:execution/phase-results result) :done)))))
+      (is (contains? (:execution/phase-results result) runner-test-done)))))
 
 ;; ============================================================================
 ;; Metrics accumulation tests
@@ -230,7 +251,7 @@
   (testing "metrics are accumulated across phases"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (map? (:execution/metrics result)))
       (is (contains? (:execution/metrics result) :tokens)))))
@@ -264,7 +285,7 @@
   (testing "FSM state transitions on completion"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (= :completed (:_state (:execution/fsm-state result))))))
@@ -284,8 +305,8 @@
     (let [;; Build a minimal context that looks like a completed pipeline
           fake-ctx {:execution/artifacts [{:type :file :path "out.txt"}]
                     :execution/phase-results {:plan {:phase/status :succeeded}
-                                              :done {:phase/status :succeeded}}
-                    :execution/current-phase :done
+                                              runner-test-done {:phase/status :succeeded}}
+                    :execution/current-phase runner-test-done
                     :execution/status :completed}
           ;; Call extract-output via its var (private fn)
           result (ai.miniforge.workflow.runner/extract-output fake-ctx)
@@ -293,7 +314,7 @@
       (is (some? output) ":execution/output should be present")
       (is (= [{:type :file :path "out.txt"}] (:artifacts output)))
       (is (= {:plan {:phase/status :succeeded}
-              :done {:phase/status :succeeded}}
+              runner-test-done {:phase/status :succeeded}}
              (:phase-results output)))
       (is (= {:phase/status :succeeded} (:last-phase-result output)))
       (is (= :completed (:status output))))))
@@ -302,7 +323,7 @@
   (testing "run-pipeline returns context with :execution/output populated"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (some? (:execution/output result))
@@ -311,7 +332,7 @@
         (is (= :completed (:status output)))
         (is (vector? (:artifacts output)))
         (is (map? (:phase-results output)))
-        (is (contains? (:phase-results output) :done))
+        (is (contains? (:phase-results output) runner-test-done))
         (is (some? (:last-phase-result output)))))))
 
 (deftest context-initializes-output-nil-test
@@ -331,7 +352,7 @@
     (let [env-id (random-uuid)
           workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"}
                                        {:executor       ::stub-executor
                                         :environment-id env-id
@@ -350,7 +371,7 @@
         (fn []
           (let [workflow {:workflow/id :test
                           :workflow/version "1.0.0"
-                          :workflow/pipeline [{:phase :done}]}
+                          :workflow/pipeline [{:phase runner-test-done}]}
                 result (runner/run-pipeline workflow {:task "Test"} {})]
             (is (= :completed (:execution/status result)))
             (is (nil? (:execution/environment-id result)))

--- a/docs/pull-requests/2026-05-09-fix-test-workflow-runner-phase-loading.md
+++ b/docs/pull-requests/2026-05-09-fix-test-workflow-runner-phase-loading.md
@@ -1,0 +1,29 @@
+# fix(test): isolate workflow runner phase loading
+
+## Summary
+
+This PR makes workflow runner test families explicitly bind their phase loader
+configuration so they pass under project-scoped Polylith execution.
+
+## Problem
+
+Runner-oriented workflow tests were still resolving phases through ambient
+loader configuration. That worked under the older wider classpath and failed
+under narrowed stable-derived project runs.
+
+## Changes
+
+- update `workflow.runner-test`
+- update `workflow.runner-extended-test`
+- update `workflow.runner-iteration-test`
+- update `workflow.run7-regression-test`
+- all of the above now use explicit phase-loader fixtures instead of ambient
+  product phase namespaces
+
+## Validation
+
+- `ai.miniforge.workflow.runner-test`
+- `ai.miniforge.workflow.runner-extended-test`
+- `ai.miniforge.workflow.runner-iteration-test`
+- `ai.miniforge.workflow.run7-regression-test`
+- full `bb pre-commit` via the normal commit hook path


### PR DESCRIPTION
# fix(test): isolate workflow runner phase loading

## Summary

This PR makes workflow runner test families explicitly bind their phase loader
configuration so they pass under project-scoped Polylith execution.

## Problem

Runner-oriented workflow tests were still resolving phases through ambient
loader configuration. That worked under the older wider classpath and failed
under narrowed stable-derived project runs.

## Changes

- update `workflow.runner-test`
- update `workflow.runner-extended-test`
- update `workflow.runner-iteration-test`
- update `workflow.run7-regression-test`
- all of the above now use explicit phase-loader fixtures instead of ambient
  product phase namespaces

## Validation

- `ai.miniforge.workflow.runner-test`
- `ai.miniforge.workflow.runner-extended-test`
- `ai.miniforge.workflow.runner-iteration-test`
- `ai.miniforge.workflow.run7-regression-test`
- full `bb pre-commit` via the normal commit hook path
