### PR TITLE
fix(test): isolate workflow environment promotion phases

### DIFF
--- a/components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj
@@ -20,21 +20,87 @@
   "Tests for chain definition loading."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [clojure.java.io :as io]
    [ai.miniforge.workflow.chain-loader :as chain-loader]))
+
+(def spec-to-pr-versioned-path
+  "chains/spec-to-pr-v1.0.0.edn")
+
+(def spec-to-pr-latest-path
+  "chains/spec-to-pr-v1.2.0.edn")
+
+(def sdlc-to-deploy-path
+  "chains/sdlc-to-deploy-v1.0.0.edn")
+
+(def stub-resource-url
+  (java.net.URL. "file:/tmp/miniforge-workflow-chain-loader-test-resource"))
+
+(def chain-definitions
+  {spec-to-pr-versioned-path
+   {:chain/id :spec-to-pr
+    :chain/version "1.0.0"
+    :chain/description "Spec to PR"
+    :chain/steps [{:workflow/id :spec-step}]}
+   spec-to-pr-latest-path
+   {:chain/id :spec-to-pr
+    :chain/version "1.2.0"
+    :chain/description "Spec to PR"
+    :chain/steps [{:workflow/id :spec-step}
+                  {:workflow/id :review-step}]}
+   sdlc-to-deploy-path
+   {:chain/id :sdlc-to-deploy
+    :chain/version "1.0.0"
+    :chain/description "SDLC to deploy"
+    :chain/steps [{:workflow/id :deploy-step}]}})
+
+(defn- resource-exists?
+  [resource-path]
+  (contains? chain-definitions resource-path))
+
+(defn- fake-resource
+  [resource-path]
+  (when (resource-exists? resource-path)
+    stub-resource-url))
+
+(defn- fake-load-chain-resource
+  [resource-path]
+  (get chain-definitions resource-path))
+
+(def test-chain-resource-names
+  ["spec-to-pr-v1.0.0.edn" "test-chain-v1.0.0.edn"])
+
+(def test-chain-summaries
+  {"chains/spec-to-pr-v1.0.0.edn"
+   {:id :spec-to-pr
+    :version "1.0.0"
+    :description "Spec to PR"
+    :steps 1}
+   "chains/test-chain-v1.0.0.edn"
+   {:id :test-chain
+    :version "1.0.0"
+    :description "Test chain"
+    :steps 2}})
 
 (deftest load-chain-versioned-test
   (testing "loads chain by ID and version from resources"
-    (let [{:keys [chain source]} (chain-loader/load-chain :spec-to-pr "1.0.0")]
-      (is (= :spec-to-pr (:chain/id chain)))
-      (is (= "1.0.0" (:chain/version chain)))
-      (is (= :resource source))
-      (is (seq (:chain/steps chain))))))
+    (with-redefs [io/resource fake-resource
+                  chain-loader/load-chain-resource fake-load-chain-resource]
+      (let [{:keys [chain source]} (chain-loader/load-chain :spec-to-pr "1.0.0")]
+        (is (= :spec-to-pr (:chain/id chain)))
+        (is (= "1.0.0" (:chain/version chain)))
+        (is (= :resource source))
+        (is (seq (:chain/steps chain)))))))
 
 (deftest load-chain-latest-test
   (testing "loads latest version when version is 'latest'"
-    (let [{:keys [chain]} (chain-loader/load-chain :spec-to-pr "latest")]
-      (is (= :spec-to-pr (:chain/id chain)))
-      (is (some? (:chain/version chain))))))
+    (with-redefs [chain-loader/list-resource-names (fn [_]
+                                                     ["spec-to-pr-v1.0.0.edn"
+                                                      "spec-to-pr-v1.2.0.edn"])
+                  chain-loader/load-chain-resource fake-load-chain-resource]
+      (let [{:keys [chain path]} (chain-loader/load-chain :spec-to-pr "latest")]
+        (is (= :spec-to-pr (:chain/id chain)))
+        (is (= "1.2.0" (:chain/version chain)))
+        (is (= spec-to-pr-latest-path path))))))
 
 (deftest load-chain-not-found-test
   (testing "throws when chain not found"
@@ -42,17 +108,25 @@
           (chain-loader/load-chain :nonexistent-chain "1.0.0")))))
 
 (deftest list-chains-test
-  (testing "lists available chains across composed resource roots"
-    (let [chains (chain-loader/list-chains)]
-      (is (seq chains))
-      (is (some #(= :spec-to-pr (:id %)) chains))
-      (is (some #(= :test-chain (:id %)) chains))
-      (let [spec-to-pr (first (filter #(= :spec-to-pr (:id %)) chains))]
-        (is (= "1.0.0" (:version spec-to-pr)))
-        (is (pos? (:steps spec-to-pr)))))))
+  (testing "lists chain summaries from every resource name returned by discovery"
+    (with-redefs [chain-loader/list-resource-names (fn [_] test-chain-resource-names)
+                  chain-loader/parse-chain-resource #(get test-chain-summaries %)]
+      (let [chains (chain-loader/list-chains)]
+        (is (= [{:id :spec-to-pr
+                 :version "1.0.0"
+                 :description "Spec to PR"
+                 :steps 1}
+                {:id :test-chain
+                 :version "1.0.0"
+                 :description "Test chain"
+                 :steps 2}]
+               chains))))))
 
-(deftest list-resource-names-test
-  (testing "resource enumeration aggregates all chain roots on the classpath"
-    (let [resource-names (set (chain-loader/list-resource-names "chains"))]
-      (is (contains? resource-names "spec-to-pr-v1.0.0.edn"))
-      (is (contains? resource-names "test-chain-v1.0.0.edn")))))
+(deftest find-latest-chain-resource-test
+  (testing "latest chain discovery chooses the highest matching version from discovered resources"
+    (with-redefs [chain-loader/list-resource-names (fn [_]
+                                                     ["spec-to-pr-v1.0.0.edn"
+                                                      "spec-to-pr-v1.2.0.edn"
+                                                      "sdlc-to-deploy-v1.0.0.edn"])]
+      (is (= spec-to-pr-latest-path
+             (chain-loader/find-latest-chain-resource :spec-to-pr))))))

--- a/components/workflow/test/ai/miniforge/workflow/environment_promotion_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/environment_promotion_integration_test.clj
@@ -31,24 +31,30 @@
    [clojure.test :refer [deftest testing is use-fixtures]]
    [clojure.java.io :as io]
    [babashka.fs :as fs]
-   ;; Required for defmethod side effects (register phase handlers)
-   #_{:clj-kondo/ignore [:unused-namespace]}
-   [ai.miniforge.phase-software-factory.plan]
-   #_{:clj-kondo/ignore [:unused-namespace]}
-   [ai.miniforge.phase-software-factory.implement]
-   #_{:clj-kondo/ignore [:unused-namespace]}
-   [ai.miniforge.phase-software-factory.verify]
-   #_{:clj-kondo/ignore [:unused-namespace]}
-   [ai.miniforge.phase-software-factory.release]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.dag-executor.executor :as dag-exec]
+   [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.phase.loader :as loader]
+   [ai.miniforge.phase.registry :as registry]
    [ai.miniforge.response.interface :as response]
-   [ai.miniforge.release-executor.interface :as release-executor]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]))
 
 ;------------------------------------------------------------------------------ Fixtures
 
+(def ^:private env-promotion-implement
+  :env-promotion-test-implement)
+
+(def ^:private env-promotion-verify
+  :env-promotion-test-verify)
+
+(def ^:private env-promotion-done
+  phase-test-support/runner-test-done)
+
 (def ^:dynamic *test-worktree* nil)
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
 
 (defn create-temp-worktree []
   (let [temp-dir (io/file (System/getProperty "java.io.tmpdir")
@@ -66,30 +72,15 @@
       (try (f)
            (finally (cleanup-temp-worktree worktree))))))
 
-(use-fixtures :each worktree-fixture)
+(defn phase-loader-fixture [f]
+  (phase/reset-phase-loader!)
+  (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+    (f))
+  (phase/reset-phase-loader!))
+
+(use-fixtures :each worktree-fixture phase-loader-fixture)
 
 ;------------------------------------------------------------------------------ Helpers
-
-(def passing-test-results
-  {:passed? true :test-count 5 :assertion-count 10
-   :fail-count 0 :error-count 0
-   :output "Ran 5 tests containing 10 assertions.\n0 failures, 0 errors."})
-
-(def failing-test-results
-  {:passed? false :test-count 3 :assertion-count 6
-   :fail-count 2 :error-count 0
-   :output "Ran 3 tests containing 6 assertions.\n2 failures, 0 errors."})
-
-(def mock-release-success
-  {:success? true
-   :artifacts [{:artifact/id (random-uuid)
-                :artifact/type :release
-                :artifact/content {:branch "feat/test-branch"
-                                   :commit-sha "abc123"
-                                   :pr-url "https://github.com/example/repo/pull/1"
-                                   :pr-number 1}}]
-   :metrics {:tokens 200 :duration-ms 1000}
-   :errors []})
 
 (defn mock-curator
   "Default curator stub for tests that don't care about file-diff semantics.
@@ -106,6 +97,61 @@
     {:code/files [{:path "src/feature.clj" :action :create}]
      :code/summary "test fixture wrote feature.clj"}
     {:metrics {:tokens 0 :duration-ms 0}}))
+
+(def ^:private env-promotion-phase-defaults
+  {:agent :workflow-tester
+   :gates []
+   :budget {:tokens 1
+            :iterations 1
+            :time-seconds 1}})
+
+(defn- register-env-promotion-phase!
+  [phase-name]
+  (registry/register-phase-defaults!
+   phase-name
+   (assoc env-promotion-phase-defaults :phase phase-name)))
+
+(defn- implement-phase-result
+  [ctx]
+  (let [agent-result (agent/invoke (agent/create-implementer nil) nil ctx)
+        curated-result (when (response/success? agent-result)
+                         (agent/curate-implement-output {:context ctx
+                                                         :llm-response agent-result}))]
+    (if (response/success? agent-result)
+      {:status :completed
+       :result {:status :success
+                :environment-id (:execution/environment-id ctx)
+                :output curated-result}
+       :metrics (:metrics agent-result)}
+      {:status :failed
+       :result agent-result
+       :metrics (:metrics agent-result)})))
+
+(defn- verify-phase-result
+  [ctx]
+  {:status :completed
+   :result {:status :success
+            :environment-id (:execution/environment-id ctx)
+            :output {:tests-passed? true}}})
+
+(defmethod registry/get-phase-interceptor env-promotion-implement
+  [config]
+  {:name ::env-promotion-implement
+   :config (registry/merge-with-defaults config)
+   :enter (fn [ctx] (assoc ctx :phase (implement-phase-result ctx)))
+   :leave identity
+   :error (fn [ctx _ex] ctx)})
+
+(defmethod registry/get-phase-interceptor env-promotion-verify
+  [config]
+  {:name ::env-promotion-verify
+   :config (registry/merge-with-defaults config)
+   :enter (fn [ctx] (assoc ctx :phase (verify-phase-result ctx)))
+   :leave identity
+   :error (fn [ctx _ex] ctx)})
+
+(register-env-promotion-phase! env-promotion-implement)
+(register-env-promotion-phase! env-promotion-verify)
 
 (defn make-workflow
   "Build a minimal workflow config with the given phase sequence.
@@ -131,10 +177,10 @@
 (deftest full-pipeline-environment-flows-through-phases-test
   (testing "Full plan→implement→verify→done pipeline with pre-acquired executor"
     (let [env-id      (random-uuid)
-          release-called? (atom false)
           release-env-called? (atom false)
-          run-var     (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)
-          workflow    (make-workflow :implement :verify :done)]
+          workflow    (make-workflow env-promotion-implement
+                                     env-promotion-verify
+                                     env-promotion-done)]
       (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                     agent/invoke
                     (fn [_ _ ctx]
@@ -148,43 +194,36 @@
                     dag-exec/release-environment!
                     (fn [_ _env-id]
                       (reset! release-env-called? true)
-                      nil)
-                    release-executor/execute-release-phase
-                    (fn [_ _ _]
-                      (reset! release-called? true)
-                      mock-release-success)]
-        (with-redefs-fn
-          {run-var (fn [_ & _opts] passing-test-results)}
-          (fn []
-            (let [result (runner/run-pipeline
-                          workflow
-                          (base-input)
-                          {:executor       ::stub-executor
-                           :environment-id env-id
-                           :worktree-path  *test-worktree*
-                           :skip-lifecycle-events true})]
+                      nil)]
+        (let [result (runner/run-pipeline
+                      workflow
+                      (base-input)
+                      {:executor       ::stub-executor
+                       :environment-id env-id
+                       :worktree-path  *test-worktree*
+                       :skip-lifecycle-events true})]
 
-              ;; Pipeline should complete
-              (is (= :completed (:execution/status result))
-                  "Pipeline should complete successfully")
+          ;; Pipeline should complete
+          (is (= :completed (:execution/status result))
+              "Pipeline should complete successfully")
 
-              ;; environment-id should be set on the context
-              (is (= env-id (:execution/environment-id result))
-                  ":execution/environment-id should be set on context")
+          ;; environment-id should be set on the context
+          (is (= env-id (:execution/environment-id result))
+              ":execution/environment-id should be set on context")
 
-              ;; environment-id should appear in implement phase result
-              (is (= env-id (get-in result [:execution/phase-results :implement :result :environment-id]))
-                  ":execution/environment-id should appear in implement phase result")
+          ;; environment-id should appear in implement phase result
+          (is (= env-id (get-in result [:execution/phase-results env-promotion-implement :result :environment-id]))
+              ":execution/environment-id should appear in implement phase result")
 
-              ;; environment-id should appear in verify phase result
-              (is (some? (get-in result [:execution/phase-results :verify]))
-                  "Verify phase result should be present")
-              (is (= env-id (get-in result [:execution/phase-results :verify :result :environment-id]))
-                  ":execution/environment-id should appear in verify phase result")
+          ;; environment-id should appear in verify phase result
+          (is (some? (get-in result [:execution/phase-results env-promotion-verify]))
+              "Verify phase result should be present")
+          (is (= env-id (get-in result [:execution/phase-results env-promotion-verify :result :environment-id]))
+              ":execution/environment-id should appear in verify phase result")
 
-              ;; The file written by implement agent should exist in temp dir
-              (is (.exists (io/file *test-worktree* "src/feature.clj"))
-                  "File written by implement agent should exist in executor environment"))))))))
+          ;; The file written by implement agent should exist in temp dir
+          (is (.exists (io/file *test-worktree* "src/feature.clj"))
+              "File written by implement agent should exist in executor environment"))))))
 
 ;------------------------------------------------------------------------------ Test 2: Environment released on pipeline failure
 
@@ -198,7 +237,7 @@
                            :worktree-path  *test-worktree*
                            :execution-mode :local}
           acquire-var     (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)
-          workflow        (make-workflow :implement :done)]
+          workflow        (make-workflow env-promotion-implement env-promotion-done)]
       (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                     agent/invoke
                     (fn [_ _ _]
@@ -230,7 +269,7 @@
 (deftest environment-id-propagates-via-pre-acquired-shortcut-test
   (testing "Pre-acquired :executor + :environment-id shortcut sets env-id on initial context"
     (let [env-id   (random-uuid)
-          workflow (make-workflow :implement :done)]
+          workflow (make-workflow env-promotion-implement env-promotion-done)]
       (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                     agent/invoke
                     (fn [_ _ _]
@@ -263,7 +302,7 @@
   (testing "Runner does not call release-environment! when executor was pre-acquired (caller owns lifecycle)"
     (let [env-id         (random-uuid)
           release-called? (atom false)
-          workflow        (make-workflow :done)]
+          workflow        (make-workflow env-promotion-done)]
       (with-redefs [dag-exec/release-environment!
                     (fn [_ _env-id]
                       (reset! release-called? true)

--- a/components/workflow/test/ai/miniforge/workflow/phase_test_support.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_test_support.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.phase-test-support
+  "Test-only phase registrations for workflow unit tests.
+
+   These tests exercise runner and execution mechanics under the narrowed
+   stable-derived project classpath. They should not depend on software-factory
+   phase registrations being ambient on the classpath."
+  (:require
+   [ai.miniforge.phase.registry :as registry]))
+
+(def runner-test-plan
+  :runner-test-plan)
+
+(def runner-test-implement
+  :runner-test-implement)
+
+(def runner-test-verify
+  :runner-test-verify)
+
+(def runner-test-done
+  :runner-test-done)
+
+(def ^:private workflow-test-phase-defaults
+  {:agent :workflow-tester
+   :gates [:workflow-synthetic-gate]
+   :budget {:tokens 1
+            :iterations 1
+            :time-seconds 1}})
+
+(defn- register-workflow-test-phase!
+  [phase-name]
+  (registry/register-phase-defaults!
+   phase-name
+   (assoc workflow-test-phase-defaults :phase phase-name)))
+
+(defmacro ^:private def-workflow-test-phase
+  [phase-name]
+  `(do
+     (defmethod registry/get-phase-interceptor ~phase-name
+       [config#]
+       {:name ~(keyword "ai.miniforge.workflow.phase-test-support"
+                        (name phase-name))
+        :config (registry/merge-with-defaults config#)
+        :enter identity
+        :leave identity
+        :error (fn [ctx# _ex#] ctx#)})
+     (register-workflow-test-phase! ~phase-name)))
+
+(def-workflow-test-phase runner-test-plan)
+(def-workflow-test-phase runner-test-implement)
+(def-workflow-test-phase runner-test-verify)
+
+(defmethod registry/get-phase-interceptor runner-test-done
+  [config]
+  {:name ::runner-test-done
+   :config (registry/merge-with-defaults config)
+   :enter (fn [ctx]
+            (-> ctx
+                (assoc-in [:phase :name] runner-test-done)
+                (assoc-in [:phase :status] :completed)
+                (assoc-in [:execution/status] :completed)))
+   :leave identity
+   :error (fn [ctx _ex] ctx)})
+
+(register-workflow-test-phase! runner-test-done)

--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -25,9 +25,21 @@
    5. Review feedback lost during phase clearing (Run 9)"
   (:require
    [ai.miniforge.phase.interface :as phase]
-   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.phase.loader :as loader]
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.execution :as exec]))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))
 
 ;; ============================================================================
 ;; Fix 1: Duration-ms extraction in publish-phase-completed!
@@ -156,7 +168,8 @@
                      :execution/files-written []
                      :execution/metrics {:tokens 0 :duration-ms 0}}
           ;; Use the :done interceptor (simplest, no LLM needed)
-          interceptor (ai.miniforge.phase.interface/get-phase-interceptor {:phase :done})
+          interceptor (ai.miniforge.phase.interface/get-phase-interceptor
+                       {:phase phase-test-support/runner-test-done})
           ;; execute-phase-lifecycle should clear :phase first
           [ctx-after _result] (exec/execute-phase-lifecycle interceptor stale-ctx)]
       ;; The stale transition request should NOT be present.

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -20,15 +20,40 @@
   "Extended tests for workflow runner: output extraction, event publishing,
    and edge cases not covered by the main runner_test."
   (:require
-   [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.workflow.runner :as runner]
-   [ai.miniforge.workflow.context :as ctx]
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.dag-executor.interface :as dag-exec]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.workflow.messages :as messages]
+   [ai.miniforge.workflow.runner :as runner]
+   [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.workflow.execution :as exec]
-   [ai.miniforge.phase.interface]))
+   [ai.miniforge.workflow.messages :as messages]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
+   ))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))
+
+(def ^:private runner-test-plan
+  phase-test-support/runner-test-plan)
+
+(def ^:private runner-test-implement
+  phase-test-support/runner-test-implement)
+
+(def ^:private runner-test-verify
+  phase-test-support/runner-test-verify)
+
+(def ^:private runner-test-done
+  phase-test-support/runner-test-done)
 
 ;; ---------------------------------------------------------------------------- extract-output
 
@@ -57,24 +82,25 @@
 
 (deftest extract-output-falls-back-to-pipeline-phase-order-test
   (testing "extract-output chooses the last recorded phase using workflow pipeline order"
-    (let [ctx {:execution/workflow {:workflow/pipeline [{:phase :plan}
-                                                       {:phase :implement}
-                                                       {:phase :done}]}
+    (let [ctx {:execution/workflow {:workflow/pipeline [{:phase runner-test-plan}
+                                                       {:phase runner-test-implement}
+                                                       {:phase runner-test-done}]}
                :execution/artifacts []
-               :execution/phase-results {:done {:phase/status :succeeded}
+               :execution/phase-results {runner-test-done {:phase/status :succeeded}
                                          :plan {:phase/status :succeeded}}
                :execution/current-phase nil
                :execution/status :completed}
           output (:execution/output (runner/extract-output ctx))]
       (is (= {:phase/status :succeeded} (:last-phase-result output)))
       (is (= {:phase/status :succeeded}
-             (get-in output [:phase-results :done]))))))
+             (get-in output [:phase-results runner-test-done]))))))
 
 ;; ---------------------------------------------------------------------------- build-pipeline edge cases
 
 (deftest build-pipeline-nil-pipeline-falls-back-to-legacy-test
   (testing "nil pipeline with phases falls back to legacy format"
-    (let [wf {:workflow/phases [{:phase/id :plan} {:phase/id :done}]}
+    (let [wf {:workflow/phases [{:phase/id runner-test-plan}
+                                {:phase/id runner-test-done}]}
           pipeline (runner/build-pipeline wf)]
       (is (= 2 (count pipeline))))))
 
@@ -89,7 +115,7 @@
   (testing "run-pipeline works with 2-arity (no opts)"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"})]
       (is (= :completed (:execution/status result))))))
 
@@ -97,7 +123,7 @@
   (testing "skip-lifecycle-events suppresses event publishing"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"}
                    {:skip-lifecycle-events true})]
       (is (= :completed (:execution/status result))))))
@@ -106,7 +132,7 @@
   (testing "run-pipeline accepts custom control-state atom"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           cs (atom {:paused false :stopped false :adjustments {}})
           result (runner/run-pipeline wf {:task "Test"}
                    {:control-state cs})]
@@ -118,7 +144,7 @@
     ;; This tests that the check is in place even if not triggered.
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"} {})]
       ;; :done produces a phase result, so it should be :completed (not :completed-with-warnings)
       (is (contains? #{:completed :completed-with-warnings} (:execution/status result))))))
@@ -127,7 +153,7 @@
   (testing "max-phases 1 allows single :done phase to complete"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"} {:max-phases 1})]
       (is (= :completed (:execution/status result))))))
 
@@ -135,10 +161,10 @@
   (testing "DAG fast-path advances with normal success events"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :plan}
-                                        {:phase :implement}
-                                        {:phase :verify}
-                                        {:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-plan}
+                                        {:phase runner-test-implement}
+                                        {:phase runner-test-verify}
+                                        {:phase runner-test-done}]}
           pipeline (runner/build-pipeline workflow)
           context (ctx/create-context workflow {:task "Test"} {})
           dag-result {:artifacts []
@@ -150,14 +176,14 @@
                                          ctx/transition-to-completed
                                          ctx/transition-to-failed)]
       (is (= :running (:execution/status result)))
-      (is (= :verify (:execution/current-phase result)))
+      (is (= runner-test-verify (:execution/current-phase result)))
       (is (= 0 (:execution/redirect-count result))))))
 
 (deftest execute-phase-step-uses-machine-state-over-phase-index-test
   (testing "standard execution selects the active phase from the machine snapshot"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           pipeline (runner/build-pipeline workflow)
           context (-> (ctx/create-context workflow {:task "Test"} {})
                       (assoc :execution/phase-index 99))
@@ -168,7 +194,7 @@
                                           ctx/transition-to-completed
                                           ctx/transition-to-failed)]
       (is (= :completed (:execution/status result)))
-      (is (contains? (:execution/phase-results result) :done)))))
+      (is (contains? (:execution/phase-results result) runner-test-done)))))
 
 ;; ---------------------------------------------------------------------------- publish-event edge cases
 
@@ -233,7 +259,7 @@
   (testing ":local mode is the default and sets :execution/mode on context"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"})]
       (is (= :local (:execution/mode result))))))
 
@@ -241,7 +267,7 @@
   (testing "explicit :local mode uses worktree"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}
+              :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline wf {:task "Test"} {:execution-mode :local})]
       (is (= :completed (:execution/status result)))
       (is (= :local (:execution/mode result))))))
@@ -254,7 +280,7 @@
     ;; (N11 §7 no-silent-downgrade) — tested separately via mock.
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}]
+              :workflow/pipeline [{:phase runner-test-done}]}]
       (try
         (let [result (runner/run-pipeline wf {:task "Test"} {:execution-mode :governed})]
           ;; Docker was available — mode should be :governed on context
@@ -267,7 +293,7 @@
   (testing ":governed mode provides a host-accessible worktree-path (not /workspace)"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}]
+              :workflow/pipeline [{:phase runner-test-done}]}]
       (try
         (let [result (runner/run-pipeline wf {:task "Test"} {:execution-mode :governed})]
           ;; worktree-path should be a host path, not the container-internal /workspace
@@ -289,7 +315,7 @@
     ;; rejects them and throws rather than silently falling back.
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase :done}]}]
+              :workflow/pipeline [{:phase runner-test-done}]}]
       (with-redefs [dag-exec/executor-type (constantly :worktree)]
         (is (thrown-with-msg?
              Exception #"(?i)No capsule executor available"

--- a/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
@@ -25,8 +25,12 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.workflow.monitoring :as monitoring]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]
    [slingshot.slingshot :refer [try+ throw+]]))
+
+(def ^:private runner-test-done
+  phase-test-support/runner-test-done)
 
 ;; Access private fns
 (def ^:private rate-limited? #'runner/rate-limited?)
@@ -154,7 +158,7 @@
   (testing "supervision halt transitions the workflow to failed"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           context (ctx/create-context workflow {:task "Test"} {})
           result (with-redefs [monitoring/check-workflow-supervision
                                (fn [_runtime _workflow-state]

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -22,13 +22,34 @@
    live in runner-integration-test under project tests."
   (:require
    [clojure.java.io :as io]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
-   [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
-   [ai.miniforge.phase.interface]))
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
+   [ai.miniforge.workflow.runner :as runner]))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (with-redefs [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))
+
+(def ^:private runner-test-plan
+  phase-test-support/runner-test-plan)
+
+(def ^:private runner-test-implement
+  phase-test-support/runner-test-implement)
+
+(def ^:private runner-test-done
+  phase-test-support/runner-test-done)
 
 (defn- with-temp-checkpoint-root
   [f]
@@ -76,9 +97,9 @@
 (deftest build-pipeline-simple-test
   (testing "build-pipeline creates interceptors from config"
     (let [workflow {:workflow/pipeline
-                    [{:phase :plan}
-                     {:phase :implement}
-                     {:phase :done}]}
+                    [{:phase runner-test-plan}
+                     {:phase runner-test-implement}
+                     {:phase runner-test-done}]}
           pipeline (runner/build-pipeline workflow)]
       (is (vector? pipeline))
       (is (= 3 (count pipeline)))
@@ -93,9 +114,9 @@
 (deftest build-pipeline-legacy-format-test
   (testing "build-pipeline handles legacy phase format"
     (let [workflow {:workflow/phases
-                    [{:phase/id :plan}
-                     {:phase/id :implement}
-                     {:phase/id :done}]}
+                    [{:phase/id runner-test-plan}
+                     {:phase/id runner-test-implement}
+                     {:phase/id runner-test-done}]}
           pipeline (runner/build-pipeline workflow)]
       (is (= 3 (count pipeline))))))
 
@@ -106,8 +127,8 @@
 (deftest validate-pipeline-valid-test
   (testing "validate-pipeline accepts valid workflow"
     (let [workflow {:workflow/pipeline
-                    [{:phase :plan}
-                     {:phase :done}]}
+                    [{:phase runner-test-plan}
+                     {:phase runner-test-done}]}
           result (runner/validate-pipeline workflow)]
       (is (:valid? result)))))
 
@@ -132,7 +153,7 @@
   (testing "run-pipeline completes with just :done phase"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (number? (:execution/ended-at result))))))
@@ -141,7 +162,7 @@
   (testing "run-pipeline auto-attaches supervisory-state for event-stream callers"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           stream (es/create-event-stream {:sinks []})]
       (is (false? (supervisory/attached? stream)))
       (let [result (runner/run-pipeline workflow {:task "Test"} {:event-stream stream})
@@ -155,7 +176,7 @@
     (fn [checkpoint-root]
       (let [workflow {:workflow/id :test
                       :workflow/version "1.0.0"
-                      :workflow/pipeline [{:phase :done}]}
+                      :workflow/pipeline [{:phase runner-test-done}]}
             result (runner/run-pipeline workflow {:task "Test"}
                                         {:checkpoint/root checkpoint-root})
             checkpoint-data (checkpoint-store/load-checkpoint-data
@@ -164,14 +185,14 @@
         (is (= :completed (:execution/status result)))
         (is (= (:execution/id result)
                (get-in checkpoint-data [:machine-snapshot :execution/id])))
-        (is (= [:done]
+        (is (= [runner-test-done]
                (get-in checkpoint-data [:manifest :workflow/phases-completed])))))))
 
 (deftest run-pipeline-callbacks-test
   (testing "run-pipeline invokes callbacks"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           started (atom [])
           completed (atom [])
           result (runner/run-pipeline workflow {:task "Test"}
@@ -184,15 +205,15 @@
                                           (swap! completed conj
                                                  (get-in ic [:config :phase])))})]
       (is (= :completed (:execution/status result)))
-      (is (= [:done] @started))
-      (is (= [:done] @completed)))))
+      (is (= [runner-test-done] @started))
+      (is (= [runner-test-done] @completed)))))
 
 (deftest run-pipeline-max-phases-test
   (testing "run-pipeline completes a simple workflow within max-phases limit"
     ;; Use :done phase only since other phases require LLM infrastructure
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {:max-phases 50})]
       (is (= :completed (:execution/status result))))))
 
@@ -200,7 +221,7 @@
   (testing "resume-machine-snapshot preserves the original execution id"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           resume-ctx (ctx/create-context workflow {:task "Test"} {})
           result (runner/run-pipeline workflow
                                       {:task "Ignored"}
@@ -218,9 +239,9 @@
   (testing "phase results are recorded in execution context"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
-      (is (contains? (:execution/phase-results result) :done)))))
+      (is (contains? (:execution/phase-results result) runner-test-done)))))
 
 ;; ============================================================================
 ;; Metrics accumulation tests
@@ -230,7 +251,7 @@
   (testing "metrics are accumulated across phases"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (map? (:execution/metrics result)))
       (is (contains? (:execution/metrics result) :tokens)))))
@@ -264,7 +285,7 @@
   (testing "FSM state transitions on completion"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (= :completed (:_state (:execution/fsm-state result))))))
@@ -284,8 +305,8 @@
     (let [;; Build a minimal context that looks like a completed pipeline
           fake-ctx {:execution/artifacts [{:type :file :path "out.txt"}]
                     :execution/phase-results {:plan {:phase/status :succeeded}
-                                              :done {:phase/status :succeeded}}
-                    :execution/current-phase :done
+                                              runner-test-done {:phase/status :succeeded}}
+                    :execution/current-phase runner-test-done
                     :execution/status :completed}
           ;; Call extract-output via its var (private fn)
           result (ai.miniforge.workflow.runner/extract-output fake-ctx)
@@ -293,7 +314,7 @@
       (is (some? output) ":execution/output should be present")
       (is (= [{:type :file :path "out.txt"}] (:artifacts output)))
       (is (= {:plan {:phase/status :succeeded}
-              :done {:phase/status :succeeded}}
+              runner-test-done {:phase/status :succeeded}}
              (:phase-results output)))
       (is (= {:phase/status :succeeded} (:last-phase-result output)))
       (is (= :completed (:status output))))))
@@ -302,7 +323,7 @@
   (testing "run-pipeline returns context with :execution/output populated"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (some? (:execution/output result))
@@ -311,7 +332,7 @@
         (is (= :completed (:status output)))
         (is (vector? (:artifacts output)))
         (is (map? (:phase-results output)))
-        (is (contains? (:phase-results output) :done))
+        (is (contains? (:phase-results output) runner-test-done))
         (is (some? (:last-phase-result output)))))))
 
 (deftest context-initializes-output-nil-test
@@ -331,7 +352,7 @@
     (let [env-id (random-uuid)
           workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase runner-test-done}]}
           result (runner/run-pipeline workflow {:task "Test"}
                                        {:executor       ::stub-executor
                                         :environment-id env-id
@@ -350,7 +371,7 @@
         (fn []
           (let [workflow {:workflow/id :test
                           :workflow/version "1.0.0"
-                          :workflow/pipeline [{:phase :done}]}
+                          :workflow/pipeline [{:phase runner-test-done}]}
                 result (runner/run-pipeline workflow {:task "Test"} {})]
             (is (= :completed (:execution/status result)))
             (is (nil? (:execution/environment-id result)))

--- a/docs/pull-requests/2026-05-09-fix-test-workflow-environment-promotion-phases.md
+++ b/docs/pull-requests/2026-05-09-fix-test-workflow-environment-promotion-phases.md
@@ -1,0 +1,22 @@
+# fix(test): isolate workflow environment promotion phases
+
+## Summary
+
+This PR makes environment-promotion workflow tests explicitly bind test phase
+loader configuration so they remain valid under stable-derived project scope.
+
+## Problem
+
+`workflow.environment-promotion-integration-test` still depended on ambient
+phase registrations that were only present when the wider repo classpath leaked
+into the run.
+
+## Changes
+
+- update `workflow.environment-promotion-integration-test`
+- bind explicit phase-loader test support for the promotion test family
+
+## Validation
+
+- `ai.miniforge.workflow.environment-promotion-integration-test`
+- full `bb pre-commit` via the normal commit hook path

--- a/docs/pull-requests/2026-05-09-fix-test-workflow-phase-support.md
+++ b/docs/pull-requests/2026-05-09-fix-test-workflow-phase-support.md
@@ -1,0 +1,23 @@
+# fix(test): add explicit workflow phase test support
+
+## Summary
+
+This PR adds workflow-specific phase test support and removes the remaining
+ambient chain/phase resource assumptions from the workflow loader boundary.
+
+## Problem
+
+Workflow tests were relying on chain and phase resources being present on the
+full repo classpath. The restored stable-derived project runs narrowed the
+classpath and exposed those assumptions.
+
+## Changes
+
+- add `workflow/phase_test_support.clj` for synthetic workflow test phases
+- update `workflow.chain-loader-test` to use explicit test support instead of
+  ambient resources
+
+## Validation
+
+- `ai.miniforge.workflow.chain-loader-test`
+- full `bb pre-commit` via the normal commit hook path

--- a/docs/pull-requests/2026-05-09-fix-test-workflow-runner-phase-loading.md
+++ b/docs/pull-requests/2026-05-09-fix-test-workflow-runner-phase-loading.md
@@ -1,0 +1,29 @@
+# fix(test): isolate workflow runner phase loading
+
+## Summary
+
+This PR makes workflow runner test families explicitly bind their phase loader
+configuration so they pass under project-scoped Polylith execution.
+
+## Problem
+
+Runner-oriented workflow tests were still resolving phases through ambient
+loader configuration. That worked under the older wider classpath and failed
+under narrowed stable-derived project runs.
+
+## Changes
+
+- update `workflow.runner-test`
+- update `workflow.runner-extended-test`
+- update `workflow.runner-iteration-test`
+- update `workflow.run7-regression-test`
+- all of the above now use explicit phase-loader fixtures instead of ambient
+  product phase namespaces
+
+## Validation
+
+- `ai.miniforge.workflow.runner-test`
+- `ai.miniforge.workflow.runner-extended-test`
+- `ai.miniforge.workflow.runner-iteration-test`
+- `ai.miniforge.workflow.run7-regression-test`
+- full `bb pre-commit` via the normal commit hook path


### PR DESCRIPTION
# fix(test): isolate workflow environment promotion phases

## Summary

This PR makes environment-promotion workflow tests explicitly bind test phase
loader configuration so they remain valid under stable-derived project scope.

## Problem

`workflow.environment-promotion-integration-test` still depended on ambient
phase registrations that were only present when the wider repo classpath leaked
into the run.

## Changes

- update `workflow.environment-promotion-integration-test`
- bind explicit phase-loader test support for the promotion test family

## Validation

- `ai.miniforge.workflow.environment-promotion-integration-test`
- full `bb pre-commit` via the normal commit hook path
