### PR TITLE
fix(workflow): remove wall-clock waits from rate-limit tests

### DIFF
--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/clock {:local/root "../clock"}
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -26,6 +26,7 @@
    - Layer 2: Batch analysis + rate limit handling
    - Layer 3: Resume — restore DAG progress from machine snapshots"
   (:require
+   [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]))
@@ -68,6 +69,22 @@
   "Matches 'resets in 30 minutes', 'resets in 2 hours'"
   #"resets\s+in\s+(\d+)\s*(minutes?|hours?|seconds?)")
 
+(def ^:dynamic *sleep!*
+  "Injected wall-clock wait used by short reset waits.
+   Tests bind this to advance a fake clock instead of sleeping for real."
+  (fn [wait-ms]
+    (Thread/sleep wait-ms)))
+
+(defn- current-instant
+  "Current instant derived from the shared clock seam."
+  []
+  (java.time.Instant/ofEpochMilli (clock/now-ms)))
+
+(defn- current-zoned-datetime
+  "Current zoned time derived from the shared clock seam."
+  [zone]
+  (java.time.ZonedDateTime/ofInstant (current-instant) zone))
+
 (defn parse-reset-instant
   "Parse rate limit reset time from message text.
    Returns java.time.Instant or nil.
@@ -96,7 +113,7 @@
                local-time (java.time.LocalTime/parse
                            (.trim time-str)
                            formatter)
-               now (java.time.ZonedDateTime/now zone)
+               now (current-zoned-datetime zone)
                reset-today (.with now local-time)
                ;; If reset time is in the past, it means tomorrow
                reset (if (.isBefore reset-today now)
@@ -114,7 +131,7 @@
                           (re-find #"second" unit) (java.time.Duration/ofSeconds amount)
                           (re-find #"minute" unit) (java.time.Duration/ofMinutes amount)
                           (re-find #"hour" unit) (java.time.Duration/ofHours amount))]
-           (.plus (java.time.Instant/now) duration))
+           (.plus (current-instant) duration))
          (catch Exception _ nil))))))
 
 (def ^:private short-wait-threshold-ms
@@ -131,7 +148,7 @@
 (defn millis-until-reset
   "Calculate milliseconds until a reset instant. Returns 0 if already past."
   [reset-instant]
-  (max 0 (- (.toEpochMilli reset-instant) (System/currentTimeMillis))))
+  (max 0 (- (.toEpochMilli reset-instant) (clock/now-ms))))
 
 (defn rate-limit-error?
   "Check if a DAG result indicates a rate limit error."
@@ -281,7 +298,7 @@
                     {:data {:reset-at (str reset-instant)
                             :wait-ms wait-ms
                             :wait-minutes wait-minutes}})
-          (Thread/sleep wait-ms)
+          (*sleep!* wait-ms)
           {:waited? true :wait-ms wait-ms})
 
       ;; Medium wait (30min - 2hrs) — checkpoint, schedule auto-resume

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
@@ -20,9 +20,13 @@
   "Tests for DAG execution pausing on rate limits and plan->dag-tasks dependency handling."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
+   [ai.miniforge.workflow.dag-resilience :as resilience]
    [ai.miniforge.dag-executor.interface :as dag]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log])
+  (:import
+   [java.time Instant]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -41,7 +45,8 @@
 
 (deftest test-dag-execution-pauses-on-rate-limit
   (testing "DAG execution returns paused result when all tasks hit rate limits"
-    (let [[logger _] (log/collecting-logger)
+    (let [fixed-now (Instant/parse "2026-05-09T17:00:00Z")
+          [logger _] (log/collecting-logger)
           ;; Use real UUIDs as task IDs since plan->dag-tasks expects them
           task-a (random-uuid)
           task-b (random-uuid)
@@ -54,20 +59,21 @@
                              {:task/id task-b
                               :task/description "Task B"
                               :task/type :implement
-                              :task/dependencies []}]}
-          ;; Mock execute-single-task to return rate limit errors
-          _original-fn @(resolve 'ai.miniforge.workflow.dag-orchestrator/execute-single-task)]
-      (with-redefs [ai.miniforge.workflow.dag-orchestrator/execute-single-task
+                              :task/dependencies []}]}]
+      (with-redefs [clock/now-ms (fn [] (.toEpochMilli fixed-now))
+                    ai.miniforge.workflow.dag-orchestrator/execute-single-task
                     (fn [_task-def _context]
                       (dag/err :task-execution-failed
-                               "You've hit your limit · resets 2pm"
+                               "You've hit your limit · resets 2pm (America/Los_Angeles)"
                                {}))]
-        (let [result (ai.miniforge.workflow.dag-orchestrator/execute-plan-as-dag
-                      plan {:logger logger})]
-          (is (not (:success? result)))
-          (is (true? (:paused? result)))
-          (is (string? (:pause-reason result)))
-          (is (= [] (:completed-task-ids result))))))))
+        (binding [resilience/*sleep!* (fn [_]
+                                        (throw (ex-info "unexpected short sleep in pause test" {})))]
+          (let [result (ai.miniforge.workflow.dag-orchestrator/execute-plan-as-dag
+                        plan {:logger logger})]
+            (is (not (:success? result)))
+            (is (true? (:paused? result)))
+            (is (string? (:pause-reason result)))
+            (is (= [] (:completed-task-ids result)))))))))
 
 (deftest test-dag-execution-partial-rate-limit
   (testing "DAG pauses when some tasks succeed and others hit rate limits"

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_failover_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_failover_test.clj
@@ -21,6 +21,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
+   [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.workflow.dag-resilience :as resilience]
    [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
    [ai.miniforge.dag-executor.interface :as dag]
@@ -78,31 +79,42 @@
 ;; parse-reset-instant tests
 
 (deftest test-parse-reset-instant-absolute-time
-  (testing "parses 'resets 2pm' as an instant"
-    (let [text "You've hit your limit · resets 2pm"
-          result (resilience/parse-reset-instant text)]
-      (is (instance? Instant result))
-      (is (.isAfter result (Instant/now)))))
+  (let [fixed-now (Instant/parse "2026-05-09T20:00:00Z")]
+    (with-redefs [clock/now-ms (fn [] (.toEpochMilli fixed-now))]
+      (testing "parses 'resets 2pm' using the system timezone"
+        (let [text "You've hit your limit · resets 2pm"
+              result (resilience/parse-reset-instant text)
+              expected (-> (java.time.ZonedDateTime/ofInstant
+                            fixed-now
+                            (java.time.ZoneId/systemDefault))
+                           (.withHour 14)
+                           (.withMinute 0)
+                           (.withSecond 0)
+                           (.withNano 0)
+                           (#(if (.isBefore % (java.time.ZonedDateTime/ofInstant
+                                               fixed-now
+                                               (java.time.ZoneId/systemDefault)))
+                               (.plusDays % 1)
+                               %))
+                           (.toInstant))]
+          (is (= expected result))))
 
-  (testing "parses 'resets 2pm (America/Los_Angeles)' with timezone"
-    (let [text "You've hit your limit · resets 2pm (America/Los_Angeles)"
-          result (resilience/parse-reset-instant text)]
-      (is (instance? Instant result))))
+      (testing "parses 'resets 2pm (America/Los_Angeles)' with explicit timezone"
+        (let [text "You've hit your limit · resets 2pm (America/Los_Angeles)"
+              result (resilience/parse-reset-instant text)]
+          (is (= (Instant/parse "2026-05-09T21:00:00Z") result))))
 
-  (testing "parses 'resets 2:30pm' with minutes"
-    (let [text "resets 2:30pm"
-          result (resilience/parse-reset-instant text)]
-      (is (instance? Instant result)))))
+      (testing "parses 'resets 2:30pm' with minutes"
+        (let [text "resets 2:30pm (America/Los_Angeles)"
+              result (resilience/parse-reset-instant text)]
+          (is (= (Instant/parse "2026-05-09T21:30:00Z") result)))))))
 
 (deftest test-parse-reset-instant-relative-time
-  (testing "parses 'resets in 30 minutes' as relative duration"
-    (let [before (Instant/now)
-          result (resilience/parse-reset-instant "resets in 30 minutes")
-          after (Instant/now)]
-      (is (instance? Instant result))
-      ;; Should be approximately 30 minutes from now
-      (is (> (.toEpochMilli result) (+ (.toEpochMilli before) 1790000)))
-      (is (< (.toEpochMilli result) (+ (.toEpochMilli after) 1810000))))))
+  (testing "parses 'resets in 30 minutes' against the injected clock"
+    (let [fixed-now (Instant/parse "2026-05-09T20:00:00Z")]
+      (with-redefs [clock/now-ms (fn [] (.toEpochMilli fixed-now))]
+        (is (= (Instant/parse "2026-05-09T20:30:00Z")
+               (resilience/parse-reset-instant "resets in 30 minutes")))))))
 
 (deftest test-parse-reset-instant-no-match
   (testing "returns nil for non-reset text"
@@ -114,14 +126,22 @@
 
 (deftest test-handle-rate-limited-batch-waits-for-reset
   (testing "waits for reset when reset time is imminent (relative)"
-    (let [[logger _] (log/collecting-logger)
+    (let [fake-now (atom (.toEpochMilli (Instant/parse "2026-05-09T20:00:00Z")))
+          [logger _] (log/collecting-logger)
           rate-limit-msg "You've hit your limit · resets in 1 seconds"
           results {:b (dag/err :task-execution-failed rate-limit-msg {:task-id :b})}
-          decision (resilience/handle-rate-limited-batch
-                    {} #{:b} #{:a} logger results)]
-      ;; Should have waited and returned :continue
-      (is (= :continue (:action decision)))
-      (is (number? (:waited-ms decision))))))
+          sleep-calls (atom [])]
+      (with-redefs [clock/now-ms (fn [] @fake-now)]
+        (binding [resilience/*sleep!* (fn [wait-ms]
+                                        (swap! sleep-calls conj wait-ms)
+                                        (swap! fake-now + wait-ms))]
+          (let [decision (resilience/handle-rate-limited-batch
+                          {} #{:b} #{:a} logger results)]
+            (is (= :continue (:action decision)))
+            (is (= 1000 (:waited-ms decision)))
+            (is (= [1000] @sleep-calls))
+            (is (= (.toEpochMilli (Instant/parse "2026-05-09T20:00:01Z"))
+                   @fake-now))))))))
 
 (deftest test-handle-rate-limited-batch-pauses-without-results
   (testing "pauses when no results provided (backward compat)"

--- a/docs/pull-requests/2026-05-09-fix-workflow-rate-limit-clock-tests.md
+++ b/docs/pull-requests/2026-05-09-fix-workflow-rate-limit-clock-tests.md
@@ -1,0 +1,80 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix(workflow): remove wall-clock waits from rate-limit tests
+
+## Overview
+
+Make the workflow DAG resilience tests deterministic by routing
+rate-limit time calculations through the shared clock component and
+injecting short waits in tests instead of sleeping against the real
+wall clock.
+
+The immediate trigger was `dag_resilience_execution_test` hanging the
+changed-bricks hook near local `2pm`. The test used a literal
+`"You've hit your limit · resets 2pm"` message, and
+`wait-for-reset!` computed the real wait from `System/currentTimeMillis`
+and then called `Thread/sleep`. When the suite happened to run shortly
+before `2pm`, the test exercised the short-wait path and stalled the
+whole hook.
+
+## Root cause
+
+`components/workflow/src/ai/miniforge/workflow/dag_resilience.clj`
+mixed two hard-coded wall-clock dependencies into rate-limit handling:
+
+- `parse-reset-instant` used `Instant/now` and `ZonedDateTime/now`
+- `millis-until-reset` used `System/currentTimeMillis`
+- `wait-for-reset!` called `Thread/sleep` directly
+
+That made the tests time-sensitive in two ways:
+
+- absolute reset strings like `"resets 2pm"` changed behaviour based
+  on when the suite happened to run
+- relative reset strings like `"resets in 1 seconds"` always incurred
+  a real sleep
+
+## Fix
+
+- Add `ai.miniforge/clock` as an explicit workflow dependency.
+- Route reset-time parsing and wait-duration math through
+  `ai.miniforge.clock.interface/now-ms`.
+- Add a dynamic `*sleep!*` seam in `dag_resilience.clj` so tests can
+  advance a fake clock instead of sleeping.
+- Rewrite the resilience tests to use fixed instants and explicit
+  timezone expectations.
+- Rewrite the DAG execution pause test to pin the clock to a known
+  instant and assert that the pause path does **not** invoke the short
+  sleep branch.
+
+I did not add `tick` or `tea-time` here because the repo already has a
+first-party clock abstraction with explicit test guidance. Using that
+existing seam keeps the production code smaller and avoids introducing
+another time-control abstraction just for one workflow component.
+
+## Files changed
+
+- `components/workflow/deps.edn`
+- `components/workflow/src/ai/miniforge/workflow/dag_resilience.clj`
+- `components/workflow/test/ai/miniforge/workflow/dag_resilience_failover_test.clj`
+- `components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj`
+
+## Verification
+
+- `clj-kondo --lint` on the touched workflow files: clean
+- focused workflow resilience tests:
+  - `ai.miniforge.workflow.dag-resilience-failover-test`
+  - `ai.miniforge.workflow.dag-resilience-execution-test`
+- `bb test` changed-bricks sweep: green
+  - `5525` tests
+  - `24493` assertions
+  - `0` failures
+  - `0` errors
+
+## Test plan
+
+- [x] Lint touched workflow files
+- [x] Run focused DAG resilience tests
+- [x] Run changed-bricks proof path (`bb test`)


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix(workflow): remove wall-clock waits from rate-limit tests

## Overview

Make the workflow DAG resilience tests deterministic by routing
rate-limit time calculations through the shared clock component and
injecting short waits in tests instead of sleeping against the real
wall clock.

The immediate trigger was `dag_resilience_execution_test` hanging the
changed-bricks hook near local `2pm`. The test used a literal
`"You've hit your limit · resets 2pm"` message, and
`wait-for-reset!` computed the real wait from `System/currentTimeMillis`
and then called `Thread/sleep`. When the suite happened to run shortly
before `2pm`, the test exercised the short-wait path and stalled the
whole hook.

## Root cause

`components/workflow/src/ai/miniforge/workflow/dag_resilience.clj`
mixed two hard-coded wall-clock dependencies into rate-limit handling:

- `parse-reset-instant` used `Instant/now` and `ZonedDateTime/now`
- `millis-until-reset` used `System/currentTimeMillis`
- `wait-for-reset!` called `Thread/sleep` directly

That made the tests time-sensitive in two ways:

- absolute reset strings like `"resets 2pm"` changed behaviour based
  on when the suite happened to run
- relative reset strings like `"resets in 1 seconds"` always incurred
  a real sleep

## Fix

- Add `ai.miniforge/clock` as an explicit workflow dependency.
- Route reset-time parsing and wait-duration math through
  `ai.miniforge.clock.interface/now-ms`.
- Add a dynamic `*sleep!*` seam in `dag_resilience.clj` so tests can
  advance a fake clock instead of sleeping.
- Rewrite the resilience tests to use fixed instants and explicit
  timezone expectations.
- Rewrite the DAG execution pause test to pin the clock to a known
  instant and assert that the pause path does **not** invoke the short
  sleep branch.

I did not add `tick` or `tea-time` here because the repo already has a
first-party clock abstraction with explicit test guidance. Using that
existing seam keeps the production code smaller and avoids introducing
another time-control abstraction just for one workflow component.

## Files changed

- `components/workflow/deps.edn`
- `components/workflow/src/ai/miniforge/workflow/dag_resilience.clj`
- `components/workflow/test/ai/miniforge/workflow/dag_resilience_failover_test.clj`
- `components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj`

## Verification

- `clj-kondo --lint` on the touched workflow files: clean
- focused workflow resilience tests:
  - `ai.miniforge.workflow.dag-resilience-failover-test`
  - `ai.miniforge.workflow.dag-resilience-execution-test`
- `bb test` changed-bricks sweep: green
  - `5525` tests
  - `24493` assertions
  - `0` failures
  - `0` errors

## Test plan

- [x] Lint touched workflow files
- [x] Run focused DAG resilience tests
- [x] Run changed-bricks proof path (`bb test`)
