### PR TITLE
feat(test): wire stable-derived bb test tasks

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -73,8 +73,35 @@
   ;; ──────────────────────────────────────────────────────────────────────────
 
   test
-  {:doc  "Run changed brick tests in parallel (since main)"
-   :task (let [exit (run-stream! "bb" "scripts/test-changed-bricks.bb")]
+  {:doc  "Run stable-derived changed-and-affected project tests"
+   :task (let [exit (run-stream! "bb" "scripts/test-since-stable.bb")]
+           (when-not (zero? exit)
+             (System/exit exit)))}
+
+  test:since-stable
+  {:doc  "Run stable-derived changed-and-affected project tests"
+   :task (let [exit (run-stream! "bb" "scripts/test-since-stable.bb")]
+           (when-not (zero? exit)
+             (System/exit exit)))}
+
+  test:since-stable:subset
+  {:doc  "Run one explicit or detected stable-derived project subset"
+   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb" "mode:subset"]
+                                               *command-line-args*))]
+           (when-not (zero? exit)
+             (System/exit exit)))}
+
+  test:since-stable:expand
+  {:doc  "Run additive stable-derived diagnostic subsets"
+   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb" "mode:expand"]
+                                               *command-line-args*))]
+           (when-not (zero? exit)
+             (System/exit exit)))}
+
+  test:since-stable:bisect
+  {:doc  "Run breadth-first bisect stable-derived diagnostic subsets"
+   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb" "mode:bisect"]
+                                               *command-line-args*))]
            (when-not (zero? exit)
              (System/exit exit)))}
 
@@ -106,7 +133,7 @@
   test:all
   {:doc  "Run full suite (unit bricks + project integration tests)"
    :task (do
-           (run 'test)
+           (run 'test:poly)
            (run 'test:integration))}
 
   ccov

--- a/bb.edn
+++ b/bb.edn
@@ -86,22 +86,25 @@
 
   test:since-stable:subset
   {:doc  "Run one explicit or detected stable-derived project subset"
-   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb" "mode:subset"]
-                                               *command-line-args*))]
+   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb"]
+                                               *command-line-args*
+                                               ["mode:subset"]))]
            (when-not (zero? exit)
              (System/exit exit)))}
 
   test:since-stable:expand
   {:doc  "Run additive stable-derived diagnostic subsets"
-   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb" "mode:expand"]
-                                               *command-line-args*))]
+   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb"]
+                                               *command-line-args*
+                                               ["mode:expand"]))]
            (when-not (zero? exit)
              (System/exit exit)))}
 
   test:since-stable:bisect
   {:doc  "Run breadth-first bisect stable-derived diagnostic subsets"
-   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb" "mode:bisect"]
-                                               *command-line-args*))]
+   :task (let [exit (apply run-stream! (concat ["bb" "scripts/test-since-stable.bb"]
+                                               *command-line-args*
+                                               ["mode:bisect"]))]
            (when-not (zero? exit)
              (System/exit exit)))}
 

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
@@ -196,6 +196,22 @@
   []
   changed-or-affected-projects-argv)
 
+(defn changed-projects-since-stable-command
+  "Return the argv that queries Polylith for changed-or-affected
+   projects since the current stable tag anchor."
+  []
+  (let [argv (vec (changed-projects-command))
+        marker "get:changes:changed-or-affected-projects"
+        marker-index (.indexOf argv marker)]
+    (if (neg? marker-index)
+      (throw (ex-info "Changed-projects command is missing the Polylith change marker."
+                      {:argv argv
+                       :marker marker}))
+      (let [insert-index (inc marker-index)]
+        (vec (concat (subvec argv 0 insert-index)
+                     ["since:stable"]
+                     (subvec argv insert-index)))))))
+
 (defn parse-project-list-output
   "Parse a Polylith `ws get:changes:changed-or-affected-projects`
    response into a vector of project names."

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
@@ -77,6 +77,12 @@
   []
   (core/changed-projects-command))
 
+(defn changed-projects-since-stable-command
+  "Return the argv that asks Polylith for changed-or-affected projects
+   relative to the current stable tag anchor."
+  []
+  (core/changed-projects-since-stable-command))
+
 (defn parse-project-list-output
   "Parse a changed-or-affected project list response into project names."
   [output]

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -191,6 +191,12 @@
             "skip:dev" "color-mode:none"]
            (sut/changed-projects-command)))))
 
+(deftest test-changed-projects-since-stable-command-inserts-after-change-marker
+  (testing "stable-derived diagnostics insert since:stable next to the Polylith change query"
+    (is (= ["clojure" "-M:poly" "ws" "get:changes:changed-or-affected-projects"
+            "since:stable" "skip:dev" "color-mode:none"]
+           (sut/changed-projects-since-stable-command)))))
+
 (deftest test-parse-project-list-output-reads-edn-vectors
   (testing "Polylith ws output parses into project names"
     (is (= ["miniforge" "miniforge-core"]

--- a/docs/pull-requests/2026-05-10-wire-stable-derived-test-scope-into-bb-tasks.md
+++ b/docs/pull-requests/2026-05-10-wire-stable-derived-test-scope-into-bb-tasks.md
@@ -1,0 +1,41 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# feat(test): wire stable-derived scope and diagnostics into bb tasks
+
+## Overview
+
+Wire the `bb` task surface to a stable-derived Polylith test wrapper
+and add diagnostic commands for subset, expand, and bisect runs.
+
+## Why
+
+The repo needed two operational fixes:
+
+- `bb test` should use the real stable-derived changed-and-affected
+  project set instead of a custom opaque approximation
+- when the narrowed path fails, there needs to be a first-class way to
+  isolate the failing project subset quickly instead of rerunning the
+  whole hook blindly
+
+## What changed
+
+- wire `bb test` through the stable-derived wrapper
+- add `test:since-stable`, `test:since-stable:subset`,
+  `test:since-stable:expand`, and `test:since-stable:bisect`
+- add `scripts/test-since-stable.bb` as a thin runtime wrapper over the
+  shared `bb-test-runner` planning helpers
+- keep `test:all` on the full Poly unit-brick path instead of the
+  narrowed stable-derived path
+
+## Files changed
+
+- `bb.edn`
+- `scripts/test-since-stable.bb`
+
+## Verification
+
+- `bb test:since-stable:subset`
+- `bb pre-commit`

--- a/scripts/test-since-stable.bb
+++ b/scripts/test-since-stable.bb
@@ -69,13 +69,12 @@
 
 (defn- changed-projects-since-stable
   []
-  (let [[prefix suffix] (split-at 4 (bb-test-runner/changed-projects-command))]
-    (->> (sh-string (concat prefix ["since:stable"] suffix))
-         bb-test-runner/parse-project-list-output)))
+  (->> (sh-string (bb-test-runner/changed-projects-since-stable-command))
+       bb-test-runner/parse-project-list-output))
 
 (defn- full-suite-step
   []
-  {:label "No stable tag found; running full Poly test suite"
+  {:label "No stable tag found locally; fetch tags or create a stable tag anchor to avoid a full Poly test sweep"
    :argv ["clojure" "-M:poly" "test"]})
 
 (defn- effective-plan

--- a/scripts/test-since-stable.bb
+++ b/scripts/test-since-stable.bb
@@ -1,0 +1,107 @@
+#!/usr/bin/env bb
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(require '[babashka.process :as p]
+         '[clojure.string :as str]
+         '[ai.miniforge.bb-test-runner.interface :as bb-test-runner])
+
+(def ^:private clean-env
+  (bb-test-runner/sanitize-git-worktree-env (into {} (System/getenv))))
+
+(defn- sh-string
+  [argv]
+  (let [{:keys [exit out err]} (apply p/sh (concat [{:out :string
+                                                     :err :string
+                                                     :env clean-env}]
+                                                   argv))]
+    (when-not (zero? exit)
+      (binding [*out* *err*]
+        (when-not (str/blank? err)
+          (println err)))
+      (throw (ex-info "Command failed."
+                      {:argv argv
+                       :exit exit
+                       :err err})))
+    out))
+
+(defn- run-step!
+  [{:keys [label argv]}]
+  (println (str "▶ " label))
+  (let [proc (apply p/process (concat [{:out :inherit
+                                        :err :inherit
+                                        :env clean-env}]
+                                      argv))
+        heartbeat-ms (* 1000 (bb-test-runner/heartbeat-seconds clean-env))]
+    (loop [elapsed heartbeat-ms]
+      (let [result (deref proc heartbeat-ms ::timeout)]
+        (if (= ::timeout result)
+          (do
+            (println (str "  Stable-derived tests still running... "
+                          (quot elapsed 1000)
+                          "s elapsed"))
+            (recur (+ elapsed heartbeat-ms)))
+          (:exit result))))))
+
+(defn- stable-tags
+  []
+  (->> (sh-string (concat ["git" "tag" "-l"]
+                          (bb-test-runner/stable-tag-globs)))
+       str/split-lines
+       (map str/trim)
+       (remove str/blank?)
+       vec))
+
+(defn- changed-projects-since-stable
+  []
+  (let [[prefix suffix] (split-at 4 (bb-test-runner/changed-projects-command))]
+    (->> (sh-string (concat prefix ["since:stable"] suffix))
+         bb-test-runner/parse-project-list-output)))
+
+(defn- full-suite-step
+  []
+  {:label "No stable tag found; running full Poly test suite"
+   :argv ["clojure" "-M:poly" "test"]})
+
+(defn- effective-plan
+  [parsed-args]
+  (let [mode (or (:mode parsed-args) :subset)
+        projects (or (seq (:projects parsed-args))
+                     (seq (changed-projects-since-stable)))]
+    (when (seq projects)
+      (bb-test-runner/diagnostic-test-plan
+       (assoc parsed-args
+              :mode mode
+              :projects (vec projects))))))
+
+(defn -main
+  [& args]
+  (let [parsed-args (bb-test-runner/parse-diagnostic-args args)]
+    (if-not (bb-test-runner/stable-tags-present? (stable-tags))
+      (System/exit (run-step! (full-suite-step)))
+      (if-let [plan (effective-plan parsed-args)]
+        (do
+          (println (:summary plan))
+          (doseq [step (:steps plan)]
+            (let [exit (run-step! step)]
+              (when-not (zero? exit)
+                (System/exit exit))))
+          (println "✓ Stable-derived test plan passed"))
+        (println "✓ No changed or affected projects since stable")))))
+
+(apply -main *command-line-args*)


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# feat(test): wire stable-derived scope and diagnostics into bb tasks

## Overview

Wire the `bb` task surface to a stable-derived Polylith test wrapper
and add diagnostic commands for subset, expand, and bisect runs.

## Why

The repo needed two operational fixes:

- `bb test` should use the real stable-derived changed-and-affected
  project set instead of a custom opaque approximation
- when the narrowed path fails, there needs to be a first-class way to
  isolate the failing project subset quickly instead of rerunning the
  whole hook blindly

## What changed

- wire `bb test` through the stable-derived wrapper
- add `test:since-stable`, `test:since-stable:subset`,
  `test:since-stable:expand`, and `test:since-stable:bisect`
- add `scripts/test-since-stable.bb` as a thin runtime wrapper over the
  shared `bb-test-runner` planning helpers
- keep `test:all` on the full Poly unit-brick path instead of the
  narrowed stable-derived path

## Files changed

- `bb.edn`
- `scripts/test-since-stable.bb`

## Verification

- `bb test:since-stable:subset`
- `bb pre-commit`
