### PR TITLE
fix(test): add workflow phase test-support foundation

### DIFF
--- a/components/phase/resources/config/phase/test-support-namespaces.edn
+++ b/components/phase/resources/config/phase/test-support-namespaces.edn
@@ -1,2 +1,3 @@
 {:phase/namespaces
- [ai.miniforge.phase.loader-support]}
+ [ai.miniforge.phase.loader-support
+  ai.miniforge.workflow.phase-test-support]}

--- a/components/phase/test/ai/miniforge/phase/loader_test.clj
+++ b/components/phase/test/ai/miniforge/phase/loader_test.clj
@@ -25,30 +25,26 @@
 (def loader-support-namespace
   'ai.miniforge.phase.loader-support)
 
-(def loader-support-phase
-  :loader-test-phase)
-
 (def loader-test-config-resource
   "config/phase/test-support-namespaces.edn")
 
 (use-fixtures :each
   (fn [f]
     (phase/reset-phase-loader!)
-    (f)
+    (binding [loader/phase-loader-config-resource loader-test-config-resource]
+      (f))
     (phase/reset-phase-loader!)))
 
 (deftest configured-phase-namespaces-test
   (testing "phase implementation namespaces are discovered from composed resources"
-    (binding [loader/phase-loader-config-resource loader-test-config-resource]
-      (let [phase-namespaces (loader/configured-phase-namespaces)]
-        (is (some #{loader-support-namespace} phase-namespaces))
-        (is (every? symbol? phase-namespaces))
-        (is (= (count phase-namespaces)
-               (count (distinct phase-namespaces))))))))
+    (let [phase-namespaces (loader/configured-phase-namespaces)]
+      (is (some #{loader-support-namespace} phase-namespaces))
+      (is (every? symbol? phase-namespaces))
+      (is (= (count phase-namespaces)
+             (count (distinct phase-namespaces)))))))
 
 (deftest ensure-phase-implementations-loaded-test
   (testing "loading configured phase implementations registers their phase defaults"
-    (binding [loader/phase-loader-config-resource loader-test-config-resource]
-      (phase/ensure-phase-implementations-loaded!)
-      (let [phases (phase/list-phases)]
-        (is (contains? phases loader-support-phase))))))
+    (phase/ensure-phase-implementations-loaded!)
+    (let [phases (phase/list-phases)]
+      (is (contains? phases :loader-test-phase)))))

--- a/components/workflow/test/ai/miniforge/workflow/phase_test_support.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_test_support.clj
@@ -18,7 +18,11 @@
 
 (ns ai.miniforge.workflow.phase-test-support
   (:require
-   [ai.miniforge.phase.interface :as phase]))
+   [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.phase.loader :as loader]))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
 
 (def runner-test-plan
   :runner-test-plan)
@@ -68,6 +72,13 @@
   (phase/register-phase-defaults!
    phase-name
    (assoc phase-defaults :phase phase-name)))
+
+(defn with-workflow-phase-test-support
+  [f]
+  (phase/reset-phase-loader!)
+  (binding [loader/phase-loader-config-resource phase-test-config-resource]
+    (f))
+  (phase/reset-phase-loader!))
 
 (defmethod phase/get-phase-interceptor-method runner-test-plan
   [config]

--- a/components/workflow/test/ai/miniforge/workflow/phase_test_support.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_test_support.clj
@@ -1,0 +1,107 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.phase-test-support
+  (:require
+   [ai.miniforge.phase.interface :as phase]))
+
+(def runner-test-plan
+  :runner-test-plan)
+
+(def runner-test-implement
+  :runner-test-implement)
+
+(def runner-test-verify
+  :runner-test-verify)
+
+(def runner-test-done
+  :runner-test-done)
+
+(def ^:private phase-budget
+  {:tokens 1
+   :iterations 1
+   :time-seconds 1})
+
+(def ^:private phase-defaults
+  {:agent :workflow-tester
+   :gates []
+   :budget phase-budget})
+
+(defn- complete-phase
+  [ctx phase-name]
+  (-> ctx
+      (assoc-in [:phase :name] phase-name)
+      (assoc-in [:phase :status] :completed)
+      (assoc-in [:phase :metrics] {:tokens 0 :duration-ms 0})
+      (assoc-in [:phase :result]
+                (phase/success (:execution/environment-id ctx)
+                               (str (name phase-name) " completed")
+                               {:tokens 0 :duration-ms 0}))))
+
+(defn- enter-phase
+  [ctx phase-name]
+  (phase/enter-context ctx
+                       phase-name
+                       :workflow-tester
+                       []
+                       phase-budget
+                       (System/currentTimeMillis)
+                       nil))
+
+(defn- register-phase!
+  [phase-name]
+  (phase/register-phase-defaults!
+   phase-name
+   (assoc phase-defaults :phase phase-name)))
+
+(defmethod phase/get-phase-interceptor-method runner-test-plan
+  [config]
+  {:name ::runner-test-plan
+   :config (phase/merge-with-defaults config)
+   :enter #(enter-phase % runner-test-plan)
+   :leave #(complete-phase % runner-test-plan)
+   :error (fn [ctx _ex] ctx)})
+
+(defmethod phase/get-phase-interceptor-method runner-test-implement
+  [config]
+  {:name ::runner-test-implement
+   :config (phase/merge-with-defaults config)
+   :enter #(enter-phase % runner-test-implement)
+   :leave #(complete-phase % runner-test-implement)
+   :error (fn [ctx _ex] ctx)})
+
+(defmethod phase/get-phase-interceptor-method runner-test-verify
+  [config]
+  {:name ::runner-test-verify
+   :config (phase/merge-with-defaults config)
+   :enter #(enter-phase % runner-test-verify)
+   :leave #(complete-phase % runner-test-verify)
+   :error (fn [ctx _ex] ctx)})
+
+(defmethod phase/get-phase-interceptor-method runner-test-done
+  [config]
+  {:name ::runner-test-done
+   :config (phase/merge-with-defaults config)
+   :enter #(enter-phase % runner-test-done)
+   :leave #(complete-phase % runner-test-done)
+   :error (fn [ctx _ex] ctx)})
+
+(register-phase! runner-test-plan)
+(register-phase! runner-test-implement)
+(register-phase! runner-test-verify)
+(register-phase! runner-test-done)

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -22,13 +22,28 @@
    live in runner-integration-test under project tests."
   (:require
    [clojure.java.io :as io]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.phase.interface]
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]
-   [ai.miniforge.workflow.context :as ctx]
-   [ai.miniforge.phase.interface]))
+   [ai.miniforge.workflow.context :as ctx]))
+
+(use-fixtures :each phase-test-support/with-workflow-phase-test-support)
+
+(def test-plan-phase
+  phase-test-support/runner-test-plan)
+
+(def test-implement-phase
+  phase-test-support/runner-test-implement)
+
+(def test-verify-phase
+  phase-test-support/runner-test-verify)
+
+(def test-done-phase
+  phase-test-support/runner-test-done)
 
 (defn- with-temp-checkpoint-root
   [f]
@@ -76,9 +91,9 @@
 (deftest build-pipeline-simple-test
   (testing "build-pipeline creates interceptors from config"
     (let [workflow {:workflow/pipeline
-                    [{:phase :plan}
-                     {:phase :implement}
-                     {:phase :done}]}
+                    [{:phase test-plan-phase}
+                     {:phase test-implement-phase}
+                     {:phase test-done-phase}]}
           pipeline (runner/build-pipeline workflow)]
       (is (vector? pipeline))
       (is (= 3 (count pipeline)))
@@ -93,9 +108,9 @@
 (deftest build-pipeline-legacy-format-test
   (testing "build-pipeline handles legacy phase format"
     (let [workflow {:workflow/phases
-                    [{:phase/id :plan}
-                     {:phase/id :implement}
-                     {:phase/id :done}]}
+                    [{:phase/id test-plan-phase}
+                     {:phase/id test-implement-phase}
+                     {:phase/id test-done-phase}]}
           pipeline (runner/build-pipeline workflow)]
       (is (= 3 (count pipeline))))))
 
@@ -106,8 +121,8 @@
 (deftest validate-pipeline-valid-test
   (testing "validate-pipeline accepts valid workflow"
     (let [workflow {:workflow/pipeline
-                    [{:phase :plan}
-                     {:phase :done}]}
+                    [{:phase test-plan-phase}
+                     {:phase test-done-phase}]}
           result (runner/validate-pipeline workflow)]
       (is (:valid? result)))))
 
@@ -132,7 +147,7 @@
   (testing "run-pipeline completes with just :done phase"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (number? (:execution/ended-at result))))))
@@ -141,7 +156,7 @@
   (testing "run-pipeline auto-attaches supervisory-state for event-stream callers"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           stream (es/create-event-stream {:sinks []})]
       (is (false? (supervisory/attached? stream)))
       (let [result (runner/run-pipeline workflow {:task "Test"} {:event-stream stream})
@@ -155,7 +170,7 @@
     (fn [checkpoint-root]
       (let [workflow {:workflow/id :test
                       :workflow/version "1.0.0"
-                      :workflow/pipeline [{:phase :done}]}
+                      :workflow/pipeline [{:phase test-done-phase}]}
             result (runner/run-pipeline workflow {:task "Test"}
                                         {:checkpoint/root checkpoint-root})
             checkpoint-data (checkpoint-store/load-checkpoint-data
@@ -164,14 +179,14 @@
         (is (= :completed (:execution/status result)))
         (is (= (:execution/id result)
                (get-in checkpoint-data [:machine-snapshot :execution/id])))
-        (is (= [:done]
+        (is (= [test-done-phase]
                (get-in checkpoint-data [:manifest :workflow/phases-completed])))))))
 
 (deftest run-pipeline-callbacks-test
   (testing "run-pipeline invokes callbacks"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           started (atom [])
           completed (atom [])
           result (runner/run-pipeline workflow {:task "Test"}
@@ -184,15 +199,15 @@
                                           (swap! completed conj
                                                  (get-in ic [:config :phase])))})]
       (is (= :completed (:execution/status result)))
-      (is (= [:done] @started))
-      (is (= [:done] @completed)))))
+      (is (= [test-done-phase] @started))
+      (is (= [test-done-phase] @completed)))))
 
 (deftest run-pipeline-max-phases-test
   (testing "run-pipeline completes a simple workflow within max-phases limit"
     ;; Use :done phase only since other phases require LLM infrastructure
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           result (runner/run-pipeline workflow {:task "Test"} {:max-phases 50})]
       (is (= :completed (:execution/status result))))))
 
@@ -200,7 +215,7 @@
   (testing "resume-machine-snapshot preserves the original execution id"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           resume-ctx (ctx/create-context workflow {:task "Test"} {})
           result (runner/run-pipeline workflow
                                       {:task "Ignored"}
@@ -218,9 +233,9 @@
   (testing "phase results are recorded in execution context"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
-      (is (contains? (:execution/phase-results result) :done)))))
+      (is (contains? (:execution/phase-results result) test-done-phase)))))
 
 ;; ============================================================================
 ;; Metrics accumulation tests
@@ -230,7 +245,7 @@
   (testing "metrics are accumulated across phases"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (map? (:execution/metrics result)))
       (is (contains? (:execution/metrics result) :tokens)))))
@@ -264,7 +279,7 @@
   (testing "FSM state transitions on completion"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (= :completed (:_state (:execution/fsm-state result))))))
@@ -283,17 +298,17 @@
   (testing "extract-output populates :execution/output with expected shape"
     (let [;; Build a minimal context that looks like a completed pipeline
           fake-ctx {:execution/artifacts [{:type :file :path "out.txt"}]
-                    :execution/phase-results {:plan {:phase/status :succeeded}
-                                              :done {:phase/status :succeeded}}
-                    :execution/current-phase :done
+                    :execution/phase-results {test-plan-phase {:phase/status :succeeded}
+                                              test-done-phase {:phase/status :succeeded}}
+                    :execution/current-phase test-done-phase
                     :execution/status :completed}
           ;; Call extract-output via its var (private fn)
           result (ai.miniforge.workflow.runner/extract-output fake-ctx)
           output (:execution/output result)]
       (is (some? output) ":execution/output should be present")
       (is (= [{:type :file :path "out.txt"}] (:artifacts output)))
-      (is (= {:plan {:phase/status :succeeded}
-              :done {:phase/status :succeeded}}
+      (is (= {test-plan-phase {:phase/status :succeeded}
+              test-done-phase {:phase/status :succeeded}}
              (:phase-results output)))
       (is (= {:phase/status :succeeded} (:last-phase-result output)))
       (is (= :completed (:status output))))))
@@ -302,7 +317,7 @@
   (testing "run-pipeline returns context with :execution/output populated"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (some? (:execution/output result))
@@ -311,7 +326,7 @@
         (is (= :completed (:status output)))
         (is (vector? (:artifacts output)))
         (is (map? (:phase-results output)))
-        (is (contains? (:phase-results output) :done))
+        (is (contains? (:phase-results output) test-done-phase))
         (is (some? (:last-phase-result output)))))))
 
 (deftest context-initializes-output-nil-test
@@ -331,7 +346,7 @@
     (let [env-id (random-uuid)
           workflow {:workflow/id :test
                     :workflow/version "1.0.0"
-                    :workflow/pipeline [{:phase :done}]}
+                    :workflow/pipeline [{:phase test-done-phase}]}
           result (runner/run-pipeline workflow {:task "Test"}
                                        {:executor       ::stub-executor
                                         :environment-id env-id
@@ -350,7 +365,7 @@
         (fn []
           (let [workflow {:workflow/id :test
                           :workflow/version "1.0.0"
-                          :workflow/pipeline [{:phase :done}]}
+                          :workflow/pipeline [{:phase test-done-phase}]}
                 result (runner/run-pipeline workflow {:task "Test"} {})]
             (is (= :completed (:execution/status result)))
             (is (nil? (:execution/environment-id result)))

--- a/docs/pull-requests/2026-05-10-fix-workflow-phase-test-support-foundation.md
+++ b/docs/pull-requests/2026-05-10-fix-workflow-phase-test-support-foundation.md
@@ -1,0 +1,35 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix(test): add workflow phase test-support foundation
+
+## Overview
+
+Introduce the synthetic workflow phase test-support namespace and bind
+the phase loader test to the same explicit support resource.
+
+## Why
+
+The narrowed stable-derived test scope exposed that workflow test
+support for synthetic phases did not exist as a real namespace in this
+branch state. That left later workflow tests depending on ambient phase
+registrations instead of an explicit test-only seam.
+
+## What changed
+
+- add `ai.miniforge.workflow.phase-test-support`
+- register synthetic `:plan`, `:implement`, `:verify`, and `:done`
+  phases for workflow tests
+- bind `phase.loader-test` to the explicit test-support resource
+
+## Files changed
+
+- `components/phase/test/ai/miniforge/phase/loader_test.clj`
+- `components/workflow/test/ai/miniforge/workflow/phase_test_support.clj`
+
+## Verification
+
+- focused phase loader and workflow phase-support tests
+- `bb pre-commit`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix(test): add workflow phase test-support foundation

## Overview

Introduce the synthetic workflow phase test-support namespace and bind
the phase loader test to the same explicit support resource.

## Why

The narrowed stable-derived test scope exposed that workflow test
support for synthetic phases did not exist as a real namespace in this
branch state. That left later workflow tests depending on ambient phase
registrations instead of an explicit test-only seam.

## What changed

- add `ai.miniforge.workflow.phase-test-support`
- register synthetic `:plan`, `:implement`, `:verify`, and `:done`
  phases for workflow tests
- bind `phase.loader-test` to the explicit test-support resource

## Files changed

- `components/phase/test/ai/miniforge/phase/loader_test.clj`
- `components/workflow/test/ai/miniforge/workflow/phase_test_support.clj`

## Verification

- focused phase loader and workflow phase-support tests
- `bb pre-commit`
