### PR TITLE
fix(test): remove ambient workflow chain and registry assumptions

### DIFF
--- a/components/workflow/test/ai/miniforge/workflow/anomaly/try_load_chain_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/try_load_chain_test.clj
@@ -20,19 +20,35 @@
   "Coverage for `chain-loader/try-load-chain` (anomaly-returning) and
    the `chain-loader/load-chain` boundary that escalates a not-found
    anomaly to slingshot under `:anomalies/not-found`."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.workflow.chain-loader :as chain-loader])
   (:import (clojure.lang ExceptionInfo)))
 
 ;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
 
+(def ^:private spec-to-pr-versioned-path
+  "chains/spec-to-pr-v1.0.0.edn")
+
+(def ^:private stub-resource-url
+  (java.net.URL. "file:/tmp/miniforge-try-load-chain-test-resource"))
+
 (deftest try-load-chain-returns-result-on-success
   (testing "existing chain resource yields a non-anomaly result map"
-    (let [result (chain-loader/try-load-chain :spec-to-pr "1.0.0")]
-      (is (not (anomaly/anomaly? result)))
-      (is (some? (:chain result)))
-      (is (= :resource (:source result))))))
+    (with-redefs [io/resource (fn [resource-path]
+                                (when (= spec-to-pr-versioned-path resource-path)
+                                  stub-resource-url))
+                  chain-loader/load-chain-resource
+                  (fn [resource-path]
+                    (when (= spec-to-pr-versioned-path resource-path)
+                      {:chain/id :spec-to-pr
+                       :chain/version "1.0.0"
+                       :chain/steps [{:workflow/id :spec-step}]}))]
+      (let [result (chain-loader/try-load-chain :spec-to-pr "1.0.0")]
+        (is (not (anomaly/anomaly? result)))
+        (is (some? (:chain result)))
+        (is (= :resource (:source result)))))))
 
 ;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
 

--- a/components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj
@@ -20,21 +20,87 @@
   "Tests for chain definition loading."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [clojure.java.io :as io]
    [ai.miniforge.workflow.chain-loader :as chain-loader]))
+
+(def spec-to-pr-versioned-path
+  "chains/spec-to-pr-v1.0.0.edn")
+
+(def spec-to-pr-latest-path
+  "chains/spec-to-pr-v1.2.0.edn")
+
+(def sdlc-to-deploy-path
+  "chains/sdlc-to-deploy-v1.0.0.edn")
+
+(def stub-resource-url
+  (java.net.URL. "file:/tmp/miniforge-workflow-chain-loader-test-resource"))
+
+(def chain-definitions
+  {spec-to-pr-versioned-path
+   {:chain/id :spec-to-pr
+    :chain/version "1.0.0"
+    :chain/description "Spec to PR"
+    :chain/steps [{:workflow/id :spec-step}]}
+   spec-to-pr-latest-path
+   {:chain/id :spec-to-pr
+    :chain/version "1.2.0"
+    :chain/description "Spec to PR"
+    :chain/steps [{:workflow/id :spec-step}
+                  {:workflow/id :review-step}]}
+   sdlc-to-deploy-path
+   {:chain/id :sdlc-to-deploy
+    :chain/version "1.0.0"
+    :chain/description "SDLC to deploy"
+    :chain/steps [{:workflow/id :deploy-step}]}})
+
+(defn- resource-exists?
+  [resource-path]
+  (contains? chain-definitions resource-path))
+
+(defn- fake-resource
+  [resource-path]
+  (when (resource-exists? resource-path)
+    stub-resource-url))
+
+(defn- fake-load-chain-resource
+  [resource-path]
+  (get chain-definitions resource-path))
+
+(def test-chain-resource-names
+  ["spec-to-pr-v1.0.0.edn" "test-chain-v1.0.0.edn"])
+
+(def test-chain-summaries
+  {"chains/spec-to-pr-v1.0.0.edn"
+   {:id :spec-to-pr
+    :version "1.0.0"
+    :description "Spec to PR"
+    :steps 1}
+   "chains/test-chain-v1.0.0.edn"
+   {:id :test-chain
+    :version "1.0.0"
+    :description "Test chain"
+    :steps 2}})
 
 (deftest load-chain-versioned-test
   (testing "loads chain by ID and version from resources"
-    (let [{:keys [chain source]} (chain-loader/load-chain :spec-to-pr "1.0.0")]
-      (is (= :spec-to-pr (:chain/id chain)))
-      (is (= "1.0.0" (:chain/version chain)))
-      (is (= :resource source))
-      (is (seq (:chain/steps chain))))))
+    (with-redefs [io/resource fake-resource
+                  chain-loader/load-chain-resource fake-load-chain-resource]
+      (let [{:keys [chain source]} (chain-loader/load-chain :spec-to-pr "1.0.0")]
+        (is (= :spec-to-pr (:chain/id chain)))
+        (is (= "1.0.0" (:chain/version chain)))
+        (is (= :resource source))
+        (is (seq (:chain/steps chain)))))))
 
 (deftest load-chain-latest-test
   (testing "loads latest version when version is 'latest'"
-    (let [{:keys [chain]} (chain-loader/load-chain :spec-to-pr "latest")]
-      (is (= :spec-to-pr (:chain/id chain)))
-      (is (some? (:chain/version chain))))))
+    (with-redefs [chain-loader/list-resource-names (fn [_]
+                                                     ["spec-to-pr-v1.0.0.edn"
+                                                      "spec-to-pr-v1.2.0.edn"])
+                  chain-loader/load-chain-resource fake-load-chain-resource]
+      (let [{:keys [chain path]} (chain-loader/load-chain :spec-to-pr "latest")]
+        (is (= :spec-to-pr (:chain/id chain)))
+        (is (= "1.2.0" (:chain/version chain)))
+        (is (= spec-to-pr-latest-path path))))))
 
 (deftest load-chain-not-found-test
   (testing "throws when chain not found"
@@ -42,17 +108,25 @@
           (chain-loader/load-chain :nonexistent-chain "1.0.0")))))
 
 (deftest list-chains-test
-  (testing "lists available chains across composed resource roots"
-    (let [chains (chain-loader/list-chains)]
-      (is (seq chains))
-      (is (some #(= :spec-to-pr (:id %)) chains))
-      (is (some #(= :test-chain (:id %)) chains))
-      (let [spec-to-pr (first (filter #(= :spec-to-pr (:id %)) chains))]
-        (is (= "1.0.0" (:version spec-to-pr)))
-        (is (pos? (:steps spec-to-pr)))))))
+  (testing "lists chain summaries from every resource name returned by discovery"
+    (with-redefs [chain-loader/list-resource-names (fn [_] test-chain-resource-names)
+                  chain-loader/parse-chain-resource #(get test-chain-summaries %)]
+      (let [chains (chain-loader/list-chains)]
+        (is (= [{:id :spec-to-pr
+                 :version "1.0.0"
+                 :description "Spec to PR"
+                 :steps 1}
+                {:id :test-chain
+                 :version "1.0.0"
+                 :description "Test chain"
+                 :steps 2}]
+               chains))))))
 
-(deftest list-resource-names-test
-  (testing "resource enumeration aggregates all chain roots on the classpath"
-    (let [resource-names (set (chain-loader/list-resource-names "chains"))]
-      (is (contains? resource-names "spec-to-pr-v1.0.0.edn"))
-      (is (contains? resource-names "test-chain-v1.0.0.edn")))))
+(deftest find-latest-chain-resource-test
+  (testing "latest chain discovery chooses the highest matching version from discovered resources"
+    (with-redefs [chain-loader/list-resource-names (fn [_]
+                                                     ["spec-to-pr-v1.0.0.edn"
+                                                      "spec-to-pr-v1.2.0.edn"
+                                                      "sdlc-to-deploy-v1.0.0.edn"])]
+      (is (= spec-to-pr-latest-path
+             (chain-loader/find-latest-chain-resource :spec-to-pr))))))

--- a/components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj
@@ -93,7 +93,8 @@
 
 (deftest load-chain-latest-test
   (testing "loads latest version when version is 'latest'"
-    (with-redefs [chain-loader/list-resource-names (fn [_]
+    (with-redefs [io/resource fake-resource
+                  chain-loader/list-resource-names (fn [_]
                                                      ["spec-to-pr-v1.0.0.edn"
                                                       "spec-to-pr-v1.2.0.edn"])
                   chain-loader/load-chain-resource fake-load-chain-resource]

--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -25,9 +25,21 @@
    5. Review feedback lost during phase clearing (Run 9)"
   (:require
    [ai.miniforge.phase.interface :as phase]
-   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.phase.loader :as loader]
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.execution :as exec]))
+
+(def phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (binding [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))
 
 ;; ============================================================================
 ;; Fix 1: Duration-ms extraction in publish-phase-completed!
@@ -143,7 +155,8 @@
   (testing "execute-phase-lifecycle clears :phase before entering next phase"
     ;; Simulate a context with a stale :phase map from a previous phase
     ;; (e.g., verify left a redirect transition request on it)
-    (let [stale-phase (phase/request-redirect {:name :verify
+    (let [stale-phase #_{:clj-kondo/ignore [:unresolved-var]}
+                      (phase/request-redirect {:name :verify
                                                :status :failed
                                                :duration-ms 3000}
                                               :implement)
@@ -156,40 +169,13 @@
                      :execution/files-written []
                      :execution/metrics {:tokens 0 :duration-ms 0}}
           ;; Use the :done interceptor (simplest, no LLM needed)
-          interceptor (ai.miniforge.phase.interface/get-phase-interceptor {:phase :done})
+          interceptor (ai.miniforge.phase.interface/get-phase-interceptor
+                       {:phase phase-test-support/runner-test-done})
           ;; execute-phase-lifecycle should clear :phase first
           [ctx-after _result] (exec/execute-phase-lifecycle interceptor stale-ctx)]
       ;; The stale transition request should NOT be present.
       (is (nil? (get-in ctx-after [:phase :phase/transition-request]))
           "Stale phase transition request must not leak"))))
-
-(deftest enter-failure-skips-leave-test
-  (testing "execute-phase-lifecycle does not invoke leave when enter fails before phase context exists"
-    (let [leave-called? (atom false)
-          interceptor {:config {:phase :failing-phase}
-                       :enter (fn [_]
-                                (throw (ex-info "enter failed" {:phase :failing-phase})))
-                       :leave (fn [ctx]
-                                (reset! leave-called? true)
-                                ctx)
-                       :error (fn [ctx ex]
-                                (-> ctx
-                                    (assoc-in [:phase :status] :failed)
-                                    (assoc-in [:phase :error]
-                                              {:message (ex-message ex)
-                                               :data (ex-data ex)})))}
-          ctx {:execution/input {}
-               :execution/phase-results {}
-               :execution/errors []
-               :execution/response-chain {:operation :test :succeeded? true}
-               :execution/artifacts []
-               :execution/files-written []
-               :execution/metrics {:tokens 0 :duration-ms 0}}
-          [ctx-after phase-result] (exec/execute-phase-lifecycle interceptor ctx)]
-      (is (false? @leave-called?)
-          "Leave must not run when enter failed before establishing phase context")
-      (is (= :failed (:status phase-result)))
-      (is (= "enter failed" (get-in ctx-after [:phase :error :message]))))))
 
 ;; ============================================================================
 ;; Fix 5: Review feedback survives :phase clearing (Run 9 bug)

--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -177,6 +177,26 @@
       (is (nil? (get-in ctx-after [:phase :phase/transition-request]))
           "Stale phase transition request must not leak"))))
 
+(deftest enter-failure-skips-leave-test
+  (testing "execute-phase-lifecycle does not invoke :leave when :enter never established phase context"
+    (let [leave-called? (atom false)
+          interceptor {:name ::failing-enter
+                       :config {}
+                       :enter (fn [_ctx]
+                                (throw (ex-info "enter blew up" {:type :test/enter-failed})))
+                       :leave (fn [ctx]
+                                (reset! leave-called? true)
+                                ctx)
+                       :error (fn [ctx ex]
+                                (assoc ctx :phase {:status :failed
+                                                   :error (ex-message ex)}))}
+          [ctx-after phase-result] (exec/execute-phase-lifecycle interceptor {})]
+      (is (false? @leave-called?))
+      (is (= {:status :failed
+              :error "enter blew up"}
+             phase-result))
+      (is (= phase-result (:phase ctx-after))))))
+
 ;; ============================================================================
 ;; Fix 5: Review feedback survives :phase clearing (Run 9 bug)
 ;;

--- a/docs/pull-requests/2026-05-10-fix-workflow-chain-loader-test-scope.md
+++ b/docs/pull-requests/2026-05-10-fix-workflow-chain-loader-test-scope.md
@@ -1,0 +1,36 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix(test): remove ambient workflow chain and registry assumptions
+
+## Overview
+
+Finish the remaining workflow-side stable-derived cleanup by making the
+chain-loader and run7 regression tests use explicit narrowed-scope test
+inputs instead of ambient project state.
+
+## Why
+
+`run7_regression_test`, `chain_loader_test`, and `try_load_chain_test`
+were still assuming project-wide resources or registry pollution were
+present. Narrowed Polylith project runs exposed those hidden
+dependencies.
+
+## What changed
+
+- make run7 use the synthetic done phase instead of registry pollution
+- make chain-loader tests assert against explicit or stubbed resources
+- make try-load-chain scope match the real narrowed resource boundary
+
+## Files changed
+
+- `components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj`
+- `components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj`
+- `components/workflow/test/ai/miniforge/workflow/anomaly/try_load_chain_test.clj`
+
+## Verification
+
+- focused narrowed-scope workflow tests
+- `bb pre-commit`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix(test): remove ambient workflow chain and registry assumptions

## Overview

Finish the remaining workflow-side stable-derived cleanup by making the
chain-loader and run7 regression tests use explicit narrowed-scope test
inputs instead of ambient project state.

## Why

`run7_regression_test`, `chain_loader_test`, and `try_load_chain_test`
were still assuming project-wide resources or registry pollution were
present. Narrowed Polylith project runs exposed those hidden
dependencies.

## What changed

- make run7 use the synthetic done phase instead of registry pollution
- make chain-loader tests assert against explicit or stubbed resources
- make try-load-chain scope match the real narrowed resource boundary

## Files changed

- `components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj`
- `components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj`
- `components/workflow/test/ai/miniforge/workflow/anomaly/try_load_chain_test.clj`

## Verification

- focused narrowed-scope workflow tests
- `bb pre-commit`
