### PR TITLE
fix(test): add CLI progress display coverage

### DIFF
--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/display_output_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/display_output_test.clj
@@ -29,6 +29,7 @@
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
    [cheshire.core :as json]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.cli.workflow-runner.display :as display]))
 
 ;------------------------------------------------------------------------------ Helpers
@@ -308,6 +309,59 @@
       (is (str/includes? line "recovered")))))
 
 ;------------------------------------------------------------------------------ Layer 6
+;; start-progress! integration
+
+(deftest start-progress-subscribes-and-prints-test
+  (testing "start-progress! prints lifecycle events and returns a cleanup fn"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          output (with-out-str
+                   (let [cleanup (display/start-progress! stream false)]
+                     (es/publish! stream (es/workflow-started stream wf-id))
+                     (es/publish! stream (es/phase-started stream wf-id :plan))
+                     (cleanup)))]
+      (is (not (str/blank? output))
+          "Published workflow events should render progress output"))))
+
+(deftest start-progress-cleanup-stops-output-test
+  (testing "cleanup unsubscribes the progress listener"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)]
+      (let [cleanup (display/start-progress! stream false)]
+        (with-out-str (es/publish! stream (es/workflow-started stream wf-id)))
+        (cleanup))
+      (let [output (with-out-str
+                     (es/publish! stream (es/workflow-completed stream wf-id :success 1000)))]
+        (is (str/blank? output)
+            "No output should be produced after cleanup")))))
+
+(deftest start-progress-deduplicates-identical-lines-test
+  (testing "back-to-back identical event lines are deduplicated"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          output (with-out-str
+                   (let [cleanup (display/start-progress! stream false)]
+                     (let [event (es/workflow-started stream wf-id)]
+                       (es/publish! stream event)
+                       (es/publish! stream event))
+                     (cleanup)))]
+      (is (= 1 (count (remove str/blank? (str/split-lines output))))
+          "Duplicate lines should only print once"))))
+
+(deftest start-progress-different-events-not-deduplicated-test
+  (testing "distinct events each produce their own output line"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          output (with-out-str
+                   (let [cleanup (display/start-progress! stream false)]
+                     (es/publish! stream (es/workflow-started stream wf-id))
+                     (es/publish! stream (es/phase-started stream wf-id :plan))
+                     (es/publish! stream (es/agent-started stream wf-id :planner))
+                     (cleanup)))]
+      (is (= 3 (count (remove str/blank? (str/split-lines output))))
+          "Distinct events must each print once"))))
+
+;------------------------------------------------------------------------------ Layer 7
 ;; format-demo-line edge cases
 
 (deftest format-demo-line-nil-phase-test

--- a/components/event-stream/test/ai/miniforge/event_stream/progress_integration_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/progress_integration_test.clj
@@ -21,10 +21,9 @@
 
    Verifies that:
    1. Workflow launch emits required lifecycle events in correct order
-   2. All event types (phase, agent, tool, gate) are handled by display formatters
-   3. Event ordering and visibility in a simulated end-to-end run
-   4. Display start-progress! subscription and cleanup lifecycle
-   5. Chain event lifecycle ordering"
+   2. Event ordering and visibility in a simulated end-to-end run
+   3. Chain event lifecycle ordering
+   4. Event-stream subscribers can filter and observe full workflow runs"
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.interface :as es]))

--- a/docs/pull-requests/2026-05-10-fix-cli-event-stream-test-boundaries.md
+++ b/docs/pull-requests/2026-05-10-fix-cli-event-stream-test-boundaries.md
@@ -1,0 +1,33 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix(test): restore CLI and event-stream test boundaries
+
+## Overview
+
+Move the progress-display tests back to the CLI base boundary and keep
+the event-stream tests focused on event-stream behavior only.
+
+## Why
+
+The old event-stream progress integration test imported a CLI-base seam.
+That was an illegal cross-boundary dependency and only stayed green
+because wider project test runs masked it.
+
+## What changed
+
+- move CLI progress display coverage into the CLI base test namespace
+- remove the CLI seam dependency from the event-stream test
+- keep equivalent lifecycle assertions at the correct boundary
+
+## Files changed
+
+- `bases/cli/test/ai/miniforge/cli/workflow_runner/display_output_test.clj`
+- `components/event-stream/test/ai/miniforge/event_stream/progress_integration_test.clj`
+
+## Verification
+
+- focused CLI/event-stream tests
+- `bb pre-commit`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix(test): restore CLI and event-stream test boundaries

## Overview

Move the progress-display tests back to the CLI base boundary and keep
the event-stream tests focused on event-stream behavior only.

## Why

The old event-stream progress integration test imported a CLI-base seam.
That was an illegal cross-boundary dependency and only stayed green
because wider project test runs masked it.

## What changed

- move CLI progress display coverage into the CLI base test namespace
- remove the CLI seam dependency from the event-stream test
- keep equivalent lifecycle assertions at the correct boundary

## Files changed

- `bases/cli/test/ai/miniforge/cli/workflow_runner/display_output_test.clj`
- `components/event-stream/test/ai/miniforge/event_stream/progress_integration_test.clj`

## Verification

- focused CLI/event-stream tests
- `bb pre-commit`
