### PR TITLE
feat(test): add stable-derived bb-test-runner helpers

### DIFF
--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
@@ -152,7 +152,13 @@
 (defn stable-tags-present?
   "True when `tags` contains at least one recognized stable tag."
   [tags]
-  (boolean (seq tags)))
+  (boolean
+   (some (fn [tag]
+           (let [normalized (some-> tag str str/trim not-empty)]
+             (and normalized
+                  (or (str/starts-with? normalized "stable-")
+                      (str/starts-with? normalized "stable/")))))
+         tags)))
 
 (defn parse-project-selector
   "Parse a Polylith project selector or env value into a vector of

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
@@ -41,6 +41,22 @@
 (def ^:private default-coverage-output
   "target/coverage")
 
+(def ^:private stable-tag-glob-patterns
+  "Supported stable-tag glob patterns.
+   The repo has historical `stable-*` tags and a few older `stable/*`
+   variants, so the wrapper treats both as stable baselines."
+  ["stable-*" "stable/*"])
+
+(def ^:private default-heartbeat-seconds
+  30)
+
+(def ^:private git-worktree-env-keys
+  ["GIT_INDEX_FILE" "GIT_DIR" "GIT_WORK_TREE" "GIT_COMMON_DIR"])
+
+(def ^:private changed-or-affected-projects-argv
+  ["clojure" "-M:poly" "ws" "get:changes:changed-or-affected-projects"
+   "skip:dev" "color-mode:none"])
+
 (defn- path-segments
   [path]
   (str/split path #"/"))
@@ -126,6 +142,93 @@
      :deps (assoc deps
                   'cloverage/cloverage
                   {:mvn/version cloverage-version})}))
+
+(defn stable-tag-globs
+  "Return the stable-tag glob patterns recognized by Miniforge's
+   stable-derived test scope."
+  []
+  stable-tag-glob-patterns)
+
+(defn stable-tags-present?
+  "True when `tags` contains at least one recognized stable tag."
+  [tags]
+  (boolean (seq tags)))
+
+(defn parse-project-selector
+  "Parse a Polylith project selector or env value into a vector of
+   project names.
+
+   Accepted forms:
+   - `project:proj1:proj2`
+   - `proj1:proj2`
+   - `proj1,proj2`"
+  [selector]
+  (let [raw (some-> selector str/trim not-empty)
+        value (cond
+                (nil? raw) nil
+                (str/starts-with? raw "project:")
+                (subs raw (count "project:"))
+                :else raw)]
+    (->> (some-> value (str/split #"[,:]"))
+         (map str/trim)
+         (remove str/blank?)
+         vec)))
+
+(defn format-project-selector
+  "Render an explicit Polylith project selector argument from project
+   names."
+  [projects]
+  (when (seq projects)
+    (str "project:" (str/join ":" projects))))
+
+(defn changed-projects-command
+  "Return the argv that queries Polylith for the current changed-or-
+   affected project set."
+  []
+  changed-or-affected-projects-argv)
+
+(defn parse-project-list-output
+  "Parse a Polylith `ws get:changes:changed-or-affected-projects`
+   response into a vector of project names."
+  [output]
+  (let [trimmed (some-> output str/trim not-empty)]
+    (if-not trimmed
+      []
+      (let [parsed (edn/read-string trimmed)]
+        (cond
+          (sequential? parsed) (mapv str parsed)
+          (set? parsed) (->> parsed (map str) sort vec)
+          :else (throw (ex-info "Expected a sequential or set project list."
+                                {:output output
+                                 :parsed parsed})))))))
+
+(defn sanitize-git-worktree-env
+  "Remove git worktree/index variables that must not leak into child
+   processes.
+
+   `git commit` and related flows can export worktree-specific git vars.
+   If those leak into nested `git` calls inside tests, temp repos and
+   temp worktrees stop behaving like standalone repos. The stable-derived
+   wrapper must strip them before spawning `poly test`."
+  [env]
+  (apply dissoc env git-worktree-env-keys))
+
+(defn heartbeat-seconds
+  "Return the heartbeat interval, defaulting to 30 seconds.
+   Invalid, missing, or non-positive values fall back to the default."
+  [env]
+  (let [raw (some-> (get env "MINIFORGE_TEST_HEARTBEAT_SECONDS")
+                    str/trim
+                    not-empty)]
+    (if-not raw
+      default-heartbeat-seconds
+      (let [parsed (try
+                     (Long/parseLong raw)
+                     (catch NumberFormatException _
+                       nil))]
+        (if (pos-int? parsed)
+          parsed
+          default-heartbeat-seconds)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Coverage command derivation (pure)

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
@@ -51,6 +51,49 @@
   [relative-path]
   (core/path->ns-symbol relative-path))
 
+(defn stable-tag-globs
+  "Return the stable-tag glob patterns recognized by Miniforge's
+   stable-derived test scope."
+  []
+  (core/stable-tag-globs))
+
+(defn stable-tags-present?
+  "True when `tags` contains at least one recognized stable tag."
+  [tags]
+  (core/stable-tags-present? tags))
+
+(defn parse-project-selector
+  "Parse a Polylith project selector or env value into project names."
+  [selector]
+  (core/parse-project-selector selector))
+
+(defn format-project-selector
+  "Render an explicit Polylith project selector from project names."
+  [projects]
+  (core/format-project-selector projects))
+
+(defn changed-projects-command
+  "Return the argv that asks Polylith for changed-or-affected projects."
+  []
+  (core/changed-projects-command))
+
+(defn parse-project-list-output
+  "Parse a changed-or-affected project list response into project names."
+  [output]
+  (core/parse-project-list-output output))
+
+(defn sanitize-git-worktree-env
+  "Remove git worktree/index variables that must not leak into child
+   processes spawned from git hook contexts."
+  [env]
+  (core/sanitize-git-worktree-env env))
+
+(defn heartbeat-seconds
+  "Return the configured heartbeat interval in seconds for long-running
+   test commands."
+  [env]
+  (core/heartbeat-seconds env))
+
 (defn classify-coverage-paths
   "Pure helper: split merged classpath paths into source and test roots
    suitable for Cloverage."

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -166,6 +166,11 @@
   (testing "empty stable-tag list forces full-suite fallback"
     (is (false? (sut/stable-tags-present? [])))))
 
+(deftest test-stable-tags-absent-when-input-has-no-recognized-stable-tags
+  (testing "non-stable and blank tag entries do not enable since-stable scope"
+    (is (false? (sut/stable-tags-present? ["release-2026-05-10" "feature/foo"])))
+    (is (false? (sut/stable-tags-present? ["" "   " nil])))))
+
 (deftest test-parse-project-selector-supports-poly-and-env-shapes
   (testing "project selectors accept poly syntax and env-friendly delimiters"
     (is (= ["miniforge" "miniforge-core"]

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -152,6 +152,70 @@
               "components/foo/test"]
              (:paths merged))))))
 
+(deftest test-stable-tag-globs-covers-supported-history
+  (testing "stable tag globs cover both historical naming schemes"
+    (is (= ["stable-*" "stable/*"]
+           (sut/stable-tag-globs)))))
+
+(deftest test-stable-tags-present-when-tag-seq-non-empty
+  (testing "any stable tag list enables since-stable scope"
+    (is (true? (sut/stable-tags-present? ["stable-20260506"])))
+    (is (true? (sut/stable-tags-present? ["stable/main-2026-02-27"])))))
+
+(deftest test-stable-tags-absent-when-tag-seq-empty
+  (testing "empty stable-tag list forces full-suite fallback"
+    (is (false? (sut/stable-tags-present? [])))))
+
+(deftest test-parse-project-selector-supports-poly-and-env-shapes
+  (testing "project selectors accept poly syntax and env-friendly delimiters"
+    (is (= ["miniforge" "miniforge-core"]
+           (sut/parse-project-selector "project:miniforge:miniforge-core")))
+    (is (= ["miniforge" "miniforge-core"]
+           (sut/parse-project-selector "miniforge:miniforge-core")))
+    (is (= ["miniforge" "miniforge-core"]
+           (sut/parse-project-selector "miniforge,miniforge-core")))))
+
+(deftest test-format-project-selector-renders-poly-project-arg
+  (testing "project vectors render as a Polylith project selector"
+    (is (= "project:miniforge:miniforge-core"
+           (sut/format-project-selector ["miniforge" "miniforge-core"])))))
+
+(deftest test-changed-projects-command-matches-polylith-ws-query
+  (testing "stable-derived diagnostics query the native changed project set"
+    (is (= ["clojure" "-M:poly" "ws" "get:changes:changed-or-affected-projects"
+            "skip:dev" "color-mode:none"]
+           (sut/changed-projects-command)))))
+
+(deftest test-parse-project-list-output-reads-edn-vectors
+  (testing "Polylith ws output parses into project names"
+    (is (= ["miniforge" "miniforge-core"]
+           (sut/parse-project-list-output "[\"miniforge\" \"miniforge-core\"]")))))
+
+(deftest test-sanitize-git-worktree-env-strips-worktree-vars
+  (testing "git worktree vars do not leak into child test processes"
+    (is (= {"PATH" "/usr/bin" "FOO" "bar"}
+           (sut/sanitize-git-worktree-env
+            {"PATH" "/usr/bin"
+             "FOO" "bar"
+             "GIT_INDEX_FILE" "/tmp/index"
+             "GIT_DIR" "/tmp/git"
+             "GIT_WORK_TREE" "/tmp/worktree"
+             "GIT_COMMON_DIR" "/tmp/common"})))))
+
+(deftest test-heartbeat-seconds-defaults-on-missing-env
+  (testing "missing env key falls back to the default heartbeat"
+    (is (= 30 (sut/heartbeat-seconds {})))))
+
+(deftest test-heartbeat-seconds-accepts-positive-env-value
+  (testing "positive configured heartbeat is honored"
+    (is (= 45 (sut/heartbeat-seconds {"MINIFORGE_TEST_HEARTBEAT_SECONDS" "45"})))))
+
+(deftest test-heartbeat-seconds-rejects-invalid-env-value
+  (testing "invalid heartbeat values fall back to the default"
+    (is (= 30 (sut/heartbeat-seconds {"MINIFORGE_TEST_HEARTBEAT_SECONDS" "abc"})))
+    (is (= 30 (sut/heartbeat-seconds {"MINIFORGE_TEST_HEARTBEAT_SECONDS" "0"})))
+    (is (= 30 (sut/heartbeat-seconds {"MINIFORGE_TEST_HEARTBEAT_SECONDS" "-5"})))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (clojure.test/run-tests 'ai.miniforge.bb-test-runner.core-test)

--- a/docs/pull-requests/2026-05-10-feat-bb-test-runner-stable-derived-helpers.md
+++ b/docs/pull-requests/2026-05-10-feat-bb-test-runner-stable-derived-helpers.md
@@ -1,0 +1,40 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# feat(test): add stable-derived planning helpers to bb-test-runner
+
+## Overview
+
+Add pure stable-derived planning helpers to `bb-test-runner` so the
+test-scope logic can be exercised under JVM tests and reused by the
+Babashka wrapper.
+
+## Why
+
+The repo needed a real programmable surface for:
+
+- detecting stable tags
+- deriving changed-or-affected project queries
+- ordering/expanding/bisecting project subsets
+- sanitizing leaked git worktree environment
+- deriving heartbeat configuration
+
+Without that surface, the wrapper logic stayed opaque and harder to
+test directly.
+
+## What changed
+
+- add stable-derived helper functions to `bb-test-runner.core`
+- expose the helper surface through `bb-test-runner.interface`
+
+## Files changed
+
+- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj`
+- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj`
+
+## Verification
+
+- helper-focused `bb-test-runner` tests
+- `bb pre-commit`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# feat(test): add stable-derived planning helpers to bb-test-runner

## Overview

Add pure stable-derived planning helpers to `bb-test-runner` so the
test-scope logic can be exercised under JVM tests and reused by the
Babashka wrapper.

## Why

The repo needed a real programmable surface for:

- detecting stable tags
- deriving changed-or-affected project queries
- ordering/expanding/bisecting project subsets
- sanitizing leaked git worktree environment
- deriving heartbeat configuration

Without that surface, the wrapper logic stayed opaque and harder to
test directly.

## What changed

- add stable-derived helper functions to `bb-test-runner.core`
- expose the helper surface through `bb-test-runner.interface`

## Files changed

- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj`
- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj`

## Verification

- helper-focused `bb-test-runner` tests
- `bb pre-commit`
