### PR TITLE
feat(test): add bb-test-runner diagnostic group planning

### DIFF
--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
@@ -50,6 +50,9 @@
 (def ^:private default-heartbeat-seconds
   30)
 
+(def ^:private default-expand-start-size
+  1)
+
 (def ^:private git-worktree-env-keys
   ["GIT_INDEX_FILE" "GIT_DIR" "GIT_WORK_TREE" "GIT_COMMON_DIR"])
 
@@ -299,6 +302,79 @@
     (case direction
       :back (vec (reverse ordered))
       ordered)))
+
+(defn- positive-start-size
+  [project-count requested-size]
+  (-> (or requested-size default-expand-start-size)
+      (max default-expand-start-size)
+      (min project-count)))
+
+(defn expand-project-groups
+  "Return additive project groups that double in size until they cover
+   the full ordered project set."
+  [projects start-size]
+  (let [project-count (count projects)]
+    (when (pos? project-count)
+      (loop [group-size (positive-start-size project-count start-size)
+             groups []]
+        (let [group (subvec (vec projects) 0 group-size)
+              next-groups (conj groups group)]
+          (if (= group-size project-count)
+            next-groups
+            (recur (min project-count (* 2 group-size))
+                   next-groups)))))))
+
+(defn bisect-project-groups
+  "Return contiguous project groups in breadth-first binary partition
+   order."
+  [projects]
+  (letfn [(split-groups [group]
+            (let [group (vec group)
+                  group-count (count group)]
+              (cond
+                (zero? group-count) []
+                (= 1 group-count) [group]
+                :else (let [mid (quot group-count 2)
+                            left (subvec group 0 mid)
+                            right (subvec group mid)]
+                        (into [left right]
+                              (concat (when (> (count left) 1)
+                                        (split-groups left))
+                                      (when (> (count right) 1)
+                                        (split-groups right))))))))]
+    (split-groups projects)))
+
+(defn diagnostic-test-plan
+  "Return a stable-derived diagnostic plan over an explicit project
+   vector."
+  [{:keys [mode projects start-size direction order seed]}]
+  (let [ordered-projects (order-projects (vec projects)
+                                         {:direction direction
+                                          :order order
+                                          :seed seed})
+        project-groups (case mode
+                         :expand (expand-project-groups ordered-projects start-size)
+                         :bisect (bisect-project-groups ordered-projects)
+                         [(vec ordered-projects)])
+        total-groups (count project-groups)]
+    {:mode mode
+     :summary (str "Running "
+                   (name mode)
+                   " diagnostics across "
+                   (count ordered-projects)
+                   " stable-derived projects.")
+     :projects ordered-projects
+     :steps (mapv (fn [index group]
+                    {:label (str (name mode)
+                                 " project subset "
+                                 (inc index) "/"
+                                 total-groups
+                                 " ("
+                                 (count group)
+                                 " projects)")
+                     :argv ["clojure" "-M:poly" "test" (format-project-selector group)]})
+                  (range)
+                  project-groups)}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Coverage command derivation (pure)

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
@@ -313,11 +313,13 @@
   "Return additive project groups that double in size until they cover
    the full ordered project set."
   [projects start-size]
-  (let [project-count (count projects)]
-    (when (pos? project-count)
+  (let [project-vec (vec projects)
+        project-count (count project-vec)]
+    (if (zero? project-count)
+      []
       (loop [group-size (positive-start-size project-count start-size)
              groups []]
-        (let [group (subvec (vec projects) 0 group-size)
+        (let [group (subvec project-vec 0 group-size)
               next-groups (conj groups group)]
           (if (= group-size project-count)
             next-groups
@@ -328,51 +330,59 @@
   "Return contiguous project groups in breadth-first binary partition
    order."
   [projects]
-  (letfn [(split-groups [group]
-            (let [group (vec group)
-                  group-count (count group)]
-              (cond
-                (zero? group-count) []
-                (= 1 group-count) [group]
-                :else (let [mid (quot group-count 2)
-                            left (subvec group 0 mid)
-                            right (subvec group mid)]
-                        (into [left right]
-                              (concat (when (> (count left) 1)
-                                        (split-groups left))
-                                      (when (> (count right) 1)
-                                        (split-groups right))))))))]
-    (split-groups projects)))
+  (let [root (vec projects)]
+    (loop [queue (cond-> clojure.lang.PersistentQueue/EMPTY
+                   (> (count root) 1) (conj root))
+           groups []]
+      (if (empty? queue)
+        groups
+        (let [group (peek queue)
+              queue-tail (pop queue)
+              mid (quot (count group) 2)
+              left (subvec group 0 mid)
+              right (subvec group mid)
+              next-groups (cond-> groups
+                            (seq left) (conj left)
+                            (seq right) (conj right))
+              next-queue (cond-> queue-tail
+                           (> (count left) 1) (conj left)
+                           (> (count right) 1) (conj right))]
+          (recur next-queue next-groups))))))
 
 (defn diagnostic-test-plan
   "Return a stable-derived diagnostic plan over an explicit project
    vector."
   [{:keys [mode projects start-size direction order seed]}]
-  (let [ordered-projects (order-projects (vec projects)
+  (let [effective-mode (or mode :subset)
+        ordered-projects (order-projects (vec projects)
                                          {:direction direction
                                           :order order
                                           :seed seed})
-        project-groups (case mode
-                         :expand (expand-project-groups ordered-projects start-size)
-                         :bisect (bisect-project-groups ordered-projects)
-                         [(vec ordered-projects)])
+        project-groups (if (empty? ordered-projects)
+                         []
+                         (case effective-mode
+                           :expand (expand-project-groups ordered-projects start-size)
+                           :bisect (bisect-project-groups ordered-projects)
+                           [(vec ordered-projects)]))
         total-groups (count project-groups)]
-    {:mode mode
+    {:mode effective-mode
      :summary (str "Running "
-                   (name mode)
+                   (name effective-mode)
                    " diagnostics across "
                    (count ordered-projects)
                    " stable-derived projects.")
      :projects ordered-projects
      :steps (mapv (fn [index group]
-                    {:label (str (name mode)
+                    (let [selector (format-project-selector group)]
+                      {:label (str (name effective-mode)
                                  " project subset "
                                  (inc index) "/"
                                  total-groups
                                  " ("
                                  (count group)
                                  " projects)")
-                     :argv ["clojure" "-M:poly" "test" (format-project-selector group)]})
+                       :argv (cond-> ["clojure" "-M:poly" "test"]
+                               selector (conj selector))}))
                   (range)
                   project-groups)}))
 

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
@@ -104,6 +104,21 @@
   [projects opts]
   (core/order-projects projects opts))
 
+(defn expand-project-groups
+  "Return additive project groups that double in size until full scope."
+  [projects start-size]
+  (core/expand-project-groups projects start-size))
+
+(defn bisect-project-groups
+  "Return contiguous project groups in breadth-first binary partition order."
+  [projects]
+  (core/bisect-project-groups projects))
+
+(defn diagnostic-test-plan
+  "Return a stable-derived diagnostic plan over an explicit project set."
+  [opts]
+  (core/diagnostic-test-plan opts))
+
 (defn classify-coverage-paths
   "Pure helper: split merged classpath paths into source and test roots
    suitable for Cloverage."

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -263,6 +263,31 @@
             {:order :random
              :seed 17})))))
 
+(deftest test-expand-project-groups-doubles-prefix-size
+  (testing "additive expansion doubles until the full set is included"
+    (is (= [["a"] ["a" "b"] ["a" "b" "c" "d"] ["a" "b" "c" "d" "e"]]
+           (sut/expand-project-groups ["a" "b" "c" "d" "e"] 1)))))
+
+(deftest test-bisect-project-groups-partitions-breadth-first
+  (testing "bisect produces contiguous binary groups"
+    (is (= [["a" "b"] ["c" "d"] ["a"] ["b"] ["c"] ["d"]]
+           (sut/bisect-project-groups ["a" "b" "c" "d"])))))
+
+(deftest test-diagnostic-test-plan-builds-expand-steps
+  (testing "diagnostic plans render executable Poly test steps"
+    (is (= {:mode :expand
+            :summary "Running expand diagnostics across 3 stable-derived projects."
+            :projects ["a" "b" "c"]
+            :steps [{:label "expand project subset 1/3 (1 projects)"
+                     :argv ["clojure" "-M:poly" "test" "project:a"]}
+                    {:label "expand project subset 2/3 (2 projects)"
+                     :argv ["clojure" "-M:poly" "test" "project:a:b"]}
+                    {:label "expand project subset 3/3 (3 projects)"
+                     :argv ["clojure" "-M:poly" "test" "project:a:b:c"]}]}
+           (sut/diagnostic-test-plan {:mode :expand
+                                      :projects ["a" "b" "c"]
+                                      :start-size 1})))))
+
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -266,12 +266,31 @@
 (deftest test-expand-project-groups-doubles-prefix-size
   (testing "additive expansion doubles until the full set is included"
     (is (= [["a"] ["a" "b"] ["a" "b" "c" "d"] ["a" "b" "c" "d" "e"]]
-           (sut/expand-project-groups ["a" "b" "c" "d" "e"] 1)))))
+           (sut/expand-project-groups ["a" "b" "c" "d" "e"] 1))))
+  (testing "empty project input yields an empty expansion plan"
+    (is (= []
+           (sut/expand-project-groups [] 1)))))
 
 (deftest test-bisect-project-groups-partitions-breadth-first
   (testing "bisect produces contiguous binary groups"
     (is (= [["a" "b"] ["c" "d"] ["a"] ["b"] ["c"] ["d"]]
-           (sut/bisect-project-groups ["a" "b" "c" "d"])))))
+           (sut/bisect-project-groups ["a" "b" "c" "d"]))))
+  (testing "larger project sets keep a true breadth-first traversal order"
+    (is (= [["a" "b" "c" "d"]
+            ["e" "f" "g" "h"]
+            ["a" "b"]
+            ["c" "d"]
+            ["e" "f"]
+            ["g" "h"]
+            ["a"]
+            ["b"]
+            ["c"]
+            ["d"]
+            ["e"]
+            ["f"]
+            ["g"]
+            ["h"]]
+           (sut/bisect-project-groups ["a" "b" "c" "d" "e" "f" "g" "h"])))))
 
 (deftest test-diagnostic-test-plan-builds-expand-steps
   (testing "diagnostic plans render executable Poly test steps"
@@ -286,6 +305,21 @@
                      :argv ["clojure" "-M:poly" "test" "project:a:b:c"]}]}
            (sut/diagnostic-test-plan {:mode :expand
                                       :projects ["a" "b" "c"]
+                                      :start-size 1}))))
+  (testing "missing mode defaults to subset"
+    (is (= {:mode :subset
+            :summary "Running subset diagnostics across 2 stable-derived projects."
+            :projects ["a" "b"]
+            :steps [{:label "subset project subset 1/1 (2 projects)"
+                     :argv ["clojure" "-M:poly" "test" "project:a:b"]}]}
+           (sut/diagnostic-test-plan {:projects ["a" "b"]}))))
+  (testing "empty project sets yield an empty step plan"
+    (is (= {:mode :expand
+            :summary "Running expand diagnostics across 0 stable-derived projects."
+            :projects []
+            :steps []}
+           (sut/diagnostic-test-plan {:mode :expand
+                                      :projects []
                                       :start-size 1})))))
 
 

--- a/docs/pull-requests/2026-05-10-feat-bb-test-runner-diagnostic-group-planning.md
+++ b/docs/pull-requests/2026-05-10-feat-bb-test-runner-diagnostic-group-planning.md
@@ -1,0 +1,41 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# feat(test): add bb-test-runner diagnostic group planning
+
+## Overview
+
+Add the pure grouping and plan-construction helpers for stable-derived
+diagnostic runs.
+
+## Why
+
+Once the stable-derived project set is known and the diagnostic options
+are parsed, the next seam is deterministic grouping:
+
+- additive expansion to grow the subset quickly
+- breadth-first bisect grouping to isolate failures faster
+- rendered Poly test steps that higher layers can execute directly
+
+Keeping that logic pure makes the later script/task wiring much smaller
+and easier to verify.
+
+## What changed
+
+- add additive expand grouping helpers
+- add breadth-first bisect grouping helpers
+- add stable-derived diagnostic plan synthesis
+- add direct JVM tests for expand, bisect, and rendered plan steps
+
+## Files changed
+
+- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj`
+- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj`
+- `components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj`
+
+## Verification
+
+- focused `bb-test-runner.core-test`
+- `bb pre-commit`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# feat(test): add bb-test-runner diagnostic group planning

## Overview

Add the pure grouping and plan-construction helpers for stable-derived
diagnostic runs.

## Why

Once the stable-derived project set is known and the diagnostic options
are parsed, the next seam is deterministic grouping:

- additive expansion to grow the subset quickly
- breadth-first bisect grouping to isolate failures faster
- rendered Poly test steps that higher layers can execute directly

Keeping that logic pure makes the later script/task wiring much smaller
and easier to verify.

## What changed

- add additive expand grouping helpers
- add breadth-first bisect grouping helpers
- add stable-derived diagnostic plan synthesis
- add direct JVM tests for expand, bisect, and rendered plan steps

## Files changed

- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj`
- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj`
- `components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj`

## Verification

- focused `bb-test-runner.core-test`
- `bb pre-commit`
