### PR TITLE
feat(test): add bb-test-runner diagnostic arg helpers

### DIFF
--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
@@ -236,6 +236,60 @@
           parsed
           default-heartbeat-seconds)))))
 
+(defn parse-diagnostic-args
+  "Parse supported stable-derived diagnostic CLI arguments.
+
+   Supported forms:
+   - `mode:subset|expand|bisect`
+   - `project:proj1:proj2`
+   - `start-size:N`
+   - `direction:front|back`
+   - `order:declared|random`
+   - `seed:N`"
+  [args]
+  (reduce
+   (fn [acc arg]
+     (cond
+       (str/starts-with? arg "mode:")
+       (assoc acc :mode (keyword (subs arg (count "mode:"))))
+
+       (str/starts-with? arg "project:")
+       (assoc acc :projects (parse-project-selector arg))
+
+       (str/starts-with? arg "start-size:")
+       (let [raw (subs arg (count "start-size:"))]
+         (assoc acc :start-size (Long/parseLong raw)))
+
+       (str/starts-with? arg "direction:")
+       (assoc acc :direction (keyword (subs arg (count "direction:"))))
+
+       (str/starts-with? arg "order:")
+       (assoc acc :order (keyword (subs arg (count "order:"))))
+
+       (str/starts-with? arg "seed:")
+       (let [raw (subs arg (count "seed:"))]
+         (assoc acc :seed (Long/parseLong raw)))
+
+       :else acc))
+   {}
+   args))
+
+(defn- shuffle-projects
+  [projects seed]
+  (let [alist (java.util.ArrayList. ^java.util.Collection projects)]
+    (java.util.Collections/shuffle alist (java.util.Random. (long (or seed 0))))
+    (vec alist)))
+
+(defn order-projects
+  "Apply diagnostic ordering controls to a project vector."
+  [projects {:keys [direction order seed]}]
+  (let [ordered (case order
+                  :random (shuffle-projects projects seed)
+                  (vec projects))]
+    (case direction
+      :back (vec (reverse ordered))
+      ordered)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Coverage command derivation (pure)
 

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
@@ -236,6 +236,18 @@
           parsed
           default-heartbeat-seconds)))))
 
+(defn- parse-long-arg
+  [arg prefix]
+  (let [raw (subs arg (count prefix))]
+    (try
+      (Long/parseLong raw)
+      (catch NumberFormatException ex
+        (throw (ex-info "Invalid stable-derived diagnostic argument."
+                        {:arg arg
+                         :prefix prefix
+                         :expected-format (str prefix "N")}
+                        ex))))))
+
 (defn parse-diagnostic-args
   "Parse supported stable-derived diagnostic CLI arguments.
 
@@ -257,8 +269,7 @@
        (assoc acc :projects (parse-project-selector arg))
 
        (str/starts-with? arg "start-size:")
-       (let [raw (subs arg (count "start-size:"))]
-         (assoc acc :start-size (Long/parseLong raw)))
+       (assoc acc :start-size (parse-long-arg arg "start-size:"))
 
        (str/starts-with? arg "direction:")
        (assoc acc :direction (keyword (subs arg (count "direction:"))))
@@ -267,8 +278,7 @@
        (assoc acc :order (keyword (subs arg (count "order:"))))
 
        (str/starts-with? arg "seed:")
-       (let [raw (subs arg (count "seed:"))]
-         (assoc acc :seed (Long/parseLong raw)))
+       (assoc acc :seed (parse-long-arg arg "seed:"))
 
        :else acc))
    {}

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
@@ -94,6 +94,16 @@
   [env]
   (core/heartbeat-seconds env))
 
+(defn parse-diagnostic-args
+  "Parse supported stable-derived diagnostic CLI arguments."
+  [args]
+  (core/parse-diagnostic-args args))
+
+(defn order-projects
+  "Apply diagnostic ordering controls to a project vector."
+  [projects opts]
+  (core/order-projects projects opts))
+
 (defn classify-coverage-paths
   "Pure helper: split merged classpath paths into source and test roots
    suitable for Cloverage."

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -221,6 +221,30 @@
     (is (= 30 (sut/heartbeat-seconds {"MINIFORGE_TEST_HEARTBEAT_SECONDS" "0"})))
     (is (= 30 (sut/heartbeat-seconds {"MINIFORGE_TEST_HEARTBEAT_SECONDS" "-5"})))))
 
+(deftest test-parse-diagnostic-args-reads-supported-options
+  (testing "diagnostic CLI args parse into a stable-derived plan request"
+    (is (= {:mode :expand
+            :projects ["miniforge" "miniforge-core"]
+            :start-size 2
+            :direction :back
+            :order :random
+            :seed 17}
+           (sut/parse-diagnostic-args
+            ["mode:expand"
+             "project:miniforge:miniforge-core"
+             "start-size:2"
+             "direction:back"
+             "order:random"
+             "seed:17"])))))
+
+(deftest test-order-projects-supports-declared-and-backward-order
+  (testing "diagnostic ordering keeps stable sequences controllable"
+    (is (= ["a" "b" "c"]
+           (sut/order-projects ["a" "b" "c"] {:order :declared})))
+    (is (= ["c" "b" "a"]
+           (sut/order-projects ["a" "b" "c"] {:direction :back})))))
+
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (clojure.test/run-tests 'ai.miniforge.bb-test-runner.core-test)

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -237,12 +237,31 @@
              "order:random"
              "seed:17"])))))
 
+(deftest test-parse-diagnostic-args-rejects-invalid-numeric-values
+  (testing "numeric diagnostic args fail with contextual ex-info"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid stable-derived diagnostic argument"
+         (sut/parse-diagnostic-args ["start-size:abc"])))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid stable-derived diagnostic argument"
+         (sut/parse-diagnostic-args ["seed:not-a-number"])))))
+
 (deftest test-order-projects-supports-declared-and-backward-order
   (testing "diagnostic ordering keeps stable sequences controllable"
     (is (= ["a" "b" "c"]
            (sut/order-projects ["a" "b" "c"] {:order :declared})))
     (is (= ["c" "b" "a"]
            (sut/order-projects ["a" "b" "c"] {:direction :back})))))
+
+(deftest test-order-projects-random-order-is-deterministic-for-a-seed
+  (testing "random ordering is stable for the same input seed"
+    (is (= ["a" "c" "e" "d" "b"]
+           (sut/order-projects
+            ["a" "b" "c" "d" "e"]
+            {:order :random
+             :seed 17})))))
 
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/docs/pull-requests/2026-05-10-test-bb-test-runner-stable-derived-helpers.md
+++ b/docs/pull-requests/2026-05-10-test-bb-test-runner-stable-derived-helpers.md
@@ -1,0 +1,38 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# test(bb): cover stable-derived bb-test-runner helpers
+
+## Overview
+
+Add direct JVM coverage for the new stable-derived `bb-test-runner`
+helper surface, starting with the pure parsing and ordering seams.
+
+## Why
+
+The new stable-derived planning path only pays off if it stays
+provably deterministic. The helper layer is pure enough to test without
+spawning real Babashka tasks, so this PR starts by locking down the
+option parsing and project ordering logic directly.
+
+## What changed
+
+- add helper-level tests for stable-tag handling
+- add project selector parsing/formatting coverage
+- add diagnostic arg parsing coverage
+- add project ordering coverage
+- add git worktree env sanitization coverage
+- add heartbeat config coverage
+
+## Files changed
+
+- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj`
+- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj`
+- `components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj`
+
+## Verification
+
+- focused `bb-test-runner.core-test`
+- `bb pre-commit`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# test(bb): cover stable-derived bb-test-runner helpers

## Overview

Add direct JVM coverage for the new stable-derived `bb-test-runner`
helper surface, starting with the pure parsing and ordering seams.

## Why

The new stable-derived planning path only pays off if it stays
provably deterministic. The helper layer is pure enough to test without
spawning real Babashka tasks, so this PR starts by locking down the
option parsing and project ordering logic directly.

## What changed

- add helper-level tests for stable-tag handling
- add project selector parsing/formatting coverage
- add diagnostic arg parsing coverage
- add project ordering coverage
- add git worktree env sanitization coverage
- add heartbeat config coverage

## Files changed

- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj`
- `components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj`
- `components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj`

## Verification

- focused `bb-test-runner.core-test`
- `bb pre-commit`
