### PR TITLE
feat(event-stream): per-workflow manifest + lease + heartbeat (BD-2b sub-2)

### DIFF
--- a/components/event-stream/deps.edn
+++ b/components/event-stream/deps.edn
@@ -3,6 +3,7 @@
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/schema {:local/root "../schema"}
+        cheshire/cheshire {:mvn/version "5.13.0"}
         com.cognitect/transit-clj {:mvn/version "1.0.333"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/event-stream/resources/config/event-stream/manifest-defaults.edn
+++ b/components/event-stream/resources/config/event-stream/manifest-defaults.edn
@@ -1,0 +1,47 @@
+;; Per-workflow manifest defaults (BD-2b sub-2). Centralised here so
+;; the contract values (enums, filename, schema version) live in one
+;; place visible from both the Clojure schema and any future tooling
+;; that needs to read them without booting the namespace, and so the
+;; operator-tunable knobs (lease TTL, heartbeat period) can be
+;; overridden without code edits.
+;;
+;; The cross-repo JSON Schema fixture at
+;; `contracts/event-stream/manifest.schema.json` mirrors the contract
+;; values below; if you change one of those, change both — the Clojure
+;; producer and Rust consumer (BD-2c) both validate against the same
+;; shape.
+{;; Wire format. Bumped only on incompatible shape changes — additive
+ ;; keys do not require a bump per the RFC's forward-compatibility
+ ;; rule.
+ :schema-version  "1.0.0"
+
+ ;; Manifest file basename. Cross-repo contract — Rust looks for the
+ ;; same name on disk.
+ :manifest-filename "manifest.json"
+
+ ;; Workflow lifecycle. `:crashed` is a slow-path classification (see
+ ;; BD-2b sub-3) when no terminal event is observed and the owner
+ ;; lease is stale + pid gone.
+ :workflow-statuses [:active :completed :failed :cancelled :crashed]
+
+ ;; Storage lifecycle. State-machine edges (forward-only except an
+ ;; `:archiving → :live` rollback for sub-3's aborted-archive
+ ;; recovery): :live → :archiving → :archived → :tombstoned.
+ :archive-statuses  [:live :archiving :archived :tombstoned]
+
+ ;; Snapshot availability. `:pending` / `:failed` mean BD-2c synthesis
+ ;; timed out or errored; consumers fall back to raw-event replay
+ ;; (preserved by `raw_events_retained: true` in those states).
+ :snapshot-statuses [:none :available :pending :failed]
+
+ ;; Operator knobs — tunable without code edits.
+
+ ;; How long a lease counts as fresh. Sub-3 cleanup classifies a
+ ;; workflow as crashed only if the lease is older than this AND the
+ ;; owner pid is gone.
+ :default-lease-ttl-seconds 60
+
+ ;; How often `start-heartbeat!` renews the lease while the workflow
+ ;; is alive. Half the lease TTL by default so a single missed renew
+ ;; does not falsely flag the workflow as crashed.
+ :heartbeat-period-seconds 30}

--- a/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
@@ -42,6 +42,7 @@
   {:miniforge/runtime :jvm-only}
   (:require
    [cheshire.core :as json]
+   [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [malli.core :as m])
@@ -55,49 +56,30 @@
    [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants — lifecycle / storage / snapshot enums
+;; Defaults — enums, filenames, operator knobs all loaded from
+;; `resources/config/event-stream/manifest-defaults.edn`. Pulling them
+;; out keeps the contract values in one place visible to both the
+;; Malli schema below and the cross-repo JSON Schema fixture at
+;; `contracts/event-stream/manifest.schema.json`, and lets operators
+;; tune the runtime knobs (TTL, heartbeat period) without code edits.
 
-(def ^:const schema-version
-  "Wire-format version of the manifest. Bumped only on incompatible
-   shape changes — additive keys do not require a bump per the RFC's
-   forward-compatibility rule."
-  "1.0.0")
+(def defaults
+  "Manifest defaults loaded from
+   `resources/config/event-stream/manifest-defaults.edn` at namespace
+   load. Keys: `:schema-version`, `:manifest-filename`,
+   `:workflow-statuses`, `:archive-statuses`, `:snapshot-statuses`,
+   `:default-lease-ttl-seconds`, `:heartbeat-period-seconds`."
+  (-> (io/resource "config/event-stream/manifest-defaults.edn")
+      slurp
+      edn/read-string))
 
-(def workflow-statuses
-  "Workflow-lifecycle states. `crashed` is a slow-path classification
-   (see BD-2b sub-3) — the workflow's process exited without writing a
-   terminal event."
-  [:active :completed :failed :cancelled :crashed])
-
-(def archive-statuses
-  "Storage-lifecycle states for the workflow's events on disk:
-     :live       — still in events/live/{workflow-id}/
-     :archiving  — sub-3 atomic archive in flight (recovery target)
-     :archived   — events moved to archived/{workflow-id}/
-     :tombstoned — raw events deleted, snapshot retained"
-  [:live :archiving :archived :tombstoned])
-
-(def snapshot-statuses
-  "Snapshot availability states:
-     :none       — no snapshot has been written
-     :available  — snapshot.transit.json exists and is readable
-     :pending    — sub-3 synthesis timed out; should be retried
-     :failed     — sub-3 synthesis errored; investigate"
-  [:none :available :pending :failed])
-
-(def ^:const default-lease-ttl-seconds
-  "Default lease TTL. Sub-3 cleanup classifies a workflow as crashed
-   only if the lease is older than this AND the owner pid is gone."
-  60)
-
-(def ^:const heartbeat-period-seconds
-  "How often `start-heartbeat!` renews the lease while the workflow is
-   alive. Half the lease TTL by default so a single missed renew does
-   not falsely flag the workflow as crashed."
-  30)
-
-(def ^:const manifest-filename
-  "manifest.json")
+(def schema-version       (:schema-version defaults))
+(def manifest-filename    (:manifest-filename defaults))
+(def workflow-statuses    (:workflow-statuses defaults))
+(def archive-statuses     (:archive-statuses defaults))
+(def snapshot-statuses    (:snapshot-statuses defaults))
+(def default-lease-ttl-seconds (:default-lease-ttl-seconds defaults))
+(def heartbeat-period-seconds  (:heartbeat-period-seconds defaults))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Malli schema — mirrors the RFC v4 shape and the cross-repo

--- a/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
@@ -103,10 +103,17 @@
 ;; Malli schema — mirrors the RFC v4 shape and the cross-repo
 ;; JSON Schema at `contracts/event-stream/manifest.schema.json`.
 
+(def ^:private snowflake-event-id-re
+  "16-char lowercase hex per the BD-2b sub-1 Snowflake filename
+   grammar. The cross-repo JSON Schema validates the same shape."
+  #"^[0-9a-f]{16}$")
+
 (def Manifest
   "Open Malli schema for the per-workflow manifest map. Open: future
    keys (e.g. additional snapshot-status detail) pass through without
-   a schema bump per the RFC's forward-compatibility rule."
+   a schema bump per the RFC's forward-compatibility rule. Constraints
+   mirror `contracts/event-stream/manifest.schema.json` so the Clojure
+   producer and the eventual Rust consumer can't drift on validation."
   [:map
    [:workflow_id :uuid]
    [:schema_version [:string {:min 1}]]
@@ -119,8 +126,8 @@
    [:archived_at {:optional true} [:maybe :string]]
    [:snapshot_watermark
     [:map
-     [:workflow_sequence_number :int]
-     [:last_event_id {:optional true} [:maybe :string]]]]
+     [:workflow_sequence_number [:int {:min 0}]]
+     [:last_event_id {:optional true} [:maybe [:re snowflake-event-id-re]]]]]
    [:raw_events_retained :boolean]
    [:raw_events_retained_until {:optional true} [:maybe :string]]
    [:owner
@@ -314,8 +321,12 @@
         _           (.mkdirs dir)
         ^File final (manifest-path dir)
         ^File tmp   (io/file dir (str manifest-filename ".tmp"))]
-    ;; Serialize as JSON with stringified UUIDs / kebab-case keywords.
-    ;; cheshire's :keyword-fn names the keys back as kebab-case strings.
+    ;; Cheshire writes keyword keys via `name`, so the snake_case keys
+    ;; in the manifest map (e.g. `:workflow_id`) round-trip as
+    ;; `"workflow_id"` on disk. Keyword *values* (status enums, the
+    ;; UUID workflow id) need explicit conversion before serialization
+    ;; — the `update`s below stringify them; `load-manifest` reverses
+    ;; the conversions on read.
     (with-open [w (io/writer tmp)]
       (json/generate-stream
         (-> manifest
@@ -350,21 +361,42 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Heartbeat — periodic lease renewal while the workflow is live.
 
+(defn- default-heartbeat-error-log!
+  "Last-resort logging when no `:on-error` callback is supplied. Writes
+   a single-line warning to stderr so persistent IO failures during
+   the heartbeat are observable in the operator's terminal / CI logs
+   rather than silently disappearing. The workflow runner is the
+   normal caller and should prefer to wire its own logger via
+   `:on-error`."
+  [^Throwable t workflow-dir]
+  (binding [*out* *err*]
+    (println (str "WARNING: manifest heartbeat renew failed for "
+                  (.getAbsolutePath ^File (io/file workflow-dir))
+                  ": " (.getMessage t)))))
+
 (defn ^ScheduledExecutorService start-heartbeat!
   "Start a single-threaded scheduled executor that renews the
    manifest's lease every `:period-seconds` (default
    `heartbeat-period-seconds`). Returns the executor handle for
    `stop-heartbeat!`.
 
-   The renew is best-effort — it logs but does not throw on transient
-   IO errors so a missed beat doesn't crash the workflow runner. The
-   sub-3 cleanup path's `lease-fresh?` check tolerates a single missed
-   renew via the TTL > period default."
+   Renew failures: a transient IO error during a beat must not crash
+   the workflow runner. By default any caught Throwable is reported
+   via `default-heartbeat-error-log!` (a stderr warning) so persistent
+   failures are visible. Callers that have a structured logger
+   should pass `:on-error` instead — that callback fully replaces the
+   default and is the recommended path for production wiring.
+
+   The sub-3 cleanup path's `lease-fresh?` check tolerates a single
+   missed renew via the TTL > period default, so a one-off swallowed
+   error does not falsely flag the workflow as crashed."
   ([workflow-dir]
    (start-heartbeat! workflow-dir {}))
   ([workflow-dir {:keys [period-seconds on-error]
                   :or   {period-seconds heartbeat-period-seconds}}]
-   (let [^ScheduledExecutorService ex
+   (let [report-error (or on-error
+                          #(default-heartbeat-error-log! % workflow-dir))
+         ^ScheduledExecutorService ex
          (Executors/newSingleThreadScheduledExecutor
            (reify java.util.concurrent.ThreadFactory
              (newThread [_ r]
@@ -374,8 +406,7 @@
                            ^Runnable
                            (fn []
                              (try (renew-lease! workflow-dir)
-                                  (catch Throwable t
-                                    (when on-error (on-error t)))))
+                                  (catch Throwable t (report-error t))))
                            (long period-seconds)
                            (long period-seconds)
                            TimeUnit/SECONDS)

--- a/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
@@ -1,0 +1,393 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.manifest
+  "Per-workflow manifest: lifecycle state, archive state, snapshot
+   watermark, owner lease (BD-2b sub-2 of the RFC at
+   `docs/design/event-stream-replay-retention.md`).
+
+   The manifest is the keystone for BD-2b/2c. It carries:
+     - workflow lifecycle  (`status`)
+     - storage lifecycle   (`archive_status`)
+     - snapshot availability (`snapshot_status`)
+     - snapshot watermark  (workflow_sequence_number + last_event_id)
+     - owner lease         (pid / host / heartbeat / TTL)
+
+   Sub-3 (atomic archive) and BD-2c (snapshots, consumer hydration)
+   read/write the same shape. The cross-repo JSON Schema fixture lives
+   at `contracts/event-stream/manifest.schema.json` so the Rust
+   consumer can decode the same on-disk form without us re-deriving
+   the contract.
+
+   JVM-only: writes JSON via `cheshire`, reads pid/host via
+   `java.lang.management` and `java.net`, and runs heartbeats on a
+   `ScheduledExecutorService`. The BB-runtime CLI never touches this
+   namespace — it's used by the workflow runner (lifecycle hooks) and
+   by the cleanup path (sub-3) which both run on the JVM."
+  {:miniforge/runtime :jvm-only}
+  (:require
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [malli.core :as m])
+  (:import
+   [java.io File]
+   [java.lang.management ManagementFactory]
+   [java.net InetAddress]
+   [java.nio.file Files StandardCopyOption]
+   [java.nio.file.attribute FileAttribute]
+   [java.time Instant]
+   [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants — lifecycle / storage / snapshot enums
+
+(def ^:const schema-version
+  "Wire-format version of the manifest. Bumped only on incompatible
+   shape changes — additive keys do not require a bump per the RFC's
+   forward-compatibility rule."
+  "1.0.0")
+
+(def workflow-statuses
+  "Workflow-lifecycle states. `crashed` is a slow-path classification
+   (see BD-2b sub-3) — the workflow's process exited without writing a
+   terminal event."
+  [:active :completed :failed :cancelled :crashed])
+
+(def archive-statuses
+  "Storage-lifecycle states for the workflow's events on disk:
+     :live       — still in events/live/{workflow-id}/
+     :archiving  — sub-3 atomic archive in flight (recovery target)
+     :archived   — events moved to archived/{workflow-id}/
+     :tombstoned — raw events deleted, snapshot retained"
+  [:live :archiving :archived :tombstoned])
+
+(def snapshot-statuses
+  "Snapshot availability states:
+     :none       — no snapshot has been written
+     :available  — snapshot.transit.json exists and is readable
+     :pending    — sub-3 synthesis timed out; should be retried
+     :failed     — sub-3 synthesis errored; investigate"
+  [:none :available :pending :failed])
+
+(def ^:const default-lease-ttl-seconds
+  "Default lease TTL. Sub-3 cleanup classifies a workflow as crashed
+   only if the lease is older than this AND the owner pid is gone."
+  60)
+
+(def ^:const heartbeat-period-seconds
+  "How often `start-heartbeat!` renews the lease while the workflow is
+   alive. Half the lease TTL by default so a single missed renew does
+   not falsely flag the workflow as crashed."
+  30)
+
+(def ^:const manifest-filename
+  "manifest.json")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Malli schema — mirrors the RFC v4 shape and the cross-repo
+;; JSON Schema at `contracts/event-stream/manifest.schema.json`.
+
+(def Manifest
+  "Open Malli schema for the per-workflow manifest map. Open: future
+   keys (e.g. additional snapshot-status detail) pass through without
+   a schema bump per the RFC's forward-compatibility rule."
+  [:map
+   [:workflow_id :uuid]
+   [:schema_version [:string {:min 1}]]
+   [:status (into [:enum] workflow-statuses)]
+   [:archive_status (into [:enum] archive-statuses)]
+   [:snapshot_status (into [:enum] snapshot-statuses)]
+   [:snapshot_failure_reason {:optional true} [:maybe :string]]
+   [:created_at :string]
+   [:completed_at {:optional true} [:maybe :string]]
+   [:archived_at {:optional true} [:maybe :string]]
+   [:snapshot_watermark
+    [:map
+     [:workflow_sequence_number :int]
+     [:last_event_id {:optional true} [:maybe :string]]]]
+   [:raw_events_retained :boolean]
+   [:raw_events_retained_until {:optional true} [:maybe :string]]
+   [:owner
+    [:map
+     [:pid [:string {:min 1}]]
+     [:host [:string {:min 1}]]
+     [:lease_renewed_at :string]
+     [:lease_ttl_seconds [:int {:min 1}]]]]])
+
+(defn valid?
+  "True if `m` matches the manifest schema."
+  [m]
+  (m/validate Manifest m))
+
+(defn explain
+  "Return a malli explanation when `m` does not match. nil when valid."
+  [m]
+  (m/explain Manifest m))
+
+;------------------------------------------------------------------------------ Layer 0
+;; State machine
+
+(def ^:private legal-archive-transitions
+  "Forward-only edges. Backwards moves (e.g. archived → live) are
+   never legal — once events have been moved they don't come back."
+  {:live       #{:archiving}
+   :archiving  #{:archived :live}        ; rollback to :live on aborted archive
+   :archived   #{:tombstoned}
+   :tombstoned #{}})
+
+(defn legal-archive-transition?
+  "True iff the manifest may move from `from` to `to`."
+  [from to]
+  (boolean (contains? (get legal-archive-transitions from #{}) to)))
+
+(defn transition-archive
+  "Pure: move the manifest's `archive_status` from its current value
+   to `to`, returning the updated manifest. Throws ex-info on illegal
+   moves so callers can't silently corrupt the state machine."
+  [manifest to]
+  (let [from (:archive_status manifest)]
+    (if (legal-archive-transition? from to)
+      (assoc manifest :archive_status to)
+      (throw (ex-info "Illegal archive_status transition"
+                      {:reason :illegal-archive-transition
+                       :from   from
+                       :to     to
+                       :workflow-id (:workflow_id manifest)})))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Owner / lease primitives
+
+(defn- ^String iso-now
+  "ISO-8601 instant for `lease_renewed_at` / `created_at` etc."
+  []
+  (str (Instant/now)))
+
+(defn- ^String pid-string
+  "Process id as a string. Built from the JMX runtime bean name —
+   `pid@host` on hotspot — so we don't need Java-9-only APIs."
+  []
+  (let [name (.getName (ManagementFactory/getRuntimeMXBean))]
+    (first (str/split name #"@"))))
+
+(defn- ^String hostname-string
+  "Best-effort canonical hostname. Falls back to `\"unknown-host\"` if
+   DNS / lookup fails — the field is informational, not load-bearing."
+  []
+  (try (.getCanonicalHostName (InetAddress/getLocalHost))
+       (catch Exception _ "unknown-host")))
+
+(defn fresh-owner
+  "Build an owner map with the calling process's pid + host, marking
+   the lease as renewed right now."
+  ([] (fresh-owner default-lease-ttl-seconds))
+  ([ttl-seconds]
+   {:pid               (pid-string)
+    :host              (hostname-string)
+    :lease_renewed_at  (iso-now)
+    :lease_ttl_seconds ttl-seconds}))
+
+(defn renew-lease
+  "Pure: update `manifest`'s `:owner.lease_renewed_at` to now. Does
+   not change pid/host/ttl — those are stamped at acquisition and
+   only re-stamped when the workflow is re-claimed."
+  [manifest]
+  (assoc-in manifest [:owner :lease_renewed_at] (iso-now)))
+
+(defn lease-fresh?
+  "True if `manifest`'s lease was renewed within `ttl_seconds` of `now`.
+   Pure — caller passes `now` as an `Instant` for testability."
+  ([manifest] (lease-fresh? manifest (Instant/now)))
+  ([manifest ^Instant now]
+   (let [renewed (Instant/parse ^String (get-in manifest [:owner :lease_renewed_at]))
+         ttl-s   (long (get-in manifest [:owner :lease_ttl_seconds]))
+         age-s   (- (.getEpochSecond now) (.getEpochSecond renewed))]
+     (<= age-s ttl-s))))
+
+(defn owner-pid-alive?
+  "True if the manifest's `:owner.pid` corresponds to a running
+   process on this host. Use `ProcessHandle/of` (Java 9+). Returns
+   false when host doesn't match — cross-host pid checks are out of
+   scope (single-machine non-goal per the RFC)."
+  [manifest]
+  (let [owner-host (get-in manifest [:owner :host])]
+    (and (= owner-host (hostname-string))
+         (try
+           (let [pid (Long/parseLong (get-in manifest [:owner :pid]))]
+             (.isPresent (java.lang.ProcessHandle/of pid)))
+           (catch Exception _ false)))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Manifest construction
+
+(defn init-active
+  "Build a fresh `:active` / `:live` manifest for a new workflow.
+   Owner is the calling process. Snapshot watermark starts at
+   sequence 0 with no event id — sub-3 / BD-2c update it as
+   checkpoints land."
+  [workflow-id & [{:keys [ttl-seconds] :or {ttl-seconds default-lease-ttl-seconds}}]]
+  {:workflow_id              workflow-id
+   :schema_version           schema-version
+   :status                   :active
+   :archive_status           :live
+   :snapshot_status          :none
+   :snapshot_failure_reason  nil
+   :created_at               (iso-now)
+   :completed_at             nil
+   :archived_at              nil
+   :snapshot_watermark       {:workflow_sequence_number 0
+                              :last_event_id            nil}
+   :raw_events_retained      true
+   :raw_events_retained_until nil
+   :owner                    (fresh-owner ttl-seconds)})
+
+(defn mark-terminal
+  "Pure: set `status` to a terminal value (`:completed | :failed |
+   :cancelled`) and stamp `completed_at`. Does NOT change
+   archive_status — that's a separate state machine driven by sub-3."
+  [manifest status]
+  (assert (contains? #{:completed :failed :cancelled} status)
+          (str "mark-terminal expects a terminal status, got " status))
+  (assoc manifest
+         :status       status
+         :completed_at (iso-now)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; File IO — atomic write via temp + Files/move(ATOMIC_MOVE)
+
+(defn manifest-path
+  "Return the manifest.json path under `workflow-dir`. The caller
+   chooses live/{wid} vs archived/{wid} — manifest is the same shape
+   in both."
+  ^File [workflow-dir]
+  (io/file workflow-dir manifest-filename))
+
+(defn load-manifest
+  "Read and parse a manifest from disk. Returns the parsed map (with
+   keyword keys) or nil when the file is absent. Throws if present
+   but unparseable — a corrupted manifest is a real bug, not a
+   recoverable signal."
+  [workflow-dir]
+  (let [^File f (manifest-path workflow-dir)]
+    (when (.exists f)
+      (let [raw (json/parse-string (slurp f) true)]
+        (cond-> raw
+          ;; cheshire returns strings for the workflow_id; restore the UUID.
+          (string? (:workflow_id raw))
+          (update :workflow_id #(java.util.UUID/fromString %))
+          ;; status / archive_status / snapshot_status come back as strings.
+          (string? (:status raw))          (update :status keyword)
+          (string? (:archive_status raw))  (update :archive_status keyword)
+          (string? (:snapshot_status raw)) (update :snapshot_status keyword))))))
+
+(defn save-manifest!
+  "Atomically write `manifest` to `workflow-dir/manifest.json`.
+
+   Writes to `manifest.json.tmp` first, fsyncs, then `Files/move`s
+   with `ATOMIC_MOVE` + `REPLACE_EXISTING`. A reader during the move
+   sees either the old file or the new — never a half-written one.
+
+   Throws on schema-validation failure so callers can't silently
+   persist a corrupt shape."
+  [workflow-dir manifest]
+  (when-let [err (explain manifest)]
+    (throw (ex-info "Manifest fails schema validation"
+                    {:reason :invalid-manifest
+                     :workflow-dir (.getAbsolutePath ^File (io/file workflow-dir))
+                     :error err})))
+  (let [^File dir   (io/file workflow-dir)
+        _           (.mkdirs dir)
+        ^File final (manifest-path dir)
+        ^File tmp   (io/file dir (str manifest-filename ".tmp"))]
+    ;; Serialize as JSON with stringified UUIDs / kebab-case keywords.
+    ;; cheshire's :keyword-fn names the keys back as kebab-case strings.
+    (with-open [w (io/writer tmp)]
+      (json/generate-stream
+        (-> manifest
+            (update :workflow_id str)
+            (update :status name)
+            (update :archive_status name)
+            (update :snapshot_status name))
+        w
+        {:pretty true}))
+    ;; fsync the tmp file before moving so a crash mid-rename doesn't
+    ;; leave an empty manifest on disk.
+    (with-open [raf (java.io.RandomAccessFile. tmp "rw")]
+      (.force (.getChannel raf) true))
+    (Files/move (.toPath tmp)
+                (.toPath final)
+                (into-array java.nio.file.CopyOption
+                            [StandardCopyOption/ATOMIC_MOVE
+                             StandardCopyOption/REPLACE_EXISTING]))
+    final))
+
+(defn renew-lease!
+  "Re-stamp the lease and write the manifest atomically. Returns the
+   updated manifest. Idempotent — a missing manifest is a no-op
+   returning nil so the heartbeat doesn't crash if the workflow is
+   archived between ticks."
+  [workflow-dir]
+  (when-let [m (load-manifest workflow-dir)]
+    (let [renewed (renew-lease m)]
+      (save-manifest! workflow-dir renewed)
+      renewed)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Heartbeat — periodic lease renewal while the workflow is live.
+
+(defn ^ScheduledExecutorService start-heartbeat!
+  "Start a single-threaded scheduled executor that renews the
+   manifest's lease every `:period-seconds` (default
+   `heartbeat-period-seconds`). Returns the executor handle for
+   `stop-heartbeat!`.
+
+   The renew is best-effort — it logs but does not throw on transient
+   IO errors so a missed beat doesn't crash the workflow runner. The
+   sub-3 cleanup path's `lease-fresh?` check tolerates a single missed
+   renew via the TTL > period default."
+  ([workflow-dir]
+   (start-heartbeat! workflow-dir {}))
+  ([workflow-dir {:keys [period-seconds on-error]
+                  :or   {period-seconds heartbeat-period-seconds}}]
+   (let [^ScheduledExecutorService ex
+         (Executors/newSingleThreadScheduledExecutor
+           (reify java.util.concurrent.ThreadFactory
+             (newThread [_ r]
+               (doto (Thread. r "miniforge-manifest-heartbeat")
+                 (.setDaemon true)))))]
+     (.scheduleAtFixedRate ex
+                           ^Runnable
+                           (fn []
+                             (try (renew-lease! workflow-dir)
+                                  (catch Throwable t
+                                    (when on-error (on-error t)))))
+                           (long period-seconds)
+                           (long period-seconds)
+                           TimeUnit/SECONDS)
+     ex)))
+
+(defn stop-heartbeat!
+  "Shut the heartbeat executor down. Waits up to `:timeout-ms`
+   (default 1000) for the in-flight renew to finish, then forces."
+  ([^ScheduledExecutorService ex] (stop-heartbeat! ex {}))
+  ([^ScheduledExecutorService ex {:keys [timeout-ms] :or {timeout-ms 1000}}]
+   (when ex
+     (.shutdown ex)
+     (when-not (.awaitTermination ex (long timeout-ms) TimeUnit/MILLISECONDS)
+       (.shutdownNow ex))
+     nil)))

--- a/components/event-stream/test/ai/miniforge/event_stream/manifest_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/manifest_test.clj
@@ -1,0 +1,212 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.manifest-test
+  "Tests for the BD-2b sub-2 per-workflow manifest module."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.event-stream.manifest :as manifest])
+  (:import
+   [java.time Instant]
+   [java.util UUID]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- with-temp-dir [f]
+  (let [dir (java.nio.file.Files/createTempDirectory
+             "manifest-test-"
+             (into-array java.nio.file.attribute.FileAttribute []))]
+    (try
+      (f (.toFile dir))
+      (finally
+        (doseq [file (reverse (file-seq (.toFile dir)))]
+          (.delete ^java.io.File file))))))
+
+;; The id is informational at the wire layer (tests round-trip it as a
+;; UUID); workflow lifecycle wiring uses a real run id.
+(def ^:private test-workflow-id
+  (UUID/fromString "00000000-0000-0000-0000-000000000001"))
+
+;; Default lease window for tests is much shorter than the production
+;; default so `lease-fresh?` can be exercised against synthetic clock
+;; advances without waiting wall-time minutes.
+(def ^:private ^:const ^long short-ttl-seconds 5)
+
+;------------------------------------------------------------------------------ Schema
+
+(deftest init-active-produces-valid-manifest
+  (let [m (manifest/init-active test-workflow-id)]
+    (is (manifest/valid? m)
+        (str "init-active should produce a schema-valid manifest, got "
+             (pr-str (manifest/explain m))))
+    (is (= :active (:status m)))
+    (is (= :live (:archive_status m)))
+    (is (= :none (:snapshot_status m)))
+    (is (true? (:raw_events_retained m)))
+    (is (= 0 (get-in m [:snapshot_watermark :workflow_sequence_number])))
+    (is (nil? (get-in m [:snapshot_watermark :last_event_id])))))
+
+(deftest valid?-rejects-missing-required-fields
+  (is (not (manifest/valid? {})))
+  (is (some? (manifest/explain {}))))
+
+(deftest valid?-rejects-unknown-status-enum
+  (let [m (assoc (manifest/init-active test-workflow-id)
+                 :status :wat)]
+    (is (not (manifest/valid? m))
+        "unknown :status enum value must fail validation")))
+
+;------------------------------------------------------------------------------ State machine
+
+(deftest legal-archive-transitions-table
+  (testing "forward edges"
+    (is (manifest/legal-archive-transition? :live :archiving))
+    (is (manifest/legal-archive-transition? :archiving :archived))
+    (is (manifest/legal-archive-transition? :archived :tombstoned)))
+  (testing "rollback :archiving → :live (aborted archive)"
+    (is (manifest/legal-archive-transition? :archiving :live)))
+  (testing "tombstoned is terminal"
+    (is (not (manifest/legal-archive-transition? :tombstoned :live)))
+    (is (not (manifest/legal-archive-transition? :tombstoned :archived))))
+  (testing "no skipping :archiving"
+    (is (not (manifest/legal-archive-transition? :live :archived))))
+  (testing "no resurrection from :archived"
+    (is (not (manifest/legal-archive-transition? :archived :live)))
+    (is (not (manifest/legal-archive-transition? :archived :archiving)))))
+
+(deftest transition-archive-throws-on-illegal-move
+  (let [m (manifest/init-active test-workflow-id)]
+    (is (= :archiving
+           (:archive_status (manifest/transition-archive m :archiving)))
+        "live → archiving is the canonical happy path")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Illegal archive_status transition"
+                          (manifest/transition-archive m :archived))
+        "live → archived must skip :archiving and is illegal")))
+
+(deftest mark-terminal-stamps-completed-at-and-status
+  (let [m (manifest/init-active test-workflow-id)]
+    (let [done (manifest/mark-terminal m :completed)]
+      (is (= :completed (:status done)))
+      (is (some? (:completed_at done))
+          "completed_at must be stamped on terminal mark"))
+    (is (thrown? AssertionError
+                 (manifest/mark-terminal m :archived))
+        "mark-terminal must reject non-terminal status keywords")))
+
+;------------------------------------------------------------------------------ Lease primitives
+
+(deftest renew-lease-bumps-renewed-at
+  ;; Pre-stamp `lease_renewed_at` with a known past instant so the
+  ;; test doesn't depend on JVM clock resolution to observe a delta.
+  (let [m       (-> (manifest/init-active test-workflow-id
+                                          {:ttl-seconds short-ttl-seconds})
+                    (assoc-in [:owner :lease_renewed_at]
+                              (str (Instant/parse "2026-05-08T00:00:00Z"))))
+        before  (get-in m [:owner :lease_renewed_at])
+        renewed (manifest/renew-lease m)
+        after   (get-in renewed [:owner :lease_renewed_at])]
+    (is (not= before after)
+        "renew-lease must update lease_renewed_at")
+    (is (.isAfter (Instant/parse ^String after)
+                  (Instant/parse ^String before)))))
+
+(deftest lease-fresh?-respects-ttl
+  (let [m   (manifest/init-active test-workflow-id
+                                  {:ttl-seconds short-ttl-seconds})
+        ;; Anchor a known renewed-at and probe the freshness window.
+        m'  (assoc-in m [:owner :lease_renewed_at]
+                      (str (Instant/parse "2026-05-08T00:00:00Z")))]
+    (is (manifest/lease-fresh? m' (Instant/parse "2026-05-08T00:00:00Z"))
+        "renewed-now is trivially fresh")
+    (is (manifest/lease-fresh? m' (Instant/parse "2026-05-08T00:00:04Z"))
+        "1s before TTL boundary is fresh")
+    (is (manifest/lease-fresh? m' (Instant/parse "2026-05-08T00:00:05Z"))
+        "exactly at TTL boundary is fresh (≤, not <)")
+    (is (not (manifest/lease-fresh? m' (Instant/parse "2026-05-08T00:00:06Z")))
+        "past TTL boundary is stale")))
+
+(deftest owner-pid-alive?-true-for-self
+  ;; The lease was just stamped with our own pid + host, so the
+  ;; alive-check must return true for this process.
+  (let [m (manifest/init-active test-workflow-id)]
+    (is (manifest/owner-pid-alive? m))))
+
+(deftest owner-pid-alive?-false-for-different-host
+  (let [m (assoc-in (manifest/init-active test-workflow-id)
+                    [:owner :host] "definitely-not-this-host.invalid")]
+    (is (not (manifest/owner-pid-alive? m))
+        "cross-host pid checks are out of scope; treat as not-alive")))
+
+(deftest owner-pid-alive?-false-for-bogus-pid
+  (let [m (assoc-in (manifest/init-active test-workflow-id)
+                    [:owner :pid] "99999999")]
+    (is (not (manifest/owner-pid-alive? m))
+        "a pid with no live process must be reported dead")))
+
+;------------------------------------------------------------------------------ Atomic IO
+
+(deftest save-then-load-round-trips
+  (with-temp-dir
+    (fn [dir]
+      (let [m       (manifest/init-active test-workflow-id)
+            _       (manifest/save-manifest! dir m)
+            loaded  (manifest/load-manifest dir)]
+        (is (= (:workflow_id m) (:workflow_id loaded)))
+        (is (= (:status m) (:status loaded)))
+        (is (= (:archive_status m) (:archive_status loaded)))
+        (is (= (:snapshot_status m) (:snapshot_status loaded)))
+        (is (= (:owner m) (:owner loaded))
+            "owner round-trips byte-for-byte through JSON")))))
+
+(deftest load-manifest-returns-nil-when-absent
+  (with-temp-dir
+    (fn [dir]
+      (is (nil? (manifest/load-manifest dir))))))
+
+(deftest save-manifest!-rejects-invalid-shape
+  (with-temp-dir
+    (fn [dir]
+      (let [bogus (assoc (manifest/init-active test-workflow-id)
+                         :status :not-a-status)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"fails schema validation"
+                              (manifest/save-manifest! dir bogus)))))))
+
+(deftest renew-lease!-no-op-when-manifest-absent
+  (with-temp-dir
+    (fn [dir]
+      (is (nil? (manifest/renew-lease! dir))
+          "missing manifest is a no-op so a heartbeat tick can race
+           archival without crashing"))))
+
+(deftest renew-lease!-bumps-on-disk
+  (with-temp-dir
+    (fn [dir]
+      (let [m       (-> (manifest/init-active test-workflow-id)
+                        (assoc-in [:owner :lease_renewed_at]
+                                  (str (Instant/parse "2026-05-08T00:00:00Z"))))
+            _       (manifest/save-manifest! dir m)
+            before  (get-in (manifest/load-manifest dir)
+                            [:owner :lease_renewed_at])
+            _       (manifest/renew-lease! dir)
+            after   (get-in (manifest/load-manifest dir)
+                            [:owner :lease_renewed_at])]
+        (is (not= before after))
+        (is (.isAfter (Instant/parse ^String after)
+                      (Instant/parse ^String before)))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/manifest_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/manifest_test.clj
@@ -71,6 +71,28 @@
     (is (not (manifest/valid? m))
         "unknown :status enum value must fail validation")))
 
+(deftest valid?-rejects-negative-watermark-sequence
+  (let [m (assoc-in (manifest/init-active test-workflow-id)
+                    [:snapshot_watermark :workflow_sequence_number] -1)]
+    (is (not (manifest/valid? m))
+        "watermark sequence must be ≥ 0 to mirror the JSON Schema contract")))
+
+(deftest valid?-rejects-malformed-event-id
+  (let [base (manifest/init-active test-workflow-id)]
+    (is (not (manifest/valid?
+              (assoc-in base [:snapshot_watermark :last_event_id] "not-hex")))
+        "non-hex last_event_id must fail validation")
+    (is (not (manifest/valid?
+              (assoc-in base [:snapshot_watermark :last_event_id] "ABCDEF1234567890")))
+        "uppercase hex must fail (lowercase-only by RFC contract)")
+    (is (not (manifest/valid?
+              (assoc-in base [:snapshot_watermark :last_event_id] "abc")))
+        "wrong-length hex must fail")
+    (is (manifest/valid?
+         (assoc-in base [:snapshot_watermark :last_event_id]
+                   "018f3a9c8e4b12d0"))
+        "16-char lowercase hex passes")))
+
 ;------------------------------------------------------------------------------ State machine
 
 (deftest legal-archive-transitions-table

--- a/contracts/event-stream/manifest.schema.json
+++ b/contracts/event-stream/manifest.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://miniforge.ai/schemas/event-stream/manifest.schema.json",
+  "title": "WorkflowManifest",
+  "description": "Per-workflow manifest carrying lifecycle state, archive lifecycle, snapshot availability, snapshot watermark, and owner lease. Cross-repo on-disk contract per the BD-2 RFC (docs/design/event-stream-replay-retention.md). Producer (Clojure event-stream/manifest) and consumer (Rust supervisory-entities WorkflowManifest, BD-2c) both validate against this schema. Open: additional `:spec/*`-style or `snapshot_*` keys may appear in future versions; consumers MUST tolerate unknown top-level fields.",
+  "type": "object",
+  "required": [
+    "workflow_id",
+    "schema_version",
+    "status",
+    "archive_status",
+    "snapshot_status",
+    "created_at",
+    "snapshot_watermark",
+    "raw_events_retained",
+    "owner"
+  ],
+  "properties": {
+    "workflow_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "UUID of the WorkflowRun this manifest tracks."
+    },
+    "schema_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Wire-format version. Bumped only on incompatible shape changes; additive keys do not require a bump."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "completed", "failed", "cancelled", "crashed"],
+      "description": "Workflow lifecycle. `crashed` is a slow-path classification (BD-2b sub-3) when no terminal event is observed and the owner lease is stale + pid gone."
+    },
+    "archive_status": {
+      "type": "string",
+      "enum": ["live", "archiving", "archived", "tombstoned"],
+      "description": "Storage lifecycle. State-machine edges (forward-only except `archiving → live` rollback): live → archiving → archived → tombstoned."
+    },
+    "snapshot_status": {
+      "type": "string",
+      "enum": ["none", "available", "pending", "failed"],
+      "description": "Snapshot availability. `pending`/`failed` mean the BD-2c sub-3 synthesis attempt timed out or errored; consumers fall back to raw-event replay (which is preserved by `raw_events_retained: true` in those states)."
+    },
+    "snapshot_failure_reason": {
+      "type": ["string", "null"],
+      "description": "Populated when `snapshot_status` is `pending` or `failed`. Free-form diagnostic string."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 instant when the manifest was first written (workflow start)."
+    },
+    "completed_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO-8601 instant when `status` transitioned to a terminal value. Null until terminal."
+    },
+    "archived_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO-8601 instant when `archive_status` transitioned to `archived`. Null while live or archiving."
+    },
+    "snapshot_watermark": {
+      "type": "object",
+      "description": "Watermark for snapshot replay. `workflow_sequence_number` is the per-workflow logical sequence the snapshot covers up to; `last_event_id` is the Snowflake event id (16-char lowercase hex) of that last event so consumers can skip filenames lex-below the watermark without parsing payloads.",
+      "required": ["workflow_sequence_number"],
+      "properties": {
+        "workflow_sequence_number": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_event_id": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{16}$"
+        }
+      }
+    },
+    "raw_events_retained": {
+      "type": "boolean",
+      "description": "When true, the slow-path cleanup (BD-2b sub-3) MUST NOT delete this workflow's raw event tail under ordinary tail-deletion. Set true on crashed workflows whose snapshot is pending/failed, so the only reconstructable state is preserved."
+    },
+    "raw_events_retained_until": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO-8601 instant after which raw events become eligible for deletion. Null while `raw_events_retained` is true."
+    },
+    "owner": {
+      "type": "object",
+      "description": "Process that holds the live lease. Sub-3 cleanup classifies a workflow as `crashed` only if (lease > TTL old) AND (pid not running) AND (host matches).",
+      "required": ["pid", "host", "lease_renewed_at", "lease_ttl_seconds"],
+      "properties": {
+        "pid": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Process id as a string (decimal). String-typed for cross-platform/cross-runtime safety."
+        },
+        "host": {
+          "type": "string",
+          "minLength": 1
+        },
+        "lease_renewed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 instant of the most recent renewal. Heartbeat updates this every period; `lease_ttl_seconds` defines how stale it can be before the workflow is treated as crashed."
+        },
+        "lease_ttl_seconds": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Second BD-2b implementation slice off the [design RFC (#795)](https://github.com/miniforge-ai/miniforge/pull/795). The manifest is the keystone for sub-3 (atomic archive + scheduled cleanup) and BD-2c (snapshots, consumer hydration) — both build on the schema, state machine, and lease primitives this PR introduces.

## What lands

- **`event-stream.manifest`** (jvm-only namespace):
  - Workflow lifecycle / archive lifecycle / snapshot status enums.
  - Forward-only state machine for `archive_status` (`live → archiving → archived → tombstoned`) plus a single rollback edge `archiving → live` for sub-3's aborted-archive recovery. `transition-archive` throws ex-info on illegal moves so callers can't silently corrupt state.
  - Open Malli schema covering all RFC-defined fields with the documented optional/maybe shapes.
  - **Atomic IO** via temp + `Files/move(ATOMIC_MOVE, REPLACE_EXISTING)` with explicit channel fsync on the tmp before rename. A crash mid-write cannot leave a half-readable manifest on disk. Schema-validated on save.
  - **Lease primitives**: `fresh-owner`, `renew-lease`, `lease-fresh?` (TTL boundary `<=`), `owner-pid-alive?` (host match + `ProcessHandle/of`). Pure where possible; the `lease-fresh?` boundary uses an injectable `now` so tests don't depend on wall-clock advancement.
  - **Heartbeat**: `start-heartbeat!` / `stop-heartbeat!` running a single-threaded `ScheduledExecutorService`. Defaults: TTL 60s, period 30s — a single missed beat doesn't falsely flag the workflow as crashed. `:on-error` callback so a transient renew failure doesn't crash the workflow runner.

- **Cross-repo JSON Schema fixture** at `contracts/event-stream/manifest.schema.json`. Per the RFC's "On-disk contract" section, this is the source of truth that BD-2c's Rust `WorkflowManifest` type validates against.

- **Tests** (`manifest_test.clj`): schema validation positive/negative, state machine table (forward edges, rollback, terminal, no-skip, no-resurrection), `mark-terminal` rejection of non-terminal status, lease boundary semantics (renewal bumps timestamp; `lease-fresh?` at exact TTL / 1s before / 1s after; `owner-pid-alive?` for self / different host / bogus pid), atomic IO round-trip, absent-manifest no-ops, bad shape rejected.

## Out of scope (deferred)

- **Workflow-runner wiring** — `bases/cli/workflow_runner.clj` calling `init-active` on start, `mark-terminal` on shutdown, `start-heartbeat!` while alive. The manifest module is standalone and tested independently here; wiring lands paired with sub-3 so the activation is bundled with the archive logic that actually consumes the manifest.
- BD-2b sub-3: atomic archive operation, scheduled cleanup with budgets, crashed-snapshot synthesis.
- BD-2c: snapshot emission, consumer hydration, summaries index.

## Why JVM-only

Writes JSON via `cheshire`, reads pid/host via `java.lang.management` and `java.net`, runs heartbeats on `ScheduledExecutorService`. None of these are in BB's classpath. The BB-runtime CLI never invokes manifest fns. Marked via `{:miniforge/runtime :jvm-only}` ns metadata so `tests/graalvm_compatibility_test.clj` skips the file from BB load.

## Validation

```
bb pre-commit
```

All checks passed. New `cheshire` dep added to `event-stream/deps.edn` (already used in `llm`/`tool-registry`).

## Test plan

- [ ] reviewer agrees the state machine's single rollback edge (`archiving → live`) is the right shape vs forward-only-no-exceptions
- [ ] reviewer agrees deferring workflow-runner wiring to the sub-3 PR is the right scoping
- [ ] reviewer agrees the JSON Schema fixture path (`contracts/event-stream/`) is acceptable as the cross-repo source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)