### PR TITLE
fix(release-executor): honor phase-boundary commits when staging for release

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -166,16 +166,27 @@
        (> deletions (* 3 (max 1 additions)))))
 
 (defn step-validate-diff
-  "Validate staged diff is not destructive before committing.
-   Rejects changes that delete more tests than they add or that empty files.
-   Routes through the executor (sandbox) so governed-mode capsules never
-   shell out to the host."
+  "Validate diff is not destructive before committing. Rejects changes
+   that delete more tests than they add or that empty files. Routes
+   through the executor (sandbox) so governed-mode capsules never
+   shell out to the host.
+
+   In the boundary-commits case (`:preexisting-commits true`), the
+   staged index is empty — the work is in commits on the branch, not
+   in the index — so validation reads the range diff
+   `origin/<base>..HEAD` instead. Without this branch the destructive-
+   diff gate would silently no-op on every boundary-commit release."
   [state]
   (if (failed? state)
     state
-    (let [{:keys [executor environment-id logger]} state
-          diff-stats  (sandbox/diff-stats executor environment-id)
-          test-counts (sandbox/count-test-defs executor environment-id)]
+    (let [{:keys [executor environment-id logger base-branch]} state
+          preexisting? (get-in state [:write-metrics :preexisting-commits])
+          diff-stats  (if preexisting?
+                        (sandbox/diff-stats-range executor environment-id base-branch)
+                        (sandbox/diff-stats executor environment-id))
+          test-counts (if preexisting?
+                        (sandbox/count-test-defs-range executor environment-id base-branch)
+                        (sandbox/count-test-defs executor environment-id))]
       (cond
         (net-negative-tests? test-counts)
         (let [data {:added (:added test-counts) :removed (:removed test-counts)}]

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -117,26 +117,41 @@
   "Stage all dirty files in the executor environment.
 
    In the environment model, files are already in the worktree (written by
-   the implement agent); this step stages them for commit."
+   the implement agent); this step stages them for commit.
+
+   Empty-stage handling: when nothing is dirty, the implementer's writes
+   may already be committed on the branch as phase-boundary commits (the
+   workflow runtime persists each phase boundary as a commit on the task
+   branch since 2026-04-30). In that case `git rev-list --count
+   origin/<base>..HEAD` reports the carry-forward commits and we treat
+   that as success — step-commit will skip cleanly and step-push will
+   ship the existing commits."
   [state]
   (if (failed? state)
     state
-    (let [{:keys [executor environment-id]} state
+    (let [{:keys [executor environment-id base-branch]} state
           stage-r (sandbox/stage-files! executor environment-id :all)
           staged-r (when (result/succeeded? stage-r)
-                     (sandbox/exec! executor environment-id "git diff --cached --name-only"))]
+                     (sandbox/exec! executor environment-id "git diff --cached --name-only"))
+          staged-output (get staged-r :output "")
+          staged-count (count (remove str/blank? (str/split-lines staged-output)))]
       (cond
         (not (result/succeeded? stage-r))
         (fail state :stage-failed (:error stage-r))
 
-        (str/blank? (get staged-r :output ""))
-        (fail state :no-files-to-stage (msg/t :step/no-files-to-stage))
+        (pos? staged-count)
+        (assoc state :write-metrics {:total-operations staged-count
+                                     :files-written staged-count})
+
+        ;; Nothing dirty in the worktree, but the branch may already
+        ;; carry the work as boundary commits — accept that as success.
+        (let [ahead (sandbox/commits-ahead-of-base executor environment-id base-branch)]
+          (and ahead (pos? ahead)))
+        (assoc state :write-metrics {:total-operations 0 :files-written 0
+                                     :preexisting-commits true})
 
         :else
-        (let [staged-count (count (remove str/blank?
-                                          (str/split-lines (:output staged-r ""))))]
-          (assoc state :write-metrics {:total-operations staged-count
-                                       :files-written staged-count}))))))
+        (fail state :no-files-to-stage (msg/t :step/no-files-to-stage))))))
 
 (defn- net-negative-tests?
   "True when the diff removes more test definitions than it adds."
@@ -178,9 +193,27 @@
                          {:data (merge {} diff-stats test-counts)}))
             state)))))
 
-(defn step-commit [state]
-  (if (failed? state)
-    state
+(defn step-commit
+  "Commit the staged changes with the release-meta message.
+
+   Skipped when step-stage-dirty-files found no dirty files and the
+   branch already carries the work as phase-boundary commits — the
+   existing HEAD becomes the release commit and the boundary-commit
+   messages are what end up in the PR. (This matches the worktree-as-
+   artifact handoff model: the work is in the branch already; release
+   is publishing it, not re-recording it.)"
+  [state]
+  (cond
+    (failed? state) state
+
+    (get-in state [:write-metrics :preexisting-commits])
+    (let [sha-r (sandbox/exec! (:executor state) (:environment-id state)
+                               "git rev-parse HEAD")]
+      (cond-> state
+        (result/succeeded? sha-r)
+        (assoc :commit-sha (str/trim (:output sha-r "")))))
+
+    :else
     (let [{:keys [release-meta executor environment-id]} state
           result (sandbox/commit-changes! executor environment-id
                                           (:release/commit-message release-meta))]

--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -81,7 +81,7 @@
    the per-phase boundary commits the workflow runtime makes after
    plan/implement/verify/review. If we branched off `origin/<base>`
    instead, those commits would be discarded and a downstream
-   `git add -A` would find nothing to stage. `:base-branch` is still
+   `git add .` would find nothing to stage. `:base-branch` is still
    tracked for the PR-creation step, which uses it as the merge base."
   [executor env-id branch-name base-branch]
   (let [checkout-r (exec! executor env-id
@@ -232,21 +232,32 @@
 ;------------------------------------------------------------------------------ Layer 1.5
 ;; Diff inspection (governed equivalents of git/diff-stats, git/count-test-defs)
 
+(defn- numstat-totals
+  "Parse `git diff <range> --numstat` output into {:additions :deletions :files}."
+  [output]
+  (let [lines (remove str/blank? (str/split-lines (str/trim (or output ""))))
+        parsed (keep (fn [line]
+                       (when-let [[_ adds dels] (re-matches #"(\d+)\t(\d+)\t.*" line)]
+                         {:additions (parse-long adds)
+                          :deletions (parse-long dels)}))
+                     lines)]
+    {:additions (reduce + 0 (map :additions parsed))
+     :deletions (reduce + 0 (map :deletions parsed))
+     :files (count parsed)}))
+
+(defn- count-deftest
+  "Count `(deftest …` lines added vs removed in a unified diff body."
+  [diff-text]
+  {:added   (count (re-seq #"(?m)^\+.*\(deftest " (or diff-text "")))
+   :removed (count (re-seq #"(?m)^-.*\(deftest " (or diff-text "")))})
+
 (defn diff-stats
   "Get staged diff stats via executor. Mirrors git/diff-stats.
    Returns {:additions N :deletions N :files N} or nil."
   [executor env-id]
   (let [r (exec! executor env-id "git diff --cached --numstat")]
     (when (result/succeeded? r)
-      (let [lines (remove str/blank? (str/split-lines (str/trim (:output r ""))))
-            parsed (keep (fn [line]
-                           (when-let [[_ adds dels] (re-matches #"(\d+)\t(\d+)\t.*" line)]
-                             {:additions (parse-long adds)
-                              :deletions (parse-long dels)}))
-                         lines)]
-        {:additions (reduce + 0 (map :additions parsed))
-         :deletions (reduce + 0 (map :deletions parsed))
-         :files (count parsed)}))))
+      (numstat-totals (:output r "")))))
 
 (defn count-test-defs
   "Count deftest forms in staged changes via executor. Mirrors git/count-test-defs.
@@ -254,10 +265,29 @@
   [executor env-id]
   (let [r (exec! executor env-id "git diff --cached -U0")]
     (when (result/succeeded? r)
-      (let [diff-text (:output r "")
-            added   (count (re-seq #"(?m)^\+.*\(deftest " diff-text))
-            removed (count (re-seq #"(?m)^-.*\(deftest " diff-text))]
-        {:added added :removed removed}))))
+      (count-deftest (:output r "")))))
+
+(defn diff-stats-range
+  "Get diff stats for `origin/<base>..HEAD` (the carry-forward range
+   used by the release branch when phase-boundary commits already
+   contain the work). Mirrors `diff-stats` but reads the merge-base
+   range rather than the staged index."
+  [executor env-id base-branch]
+  (let [r (exec! executor env-id
+                 (str "git diff origin/" base-branch "..HEAD --numstat"))]
+    (when (result/succeeded? r)
+      (numstat-totals (:output r "")))))
+
+(defn count-test-defs-range
+  "Count deftest forms added/removed in `origin/<base>..HEAD`. Mirrors
+   `count-test-defs` but reads the merge-base range so the destructive-
+   diff gate keeps inspecting the actual commits being released, not
+   just the staged index (which is empty in the boundary-commits case)."
+  [executor env-id base-branch]
+  (let [r (exec! executor env-id
+                 (str "git diff origin/" base-branch "..HEAD -U0"))]
+    (when (result/succeeded? r)
+      (count-deftest (:output r "")))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; File batch operations (mirrors files.clj write-and-stage-files!)

--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -73,22 +73,35 @@
         (str/replace #"refs/remotes/origin/" ""))))
 
 (defn try-checkout-branch
-  "Try to checkout a branch, retrying with timestamp suffix if it already exists."
+  "Try to checkout a new branch off the current HEAD, retrying with a
+   timestamp suffix if the desired name already exists.
+
+   Branches off HEAD (not `origin/<base-branch>`) so the new branch
+   inherits whatever commits the task worktree already carries — e.g.
+   the per-phase boundary commits the workflow runtime makes after
+   plan/implement/verify/review. If we branched off `origin/<base>`
+   instead, those commits would be discarded and a downstream
+   `git add -A` would find nothing to stage. `:base-branch` is still
+   tracked for the PR-creation step, which uses it as the merge base."
   [executor env-id branch-name base-branch]
   (let [checkout-r (exec! executor env-id
-                          (str "git checkout -b " branch-name " origin/" base-branch))]
+                          (str "git checkout -b " branch-name))]
     (if (result/succeeded? checkout-r)
       (result/shell-success {:branch branch-name :base-branch base-branch})
       (let [ts-name (str branch-name "-" (System/currentTimeMillis))
             retry-r (exec! executor env-id
-                           (str "git checkout -b " ts-name " origin/" base-branch))]
+                           (str "git checkout -b " ts-name))]
         (if (result/succeeded? retry-r)
           (result/shell-success {:branch ts-name :base-branch base-branch})
           (result/shell-failure (str "Failed to create branch: " (:error retry-r))
                                {:branch nil}))))))
 
 (defn create-branch!
-  "Create a new git branch inside the sandbox container.
+  "Create a new git branch inside the sandbox container, off the current
+   HEAD (so phase-boundary commits already on the task branch carry
+   forward). Fetches `origin/<default-branch>` first so the PR-creation
+   step has a fresh merge base to compare against.
+
    Returns {:success? bool :branch string :base-branch string :error string}"
   [executor env-id branch-name]
   (let [default-branch (detect-default-branch executor env-id)
@@ -96,6 +109,22 @@
     (if-not (result/succeeded? fetch-r)
       (result/shell-failure (str "Failed to fetch: " (:error fetch-r)) {:branch nil})
       (try-checkout-branch executor env-id branch-name default-branch))))
+
+(defn commits-ahead-of-base
+  "Count commits on HEAD that aren't on `origin/<base-branch>`. Returns
+   nil on git failure (caller treats nil as 'unknown', not zero). Used
+   by step-stage-dirty-files to recognise that a clean worktree may
+   still carry unreleased work in the form of boundary commits — when
+   the implementer's writes were committed at the implement-phase
+   boundary, the release branch inherits them and there is nothing
+   left to stage."
+  [executor env-id base-branch]
+  (let [r (exec! executor env-id
+                 (str "git rev-list --count origin/" base-branch "..HEAD"))]
+    (when (result/succeeded? r)
+      (try
+        (Long/parseLong (str/trim (:output r "0")))
+        (catch NumberFormatException _ nil)))))
 
 (defn write-file!
   "Write content to a file inside the sandbox container.

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -156,13 +156,13 @@
       (is (= :no-files-to-stage (:type (first (:errors result))))))))
 
 (deftest release-succeeds-when-boundary-commits-already-on-branch-test
-  (testing "Run-7 dogfood regression: implementer writes were committed at the
-            implement-phase boundary, leaving the worktree clean by the time
-            release runs. step-create-branch now branches off HEAD (carrying
-            the boundary commits), step-stage-dirty-files accepts an empty
-            stage when the branch is already ahead of base, and step-commit
-            skips creating a new commit (the existing HEAD becomes the
-            release commit)."
+  (testing "Run-8 dogfood regression (2026-05-10): implementer writes were
+            committed at the implement-phase boundary, leaving the worktree
+            clean by the time release runs. step-create-branch now branches
+            off HEAD (carrying the boundary commits), step-stage-dirty-files
+            accepts an empty stage when the branch is already ahead of base,
+            and step-commit skips creating a new commit (the existing HEAD
+            becomes the release commit)."
     (let [[exec cmds] (create-mock-executor
                        :responses {"gh auth"          {:exit-code 0 :stdout "Logged in" :stderr ""}
                                    "git symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}
@@ -184,7 +184,41 @@
       (is (some #(clojure.string/includes? % "git rev-list --count origin/main..HEAD") @cmds)
           "release should consult `git rev-list --count origin/main..HEAD` to detect carry-forward commits")
       (is (not-any? #(clojure.string/starts-with? % "git commit") @cmds)
-          "step-commit must NOT issue a new commit when the boundary commits already exist on the branch"))))
+          "step-commit must NOT issue a new commit when the boundary commits already exist on the branch")
+      (is (some #(clojure.string/includes? % "git diff origin/main..HEAD --numstat") @cmds)
+          "step-validate-diff must inspect the range diff (origin/<base>..HEAD), not
+           the empty staged diff — boundary commits otherwise bypass the destructive-
+           diff gate entirely."))))
+
+(deftest release-rejects-destructive-boundary-commits-test
+  (testing "step-validate-diff still rejects a destructive release when the
+            destructive content lives in boundary commits rather than the
+            staged index. Covers the case where the implementer's commits
+            net-delete tests; without range-diff validation the destructive-
+            diff gate would no-op silently."
+    (let [destructive-numstat "0\t40\tcomponents/foo/test/foo_test.clj\n"
+          destructive-diff    "diff --git a/components/foo/test/foo_test.clj b/components/foo/test/foo_test.clj\n-(deftest a)\n-(deftest b)\n-(deftest c)\n"
+          [exec _] (create-mock-executor
+                    :responses {"gh auth"          {:exit-code 0 :stdout "Logged in" :stderr ""}
+                                "git symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}
+                                "git fetch"        {:exit-code 0 :stdout "" :stderr ""}
+                                "git checkout"     {:exit-code 0 :stdout "" :stderr ""}
+                                "git add"          {:exit-code 0 :stdout "" :stderr ""}
+                                "git diff --cached"  {:exit-code 0 :stdout "" :stderr ""}
+                                "git diff origin/main..HEAD --numstat" {:exit-code 0 :stdout destructive-numstat :stderr ""}
+                                "git diff origin/main..HEAD -U0"       {:exit-code 0 :stdout destructive-diff    :stderr ""}
+                                "git rev-list"     {:exit-code 0 :stdout "1\n" :stderr ""}
+                                "git rev-parse"    {:exit-code 0 :stdout "deadbeef\n" :stderr ""}})
+          result (core/execute-release-phase
+                  (make-workflow-state)
+                  {:executor exec
+                   :environment-id "mock-env"
+                   :worktree-path "/tmp/wt"
+                   :create-pr? false}
+                  {:release-meta test-release-meta})]
+      (is (not (:success? result))
+          "release must fail when range diff shows net-negative tests, even in boundary-commits mode")
+      (is (= :destructive-diff (:type (first (:errors result))))))))
 
 ;; ============================================================================
 ;; gh-exec-opts and governed-mode token injection

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -137,13 +137,14 @@
       (is (not (some #(clojure.string/includes? % "base64 -d") @cmds))))))
 
 (deftest release-fails-when-nothing-staged
-  (testing "release fails when git diff --cached shows nothing staged"
+  (testing "release fails when git diff --cached shows nothing staged AND no commits ahead of base"
     (let [[exec _] (create-mock-executor
                     :responses {"git symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}
                                 "git fetch"        {:exit-code 0 :stdout "" :stderr ""}
                                 "git checkout"     {:exit-code 0 :stdout "" :stderr ""}
                                 "git add"          {:exit-code 0 :stdout "" :stderr ""}
-                                "git diff"         {:exit-code 0 :stdout "" :stderr ""}}) ;; empty — nothing staged
+                                "git diff"         {:exit-code 0 :stdout "" :stderr ""} ;; empty — nothing staged
+                                "git rev-list"     {:exit-code 0 :stdout "0\n" :stderr ""}}) ;; no commits ahead
           result (core/execute-release-phase
                   (make-workflow-state)
                   {:executor exec
@@ -153,6 +154,37 @@
                   {:release-meta test-release-meta})]
       (is (not (:success? result)))
       (is (= :no-files-to-stage (:type (first (:errors result))))))))
+
+(deftest release-succeeds-when-boundary-commits-already-on-branch-test
+  (testing "Run-7 dogfood regression: implementer writes were committed at the
+            implement-phase boundary, leaving the worktree clean by the time
+            release runs. step-create-branch now branches off HEAD (carrying
+            the boundary commits), step-stage-dirty-files accepts an empty
+            stage when the branch is already ahead of base, and step-commit
+            skips creating a new commit (the existing HEAD becomes the
+            release commit)."
+    (let [[exec cmds] (create-mock-executor
+                       :responses {"gh auth"          {:exit-code 0 :stdout "Logged in" :stderr ""}
+                                   "git symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}
+                                   "git fetch"        {:exit-code 0 :stdout "" :stderr ""}
+                                   "git checkout"     {:exit-code 0 :stdout "" :stderr ""}
+                                   "git add"          {:exit-code 0 :stdout "" :stderr ""}
+                                   "git diff"         {:exit-code 0 :stdout "" :stderr ""} ;; nothing dirty
+                                   "git rev-list"     {:exit-code 0 :stdout "4\n" :stderr ""} ;; 4 boundary commits ahead
+                                   "git rev-parse"    {:exit-code 0 :stdout "deadbeef\n" :stderr ""}})
+          result (core/execute-release-phase
+                  (make-workflow-state)
+                  {:executor exec
+                   :environment-id "mock-env"
+                   :worktree-path "/tmp/wt"
+                   :create-pr? false}
+                  {:release-meta test-release-meta})]
+      (is (:success? result)
+          "release must succeed when boundary commits already carry the work")
+      (is (some #(clojure.string/includes? % "git rev-list --count origin/main..HEAD") @cmds)
+          "release should consult `git rev-list --count origin/main..HEAD` to detect carry-forward commits")
+      (is (not-any? #(clojure.string/starts-with? % "git commit") @cmds)
+          "step-commit must NOT issue a new commit when the boundary commits already exist on the branch"))))
 
 ;; ============================================================================
 ;; gh-exec-opts and governed-mode token injection

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -124,6 +124,37 @@
       (is (not (:success? result)))
       (is (clojure.string/includes? (:error result) "fetch")))))
 
+(deftest create-branch-uses-head-not-origin-base-test
+  (testing "create-branch! checks out off HEAD so phase-boundary commits
+            already on the task branch carry forward into the release branch"
+    (let [[exec cmds] (create-mock-executor
+                       :responses {"git symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}
+                                   "git fetch" {:exit-code 0 :stdout "" :stderr ""}
+                                   "git checkout" {:exit-code 0 :stdout "" :stderr ""}})
+          result (sandbox/create-branch! exec "env-1" "release/x")]
+      (is (:success? result))
+      (is (= "main" (:base-branch result)))
+      (let [checkout (some #(when (clojure.string/includes? % "git checkout -b release/x") %) @cmds)]
+        (is (some? checkout)
+            "checkout command must be issued for the new branch")
+        (is (not (clojure.string/includes? checkout "origin/main"))
+            "checkout must not reset to origin/<base>; HEAD is the source of truth
+             so prior phase-boundary commits stay on the new branch")))))
+
+(deftest commits-ahead-of-base-parses-count-test
+  (testing "commits-ahead-of-base returns the parsed integer count"
+    (let [[exec _] (create-mock-executor
+                    :responses {"git rev-list" {:exit-code 0 :stdout "3\n" :stderr ""}})]
+      (is (= 3 (sandbox/commits-ahead-of-base exec "env-1" "main")))))
+  (testing "commits-ahead-of-base returns nil on git failure"
+    (let [[exec _] (create-mock-executor
+                    :responses {"git rev-list" {:exit-code 128 :stdout "" :stderr "fatal"}})]
+      (is (nil? (sandbox/commits-ahead-of-base exec "env-1" "main")))))
+  (testing "commits-ahead-of-base returns nil on unparseable output (treat as unknown, not zero)"
+    (let [[exec _] (create-mock-executor
+                    :responses {"git rev-list" {:exit-code 0 :stdout "" :stderr ""}})]
+      (is (nil? (sandbox/commits-ahead-of-base exec "env-1" "main"))))))
+
 ;; ============================================================================
 ;; write-file! tests
 ;; ============================================================================


### PR DESCRIPTION
## Summary
Three coordinated changes so release-executor stops fighting the worktree-as-artifact handoff model:

1. `sandbox/try-checkout-branch` branches off HEAD (not `origin/<base>`), so phase-boundary commits already on the task branch carry forward.
2. New `sandbox/commits-ahead-of-base` helper parses `git rev-list --count origin/<base>..HEAD`.
3. `step-stage-dirty-files` accepts an empty stage when the branch is ahead of base; `step-commit` skips creating a new commit (existing HEAD becomes the release commit).

## Why
Stage 3 dogfood Run 8 (workflow `103327aa`, 2026-05-10): plan ✓ → implement ✓ → verify ✓ → review ✓ → release ✗ with `release-executor/no-files-to-stage`. The work was real — 4 phase-boundary commits sat on the task branch — but `step-create-branch` did `git checkout -b release/x origin/main`, hard-resetting the worktree onto a fresh branch off origin/main and discarding the implementer's commits. `step-stage-dirty-files` then found nothing dirty and terminated.

## Tests
- `create-branch-uses-head-not-origin-base-test` — checkout must not include `origin/<base>`.
- `commits-ahead-of-base-parses-count-test` — count parsing + failure modes (nil on flaky git, not 0).
- `release-succeeds-when-boundary-commits-already-on-branch-test` — Run-8 end-to-end: empty dirty + 4 commits ahead → success, no `git commit` issued.
- Existing `release-fails-when-nothing-staged` updated to also assert zero commits ahead so the genuine empty-release case still terminates.

## Test plan
- [ ] CI green
- [ ] Re-dogfood Stage 3 — release should walk through to PR creation