### PR TITLE
fix(dag): roll cost-usd + failed-task metrics into DAG aggregate

### DIFF
--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -284,7 +284,14 @@
                                :duration-ms duration}}))
           (-> loop-state
               (set-artifact artifact)
+              ;; :cost-usd carries through the same way :tokens does
+              ;; — generate-fn is expected to return it at top level
+              ;; (default 0.0 when absent) so add-metric-values'
+              ;; merge-with + can sum across iterations. Without this
+              ;; the :loop/metrics map keeps :cost-usd at its initial
+              ;; 0.0 and the workflow runner banner reports $0.0000.
               (update-metrics {:tokens (:tokens result 0)
+                               :cost-usd (:cost-usd result 0.0)
                                :duration-ms duration
                                :generate-calls 1})
               (transition :validating)))
@@ -384,7 +391,12 @@
                      result)
             loop-state (-> loop-state
                            (add-repair-attempt attempt)
+                           ;; Same :cost-usd forwarding as the
+                           ;; generate-step. Repair calls were
+                           ;; previously dropping cost on every
+                           ;; iteration.
                            (update-metrics {:tokens (:tokens-used result 0)
+                                            :cost-usd (:cost-usd result 0.0)
                                             :repair-calls 1}))]
         (cond
           ;; Repair succeeded

--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -175,6 +175,20 @@
   [loop-state metric-updates]
   (update loop-state :loop/metrics add-metric-values metric-updates))
 
+(defn- sum-repair-result-metrics
+  "repair/attempt-repair returns top-level shapes that hold per-attempt
+   results in `:results`. The metrics fields (`:tokens-used`,
+   `:cost-usd`) are on those entries, not on the outer map. Sum
+   them so the loop's :cost-usd / :tokens accumulators see what
+   each repair iteration actually cost.
+
+   Returns a `{:tokens N :cost-usd N}` map ready to thread into
+   `update-metrics`. Empty / missing :results yields zeros."
+  [repair-result]
+  (let [results (:results repair-result [])]
+    {:tokens   (->> results (map #(or (:tokens-used %) 0))  (reduce + 0))
+     :cost-usd (->> results (map #(or (:cost-usd %) 0.0))   (reduce + 0.0))}))
+
 (defn add-gate-results
   "Add gate results to loop state."
   [loop-state results]
@@ -389,15 +403,19 @@
                      iteration
                      errors
                      result)
+            ;; repair/attempt-repair returns aggregate shapes
+            ;; (make-success-result / make-max-attempts-result /
+            ;; make-exhausted-strategies-result / make-escalation-
+            ;; result) that put per-attempt metrics under :results,
+            ;; not at the top level. Reading (:tokens-used result)
+            ;; would always default to zero and starve the loop's
+            ;; :cost-usd / :tokens accumulation. Sum the per-attempt
+            ;; entries before threading them into update-metrics.
+            repair-totals (sum-repair-result-metrics result)
             loop-state (-> loop-state
                            (add-repair-attempt attempt)
-                           ;; Same :cost-usd forwarding as the
-                           ;; generate-step. Repair calls were
-                           ;; previously dropping cost on every
-                           ;; iteration.
-                           (update-metrics {:tokens (:tokens-used result 0)
-                                            :cost-usd (:cost-usd result 0.0)
-                                            :repair-calls 1}))]
+                           (update-metrics
+                            (assoc repair-totals :repair-calls 1)))]
         (cond
           ;; Repair succeeded
           (repair/succeeded? result)

--- a/components/loop/test/ai/miniforge/loop/inner_test.clj
+++ b/components/loop/test/ai/miniforge/loop/inner_test.clj
@@ -326,6 +326,50 @@
       (is (:success result))
       (is (= 1 (:iterations result))))))
 
+;------------------------------------------------------------------------------ sum-repair-result-metrics — pin per-attempt aggregation
+
+(def ^:private sum-repair-result-metrics
+  (var-get #'inner/sum-repair-result-metrics))
+
+;; Cost epsilon for IEEE-double tolerance — 0.005 + 0.012 ≈ 0.017
+;; round-trips through doubles without exact equality.
+(def ^:private cost-usd-epsilon 1.0e-6)
+
+(def ^:private repair-result-fixture
+  "Shape that matches what repair/attempt-repair returns:
+   per-attempt entries live under :results, NOT at the top level.
+   Aggregation has to traverse :results to see real token / cost
+   counts."
+  {:success? false
+   :attempts 2
+   :results  [{:strategy :llm-fix :tokens-used 500  :cost-usd 0.005}
+              {:strategy :retry   :tokens-used 0    :cost-usd 0.0}
+              {:strategy :llm-fix :tokens-used 1200 :cost-usd 0.012}]
+   :errors   [{:code :test}]})
+
+(deftest sum-repair-result-metrics-aggregates-from-results-vector-test
+  (testing "Per-attempt metrics in :results sum into the returned
+            map. Pin the contract: callers can thread the result
+            into update-metrics and have it flow into :loop/metrics
+            instead of always reading zeros from the top-level keys
+            (which repair/attempt-repair never sets)."
+    (let [{:keys [tokens cost-usd]}
+          (sum-repair-result-metrics repair-result-fixture)]
+      (is (= 1700 tokens)
+          "tokens summed across all repair attempts")
+      (is (< (Math/abs (- 0.017 cost-usd)) cost-usd-epsilon)
+          "cost-usd summed within IEEE rounding tolerance"))))
+
+(deftest sum-repair-result-metrics-handles-empty-or-missing-results-test
+  (testing "Empty / missing :results returns zero metrics rather
+            than nil — keeps downstream merge-with + safe."
+    (let [no-results {:success? false :attempts 0}]
+      (is (= {:tokens 0 :cost-usd 0.0}
+             (sum-repair-result-metrics no-results))))
+    (let [empty-results {:success? false :attempts 0 :results []}]
+      (is (= {:tokens 0 :cost-usd 0.0}
+             (sum-repair-result-metrics empty-results))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.loop.inner-test)

--- a/components/workflow/src/ai/miniforge/workflow/configurable.clj
+++ b/components/workflow/src/ai/miniforge/workflow/configurable.clj
@@ -36,10 +36,10 @@
 ;; Constants and result helpers
 
 (def zero-metrics
-  "Canonical zeroed metrics for configurable workflow results."
-  {:tokens 0
-   :cost-usd 0.0
-   :duration-ms 0})
+  "Canonical zeroed metrics for configurable workflow results.
+   Aliases dag-orchestrator's zero-metrics so both layers can't
+   drift on what an empty metrics map looks like."
+  dag-orch/zero-metrics)
 
 (defn- phase-error
   [error-type message & [extra]]

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -1347,15 +1347,31 @@
         err-results (->> results (filter #(not (dag/ok? (second %)))) (map first))]
     {:completed ok-results :failed err-results}))
 
+(defn- result-metrics
+  "Extract per-task `:metrics` from a dag/ok OR dag/err result.
+   `dag/ok` puts the data payload under `:data`; `dag/err` puts the
+   caller-supplied data under `:error :data`. The previous rollup
+   only inspected `:data`, which silently dropped every failed
+   task's tokens / cost / duration at the aggregate. With 8 failed
+   tasks in a dogfood run that's a 100% loss of cost telemetry."
+  [result]
+  (if (dag/ok? result)
+    (get-in result [:data :metrics])
+    (get-in result [:error :data :metrics])))
+
 (defn aggregate-results [all-results]
   (let [results (vals all-results)
         artifacts (->> results (mapcat #(get-in % [:data :artifacts] [])))
         pr-infos (->> results (keep #(get-in % [:data :pr-info])) vec)
         worktree-paths (->> results (keep #(get-in % [:data :worktree-path])) vec)
-        total-tokens (->> results (map #(get-in % [:data :metrics :tokens] 0)) (reduce + 0))
-        total-cost (->> results (map #(get-in % [:data :metrics :cost-usd] 0.0)) (reduce + 0.0))
-        total-duration (->> results (map #(get-in % [:data :metrics :duration-ms] 0)) (reduce + 0))]
-    (cond-> {:artifacts artifacts :total-tokens total-tokens :total-cost total-cost :total-duration total-duration}
+        metrics (map result-metrics results)
+        total-tokens   (->> metrics (map #(get % :tokens 0))      (reduce + 0))
+        total-cost     (->> metrics (map #(get % :cost-usd 0.0))  (reduce + 0.0))
+        total-duration (->> metrics (map #(get % :duration-ms 0)) (reduce + 0))]
+    (cond-> {:artifacts artifacts
+             :total-tokens total-tokens
+             :total-cost total-cost
+             :total-duration total-duration}
       (seq pr-infos) (assoc :pr-infos pr-infos)
       (seq worktree-paths) (assoc :worktree-paths worktree-paths))))
 

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -50,15 +50,22 @@
 
 ;--- Layer 0: Result Constructors
 
+(def zero-metrics
+  "Canonical zeroed metrics for DAG / inner-workflow results. Used as
+   the default when no per-task metrics flow through. Single source
+   of truth — configurable.clj aliases this so the workflow stack
+   doesn't drift on what an empty metrics map looks like."
+  {:tokens 0 :cost-usd 0.0 :duration-ms 0})
+
 (defn workflow-success [artifact metrics]
   {:success? true
    :artifact artifact
-   :metrics (or metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0})})
+   :metrics (or metrics zero-metrics)})
 
 (defn workflow-failure [error metrics]
   {:success? false
    :error error
-   :metrics (or metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0})})
+   :metrics (or metrics zero-metrics)})
 
 (defn dag-execution-result [completed failed artifacts metrics-agg & {:keys [unreached] :or {unreached 0}}]
   {:success? (and (zero? failed) (zero? unreached))
@@ -1252,7 +1259,7 @@
            :description description
            :status :implemented
            :artifacts []
-           :metrics {:tokens 0 :cost-usd 0.0}}))
+           :metrics zero-metrics}))
 
 (defn execute-single-task [task-def context]
   (let [task-id (:task/id task-def)

--- a/components/workflow/src/ai/miniforge/workflow/dag_task_runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_task_runner.clj
@@ -56,15 +56,24 @@
 (defn- create-generate-fn [impl-agent context]
   (fn [t _ctx]
     (let [result (agent/invoke impl-agent t context)]
+      ;; Forward the full metrics triple from the agent's response so
+      ;; the inner loop can roll cost + tokens up into :loop/metrics.
+      ;; Previously only :tokens was carried, leaving :cost-usd dropped
+      ;; on every DAG task and surfacing as $0.0000 in the runner
+      ;; banner despite real backend costs.
       {:artifact (:artifact result)
-       :tokens (or (get-in result [:metrics :tokens]) 0)})))
+       :tokens   (or (get-in result [:metrics :tokens]) 0)
+       :cost-usd (or (get-in result [:metrics :cost-usd]) 0.0)})))
 
 (defn- create-repair-fn [impl-agent context]
   (fn [old-artifact errors _ctx]
     (let [result (agent/repair impl-agent old-artifact errors context)]
-      {:success? (:success result)
-       :artifact (:repaired result old-artifact)
-       :tokens-used (or (get-in result [:metrics :tokens]) 0)})))
+      ;; Same metrics-forwarding fix — repair iterations were also
+      ;; dropping :cost-usd on every call.
+      {:success?    (:success result)
+       :artifact    (:repaired result old-artifact)
+       :tokens-used (or (get-in result [:metrics :tokens]) 0)
+       :cost-usd    (or (get-in result [:metrics :cost-usd]) 0.0)})))
 
 (defn- run-mini-workflow [task-def context]
   (let [impl-agent (agent/create-implementer {:llm-backend (:llm-backend context)})

--- a/components/workflow/src/ai/miniforge/workflow/dag_task_runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_task_runner.clj
@@ -27,19 +27,30 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.loop.interface :as loop]
-   [ai.miniforge.task.interface :as task]))
+   [ai.miniforge.task.interface :as task]
+   [ai.miniforge.workflow.dag-orchestrator :as dag-orch]))
+
+;--- Constants
+
+(def ^:private mini-workflow-max-iterations
+  "Inner generate/repair loop iteration cap for a single DAG task.
+   Three is the historical setting carried over from the inline call
+   site; lifted here so it can be tuned without hunting through the
+   run-mini-workflow body. Distinct from the parent workflow's
+   :max-iterations on the outer SDLC loop."
+  3)
 
 ;--- Result Constructors (private, used only within mini-workflow)
 
 (defn- workflow-success [artifact metrics]
   {:success? true
    :artifact artifact
-   :metrics (or metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0})})
+   :metrics (or metrics dag-orch/zero-metrics)})
 
 (defn- workflow-failure [error metrics]
   {:success? false
    :error error
-   :metrics (or metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0})})
+   :metrics (or metrics dag-orch/zero-metrics)})
 
 ;--- Mini-Workflow Execution
 
@@ -56,11 +67,12 @@
 (defn- create-generate-fn [impl-agent context]
   (fn [t _ctx]
     (let [result (agent/invoke impl-agent t context)]
-      ;; Forward the full metrics triple from the agent's response so
-      ;; the inner loop can roll cost + tokens up into :loop/metrics.
-      ;; Previously only :tokens was carried, leaving :cost-usd dropped
-      ;; on every DAG task and surfacing as $0.0000 in the runner
-      ;; banner despite real backend costs.
+      ;; Forward :tokens and :cost-usd from the agent response. The
+      ;; inner loop measures :duration-ms locally from a wall-clock
+      ;; delta, so we don't (and don't need to) forward duration here.
+      ;; Previously only :tokens was carried, leaving :cost-usd
+      ;; dropped on every DAG task and surfacing as $0.0000 in the
+      ;; runner banner despite real backend costs.
       {:artifact (:artifact result)
        :tokens   (or (get-in result [:metrics :tokens]) 0)
        :cost-usd (or (get-in result [:metrics :cost-usd]) 0.0)})))
@@ -68,8 +80,9 @@
 (defn- create-repair-fn [impl-agent context]
   (fn [old-artifact errors _ctx]
     (let [result (agent/repair impl-agent old-artifact errors context)]
-      ;; Same metrics-forwarding fix — repair iterations were also
-      ;; dropping :cost-usd on every call.
+      ;; Same :tokens + :cost-usd forwarding as the generate-fn
+      ;; (duration is measured loop-side). Repair iterations were
+      ;; previously dropping :cost-usd on every call.
       {:success?    (:success result)
        :artifact    (:repaired result old-artifact)
        :tokens-used (or (get-in result [:metrics :tokens]) 0)
@@ -80,7 +93,7 @@
         inner-task (create-inner-task task-def)
         generate-fn (create-generate-fn impl-agent context)
         loop-context (assoc context
-                            :max-iterations 3
+                            :max-iterations mini-workflow-max-iterations
                             :repair-fn (create-repair-fn impl-agent context))
         loop-result (loop/run-simple inner-task generate-fn loop-context)]
     (if (:success loop-result)
@@ -106,7 +119,7 @@
            :description description
            :status :implemented
            :artifacts []
-           :metrics {:tokens 0 :cost-usd 0.0}}))
+           :metrics dag-orch/zero-metrics}))
 
 (defn execute-single-task
   "Run a single DAG task. When an :llm-backend is present in context,

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -311,6 +311,45 @@
           "the multi-parent detection is logged for plan-quality observability —
            dashboard surfaces fan-in even though it doesn't reject"))))
 
+;------------------------------------------------------------------------------ aggregate-results — metrics rollup across ok + err
+
+(deftest aggregate-results-sums-metrics-from-ok-and-err-test
+  (testing "Both dag/ok and dag/err results contribute to the
+            aggregate :total-tokens / :total-cost / :total-duration.
+            Pre-fix the rollup only inspected `[:data :metrics ...]`
+            which silently dropped every failed task — for a dogfood
+            run with all tasks failing, total-tokens reported zero
+            despite a per-task implementer carrying real token counts.
+            With the fix, dag/err's `[:error :data :metrics ...]`
+            shape is also picked up so failed tasks contribute to the
+            rollup the same way completed ones do."
+    (let [ok-result  (dag/ok  {:metrics {:tokens 1000 :cost-usd 0.01 :duration-ms 5000}})
+          err-result (dag/err :task-execution-failed
+                              "boom"
+                              {:metrics {:tokens 2500 :cost-usd 0.03 :duration-ms 12000}})
+          mixed      {:t-ok ok-result :t-err err-result}
+          agg        (dag-orch/aggregate-results mixed)]
+      (is (= 3500 (:total-tokens agg))
+          "ok + err token contributions both flow into the rollup")
+      (is (= 0.04 (:total-cost agg))
+          ":cost-usd from both results sums correctly via the
+           ok/err-aware accessor")
+      (is (= 17000 (:total-duration agg))
+          ":duration-ms also rolls up from both shapes"))))
+
+(deftest aggregate-results-handles-missing-metrics-gracefully-test
+  (testing "Tasks with no :metrics key on either ok or err shape
+            contribute zero rather than throwing or producing nil
+            sums. Older callers that build dag/ok without :metrics
+            (placeholder paths) must keep working."
+    (let [no-metrics-ok  (dag/ok  {:status :implemented :artifacts []})
+          no-metrics-err (dag/err :task-execution-failed "boom" {})
+          mixed          {:t1 no-metrics-ok :t2 no-metrics-err}
+          agg            (dag-orch/aggregate-results mixed)]
+      (is (= 0 (:total-tokens agg)))
+      (is (= 0.0 (:total-cost agg)))
+      (is (= 0 (:total-duration agg))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (clojure.test/run-tests 'ai.miniforge.workflow.dag-orchestrator-test)

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -313,6 +313,25 @@
 
 ;------------------------------------------------------------------------------ aggregate-results — metrics rollup across ok + err
 
+;; Cost-USD assertions tolerate IEEE-754 rounding because :cost-usd is
+;; a double in this layer. 0.01 + 0.03 in IEEE doubles ≈
+;; 0.039999999999999994 — direct = comparison flakes per host. A
+;; sub-cent epsilon is well below any rollup precision a caller
+;; relies on.
+(def ^:private cost-usd-epsilon 1.0e-6)
+
+(defn- approx=
+  [expected actual]
+  (< (Math/abs (double (- expected actual))) cost-usd-epsilon))
+
+;; Test fixtures lifted into named data so the assertion shape and
+;; the input shape can be read together. Lets each row's metrics
+;; carry semantic meaning beyond raw integers in deftest body.
+(def ^:private aggregate-rollup-fixture
+  {:ok    {:tokens 1000 :cost-usd 0.01 :duration-ms 5000}
+   :err   {:tokens 2500 :cost-usd 0.03 :duration-ms 12000}
+   :sum   {:tokens 3500 :cost-usd 0.04 :duration-ms 17000}})
+
 (deftest aggregate-results-sums-metrics-from-ok-and-err-test
   (testing "Both dag/ok and dag/err results contribute to the
             aggregate :total-tokens / :total-cost / :total-duration.
@@ -323,18 +342,18 @@
             With the fix, dag/err's `[:error :data :metrics ...]`
             shape is also picked up so failed tasks contribute to the
             rollup the same way completed ones do."
-    (let [ok-result  (dag/ok  {:metrics {:tokens 1000 :cost-usd 0.01 :duration-ms 5000}})
-          err-result (dag/err :task-execution-failed
-                              "boom"
-                              {:metrics {:tokens 2500 :cost-usd 0.03 :duration-ms 12000}})
+    (let [{:keys [ok err sum]} aggregate-rollup-fixture
+          ok-result  (dag/ok  {:metrics ok})
+          err-result (dag/err :task-execution-failed "boom"
+                              {:metrics err})
           mixed      {:t-ok ok-result :t-err err-result}
           agg        (dag-orch/aggregate-results mixed)]
-      (is (= 3500 (:total-tokens agg))
+      (is (= (:tokens sum) (:total-tokens agg))
           "ok + err token contributions both flow into the rollup")
-      (is (= 0.04 (:total-cost agg))
-          ":cost-usd from both results sums correctly via the
-           ok/err-aware accessor")
-      (is (= 17000 (:total-duration agg))
+      (is (approx= (:cost-usd sum) (:total-cost agg))
+          ":cost-usd from both results sums correctly via the ok/err-
+           aware accessor (within IEEE-double rounding)")
+      (is (= (:duration-ms sum) (:total-duration agg))
           ":duration-ms also rolls up from both shapes"))))
 
 (deftest aggregate-results-handles-missing-metrics-gracefully-test

--- a/projects/miniforge/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -189,7 +189,13 @@
 ;; execute-single-task tests
 
 (deftest test-execute-single-task-placeholder
-  (testing "returns placeholder result without LLM backend"
+  (testing "returns placeholder result without LLM backend.
+            Placeholder :metrics now uses dag-orchestrator/zero-metrics
+            (`{:tokens 0 :cost-usd 0.0 :duration-ms 0}`) so the shape
+            matches every other zero-metrics emission in the workflow
+            stack — the previous {:tokens 0 :cost-usd 0.0} omission
+            of :duration-ms was the inconsistency that motivated
+            consolidating to a single canonical constant."
     (let [task-def {:task/id :test-task
                     :task/description "Test task"}
           result (task-runner/execute-single-task task-def {})]
@@ -199,7 +205,9 @@
         (is (= "Test task" (:description data)))
         (is (= :implemented (:status data)))
         (is (= [] (:artifacts data)))
-        (is (= {:tokens 0 :cost-usd 0.0} (:metrics data)))))))
+        (is (= {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+               (:metrics data))
+            "placeholder metrics shape matches dag-orchestrator/zero-metrics")))))
 
 (deftest test-execute-single-task-default-description
   (testing "uses default description when missing"


### PR DESCRIPTION
## Summary

Surfaced by the 2026-05-10 dogfood: a workflow consumed 25k+ tokens and reported \`Cost: \$0.0000\`; the \`:dag-result :metrics\` came back \`{:tokens 0 :cost-usd 0.0 :duration-ms 0}\` despite 8 sub-tasks each carrying real per-task metrics. **Two independent propagation gaps stacked into one symptom.**

- **Gap 1 (the dominant one) — ok/err shape mismatch in \`aggregate-results\`.** \`(get-in % [:data :metrics ...])\` works for \`dag/ok\` but \`dag/err\` puts the caller-supplied data under \`[:error :data ...]\`. With every dogfood task failing, 100% of per-task metrics dropped at the rollup. Added a private \`result-metrics\` accessor that handles both shapes; the aggregator now sums tokens / cost / duration uniformly across ok and err.
- **Gap 2 — \`:cost-usd\` dropped through the inner-loop shim.** \`dag-task-runner/create-generate-fn\` and \`create-repair-fn\` forwarded \`:tokens\` only, throwing away cost. The inner loop's \`update-metrics\` calls likewise threaded only :tokens + locally-computed :duration-ms. Both shims now forward :cost-usd; loop update-metrics calls (generate + repair) thread it through \`add-metric-values\`'s merge-with + so the value accumulates across iterations.

## Test plan

- [x] \`aggregate-results-sums-metrics-from-ok-and-err-test\` — one dag/ok (1000 tok, \$0.01) + one dag/err (2500 tok, \$0.03) ⇒ asserts rollup of (3500, 0.04, 17000). Pre-fix the err side contributed zero.
- [x] \`aggregate-results-handles-missing-metrics-gracefully-test\` — placeholder path with no \`:metrics\` keys returns zero rather than NPE.
- [x] Existing dag-orchestrator + dag-resilience-execution + loop inner + loop metrics-accumulation suites stay green.
- [x] Suite: 41 tests / 133 assertions across the affected namespaces; 0 failures / 0 errors. Full pre-commit suite green.

## What this doesn't fix

- **Cost calculation itself for the claude backend** when its CLI doesn't surface \`:total_cost_usd\`. Separate fix in the LLM client layer; this PR only ensures cost flows when upstream provides it.
- **Workflow-runner banner duration accounting** also wrong in the dogfood run (banner reported 9.7m vs ~50m wall). Different code path; separate fix.

Refs: \`~/.claude/projects/.../memory/project_dogfood_findings_2026_05_10.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)