### PR TITLE
feat(n13): listener registry implementation

### DIFF
--- a/components/pr-lifecycle/resources/config/listener-registry/defaults.edn
+++ b/components/pr-lifecycle/resources/config/listener-registry/defaults.edn
@@ -1,0 +1,33 @@
+;; Listener Registry — per-component configuration defaults.
+;;
+;; Loaded once at namespace load via `clojure.edn/read-string` and
+;; folded into the public `def`s exposed from
+;; `ai.miniforge.pr-lifecycle.listener-registry`. Keep code-side
+;; constants out of the source — operators changing tunables
+;; shouldn't need to recompile.
+;;
+;; Per N13 §2.7 + specs/informative/n13-listener-registry.md.
+
+{;; Spec / artifact format version. Tracks the spec document
+ ;; version on the same cadence — bumping the spec bumps this.
+ :registry/version           "0.1.0"
+
+ ;; On-disk artifact path, relative to the worktree root.
+ :default-storage-path       ".miniforge/listener-registry.edn"
+
+ ;; Default `:ttl-seconds` per spec §Lifecycle. 7 days.
+ :default-ttl-seconds        604800
+
+ ;; Enumerated `:runtime` values per spec schema.
+ :valid-runtimes             #{:claude-cli :codex :miniforge :webhook}
+
+ ;; Enumerated `:resume-channel/kind` values per spec §Dispatch.
+ :valid-channel-kinds        #{:pty :miniforge-ipc :webhook}
+
+ ;; Enumerated `:status` values per spec §Lifecycle states.
+ :valid-statuses             #{:active :dispatched :expired :cancelled}
+
+ ;; The three canonical registration moments per spec
+ ;; §Registration moments. Registration with any other
+ ;; `:registered-by` MUST be rejected.
+ :valid-registered-by        #{:authoring-agent :operator :workflow}}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -40,6 +40,7 @@
    [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]
    [ai.miniforge.pr-lifecycle.github :as github]
+   [ai.miniforge.pr-lifecycle.listener-registry :as listener-registry]
    [ai.miniforge.pr-lifecycle.review-scheduler :as review-scheduler]
    [ai.miniforge.pr-lifecycle.triage :as triage]
    [ai.miniforge.pr-lifecycle.merge :as merge]
@@ -393,6 +394,71 @@
 (def fetch-pr-head!
   "Fetch the PR head into `refs/miniforge-review/pr-<n>`. DAG result."
   review-scheduler/fetch-pr-head!)
+
+;------------------------------------------------------------------------------ Layer 2.7
+;; Listener registry (N13 §2.7)
+
+(def listener-registry-default-storage-path
+  "Default on-disk path for the listener registry artifact, relative
+   to the worktree root."
+  listener-registry/default-storage-path)
+
+(def listener-registry-default-ttl-seconds
+  "Default `:ttl-seconds` per spec §Lifecycle (7 days)."
+  listener-registry/default-ttl-seconds)
+
+(def register-listener!
+  "Persist a new listener entry per N13 §2.7. Required `params` keys:
+   `:pr/url :pr/repo-id :pr/number :agent/id :runtime :resume-channel
+   :registered-by`. Returns DAG result `(dag/ok {:listener-id <uuid>
+   :path <storage-path>})` on success.
+
+   Registration is rejected when `:registered-by` isn't one of the
+   three canonical moments (`:authoring-agent` / `:operator` /
+   `:workflow`) per spec §Registration moments."
+  listener-registry/register!)
+
+(def unregister-listener!
+  "Transition `listener-id` (under `pr-url`) to `:cancelled`. Returns
+   `(dag/err :listener-registry/listener-not-found ...)` if no such
+   entry exists."
+  listener-registry/unregister!)
+
+(def mark-listener-dispatched!
+  "Transition `listener-id` to `:dispatched`, recording
+   `:resume/dispatched-at` and `:resume/dispatch-id`. Called by the
+   Resume Signal Dispatcher (separate component) on a successful
+   primer delivery."
+  listener-registry/mark-dispatched!)
+
+(def cancel-listeners-on-pr-close!
+  "Transition every `:active` listener for `pr-url` to `:cancelled`.
+   Called when `pull_request.closed` arrives with `merged: false`."
+  listener-registry/mark-cancelled-on-pr-close!)
+
+(def sweep-expired-listeners!
+  "Transition every `:active` entry whose TTL has elapsed to
+   `:expired`. Idempotent."
+  listener-registry/sweep-expired!)
+
+(def read-listener-registry
+  "Load the registry from `worktree-path`'s `.miniforge/listener-registry.edn`.
+   Returns `(dag/ok <registry>)` (empty registry on missing file) or
+   typed error on parse failure."
+  listener-registry/read-registry)
+
+(def listeners-for-pr
+  "Pure: return all entries (any status) for `pr-url`."
+  listener-registry/entries-for-pr)
+
+(def active-listeners-for-pr
+  "Pure: return entries with `:status :active` for `pr-url`."
+  listener-registry/active-entries-for-pr)
+
+(def listeners-for-agent
+  "Pure: return all entries (any status) bound to `agent-id` across
+   all PRs."
+  listener-registry/entries-for-agent)
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Fix loop

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/listener_registry.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/listener_registry.clj
@@ -197,25 +197,41 @@
   [worktree-path]
   (str (fs/path (str worktree-path) default-storage-path)))
 
-(defn- registry-shape?
-  "Cheap structural check: registry MUST be a map with the three
-   required top-level keys. Catches the common corruption mode where
-   `edn/read-string` reads only the first form and silently ignores
-   trailing garbage (e.g. `\"foo bar\"` parses to the symbol `foo` and
-   never throws)."
-  [v]
-  (and (map? v)
-       (contains? v :registry/version)
-       (contains? v :registry/last-updated)
-       (contains? v :registry/listeners)
-       (map? (:registry/listeners v))))
+(defn- read-single-edn-form
+  "Read exactly one EDN form from `raw`, asserting EOF after.
+   Returns the parsed value or throws ex-info on:
+   - parse failure inside `edn/read` (re-thrown)
+   - trailing forms (a valid first form followed by anything but
+     whitespace / EOF)
+
+   Using PushbackReader + double-read with `:eof` sentinel is the
+   only way to detect trailing garbage without parsing the whole
+   string first. `edn/read-string` reads the first form and silently
+   discards the rest, so a corrupted file like `\"{:a 1} extra junk\"`
+   would otherwise round-trip as `{:a 1}`."
+  [raw]
+  (let [eof-sentinel ::eof
+        rdr (java.io.PushbackReader. (java.io.StringReader. ^String raw))
+        first-form (edn/read {:eof eof-sentinel} rdr)
+        next-form  (edn/read {:eof eof-sentinel} rdr)]
+    (when-not (identical? eof-sentinel next-form)
+      (throw (ex-info "trailing forms after first registry value"
+                      {:trailing next-form})))
+    first-form))
 
 (defn read-registry
   "Read the registry from `worktree-path`'s `.miniforge/listener-registry.edn`.
-   Returns the registry map on success; `empty-registry` on missing
-   file. Returns `(dag/err :listener-registry/read-failed ...)` on
-   parse failure or when the parsed value doesn't match the registry
-   shape."
+   Returns `(dag/ok <registry>)` on success; `(dag/ok empty-registry)`
+   on missing or blank file. Returns `(dag/err :listener-registry/read-failed ...)`
+   on:
+   - parse failure (corrupt EDN)
+   - trailing forms after the first value (silent corruption mode)
+   - schema mismatch against the malli `Registry` schema (e.g.
+     `:registry/listeners` value is a list rather than a vector,
+     which would later trip up `update-entry-status`)
+
+   Schema-mismatch errors carry an `:explain` key under `:data` with
+   the malli explanation so callers can surface a structured diagnostic."
   [worktree-path]
   (let [path (storage-path worktree-path)]
     (try
@@ -230,16 +246,28 @@
             (dag/ok empty-registry)
 
             :else
-            (let [parsed (edn/read-string raw)]
-              (if (registry-shape? parsed)
-                (dag/ok parsed)
+            (let [parsed (read-single-edn-form raw)]
+              (cond
+                (not (m/validate Registry parsed))
                 (dag/err :listener-registry/read-failed
-                         (str "registry file " path " did not parse to a registry-shaped map")
-                         {:path path}))))))
+                         (str "registry file " path " failed Registry schema validation")
+                         {:path path
+                          :explain (m/explain Registry parsed)})
+
+                :else
+                (dag/ok parsed))))))
       (catch Throwable e
         (dag/err :listener-registry/read-failed
                  (str "failed to read " path ": " (.getMessage e))
-                 {:path path})))))
+                 (cond-> {:path path}
+                   (ex-data e) (assoc :ex-data (ex-data e))))))))
+
+(defn- best-effort-delete!
+  "Try to delete `path`; swallow any throwable. Used to keep
+   `.miniforge/` clean of leftover `.tmp` files when an atomic
+   move fails (e.g., on filesystems that don't support it)."
+  [path]
+  (try (fs/delete path) (catch Throwable _ nil)))
 
 (defn write-registry!
   "Write `registry` atomically to `worktree-path`'s storage path.
@@ -247,7 +275,10 @@
    the canonical path. Eliminates partial reads from concurrent
    readers — the rename is atomic on POSIX filesystems.
 
-   Creates `.miniforge/` if it doesn't exist."
+   Creates `.miniforge/` if it doesn't exist. On move failure
+   (e.g. atomic move not supported on the underlying filesystem),
+   best-effort-deletes the leftover `.tmp` file so it doesn't
+   accumulate under `.miniforge/`."
   [worktree-path registry]
   (let [path     (storage-path worktree-path)
         tmp-path (str path ".tmp")
@@ -255,9 +286,13 @@
     (try
       (when-not (fs/exists? parent) (fs/create-dirs parent))
       (spit tmp-path (pr-str registry))
-      (fs/move tmp-path path {:replace-existing true :atomic-move true})
-      (dag/ok {:path path :listener-count
-               (reduce + 0 (map count (vals (:registry/listeners registry))))})
+      (try
+        (fs/move tmp-path path {:replace-existing true :atomic-move true})
+        (dag/ok {:path path :listener-count
+                 (reduce + 0 (map count (vals (:registry/listeners registry))))})
+        (catch Throwable move-err
+          (best-effort-delete! tmp-path)
+          (throw move-err)))
       (catch Throwable e
         (dag/err :listener-registry/write-failed
                  (str "failed to write " path ": " (.getMessage e))
@@ -329,43 +364,73 @@
                      (.getMessage e)
                      (ex-data e))))))))
 
-(defn- transition!
-  "Internal: load → update one entry → write. `update-fn` receives
-   the entry and returns its replacement (or itself unchanged)."
-  [worktree-path pr-url listener-id update-fn err-code-on-missing]
+(defn- transition-from-active!
+  "Internal: load → assert entry is `:active` → update → write.
+   Returns:
+   - `:listener-registry/listener-not-found` when no such entry exists.
+   - `:listener-registry/wrong-status` when the entry's current status
+     is anything other than `:active` — guards against overwriting
+     terminal states (`:dispatched`, `:expired`, `:cancelled`) per
+     spec §Lifecycle, which models all transitions as `:active → X`.
+   - `(dag/ok ...)` from `write-registry!` on the happy path.
+
+   `update-fn` receives the entry (guaranteed `:status :active`) and
+   returns its replacement."
+  [worktree-path pr-url listener-id update-fn]
   (let [r (read-registry worktree-path)]
     (if-not (dag/ok? r)
       r
       (let [registry (:data r)
             bucket   (entries-for-pr registry pr-url)
-            present? (some #(= listener-id (:listener/id %)) bucket)]
-        (if-not present?
-          (dag/err err-code-on-missing
+            entry    (first (filter #(= listener-id (:listener/id %)) bucket))]
+        (cond
+          (nil? entry)
+          (dag/err :listener-registry/listener-not-found
                    (str "no listener entry " listener-id " for " pr-url)
                    {:pr-url pr-url :listener-id listener-id})
+
+          (not= :active (:status entry))
+          (dag/err :listener-registry/wrong-status
+                   (str "listener " listener-id " on " pr-url
+                        " is " (:status entry) ", expected :active")
+                   {:pr-url pr-url
+                    :listener-id listener-id
+                    :current-status (:status entry)
+                    :expected-status :active})
+
+          :else
           (let [next-reg (update-entry-status registry pr-url listener-id update-fn)]
             (write-registry! worktree-path next-reg)))))))
 
 (defn unregister!
-  "Transition `listener-id` for `pr-url` to `:cancelled`. No-op (typed
-   error) when no such entry exists."
+  "Transition `listener-id` for `pr-url` from `:active` to `:cancelled`.
+
+   Returns typed error when:
+   - no such entry exists (`:listener-registry/listener-not-found`)
+   - the entry is already in a terminal state
+     (`:listener-registry/wrong-status`) — does NOT overwrite
+     `:dispatched` / `:expired` / `:cancelled` per spec §Lifecycle."
   [worktree-path pr-url listener-id]
-  (transition! worktree-path pr-url listener-id
-               (fn [e] (assoc e :status :cancelled))
-               :listener-registry/listener-not-found))
+  (transition-from-active! worktree-path pr-url listener-id
+                           (fn [e] (assoc e :status :cancelled))))
 
 (defn mark-dispatched!
-  "Transition to `:dispatched`, recording `:resume/dispatched-at` and
+  "Transition `listener-id` for `pr-url` from `:active` to
+   `:dispatched`, recording `:resume/dispatched-at` and
    `:resume/dispatch-id`. Called by the Resume Signal Dispatcher
-   after a successful primer delivery."
+   after a successful primer delivery.
+
+   Returns `:listener-registry/wrong-status` rather than overwriting
+   when the entry is already in a terminal state — prevents
+   double-dispatch and accidental resurrection of cancelled/expired
+   listeners."
   [worktree-path pr-url listener-id dispatch-id]
-  (transition! worktree-path pr-url listener-id
-               (fn [e]
-                 (assoc e
-                        :status :dispatched
-                        :resume/dispatched-at (now-inst)
-                        :resume/dispatch-id dispatch-id))
-               :listener-registry/listener-not-found))
+  (transition-from-active! worktree-path pr-url listener-id
+                           (fn [e]
+                             (assoc e
+                                    :status :dispatched
+                                    :resume/dispatched-at (now-inst)
+                                    :resume/dispatch-id dispatch-id))))
 
 (defn mark-cancelled-on-pr-close!
   "Transition every `:active` listener for `pr-url` to `:cancelled`.

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/listener_registry.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/listener_registry.clj
@@ -1,0 +1,417 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.listener-registry
+  "Persistent registry of agents waiting on PR merges (N13 §2.7,
+   `specs/informative/n13-listener-registry.md`).
+
+   Each listener entry binds a (PR URL, agent) pair so the Resume
+   Signal Dispatcher (separate component, follow-up PR) can deliver
+   a structured resume primer to the right agent on
+   `pull_request.closed.merged`.
+
+   This namespace ships the persistence primitive only. v0 stores
+   the current-state snapshot in
+   `<repo>/.miniforge/listener-registry.edn` with write-rename
+   atomicity. The append-only event log called for in the spec
+   (§Lifecycle) is a v1 hardening; the schema already supports
+   that shape via per-entry `:status`, so v1 will switch the
+   storage backend without changing the public surface.
+
+   Layer 0: schema + validation
+   Layer 1: pure state operations
+   Layer 2: persistence (read / write-rename)
+   Layer 3: lifecycle entry points (register! / unregister! /
+            mark-dispatched! / mark-cancelled-on-pr-close! /
+            sweep-expired!)"
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [babashka.fs :as fs]
+   [clojure.edn :as edn]
+   [clojure.string :as str]
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema + constants
+
+(def registry-version
+  "On-disk artifact format version. Tracks the spec document version."
+  "0.1.0")
+
+(def default-storage-path
+  "Default path under the worktree where the registry artifact lives."
+  ".miniforge/listener-registry.edn")
+
+(def default-ttl-seconds
+  "Default `:ttl-seconds` per spec §Lifecycle. 7 days."
+  604800)
+
+(def valid-runtimes
+  #{:claude-cli :codex :miniforge :webhook})
+
+(def valid-channel-kinds
+  #{:pty :miniforge-ipc :webhook})
+
+(def valid-statuses
+  #{:active :dispatched :expired :cancelled})
+
+(def valid-registered-by
+  "The three canonical registration moments per spec §Registration moments.
+   Registration with any other `:registered-by` MUST be rejected."
+  #{:authoring-agent :operator :workflow})
+
+(def ChannelKindEnum  (into [:enum] valid-channel-kinds))
+(def RuntimeEnum      (into [:enum] valid-runtimes))
+(def StatusEnum       (into [:enum] valid-statuses))
+(def RegisteredByEnum (into [:enum] valid-registered-by))
+
+(def ResumeChannel
+  [:map
+   [:channel/kind   ChannelKindEnum]
+   [:channel/target :string]
+   [:channel/auth   {:optional true} [:maybe :map]]])
+
+(def ListenerEntry
+  [:map
+   [:listener/id          uuid?]
+   [:pr/url               :string]
+   [:pr/repo-id           :string]
+   [:pr/number            pos-int?]
+   [:agent/id             :string]
+   [:session/id           {:optional true} [:maybe :string]]
+   [:runtime              RuntimeEnum]
+   [:resume-channel       ResumeChannel]
+   [:registered-at        inst?]
+   [:registered-by        RegisteredByEnum]
+   [:ttl-seconds          {:optional true} pos-int?]
+   [:status               StatusEnum]
+   [:resume/dispatched-at {:optional true} [:maybe inst?]]
+   [:resume/dispatch-id   {:optional true} [:maybe uuid?]]
+   [:notes                {:optional true} [:maybe :string]]])
+
+(def Registry
+  [:map
+   [:registry/version      :string]
+   [:registry/last-updated inst?]
+   [:registry/listeners    [:map-of :string [:vector ListenerEntry]]]])
+
+(defn validate-entry!
+  "Throw on invalid entry; return entry otherwise. Used by `register!`."
+  [entry]
+  (when-not (m/validate ListenerEntry entry)
+    (throw (ex-info "invalid listener entry"
+                    {:errors (m/explain ListenerEntry entry)
+                     :anomaly :listener-registry/invalid-entry})))
+  entry)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pure state operations
+
+(def empty-registry
+  {:registry/version      registry-version
+   :registry/last-updated #inst "1970-01-01T00:00:00.000-00:00"
+   :registry/listeners    {}})
+
+(defn- now-inst [] (java.util.Date.))
+
+(defn- with-touched-timestamp
+  [registry]
+  (assoc registry :registry/last-updated (now-inst)))
+
+(defn add-entry
+  "Pure: append `entry` to the registry under its `:pr/url` key."
+  [registry entry]
+  (-> registry
+      (update-in [:registry/listeners (:pr/url entry)] (fnil conj []) entry)
+      with-touched-timestamp))
+
+(defn entries-for-pr
+  "Return all entries (any status) for `pr-url`, or empty vector."
+  [registry pr-url]
+  (get-in registry [:registry/listeners pr-url] []))
+
+(defn active-entries-for-pr
+  "Return the subset of entries-for-pr with `:status :active`."
+  [registry pr-url]
+  (filterv #(= :active (:status %)) (entries-for-pr registry pr-url)))
+
+(defn entries-for-agent
+  "Return all entries (any status) bound to `agent-id` across all PRs."
+  [registry agent-id]
+  (into []
+        (comp (mapcat val)
+              (filter #(= agent-id (:agent/id %))))
+        (:registry/listeners registry)))
+
+(defn update-entry-status
+  "Pure: find the entry matching `listener-id` (within the listeners
+   for `pr-url`) and apply `update-fn` to it. Returns the updated
+   registry (with bumped timestamp). When the entry is not found,
+   returns the registry unchanged.
+
+   `update-fn` receives the entry and returns its replacement."
+  [registry pr-url listener-id update-fn]
+  (let [path  [:registry/listeners pr-url]
+        bucket (get-in registry path [])
+        idx   (first (keep-indexed
+                      (fn [i e]
+                        (when (= listener-id (:listener/id e)) i))
+                      bucket))]
+    (if idx
+      (-> registry
+          (update-in path
+                     (fn [b] (update b idx update-fn)))
+          with-touched-timestamp)
+      registry)))
+
+(defn auto-expirable?
+  "Pure: true when `entry` is `:active`, has `:ttl-seconds`, and the
+   wall-clock cutoff (`registered-at + ttl-seconds`) is in the past
+   relative to `now`."
+  [entry now]
+  (and (= :active (:status entry))
+       (let [ttl (or (:ttl-seconds entry) default-ttl-seconds)
+             reg-at (.getTime ^java.util.Date (:registered-at entry))
+             cutoff (+ reg-at (* 1000 ttl))]
+         (<= cutoff (.getTime ^java.util.Date now)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Persistence (read + write-rename)
+
+(defn- storage-path
+  [worktree-path]
+  (str (fs/path (str worktree-path) default-storage-path)))
+
+(defn- registry-shape?
+  "Cheap structural check: registry MUST be a map with the three
+   required top-level keys. Catches the common corruption mode where
+   `edn/read-string` reads only the first form and silently ignores
+   trailing garbage (e.g. `\"foo bar\"` parses to the symbol `foo` and
+   never throws)."
+  [v]
+  (and (map? v)
+       (contains? v :registry/version)
+       (contains? v :registry/last-updated)
+       (contains? v :registry/listeners)
+       (map? (:registry/listeners v))))
+
+(defn read-registry
+  "Read the registry from `worktree-path`'s `.miniforge/listener-registry.edn`.
+   Returns the registry map on success; `empty-registry` on missing
+   file. Returns `(dag/err :listener-registry/read-failed ...)` on
+   parse failure or when the parsed value doesn't match the registry
+   shape."
+  [worktree-path]
+  (let [path (storage-path worktree-path)]
+    (try
+      (cond
+        (not (fs/exists? path))
+        (dag/ok empty-registry)
+
+        :else
+        (let [raw (slurp path)]
+          (cond
+            (str/blank? raw)
+            (dag/ok empty-registry)
+
+            :else
+            (let [parsed (edn/read-string raw)]
+              (if (registry-shape? parsed)
+                (dag/ok parsed)
+                (dag/err :listener-registry/read-failed
+                         (str "registry file " path " did not parse to a registry-shaped map")
+                         {:path path}))))))
+      (catch Throwable e
+        (dag/err :listener-registry/read-failed
+                 (str "failed to read " path ": " (.getMessage e))
+                 {:path path})))))
+
+(defn write-registry!
+  "Write `registry` atomically to `worktree-path`'s storage path.
+   Strategy: serialize EDN, write to `<path>.tmp`, then `mv` over
+   the canonical path. Eliminates partial reads from concurrent
+   readers — the rename is atomic on POSIX filesystems.
+
+   Creates `.miniforge/` if it doesn't exist."
+  [worktree-path registry]
+  (let [path     (storage-path worktree-path)
+        tmp-path (str path ".tmp")
+        parent   (str (fs/parent path))]
+    (try
+      (when-not (fs/exists? parent) (fs/create-dirs parent))
+      (spit tmp-path (pr-str registry))
+      (fs/move tmp-path path {:replace-existing true :atomic-move true})
+      (dag/ok {:path path :listener-count
+               (reduce + 0 (map count (vals (:registry/listeners registry))))})
+      (catch Throwable e
+        (dag/err :listener-registry/write-failed
+                 (str "failed to write " path ": " (.getMessage e))
+                 {:path path})))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Lifecycle entry points
+
+(defn- new-listener-id [] (random-uuid))
+
+(defn register!
+  "Persist a new listener entry for `pr-url` against `agent-id`.
+
+   Required keys in `params`:
+   - `:pr/url`           — full PR URL
+   - `:pr/repo-id`       — '<org>/<repo>'
+   - `:pr/number`        — pos int
+   - `:agent/id`         — runtime-stable agent id
+   - `:runtime`          — one of `valid-runtimes`
+   - `:resume-channel`   — `{:channel/kind :channel/target :channel/auth?}`
+   - `:registered-by`    — one of `valid-registered-by`. Registration
+                           with any other value MUST be rejected
+                           (spec §Registration moments).
+
+   Optional keys:
+   - `:session/id`       — current agent session uuid string
+   - `:ttl-seconds`      — default `default-ttl-seconds`
+   - `:notes`            — free-form
+
+   Returns DAG result with `(dag/ok {:listener-id <uuid> :path ...})`
+   on success or typed error on schema/storage failure."
+  [worktree-path params]
+  (let [registered-by (:registered-by params)]
+    (cond
+      (not (contains? valid-registered-by registered-by))
+      (dag/err :listener-registry/invalid-registered-by
+               (str ":registered-by must be one of " valid-registered-by)
+               {:received registered-by})
+
+      :else
+      (let [entry {:listener/id     (new-listener-id)
+                   :pr/url          (:pr/url params)
+                   :pr/repo-id      (:pr/repo-id params)
+                   :pr/number       (:pr/number params)
+                   :agent/id        (:agent/id params)
+                   :session/id      (:session/id params)
+                   :runtime         (:runtime params)
+                   :resume-channel  (:resume-channel params)
+                   :registered-at   (now-inst)
+                   :registered-by   registered-by
+                   :ttl-seconds     (or (:ttl-seconds params) default-ttl-seconds)
+                   :status          :active
+                   :notes           (:notes params)}]
+        (try
+          (validate-entry! entry)
+          (let [r (read-registry worktree-path)]
+            (if-not (dag/ok? r)
+              r
+              (let [registry  (:data r)
+                    next-reg  (add-entry registry entry)
+                    write-r   (write-registry! worktree-path next-reg)]
+                (if (dag/ok? write-r)
+                  (dag/ok {:listener-id (:listener/id entry)
+                           :path (:path (:data write-r))})
+                  write-r))))
+          (catch clojure.lang.ExceptionInfo e
+            (dag/err (or (:anomaly (ex-data e))
+                         :listener-registry/invalid-entry)
+                     (.getMessage e)
+                     (ex-data e))))))))
+
+(defn- transition!
+  "Internal: load → update one entry → write. `update-fn` receives
+   the entry and returns its replacement (or itself unchanged)."
+  [worktree-path pr-url listener-id update-fn err-code-on-missing]
+  (let [r (read-registry worktree-path)]
+    (if-not (dag/ok? r)
+      r
+      (let [registry (:data r)
+            bucket   (entries-for-pr registry pr-url)
+            present? (some #(= listener-id (:listener/id %)) bucket)]
+        (if-not present?
+          (dag/err err-code-on-missing
+                   (str "no listener entry " listener-id " for " pr-url)
+                   {:pr-url pr-url :listener-id listener-id})
+          (let [next-reg (update-entry-status registry pr-url listener-id update-fn)]
+            (write-registry! worktree-path next-reg)))))))
+
+(defn unregister!
+  "Transition `listener-id` for `pr-url` to `:cancelled`. No-op (typed
+   error) when no such entry exists."
+  [worktree-path pr-url listener-id]
+  (transition! worktree-path pr-url listener-id
+               (fn [e] (assoc e :status :cancelled))
+               :listener-registry/listener-not-found))
+
+(defn mark-dispatched!
+  "Transition to `:dispatched`, recording `:resume/dispatched-at` and
+   `:resume/dispatch-id`. Called by the Resume Signal Dispatcher
+   after a successful primer delivery."
+  [worktree-path pr-url listener-id dispatch-id]
+  (transition! worktree-path pr-url listener-id
+               (fn [e]
+                 (assoc e
+                        :status :dispatched
+                        :resume/dispatched-at (now-inst)
+                        :resume/dispatch-id dispatch-id))
+               :listener-registry/listener-not-found))
+
+(defn mark-cancelled-on-pr-close!
+  "Transition every `:active` listener for `pr-url` to `:cancelled`.
+   Called when `pull_request.closed` arrives with `merged: false`
+   (spec §Deregistration). Returns DAG result with the count of
+   transitioned entries."
+  [worktree-path pr-url]
+  (let [r (read-registry worktree-path)]
+    (if-not (dag/ok? r)
+      r
+      (let [registry (:data r)
+            actives  (active-entries-for-pr registry pr-url)
+            next-reg (reduce
+                      (fn [reg e]
+                        (update-entry-status reg pr-url (:listener/id e)
+                                             (fn [e2] (assoc e2 :status :cancelled))))
+                      registry
+                      actives)
+            write-r  (write-registry! worktree-path next-reg)]
+        (if (dag/ok? write-r)
+          (dag/ok {:cancelled-count (count actives)
+                   :pr-url pr-url})
+          write-r)))))
+
+(defn sweep-expired!
+  "Transition every `:active` entry whose TTL has elapsed to
+   `:expired`. Returns DAG result with the count of transitioned
+   entries. Idempotent — re-running yields a count of 0."
+  [worktree-path]
+  (let [r (read-registry worktree-path)]
+    (if-not (dag/ok? r)
+      r
+      (let [registry (:data r)
+            now      (now-inst)
+            stale    (into []
+                           (comp (mapcat (fn [[pr-url entries]]
+                                           (map (fn [e] [pr-url e]) entries)))
+                                 (filter (fn [[_ e]] (auto-expirable? e now))))
+                           (:registry/listeners registry))
+            next-reg (reduce
+                      (fn [reg [pr-url e]]
+                        (update-entry-status reg pr-url (:listener/id e)
+                                             (fn [e2] (assoc e2 :status :expired))))
+                      registry
+                      stale)
+            write-r  (write-registry! worktree-path next-reg)]
+        (if (dag/ok? write-r)
+          (dag/ok {:expired-count (count stale)})
+          write-r)))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/listener_registry.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/listener_registry.clj
@@ -43,37 +43,41 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [babashka.fs :as fs]
    [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema + constants
+;; Configuration (loaded from per-component EDN at namespace-load)
+
+(def ^:private config
+  "Component config loaded from `resources/config/listener-registry/defaults.edn`.
+   Keeps constants (storage path, valid enums, version, TTL) out of
+   source so operators can tune without recompiling."
+  (-> (io/resource "config/listener-registry/defaults.edn")
+      slurp
+      edn/read-string))
 
 (def registry-version
   "On-disk artifact format version. Tracks the spec document version."
-  "0.1.0")
+  (:registry/version config))
 
 (def default-storage-path
   "Default path under the worktree where the registry artifact lives."
-  ".miniforge/listener-registry.edn")
+  (:default-storage-path config))
 
 (def default-ttl-seconds
-  "Default `:ttl-seconds` per spec §Lifecycle. 7 days."
-  604800)
+  "Default `:ttl-seconds` per spec §Lifecycle."
+  (:default-ttl-seconds config))
 
-(def valid-runtimes
-  #{:claude-cli :codex :miniforge :webhook})
-
-(def valid-channel-kinds
-  #{:pty :miniforge-ipc :webhook})
-
-(def valid-statuses
-  #{:active :dispatched :expired :cancelled})
+(def valid-runtimes        (:valid-runtimes config))
+(def valid-channel-kinds   (:valid-channel-kinds config))
+(def valid-statuses        (:valid-statuses config))
 
 (def valid-registered-by
   "The three canonical registration moments per spec §Registration moments.
    Registration with any other `:registered-by` MUST be rejected."
-  #{:authoring-agent :operator :workflow})
+  (:valid-registered-by config))
 
 (def ChannelKindEnum  (into [:enum] valid-channel-kinds))
 (def RuntimeEnum      (into [:enum] valid-runtimes))
@@ -219,6 +223,37 @@
                       {:trailing next-form})))
     first-form))
 
+(defn- schema-error
+  "Build a typed `:listener-registry/read-failed` for a registry value
+   that parsed but doesn't match the `Registry` malli schema."
+  [path parsed]
+  (dag/err :listener-registry/read-failed
+           (str "registry file " path " failed Registry schema validation")
+           {:path    path
+            :explain (m/explain Registry parsed)}))
+
+(defn- decode-registry-blob
+  "Pure: parse and validate `raw`. Treats blank as `empty-registry`.
+   Returns DAG result. Splits the work out of `read-registry` so the
+   stage check (file exists, content non-blank, parses, schema-valid)
+   doesn't need the cond-inside-cond-inside-cond shape."
+  [path raw]
+  (if (str/blank? raw)
+    (dag/ok empty-registry)
+    (let [parsed (read-single-edn-form raw)]
+      (if (m/validate Registry parsed)
+        (dag/ok parsed)
+        (schema-error path parsed)))))
+
+(defn- read-failure
+  "Build a typed `:listener-registry/read-failed` for a slurp /
+   parse / I/O exception. Surfaces ex-data when present."
+  [path ^Throwable e]
+  (dag/err :listener-registry/read-failed
+           (str "failed to read " path ": " (.getMessage e))
+           (cond-> {:path path}
+             (ex-data e) (assoc :ex-data (ex-data e)))))
+
 (defn read-registry
   "Read the registry from `worktree-path`'s `.miniforge/listener-registry.edn`.
    Returns `(dag/ok <registry>)` on success; `(dag/ok empty-registry)`
@@ -235,32 +270,11 @@
   [worktree-path]
   (let [path (storage-path worktree-path)]
     (try
-      (cond
-        (not (fs/exists? path))
-        (dag/ok empty-registry)
-
-        :else
-        (let [raw (slurp path)]
-          (cond
-            (str/blank? raw)
-            (dag/ok empty-registry)
-
-            :else
-            (let [parsed (read-single-edn-form raw)]
-              (cond
-                (not (m/validate Registry parsed))
-                (dag/err :listener-registry/read-failed
-                         (str "registry file " path " failed Registry schema validation")
-                         {:path path
-                          :explain (m/explain Registry parsed)})
-
-                :else
-                (dag/ok parsed))))))
+      (if (fs/exists? path)
+        (decode-registry-blob path (slurp path))
+        (dag/ok empty-registry))
       (catch Throwable e
-        (dag/err :listener-registry/read-failed
-                 (str "failed to read " path ": " (.getMessage e))
-                 (cond-> {:path path}
-                   (ex-data e) (assoc :ex-data (ex-data e))))))))
+        (read-failure path e)))))
 
 (defn- best-effort-delete!
   "Try to delete `path`; swallow any throwable. Used to keep
@@ -303,6 +317,54 @@
 
 (defn- new-listener-id [] (random-uuid))
 
+(defn- build-entry
+  "Pure: assemble a fully-shaped `ListenerEntry` from `params`,
+   stamping a fresh `:listener/id`, `:registered-at`, default
+   `:ttl-seconds`, and `:status :active`."
+  [params]
+  {:listener/id     (new-listener-id)
+   :pr/url          (:pr/url params)
+   :pr/repo-id      (:pr/repo-id params)
+   :pr/number       (:pr/number params)
+   :agent/id        (:agent/id params)
+   :session/id      (:session/id params)
+   :runtime         (:runtime params)
+   :resume-channel  (:resume-channel params)
+   :registered-at   (now-inst)
+   :registered-by   (:registered-by params)
+   :ttl-seconds     (or (:ttl-seconds params) default-ttl-seconds)
+   :status          :active
+   :notes           (:notes params)})
+
+(defn- registration-success
+  "Build the success payload returned to the caller of `register!`."
+  [entry write-result]
+  (dag/ok {:listener-id (:listener/id entry)
+           :path        (:path (:data write-result))}))
+
+(defn- persist-new-entry!
+  "Read → add → write. Internal helper for `register!`. Assumes the
+   caller has already validated the entry."
+  [worktree-path entry]
+  (let [r (read-registry worktree-path)]
+    (if-not (dag/ok? r)
+      r
+      (let [next-reg (add-entry (:data r) entry)
+            write-r  (write-registry! worktree-path next-reg)]
+        (if (dag/ok? write-r)
+          (registration-success entry write-r)
+          write-r)))))
+
+(defn- invalid-entry-error
+  "Translate a malli-validation `ExceptionInfo` from `validate-entry!`
+   into a typed DAG error. Honors a caller-supplied `:anomaly` key
+   when present."
+  [^Throwable e]
+  (let [data (ex-data e)]
+    (dag/err (or (:anomaly data) :listener-registry/invalid-entry)
+             (.getMessage e)
+             data)))
+
 (defn register!
   "Persist a new listener entry for `pr-url` against `agent-id`.
 
@@ -326,52 +388,60 @@
    on success or typed error on schema/storage failure."
   [worktree-path params]
   (let [registered-by (:registered-by params)]
-    (cond
-      (not (contains? valid-registered-by registered-by))
+    (if-not (contains? valid-registered-by registered-by)
       (dag/err :listener-registry/invalid-registered-by
                (str ":registered-by must be one of " valid-registered-by)
                {:received registered-by})
-
-      :else
-      (let [entry {:listener/id     (new-listener-id)
-                   :pr/url          (:pr/url params)
-                   :pr/repo-id      (:pr/repo-id params)
-                   :pr/number       (:pr/number params)
-                   :agent/id        (:agent/id params)
-                   :session/id      (:session/id params)
-                   :runtime         (:runtime params)
-                   :resume-channel  (:resume-channel params)
-                   :registered-at   (now-inst)
-                   :registered-by   registered-by
-                   :ttl-seconds     (or (:ttl-seconds params) default-ttl-seconds)
-                   :status          :active
-                   :notes           (:notes params)}]
+      (let [entry (build-entry params)]
         (try
           (validate-entry! entry)
-          (let [r (read-registry worktree-path)]
-            (if-not (dag/ok? r)
-              r
-              (let [registry  (:data r)
-                    next-reg  (add-entry registry entry)
-                    write-r   (write-registry! worktree-path next-reg)]
-                (if (dag/ok? write-r)
-                  (dag/ok {:listener-id (:listener/id entry)
-                           :path (:path (:data write-r))})
-                  write-r))))
+          (persist-new-entry! worktree-path entry)
           (catch clojure.lang.ExceptionInfo e
-            (dag/err (or (:anomaly (ex-data e))
-                         :listener-registry/invalid-entry)
-                     (.getMessage e)
-                     (ex-data e))))))))
+            (invalid-entry-error e)))))))
+
+(defn- find-listener
+  "Pure: locate the entry matching `listener-id` within the bucket
+   for `pr-url`. Returns the entry or nil."
+  [registry pr-url listener-id]
+  (first (filter #(= listener-id (:listener/id %))
+                 (entries-for-pr registry pr-url))))
+
+(defn- not-found-error
+  [pr-url listener-id]
+  (dag/err :listener-registry/listener-not-found
+           (str "no listener entry " listener-id " for " pr-url)
+           {:pr-url pr-url :listener-id listener-id}))
+
+(defn- wrong-status-error
+  [pr-url listener-id current-status]
+  (dag/err :listener-registry/wrong-status
+           (str "listener " listener-id " on " pr-url
+                " is " current-status ", expected :active")
+           {:pr-url          pr-url
+            :listener-id     listener-id
+            :current-status  current-status
+            :expected-status :active}))
+
+(defn- check-active-entry
+  "Return `(dag/ok entry)` when the listener exists in `registry`
+   under `pr-url` AND is currently `:active`. Otherwise a typed
+   error per the two failure modes."
+  [registry pr-url listener-id]
+  (let [entry (find-listener registry pr-url listener-id)]
+    (cond
+      (nil? entry)                    (not-found-error pr-url listener-id)
+      (not= :active (:status entry))  (wrong-status-error pr-url listener-id (:status entry))
+      :else                           (dag/ok entry))))
 
 (defn- transition-from-active!
   "Internal: load → assert entry is `:active` → update → write.
+
    Returns:
    - `:listener-registry/listener-not-found` when no such entry exists.
-   - `:listener-registry/wrong-status` when the entry's current status
-     is anything other than `:active` — guards against overwriting
-     terminal states (`:dispatched`, `:expired`, `:cancelled`) per
-     spec §Lifecycle, which models all transitions as `:active → X`.
+   - `:listener-registry/wrong-status` when the entry isn't `:active`
+     — guards against overwriting terminal states (`:dispatched`,
+     `:expired`, `:cancelled`) per spec §Lifecycle, which models all
+     transitions as `:active → X`.
    - `(dag/ok ...)` from `write-registry!` on the happy path.
 
    `update-fn` receives the entry (guaranteed `:status :active`) and
@@ -381,26 +451,32 @@
     (if-not (dag/ok? r)
       r
       (let [registry (:data r)
-            bucket   (entries-for-pr registry pr-url)
-            entry    (first (filter #(= listener-id (:listener/id %)) bucket))]
-        (cond
-          (nil? entry)
-          (dag/err :listener-registry/listener-not-found
-                   (str "no listener entry " listener-id " for " pr-url)
-                   {:pr-url pr-url :listener-id listener-id})
+            check    (check-active-entry registry pr-url listener-id)]
+        (if-not (dag/ok? check)
+          check
+          (write-registry! worktree-path
+                           (update-entry-status registry pr-url listener-id update-fn)))))))
 
-          (not= :active (:status entry))
-          (dag/err :listener-registry/wrong-status
-                   (str "listener " listener-id " on " pr-url
-                        " is " (:status entry) ", expected :active")
-                   {:pr-url pr-url
-                    :listener-id listener-id
-                    :current-status (:status entry)
-                    :expected-status :active})
+(defn- mark-cancelled
+  "Pure entry update: `:active → :cancelled`."
+  [entry]
+  (assoc entry :status :cancelled))
 
-          :else
-          (let [next-reg (update-entry-status registry pr-url listener-id update-fn)]
-            (write-registry! worktree-path next-reg)))))))
+(defn- mark-dispatched
+  "Pure entry update: `:active → :dispatched` with timestamp +
+   dispatch-id stamped. Closes over `dispatch-id` so the public
+   `mark-dispatched!` doesn't need an inline anonymous fn."
+  [dispatch-id]
+  (fn [entry]
+    (assoc entry
+           :status :dispatched
+           :resume/dispatched-at (now-inst)
+           :resume/dispatch-id dispatch-id)))
+
+(defn- mark-expired
+  "Pure entry update: `:active → :expired`."
+  [entry]
+  (assoc entry :status :expired))
 
 (defn unregister!
   "Transition `listener-id` for `pr-url` from `:active` to `:cancelled`.
@@ -411,8 +487,7 @@
      (`:listener-registry/wrong-status`) — does NOT overwrite
      `:dispatched` / `:expired` / `:cancelled` per spec §Lifecycle."
   [worktree-path pr-url listener-id]
-  (transition-from-active! worktree-path pr-url listener-id
-                           (fn [e] (assoc e :status :cancelled))))
+  (transition-from-active! worktree-path pr-url listener-id mark-cancelled))
 
 (defn mark-dispatched!
   "Transition `listener-id` for `pr-url` from `:active` to
@@ -425,12 +500,13 @@
    double-dispatch and accidental resurrection of cancelled/expired
    listeners."
   [worktree-path pr-url listener-id dispatch-id]
-  (transition-from-active! worktree-path pr-url listener-id
-                           (fn [e]
-                             (assoc e
-                                    :status :dispatched
-                                    :resume/dispatched-at (now-inst)
-                                    :resume/dispatch-id dispatch-id))))
+  (transition-from-active! worktree-path pr-url listener-id (mark-dispatched dispatch-id)))
+
+(defn- apply-cancel-to
+  "Reduce step: cancel one `entry` in-place under its known `pr-url`.
+   Closure-free — `pr-url` arrives via the entry's bucket lookup."
+  [pr-url registry entry]
+  (update-entry-status registry pr-url (:listener/id entry) mark-cancelled))
 
 (defn mark-cancelled-on-pr-close!
   "Transition every `:active` listener for `pr-url` to `:cancelled`.
@@ -443,17 +519,39 @@
       r
       (let [registry (:data r)
             actives  (active-entries-for-pr registry pr-url)
-            next-reg (reduce
-                      (fn [reg e]
-                        (update-entry-status reg pr-url (:listener/id e)
-                                             (fn [e2] (assoc e2 :status :cancelled))))
-                      registry
-                      actives)
+            next-reg (reduce (partial apply-cancel-to pr-url) registry actives)
             write-r  (write-registry! worktree-path next-reg)]
         (if (dag/ok? write-r)
-          (dag/ok {:cancelled-count (count actives)
-                   :pr-url pr-url})
+          (dag/ok {:cancelled-count (count actives) :pr-url pr-url})
           write-r)))))
+
+(defn- pair-with-pr-url
+  "Pure: turn one `[pr-url entries]` map-entry into a seq of
+   `[pr-url entry]` pairs. Used by `collect-expirable-pairs`."
+  [[pr-url entries]]
+  (map (fn [e] [pr-url e]) entries))
+
+(defn- pair-expirable?
+  "Pure: predicate for [pr-url entry] pairs against a fixed `now`.
+   Returns a function so `filter` doesn't need a closure-bearing
+   anonymous fn at the call site."
+  [now]
+  (fn [[_ entry]] (auto-expirable? entry now)))
+
+(defn- collect-expirable-pairs
+  "Pure: walk `registry`'s listener buckets and return a vector of
+   `[pr-url entry]` pairs whose entries are auto-expirable as of
+   `now`."
+  [registry now]
+  (into []
+        (comp (mapcat pair-with-pr-url)
+              (filter (pair-expirable? now)))
+        (:registry/listeners registry)))
+
+(defn- apply-expire-to
+  "Reduce step: expire one [pr-url entry] pair in `registry`."
+  [registry [pr-url entry]]
+  (update-entry-status registry pr-url (:listener/id entry) mark-expired))
 
 (defn sweep-expired!
   "Transition every `:active` entry whose TTL has elapsed to
@@ -464,18 +562,8 @@
     (if-not (dag/ok? r)
       r
       (let [registry (:data r)
-            now      (now-inst)
-            stale    (into []
-                           (comp (mapcat (fn [[pr-url entries]]
-                                           (map (fn [e] [pr-url e]) entries)))
-                                 (filter (fn [[_ e]] (auto-expirable? e now))))
-                           (:registry/listeners registry))
-            next-reg (reduce
-                      (fn [reg [pr-url e]]
-                        (update-entry-status reg pr-url (:listener/id e)
-                                             (fn [e2] (assoc e2 :status :expired))))
-                      registry
-                      stale)
+            stale    (collect-expirable-pairs registry (now-inst))
+            next-reg (reduce apply-expire-to registry stale)
             write-r  (write-registry! worktree-path next-reg)]
         (if (dag/ok? write-r)
           (dag/ok {:expired-count (count stale)})

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/listener_registry_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/listener_registry_test.clj
@@ -187,17 +187,59 @@
     (is (false? (reg/auto-expirable? cancelled-old now))
         "non-active entries don't auto-expire")))
 
+;; Deterministic registry construction: build the snapshot directly
+;; via pure helpers so we can dial `:registered-at` into the past
+;; without touching wall-clock time. Avoids the Thread/sleep
+;; flakiness that bites under CI load.
+
+(defn- write-state!
+  "Build a registry from `entries`, write it through `write-registry!`,
+   and return the entries actually persisted. `entries` are caller-
+   supplied entry maps (must include all required fields)."
+  [entries]
+  (let [reg (reduce reg/add-entry reg/empty-registry entries)
+        r   (reg/write-registry! *worktree* reg)]
+    (assert (dag/ok? r) "test fixture failed to write registry")
+    entries))
+
+(defn- entry
+  "Build a fully-shaped ListenerEntry for tests with the supplied
+   overrides. Required keys default from base-params; `:registered-at`
+   defaults to now."
+  [overrides]
+  (merge {:listener/id     (random-uuid)
+          :pr/url          (:pr/url base-params)
+          :pr/repo-id      (:pr/repo-id base-params)
+          :pr/number       (:pr/number base-params)
+          :agent/id        (:agent/id base-params)
+          :session/id      nil
+          :runtime         (:runtime base-params)
+          :resume-channel  (:resume-channel base-params)
+          :registered-at   (java.util.Date.)
+          :registered-by   (:registered-by base-params)
+          :ttl-seconds     reg/default-ttl-seconds
+          :status          :active
+          :notes           nil}
+         overrides))
+
+(defn- past-inst
+  "Return an inst `seconds-ago` before now."
+  [seconds-ago]
+  (java.util.Date. (- (.getTime (java.util.Date.)) (* 1000 seconds-ago))))
+
 (deftest sweep-expired-transitions-stale-actives
-  (testing "sweep-expired! flips :active entries past TTL to :expired"
-    (let [_  (reg/register! *worktree* (assoc base-params :ttl-seconds 1))
-          r2 (reg/register! *worktree* (assoc base-params :agent/id "agent-B"
-                                              :ttl-seconds reg/default-ttl-seconds))]
-      (is (dag/ok? r2))
-      (Thread/sleep 1100) ; let the agent-A entry's 1s TTL elapse
+  (testing "sweep-expired! flips :active entries past TTL to :expired (deterministic)"
+    (let [stale (entry {:agent/id "agent-A"
+                        :ttl-seconds 60
+                        :registered-at (past-inst (* 60 60))}) ; 1 hour ago, ttl 60s
+          fresh (entry {:agent/id "agent-B"
+                        :ttl-seconds reg/default-ttl-seconds
+                        :registered-at (java.util.Date.)})]
+      (write-state! [stale fresh])
       (let [r (reg/sweep-expired! *worktree*)]
         (is (dag/ok? r))
         (is (= 1 (-> r :data :expired-count))
-            "only the 1-second-TTL entry expires; the default-TTL one survives")
+            "only the stale entry expires; the fresh one survives")
         (let [statuses (->> (reg/entries-for-pr
                              (:data (reg/read-registry *worktree*))
                              (:pr/url base-params))
@@ -206,10 +248,11 @@
           (is (= #{:expired :active} statuses)))))))
 
 (deftest sweep-expired-is-idempotent
-  (testing "running sweep twice yields 0 the second time"
-    (let [_ (reg/register! *worktree* (assoc base-params :ttl-seconds 1))
-          _ (Thread/sleep 1100)
-          r1 (reg/sweep-expired! *worktree*)
+  (testing "running sweep twice yields 0 the second time (deterministic)"
+    (write-state! [(entry {:agent/id "agent-A"
+                           :ttl-seconds 60
+                           :registered-at (past-inst (* 60 60))})])
+    (let [r1 (reg/sweep-expired! *worktree*)
           r2 (reg/sweep-expired! *worktree*)]
       (is (= 1 (-> r1 :data :expired-count)))
       (is (= 0 (-> r2 :data :expired-count))))))
@@ -247,3 +290,96 @@
       (is (fs/exists? mf-dir) ".miniforge dir created")
       (is (fs/exists? (fs/path mf-dir "listener-registry.edn"))
           "registry artifact written"))))
+
+;; ── transition guards (terminal states are sticky) ───────────────────
+
+(deftest unregister-rejects-non-active-entries
+  (testing "unregister! returns :wrong-status on already-cancelled entries (no overwrite)"
+    (let [r1 (reg/register! *worktree* base-params)
+          lid (-> r1 :data :listener-id)
+          _   (reg/unregister! *worktree* (:pr/url base-params) lid) ; first call: ok
+          r2  (reg/unregister! *worktree* (:pr/url base-params) lid)] ; second: guard fires
+      (is (not (dag/ok? r2)))
+      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
+      (is (= :cancelled (get-in r2 [:error :data :current-status])))
+      (is (= :active    (get-in r2 [:error :data :expected-status]))))))
+
+(deftest unregister-rejects-dispatched-entries
+  (testing "unregister! does NOT downgrade a :dispatched entry to :cancelled"
+    (let [r1 (reg/register! *worktree* base-params)
+          lid (-> r1 :data :listener-id)
+          _   (reg/mark-dispatched! *worktree* (:pr/url base-params) lid (random-uuid))
+          r2  (reg/unregister! *worktree* (:pr/url base-params) lid)]
+      (is (not (dag/ok? r2)))
+      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
+      (let [entries (reg/entries-for-pr (:data (reg/read-registry *worktree*))
+                                        (:pr/url base-params))]
+        (is (= :dispatched (:status (first entries)))
+            "entry remains :dispatched, not silently overwritten")))))
+
+(deftest mark-dispatched-rejects-non-active-entries
+  (testing "mark-dispatched! refuses to dispatch a cancelled listener"
+    (let [r1 (reg/register! *worktree* base-params)
+          lid (-> r1 :data :listener-id)
+          _   (reg/unregister! *worktree* (:pr/url base-params) lid)
+          r2  (reg/mark-dispatched! *worktree* (:pr/url base-params) lid (random-uuid))]
+      (is (not (dag/ok? r2)))
+      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
+      (is (= :cancelled (get-in r2 [:error :data :current-status]))))))
+
+(deftest mark-dispatched-is-not-idempotent-by-design
+  (testing "double-dispatch is rejected, not silently re-stamped"
+    (let [r1 (reg/register! *worktree* base-params)
+          lid (-> r1 :data :listener-id)
+          d1  (random-uuid)
+          d2  (random-uuid)
+          _   (reg/mark-dispatched! *worktree* (:pr/url base-params) lid d1)
+          r2  (reg/mark-dispatched! *worktree* (:pr/url base-params) lid d2)]
+      (is (not (dag/ok? r2)))
+      (let [entries (reg/entries-for-pr (:data (reg/read-registry *worktree*))
+                                        (:pr/url base-params))
+            entry (first entries)]
+        (is (= d1 (:resume/dispatch-id entry))
+            "first dispatch-id sticks; second call doesn't overwrite")))))
+
+;; ── read strictness (trailing forms + schema) ────────────────────────
+
+(deftest read-rejects-trailing-forms
+  (testing "valid registry followed by trailing data is rejected as :read-failed"
+    (let [path (str (fs/path *worktree* reg/default-storage-path))]
+      (fs/create-dirs (fs/parent path))
+      (spit path (str (pr-str reg/empty-registry) " {:trailing :junk}")))
+    (let [r (reg/read-registry *worktree*)]
+      (is (not (dag/ok? r)))
+      (is (= :listener-registry/read-failed (get-in r [:error :code]))))))
+
+(deftest read-rejects-schema-mismatch
+  (testing ":registry/listeners as a list (not a vector) fails malli validation on load"
+    (let [path (str (fs/path *worktree* reg/default-storage-path))
+          ;; bypass our normal write so we can craft a bad-but-shaped artifact
+          bad  {:registry/version reg/registry-version
+                :registry/last-updated (java.util.Date.)
+                :registry/listeners {"https://github.com/o/r/pull/1"
+                                     '({:listener/id (random-uuid)})}}]
+      (fs/create-dirs (fs/parent path))
+      (spit path (pr-str bad)))
+    (let [r (reg/read-registry *worktree*)]
+      (is (not (dag/ok? r)))
+      (is (= :listener-registry/read-failed (get-in r [:error :code])))
+      (is (some? (get-in r [:error :data :explain]))
+          "malli explain payload is included so callers can diagnose"))))
+
+;; ── tmp file cleanup on move failure ─────────────────────────────────
+
+(deftest write-cleans-up-tmp-on-move-failure
+  (testing "if fs/move throws, the .tmp file written by spit is best-effort-deleted"
+    (let [path (str (fs/path *worktree* reg/default-storage-path))
+          tmp-path (str path ".tmp")]
+      (with-redefs [babashka.fs/move (fn [& _]
+                                        (throw (java.lang.UnsupportedOperationException.
+                                                "atomic-move not supported on this fs (simulated)")))]
+        (let [r (reg/write-registry! *worktree* reg/empty-registry)]
+          (is (not (dag/ok? r)))
+          (is (= :listener-registry/write-failed (get-in r [:error :code])))
+          (is (not (fs/exists? tmp-path))
+              ".tmp file should be deleted on move failure to avoid accumulating stale artifacts"))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/listener_registry_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/listener_registry_test.clj
@@ -1,0 +1,249 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.listener-registry-test
+  "Tests for the N13 §2.7 listener registry persistence primitive."
+  (:require [babashka.fs :as fs]
+            [clojure.edn :as edn]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.dag-executor.interface :as dag]
+            [ai.miniforge.pr-lifecycle.listener-registry :as reg]))
+
+;; ── fixture: ephemeral worktree ──────────────────────────────────────
+
+(def ^:dynamic *worktree* nil)
+
+(defn worktree-fixture [f]
+  (let [w (str (fs/create-temp-dir {:prefix "listener-registry-test-"}))]
+    (try
+      (binding [*worktree* w] (f))
+      (finally (try (fs/delete-tree w) (catch Throwable _ nil))))))
+
+(use-fixtures :each worktree-fixture)
+
+;; ── helpers ──────────────────────────────────────────────────────────
+
+(def ^:private base-params
+  {:pr/url         "https://github.com/o/r/pull/42"
+   :pr/repo-id     "o/r"
+   :pr/number      42
+   :agent/id       "agent-A"
+   :runtime        :claude-cli
+   :resume-channel {:channel/kind   :pty
+                    :channel/target "pty-7"}
+   :registered-by  :authoring-agent})
+
+(defn- count-listeners-on-disk
+  "Read the file directly and tally entries (cross-checks our pure ops)."
+  []
+  (let [path (str (fs/path *worktree* reg/default-storage-path))]
+    (if (fs/exists? path)
+      (let [reg (edn/read-string (slurp path))]
+        (reduce + 0 (map count (vals (:registry/listeners reg)))))
+      0)))
+
+;; ── read-registry ────────────────────────────────────────────────────
+
+(deftest read-on-missing-file-yields-empty-registry
+  (let [r (reg/read-registry *worktree*)]
+    (is (dag/ok? r))
+    (is (= reg/registry-version (-> r :data :registry/version)))
+    (is (= {} (-> r :data :registry/listeners)))))
+
+(deftest read-on-blank-file-yields-empty-registry
+  (let [path (str (fs/path *worktree* reg/default-storage-path))]
+    (fs/create-dirs (fs/parent path))
+    (spit path "")
+    (let [r (reg/read-registry *worktree*)]
+      (is (dag/ok? r))
+      (is (= reg/registry-version (-> r :data :registry/version))))))
+
+(deftest read-on-corrupt-edn-returns-typed-error
+  (let [path (str (fs/path *worktree* reg/default-storage-path))]
+    (fs/create-dirs (fs/parent path))
+    (spit path "this is { not edn")
+    (let [r (reg/read-registry *worktree*)]
+      (is (not (dag/ok? r)))
+      (is (= :listener-registry/read-failed (get-in r [:error :code]))))))
+
+;; ── register! ────────────────────────────────────────────────────────
+
+(deftest register-happy-path
+  (testing "register! persists an entry and returns its id"
+    (let [r (reg/register! *worktree* base-params)]
+      (is (dag/ok? r))
+      (is (uuid? (-> r :data :listener-id)))
+      (is (= 1 (count-listeners-on-disk))))))
+
+(deftest register-rejects-bad-registered-by
+  (testing "registration outside the three canonical moments is rejected (spec §Registration moments)"
+    (doseq [bad [:rogue :unknown nil "authoring-agent"]]
+      (let [r (reg/register! *worktree* (assoc base-params :registered-by bad))]
+        (is (not (dag/ok? r))
+            (str "input " (pr-str bad)))
+        (is (= :listener-registry/invalid-registered-by (get-in r [:error :code])))))
+    (is (zero? (count-listeners-on-disk))
+        "no entry written when registration is rejected")))
+
+(deftest register-rejects-malformed-entry
+  (testing "missing required fields fail malli validation, surface typed error"
+    (let [r (reg/register! *worktree* (dissoc base-params :pr/number))]
+      (is (not (dag/ok? r)))
+      (is (= :listener-registry/invalid-entry (get-in r [:error :code]))))
+    (is (zero? (count-listeners-on-disk)))))
+
+(deftest register-multiple-entries-on-same-pr
+  (testing "multiple agents may bind to the same PR"
+    (let [r1 (reg/register! *worktree* base-params)
+          r2 (reg/register! *worktree* (assoc base-params :agent/id "agent-B"))]
+      (is (dag/ok? r1))
+      (is (dag/ok? r2))
+      (is (not= (-> r1 :data :listener-id) (-> r2 :data :listener-id))
+          "each registration gets a fresh listener-id")
+      (is (= 2 (count-listeners-on-disk))))))
+
+(deftest register-defaults-ttl
+  (let [r (reg/register! *worktree* (dissoc base-params :ttl-seconds))]
+    (is (dag/ok? r))
+    (let [reg-state (:data (reg/read-registry *worktree*))
+          entry (first (reg/active-entries-for-pr reg-state (:pr/url base-params)))]
+      (is (= reg/default-ttl-seconds (:ttl-seconds entry))))))
+
+;; ── transitions ──────────────────────────────────────────────────────
+
+(deftest unregister-marks-cancelled
+  (let [r1 (reg/register! *worktree* base-params)
+        lid (-> r1 :data :listener-id)
+        r2 (reg/unregister! *worktree* (:pr/url base-params) lid)]
+    (is (dag/ok? r2))
+    (let [entries (reg/entries-for-pr (:data (reg/read-registry *worktree*))
+                                      (:pr/url base-params))]
+      (is (= 1 (count entries)))
+      (is (= :cancelled (:status (first entries)))))))
+
+(deftest unregister-missing-listener-returns-typed-error
+  (let [r (reg/unregister! *worktree* (:pr/url base-params) (random-uuid))]
+    (is (not (dag/ok? r)))
+    (is (= :listener-registry/listener-not-found (get-in r [:error :code])))))
+
+(deftest mark-dispatched-records-dispatch-id-and-timestamp
+  (let [r1 (reg/register! *worktree* base-params)
+        lid (-> r1 :data :listener-id)
+        did (random-uuid)
+        r2 (reg/mark-dispatched! *worktree* (:pr/url base-params) lid did)]
+    (is (dag/ok? r2))
+    (let [entries (reg/entries-for-pr (:data (reg/read-registry *worktree*))
+                                      (:pr/url base-params))
+          entry (first entries)]
+      (is (= :dispatched (:status entry)))
+      (is (= did (:resume/dispatch-id entry)))
+      (is (inst? (:resume/dispatched-at entry))))))
+
+(deftest cancel-on-pr-close-transitions-only-active-entries
+  (testing "actives become :cancelled, already-dispatched/cancelled stay put"
+    (let [_  (reg/register! *worktree* base-params)
+          r2 (reg/register! *worktree* (assoc base-params :agent/id "agent-B"))
+          _  (reg/mark-dispatched! *worktree* (:pr/url base-params)
+                                   (-> r2 :data :listener-id)
+                                   (random-uuid))
+          r3 (reg/mark-cancelled-on-pr-close! *worktree* (:pr/url base-params))]
+      (is (dag/ok? r3))
+      (is (= 1 (-> r3 :data :cancelled-count))
+          "only the still-active entry transitions; the :dispatched one is left alone")
+      (let [statuses (->> (reg/entries-for-pr
+                           (:data (reg/read-registry *worktree*))
+                           (:pr/url base-params))
+                          (map :status)
+                          set)]
+        (is (= #{:cancelled :dispatched} statuses))))))
+
+;; ── auto-expiry ──────────────────────────────────────────────────────
+
+(deftest auto-expirable-predicate
+  (let [now    (java.util.Date.)
+        old    (java.util.Date. (- (.getTime now)
+                                   (* 1000 (+ reg/default-ttl-seconds 60))))
+        recent (java.util.Date. (- (.getTime now) 1000))
+        active-old   {:status :active :registered-at old   :ttl-seconds reg/default-ttl-seconds}
+        active-fresh {:status :active :registered-at recent :ttl-seconds reg/default-ttl-seconds}
+        cancelled-old {:status :cancelled :registered-at old :ttl-seconds reg/default-ttl-seconds}]
+    (is (true?  (reg/auto-expirable? active-old now)))
+    (is (false? (reg/auto-expirable? active-fresh now)))
+    (is (false? (reg/auto-expirable? cancelled-old now))
+        "non-active entries don't auto-expire")))
+
+(deftest sweep-expired-transitions-stale-actives
+  (testing "sweep-expired! flips :active entries past TTL to :expired"
+    (let [_  (reg/register! *worktree* (assoc base-params :ttl-seconds 1))
+          r2 (reg/register! *worktree* (assoc base-params :agent/id "agent-B"
+                                              :ttl-seconds reg/default-ttl-seconds))]
+      (is (dag/ok? r2))
+      (Thread/sleep 1100) ; let the agent-A entry's 1s TTL elapse
+      (let [r (reg/sweep-expired! *worktree*)]
+        (is (dag/ok? r))
+        (is (= 1 (-> r :data :expired-count))
+            "only the 1-second-TTL entry expires; the default-TTL one survives")
+        (let [statuses (->> (reg/entries-for-pr
+                             (:data (reg/read-registry *worktree*))
+                             (:pr/url base-params))
+                            (map :status)
+                            set)]
+          (is (= #{:expired :active} statuses)))))))
+
+(deftest sweep-expired-is-idempotent
+  (testing "running sweep twice yields 0 the second time"
+    (let [_ (reg/register! *worktree* (assoc base-params :ttl-seconds 1))
+          _ (Thread/sleep 1100)
+          r1 (reg/sweep-expired! *worktree*)
+          r2 (reg/sweep-expired! *worktree*)]
+      (is (= 1 (-> r1 :data :expired-count)))
+      (is (= 0 (-> r2 :data :expired-count))))))
+
+;; ── lookup ───────────────────────────────────────────────────────────
+
+(deftest lookup-by-pr-and-by-agent
+  (let [_ (reg/register! *worktree* base-params)
+        _ (reg/register! *worktree* (assoc base-params :agent/id "agent-B"))
+        _ (reg/register! *worktree* (assoc base-params
+                                           :pr/url "https://github.com/o/r/pull/99"
+                                           :pr/number 99))
+        registry (:data (reg/read-registry *worktree*))]
+    (is (= 2 (count (reg/entries-for-pr registry (:pr/url base-params)))))
+    (is (= 1 (count (reg/entries-for-pr registry "https://github.com/o/r/pull/99"))))
+    (is (= 2 (count (reg/entries-for-agent registry "agent-A")))
+        "agent-A is bound to PR 42 and PR 99")
+    (is (= 1 (count (reg/entries-for-agent registry "agent-B"))))))
+
+;; ── persistence atomicity ────────────────────────────────────────────
+
+(deftest write-rename-atomicity
+  (testing "no .tmp files leak after register!"
+    (reg/register! *worktree* base-params)
+    (let [tmp-files (filter #(re-find #"\.tmp$" (str %))
+                            (fs/list-dir (fs/path *worktree* ".miniforge")))]
+      (is (empty? tmp-files)
+          "the temp file used for write-rename should be gone after a successful write"))))
+
+(deftest write-creates-miniforge-dir-when-missing
+  (testing ".miniforge/ is created on first register"
+    (let [mf-dir (fs/path *worktree* ".miniforge")]
+      (is (not (fs/exists? mf-dir)) "fresh worktree has no .miniforge dir")
+      (reg/register! *worktree* base-params)
+      (is (fs/exists? mf-dir) ".miniforge dir created")
+      (is (fs/exists? (fs/path mf-dir "listener-registry.edn"))
+          "registry artifact written"))))

--- a/docs/pull-requests/2026-05-09-feat-n13-listener-registry-impl.md
+++ b/docs/pull-requests/2026-05-09-feat-n13-listener-registry-impl.md
@@ -1,0 +1,121 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# feat(n13): listener registry implementation
+
+## Overview
+
+Implements the persistence primitive for the N13 §2.7 listener
+registry — the binding from PR URL → set of agents waiting on the
+PR's merge. The schema landed in #808 (`specs/informative/n13-listener-registry.md`);
+this PR ships the read/write/transition code that makes it usable.
+
+The registry is a prerequisite for the **Resume Signal Dispatcher**
+(separate follow-up PR), which will deliver structured resume
+primers to each `:active` listener on `pull_request.closed.merged`.
+
+## Why now
+
+Operator-behavior mining (#808 motivation) ranked manual `merged`
+acks as the highest-volume operator turn — ~448 instances across
+recent sessions. The dispatcher kills that whole turn class; the
+dispatcher needs the registry. This PR is the immediate prerequisite
+and unlocks the highest-leverage operator-load reduction in the
+N13 backlog.
+
+## Design
+
+### Storage
+
+- Single per-worktree artifact at `<worktree>/.miniforge/listener-registry.edn`
+- **Write-rename atomicity**: serialize → write `<path>.tmp` → POSIX-atomic
+  `mv` over canonical path. Eliminates partial reads from concurrent readers.
+- `.miniforge/` auto-created on first register
+- v0 is single-process (no file lock). v1 hardening adds locking only
+  if a use case justifies it.
+
+### State model
+
+- v0 stores the **current-state snapshot** (per-entry `:status` field
+  per the spec schema).
+- The append-only event log called for in spec §Lifecycle is **v1
+  hardening** (audit trail, time-travel) — schema already supports it
+  via `:status`, so v1 swaps the storage backend without changing the
+  public surface.
+
+### Schema validation
+
+- Malli schemas (`ListenerEntry`, `Registry`, `ResumeChannel`) — matches
+  codebase conventions (`compliance-scanner.schema`, etc.).
+- `validate-entry!` throws on register; `read-registry` enforces
+  structural shape on load (catches the common corruption mode where
+  `edn/read-string` reads only the first form and silently ignores
+  trailing garbage).
+
+### Registration moments
+
+- Spec §Registration moments: registration MUST come from one of
+  `:authoring-agent` / `:operator` / `:workflow`. `register!`
+  rejects any other `:registered-by` value with a typed error.
+
+## Public API
+
+All re-exported through `pr-lifecycle.interface`:
+
+| API                                | Behavior                                                              |
+| ---------------------------------- | --------------------------------------------------------------------- |
+| `register-listener!`               | Persist a new entry, return `:listener-id`. Validates registration moment + schema. |
+| `unregister-listener!`             | Transition `:active → :cancelled`.                                    |
+| `mark-listener-dispatched!`        | Transition `:active → :dispatched`, records `:resume/dispatched-at` + `:resume/dispatch-id`. |
+| `cancel-listeners-on-pr-close!`    | Bulk transition every `:active` for a PR URL → `:cancelled`. Used when PR closes without merge. |
+| `sweep-expired-listeners!`         | Bulk transition every `:active` past TTL → `:expired`. Idempotent.   |
+| `read-listener-registry`           | Load the registry; returns `empty-registry` on missing file.          |
+| `listeners-for-pr` / `active-listeners-for-pr` / `listeners-for-agent` | Pure queries. |
+
+State transition table:
+
+```text
+register     :→ :active
+unregister!  :active → :cancelled
+mark-dispatched!         :active → :dispatched
+mark-cancelled-on-pr-close! :active → :cancelled (bulk per PR)
+sweep-expired!           :active → :expired (TTL-driven, bulk)
+```
+
+## Test plan
+
+- [x] `clj-kondo`: clean.
+- [x] `listener-registry-test`: 18 tests / 57 assertions pass.
+- [x] Coverage:
+  - Read on missing / blank / corrupt-EDN files
+  - register happy path + bad `:registered-by` rejection + malformed-entry rejection + multiple entries per PR + TTL
+    default
+  - Each transition (unregister / mark-dispatched / cancel-on-pr-close / sweep-expired)
+  - `auto-expirable?` predicate edge cases
+  - sweep idempotency
+  - Lookup by PR + by agent
+  - Write-rename leaves no `.tmp` files
+  - `.miniforge/` auto-created
+- [x] `bb pre-commit`: pending (will run on commit).
+
+## What's NOT in this PR
+
+- **Resume Signal Dispatcher** — uses this registry, lands separately.
+- **Listener registration from release phase / authoring agents** —
+  currently the registry is only written via direct API calls.
+  Wiring registration into the release phase + N11 operator binding
+  surface is its own work.
+- **Append-only event log storage** — v1 hardening per design note above.
+- **File locking** — single-process v0; multi-process needs adding.
+- **Multi-tenant store** — Enterprise (per N12); single-tenant artifact
+  path is the default.
+
+## References
+
+- Spec: N13 §2.7 + `specs/informative/n13-listener-registry.md` (both from #808).
+- #808 — N13 foundations.
+- #818 — `pr review --post`.
+- #837 — `pr review-monitor`.
+- Resume Signal Dispatcher — next PR after this one.

--- a/docs/pull-requests/2026-05-09-feat-n13-listener-registry-impl.md
+++ b/docs/pull-requests/2026-05-09-feat-n13-listener-registry-impl.md
@@ -98,7 +98,7 @@ sweep-expired!           :active → :expired (TTL-driven, bulk)
   - Lookup by PR + by agent
   - Write-rename leaves no `.tmp` files
   - `.miniforge/` auto-created
-- [x] `bb pre-commit`: pending (will run on commit).
+- [x] `bb pre-commit`: ✅ ALL PRE-COMMIT CHECKS PASSED.
 
 ## What's NOT in this PR
 


### PR DESCRIPTION
## Summary

Persistence primitive for the N13 §2.7 listener registry — the binding from PR URL → set of agents waiting on the PR's merge. Schema landed in [#808](https://github.com/miniforge-ai/miniforge/pull/808) (`specs/informative/n13-listener-registry.md`); this PR ships the read/write/transition code that makes it usable.

Prerequisite for the **Resume Signal Dispatcher** (next PR), which delivers structured resume primers to each `:active` listener on `pull_request.closed.merged`. The dispatcher is the operator-load killer per the #808 mining (~448 manual `merged` acks across recent sessions); registry is the gate.

Full PR doc: [`docs/pull-requests/2026-05-09-feat-n13-listener-registry-impl.md`](docs/pull-requests/2026-05-09-feat-n13-listener-registry-impl.md).

## Design

- **Storage**: per-worktree artifact at `<worktree>/.miniforge/listener-registry.edn`. `.miniforge/` auto-created on first register.
- **Atomicity**: write-rename — serialize → write `<path>.tmp` → POSIX-atomic `mv` over canonical path. Eliminates partial reads from concurrent readers.
- **State model**: v0 stores the current-state snapshot per the spec schema's `:status` field. The append-only event log called for in spec §Lifecycle is **v1 hardening** — schema already supports it, v1 swaps backend without changing the public surface.
- **Schema validation**: malli (`ListenerEntry`, `Registry`, `ResumeChannel`). `read-registry` enforces structural shape on load — catches the corruption mode where `edn/read-string` reads only the first form and silently ignores trailing garbage.
- **Registration moments**: `:authoring-agent` / `:operator` / `:workflow` per spec §Registration moments. Other `:registered-by` values rejected with typed error.

## Public API (re-exported through `pr-lifecycle.interface`)

| API | Behavior |
|---|---|
| `register-listener!` | Persist a new entry, return `:listener-id`. Validates registration moment + schema. |
| `unregister-listener!` | `:active → :cancelled` |
| `mark-listener-dispatched!` | `:active → :dispatched`, records `:resume/dispatched-at` + `:resume/dispatch-id` |
| `cancel-listeners-on-pr-close!` | Bulk `:active → :cancelled` for a PR URL (PR closed without merge) |
| `sweep-expired-listeners!` | Bulk `:active → :expired` past TTL. Idempotent. |
| `read-listener-registry` | Load registry; `empty-registry` on missing file |
| `listeners-for-pr` / `active-listeners-for-pr` / `listeners-for-agent` | Pure queries |

## Test plan

- [x] `clj-kondo`: clean.
- [x] `listener-registry-test`: 18 tests / 57 assertions pass.
- [x] Coverage: read on missing/blank/corrupt-EDN; register happy path + bad-`:registered-by` rejection + malformed-entry rejection + multiple entries per PR + TTL default; every state transition; `auto-expirable?` edge cases; sweep idempotency; lookup by PR + agent; write-rename leaves no `.tmp` files; `.miniforge/` auto-created.
- [x] `bb pre-commit`: ✅ ALL PRE-COMMIT CHECKS PASSED.

## Commit budget

853 insertions across 4 files. Override rationale: cohesive registry primitive — schema + storage + lifecycle + interface + tests + docs ship together. Splitting creates artificial cross-PR deps (interface without impl is dead code; impl without tests can't be verified; tests without persistence can't be exercised). Logged via `MINIFORGE_COMMIT_BUDGET_OVERRIDE`.

## What's NOT in this PR

- **Resume Signal Dispatcher** — uses this registry, lands separately.
- **Listener registration from release phase / authoring agents** — currently the registry is only written via direct API calls. Wiring registration into the release phase + N11 operator binding surface is its own work.
- **Append-only event log storage** — v1 hardening per design note above.
- **File locking** — single-process v0; multi-process needs adding.
- **Multi-tenant store** — Enterprise (per N12); single-tenant artifact path is the default.

## References

- Spec: N13 §2.7 + `specs/informative/n13-listener-registry.md` (both from #808).
- #808 — N13 foundations.
- #818 — `pr review --post`.
- #837 — `pr review-monitor`.
- Resume Signal Dispatcher — next PR after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)