### PR TITLE
fix(workflow): report wall-clock duration in runner banner

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -249,18 +249,64 @@
               exec-metrics
               (select-keys phase-metrics [:tokens :cost-usd :duration-ms])))
 
+(defn- ->epoch-millis
+  "Coerce a :execution/started-at / :execution/ended-at value to a
+   long epoch-millis. Different writers use different representations
+   (context.clj writes Long via System/currentTimeMillis;
+   runner.clj writes java.time.Instant via Instant/now), and we
+   need to subtract them — that inconsistency is its own bug, but
+   coercing here keeps the wall-clock stamp from NPE-ing on either
+   shape. Returns nil for unrecognised inputs so the caller skips
+   the stamp instead of producing nonsense."
+  [t]
+  (cond
+    (number? t)                          (long t)
+    (instance? java.time.Instant t)      (.toEpochMilli ^java.time.Instant t)
+    :else                                nil))
+
+(defn- stamp-wall-clock-duration
+  "Overwrite :execution/metrics :duration-ms with the actual workflow
+   wall-clock (`ended-at` − `started-at`). Tokens and cost still sum
+   correctly across phases — those are independent per-phase resource
+   consumption — but :duration-ms is the user-facing 'how long did
+   this run take' answer, which under DAG parallelism and per-phase
+   summing diverges from the wall-clock the user is watching.
+
+   Pre-fix, the runner banner reported `Duration: 9.7m` for a ~50m
+   wall run because :duration-ms was sum-of-phases — an aggregate
+   that means little when phases run in parallel and even less when
+   sub-workflow duration didn't propagate. Post-fix, banner shows
+   wall-clock; sum-of-phases is recoverable from the per-phase
+   results if a future analysis ever needs it."
+  [ctx]
+  (let [started-at (->epoch-millis (:execution/started-at ctx))
+        ended-at   (->epoch-millis (:execution/ended-at ctx))]
+    (if (and started-at ended-at)
+      (assoc-in ctx [:execution/metrics :duration-ms]
+                (max 0 (- ended-at started-at)))
+      ctx)))
+
 (defn transition-to-completed
-  "Transition workflow to completed state using FSM."
+  "Transition workflow to completed state using FSM. Stamps
+   :execution/ended-at and overwrites :execution/metrics
+   :duration-ms with the wall-clock so the runner banner reflects
+   how long the run actually took (not sum-of-phases under
+   parallelism)."
   [ctx]
   (-> (if (:execution/fsm-machine ctx)
         (transition-execution ctx :complete)
         (assoc ctx :execution/status :completed))
-      (assoc :execution/ended-at (System/currentTimeMillis))))
+      (assoc :execution/ended-at (System/currentTimeMillis))
+      stamp-wall-clock-duration))
 
 (defn transition-to-failed
-  "Transition workflow to failed state using FSM."
+  "Transition workflow to failed state using FSM. Same wall-clock
+   duration semantics as transition-to-completed — duration is
+   reported even on failure so the user can see how long the run
+   ran before failing."
   [ctx]
   (-> (if (:execution/fsm-machine ctx)
         (transition-execution ctx :fail)
         (assoc ctx :execution/status :failed))
-      (assoc :execution/ended-at (System/currentTimeMillis))))
+      (assoc :execution/ended-at (System/currentTimeMillis))
+      stamp-wall-clock-duration))

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -251,13 +251,18 @@
 
 (defn- ->epoch-millis
   "Coerce a :execution/started-at / :execution/ended-at value to a
-   long epoch-millis. Different writers use different representations
-   (context.clj writes Long via System/currentTimeMillis;
-   runner.clj writes java.time.Instant via Instant/now), and we
-   need to subtract them — that inconsistency is its own bug, but
-   coercing here keeps the wall-clock stamp from NPE-ing on either
-   shape. Returns nil for unrecognised inputs so the caller skips
-   the stamp instead of producing nonsense."
+   long epoch-millis. Different writers use different
+   representations (context.clj writes Long via
+   System/currentTimeMillis; runner.clj writes java.time.Instant via
+   Instant/now), and the wall-clock stamp needs to subtract them.
+   That inconsistency is its own bug; coercing here keeps the stamp
+   from failing on either shape — specifically:
+
+     - nil started-at / ended-at → nil here, caller skips the stamp;
+     - Instant input → unguarded subtraction would
+       ClassCastException (java.time.Instant is not a Number);
+     - any unrecognised type → nil, caller skips rather than
+       producing nonsense."
   [t]
   (cond
     (number? t)                          (long t)

--- a/components/workflow/test/ai/miniforge/workflow/context_duration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/context_duration_test.clj
@@ -1,0 +1,132 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.context-duration-test
+  "Pin the wall-clock semantic of :execution/metrics :duration-ms.
+   Pre-fix the field summed per-phase :duration-ms which under DAG
+   parallelism overcounted (3 parallel sub-workflows × ~50m each =
+   150m sum) or undercounted (sub-workflow durations didn't propagate
+   into parent metrics). Post-fix it's the workflow wall-clock
+   (`ended-at` − `started-at`)."
+  (:require
+   [ai.miniforge.workflow.context :as context]
+   [clojure.test :refer [deftest is testing]]))
+
+(def ^:private synthetic-started-at
+  "Fixed instant in epoch ms — keeps the assertion deterministic."
+  1000000000)
+
+(def ^:private synthetic-ended-at
+  "Synthetic-started + 50 minutes. Matches the dogfood scenario
+   that surfaced this bug: ~50m wall, banner reported 9.7m."
+  (+ synthetic-started-at (* 50 60 1000)))
+
+(def ^:private fifty-minutes-ms
+  (* 50 60 1000))
+
+(deftest transition-to-completed-stamps-wall-clock-duration-test
+  (testing "transition-to-completed sets :execution/metrics :duration-ms
+            to (ended-at − started-at), overwriting any sum-of-phases
+            value the merge-phase-metrics step accumulated. Tokens
+            and cost stay summed across phases — those represent
+            independent per-phase resource consumption — but
+            duration is wall-clock so the runner banner shows the
+            user how long the run actually took."
+    (let [ctx {:execution/started-at synthetic-started-at
+               :execution/metrics    {:tokens 25864
+                                      :cost-usd 0.42
+                                      :duration-ms 582000}}
+          completed (with-redefs [context/transition-execution identity]
+                      (-> ctx
+                          (assoc :execution/ended-at synthetic-ended-at)
+                          context/transition-to-completed))]
+      ;; transition-to-completed re-stamps :execution/ended-at with
+      ;; (System/currentTimeMillis); we control started-at so the
+      ;; computed duration is approximately (now − synthetic-started)
+      ;; — which dwarfs any plausible run, so an exact assertion
+      ;; would be brittle. Assert the inequality + ordering instead.
+      (is (>= (get-in completed [:execution/metrics :duration-ms])
+              fifty-minutes-ms)
+          "wall-clock duration is at least the synthetic 50m gap —
+           the actual stamp uses currentTimeMillis so it's larger,
+           not smaller, than the synthetic gap")
+      (is (= 25864 (get-in completed [:execution/metrics :tokens]))
+          "tokens preserved")
+      (is (= 0.42 (get-in completed [:execution/metrics :cost-usd]))
+          "cost preserved"))))
+
+(deftest transition-to-failed-stamps-wall-clock-duration-test
+  (testing "Failed workflows also report wall-clock duration so
+            the user can see how long the run ran before failing."
+    (let [ctx {:execution/started-at synthetic-started-at
+               :execution/metrics    {:tokens 1000
+                                      :cost-usd 0.01
+                                      :duration-ms 30000}}
+          failed (with-redefs [context/transition-execution identity]
+                   (-> ctx
+                       (assoc :execution/ended-at synthetic-ended-at)
+                       context/transition-to-failed))]
+      (is (>= (get-in failed [:execution/metrics :duration-ms])
+              fifty-minutes-ms)
+          "duration reflects the synthetic 50m gap floor"))))
+
+(deftest transition-without-started-at-leaves-duration-untouched-test
+  (testing "When :execution/started-at is missing (older callers /
+            partial state), the wall-clock stamp is a no-op rather
+            than producing nonsense. The pre-existing per-phase sum
+            is preserved as a fallback."
+    (let [ctx {:execution/metrics {:tokens 100
+                                   :cost-usd 0.001
+                                   :duration-ms 5000}}
+          completed (with-redefs [context/transition-execution identity]
+                      (context/transition-to-completed ctx))]
+      (is (= 5000 (get-in completed [:execution/metrics :duration-ms]))
+          "no started-at → duration left as the pre-existing value")
+      (is (some? (:execution/ended-at completed))
+          "ended-at is still stamped"))))
+
+(deftest transition-handles-instant-shape-started-at-test
+  (testing "Pre-existing inconsistency: context.clj writes
+            :execution/started-at as System/currentTimeMillis (Long),
+            runner.clj writes it as java.time.Instant/now. The
+            wall-clock stamp must coerce either shape to epoch
+            millis before subtracting, otherwise it ClassCastException
+            on Instant inputs and crashes the workflow's terminal
+            transition.
+
+            Surfaced by run-pipeline-empty-test + fsm-state-tracked-
+            test in the pre-commit suite — both use the runner
+            path and were ERROR-ing on the unguarded subtraction
+            until ->epoch-millis was added."
+    (let [started-instant (java.time.Instant/ofEpochMilli synthetic-started-at)
+          ctx {:execution/started-at started-instant
+               :execution/metrics    {:tokens 0 :cost-usd 0.0
+                                      :duration-ms 0}}
+          completed (with-redefs [context/transition-execution identity]
+                      (-> ctx
+                          (assoc :execution/ended-at synthetic-ended-at)
+                          context/transition-to-completed))]
+      (is (>= (get-in completed [:execution/metrics :duration-ms])
+              fifty-minutes-ms)
+          "Instant-shaped started-at coerces to millis without throwing"))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.workflow.context-duration-test)
+
+  :leave-this-here)

--- a/components/workflow/test/ai/miniforge/workflow/context_duration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/context_duration_test.clj
@@ -31,59 +31,58 @@
   "Fixed instant in epoch ms — keeps the assertion deterministic."
   1000000000)
 
-(def ^:private synthetic-ended-at
-  "Synthetic-started + 50 minutes. Matches the dogfood scenario
-   that surfaced this bug: ~50m wall, banner reported 9.7m."
-  (+ synthetic-started-at (* 50 60 1000)))
-
-(def ^:private fifty-minutes-ms
-  (* 50 60 1000))
+;; transition-to-completed and transition-to-failed both stamp
+;; :execution/ended-at with (System/currentTimeMillis) at call
+;; time, so we never preset it in the input ctx. Pre-fix tests
+;; were assoc'ing a synthetic ended-at that the transition
+;; immediately overwrote — misleading to readers and didn't
+;; tighten the assertion.
 
 (deftest transition-to-completed-stamps-wall-clock-duration-test
   (testing "transition-to-completed sets :execution/metrics :duration-ms
-            to (ended-at − started-at), overwriting any sum-of-phases
-            value the merge-phase-metrics step accumulated. Tokens
-            and cost stay summed across phases — those represent
-            independent per-phase resource consumption — but
-            duration is wall-clock so the runner banner shows the
-            user how long the run actually took."
+            to (ended-at − started-at) — exact difference, not just
+            a value larger than something. Pin the difference
+            semantic by computing the expected delta from the
+            ended-at the transition itself stamps. Tokens and cost
+            stay summed across phases (independent per-phase
+            resource consumption); duration is wall-clock so the
+            runner banner shows the user how long the run took."
     (let [ctx {:execution/started-at synthetic-started-at
                :execution/metrics    {:tokens 25864
                                       :cost-usd 0.42
                                       :duration-ms 582000}}
           completed (with-redefs [context/transition-execution identity]
-                      (-> ctx
-                          (assoc :execution/ended-at synthetic-ended-at)
-                          context/transition-to-completed))]
-      ;; transition-to-completed re-stamps :execution/ended-at with
-      ;; (System/currentTimeMillis); we control started-at so the
-      ;; computed duration is approximately (now − synthetic-started)
-      ;; — which dwarfs any plausible run, so an exact assertion
-      ;; would be brittle. Assert the inequality + ordering instead.
-      (is (>= (get-in completed [:execution/metrics :duration-ms])
-              fifty-minutes-ms)
-          "wall-clock duration is at least the synthetic 50m gap —
-           the actual stamp uses currentTimeMillis so it's larger,
-           not smaller, than the synthetic gap")
+                      (context/transition-to-completed ctx))
+          stamped-ended-at (:execution/ended-at completed)
+          expected-duration (- stamped-ended-at synthetic-started-at)]
+      (is (= expected-duration
+             (get-in completed [:execution/metrics :duration-ms]))
+          ":duration-ms is the exact (ended-at − started-at) delta —
+           pins the difference semantic so a future regression that
+           accidentally stamps the raw timestamp (or any other large
+           value) fails this assertion")
       (is (= 25864 (get-in completed [:execution/metrics :tokens]))
           "tokens preserved")
       (is (= 0.42 (get-in completed [:execution/metrics :cost-usd]))
           "cost preserved"))))
 
 (deftest transition-to-failed-stamps-wall-clock-duration-test
-  (testing "Failed workflows also report wall-clock duration so
-            the user can see how long the run ran before failing."
+  (testing "Failed workflows also report wall-clock duration so the
+            user can see how long the run ran before failing. Same
+            difference-semantic assertion as the completed-path test
+            (not just '>= some floor')."
     (let [ctx {:execution/started-at synthetic-started-at
                :execution/metrics    {:tokens 1000
                                       :cost-usd 0.01
                                       :duration-ms 30000}}
           failed (with-redefs [context/transition-execution identity]
-                   (-> ctx
-                       (assoc :execution/ended-at synthetic-ended-at)
-                       context/transition-to-failed))]
-      (is (>= (get-in failed [:execution/metrics :duration-ms])
-              fifty-minutes-ms)
-          "duration reflects the synthetic 50m gap floor"))))
+                   (context/transition-to-failed ctx))
+          stamped-ended-at (:execution/ended-at failed)
+          expected-duration (- stamped-ended-at synthetic-started-at)]
+      (is (= expected-duration
+             (get-in failed [:execution/metrics :duration-ms]))
+          ":duration-ms is the exact (ended-at − started-at) delta
+           on the failure path too"))))
 
 (deftest transition-without-started-at-leaves-duration-untouched-test
   (testing "When :execution/started-at is missing (older callers /
@@ -105,25 +104,31 @@
             :execution/started-at as System/currentTimeMillis (Long),
             runner.clj writes it as java.time.Instant/now. The
             wall-clock stamp must coerce either shape to epoch
-            millis before subtracting, otherwise it ClassCastException
-            on Instant inputs and crashes the workflow's terminal
-            transition.
+            millis before subtracting, otherwise it
+            ClassCastException-s on Instant inputs and crashes the
+            workflow's terminal transition.
 
             Surfaced by run-pipeline-empty-test + fsm-state-tracked-
             test in the pre-commit suite — both use the runner
             path and were ERROR-ing on the unguarded subtraction
-            until ->epoch-millis was added."
+            until ->epoch-millis was added.
+
+            Same difference-semantic assertion as the Long-path
+            test: :duration-ms must equal (ended-at − coerced-
+            started-at), not just clear the no-throw bar."
     (let [started-instant (java.time.Instant/ofEpochMilli synthetic-started-at)
           ctx {:execution/started-at started-instant
                :execution/metrics    {:tokens 0 :cost-usd 0.0
                                       :duration-ms 0}}
           completed (with-redefs [context/transition-execution identity]
-                      (-> ctx
-                          (assoc :execution/ended-at synthetic-ended-at)
-                          context/transition-to-completed))]
-      (is (>= (get-in completed [:execution/metrics :duration-ms])
-              fifty-minutes-ms)
-          "Instant-shaped started-at coerces to millis without throwing"))))
+                      (context/transition-to-completed ctx))
+          stamped-ended-at (:execution/ended-at completed)
+          expected-duration (- stamped-ended-at
+                               (.toEpochMilli started-instant))]
+      (is (= expected-duration
+             (get-in completed [:execution/metrics :duration-ms]))
+          "Instant-shaped started-at coerces correctly AND stamps
+           the right delta (not just survives without throwing)"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment


### PR DESCRIPTION
## Summary

Second fix from the 2026-05-10 dogfood. A workflow that ran ~50m wall-clock reported \`Duration: 9.7m\` in the runner banner because \`:execution/metrics :duration-ms\` summed per-phase values — which under DAG parallelism either undercounts or overcounts. PR #840's DAG rollup fix would have made the overcount worse (3 parallel × ~50m = 150m sum).

- **Decision**: tokens + cost stay summed across phases (independent per-phase consumption — sum is the right semantic). Duration becomes wall-clock — answers "how long did this run take?", parallelism-aware by construction.
- **Implementation**: private \`stamp-wall-clock-duration\` overwrites \`:duration-ms\` with \`(ended-at − started-at)\` at \`transition-to-completed\` / \`transition-to-failed\`. Private \`->epoch-millis\` coerces either Long (\`System/currentTimeMillis\`) or \`java.time.Instant\` to millis before subtracting — pre-existing inconsistency: \`context.clj\` writes Long, \`runner.clj\` writes Instant, this fix happens to surface that. Fixed defensively at the read site rather than at every writer.

## Test plan

- [x] 4 tests in new \`context-duration-test\` ns:
  - \`transition-to-completed-stamps-wall-clock-duration\` — 50m synthetic gap → :duration-ms reflects floor; tokens/cost preserved.
  - \`transition-to-failed-stamps-wall-clock-duration\` — same on failure path.
  - \`transition-without-started-at-leaves-duration-untouched\` — no-op fallback preserves pre-existing :duration-ms.
  - \`transition-handles-instant-shape-started-at\` — Instant-shaped started-at coerces correctly (was ClassCastException-ing \`run-pipeline-empty-test\` + \`fsm-state-tracked-test\` until the coercion was added).
- [x] 73 / 233 / 0 / 0 across affected workflow namespaces.
- [x] Full pre-commit suite green.

Refs: \`~/.claude/projects/.../memory/project_dogfood_findings_2026_05_10.md\` (Bug 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)