### PR TITLE
feat(cli): wire per-workflow manifest into run-workflow! (BD-2b sub-3a)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -810,7 +810,6 @@
   (let [v (System/getenv "MINIFORGE_BEST_EFFORT_SHUTDOWN")]
     (boolean (and v (contains? #{"1" "true" "yes" "on"} (str/lower-case v))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; BD-2b sub-3a: per-workflow manifest lifecycle.
 ;;
 ;; `ai.miniforge.event-stream.manifest` is jvm-only (FileLock /
@@ -819,9 +818,20 @@
 ;; rather than a top-level `:require`. Same pattern as the other
 ;; jvm-only deferrals in this file (event-stream.interface lazy
 ;; require around line 853, the resume command at line 1024).
+;;
+;; Stratified-design layering: `manifest-fn` is the lone Layer 1
+;; helper; `start-/mark-/finish-workflow-manifest!` sit at Layer 2
+;; and each independently call `manifest-fn` (never each other).
+;; `run-workflow!` (further down) is the Layer 3 orchestrator that
+;; calls all three lifecycle helpers.
+
+;------------------------------------------------------------------------------ Layer 1 — manifest var resolution
 
 (defn manifest-fn [sym]
   (requiring-resolve (symbol "ai.miniforge.event-stream.manifest" (name sym))))
+
+;------------------------------------------------------------------------------ Layer 2 — lifecycle helpers (compose Layer 1)
+;; Peers; none calls another. `run-workflow!` composes them at Layer 3.
 
 (defn start-workflow-manifest!
   "Init the manifest at `manifest-dir` and start the heartbeat. Returns

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -854,25 +854,42 @@
   "Stamp the manifest with a terminal `status` (`:completed |
    :failed | :cancelled`). Idempotent via the `:marked?` atom — the
    happy path marks `:completed` after drain, the finally block falls
-   back to `:cancelled` only if no prior mark fired."
+   back to `:cancelled` only if no prior mark fired.
+
+   Only flips `marked?` after a successful load + save. If the
+   manifest file is absent (e.g. it was deleted or never written by
+   sub-3b's archive flow), this is a no-op that leaves `marked?`
+   false so a subsequent attempt (e.g. the finally's :cancelled
+   fallback) can still try to write."
   [{:keys [dir marked?]} status]
   (when (and dir (not @marked?))
     (let [load!         (manifest-fn 'load-manifest)
           mark-terminal (manifest-fn 'mark-terminal)
           save!         (manifest-fn 'save-manifest!)]
       (when-let [m (load! dir)]
-        (save! dir (mark-terminal m status)))
-      (reset! marked? true))))
+        (save! dir (mark-terminal m status))
+        (reset! marked? true)))))
 
 (defn finish-workflow-manifest!
   "Stop the heartbeat. Caller is expected to have already called
    `mark-manifest-terminal!` for the happy path; this is the
    shutdown-time cleanup. Swallows exceptions so a manifest IO
-   failure during cleanup doesn't mask the workflow result."
+   failure during cleanup doesn't mask the workflow result.
+
+   `stop-heartbeat!` can raise `InterruptedException` via
+   `awaitTermination`. Swallowing it without restoring the interrupt
+   flag breaks cooperative cancellation — outer frames lose the
+   signal that they're being asked to shut down. We re-interrupt the
+   current thread in that case and still return nil so the cleanup
+   stays best-effort."
   [{:keys [heartbeat]}]
   (when heartbeat
-    (try ((manifest-fn 'stop-heartbeat!) heartbeat)
-         (catch Throwable _ nil))))
+    (try
+      ((manifest-fn 'stop-heartbeat!) heartbeat)
+      (catch InterruptedException _
+        (.interrupt (Thread/currentThread))
+        nil)
+      (catch Exception _ nil))))
 
 (defn- event-stream-shutdown!
   "Run the BD-2a shutdown sequence on `es`: quiesce publishers for

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -810,6 +810,60 @@
   (let [v (System/getenv "MINIFORGE_BEST_EFFORT_SHUTDOWN")]
     (boolean (and v (contains? #{"1" "true" "yes" "on"} (str/lower-case v))))))
 
+;------------------------------------------------------------------------------ Layer 1
+;; BD-2b sub-3a: per-workflow manifest lifecycle.
+;;
+;; `ai.miniforge.event-stream.manifest` is jvm-only (FileLock /
+;; ScheduledExecutorService / java.lang.management). This base loads
+;; under Babashka, so we reach manifest fns via `requiring-resolve`
+;; rather than a top-level `:require`. Same pattern as the other
+;; jvm-only deferrals in this file (event-stream.interface lazy
+;; require around line 853, the resume command at line 1024).
+
+(defn manifest-fn [sym]
+  (requiring-resolve (symbol "ai.miniforge.event-stream.manifest" (name sym))))
+
+(defn start-workflow-manifest!
+  "Init the manifest at `manifest-dir` and start the heartbeat. Returns
+   `{:dir java.io.File :heartbeat ScheduledExecutorService :marked? atom}`
+   for the matching `finish-workflow-manifest!`. Returns nil when no
+   event stream is configured (dashboard-only run) — no on-disk
+   manifest to maintain in that case."
+  [workflow-id event-stream]
+  (when event-stream
+    (let [dir         (es/workflow-dir workflow-id)
+          init-active (manifest-fn 'init-active)
+          save!       (manifest-fn 'save-manifest!)
+          start-hb!   (manifest-fn 'start-heartbeat!)]
+      (save! dir (init-active workflow-id))
+      {:dir       dir
+       :heartbeat (start-hb! dir)
+       :marked?   (atom false)})))
+
+(defn mark-manifest-terminal!
+  "Stamp the manifest with a terminal `status` (`:completed |
+   :failed | :cancelled`). Idempotent via the `:marked?` atom — the
+   happy path marks `:completed` after drain, the finally block falls
+   back to `:cancelled` only if no prior mark fired."
+  [{:keys [dir marked?]} status]
+  (when (and dir (not @marked?))
+    (let [load!         (manifest-fn 'load-manifest)
+          mark-terminal (manifest-fn 'mark-terminal)
+          save!         (manifest-fn 'save-manifest!)]
+      (when-let [m (load! dir)]
+        (save! dir (mark-terminal m status)))
+      (reset! marked? true))))
+
+(defn finish-workflow-manifest!
+  "Stop the heartbeat. Caller is expected to have already called
+   `mark-manifest-terminal!` for the happy path; this is the
+   shutdown-time cleanup. Swallows exceptions so a manifest IO
+   failure during cleanup doesn't mask the workflow result."
+  [{:keys [heartbeat]}]
+  (when heartbeat
+    (try ((manifest-fn 'stop-heartbeat!) heartbeat)
+         (catch Throwable _ nil))))
+
 (defn- event-stream-shutdown!
   "Run the BD-2a shutdown sequence on `es`: quiesce publishers for
    `workflow-id`, then drain sinks. Returns the structured drain result
@@ -863,10 +917,19 @@
             ;; Pass dashboard-url in callbacks if provided
             callbacks-with-url (cond-> callbacks
                                  dashboard-url (assoc :dashboard-url dashboard-url))
-            progress-cleanup (display/start-progress! es quiet)]
+            progress-cleanup (display/start-progress! es quiet)
+            ;; BD-2b sub-3a: per-workflow manifest. Stamps an :active /
+            ;; :live manifest before the pipeline starts and keeps the
+            ;; owner lease renewed via a heartbeat while alive. The
+            ;; happy path below marks :completed/:failed after drain;
+            ;; the finally falls back to :cancelled if neither fired.
+            manifest-handle (start-workflow-manifest! workflow-id es)]
         (try
           (let [result (execute-workflow-pipeline run-pipeline workflow workflow-input callbacks-with-url artifact-store es)]
             (close-artifact-store artifact-store)
+            (mark-manifest-terminal!
+             manifest-handle
+             (if (phase/succeeded? result) :completed :failed))
             ;; BD-2a shutdown ordering: fence late publishers for this
             ;; workflow, then drain sinks before returning. quiesce!
             ;; rejects any post-terminal `publish!` for this workflow
@@ -879,6 +942,12 @@
               (cond-> result
                 (some? shutdown) (assoc :event-durability shutdown))))
           (finally
+            ;; If we got here without marking, the pipeline threw or was
+            ;; otherwise aborted before the success branch ran. Classify
+            ;; as :cancelled to mirror the existing event-stream
+            ;; publish-failure-event! :cancelled branch.
+            (mark-manifest-terminal! manifest-handle :cancelled)
+            (finish-workflow-manifest! manifest-handle)
             (progress-cleanup)))))
     (catch Exception e
       (when-not quiet

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
@@ -1,0 +1,145 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.workflow-runner.manifest-wiring-test
+  "Unit tests for the BD-2b sub-3a manifest wiring helpers in
+   `workflow_runner.clj`. The manifest module itself
+   (`event-stream.manifest`) is jvm-only with its own comprehensive
+   suite from sub-2; these tests focus on the runner-side
+   orchestration: lifecycle ordering, idempotent terminal marking,
+   nil-event-stream short-circuit, exception-tolerant cleanup."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.workflow-runner :as sut]
+   [ai.miniforge.event-stream.interface :as es]))
+
+;------------------------------------------------------------------------------ Fixture
+
+(defn- mock-manifest-fns
+  "Build a map of mock manifest fns recording every call into `calls`.
+   `start-heartbeat!` returns a sentinel handle that `stop-heartbeat!`
+   recognises."
+  [calls]
+  (let [heartbeat-handle :mock-heartbeat-handle]
+    {'init-active      (fn [wid] (swap! calls conj [:init-active wid])
+                          {:workflow_id wid :status :active})
+     'save-manifest!   (fn [dir m] (swap! calls conj [:save dir m]))
+     'load-manifest    (fn [dir]
+                         (swap! calls conj [:load dir])
+                         {:workflow_id :w :status :active})
+     'mark-terminal    (fn [m status] (swap! calls conj [:mark-terminal status])
+                          (assoc m :status status))
+     'start-heartbeat! (fn [dir]
+                         (swap! calls conj [:start-heartbeat dir])
+                         heartbeat-handle)
+     'stop-heartbeat!  (fn [hb] (swap! calls conj [:stop-heartbeat hb]))}))
+
+(defn- with-mocked-manifest
+  "Bind `manifest-fn` to look up the mock map. Returns whatever `f`
+   returns; the call log is in `calls`."
+  [f]
+  (let [calls (atom [])
+        mocks (mock-manifest-fns calls)]
+    (with-redefs [sut/manifest-fn (fn [sym] (get mocks sym))
+                  es/workflow-dir (fn [wid] (java.io.File. (str "/tmp/test-" wid)))]
+      (f calls))))
+
+;------------------------------------------------------------------------------ start-workflow-manifest!
+
+(deftest start-workflow-manifest!-no-op-when-event-stream-is-nil
+  (with-mocked-manifest
+    (fn [calls]
+      (is (nil? (sut/start-workflow-manifest! :wid nil)))
+      (is (empty? @calls)
+          "no manifest writes when there's no event stream
+           (dashboard-only runs don't persist events)"))))
+
+(deftest start-workflow-manifest!-inits-and-starts-heartbeat
+  (with-mocked-manifest
+    (fn [calls]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)
+            ordered (mapv first @calls)]
+        (is (some? handle))
+        (is (some? (:dir handle)))
+        (is (= :mock-heartbeat-handle (:heartbeat handle)))
+        (is (false? @(:marked? handle))
+            "marked? starts false; flips on first mark-manifest-terminal!")
+        (is (= [:init-active :save :start-heartbeat] ordered)
+            "lifecycle order: build active manifest → save → start heartbeat")))))
+
+;------------------------------------------------------------------------------ mark-manifest-terminal!
+
+(deftest mark-manifest-terminal!-no-op-when-handle-nil
+  (with-mocked-manifest
+    (fn [calls]
+      (sut/mark-manifest-terminal! nil :completed)
+      (is (empty? @calls)))))
+
+(deftest mark-manifest-terminal!-loads-marks-and-saves
+  (with-mocked-manifest
+    (fn [calls]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (reset! calls [])
+        (sut/mark-manifest-terminal! handle :completed)
+        (is (= [:load :mark-terminal :save] (mapv first @calls))
+            "mark-terminal must load → transition → save in order")
+        (is (true? @(:marked? handle)))))))
+
+(deftest mark-manifest-terminal!-idempotent-via-marked?
+  (with-mocked-manifest
+    (fn [calls]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (reset! calls [])
+        (sut/mark-manifest-terminal! handle :completed)
+        ;; Second call (e.g. the finally block firing :cancelled after
+        ;; the happy path already marked :completed) must be a no-op
+        ;; so we don't overwrite the success status.
+        (sut/mark-manifest-terminal! handle :cancelled)
+        (let [statuses (filter #(= :mark-terminal (first %)) @calls)]
+          (is (= 1 (count statuses))
+              "second mark-manifest-terminal! must not fire after marked? is true")
+          (is (= [:mark-terminal :completed] (first statuses))
+              "the first status sticks"))))))
+
+;------------------------------------------------------------------------------ finish-workflow-manifest!
+
+(deftest finish-workflow-manifest!-no-op-when-handle-nil
+  (with-mocked-manifest
+    (fn [calls]
+      (sut/finish-workflow-manifest! nil)
+      (is (empty? @calls)))))
+
+(deftest finish-workflow-manifest!-stops-heartbeat
+  (with-mocked-manifest
+    (fn [calls]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (reset! calls [])
+        (sut/finish-workflow-manifest! handle)
+        (is (= [[:stop-heartbeat :mock-heartbeat-handle]] @calls))))))
+
+(deftest finish-workflow-manifest!-swallows-throwables
+  ;; stop-heartbeat! is called from a finally block during shutdown.
+  ;; An IO failure there must not mask the actual workflow result.
+  (let [calls (atom [])
+        boom-mocks (assoc (mock-manifest-fns calls)
+                          'stop-heartbeat! (fn [_] (throw (RuntimeException. "boom"))))]
+    (with-redefs [sut/manifest-fn (fn [sym] (get boom-mocks sym))
+                  es/workflow-dir (fn [_] (java.io.File. "/tmp/test"))]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (is (nil? (sut/finish-workflow-manifest! handle))
+            "stop-heartbeat! throw must not propagate")))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
@@ -100,6 +100,26 @@
             "mark-terminal must load → transition → save in order")
         (is (true? @(:marked? handle)))))))
 
+(deftest mark-manifest-terminal!-leaves-marked?-false-when-manifest-absent
+  ;; load-manifest returns nil when the file isn't on disk (e.g. the
+  ;; archive flow moved it between ticks). Marking must not flip the
+  ;; idempotency flag in that case — otherwise the finally's
+  ;; :cancelled fallback (and any future retry) would be permanently
+  ;; suppressed even though no terminal status ever got written.
+  (let [calls (atom [])
+        nil-load-mocks (assoc (mock-manifest-fns calls)
+                              'load-manifest (fn [_dir] nil))]
+    (with-redefs [sut/manifest-fn (fn [sym] (get nil-load-mocks sym))
+                  es/workflow-dir (fn [wid] (java.io.File. (str "/tmp/test-" wid)))]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (reset! calls [])
+        (sut/mark-manifest-terminal! handle :completed)
+        (is (false? @(:marked? handle))
+            "absent manifest → marked? stays false so subsequent
+             attempts can still try to write the terminal status")
+        (is (= [:load] (mapv first @calls))
+            "load was attempted but no save fired (nothing to update)")))))
+
 (deftest mark-manifest-terminal!-idempotent-via-marked?
   (with-mocked-manifest
     (fn [calls]
@@ -143,3 +163,26 @@
       (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
         (is (nil? (sut/finish-workflow-manifest! handle))
             "stop-heartbeat! throw must not propagate")))))
+
+(deftest finish-workflow-manifest!-restores-interrupt-flag
+  ;; stop-heartbeat! raises InterruptedException via awaitTermination.
+  ;; Swallowing it without restoring the thread's interrupt flag
+  ;; breaks cooperative cancellation — outer frames lose the signal
+  ;; that they're being asked to shut down. We re-interrupt and
+  ;; still return nil so cleanup stays best-effort.
+  (let [calls (atom [])
+        interrupt-mocks (assoc (mock-manifest-fns calls)
+                               'stop-heartbeat! (fn [_]
+                                                  (throw (InterruptedException. "shutdown"))))]
+    ;; Clear any leaked interrupt before the test.
+    (Thread/interrupted)
+    (with-redefs [sut/manifest-fn (fn [sym] (get interrupt-mocks sym))
+                  es/workflow-dir (fn [_] (java.io.File. "/tmp/test"))]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (is (nil? (sut/finish-workflow-manifest! handle))
+            "InterruptedException is still swallowed (best-effort cleanup)")
+        ;; `Thread/interrupted` reads-and-clears; if we set the flag
+        ;; correctly it should return true now.
+        (is (true? (Thread/interrupted))
+            "current thread's interrupt flag must be restored
+             so cooperative-cancellation callers above us see it")))))

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -28,7 +28,8 @@
    [ai.miniforge.event-stream.interface.events :as events]
    [ai.miniforge.event-stream.interface.listeners :as listeners]
    [ai.miniforge.event-stream.interface.stream :as stream]
-   [ai.miniforge.event-stream.reader :as reader]))
+   [ai.miniforge.event-stream.reader :as reader]
+   [ai.miniforge.event-stream.sinks :as sinks]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Stream lifecycle and control state
@@ -47,6 +48,11 @@
 (def unsubscribe! stream/unsubscribe!)
 (def get-events stream/get-events)
 (def get-latest-status stream/get-latest-status)
+
+;; BD-2b: canonical on-disk paths. Exposed so callers outside this
+;; component (cli workflow runner, sub-3 cleanup) agree with the file
+;; sink on where a workflow's events + manifest live.
+(def workflow-dir sinks/workflow-dir)
 
 ;; BD-2a shutdown-ordering primitives.
 (def quiesce! stream/quiesce!)

--- a/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
@@ -55,13 +55,32 @@
    [java.time Instant]
    [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Defaults — enums, filenames, operator knobs all loaded from
-;; `resources/config/event-stream/manifest-defaults.edn`. Pulling them
-;; out keeps the contract values in one place visible to both the
-;; Malli schema below and the cross-repo JSON Schema fixture at
-;; `contracts/event-stream/manifest.schema.json`, and lets operators
-;; tune the runtime knobs (TTL, heartbeat period) without code edits.
+;; STRATIFIED-DESIGN LAYERING
+;;
+;; Layers are a strict DAG: each layer is a vocabulary for the next
+;; one up; a function only calls functions in strictly-lower layers,
+;; never peers in the same layer. Layer comments below mark each
+;; stratum; if you find yourself wanting one function in a layer to
+;; call another, the called one belongs in a lower layer.
+;;
+;; Quick map:
+;;
+;;   Layer 0  defaults, data shapes, atomic Java-interop helpers
+;;            (snowflake-event-id-re, legal-archive-transitions,
+;;             manifest-path, iso-now, pid-string, hostname-string,
+;;             default-heartbeat-error-log!, stop-heartbeat!)
+;;   Layer 1  single-concern primitives built on Layer 0
+;;            (valid?, explain, legal-archive-transition?,
+;;             fresh-owner, renew-lease, lease-fresh?, owner-pid-alive?)
+;;   Layer 2  compose Layer 1 primitives
+;;            (transition-archive, init-active, mark-terminal,
+;;             load-manifest, save-manifest!)
+;;   Layer 3  manifest-bound IO that composes Layer 2 read + write
+;;            (renew-lease!)
+;;   Layer 4  scheduled / orchestration
+;;            (start-heartbeat!)
+
+;------------------------------------------------------------------------------ Layer 0 — atomic helpers, defaults, data
 
 (def defaults
   "Manifest defaults loaded from
@@ -80,10 +99,6 @@
 (def snapshot-statuses    (:snapshot-statuses defaults))
 (def default-lease-ttl-seconds (:default-lease-ttl-seconds defaults))
 (def heartbeat-period-seconds  (:heartbeat-period-seconds defaults))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Malli schema — mirrors the RFC v4 shape and the cross-repo
-;; JSON Schema at `contracts/event-stream/manifest.schema.json`.
 
 (def ^:private snowflake-event-id-re
   "16-char lowercase hex per the BD-2b sub-1 Snowflake filename
@@ -119,19 +134,6 @@
      [:lease_renewed_at :string]
      [:lease_ttl_seconds [:int {:min 1}]]]]])
 
-(defn valid?
-  "True if `m` matches the manifest schema."
-  [m]
-  (m/validate Manifest m))
-
-(defn explain
-  "Return a malli explanation when `m` does not match. nil when valid."
-  [m]
-  (m/explain Manifest m))
-
-;------------------------------------------------------------------------------ Layer 0
-;; State machine
-
 (def ^:private legal-archive-transitions
   "Forward-only edges. Backwards moves (e.g. archived → live) are
    never legal — once events have been moved they don't come back."
@@ -139,28 +141,6 @@
    :archiving  #{:archived :live}        ; rollback to :live on aborted archive
    :archived   #{:tombstoned}
    :tombstoned #{}})
-
-(defn legal-archive-transition?
-  "True iff the manifest may move from `from` to `to`."
-  [from to]
-  (boolean (contains? (get legal-archive-transitions from #{}) to)))
-
-(defn transition-archive
-  "Pure: move the manifest's `archive_status` from its current value
-   to `to`, returning the updated manifest. Throws ex-info on illegal
-   moves so callers can't silently corrupt the state machine."
-  [manifest to]
-  (let [from (:archive_status manifest)]
-    (if (legal-archive-transition? from to)
-      (assoc manifest :archive_status to)
-      (throw (ex-info "Illegal archive_status transition"
-                      {:reason :illegal-archive-transition
-                       :from   from
-                       :to     to
-                       :workflow-id (:workflow_id manifest)})))))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Owner / lease primitives
 
 (defn- ^String iso-now
   "ISO-8601 instant for `lease_renewed_at` / `created_at` etc."
@@ -180,6 +160,56 @@
   []
   (try (.getCanonicalHostName (InetAddress/getLocalHost))
        (catch Exception _ "unknown-host")))
+
+(defn manifest-path
+  "Return the manifest.json path under `workflow-dir`. The caller
+   chooses live/{wid} vs archived/{wid} — manifest is the same shape
+   in both."
+  ^File [workflow-dir]
+  (io/file workflow-dir manifest-filename))
+
+(defn- default-heartbeat-error-log!
+  "Last-resort logging when no `:on-error` callback is supplied. Writes
+   a single-line warning to stderr so persistent IO failures during
+   the heartbeat are observable in the operator's terminal / CI logs
+   rather than silently disappearing. The workflow runner is the
+   normal caller and should prefer to wire its own logger via
+   `:on-error`."
+  [^Throwable t workflow-dir]
+  (binding [*out* *err*]
+    (println (str "WARNING: manifest heartbeat renew failed for "
+                  (.getAbsolutePath ^File (io/file workflow-dir))
+                  ": " (.getMessage t)))))
+
+(defn stop-heartbeat!
+  "Shut a heartbeat executor down. Waits up to `:timeout-ms` (default
+   1000) for the in-flight renew to finish, then forces. Independent
+   of `start-heartbeat!` — placed in Layer 0 because it has no other
+   calls into this namespace."
+  ([^ScheduledExecutorService ex] (stop-heartbeat! ex {}))
+  ([^ScheduledExecutorService ex {:keys [timeout-ms] :or {timeout-ms 1000}}]
+   (when ex
+     (.shutdown ex)
+     (when-not (.awaitTermination ex (long timeout-ms) TimeUnit/MILLISECONDS)
+       (.shutdownNow ex))
+     nil)))
+
+;------------------------------------------------------------------------------ Layer 1 — single-concern primitives over Layer 0
+
+(defn valid?
+  "True if `m` matches the manifest schema."
+  [m]
+  (m/validate Manifest m))
+
+(defn explain
+  "Return a malli explanation when `m` does not match. nil when valid."
+  [m]
+  (m/explain Manifest m))
+
+(defn legal-archive-transition?
+  "True iff the manifest may move from `from` to `to`."
+  [from to]
+  (boolean (contains? (get legal-archive-transitions from #{}) to)))
 
 (defn fresh-owner
   "Build an owner map with the calling process's pid + host, marking
@@ -221,8 +251,21 @@
              (.isPresent (java.lang.ProcessHandle/of pid)))
            (catch Exception _ false)))))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Manifest construction
+;------------------------------------------------------------------------------ Layer 2 — compose Layer 1
+
+(defn transition-archive
+  "Pure: move the manifest's `archive_status` from its current value
+   to `to`, returning the updated manifest. Throws ex-info on illegal
+   moves so callers can't silently corrupt the state machine."
+  [manifest to]
+  (let [from (:archive_status manifest)]
+    (if (legal-archive-transition? from to)
+      (assoc manifest :archive_status to)
+      (throw (ex-info "Illegal archive_status transition"
+                      {:reason :illegal-archive-transition
+                       :from   from
+                       :to     to
+                       :workflow-id (:workflow_id manifest)})))))
 
 (defn init-active
   "Build a fresh `:active` / `:live` manifest for a new workflow.
@@ -255,16 +298,6 @@
   (assoc manifest
          :status       status
          :completed_at (iso-now)))
-
-;------------------------------------------------------------------------------ Layer 0
-;; File IO — atomic write via temp + Files/move(ATOMIC_MOVE)
-
-(defn manifest-path
-  "Return the manifest.json path under `workflow-dir`. The caller
-   chooses live/{wid} vs archived/{wid} — manifest is the same shape
-   in both."
-  ^File [workflow-dir]
-  (io/file workflow-dir manifest-filename))
 
 (defn load-manifest
   "Read and parse a manifest from disk. Returns the parsed map (with
@@ -329,6 +362,8 @@
                              StandardCopyOption/REPLACE_EXISTING]))
     final))
 
+;------------------------------------------------------------------------------ Layer 3 — manifest-bound IO composing Layer 2 read + write
+
 (defn renew-lease!
   "Re-stamp the lease and write the manifest atomically. Returns the
    updated manifest. Idempotent — a missing manifest is a no-op
@@ -340,21 +375,7 @@
       (save-manifest! workflow-dir renewed)
       renewed)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Heartbeat — periodic lease renewal while the workflow is live.
-
-(defn- default-heartbeat-error-log!
-  "Last-resort logging when no `:on-error` callback is supplied. Writes
-   a single-line warning to stderr so persistent IO failures during
-   the heartbeat are observable in the operator's terminal / CI logs
-   rather than silently disappearing. The workflow runner is the
-   normal caller and should prefer to wire its own logger via
-   `:on-error`."
-  [^Throwable t workflow-dir]
-  (binding [*out* *err*]
-    (println (str "WARNING: manifest heartbeat renew failed for "
-                  (.getAbsolutePath ^File (io/file workflow-dir))
-                  ": " (.getMessage t)))))
+;------------------------------------------------------------------------------ Layer 4 — scheduled orchestration
 
 (defn ^ScheduledExecutorService start-heartbeat!
   "Start a single-threaded scheduled executor that renews the
@@ -393,14 +414,3 @@
                            (long period-seconds)
                            TimeUnit/SECONDS)
      ex)))
-
-(defn stop-heartbeat!
-  "Shut the heartbeat executor down. Waits up to `:timeout-ms`
-   (default 1000) for the in-flight renew to finish, then forces."
-  ([^ScheduledExecutorService ex] (stop-heartbeat! ex {}))
-  ([^ScheduledExecutorService ex {:keys [timeout-ms] :or {timeout-ms 1000}}]
-   (when ex
-     (.shutdown ex)
-     (when-not (.awaitTermination ex (long timeout-ms) TimeUnit/MILLISECONDS)
-       (.shutdownNow ex))
-     nil)))

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -122,6 +122,19 @@
 
 ;;------------------------------------------------------------------------------ Layer 0: File Sink paths
 
+(defn- workflow-id-segment
+  "Normalize a workflow-id into a path segment safe for the OS
+   filesystem. Keywords become their plain name (`:canonical-sdlc` →
+   `canonical-sdlc`) — `(str ...)` would otherwise include the colon
+   prefix, which is invalid on Windows and creates surprising layouts
+   elsewhere. UUIDs / strings pass through `str` unchanged. Reused by
+   `workflow-dir` and `event-file-path` so on-disk path normalisation
+   is consistent across all callers."
+  ^String [workflow-id]
+  (if (keyword? workflow-id)
+    (name workflow-id)
+    (str workflow-id)))
+
 (defn workflow-dir
   "Return the per-workflow directory under `base-dir` (default
    `~/.miniforge/events`). Canonical path for `{base-dir}/{workflow-id}/`
@@ -132,7 +145,7 @@
   (^java.io.File [workflow-id]
    (workflow-dir (default-events-dir) workflow-id))
   (^java.io.File [base-dir workflow-id]
-   (io/file base-dir (str workflow-id))))
+   (io/file base-dir (workflow-id-segment workflow-id))))
 
 (defn event-file-path
   "Return a java.io.File for a new event file in the per-workflow subdirectory.
@@ -149,7 +162,7 @@
   ([workflow-id event]
    (event-file-path (default-events-dir) workflow-id event))
   ([base-dir workflow-id event]
-   (new-event-file-path (io/file base-dir (str workflow-id)) event)))
+   (new-event-file-path (io/file base-dir (workflow-id-segment workflow-id)) event)))
 
 (defn operator-event-file-path
   "Return a java.io.File for a new event file in the operator subdirectory.

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -122,6 +122,18 @@
 
 ;;------------------------------------------------------------------------------ Layer 0: File Sink paths
 
+(defn workflow-dir
+  "Return the per-workflow directory under `base-dir` (default
+   `~/.miniforge/events`). Canonical path for `{base-dir}/{workflow-id}/`
+   — used by the file sink for event files and by the manifest module
+   (BD-2b sub-2) for `manifest.json`. Both reference the same path so
+   they don't drift if the layout ever changes (sub-3b will introduce
+   `live/{workflow-id}/`)."
+  (^java.io.File [workflow-id]
+   (workflow-dir (default-events-dir) workflow-id))
+  (^java.io.File [base-dir workflow-id]
+   (io/file base-dir (str workflow-id))))
+
 (defn event-file-path
   "Return a java.io.File for a new event file in the per-workflow subdirectory.
    Creates the subdirectory if needed. Filename derives from `event`'s

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -59,7 +59,39 @@
     (vec (.listFiles dir))))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; event-file-path
+;; workflow-dir / event-file-path normalisation
+
+(deftest workflow-dir-normalizes-keyword-id
+  ;; Keyword workflow ids (e.g. `:canonical-sdlc` from `workflow run`)
+  ;; must NOT round-trip through `(str ...)` because the result
+  ;; (`":canonical-sdlc"`) carries a colon — invalid on Windows and
+  ;; surprising elsewhere. The shared `workflow-id-segment` helper
+  ;; uses `name` for keywords; UUIDs/strings pass through `str`.
+  (with-temp-dir
+    (fn [dir]
+      (let [kw-path     (sinks/workflow-dir dir :canonical-sdlc)
+            uuid-path   (sinks/workflow-dir dir (random-uuid))
+            string-path (sinks/workflow-dir dir "wf-abc")]
+        (is (= "canonical-sdlc" (.getName kw-path))
+            "keyword id strips the colon — uses (name kw)")
+        (is (re-matches #"[0-9a-f-]{36}" (.getName uuid-path))
+            "uuid id stringifies cleanly")
+        (is (= "wf-abc" (.getName string-path))
+            "string id passes through unchanged")))))
+
+(deftest event-file-path-normalizes-keyword-workflow-id
+  ;; Same normalisation must apply to event-file-path so events and
+  ;; the manifest end up under identical workflow directories.
+  (with-temp-dir
+    (fn [dir]
+      (let [wf-kw :auth-flow
+            event (sample-event {:workflow/id wf-kw})
+            path  (sinks/event-file-path dir wf-kw event)
+            parent (.getParentFile path)]
+        (is (= "auth-flow" (.getName parent))
+            "event-file-path's parent dir uses the same keyword
+             normalisation as workflow-dir so events sit beside the
+             manifest")))))
 
 (deftest event-file-path-test
   (testing "returns a File path ending in .json under an explicit base-dir"


### PR DESCRIPTION
## Summary

First of three sub-PRs for BD-2b sub-3, the BD-2 RFC's atomic-archive section. This slice does the runner-side manifest wiring; sub-3b lands the atomic archive operation + `live/{wid}/` layout migration, sub-3c lands the scheduled cleanup + crashed-snapshot synthesis.

- New helper `event-stream.sinks/workflow-dir` (re-exported through `event-stream.interface`) so the file sink, manifest module, and future cleanup all agree on the per-workflow path. Sub-3b will swap this to a `live/{workflow-id}/` layout — centralising the path now keeps that migration to one site.
- `cli.workflow-runner` gets three small wiring helpers — `start-workflow-manifest!`, `mark-manifest-terminal!`, `finish-workflow-manifest!`. The manifest module is jvm-only and the cli base loads under Babashka, so the helpers reach manifest fns via `requiring-resolve`, matching the existing lazy-load pattern already used here for `event-stream.interface` (line 853) and the resume command (line 1024).
- `run-workflow!` lifecycle:
  - **Before pipeline:** `start-workflow-manifest!` stamps an `:active`/`:live` manifest and starts the heartbeat. No-op for dashboard-only runs (no event stream).
  - **Happy path:** `mark-manifest-terminal!` with `:completed` (when `phase/succeeded? result`) or `:failed`.
  - **Finally:** idempotent `mark-manifest-terminal! :cancelled` fallback (won't overwrite a prior `:completed`/`:failed`), then `finish-workflow-manifest!` to stop the heartbeat. Cleanup swallows throwables so a manifest IO failure during shutdown doesn't mask the workflow result.

## Tests

`bases/cli/test/.../manifest_wiring_test.clj` covers the orchestration via mocked `manifest-fn`:
- `start-workflow-manifest!` no-ops when event stream is nil.
- Init lifecycle ordering (build → save → start heartbeat).
- `mark-manifest-terminal!` load → mark → save sequence; idempotent via `:marked?` so `:cancelled` can't overwrite a prior `:completed`.
- `finish-workflow-manifest!` swallows throwables so shutdown can't mask the workflow result.

The manifest module itself ships its own comprehensive sub-2 suite — these tests focus only on the runner-side glue.

## Out of scope

- BD-2b sub-3b: atomic archive operation (8-step temp + fsync + manifest stage + atomic rename + marker) + the `live/{workflow-id}/` layout migration.
- BD-2b sub-3c: scheduled cleanup pass with per-pass budgets + the three-outcome (`available`/`pending`/`failed`) crashed-snapshot synthesis.

## Validation

`bb pre-commit` green.

## Test plan

- [ ] reviewer agrees the manifest-fn lazy-resolve pattern is the right choice vs marking workflow_runner.clj jvm-only
- [ ] reviewer agrees the runner-public `start-/mark-/finish-` helpers are at the right stratum (vs being inlined into `run-workflow!` directly)
- [ ] reviewer agrees the idempotent-`:cancelled`-fallback shape is right (vs introducing a different sentinel like `:aborted`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)