### PR TITLE
fix(release-executor): use merge-base diff so concurrent main movement doesn't trip destructive-diff

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -111,16 +111,19 @@
       (try-checkout-branch executor env-id branch-name default-branch))))
 
 (defn commits-ahead-of-base
-  "Count commits on HEAD that aren't on `origin/<base-branch>`. Returns
-   nil on git failure (caller treats nil as 'unknown', not zero). Used
-   by step-stage-dirty-files to recognise that a clean worktree may
-   still carry unreleased work in the form of boundary commits — when
-   the implementer's writes were committed at the implement-phase
-   boundary, the release branch inherits them and there is nothing
-   left to stage."
+  "Count commits HEAD has added since branching from `origin/<base>`.
+   Counts against the merge-base (`origin/<base>...HEAD`, three-dot
+   form, right-only) so concurrent movement of `origin/<base>` while
+   the workflow was running doesn't artificially shrink the count to
+   zero. Returns nil on git failure (caller treats nil as 'unknown',
+   not zero). Used by step-stage-dirty-files to recognise that a clean
+   worktree may still carry unreleased work in the form of boundary
+   commits — when the implementer's writes were committed at the
+   implement-phase boundary, the release branch inherits them and
+   there is nothing left to stage."
   [executor env-id base-branch]
   (let [r (exec! executor env-id
-                 (str "git rev-list --count origin/" base-branch "..HEAD"))]
+                 (str "git rev-list --count --right-only origin/" base-branch "...HEAD"))]
     (when (result/succeeded? r)
       (try
         (Long/parseLong (str/trim (:output r "0")))
@@ -268,24 +271,30 @@
       (count-deftest (:output r "")))))
 
 (defn diff-stats-range
-  "Get diff stats for `origin/<base>..HEAD` (the carry-forward range
-   used by the release branch when phase-boundary commits already
-   contain the work). Mirrors `diff-stats` but reads the merge-base
-   range rather than the staged index."
+  "Get diff stats for the changes this branch introduced since branching
+   from `origin/<base>` — i.e. `git diff origin/<base>...HEAD` with the
+   three-dot form, which compares HEAD to the merge-base rather than to
+   the current tip of `origin/<base>`. The two-dot form would compare
+   trees directly, so files merged into `origin/<base>` while the
+   workflow was running would surface as spurious deletions on the
+   branch and trip the destructive-diff gate. Mirrors `diff-stats` but
+   reads the merge-base range rather than the staged index. Used in
+   the boundary-commits release path."
   [executor env-id base-branch]
   (let [r (exec! executor env-id
-                 (str "git diff origin/" base-branch "..HEAD --numstat"))]
+                 (str "git diff origin/" base-branch "...HEAD --numstat"))]
     (when (result/succeeded? r)
       (numstat-totals (:output r "")))))
 
 (defn count-test-defs-range
-  "Count deftest forms added/removed in `origin/<base>..HEAD`. Mirrors
-   `count-test-defs` but reads the merge-base range so the destructive-
-   diff gate keeps inspecting the actual commits being released, not
-   just the staged index (which is empty in the boundary-commits case)."
+  "Count deftest forms added/removed in `origin/<base>...HEAD` (three-dot,
+   merge-base diff). Mirrors `count-test-defs` but reads the merge-base
+   range so the destructive-diff gate keeps inspecting the commits this
+   branch introduced — not deltas caused by `origin/<base>` moving
+   forward concurrently."
   [executor env-id base-branch]
   (let [r (exec! executor env-id
-                 (str "git diff origin/" base-branch "..HEAD -U0"))]
+                 (str "git diff origin/" base-branch "...HEAD -U0"))]
     (when (result/succeeded? r)
       (count-deftest (:output r "")))))
 

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -181,14 +181,19 @@
                   {:release-meta test-release-meta})]
       (is (:success? result)
           "release must succeed when boundary commits already carry the work")
-      (is (some #(clojure.string/includes? % "git rev-list --count origin/main..HEAD") @cmds)
-          "release should consult `git rev-list --count origin/main..HEAD` to detect carry-forward commits")
+      (is (some #(clojure.string/includes? % "git rev-list --count --right-only origin/main...HEAD") @cmds)
+          "release should consult the three-dot, right-only count so concurrent
+           movement of origin/<base> doesn't artificially shrink the count")
       (is (not-any? #(clojure.string/starts-with? % "git commit") @cmds)
           "step-commit must NOT issue a new commit when the boundary commits already exist on the branch")
-      (is (some #(clojure.string/includes? % "git diff origin/main..HEAD --numstat") @cmds)
-          "step-validate-diff must inspect the range diff (origin/<base>..HEAD), not
-           the empty staged diff — boundary commits otherwise bypass the destructive-
-           diff gate entirely."))))
+      (is (some #(clojure.string/includes? % "git diff origin/main...HEAD --numstat") @cmds)
+          "step-validate-diff must inspect the merge-base range diff
+           (origin/<base>...HEAD, three-dot), not the empty staged diff —
+           boundary commits otherwise bypass the destructive-diff gate
+           entirely. Three-dot form is critical: two-dot would compare to
+           the *current* origin/<base>, which can have moved while the
+           workflow was running, surfacing concurrent-merge files as
+           spurious deletions."))))
 
 (deftest release-rejects-destructive-boundary-commits-test
   (testing "step-validate-diff still rejects a destructive release when the
@@ -205,8 +210,8 @@
                                 "git checkout"     {:exit-code 0 :stdout "" :stderr ""}
                                 "git add"          {:exit-code 0 :stdout "" :stderr ""}
                                 "git diff --cached"  {:exit-code 0 :stdout "" :stderr ""}
-                                "git diff origin/main..HEAD --numstat" {:exit-code 0 :stdout destructive-numstat :stderr ""}
-                                "git diff origin/main..HEAD -U0"       {:exit-code 0 :stdout destructive-diff    :stderr ""}
+                                "git diff origin/main...HEAD --numstat" {:exit-code 0 :stdout destructive-numstat :stderr ""}
+                                "git diff origin/main...HEAD -U0"       {:exit-code 0 :stdout destructive-diff    :stderr ""}
                                 "git rev-list"     {:exit-code 0 :stdout "1\n" :stderr ""}
                                 "git rev-parse"    {:exit-code 0 :stdout "deadbeef\n" :stderr ""}})
           result (core/execute-release-phase


### PR DESCRIPTION
## Summary
Stage 3 dogfood Run 9 (workflow `3bba1d5b`, 2026-05-10): plan ✓ → implement ✓ → verify ✓ → review ✓ → release ✗ with `release-executor/destructive-diff` (25 deftests removed, 15 added). The work was clean — 725 insertions across `detector_wiring.{clj,_test.clj}` + `progress_detector/interface.clj`. The "removed" tests lived in `components/pr-lifecycle/src/.../listener_registry*` files that PR #841 had landed on `origin/main` while the dogfood was running. They were never on the release branch, so they should never have appeared in its diff.

## Why
PR #839 used the two-dot form `origin/<base>..HEAD` for the range diff. Two-dot diff compares trees directly against the *current* tip of `origin/<base>` — so concurrent main movement surfaces as spurious deletions on the branch. Three-dot `origin/<base>...HEAD` diffs HEAD against the merge-base, which is the comparison "what did this branch actually change" needs.

Three call sites updated:
- `diff-stats-range`: `..` → `...`
- `count-test-defs-range`: `..` → `...`
- `commits-ahead-of-base`: `git rev-list --count origin/<base>..HEAD` → `git rev-list --count --right-only origin/<base>...HEAD`. Same drift concern: two-dot count drops if origin/<base> moves; right-only against the merge-base stays stable.

## Tests
Regression tests assert the exact three-dot command form. `release-rejects-destructive-boundary-commits-test` mock keys updated to three-dot (substring match would have falsely matched both forms; explicit keys lock the contract).

## Test plan
- [ ] CI green
- [ ] Re-dogfood Stage 3 — release should walk through to PR creation without false-positive destructive-diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)