### PR TITLE
refactor(pr-lifecycle): exceptions-as-data cleanup

### DIFF
--- a/components/pr-lifecycle/deps.edn
+++ b/components/pr-lifecycle/deps.edn
@@ -1,9 +1,11 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/config {:local/root "../config"}
         ai.miniforge/dag-executor {:local/root "../dag-executor"}
         ai.miniforge/fsm {:local/root "../fsm"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/release-executor {:local/root "../release-executor"}
+        ai.miniforge/response {:local/root "../response"}
         ai.miniforge/loop {:local/root "../loop"}
         ai.miniforge/agent {:local/root "../agent"}
         ai.miniforge/logging {:local/root "../logging"}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -22,6 +22,7 @@
    This controller uses an explicit FSM-backed status model to drive a task
    through PR creation, CI/review monitoring, fix loops, and merge."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.ci-monitor :as ci]
    [ai.miniforge.pr-lifecycle.controller-config :as controller-config]
@@ -32,6 +33,7 @@
    [ai.miniforge.pr-lifecycle.merge :as merge]
    [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.release-executor.interface :as release]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [clojure.string :as str]))
@@ -44,6 +46,41 @@
 
 (def ^:private lifecycle-failed-status
   :failed)
+
+(defn iter-budget-result
+  "Anomaly-returning iter-budget check.
+
+   Returns `:ok` when `current` < `max-iters`, or a `:conflict`
+   anomaly when the iteration budget is exhausted. The anomaly's
+   `:anomaly/data` carries `:task-id` and `:iterations`.
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   sites `handle-ci-failure!` and `handle-review-feedback!` consume
+   the anomaly and rethrow via `response/throw-anomaly!` with
+   `:anomalies/conflict`."
+  [task-id current max-iters]
+  (if (>= current max-iters)
+    (anomaly/anomaly :conflict
+                     (messages/t :controller/max-fix-iterations-exceeded)
+                     {:task-id task-id :iterations current})
+    :ok))
+
+(defn pr-creation-result
+  "Anomaly-returning PR-creation check.
+
+   Returns `:ok` when `pr-result` is a successful DAG result, or a
+   `:fault` anomaly when the upstream `create-pr!` returns a DAG
+   error. The anomaly's `:anomaly/data` carries `:error`.
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   site `run-lifecycle!` consumes the anomaly and rethrows via
+   `response/throw-anomaly!` with `:anomalies/fault`."
+  [pr-result]
+  (if (dag/err? pr-result)
+    (anomaly/anomaly :fault
+                     (messages/t :controller/pr-creation-failed)
+                     {:error (:error pr-result)})
+    :ok))
 
 (defn- remove-nil-values
   "Drop entries whose values are nil."
@@ -378,15 +415,17 @@
         {:keys [worktree-path max-fix-iterations]} config
         current-iterations (:fix-iterations @controller)]
 
-    (when (>= current-iterations max-fix-iterations)
-      (update-status! controller :failed)
-      (add-history! controller :max-fix-iterations-exceeded {:iterations current-iterations})
-      (when logger
-        (log/warn logger :pr-lifecycle :controller/max-iterations
-                  {:message (messages/t :controller/max-fix-iterations-exceeded)
-                   :data {:task-id task-id :iterations current-iterations}}))
-      (throw (ex-info (messages/t :controller/max-fix-iterations-exceeded)
-                      {:task-id task-id :iterations current-iterations})))
+    (let [budget (iter-budget-result task-id current-iterations max-fix-iterations)]
+      (when (anomaly/anomaly? budget)
+        (update-status! controller :failed)
+        (add-history! controller :max-fix-iterations-exceeded {:iterations current-iterations})
+        (when logger
+          (log/warn logger :pr-lifecycle :controller/max-iterations
+                    {:message (:anomaly/message budget)
+                     :data (:anomaly/data budget)}))
+        (response/throw-anomaly! :anomalies/conflict
+                                 (:anomaly/message budget)
+                                 (:anomaly/data budget))))
 
     (update-status! controller :fixing)
     (swap! controller update :fix-iterations inc)
@@ -414,11 +453,13 @@
         {:keys [worktree-path max-fix-iterations auto-resolve-comments]} config
         current-iterations (:fix-iterations @controller)]
 
-    (when (>= current-iterations max-fix-iterations)
-      (update-status! controller :failed)
-      (add-history! controller :max-fix-iterations-exceeded {:iterations current-iterations})
-      (throw (ex-info (messages/t :controller/max-fix-iterations-exceeded)
-                      {:task-id task-id :iterations current-iterations})))
+    (let [budget (iter-budget-result task-id current-iterations max-fix-iterations)]
+      (when (anomaly/anomaly? budget)
+        (update-status! controller :failed)
+        (add-history! controller :max-fix-iterations-exceeded {:iterations current-iterations})
+        (response/throw-anomaly! :anomalies/conflict
+                                 (:anomaly/message budget)
+                                 (:anomaly/data budget))))
 
     (update-status! controller :fixing)
     (swap! controller update :fix-iterations inc)
@@ -516,10 +557,12 @@
     (try
       ;; Step 1: Create PR if needed
       (when-not skip-pr-creation?
-        (let [pr-result (create-pr! controller code-artifact)]
-          (when (dag/err? pr-result)
-            (throw (ex-info (messages/t :controller/pr-creation-failed)
-                            {:error (:error pr-result)})))))
+        (let [pr-result (create-pr! controller code-artifact)
+              outcome (pr-creation-result pr-result)]
+          (when (anomaly/anomaly? outcome)
+            (response/throw-anomaly! :anomalies/fault
+                                     (:anomaly/message outcome)
+                                     (:anomaly/data outcome)))))
 
       ;; Step 2: CI/Review loop
       (loop []

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
@@ -26,9 +26,11 @@
    Layer 3: Reply and resolution
    Layer 4: Orchestration (respond-to-comments!)"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.github :as github]
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]
+   [ai.miniforge.response.interface :as response]
    [babashka.process :as process]
    [clojure.string :as str]))
 
@@ -43,6 +45,20 @@
     {:owner (nth match 1)
      :repo (nth match 2)
      :number (parse-long (nth match 3))}))
+
+(defn parse-pr-url-result
+  "Anomaly-returning version of `parse-pr-url`. Returns the parsed map
+   when `url` is a recognizable GitHub PR URL, or an `:invalid-input`
+   anomaly carrying `:url` in `:anomaly/data`.
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   site `respond-to-comments!` consumes the anomaly and rethrows via
+   `response/throw-anomaly!` with `:anomalies/incorrect`."
+  [url]
+  (or (parse-pr-url url)
+      (anomaly/anomaly :invalid-input
+                       "Could not parse PR number from URL"
+                       {:url url})))
 
 (def ^:private bot-authors
   "Authors to exclude from comment processing."
@@ -191,19 +207,39 @@
                   (reply-to-fixed-comments worktree-path pr-number comment-ids fix-pr-url) nil)
       (fix-result path comment-ids false nil (get result :error)))))
 
-(defn- fetch-actionable-comments
-  "Fetch and filter PR comments to actionable review comments.
-   Returns {:comments vector :groups vector} or throws on fetch failure."
+(defn fetch-actionable-comments-result
+  "Anomaly-returning fetch + filter. Returns
+   `{:comments vector :groups vector}` on success, or a `:fault`
+   anomaly when the upstream `poller/fetch-pr-comments` errors.
+
+   This is the canonical, anomaly-returning entry point. The boundary
+   helper `fetch-actionable-comments` rethrows via
+   `response/throw-anomaly!` with `:anomalies/fault` for legacy
+   slingshot consumers."
   [worktree-path pr-number]
   (let [result (poller/fetch-pr-comments worktree-path pr-number)]
-    (when (dag/err? result)
-      (throw (ex-info "Failed to fetch PR comments"
-                      {:pr-number pr-number
-                       :error (get-in result [:error :message])})))
-    (let [all (get-in result [:data :comments])
-          actionable (filter-actionable-comments all)]
-      {:comments actionable
-       :groups (group-comments-by-file actionable)})))
+    (if (dag/err? result)
+      (anomaly/anomaly :fault
+                       "Failed to fetch PR comments"
+                       {:pr-number pr-number
+                        :error (get-in result [:error :message])})
+      (let [all (get-in result [:data :comments])
+            actionable (filter-actionable-comments all)]
+        {:comments actionable
+         :groups (group-comments-by-file actionable)}))))
+
+(defn- fetch-actionable-comments
+  "Boundary helper. Calls `fetch-actionable-comments-result`; on
+   anomaly result raises a slingshot `:anomalies/fault` throw.
+
+   Returns `{:comments vector :groups vector}` on success."
+  [worktree-path pr-number]
+  (let [result (fetch-actionable-comments-result worktree-path pr-number)]
+    (if (anomaly/anomaly? result)
+      (response/throw-anomaly! :anomalies/fault
+                               (:anomaly/message result)
+                               (:anomaly/data result))
+      result)))
 
 (defn- respond-result
   "Build the response summary map."
@@ -238,10 +274,13 @@
     :fixes [{:path :succeeded? :comment-ids :replied? :resolved?}]
     :pushed? bool}"
   [pr-url worktree-path run-fix-fn push-fn opts]
-  (let [{:keys [number]} (parse-pr-url pr-url)]
-    (when-not number
-      (throw (ex-info "Could not parse PR number from URL" {:url pr-url})))
-    (let [{:keys [comments groups]} (fetch-actionable-comments worktree-path number)]
+  (let [parsed (parse-pr-url-result pr-url)]
+    (when (anomaly/anomaly? parsed)
+      (response/throw-anomaly! :anomalies/incorrect
+                               (:anomaly/message parsed)
+                               (:anomaly/data parsed)))
+    (let [{:keys [number]} parsed
+          {:keys [comments groups]} (fetch-actionable-comments worktree-path number)]
       (if (empty? groups)
         (respond-result number 0 0 [] false)
         (let [context (gather-context worktree-path number groups)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/fetch_actionable_comments_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/fetch_actionable_comments_result_test.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.anomaly.fetch-actionable-comments-result-test
+  "Coverage for `responder/fetch-actionable-comments-result`
+   (anomaly-returning) and the private boundary helper.
+
+   Upstream poller error → `:fault` anomaly. The private boundary
+   helper rethrows via `response/throw-anomaly!` with
+   `:anomalies/fault`."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]
+   [ai.miniforge.pr-lifecycle.responder :as responder]))
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest fetch-result-returns-comments-and-groups-on-success
+  (testing "successful poller fetch returns {:comments :groups}"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _]
+                    (dag/ok {:comments [{:comment/type :review-comment
+                                         :comment/author "alice"
+                                         :comment/path "src/x.clj"
+                                         :comment/body "fix this"}]}))]
+      (let [result (responder/fetch-actionable-comments-result "/tmp" 42)]
+        (is (not (anomaly/anomaly? result)))
+        (is (vector? (:comments result)))
+        (is (vector? (:groups result)))
+        (is (= 1 (count (:comments result))))))))
+
+(deftest fetch-result-filters-bot-comments
+  (testing "bot-authored comments are filtered out"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _]
+                    (dag/ok {:comments [{:comment/type :review-comment
+                                         :comment/author "github-actions[bot]"
+                                         :comment/path "src/x.clj"
+                                         :comment/body "auto comment"}
+                                        {:comment/type :review-comment
+                                         :comment/author "alice"
+                                         :comment/path "src/x.clj"
+                                         :comment/body "real comment"}]}))]
+      (let [result (responder/fetch-actionable-comments-result "/tmp" 42)]
+        (is (= 1 (count (:comments result))))
+        (is (= "alice" (:comment/author (first (:comments result)))))))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest fetch-result-returns-anomaly-on-poller-err
+  (testing "poller DAG err yields :fault anomaly"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _] (dag/err :network "down"))]
+      (let [result (responder/fetch-actionable-comments-result "/tmp" 42)]
+        (is (anomaly/anomaly? result))
+        (is (= :fault (:anomaly/type result)))
+        (is (= 42 (:pr-number (:anomaly/data result))))
+        (is (= "down" (:error (:anomaly/data result))))))))
+
+(deftest fetch-result-anomaly-message-stable
+  (testing ":anomaly/message is the canonical fetch-failure string"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _] (dag/err :downstream "boom"))]
+      (let [result (responder/fetch-actionable-comments-result "/tmp" 42)]
+        (is (= "Failed to fetch PR comments" (:anomaly/message result)))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/iter_budget_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/iter_budget_result_test.clj
@@ -1,0 +1,117 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.anomaly.iter-budget-result-test
+  "Coverage for `controller/iter-budget-result` (anomaly-returning) and
+   the throwing boundary at `handle-ci-failure!` / `handle-review-feedback!`.
+
+   Iter-budget exhaustion returns a `:conflict` anomaly. The boundary
+   helpers escalate the anomaly to a slingshot `:anomalies/conflict`
+   throw — preserving the legacy thrown-exception contract for
+   external orchestrators that branch on `clojure.lang.ExceptionInfo`."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.pr-lifecycle.controller :as controller])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+(def ^:private test-task
+  {:task/id (random-uuid)
+   :task/type :implement
+   :task/description "test task"})
+
+;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
+
+(deftest iter-budget-result-returns-ok-when-under-budget
+  (testing "current < max returns :ok"
+    (is (= :ok (controller/iter-budget-result "task-1" 0 3)))
+    (is (= :ok (controller/iter-budget-result "task-1" 1 3)))
+    (is (= :ok (controller/iter-budget-result "task-1" 2 3)))))
+
+;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
+
+(deftest iter-budget-result-returns-anomaly-when-at-budget
+  (testing "current = max returns :conflict anomaly"
+    (let [result (controller/iter-budget-result "task-1" 3 3)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (= "task-1" (:task-id (:anomaly/data result))))
+      (is (= 3 (:iterations (:anomaly/data result)))))))
+
+(deftest iter-budget-result-returns-anomaly-when-over-budget
+  (testing "current > max returns :conflict anomaly"
+    (let [result (controller/iter-budget-result "task-1" 5 3)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (= 5 (:iterations (:anomaly/data result)))))))
+
+(deftest iter-budget-result-zero-budget-rejects-immediately
+  (testing "max=0 rejects on first attempt (current=0)"
+    (let [result (controller/iter-budget-result "task-1" 0 0)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result))))))
+
+;------------------------------------------------------------------------------ Boundary helper escalates via slingshot
+
+(deftest handle-ci-failure-escalates-budget-anomaly
+  (testing "handle-ci-failure! rethrows :conflict anomaly as ExceptionInfo"
+    (let [ctrl (controller/create-controller
+                "dag" "run" "task" test-task
+                :worktree-path "/tmp"
+                :max-fix-iterations 2)]
+      (swap! ctrl assoc :fix-iterations 2)
+      (is (thrown-with-msg? ExceptionInfo
+                            #"Max fix iterations exceeded"
+                            (controller/handle-ci-failure! ctrl "logs"))))))
+
+(deftest handle-review-feedback-escalates-budget-anomaly
+  (testing "handle-review-feedback! rethrows :conflict anomaly as ExceptionInfo"
+    (let [ctrl (controller/create-controller
+                "dag" "run" "task" test-task
+                :worktree-path "/tmp"
+                :max-fix-iterations 1)]
+      (swap! ctrl assoc :fix-iterations 1)
+      (is (thrown-with-msg? ExceptionInfo
+                            #"Max fix iterations exceeded"
+                            (controller/handle-review-feedback! ctrl [{:body "fix"}]))))))
+
+(deftest boundary-sets-failed-status-on-budget-exhaustion
+  (testing "boundary helper transitions controller to :failed before throwing"
+    (let [ctrl (controller/create-controller
+                "dag" "run" "task" test-task
+                :worktree-path "/tmp"
+                :max-fix-iterations 3)]
+      (swap! ctrl assoc :fix-iterations 3)
+      (try
+        (controller/handle-ci-failure! ctrl "logs")
+        (catch ExceptionInfo _e nil))
+      (is (= :failed (:status @ctrl))))))
+
+(deftest boundary-records-history-on-budget-exhaustion
+  (testing "boundary helper records :max-fix-iterations-exceeded in history"
+    (let [ctrl (controller/create-controller
+                "dag" "run" "task" test-task
+                :worktree-path "/tmp"
+                :max-fix-iterations 2)]
+      (swap! ctrl assoc :fix-iterations 2)
+      (try
+        (controller/handle-ci-failure! ctrl "logs")
+        (catch ExceptionInfo _e nil))
+      (is (some #(= :max-fix-iterations-exceeded (:type %))
+                (:history @ctrl))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/parse_pr_url_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/parse_pr_url_result_test.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.anomaly.parse-pr-url-result-test
+  "Coverage for `responder/parse-pr-url-result` (anomaly-returning) and
+   the boundary throw via `responder/respond-to-comments!`.
+
+   Unrecognized URL → `:invalid-input` anomaly. The boundary helper
+   escalates via `response/throw-anomaly!` with `:anomalies/incorrect`."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.pr-lifecycle.responder :as responder])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest parse-pr-url-result-returns-parsed-on-valid-url
+  (testing "github URL parses to {:owner :repo :number}"
+    (let [result (responder/parse-pr-url-result
+                  "https://github.com/miniforge-ai/miniforge/pull/123")]
+      (is (not (anomaly/anomaly? result)))
+      (is (= "miniforge-ai" (:owner result)))
+      (is (= "miniforge" (:repo result)))
+      (is (= 123 (:number result))))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest parse-pr-url-result-returns-anomaly-on-non-github-url
+  (testing "non-github URL yields :invalid-input anomaly"
+    (let [result (responder/parse-pr-url-result "https://gitlab.com/foo/bar/pull/1")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "https://gitlab.com/foo/bar/pull/1" (:url (:anomaly/data result)))))))
+
+(deftest parse-pr-url-result-returns-anomaly-on-malformed-url
+  (testing "malformed URL yields :invalid-input anomaly"
+    (let [result (responder/parse-pr-url-result "not-a-url")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
+
+(deftest parse-pr-url-result-returns-anomaly-on-nil
+  (testing "nil URL yields :invalid-input anomaly"
+    (is (anomaly/anomaly? (responder/parse-pr-url-result nil)))))
+
+;------------------------------------------------------------------------------ Boundary helper escalates via slingshot
+
+(deftest respond-to-comments-escalates-url-parse-anomaly
+  (testing "respond-to-comments! rethrows anomaly as ExceptionInfo"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Could not parse PR number from URL"
+         (responder/respond-to-comments! "https://gitlab.com/x/y/pull/1"
+                                         "/tmp"
+                                         (fn [& _] {})
+                                         (fn [] true)
+                                         {})))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/pr_creation_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/pr_creation_result_test.clj
@@ -1,0 +1,53 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.anomaly.pr-creation-result-test
+  "Coverage for `controller/pr-creation-result` (anomaly-returning).
+
+   PR-creation failure (DAG err) returns a `:fault` anomaly. The
+   boundary site `run-lifecycle!` consumes the anomaly and rethrows
+   via `response/throw-anomaly!` with `:anomalies/fault`."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.controller :as controller]))
+
+;------------------------------------------------------------------------------ Happy path
+
+(deftest pr-creation-result-returns-ok-on-success
+  (testing "successful DAG result returns :ok"
+    (is (= :ok (controller/pr-creation-result (dag/ok {:pr/id "PR-1"}))))))
+
+;------------------------------------------------------------------------------ Failure path
+
+(deftest pr-creation-result-returns-anomaly-on-dag-err
+  (testing "DAG err result returns :fault anomaly"
+    (let [pr-result (dag/err :network "connection refused")
+          result (controller/pr-creation-result pr-result)]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (some? (:error (:anomaly/data result))))
+      (is (= "PR creation failed" (:anomaly/message result))))))
+
+(deftest pr-creation-result-carries-error-detail
+  (testing ":anomaly/data carries the underlying DAG error"
+    (let [pr-result (dag/err :auth "token expired")
+          result (controller/pr-creation-result pr-result)]
+      (is (= :auth (get-in result [:anomaly/data :error :code])))
+      (is (= "token expired" (get-in result [:anomaly/data :error :message]))))))

--- a/docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md
@@ -1,0 +1,155 @@
+# refactor: exceptions-as-data cleanup of pr-lifecycle
+
+## Overview
+
+Migrates the 5 `:cleanup-needed` throw sites in
+`components/pr-lifecycle/src/.../controller.clj` (3) and
+`components/pr-lifecycle/src/.../responder.clj` (2) to anomaly-returning
+canonical fns. Boundary throws inlined via `response/throw-anomaly!` so
+external slingshot consumers (PR lifecycle orchestrator, top-level CLI
+dispatch) keep their thrown-exception contract.
+
+## Motivation
+
+Per `work/exception-cleanup-inventory.md`, `pr-lifecycle` had 5
+`:cleanup-needed` sites. Same kill-the-deprecation shape as the workflow
+and Wave 7 cleanups (PRs #777, #797, #799, #800, #801) — applied here
+directly without redesign.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary
+- `ai.miniforge.response` (merged) — slingshot `throw-anomaly!`
+
+## Layer
+
+Refactor / per-component cleanup tier.
+
+## What This Adds / Changes
+
+`components/pr-lifecycle/deps.edn`:
+
+- Adds `:local/root` deps on `ai.miniforge/anomaly` and
+  `ai.miniforge/response`.
+
+`components/pr-lifecycle/src/.../controller.clj`:
+
+- New canonical anomaly-returning fns (Layer 0):
+  - `iter-budget-result` — `:ok | :conflict anomaly` (replaces the two
+    `(>= current max)` thrown-exception sites in `handle-ci-failure!` /
+    `handle-review-feedback!`)
+  - `pr-creation-result` — `:ok | :fault anomaly` (replaces the
+    `dag/err?` thrown-exception site in `run-lifecycle!`)
+- Boundary escalation in the three callers via
+  `(response/throw-anomaly! :anomalies/conflict ...)` and
+  `(response/throw-anomaly! :anomalies/fault ...)` — preserves
+  `clojure.lang.ExceptionInfo`-shaped throw for legacy
+  `thrown-with-msg?` consumers.
+
+`components/pr-lifecycle/src/.../responder.clj`:
+
+- New canonical anomaly-returning fns (Layer 0 / Layer 4):
+  - `parse-pr-url-result` — `parsed map | :invalid-input anomaly`
+    (replaces the inline `(throw (ex-info "Could not parse PR number
+    from URL" ...))`)
+  - `fetch-actionable-comments-result` — `{:comments :groups} | :fault
+    anomaly` (replaces the inline `(throw (ex-info "Failed to fetch PR
+    comments" ...))`)
+- Private boundary helper `fetch-actionable-comments` calls the
+  anomaly-returning fn and rethrows via `:anomalies/fault` for the
+  in-component caller `respond-to-comments!`.
+- `respond-to-comments!` consumes `parse-pr-url-result` directly and
+  rethrows via `:anomalies/incorrect` on URL-parse anomaly.
+
+`components/pr-lifecycle/test/.../anomaly/` (new):
+
+- `iter_budget_result_test.clj` — 7 tests covering
+  iter-budget-result happy path, anomaly path, zero-budget edge case,
+  and boundary escalation through `handle-ci-failure!` /
+  `handle-review-feedback!` plus state-transition + history side
+  effects.
+- `pr_creation_result_test.clj` — 3 tests covering happy path, DAG err
+  → `:fault` anomaly, and `:anomaly/data` carrying the underlying error
+  detail.
+- `parse_pr_url_result_test.clj` — 5 tests covering valid URL parse,
+  non-github URL, malformed URL, nil, and boundary escalation through
+  `respond-to-comments!`.
+- `fetch_actionable_comments_result_test.clj` — 4 tests covering
+  successful fetch with bot-comment filtering, poller `dag/err`
+  yielding `:fault` anomaly, and stable anomaly message.
+
+## Per-site classification
+
+| Site (line) | Old throw | Anomaly type | Boundary throw category |
+|------------:|-----------|--------------|--------------------------|
+| controller.clj:388 | `handle-ci-failure!` (max-iter) | `:conflict` (via `iter-budget-result`) | `:anomalies/conflict` |
+| controller.clj:420 | `handle-review-feedback!` (max-iter) | `:conflict` (via `iter-budget-result`) | `:anomalies/conflict` |
+| controller.clj:521 | `run-lifecycle!` (PR-creation DAG err) | `:fault` (via `pr-creation-result`) | `:anomalies/fault` |
+| responder.clj:200 | `fetch-actionable-comments` (poller err) | `:fault` (via `fetch-actionable-comments-result`) | `:anomalies/fault` |
+| responder.clj:243 | `respond-to-comments!` (URL parse) | `:invalid-input` (via `parse-pr-url-result`) | `:anomalies/incorrect` |
+
+Boundary throws use the **general** slingshot categories
+(`:anomalies/conflict`, `:anomalies/fault`, `:anomalies/incorrect`) —
+adding a `:anomalies.pr-lifecycle/*` set would touch the response
+component, which is out of scope here.
+
+## Strata Affected
+
+- `ai.miniforge.pr-lifecycle.controller` — iter-budget + PR-creation
+  cleanup
+- `ai.miniforge.pr-lifecycle.responder` — URL-parse + comment-fetch
+  cleanup
+- New `ai.miniforge.pr-lifecycle.anomaly.*` test namespaces
+
+## Testing Plan
+
+- `clojure -M:test -m cognitect.test-runner -d test` from
+  `components/pr-lifecycle`: **319 tests / 2048 passes / 0 failures /
+  0 errors**.
+- New `anomaly.*` files: 20 tests / 45 assertions, all green.
+- Existing `controller_test.clj` `thrown-with-msg?
+  clojure.lang.ExceptionInfo` assertions continue to pass —
+  `response/throw-anomaly!` raises `ExceptionInfo` with the anomaly
+  message preserved as `(.getMessage ex)`.
+- Lint: clean.
+
+## Deployment Plan
+
+No migration. External slingshot callers continue to see the same
+`ex-info` shapes via the boundary throws (`:anomalies/conflict`,
+`:anomalies/fault`, `:anomalies/incorrect`).
+
+## Notes
+
+- **Same shape as Wave 7 PRs.** `iter-budget-result` mirrors
+  `task/transition-result`; `pr-creation-result` mirrors
+  `agent/parsed-plan-or-anomaly`; the responder split mirrors
+  `task/lookup-task` + `lookup-task!`. Saves design time.
+- **No new i18n keys.** Inline anomaly messages for the responder
+  sites use the existing inline strings — adding messages/t entries
+  would be an unrelated change.
+
+## Related Issues/PRs
+
+- Built on PR #777 (FSM-transition cleanup precedent)
+- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
+- Companion to Wave 7 cleanup PRs — operator (#797), spec-parser
+  (#799), agent (#800), task (#801)
+
+## Checklist
+
+- [x] All 5 `:cleanup-needed` pr-lifecycle sites retired
+- [x] Kill-the-deprecation pattern from PR #777 applied
+- [x] Single API per site
+- [x] Boundary throws inlined at the three caller sites
+- [x] External caller contracts preserved (`thrown-with-msg?
+      ExceptionInfo` tests still pass)
+- [x] Decomposed test files (four)
+- [x] No new throws in anomaly-returning code paths
+- [x] `pr-lifecycle` full test suite passes (319 tests / 2048
+      assertions)
+- [x] Apache 2 license headers preserved


### PR DESCRIPTION
## Summary

Migrates the 5 `:cleanup-needed` throw sites in `pr-lifecycle/controller.clj` (3) and `pr-lifecycle/responder.clj` (2) to anomaly-returning canonical fns. Boundary throws inlined via `response/throw-anomaly!` so external slingshot consumers keep their thrown-exception contract.

- `iter-budget-result`: `:ok | :conflict` (handle-ci-failure!, handle-review-feedback!)
- `pr-creation-result`: `:ok | :fault` (run-lifecycle!)
- `parse-pr-url-result`: parsed map | `:invalid-input`
- `fetch-actionable-comments-result` + private boundary helper

Full PR doc: `docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md`

## Test plan

- [x] `pr-lifecycle` full test suite: 319 tests / 2048 assertions / 0 failures
- [x] New anomaly tests: 20 tests / 45 assertions, all green
- [x] Existing `controller_test.clj` `thrown-with-msg? ExceptionInfo` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)