### PR TITLE
fix(llm): fallback cost estimate when CLI omits total_cost_usd

### DIFF
--- a/components/llm/resources/llm/cost-table.edn
+++ b/components/llm/resources/llm/cost-table.edn
@@ -1,0 +1,40 @@
+;; Per-1M-token USD pricing for backends that don't surface
+;; total_cost_usd in their streaming result frame. Used as a fallback
+;; when ai.miniforge.llm.cost/estimate-cost needs to compute a cost
+;; from the usage block alone.
+;;
+;; Source: published provider pricing as of 2026-05; update when a
+;; backend price moves or a new priced model lands.
+;;
+;; Models absent from this map estimate as $0.00 (cleaner default
+;; for free / local / unpriced backends than throwing). The fallback
+;; only fires when the streaming response itself didn't carry
+;; :cost-usd, so $0 here is also the right answer for models whose
+;; CLI already surfaces cost.
+;;
+;; All values are USD per 1,000,000 tokens.
+
+{:pricing/by-model-id
+ {;; Anthropic Claude
+  "claude-opus-4-7"           {:input-per-1m  5.00  :output-per-1m  25.00}
+  "claude-opus-4-6"           {:input-per-1m  5.00  :output-per-1m  25.00}
+  "claude-opus-4"             {:input-per-1m 15.00  :output-per-1m  75.00}
+  "claude-sonnet-4-6"         {:input-per-1m  3.00  :output-per-1m  15.00}
+  "claude-sonnet-4-5-20250929" {:input-per-1m 3.00  :output-per-1m  15.00}
+  "claude-sonnet-4"           {:input-per-1m  3.00  :output-per-1m  15.00}
+  "claude-haiku-4-5-20251001" {:input-per-1m  0.25  :output-per-1m   1.25}
+  "claude-haiku"              {:input-per-1m  0.25  :output-per-1m   1.25}
+
+  ;; OpenAI GPT-5 family. Codex CLI doesn't currently surface
+  ;; total_cost_usd; fallback estimate is what users will see.
+  "gpt-5.4-pro"               {:input-per-1m 15.00  :output-per-1m  75.00}
+  "gpt-5.4"                   {:input-per-1m  5.00  :output-per-1m  25.00}
+  "gpt-5.3-codex"             {:input-per-1m  5.00  :output-per-1m  25.00}
+  "gpt-5.2-codex"             {:input-per-1m  3.00  :output-per-1m  15.00}
+  "gpt-5.1-codex-max"         {:input-per-1m  3.00  :output-per-1m  15.00}
+  "gpt-5.2"                   {:input-per-1m  3.00  :output-per-1m  15.00}
+
+  ;; Google Gemini
+  "gemini-2.5-pro"            {:input-per-1m  3.50  :output-per-1m  10.50}
+  "gemini-2.5-flash"          {:input-per-1m  0.30  :output-per-1m   2.50}
+  "gemini-2.5-flash-lite"     {:input-per-1m  0.10  :output-per-1m   0.40}}}

--- a/components/llm/src/ai/miniforge/llm/cost.clj
+++ b/components/llm/src/ai/miniforge/llm/cost.clj
@@ -1,0 +1,114 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.llm.cost
+  "Fallback USD cost estimation from token usage when the upstream
+   CLI doesn't surface `total_cost_usd` in its streaming result.
+
+   Surfaced by the 2026-05-10 dogfood: a workflow that consumed
+   25k+ tokens reported `Cost: $0.0000` because the claude CLI
+   version in use omitted total_cost_usd from its result frame.
+   Per-token pricing is published data; this namespace consults a
+   small EDN table and computes the estimate as the fallback.
+
+   Pricing data lives in `components/llm/resources/llm/cost-table.edn`
+   so it can be audited / updated without touching code. Models
+   absent from the table estimate as $0.00 — cleaner default than
+   throwing for free / local / unpriced backends."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;; Constants
+
+(def ^:private cost-table-resource-path
+  "Classpath path to the EDN pricing table. Single source of truth
+   so callers can't drift on which file is canonical."
+  "llm/cost-table.edn")
+
+(def ^:private tokens-per-million
+  "Per-1M-token denominator for the EDN pricing table. Defined as
+   a named constant so the unit-of-pricing is readable inline at
+   estimate-cost rather than appearing as a bare 1000000 in the
+   arithmetic."
+  1000000)
+
+(def ^:private cost-table
+  "Delay-loaded pricing table. Loaded once at namespace init via
+   the resource path; nil-safe when the resource is missing
+   (returns an empty pricing map so callers see $0.00 rather than
+   throwing)."
+  (delay
+    (when-let [res (io/resource cost-table-resource-path)]
+      (-> res slurp edn/read-string :pricing/by-model-id))))
+
+;; Public API
+
+(defn pricing-for-model
+  "Return `{:input-per-1m N :output-per-1m N}` for the given
+   model-id string, or nil when the model isn't in the table.
+   Callers fold the nil to a zero-cost estimate rather than
+   throwing — see estimate-cost."
+  [model-id]
+  (when (string? model-id)
+    (get @cost-table model-id)))
+
+(defn estimate-cost
+  "Compute USD cost from a token-usage map and model-id.
+
+   Inputs:
+   - usage    — `{:input-tokens N :output-tokens N}` shape (the
+                same one parse-claude-stream-line's :usage emits).
+                nil-safe — missing token counts default to 0.
+   - model-id — string identifying the model (e.g.
+                \"claude-sonnet-4-6\"). Models not in the cost
+                table estimate to 0.00.
+
+   Returns: a double USD cost. Returns 0.0 for unpriced models
+   and for nil/empty usage — never throws, never returns nil, so
+   downstream merge-with + and cost summing stay safe."
+  [usage model-id]
+  (let [{:keys [input-per-1m output-per-1m]} (pricing-for-model model-id)
+        in-tokens  (or (:input-tokens usage) 0)
+        out-tokens (or (:output-tokens usage) 0)]
+    (if (and input-per-1m output-per-1m)
+      (+ (* in-tokens  (/ input-per-1m  tokens-per-million))
+         (* out-tokens (/ output-per-1m tokens-per-million)))
+      0.0)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Look up pricing for a known model
+  (pricing-for-model "claude-sonnet-4-6")
+  ;; => {:input-per-1m 3.0 :output-per-1m 15.0}
+
+  ;; Unknown model returns nil
+  (pricing-for-model "not-a-real-model")
+  ;; => nil
+
+  ;; Estimate cost
+  (estimate-cost {:input-tokens 10000 :output-tokens 2000}
+                 "claude-sonnet-4-6")
+  ;; => 0.06  ; 10000 * (3/1M) + 2000 * (15/1M) = 0.03 + 0.03
+
+  ;; Unknown model → 0.00
+  (estimate-cost {:input-tokens 10000 :output-tokens 2000}
+                 "free-local-model")
+  ;; => 0.0
+
+  :leave-this-here)

--- a/components/llm/src/ai/miniforge/llm/cost.clj
+++ b/components/llm/src/ai/miniforge/llm/cost.clj
@@ -50,12 +50,16 @@
 
 (def ^:private cost-table
   "Delay-loaded pricing table. Loaded once at namespace init via
-   the resource path; nil-safe when the resource is missing
-   (returns an empty pricing map so callers see $0.00 rather than
-   throwing)."
+   the resource path; defaults to an empty pricing map when the
+   resource is missing so callers see $0.00 rather than throwing.
+   Empty map matches what `pricing-for-model` returns for misses
+   in a populated table — same semantic either way."
   (delay
-    (when-let [res (io/resource cost-table-resource-path)]
-      (-> res slurp edn/read-string :pricing/by-model-id))))
+    (or (some-> (io/resource cost-table-resource-path)
+                slurp
+                edn/read-string
+                :pricing/by-model-id)
+        {})))
 
 ;; Public API
 
@@ -79,16 +83,20 @@
                 \"claude-sonnet-4-6\"). Models not in the cost
                 table estimate to 0.00.
 
-   Returns: a double USD cost. Returns 0.0 for unpriced models
-   and for nil/empty usage — never throws, never returns nil, so
-   downstream merge-with + and cost summing stay safe."
+   Returns: a primitive `double` USD cost. Returns 0.0 for unpriced
+   models and for nil/empty usage — never throws, never returns
+   nil. The explicit `(double ...)` cast normalizes the result
+   regardless of which numeric type the EDN literals + arithmetic
+   produce (BigDecimal when the EDN reader sees `3.00`, Ratio when
+   `/` returns an exact fraction), so downstream `merge-with +`
+   and cost summing see a consistent type."
   [usage model-id]
   (let [{:keys [input-per-1m output-per-1m]} (pricing-for-model model-id)
         in-tokens  (or (:input-tokens usage) 0)
         out-tokens (or (:output-tokens usage) 0)]
     (if (and input-per-1m output-per-1m)
-      (+ (* in-tokens  (/ input-per-1m  tokens-per-million))
-         (* out-tokens (/ output-per-1m tokens-per-million)))
+      (double (+ (* in-tokens  (/ input-per-1m  tokens-per-million))
+                 (* out-tokens (/ output-per-1m tokens-per-million))))
       0.0)))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -26,6 +26,7 @@
    [babashka.process :as p]
    [org.httpkit.client :as http]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.llm.cost :as cost]
    [ai.miniforge.llm.progress-monitor :as pm]
    [ai.miniforge.response.interface :as response]
    [slingshot.slingshot :refer [throw+ try+]])
@@ -1328,13 +1329,26 @@
                       {:data {:stop-reason stop-reason :num-turns num-turns
                               :content-length (count final-content)}}))
           (if (zero? exit-code)
-            (cond-> (streaming-success-response final-content exit-code
-                                                usage @accumulated-cost
-                                                stop-reason num-turns
-                                                tool-call-count final-message-preview
-                                                (:err result))
-              (seq tools) (assoc :tools-called tools)
-              session-id  (assoc :session-id session-id))
+            ;; Cost fallback: some backends (e.g. older Claude Code
+            ;; CLI versions, codex stream parser) don't surface
+            ;; total_cost_usd in the result frame, so
+            ;; @accumulated-cost stays nil and the runner banner
+            ;; reports $0.0000 despite real backend costs. When
+            ;; cost is nil but usage carries tokens, compute the
+            ;; fallback estimate from the model + usage via
+            ;; cost/estimate-cost. Models without pricing in the
+            ;; table return 0.0 (no false-positive cost), so this
+            ;; is a non-decreasing fix — never produces a wrong-
+            ;; direction value.
+            (let [resolved-cost (or @accumulated-cost
+                                    (cost/estimate-cost usage model))]
+              (cond-> (streaming-success-response final-content exit-code
+                                                  usage resolved-cost
+                                                  stop-reason num-turns
+                                                  tool-call-count final-message-preview
+                                                  (:err result))
+                (seq tools) (assoc :tools-called tools)
+                session-id  (assoc :session-id session-id)))
             (cond-> (streaming-error-response final-content exit-code (:err result)
                                               diagnostic-content
                                               timeout-info stop-reason num-turns

--- a/components/llm/test/ai/miniforge/llm/cost_test.clj
+++ b/components/llm/test/ai/miniforge/llm/cost_test.clj
@@ -1,0 +1,116 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.llm.cost-test
+  "Pins the contract for the cost-estimate fallback used when the
+   upstream CLI doesn't surface total_cost_usd in its streaming
+   result. Two surfaces: pricing-for-model (table lookup) and
+   estimate-cost (arithmetic on usage + pricing)."
+  (:require
+   [ai.miniforge.llm.cost :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+;; Cost tolerance — pricing math is exact rationals divided by
+;; tokens-per-million but the result is a Ratio that we'll
+;; eventually serialize as double. Use a tight epsilon for the
+;; assertions so a future cast to double doesn't flake.
+(def ^:private cost-usd-epsilon 1.0e-9)
+
+(defn- approx=
+  [expected actual]
+  (< (Math/abs (double (- expected actual))) cost-usd-epsilon))
+
+;------------------------------------------------------------------------------ pricing-for-model
+
+(deftest pricing-for-model-returns-entry-for-known-model-test
+  (testing "Models in the cost table return their {:input-per-1m
+            :output-per-1m} pair so the estimate-cost arithmetic
+            can multiply through."
+    (let [p (sut/pricing-for-model "claude-sonnet-4-6")]
+      (is (= 3.0  (:input-per-1m p)))
+      (is (= 15.0 (:output-per-1m p))))))
+
+(deftest pricing-for-model-nil-for-unknown-model-test
+  (testing "Unknown / unpriced models return nil so estimate-cost
+            can fold to a $0.00 estimate rather than throwing."
+    (is (nil? (sut/pricing-for-model "not-a-real-model")))
+    (is (nil? (sut/pricing-for-model "free-local-llama"))
+        "free / local models simply aren't in the table — caller
+         interprets nil as 'no pricing, no estimate'")))
+
+(deftest pricing-for-model-nil-input-safe-test
+  (testing "nil / non-string input returns nil rather than NPE-ing
+            on the get lookup — callers may pass through a config
+            map's :model value without coercion."
+    (is (nil? (sut/pricing-for-model nil)))
+    (is (nil? (sut/pricing-for-model :keyword-not-string)))
+    (is (nil? (sut/pricing-for-model 42)))))
+
+;------------------------------------------------------------------------------ estimate-cost
+
+(deftest estimate-cost-priced-model-test
+  (testing "Known model + usage → USD computed via
+            (in-tokens × in-per-1M + out-tokens × out-per-1M)
+            / 1,000,000. sonnet-4-6 at 3.0/15.0 with 10k input +
+            2k output = (10000 * 3 + 2000 * 15) / 1M = 60000/1M = 0.06"
+    (is (approx= 0.06
+                 (sut/estimate-cost {:input-tokens 10000
+                                     :output-tokens 2000}
+                                    "claude-sonnet-4-6")))))
+
+(deftest estimate-cost-unpriced-model-returns-zero-test
+  (testing "Unpriced model → 0.0 rather than nil or throw. Lets the
+            caller assoc the value into the streaming response
+            unconditionally without a nil-guard."
+    (is (= 0.0 (sut/estimate-cost {:input-tokens 100000
+                                   :output-tokens 50000}
+                                  "free-local-model")))))
+
+(deftest estimate-cost-nil-usage-returns-zero-test
+  (testing "nil / empty usage with a priced model still returns 0.0 —
+            zero tokens means zero cost, no surprises."
+    (is (= 0.0 (sut/estimate-cost nil "claude-sonnet-4-6")))
+    (is (= 0.0 (sut/estimate-cost {} "claude-sonnet-4-6")))))
+
+(deftest estimate-cost-missing-input-or-output-tokens-test
+  (testing "Partial usage maps (only :input-tokens, only
+            :output-tokens) default the missing side to 0."
+    (is (approx= 0.03
+                 (sut/estimate-cost {:input-tokens 10000}
+                                    "claude-sonnet-4-6"))
+        "10000 * 3/1M = 0.03 — :output-tokens default 0 contributes 0")
+    (is (approx= 0.03
+                 (sut/estimate-cost {:output-tokens 2000}
+                                    "claude-sonnet-4-6"))
+        "2000 * 15/1M = 0.03 — :input-tokens default 0 contributes 0")))
+
+(deftest estimate-cost-haiku-cheap-pricing-test
+  (testing "Haiku's much cheaper pricing demonstrates the table
+            is per-model (not a constant rate). 10k+2k tokens at
+            $0.25/$1.25 per 1M = (10000*0.25 + 2000*1.25)/1M =
+            (2500 + 2500)/1M = 0.005"
+    (is (approx= 0.005
+                 (sut/estimate-cost {:input-tokens 10000
+                                     :output-tokens 2000}
+                                    "claude-haiku-4-5-20251001")))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.llm.cost-test)
+
+  :leave-this-here)

--- a/components/llm/test/ai/miniforge/llm/cost_test.clj
+++ b/components/llm/test/ai/miniforge/llm/cost_test.clj
@@ -25,10 +25,13 @@
    [ai.miniforge.llm.cost :as sut]
    [clojure.test :refer [deftest is testing]]))
 
-;; Cost tolerance — pricing math is exact rationals divided by
-;; tokens-per-million but the result is a Ratio that we'll
-;; eventually serialize as double. Use a tight epsilon for the
-;; assertions so a future cast to double doesn't flake.
+;; Cost tolerance — pricing literals in the EDN table (`3.00`,
+;; `0.25`, …) read as BigDecimal, so the intermediate arithmetic
+;; mixes BigDecimal with int tokens and produces BigDecimal; the
+;; final `(double ...)` cast in estimate-cost normalises to a
+;; primitive double, but a tight epsilon keeps the assertions
+;; stable across any cast-order surprises (and matches the
+;; tolerance pattern used in dag-orchestrator-test).
 (def ^:private cost-usd-epsilon 1.0e-9)
 
 (defn- approx=


### PR DESCRIPTION
## Summary

Third fix from the 2026-05-10 dogfood. The runner banner reported \`Cost: \$0.0000\` for a 25k+ token run because the claude CLI version in use didn't surface \`total_cost_usd\` in its streaming result frame. \`parse-claude-stream-line\` reads it as nil; \`@accumulated-cost\` stays nil; \`streaming-success-response\` only assoc's \`:cost-usd\` when truthy; downstream merge-with + sums in 0.0 for every phase.

- **Fix**: when \`@accumulated-cost\` is nil at stream finalization, compute cost from the model + usage block via a new \`ai.miniforge.llm.cost/estimate-cost\` fn.
- **Pricing as data**: \`components/llm/resources/llm/cost-table.edn\` keys model-id → \`{:input-per-1m :output-per-1m}\`. Models absent from the table estimate to \$0.00 — cleaner default than throwing for free / local / unpriced backends.
- **Non-decreasing**: never produces a wrong-direction value. Only fills in \$0.00 when we'd have left it \$0.00 anyway and can do better.
- **Magic-number discipline**: \`cost-table-resource-path\`, \`tokens-per-million\` named constants. Pricing lives entirely in EDN. No bare 1,000,000 in the arithmetic.
- **Exceptions-as-data**: \`estimate-cost\` folds nil pricing / nil usage to 0.0; \`pricing-for-model\` returns nil rather than NPE on non-string input. Wire site uses plain \`or\`. No try/catch added.

## Test plan

- [x] 8 new tests / 14 assertions in \`cost-test\`:
  - \`pricing-for-model\` table lookup: known / unknown / nil-input.
  - \`estimate-cost\` arithmetic: sonnet at \$0.06 for 10k+2k tokens; unpriced model → \$0.00; nil/empty usage → \$0.00; partial usage defaults missing side to 0; haiku's much cheaper pricing demonstrates per-model table.
- [x] 59 / 271 / 0 / 0 across affected llm namespaces.
- [x] Full pre-commit suite green.

## Coverage of dogfood result-shape bugs

| Bug | PR |
|---|---|
| DAG metrics + cost-usd propagation | #840 ✓ merged |
| Wall-clock duration in runner banner | #842 ✓ merged |
| Cost calculation fallback when CLI omits total_cost_usd | this PR |

Refs: \`~/.claude/projects/.../memory/project_dogfood_findings_2026_05_10.md\` (Bug 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)