### PR TITLE
feat(n13): Resume Signal Dispatcher (N13 §2.7)

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -521,6 +521,7 @@
   :pr/resume-dispatch-gh-failed "pr resume-dispatch: PR #{n} ({url}) — failed to query gh, skipping"
   :pr/resume-dispatch-not-merged "pr resume-dispatch: PR #{n} state={state}, not merged — skipping"
   :pr/resume-dispatch-pr-summary "pr resume-dispatch: PR #{n} ({url}) — {ok}/{total} delivered ({failed} failed)"
+  :pr/resume-dispatch-pr-error "pr resume-dispatch: PR #{n} ({url}) — [{code}] {message}"
   :pr/resume-dispatch-listener-failed "pr resume-dispatch: listener {lid} — [{code}] {message}"
   :pr/resume-dispatch-failed "pr resume-dispatch failed: {message}"
 

--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -514,6 +514,16 @@
   :pr/review-monitor-pr-failed "pr review-monitor: PR #{n} ({url}) — [{code}] {message}"
   :pr/review-monitor-failed "pr review-monitor failed: {message}"
 
+  ;; PR Resume Dispatcher (N13 §2.7 Resume Signal Dispatcher)
+  :pr/resume-dispatch-repo-not-found "pr resume-dispatch: --repo path not found: {path}"
+  :pr/resume-dispatch-registry-failed "pr resume-dispatch: failed to read listener registry: [{code}] {message}"
+  :pr/resume-dispatch-pass-start "pr resume-dispatch: scanning {pr-count} PR(s) with active listeners"
+  :pr/resume-dispatch-gh-failed "pr resume-dispatch: PR #{n} ({url}) — failed to query gh, skipping"
+  :pr/resume-dispatch-not-merged "pr resume-dispatch: PR #{n} state={state}, not merged — skipping"
+  :pr/resume-dispatch-pr-summary "pr resume-dispatch: PR #{n} ({url}) — {ok}/{total} delivered ({failed} failed)"
+  :pr/resume-dispatch-listener-failed "pr resume-dispatch: listener {lid} — [{code}] {message}"
+  :pr/resume-dispatch-failed "pr resume-dispatch failed: {message}"
+
   ;; PR Monitor
   :pr/monitor-starting "Starting PR monitor for author: {author}"
   :pr/monitor-polling "Polling every {seconds}s in {dir}"

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -54,6 +54,7 @@
    [ai.miniforge.cli.main.commands.monitoring :as cmd-monitoring]
    [ai.miniforge.cli.main.commands.fleet :as cmd-fleet]
    [ai.miniforge.cli.main.commands.pr :as cmd-pr]
+   [ai.miniforge.cli.main.commands.pr-resume-dispatcher :as cmd-pr-resume]
    [ai.miniforge.cli.main.commands.pr-review-monitor :as cmd-pr-review-monitor]
    [ai.miniforge.cli.main.commands.control-plane :as cmd-cp]
    [ai.miniforge.cli.main.commands.scan :as cmd-scan]
@@ -322,6 +323,7 @@
 (defn pr-merge-cmd [m] (cmd-pr/pr-merge-cmd (get-opts m)))
 (defn pr-monitor-cmd [m] (cmd-pr/pr-monitor-cmd (get-opts m)))
 (defn pr-review-monitor-cmd [m] (cmd-pr-review-monitor/pr-review-monitor-cmd (get-opts m)))
+(defn pr-resume-dispatcher-cmd [m] (cmd-pr-resume/pr-resume-dispatcher-cmd (get-opts m)))
 
 ;; Control Plane commands
 (defn cp-status-cmd [m] (cmd-cp/status-cmd (get-opts m)))
@@ -617,6 +619,12 @@
            :pack      {:alias :p}
            :rules     {:alias :r}
            :once      {:coerce :boolean :default true}}}
+
+   ;; N13 §2.7 Resume Signal Dispatcher (single-pass v0)
+   {:cmds ["pr" "resume-dispatch"]
+    :fn pr-resume-dispatcher-cmd
+    :spec {:repo {}
+           :once {:coerce :boolean :default true}}}
 
    ;; Control Plane subcommands
    {:cmds ["control-plane" "status"]    :fn cp-status-cmd}

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_resume_dispatcher.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_resume_dispatcher.clj
@@ -86,6 +86,44 @@
               acc)))
         {})))
 
+(defn- print-listener-failure!
+  "Render one per-listener failure entry from the dispatch summary's
+   `:failed` vector to a typed error line. Pulled out so the
+   `doseq` body stays a single named call."
+  [failure]
+  (display/print-error
+   (messages/t :pr/resume-dispatch-listener-failed
+               {:lid     (str (:listener/id failure))
+                :code    (str (get-in failure [:error :code]))
+                :message (or (get-in failure [:error :message]) "")})))
+
+(defn- print-dispatch-result!
+  "Render the operator-facing summary of one
+   `dispatch-pr-merge!` call. Branches on `(dag/ok? r)` first
+   because the dispatcher returns a DAG result (per its public
+   contract); only the success branch unwraps `(:data r)` for the
+   per-PR summary line + per-listener failure lines."
+  [pr-number pr-url r]
+  (cond
+    (not (dag/ok? r))
+    (display/print-error
+     (messages/t :pr/resume-dispatch-pr-error
+                 {:n       pr-number
+                  :url     pr-url
+                  :code    (str (get-in r [:error :code]))
+                  :message (or (get-in r [:error :message]) "")}))
+
+    :else
+    (let [summary (:data r)]
+      (display/print-info
+       (messages/t :pr/resume-dispatch-pr-summary
+                   {:n      pr-number
+                    :url    pr-url
+                    :ok     (count (:dispatched summary))
+                    :failed (count (:failed summary))
+                    :total  (:listener-count summary)}))
+      (run! print-listener-failure! (:failed summary)))))
+
 (defn- dispatch-merged-pr!
   "For one PR with at least one `:active` listener: query gh, decide
    if merged, dispatch + mark on yes."
@@ -103,35 +141,10 @@
                    {:n pr-number :state (str (:state gh))}))
 
       :else
-      (let [merged-pr (merged-pr-record (first listeners) gh)
-            r (pr-lifecycle/dispatch-pr-merge! worktree-path pr-url merged-pr)]
-        (cond
-          ;; dispatch-pr-merge! returns a DAG result. Bubble registry-
-          ;; read failures (or any other top-level error) as a typed
-          ;; line; only access summary keys when (dag/ok? r).
-          (not (dag/ok? r))
-          (display/print-error
-           (messages/t :pr/resume-dispatch-pr-error
-                       {:n       pr-number
-                        :url     pr-url
-                        :code    (str (get-in r [:error :code]))
-                        :message (or (get-in r [:error :message]) "")}))
-
-          :else
-          (let [summary (:data r)]
-            (display/print-info
-             (messages/t :pr/resume-dispatch-pr-summary
-                         {:n      pr-number
-                          :url    pr-url
-                          :ok     (count (:dispatched summary))
-                          :failed (count (:failed summary))
-                          :total  (:listener-count summary)}))
-            (doseq [f (:failed summary)]
-              (display/print-error
-               (messages/t :pr/resume-dispatch-listener-failed
-                           {:lid     (str (:listener/id f))
-                            :code    (str (get-in f [:error :code]))
-                            :message (or (get-in f [:error :message]) "")})))))))))
+      (print-dispatch-result!
+       pr-number pr-url
+       (pr-lifecycle/dispatch-pr-merge!
+        worktree-path pr-url (merged-pr-record (first listeners) gh))))))
 
 (defn- run-pass!
   "One pass: read registry, group active listeners by PR, dispatch each."

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_resume_dispatcher.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_resume_dispatcher.clj
@@ -105,19 +105,33 @@
       :else
       (let [merged-pr (merged-pr-record (first listeners) gh)
             r (pr-lifecycle/dispatch-pr-merge! worktree-path pr-url merged-pr)]
-        (display/print-info
-         (messages/t :pr/resume-dispatch-pr-summary
-                     {:n        pr-number
-                      :url      pr-url
-                      :ok       (count (:dispatched r))
-                      :failed   (count (:failed r))
-                      :total    (:listener-count r)}))
-        (doseq [f (:failed r)]
+        (cond
+          ;; dispatch-pr-merge! returns a DAG result. Bubble registry-
+          ;; read failures (or any other top-level error) as a typed
+          ;; line; only access summary keys when (dag/ok? r).
+          (not (dag/ok? r))
           (display/print-error
-           (messages/t :pr/resume-dispatch-listener-failed
-                       {:lid     (str (:listener/id f))
-                        :code    (str (get-in f [:error :code]))
-                        :message (or (get-in f [:error :message]) "")})))))))
+           (messages/t :pr/resume-dispatch-pr-error
+                       {:n       pr-number
+                        :url     pr-url
+                        :code    (str (get-in r [:error :code]))
+                        :message (or (get-in r [:error :message]) "")}))
+
+          :else
+          (let [summary (:data r)]
+            (display/print-info
+             (messages/t :pr/resume-dispatch-pr-summary
+                         {:n      pr-number
+                          :url    pr-url
+                          :ok     (count (:dispatched summary))
+                          :failed (count (:failed summary))
+                          :total  (:listener-count summary)}))
+            (doseq [f (:failed summary)]
+              (display/print-error
+               (messages/t :pr/resume-dispatch-listener-failed
+                           {:lid     (str (:listener/id f))
+                            :code    (str (get-in f [:error :code]))
+                            :message (or (get-in f [:error :message]) "")})))))))))
 
 (defn- run-pass!
   "One pass: read registry, group active listeners by PR, dispatch each."

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_resume_dispatcher.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_resume_dispatcher.clj
@@ -1,0 +1,165 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.pr-resume-dispatcher
+  "N13 §2.7 Resume Signal Dispatcher CLI.
+
+   Single-pass orchestrator: walk active listeners in the registry,
+   query GitHub for each PR's merge state, dispatch resume primers
+   for the freshly-merged ones. v0 ships `--once` (single pass).
+   The persistent loop is a v1 follow-up — operators can wrap with
+   external cron the same way `pr review-monitor` works."
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [cheshire.core :as json]
+   [clojure.string :as str]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
+
+;; ── helpers ──────────────────────────────────────────────────────────
+
+(defn- gh-pr-merge-state
+  "Query GitHub for `pr-number`'s merge state in `worktree-path`'s
+   repo. Returns `{:state :MERGED|:OPEN|:CLOSED :merge-sha string?
+   :merged-at string?}` map on success or nil on gh failure.
+
+   Uses gh's `--json` projection so we get exactly the fields needed
+   in one round-trip."
+  [worktree-path pr-number]
+  (try
+    (let [r (process/shell {:dir (str worktree-path)
+                            :out :string :err :string :continue true}
+                           "gh" "pr" "view" (str pr-number)
+                           "--json" "state,mergeCommit,mergedAt")]
+      (when (zero? (:exit r))
+        (let [parsed (json/parse-string (str/trim (:out r "")) true)]
+          {:state     (keyword (:state parsed))
+           :merge-sha (get-in parsed [:mergeCommit :oid])
+           :merged-at (:mergedAt parsed)})))
+    (catch Throwable _ nil)))
+
+(defn- parse-iso-inst
+  "Parse an ISO-8601 string from gh into a java.util.Date, or nil."
+  [s]
+  (try
+    (java.util.Date/from (java.time.Instant/parse s))
+    (catch Throwable _ nil)))
+
+(defn- merged-pr-record
+  "Build the merged-PR record consumed by `dispatch-pr-merge!` from a
+   listener entry + the gh response."
+  [listener gh-response]
+  {:pr/url       (:pr/url listener)
+   :merge/sha    (:merge-sha gh-response)
+   :merged-at    (or (parse-iso-inst (:merged-at gh-response))
+                     (java.util.Date.))
+   :diff-summary nil}) ; v0 omits diff-summary; gh diff --stat is a follow-up
+
+(defn- group-active-listeners-by-pr
+  "Pure: group `entries-for-agent`-style listener bundle into
+   `{pr-url [listener ...]}` filtered to `:active`."
+  [registry]
+  (->> (:registry/listeners registry)
+       (reduce-kv
+        (fn [acc pr-url listeners]
+          (let [actives (filter #(= :active (:status %)) listeners)]
+            (if (seq actives)
+              (assoc acc pr-url (vec actives))
+              acc)))
+        {})))
+
+(defn- dispatch-merged-pr!
+  "For one PR with at least one `:active` listener: query gh, decide
+   if merged, dispatch + mark on yes."
+  [worktree-path pr-url listeners]
+  (let [pr-number (:pr/number (first listeners))
+        gh        (gh-pr-merge-state worktree-path pr-number)]
+    (cond
+      (nil? gh)
+      (display/print-error
+       (messages/t :pr/resume-dispatch-gh-failed {:n pr-number :url pr-url}))
+
+      (not= :MERGED (:state gh))
+      (display/print-info
+       (messages/t :pr/resume-dispatch-not-merged
+                   {:n pr-number :state (str (:state gh))}))
+
+      :else
+      (let [merged-pr (merged-pr-record (first listeners) gh)
+            r (pr-lifecycle/dispatch-pr-merge! worktree-path pr-url merged-pr)]
+        (display/print-info
+         (messages/t :pr/resume-dispatch-pr-summary
+                     {:n        pr-number
+                      :url      pr-url
+                      :ok       (count (:dispatched r))
+                      :failed   (count (:failed r))
+                      :total    (:listener-count r)}))
+        (doseq [f (:failed r)]
+          (display/print-error
+           (messages/t :pr/resume-dispatch-listener-failed
+                       {:lid     (str (:listener/id f))
+                        :code    (str (get-in f [:error :code]))
+                        :message (or (get-in f [:error :message]) "")})))))))
+
+(defn- run-pass!
+  "One pass: read registry, group active listeners by PR, dispatch each."
+  [worktree-path]
+  (let [r (pr-lifecycle/read-listener-registry worktree-path)]
+    (cond
+      (not (dag/ok? r))
+      (display/print-error
+       (messages/t :pr/resume-dispatch-registry-failed
+                   {:code    (str (get-in r [:error :code]))
+                    :message (or (get-in r [:error :message]) "")}))
+
+      :else
+      (let [groups (group-active-listeners-by-pr (:data r))]
+        (display/print-info
+         (messages/t :pr/resume-dispatch-pass-start
+                     {:pr-count (count groups)}))
+        (doseq [[pr-url listeners] groups]
+          (dispatch-merged-pr! worktree-path pr-url listeners))))))
+
+;; ── command entry ────────────────────────────────────────────────────
+
+(defn pr-resume-dispatcher-cmd
+  "CLI entry for `bb miniforge pr resume-dispatch`.
+
+   v0: single-pass. The persistent loop is a v1 follow-up.
+
+   Flags:
+   - --repo <path>  worktree containing `.miniforge/listener-registry.edn`
+                    AND a git remote that gh can resolve {owner}/{repo}
+                    against (defaults to cwd)
+   - --once         single pass (default; v0 has no other mode)"
+  [opts]
+  (let [worktree-path (get opts :repo (str (fs/cwd)))]
+    (cond
+      (not (fs/exists? worktree-path))
+      (display/print-error
+       (messages/t :pr/resume-dispatch-repo-not-found {:path worktree-path}))
+
+      :else
+      (try
+        (run-pass! worktree-path)
+        (catch Exception e
+          (display/print-error
+           (messages/t :pr/resume-dispatch-failed {:message (ex-message e)})))))))

--- a/components/pr-lifecycle/resources/config/resume-dispatcher/defaults.edn
+++ b/components/pr-lifecycle/resources/config/resume-dispatcher/defaults.edn
@@ -1,0 +1,15 @@
+;; Resume Signal Dispatcher — per-component configuration defaults.
+;;
+;; Loaded once at namespace load via `clojure.edn/read-string`.
+;; Operators tuning retry budget / timeouts shouldn't recompile.
+;;
+;; Per N13 §2.7 + specs/informative/n13-listener-registry.md.
+
+{;; Webhook channel — total POST attempts (initial + retries).
+ :webhook/max-attempts     3
+
+ ;; Per-attempt curl timeout (--max-time, seconds-resolution).
+ :webhook/timeout-ms       10000
+
+ ;; Initial backoff for exponential retry (doubled per attempt).
+ :webhook/backoff-base-ms  500}

--- a/components/pr-lifecycle/resources/test-fixtures/resume-dispatcher/fixtures.edn
+++ b/components/pr-lifecycle/resources/test-fixtures/resume-dispatcher/fixtures.edn
@@ -1,0 +1,27 @@
+;; Test fixtures for resume-dispatcher tests.
+;; Loaded once at test-namespace load via clojure.edn/read-string —
+;; matches the pattern used by other components/<comp>/test-resources/
+;; entries (see pipeline-config, pipeline-pack, workflow).
+;;
+;; Per the operator review on #848: keeping fixture data in EDN
+;; rather than inline source means future fixture tweaks (new
+;; channel kinds, additional listener fields, alternate PR shapes)
+;; don't require changing the test source.
+
+{:pr-url "https://github.com/o/r/pull/42"
+
+ :base-listener-params
+ {:pr/url         "https://github.com/o/r/pull/42"
+  :pr/repo-id     "o/r"
+  :pr/number      42
+  :agent/id       "agent-A"
+  :runtime        :claude-cli
+  :resume-channel {:channel/kind   :webhook
+                   :channel/target "https://hooks.example.com/agent-A"}
+  :registered-by  :authoring-agent}
+
+ :merged-pr
+ {:pr/url       "https://github.com/o/r/pull/42"
+  :merge/sha    "abc1234deadbeef"
+  :merged-at    #inst "2026-05-10T20:54:45.000-00:00"
+  :diff-summary "+50 / -12 across 3 files"}}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -41,6 +41,7 @@
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]
    [ai.miniforge.pr-lifecycle.github :as github]
    [ai.miniforge.pr-lifecycle.listener-registry :as listener-registry]
+   [ai.miniforge.pr-lifecycle.resume-dispatcher :as resume-dispatcher]
    [ai.miniforge.pr-lifecycle.review-scheduler :as review-scheduler]
    [ai.miniforge.pr-lifecycle.triage :as triage]
    [ai.miniforge.pr-lifecycle.merge :as merge]
@@ -459,6 +460,36 @@
   "Pure: return all entries (any status) bound to `agent-id` across
    all PRs."
   listener-registry/entries-for-agent)
+
+;------------------------------------------------------------------------------ Layer 2.8
+;; Resume Signal Dispatcher (N13 §2.7 §Dispatch)
+
+(def resume-dispatcher-supported-channel-kinds
+  "Channel kinds with a real handler in v0 (`#{:webhook}`)."
+  resume-dispatcher/supported-channel-kinds)
+
+(def build-resume-primer
+  "Pure: build the N13 §2.7 resume primer from a merged-PR record
+   + a single listener entry. See `resume-dispatcher/build-primer`."
+  resume-dispatcher/build-primer)
+
+(def channel-supported?
+  "Pure predicate: true when the listener's channel kind has a real
+   handler in v0."
+  resume-dispatcher/channel-supported?)
+
+(def dispatch-resume-listener!
+  "Build primer + dispatch via the listener's channel + mark
+   `:dispatched` on success. Returns DAG result. Channel-side
+   failures decorate `:error :data` with `:listener/id` for
+   correlation."
+  resume-dispatcher/dispatch-listener!)
+
+(def dispatch-pr-merge!
+  "Walk every `:active` listener for `pr-url` and dispatch each.
+   Returns `{:pr-url :listener-count :dispatched [...] :failed [...]}`.
+   Per-listener failures don't abort — they're collected."
+  resume-dispatcher/dispatch-pr-merge!)
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Fix loop

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
@@ -1,0 +1,311 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.resume-dispatcher
+  "Resume Signal Dispatcher (N13 §2.7 §Dispatch).
+
+   When a PR with registered listeners merges, build a structured
+   resume primer per spec and deliver it to each `:active` listener
+   via its declared channel, then transition the listener to
+   `:dispatched`.
+
+   v0 scope:
+   - Polling-based trigger: walk active listeners, query GitHub for
+     each PR's merged state, dispatch on transition. Webhook server
+     is a v1 hardening.
+   - `:webhook` channel: real HTTP POST with bounded retries.
+   - `:pty` + `:miniforge-ipc` channels: typed `:not-yet-wired`
+     errors. They require cooperating runtime infrastructure (Drive
+     console PTY host for `:pty`; an event-stream subscriber for
+     `:miniforge-ipc`) that v0 doesn't ship. Registered listeners
+     using these channels surface as attention items per spec §6.
+
+   Layer 0: config + primer schema
+   Layer 1: pure helpers (build primer, classify channel)
+   Layer 2: channel handlers (per-kind I/O)
+   Layer 3: dispatcher entry points (orchestrate registry +
+            channel + transition)"
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.listener-registry :as registry]
+   [babashka.process :as process]
+   [cheshire.core :as json]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Configuration + primer schema
+
+(def ^:private config
+  "Component config loaded from
+   `resources/config/resume-dispatcher/defaults.edn`. Tunables for
+   webhook retry budget, request timeout, etc., live in EDN so
+   operators don't recompile."
+  (-> (io/resource "config/resume-dispatcher/defaults.edn")
+      slurp
+      edn/read-string))
+
+(def webhook-max-attempts
+  "Number of webhook POST attempts (initial + retries) before giving up."
+  (:webhook/max-attempts config))
+
+(def webhook-timeout-ms
+  "Per-attempt timeout for the webhook POST."
+  (:webhook/timeout-ms config))
+
+(def webhook-backoff-base-ms
+  "Initial backoff (doubled per retry)."
+  (:webhook/backoff-base-ms config))
+
+(def supported-channel-kinds
+  "Channel kinds with a real handler in v0.
+   `:pty` and `:miniforge-ipc` are recognized as valid registry
+   values (per listener-registry config) but dispatch is not wired
+   yet — they return `:resume-dispatcher/not-yet-wired`."
+  #{:webhook})
+
+(def ResumePrimer
+  "Resume primer payload delivered to each listener (N13 §2.7)."
+  [:map
+   [:resume/pr-url       :string]
+   [:resume/merge-sha    :string]
+   [:resume/merged-at    inst?]
+   [:resume/diff-summary {:optional true} [:maybe :string]]
+   [:resume/listener     [:map
+                          [:agent/id   :string]
+                          [:session/id {:optional true} [:maybe :string]]]]])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pure helpers (primer construction + channel classification)
+
+(defn build-primer
+  "Pure: assemble the resume primer per N13 §2.7 from a merged-PR
+   record + a single listener entry.
+
+   `merged-pr` shape:
+     {:pr/url       string
+      :merge/sha    string
+      :merged-at    inst
+      :diff-summary string?  ; optional}"
+  [merged-pr listener]
+  {:resume/pr-url       (:pr/url merged-pr)
+   :resume/merge-sha    (:merge/sha merged-pr)
+   :resume/merged-at    (:merged-at merged-pr)
+   :resume/diff-summary (:diff-summary merged-pr)
+   :resume/listener     (cond-> {:agent/id (:agent/id listener)}
+                          (:session/id listener) (assoc :session/id (:session/id listener)))})
+
+(defn validate-primer!
+  "Throw on invalid primer; return primer otherwise. Used by
+   `dispatch-to-channel!` before any I/O."
+  [primer]
+  (when-not (m/validate ResumePrimer primer)
+    (throw (ex-info "invalid resume primer"
+                    {:errors  (m/explain ResumePrimer primer)
+                     :anomaly :resume-dispatcher/invalid-primer
+                     :primer  primer})))
+  primer)
+
+(defn channel-supported?
+  "Pure predicate: true when the listener's channel kind has a real
+   handler in v0."
+  [listener]
+  (contains? supported-channel-kinds
+             (get-in listener [:resume-channel :channel/kind])))
+
+(defn- not-yet-wired-error
+  "Build the typed error returned for `:pty` / `:miniforge-ipc`
+   listeners until the cooperating runtimes ship."
+  [listener]
+  (let [kind (get-in listener [:resume-channel :channel/kind])]
+    (dag/err :resume-dispatcher/not-yet-wired
+             (str "channel kind " kind " not yet wired in v0; "
+                  "register listener with :webhook channel until "
+                  "the cooperating runtime ships")
+             {:channel/kind kind
+              :listener/id  (:listener/id listener)})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Channel handlers (per-kind I/O)
+
+(defn- backoff-ms
+  "Pure: exponential backoff for webhook retries — base * 2^attempt."
+  [attempt]
+  (* webhook-backoff-base-ms (long (Math/pow 2 attempt))))
+
+(defn- post-webhook-once
+  "Single HTTP POST attempt to the listener's `:channel/target` URL.
+   Returns DAG result. Curl invoked via `babashka.process` to keep
+   this brick BB-compatible without pulling extra HTTP deps."
+  [target-url json-body]
+  (try
+    (let [r (process/shell {:in json-body
+                            :out :string
+                            :err :string
+                            :continue true}
+                           "curl" "--silent" "--show-error" "--fail"
+                           "--max-time" (str (quot webhook-timeout-ms 1000))
+                           "-X" "POST"
+                           "-H" "Content-Type: application/json"
+                           "--data-binary" "@-"
+                           target-url)]
+      (if (zero? (:exit r))
+        (dag/ok {:body (str/trim (:out r ""))})
+        (dag/err :resume-dispatcher/webhook-http-failed
+                 (str "curl exit " (:exit r) ": " (str/trim (:err r "")))
+                 {:exit-code (:exit r) :target target-url})))
+    (catch Throwable e
+      (dag/err :resume-dispatcher/webhook-exception
+               (.getMessage e)
+               {:target target-url}))))
+
+(defn sleep!
+  "Wrapper around `Thread/sleep`. Public (rather than `defn-`) so the
+   retry loop's sleep can be `with-redefs`'d to a no-op in unit tests
+   — `with-redefs` on a private var requires `#'ns/var` quoting which
+   is verbose; promoting this to public is the cheaper test seam."
+  [ms]
+  (Thread/sleep (long ms)))
+
+(defn- post-webhook-with-retry
+  "Webhook POST with bounded retries + exponential backoff.
+   Returns the first successful DAG result, or the last failure
+   after `webhook-max-attempts` attempts."
+  [target-url json-body]
+  (loop [attempt 0
+         last-err nil]
+    (cond
+      (>= attempt webhook-max-attempts)
+      (or last-err
+          (dag/err :resume-dispatcher/webhook-exhausted
+                   "webhook attempts exhausted with no captured error"
+                   {:target target-url}))
+
+      :else
+      (let [r (post-webhook-once target-url json-body)]
+        (if (dag/ok? r)
+          r
+          (do
+            (when (pos? attempt) (sleep! (backoff-ms attempt)))
+            (recur (inc attempt) r)))))))
+
+(defn- dispatch-via-webhook!
+  "Send the primer to the listener's webhook URL. Returns DAG result.
+   Cheshire's default keyword serialization already preserves the
+   `<ns>/<name>` form (e.g. `:resume/pr-url → \"resume/pr-url\"`),
+   which is what the spec requires receivers to parse — no key-fn
+   transformation needed."
+  [primer listener]
+  (let [target (get-in listener [:resume-channel :channel/target])
+        body   (json/generate-string primer)]
+    (cond
+      (or (nil? target) (str/blank? target))
+      (dag/err :resume-dispatcher/missing-target
+               "listener :resume-channel/:channel/target is required for :webhook"
+               {:listener/id (:listener/id listener)})
+
+      :else
+      (post-webhook-with-retry target body))))
+
+(def ^:private channel-handlers
+  "Channel-kind → handler. Closed v0 set; unsupported kinds route to
+   `not-yet-wired-error`."
+  {:webhook dispatch-via-webhook!})
+
+;------------------------------------------------------------------------------ Layer 3
+;; Dispatcher entry points (orchestrate registry + channel + transition)
+
+(defn dispatch-to-channel!
+  "Pure-ish wrapper: validate primer, look up channel handler,
+   invoke. Returns DAG result. Does NOT mark the listener
+   `:dispatched` — that's the caller's job after success."
+  [primer listener]
+  (try
+    (validate-primer! primer)
+    (let [kind (get-in listener [:resume-channel :channel/kind])
+          handler (get channel-handlers kind)]
+      (if handler
+        (handler primer listener)
+        (not-yet-wired-error listener)))
+    (catch clojure.lang.ExceptionInfo e
+      (dag/err (or (:anomaly (ex-data e)) :resume-dispatcher/invalid-primer)
+               (.getMessage e)
+               (ex-data e)))))
+
+(defn dispatch-listener!
+  "Build primer + dispatch + mark dispatched on success.
+   Returns `(dag/ok {:listener/id ... :dispatch-id ... :outcome :delivered})`
+   on success or the failing DAG result with `:listener/id` attached
+   on `:data` for diagnostics."
+  [worktree-path merged-pr listener]
+  (let [primer (build-primer merged-pr listener)
+        r      (dispatch-to-channel! primer listener)]
+    (if-not (dag/ok? r)
+      ;; Decorate with listener-id so an operator scanning the
+      ;; failure stream can correlate without re-querying the registry.
+      (update r :error (fn [err]
+                         (-> err
+                             (update :data (fnil assoc {})
+                                     :listener/id (:listener/id listener)))))
+      (let [dispatch-id (random-uuid)
+            mark-r (registry/mark-dispatched!
+                    worktree-path
+                    (:pr/url merged-pr)
+                    (:listener/id listener)
+                    dispatch-id)]
+        (if (dag/ok? mark-r)
+          (dag/ok {:listener/id   (:listener/id listener)
+                   :dispatch-id   dispatch-id
+                   :outcome       :delivered
+                   :dispatched-at (java.util.Date.)})
+          ;; Delivery succeeded but marking failed — surface the
+          ;; degraded state so the caller knows the registry is now
+          ;; out of sync with the wire. The next pass will re-deliver.
+          (dag/err :resume-dispatcher/marked-failed-after-delivery
+                   (str "primer delivered but mark-dispatched! failed: "
+                        (get-in mark-r [:error :message]))
+                   {:listener/id (:listener/id listener)
+                    :dispatch-id dispatch-id
+                    :mark-error  (:error mark-r)}))))))
+
+(defn dispatch-pr-merge!
+  "Walk every `:active` listener for `pr-url` and dispatch each.
+   Returns a summary `{:dispatched [...] :failed [...]}`. Per-listener
+   failures don't abort the pass — they're collected and surfaced.
+
+   `merged-pr` is the caller-provided merge record (see `build-primer`)."
+  [worktree-path pr-url merged-pr]
+  (let [r (registry/read-registry worktree-path)]
+    (if-not (dag/ok? r)
+      r
+      (let [actives (registry/active-entries-for-pr (:data r) pr-url)]
+        (reduce
+         (fn [acc listener]
+           (let [d (dispatch-listener! worktree-path merged-pr listener)]
+             (if (dag/ok? d)
+               (update acc :dispatched conj (:data d))
+               (update acc :failed conj
+                       {:listener/id (:listener/id listener)
+                        :error       (:error d)}))))
+         {:pr-url pr-url
+          :listener-count (count actives)
+          :dispatched []
+          :failed     []}
+         actives)))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
@@ -150,6 +150,16 @@
   [attempt]
   (* webhook-backoff-base-ms (long (Math/pow 2 attempt))))
 
+(defn- timeout-seconds
+  "Convert `webhook-timeout-ms` to a curl `--max-time` string with
+   millisecond precision. `curl --max-time` accepts decimals, so we
+   format `<seconds>.<thousandths>` rather than `(quot ms 1000)` —
+   the latter truncates to 0 if operators tune `:webhook/timeout-ms`
+   below 1000ms, and `--max-time 0` disables the timeout entirely
+   (would let the dispatcher hang on a slow/broken endpoint)."
+  []
+  (format "%.3f" (/ (double webhook-timeout-ms) 1000.0)))
+
 (defn- post-webhook-once
   "Single HTTP POST attempt to the listener's `:channel/target` URL.
    Returns DAG result. Curl invoked via `babashka.process` to keep
@@ -161,7 +171,7 @@
                             :err :string
                             :continue true}
                            "curl" "--silent" "--show-error" "--fail"
-                           "--max-time" (str (quot webhook-timeout-ms 1000))
+                           "--max-time" (timeout-seconds)
                            "-X" "POST"
                            "-H" "Content-Type: application/json"
                            "--data-binary" "@-"
@@ -186,25 +196,32 @@
 
 (defn- post-webhook-with-retry
   "Webhook POST with bounded retries + exponential backoff.
-   Returns the first successful DAG result, or the last failure
-   after `webhook-max-attempts` attempts."
-  [target-url json-body]
-  (loop [attempt 0
-         last-err nil]
-    (cond
-      (>= attempt webhook-max-attempts)
-      (or last-err
-          (dag/err :resume-dispatcher/webhook-exhausted
-                   "webhook attempts exhausted with no captured error"
-                   {:target target-url}))
 
-      :else
-      (let [r (post-webhook-once target-url json-body)]
-        (if (dag/ok? r)
-          r
-          (do
-            (when (pos? attempt) (sleep! (backoff-ms attempt)))
-            (recur (inc attempt) r)))))))
+   Backoff schedule: a failed attempt at index `i` sleeps
+   `(backoff-ms i)` before attempt `i+1`. The final attempt's
+   failure does NOT sleep (no retry follows). Concretely with
+   defaults (max-attempts=3, base=500ms):
+
+     attempt 0 fails → sleep 500ms  → attempt 1
+     attempt 1 fails → sleep 1000ms → attempt 2
+     attempt 2 fails → return error (no sleep)
+
+   Returns the first successful DAG result, or the last failure."
+  [target-url json-body]
+  (loop [attempt 0]
+    (let [r (post-webhook-once target-url json-body)
+          last-attempt? (>= (inc attempt) webhook-max-attempts)]
+      (cond
+        (dag/ok? r)
+        r
+
+        last-attempt?
+        r
+
+        :else
+        (do
+          (sleep! (backoff-ms attempt))
+          (recur (inc attempt)))))))
 
 (defn- dispatch-via-webhook!
   "Send the primer to the listener's webhook URL. Returns DAG result.
@@ -287,25 +304,35 @@
 
 (defn dispatch-pr-merge!
   "Walk every `:active` listener for `pr-url` and dispatch each.
-   Returns a summary `{:dispatched [...] :failed [...]}`. Per-listener
-   failures don't abort the pass — they're collected and surfaced.
+   Always returns a DAG result for shape consistency:
+
+   - On registry-read failure: the upstream `(dag/err ...)` is bubbled
+     unchanged so callers can branch on `(dag/ok? r)` rather than
+     guarding for two return shapes.
+   - On success (including zero active listeners): `(dag/ok summary)`
+     where summary is `{:pr-url <s> :listener-count <int> :dispatched [...]
+     :failed [...]}`.
+
+   Per-listener failures don't abort the pass — they're collected
+   into `:failed` and the overall call still returns `(dag/ok ...)`.
 
    `merged-pr` is the caller-provided merge record (see `build-primer`)."
   [worktree-path pr-url merged-pr]
   (let [r (registry/read-registry worktree-path)]
     (if-not (dag/ok? r)
       r
-      (let [actives (registry/active-entries-for-pr (:data r) pr-url)]
-        (reduce
-         (fn [acc listener]
-           (let [d (dispatch-listener! worktree-path merged-pr listener)]
-             (if (dag/ok? d)
-               (update acc :dispatched conj (:data d))
-               (update acc :failed conj
-                       {:listener/id (:listener/id listener)
-                        :error       (:error d)}))))
-         {:pr-url pr-url
-          :listener-count (count actives)
-          :dispatched []
-          :failed     []}
-         actives)))))
+      (let [actives (registry/active-entries-for-pr (:data r) pr-url)
+            summary (reduce
+                     (fn [acc listener]
+                       (let [d (dispatch-listener! worktree-path merged-pr listener)]
+                         (if (dag/ok? d)
+                           (update acc :dispatched conj (:data d))
+                           (update acc :failed conj
+                                   {:listener/id (:listener/id listener)
+                                    :error       (:error d)}))))
+                     {:pr-url pr-url
+                      :listener-count (count actives)
+                      :dispatched []
+                      :failed     []}
+                     actives)]
+        (dag/ok summary)))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
@@ -187,10 +187,32 @@
                {:target target-url}))))
 
 (defn sleep!
-  "Wrapper around `Thread/sleep`. Public (rather than `defn-`) so the
-   retry loop's sleep can be `with-redefs`'d to a no-op in unit tests
-   — `with-redefs` on a private var requires `#'ns/var` quoting which
-   is verbose; promoting this to public is the cheaper test seam."
+  "Synchronous backoff wait between retry attempts. Wraps
+   `Thread/sleep` in a redefable var so unit tests can null it out
+   without forcing `#'ns/var` quoting on a private.
+
+   Why a real `Thread/sleep` rather than core.async timeout / a
+   ScheduledExecutorService:
+
+   - The dispatcher is a serial batch orchestrator. `dispatch-pr-merge!`
+     iterates listeners sequentially; each listener's
+     `dispatch-via-webhook!` is itself a blocking shell-out to curl.
+     The whole pass is single-threaded by design.
+   - Within one listener's retry loop, `Thread/sleep` between attempts
+     blocks the same thread that's already blocked on the curl
+     subprocess. There's no concurrency to recover, no other work to
+     interleave, so async-timer machinery would add complexity (an
+     executor, a callback chain, lifecycle management) without any
+     throughput or latency benefit.
+   - When per-PR concurrency lands (a future change — `pmap` over the
+     PR-grouped listener buckets in the CLI orchestrator), each parallel
+     branch is still serial within itself, so the per-listener retry
+     loop's `sleep!` keeps making sense at that level. The concurrency
+     would live one level up, not inside this loop.
+
+   So: sync sleep is the right primitive at THIS layer. Async
+   timer infrastructure is reserved for the concurrency upgrade above
+   it, if and when it lands."
   [ms]
   (Thread/sleep (long ms)))
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
@@ -1,0 +1,298 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.resume-dispatcher-test
+  "Tests for the N13 §2.7 Resume Signal Dispatcher."
+  (:require [babashka.fs :as fs]
+            [babashka.process :as process]
+            [cheshire.core :as json]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.dag-executor.interface :as dag]
+            [ai.miniforge.pr-lifecycle.listener-registry :as registry]
+            [ai.miniforge.pr-lifecycle.resume-dispatcher :as sut]))
+
+;; ── fixture: ephemeral worktree ──────────────────────────────────────
+
+(def ^:dynamic *worktree* nil)
+
+(defn worktree-fixture [f]
+  (let [w (str (fs/create-temp-dir {:prefix "resume-dispatcher-test-"}))]
+    (try
+      (binding [*worktree* w] (f))
+      (finally (try (fs/delete-tree w) (catch Throwable _ nil))))))
+
+(use-fixtures :each worktree-fixture)
+
+;; ── fixtures ─────────────────────────────────────────────────────────
+
+(def ^:private pr-url "https://github.com/o/r/pull/42")
+
+(def ^:private base-listener-params
+  {:pr/url         pr-url
+   :pr/repo-id     "o/r"
+   :pr/number      42
+   :agent/id       "agent-A"
+   :runtime        :claude-cli
+   :resume-channel {:channel/kind   :webhook
+                    :channel/target "https://hooks.example.com/agent-A"}
+   :registered-by  :authoring-agent})
+
+(def ^:private merged-pr
+  {:pr/url       pr-url
+   :merge/sha    "abc1234deadbeef"
+   :merged-at    #inst "2026-05-10T20:54:45.000-00:00"
+   :diff-summary "+50 / -12 across 3 files"})
+
+(defn- register-listener!
+  [overrides]
+  (let [r (registry/register! *worktree* (merge base-listener-params overrides))]
+    (assert (dag/ok? r))
+    (-> r :data :listener-id)))
+
+(defn- capture-shell
+  [calls-atom result]
+  (fn [opts & args]
+    (swap! calls-atom conj {:opts opts :args (vec args)})
+    result))
+
+(defn- entry-by-id
+  "Read registry from disk, find entry by listener-id."
+  [listener-id]
+  (let [reg (-> (registry/read-registry *worktree*) :data)
+        bucket (registry/entries-for-pr reg pr-url)]
+    (first (filter #(= listener-id (:listener/id %)) bucket))))
+
+;; ── build-primer (pure) ──────────────────────────────────────────────
+
+(deftest build-primer-shape
+  (testing "primer has all spec-required keys + omits :session/id when absent"
+    (let [listener (assoc base-listener-params :session/id nil :listener/id (random-uuid))
+          primer (sut/build-primer merged-pr listener)]
+      (is (= pr-url (:resume/pr-url primer)))
+      (is (= "abc1234deadbeef" (:resume/merge-sha primer)))
+      (is (= #inst "2026-05-10T20:54:45.000-00:00" (:resume/merged-at primer)))
+      (is (= "+50 / -12 across 3 files" (:resume/diff-summary primer)))
+      (is (= "agent-A" (get-in primer [:resume/listener :agent/id])))
+      (is (not (contains? (:resume/listener primer) :session/id))
+          "session/id is dropped when nil — spec marks it optional"))))
+
+(deftest build-primer-includes-session-when-present
+  (let [listener (assoc base-listener-params :session/id "sess-001" :listener/id (random-uuid))
+        primer (sut/build-primer merged-pr listener)]
+    (is (= "sess-001" (get-in primer [:resume/listener :session/id])))))
+
+(deftest validate-primer-throws-on-bad-shape
+  (testing "validate-primer! throws ex-info with anomaly tag on missing required keys"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (sut/validate-primer! {:resume/pr-url "x"})))))
+
+;; ── channel-supported? + not-yet-wired ───────────────────────────────
+
+(deftest channel-supported-only-webhook-in-v0
+  (is (true?  (sut/channel-supported?
+               (assoc base-listener-params
+                      :resume-channel {:channel/kind :webhook
+                                       :channel/target "x"}))))
+  (is (false? (sut/channel-supported?
+               (assoc base-listener-params
+                      :resume-channel {:channel/kind :pty
+                                       :channel/target "pty-7"}))))
+  (is (false? (sut/channel-supported?
+               (assoc base-listener-params
+                      :resume-channel {:channel/kind :miniforge-ipc
+                                       :channel/target "topic-x"})))))
+
+(deftest dispatch-to-channel-pty-returns-not-yet-wired
+  (testing ":pty listener gets :resume-dispatcher/not-yet-wired with kind in :data"
+    (let [listener (assoc base-listener-params
+                          :listener/id (random-uuid)
+                          :resume-channel {:channel/kind :pty
+                                           :channel/target "pty-7"})
+          primer (sut/build-primer merged-pr listener)
+          r (sut/dispatch-to-channel! primer listener)]
+      (is (not (dag/ok? r)))
+      (is (= :resume-dispatcher/not-yet-wired (get-in r [:error :code])))
+      (is (= :pty (get-in r [:error :data :channel/kind]))))))
+
+(deftest dispatch-to-channel-miniforge-ipc-returns-not-yet-wired
+  (let [listener (assoc base-listener-params
+                        :listener/id (random-uuid)
+                        :resume-channel {:channel/kind :miniforge-ipc
+                                         :channel/target "topic-x"})
+        primer (sut/build-primer merged-pr listener)
+        r (sut/dispatch-to-channel! primer listener)]
+    (is (= :miniforge-ipc (get-in r [:error :data :channel/kind])))))
+
+;; ── webhook handler ──────────────────────────────────────────────────
+
+(deftest dispatch-webhook-happy-path
+  (testing "successful webhook POST shells out to curl with the right args + JSON body"
+    (let [calls (atom [])
+          stub  (capture-shell calls {:exit 0 :out "" :err ""})]
+      (with-redefs [process/shell stub]
+        (let [listener (assoc base-listener-params :listener/id (random-uuid))
+              primer (sut/build-primer merged-pr listener)
+              r (sut/dispatch-to-channel! primer listener)]
+          (is (dag/ok? r))
+          (is (= 1 (count @calls)))
+          (let [args (:args (first @calls))]
+            (is (some #{"curl"} args))
+            (is (some #{"-X" "POST"} args))
+            (is (some #{"https://hooks.example.com/agent-A"} args))
+            (is (some #{"Content-Type: application/json"} args)))
+          (let [stdin (get-in (first @calls) [:opts :in])
+                payload (json/parse-string stdin true)]
+            (is (= pr-url (:resume/pr-url payload)))
+            (is (= "abc1234deadbeef" (:resume/merge-sha payload)))))))))
+
+(deftest dispatch-webhook-rejects-blank-target
+  (let [listener (assoc base-listener-params
+                        :listener/id (random-uuid)
+                        :resume-channel {:channel/kind :webhook :channel/target ""})
+        primer (sut/build-primer merged-pr listener)
+        r (sut/dispatch-to-channel! primer listener)]
+    (is (not (dag/ok? r)))
+    (is (= :resume-dispatcher/missing-target (get-in r [:error :code])))))
+
+(deftest dispatch-webhook-retries-on-failure
+  (testing "transient failure is retried up to webhook-max-attempts; success on retry → ok"
+    (let [calls (atom 0)
+          ;; Fail twice, succeed on third.
+          stub (fn [_opts & _args]
+                 (swap! calls inc)
+                 (if (< @calls 3)
+                   {:exit 22 :out "" :err "HTTP/1.1 503 Service Unavailable"}
+                   {:exit 0  :out "" :err ""}))]
+      (with-redefs [process/shell stub
+                    ;; Skip the real Thread/sleep so the suite stays fast.
+                    sut/sleep! (fn [_] nil)]
+        (let [listener (assoc base-listener-params :listener/id (random-uuid))
+              primer (sut/build-primer merged-pr listener)
+              r (sut/dispatch-to-channel! primer listener)]
+          (is (dag/ok? r))
+          (is (= 3 @calls) "retried twice before success"))))))
+
+(deftest dispatch-webhook-exhausts-attempts
+  (testing "persistent failure exhausts webhook-max-attempts and returns the last error"
+    (let [calls (atom 0)
+          stub (fn [_opts & _args]
+                 (swap! calls inc)
+                 {:exit 22 :out "" :err "HTTP/1.1 500 Internal Server Error"})]
+      (with-redefs [process/shell stub
+                    sut/sleep! (fn [_] nil)]
+        (let [listener (assoc base-listener-params :listener/id (random-uuid))
+              primer (sut/build-primer merged-pr listener)
+              r (sut/dispatch-to-channel! primer listener)]
+          (is (not (dag/ok? r)))
+          (is (= sut/webhook-max-attempts @calls)
+              "called exactly webhook-max-attempts times")
+          (is (= :resume-dispatcher/webhook-http-failed (get-in r [:error :code]))))))))
+
+;; ── dispatch-listener! (delivery + mark) ─────────────────────────────
+
+(deftest dispatch-listener-marks-on-success
+  (testing "successful delivery transitions listener :active → :dispatched and stamps dispatch-id"
+    (let [stub (capture-shell (atom []) {:exit 0 :out "" :err ""})]
+      (with-redefs [process/shell stub]
+        (let [lid (register-listener! {})
+              listener (entry-by-id lid)
+              r (sut/dispatch-listener! *worktree* merged-pr listener)]
+          (is (dag/ok? r))
+          (is (= :delivered (-> r :data :outcome)))
+          (is (uuid? (-> r :data :dispatch-id)))
+          (let [post (entry-by-id lid)]
+            (is (= :dispatched (:status post)))
+            (is (= (-> r :data :dispatch-id) (:resume/dispatch-id post)))
+            (is (inst? (:resume/dispatched-at post)))))))))
+
+(deftest dispatch-listener-decorates-failure-with-listener-id
+  (testing "delivery failure surfaces :listener/id on :error :data for diagnostics"
+    (let [stub (capture-shell (atom []) {:exit 22 :out "" :err "boom"})]
+      (with-redefs [process/shell stub]
+        (let [lid (register-listener! {})
+              listener (entry-by-id lid)
+              r (sut/dispatch-listener! *worktree* merged-pr listener)]
+          (is (not (dag/ok? r)))
+          (is (= lid (get-in r [:error :data :listener/id])))
+          (let [post (entry-by-id lid)]
+            (is (= :active (:status post))
+                "listener stays :active when delivery fails — next pass retries")))))))
+
+;; ── dispatch-pr-merge! (whole-PR pass) ───────────────────────────────
+
+(deftest dispatch-pr-merge-walks-only-active-listeners
+  (testing "dispatch-pr-merge! processes :active listeners; skips already-dispatched/cancelled"
+    (let [stub (capture-shell (atom []) {:exit 0 :out "" :err ""})]
+      (with-redefs [process/shell stub]
+        (let [a (register-listener! {:agent/id "agent-A"})
+              b (register-listener! {:agent/id "agent-B"})
+              c (register-listener! {:agent/id "agent-C"})
+              ;; Cancel b; pre-dispatch c via the registry directly to
+              ;; simulate a previous run.
+              _ (registry/unregister! *worktree* pr-url b)
+              _ (registry/mark-dispatched! *worktree* pr-url c (random-uuid))
+              r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
+          (is (= pr-url (:pr-url r)))
+          (is (= 1 (:listener-count r))
+              "only the still-active listener (a) is in scope")
+          (is (= 1 (count (:dispatched r))))
+          (is (= 0 (count (:failed r))))
+          (is (= a (-> r :dispatched first :listener/id))))))))
+
+(deftest dispatch-pr-merge-collects-failures-without-aborting
+  (testing "per-listener failures don't abort the pass — they're collected"
+    ;; Stub by URL match so per-listener outcomes are deterministic.
+    ;; agent-A targets the failing endpoint; agent-B targets the OK one.
+    (let [stub (fn [_opts & args]
+                 (cond
+                   (some #{"https://hooks.example.com/fail"} args)
+                   {:exit 22 :out "" :err "boom"}
+
+                   (some #{"https://hooks.example.com/ok"} args)
+                   {:exit 0 :out "" :err ""}
+
+                   :else
+                   {:exit 1 :out "" :err "no route"}))]
+      (with-redefs [process/shell stub
+                    sut/sleep! (fn [_] nil)]
+        (let [_a (register-listener!
+                  {:agent/id "agent-A"
+                   :resume-channel {:channel/kind   :webhook
+                                    :channel/target "https://hooks.example.com/fail"}})
+              _b (register-listener!
+                  {:agent/id "agent-B"
+                   :resume-channel {:channel/kind   :webhook
+                                    :channel/target "https://hooks.example.com/ok"}})
+              r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
+          (is (= 2 (:listener-count r)))
+          (is (= 1 (count (:failed r)))
+              "agent-A failure collected; agent-B unaffected")
+          (is (= 1 (count (:dispatched r)))
+              "agent-B success despite agent-A failure"))))))
+
+(deftest dispatch-pr-merge-pty-listener-not-yet-wired
+  (testing ":pty listener flows through as a :failed entry with not-yet-wired"
+    (let [pty-listener-id (register-listener!
+                           {:agent/id "pty-agent"
+                            :resume-channel {:channel/kind :pty
+                                             :channel/target "pty-1"}})
+          r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
+      (is (= 1 (count (:failed r))))
+      (is (= :resume-dispatcher/not-yet-wired
+             (get-in (first (:failed r)) [:error :code])))
+      (is (= pty-listener-id (get-in (first (:failed r)) [:error :data :listener/id]))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
@@ -21,6 +21,8 @@
   (:require [babashka.fs :as fs]
             [babashka.process :as process]
             [cheshire.core :as json]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [ai.miniforge.dag-executor.interface :as dag]
             [ai.miniforge.pr-lifecycle.listener-registry :as registry]
@@ -39,24 +41,21 @@
 (use-fixtures :each worktree-fixture)
 
 ;; ── fixtures ─────────────────────────────────────────────────────────
+;; Loaded from `resources/test-fixtures/resume-dispatcher/fixtures.edn`
+;; rather than inlined here. Future fixture tweaks (new channel kinds,
+;; alternate PR shapes) don't need source edits. Matches the
+;; `resources/test-fixtures/` convention compliance-scanner uses —
+;; placing the file under `resources/` keeps it on the workspace
+;; classpath without per-component test-alias tweaks.
 
-(def ^:private pr-url "https://github.com/o/r/pull/42")
+(def ^:private fixtures
+  (-> (io/resource "test-fixtures/resume-dispatcher/fixtures.edn")
+      slurp
+      edn/read-string))
 
-(def ^:private base-listener-params
-  {:pr/url         pr-url
-   :pr/repo-id     "o/r"
-   :pr/number      42
-   :agent/id       "agent-A"
-   :runtime        :claude-cli
-   :resume-channel {:channel/kind   :webhook
-                    :channel/target "https://hooks.example.com/agent-A"}
-   :registered-by  :authoring-agent})
-
-(def ^:private merged-pr
-  {:pr/url       pr-url
-   :merge/sha    "abc1234deadbeef"
-   :merged-at    #inst "2026-05-10T20:54:45.000-00:00"
-   :diff-summary "+50 / -12 across 3 files"})
+(def ^:private pr-url               (:pr-url fixtures))
+(def ^:private base-listener-params (:base-listener-params fixtures))
+(def ^:private merged-pr            (:merged-pr fixtures))
 
 (defn- register-listener!
   [overrides]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
@@ -160,6 +160,24 @@
             (is (= pr-url (:resume/pr-url payload)))
             (is (= "abc1234deadbeef" (:resume/merge-sha payload)))))))))
 
+(deftest dispatch-webhook-passes-fractional-seconds-to-curl
+  (testing "curl --max-time receives fractional seconds (so a sub-1000ms timeout doesn't truncate to 0)"
+    (let [calls (atom [])
+          stub  (capture-shell calls {:exit 0 :out "" :err ""})]
+      (with-redefs [process/shell stub
+                    ;; Simulate operator tuning timeout below 1000ms.
+                    sut/webhook-timeout-ms 250]
+        (let [listener (assoc base-listener-params :listener/id (random-uuid))
+              primer (sut/build-primer merged-pr listener)]
+          (sut/dispatch-to-channel! primer listener)
+          (let [args (:args (first @calls))
+                idx  (.indexOf ^java.util.List args "--max-time")
+                seconds-str (when (>= idx 0) (nth args (inc idx)))]
+            (is (= "0.250" seconds-str)
+                "fractional precision preserved; --max-time would truncate to 0 if we used (quot ms 1000)")
+            (is (not= "0" seconds-str)
+                "--max-time 0 would disable the timeout entirely (would let dispatcher hang)")))))))
+
 (deftest dispatch-webhook-rejects-blank-target
   (let [listener (assoc base-listener-params
                         :listener/id (random-uuid)
@@ -186,6 +204,22 @@
               r (sut/dispatch-to-channel! primer listener)]
           (is (dag/ok? r))
           (is (= 3 @calls) "retried twice before success"))))))
+
+(deftest dispatch-webhook-backoff-schedule
+  (testing "backoff sleeps after attempts 0 + 1 (with backoff-ms 0 + 1) but NOT after attempt 2 (last)"
+    (let [sleeps (atom [])
+          ;; Always fail so we exhaust all attempts.
+          stub   (fn [_opts & _args]
+                   {:exit 22 :out "" :err "HTTP/1.1 500 Internal Server Error"})]
+      (with-redefs [process/shell stub
+                    sut/sleep! (fn [ms] (swap! sleeps conj ms))]
+        (let [listener (assoc base-listener-params :listener/id (random-uuid))
+              primer (sut/build-primer merged-pr listener)
+              _ (sut/dispatch-to-channel! primer listener)]
+          (is (= [(* sut/webhook-backoff-base-ms 1)   ; sleep before retry to attempt 1
+                  (* sut/webhook-backoff-base-ms 2)]  ; sleep before retry to attempt 2
+                 @sleeps)
+              "backoff schedule: base*1 then base*2; no sleep after the final attempt"))))))
 
 (deftest dispatch-webhook-exhausts-attempts
   (testing "persistent failure exhausts webhook-max-attempts and returns the last error"
@@ -246,13 +280,15 @@
               ;; simulate a previous run.
               _ (registry/unregister! *worktree* pr-url b)
               _ (registry/mark-dispatched! *worktree* pr-url c (random-uuid))
-              r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
-          (is (= pr-url (:pr-url r)))
-          (is (= 1 (:listener-count r))
+              r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)
+              summary (:data r)]
+          (is (dag/ok? r) "dispatch-pr-merge! always returns a DAG result")
+          (is (= pr-url (:pr-url summary)))
+          (is (= 1 (:listener-count summary))
               "only the still-active listener (a) is in scope")
-          (is (= 1 (count (:dispatched r))))
-          (is (= 0 (count (:failed r))))
-          (is (= a (-> r :dispatched first :listener/id))))))))
+          (is (= 1 (count (:dispatched summary))))
+          (is (= 0 (count (:failed summary))))
+          (is (= a (-> summary :dispatched first :listener/id))))))))
 
 (deftest dispatch-pr-merge-collects-failures-without-aborting
   (testing "per-listener failures don't abort the pass — they're collected"
@@ -278,11 +314,13 @@
                   {:agent/id "agent-B"
                    :resume-channel {:channel/kind   :webhook
                                     :channel/target "https://hooks.example.com/ok"}})
-              r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
-          (is (= 2 (:listener-count r)))
-          (is (= 1 (count (:failed r)))
+              r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)
+              summary (:data r)]
+          (is (dag/ok? r))
+          (is (= 2 (:listener-count summary)))
+          (is (= 1 (count (:failed summary)))
               "agent-A failure collected; agent-B unaffected")
-          (is (= 1 (count (:dispatched r)))
+          (is (= 1 (count (:dispatched summary)))
               "agent-B success despite agent-A failure"))))))
 
 (deftest dispatch-pr-merge-pty-listener-not-yet-wired
@@ -291,8 +329,25 @@
                            {:agent/id "pty-agent"
                             :resume-channel {:channel/kind :pty
                                              :channel/target "pty-1"}})
-          r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
-      (is (= 1 (count (:failed r))))
+          r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)
+          summary (:data r)]
+      (is (dag/ok? r))
+      (is (= 1 (count (:failed summary))))
       (is (= :resume-dispatcher/not-yet-wired
-             (get-in (first (:failed r)) [:error :code])))
-      (is (= pty-listener-id (get-in (first (:failed r)) [:error :data :listener/id]))))))
+             (get-in (first (:failed summary)) [:error :code])))
+      (is (= pty-listener-id (get-in (first (:failed summary)) [:error :data :listener/id]))))))
+
+(deftest dispatch-pr-merge-bubbles-registry-read-failure-as-dag-err
+  (testing "registry read failure bubbles up as the same DAG error shape (not a partial summary)"
+    (with-redefs [registry/read-registry
+                  (fn [_]
+                    {:ok? false
+                     :error {:code :listener-registry/read-failed
+                             :message "synthetic disk failure"
+                             :data {:path "/dev/null"}}})]
+      (let [r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
+        (is (not (dag/ok? r))
+            "registry-read failure bubbles as DAG err, not a half-built summary")
+        (is (= :listener-registry/read-failed (get-in r [:error :code])))
+        (is (nil? (:dispatched r))
+            "no summary keys present on the err return — caller branches on dag/ok?")))))

--- a/docs/pull-requests/2026-05-10-feat-n13-resume-signal-dispatcher.md
+++ b/docs/pull-requests/2026-05-10-feat-n13-resume-signal-dispatcher.md
@@ -114,7 +114,7 @@ interval daemon into the command.
 - [x] `resume-dispatcher-test`: 15 tests / 50 assertions pass.
 - [x] `listener-registry-test`: 25 tests / 76 assertions still pass.
 - [x] Full namespace tree loads under `:dev:test`.
-- [x] `bb pre-commit`: pending (will run on commit).
+- [x] `bb pre-commit`: ✅ ALL PRE-COMMIT CHECKS PASSED.
 - [ ] Live smoke test against a real merged PR with a registered
       webhook listener (manual, post-merge).
 

--- a/docs/pull-requests/2026-05-10-feat-n13-resume-signal-dispatcher.md
+++ b/docs/pull-requests/2026-05-10-feat-n13-resume-signal-dispatcher.md
@@ -1,0 +1,142 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# feat(n13): Resume Signal Dispatcher (N13 §2.7)
+
+## Overview
+
+When a PR with registered listeners merges, build a structured resume
+primer per N13 §2.7 and deliver it to each `:active` listener via its
+declared channel, then transition the listener to `:dispatched`. CLI:
+`bb miniforge pr resume-dispatch --repo <path>`.
+
+This is the operator-load killer the listener registry (#841/#843)
+unblocked. Per the #808 mining, manual `merged` acks were the highest-
+volume operator turn (~448 instances across recent sessions); this
+dispatcher retires that whole class for any agent registered with a
+webhook listener.
+
+## Mechanism
+
+```text
+read .miniforge/listener-registry.edn
+        │
+        ▼
+group active listeners by PR URL
+        │
+        ▼
+for each PR:  gh pr view <n> --json state,mergeCommit,mergedAt
+        │
+        ▼
+        state == MERGED?
+        │       │
+       no      yes
+        │       │
+       skip    for each :active listener:
+                 build N13 §2.7 resume primer
+                 dispatch via channel handler
+                 mark :dispatched (with dispatch-id)
+```
+
+## Channel handlers (v0)
+
+| Channel | v0 status |
+|---|---|
+| `:webhook` | **Real**: HTTP POST primer JSON, bounded retries (default 3) with exponential backoff (default 500ms base), 10s per-attempt timeout. Tunables in `resources/config/resume-dispatcher/defaults.edn`. |
+| `:pty` | Stub — returns `:resume-dispatcher/not-yet-wired`. Needs Drive console PTY host (separate component). |
+| `:miniforge-ipc` | Stub — returns `:resume-dispatcher/not-yet-wired`. Needs an event-stream subscriber. |
+
+Listeners with `:pty` or `:miniforge-ipc` channels register cleanly
+(per #841 the registry already accepts them), but `dispatch-listener!`
+returns the typed `:not-yet-wired` error so the operator sees the gap
+and can re-register with a webhook in the meantime. The two stubs
+become real handlers when their cooperating runtimes ship.
+
+## Public API (re-exported through `pr-lifecycle.interface`)
+
+| API | Behavior |
+|---|---|
+| `build-resume-primer` | Pure: assemble the N13 §2.7 primer from a merged-PR record + listener |
+| `channel-supported?` | Pure predicate: does this listener's channel kind have a real handler? |
+| `dispatch-resume-listener!` | Build + dispatch + mark for one listener; failure decorated with `:listener/id` for diagnostics |
+| `dispatch-pr-merge!` | Walk every `:active` listener for a PR; per-listener failures collected, not aborting |
+| `resume-dispatcher-supported-channel-kinds` | The v0 set (`#{:webhook}`) |
+
+## Webhook payload shape (per N13 §2.7)
+
+```json
+{
+  "resume/pr-url":       "https://github.com/o/r/pull/42",
+  "resume/merge-sha":    "abc1234deadbeef",
+  "resume/merged-at":    "2026-05-10T20:54:45Z",
+  "resume/diff-summary": null,
+  "resume/listener":     {"agent/id": "agent-A", "session/id": "sess-001"}
+}
+```
+
+Cheshire's default keyword serialization preserves the
+`<ns>/<name>` form, so receivers parse `"resume/pr-url"` directly —
+no key transformation needed.
+
+## Operator surface
+
+```bash
+# Single-pass over all active listeners (default cwd):
+bb miniforge pr resume-dispatch
+
+# Against an explicit checkout:
+bb miniforge pr resume-dispatch --repo /path/to/repo
+```
+
+External cron / loop wraps `--once` for v0. v1 will fold a poll-
+interval daemon into the command.
+
+## Failure semantics
+
+- **Per-PR gh failure** (e.g. PR doesn't exist anymore, gh auth issue):
+  surfaces an error line, skips the PR, continues to the next.
+- **Per-listener delivery failure**: collected into the pass result's
+  `:failed` vector with `:listener/id` decoration. Listener stays
+  `:active` so the next pass retries.
+- **Webhook 5xx / network errors**: bounded retries with exponential
+  backoff. After exhaustion, listener stays `:active`.
+- **Marked-failed-after-delivery** (delivery succeeded but registry
+  write failed): typed `:resume-dispatcher/marked-failed-after-delivery`
+  surfaces the degraded state. Next pass re-delivers (cheap because
+  webhook receivers are expected to be idempotent on
+  `:resume/pr-url` together with `:resume/merge-sha`).
+
+## Test plan
+
+- [x] `clj-kondo`: clean.
+- [x] `resume-dispatcher-test`: 15 tests / 50 assertions pass.
+- [x] `listener-registry-test`: 25 tests / 76 assertions still pass.
+- [x] Full namespace tree loads under `:dev:test`.
+- [x] `bb pre-commit`: pending (will run on commit).
+- [ ] Live smoke test against a real merged PR with a registered
+      webhook listener (manual, post-merge).
+
+## What's NOT in this PR (deferred)
+
+- **Daemon loop** — v1 will fold `--poll-interval` into the command.
+- **Webhook server / GitHub App** — production-grade trigger
+  (subscribe to `pull_request.closed.merged`); the v0 polling path
+  gets the same operator outcome immediately.
+- **`:pty` and `:miniforge-ipc` channel handlers** — wired when
+  cooperating runtimes ship.
+- **Diff-summary in primer** — currently nil; `gh pr diff --stat`
+  is a small follow-up.
+- **Resume-channel auth** — primer transport is HTTP today; signed
+  payloads / mTLS are v1.
+
+## References
+
+- Spec: N13 §2.7 + `specs/informative/n13-listener-registry.md`.
+- #808 — N13 foundations.
+- #818 — `pr review --post`.
+- #837 — `pr review-monitor`.
+- #841 — listener registry implementation (the prerequisite this PR
+  unblocks).
+- #843 — listener registry strata fix.


### PR DESCRIPTION
## Summary

When a PR with registered listeners merges, build a structured resume primer per N13 §2.7 and deliver it to each `:active` listener via its declared channel, then transition the listener to `:dispatched`. CLI: `bb miniforge pr resume-dispatch --repo <path>`.

This is the operator-load killer the listener registry ([#841](https://github.com/miniforge-ai/miniforge/pull/841) / [#843](https://github.com/miniforge-ai/miniforge/pull/843)) unblocked. Per the [#808](https://github.com/miniforge-ai/miniforge/pull/808) mining, manual `merged` acks were the highest-volume operator turn (~448 instances across recent sessions); this dispatcher retires that whole class for any agent registered with a webhook listener.

Full PR doc: [`docs/pull-requests/2026-05-10-feat-n13-resume-signal-dispatcher.md`](docs/pull-requests/2026-05-10-feat-n13-resume-signal-dispatcher.md).

## Mechanism (v0 polling-based)

```text
read .miniforge/listener-registry.edn
group active listeners by PR URL
for each PR: gh pr view <n> --json state,mergeCommit,mergedAt
  if state == MERGED:
    for each :active listener:
      build N13 §2.7 resume primer
      dispatch via channel handler
      mark :dispatched (with dispatch-id)
```

## Channel handlers (v0)

| Channel | Status |
|---|---|
| `:webhook` | **Real**: HTTP POST primer JSON via curl, bounded retries (default 3), exponential backoff (default 500ms base), 10s per-attempt timeout. Tunables in `resources/config/resume-dispatcher/defaults.edn`. |
| `:pty` | Stub — typed `:resume-dispatcher/not-yet-wired`. Needs Drive console PTY host. |
| `:miniforge-ipc` | Stub — same. Needs an event-stream subscriber. |

Listeners with stub channels register cleanly (registry already accepts them); the typed not-yet-wired error surfaces the gap so operators can re-register with `:webhook` in the meantime.

## Webhook payload shape (per N13 §2.7)

```json
{
  "resume/pr-url":       "https://github.com/o/r/pull/42",
  "resume/merge-sha":    "abc1234deadbeef",
  "resume/merged-at":    "2026-05-10T20:54:45Z",
  "resume/diff-summary": null,
  "resume/listener":     {"agent/id": "agent-A", "session/id": "sess-001"}
}
```

Cheshire's default keyword serialization preserves the `<ns>/<name>` form; no key transformation needed.

## Operator surface

```bash
bb miniforge pr resume-dispatch                    # default cwd
bb miniforge pr resume-dispatch --repo /path/to/repo
```

External cron / loop wraps `--once` for v0; `--poll-interval` daemon is a v1 follow-up.

## Test plan

- [x] `clj-kondo`: clean.
- [x] `resume-dispatcher-test`: 15 tests / 50 assertions pass.
- [x] `listener-registry-test`: 25 tests / 76 assertions still pass.
- [x] Full namespace tree loads.
- [x] `bb pre-commit`: ✅ ALL PRE-COMMIT CHECKS PASSED.

## Commit budget

980 insertions across 8 files. Override rationale: cohesive feature slice — dispatcher impl + config + interface re-exports + tests + CLI + i18n + docs ship together so the loop works end-to-end against a real registered webhook listener. Splitting creates artificial cross-PR deps (CLI without dispatcher is dead code; dispatcher without CLI has no operator surface).

## What's NOT in this PR (deferred)

- **Daemon loop** — v1 will fold `--poll-interval`.
- **Webhook server / GitHub App** — production trigger; v0 polling gets the same operator outcome immediately.
- **`:pty` / `:miniforge-ipc` channel handlers** — wired when cooperating runtimes ship.
- **Diff-summary in primer** — currently nil; `gh pr diff --stat` is a small follow-up.
- **Resume-channel auth** — primer transport is HTTP today; signed payloads / mTLS are v1.

## References

- Spec: N13 §2.7 + `specs/informative/n13-listener-registry.md`.
- #808 — N13 foundations.
- #818 — `pr review --post`.
- #837 — `pr review-monitor`.
- #841 — listener registry implementation (the prerequisite this PR unblocks).
- #843 — listener registry strata fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)