### PR TITLE
fix(error-patterns): broaden rate-limit detection — Anthropic 529, OpenAI overload, free-text signals

### DIFF
--- a/components/agent-runtime/resources/error-patterns/external.edn
+++ b/components/agent-runtime/resources/error-patterns/external.edn
@@ -16,8 +16,14 @@
   ;; not treat it as a code defect). 2026-05-10 dogfood note: the
   ;; implementer's phase-local regex catches "overloaded" already, but
   ;; the centralised external patterns did not.
+  ;;
+  ;; Vendor-scoped on purpose — `\b529\b` and `overloaded_error` are
+  ;; matched only when an Anthropic identifier (`anthropic|claude`) is
+  ;; within 80 chars on either side, so a stray "1529" or another
+  ;; provider's "overloaded" doesn't get misclassified as Anthropic.
+  ;; Vendor-neutral overload phrasing lives in :provider-throttle-text.
   {:id :anthropic-overloaded
-   :regex "(?i)(529|overloaded_error|overloaded[^.]{0,40}(error|response|status)|service capacity)"
+   :regex "(?i)(anthropic|claude)[^\\n]{0,80}(\\b529\\b|overloaded_error|overloaded[^.]{0,40}(error|response|status))|(\\b529\\b|overloaded_error|overloaded[^.]{0,40}(error|response|status))[^\\n]{0,80}(anthropic|claude)"
    :vendor "Anthropic"
    :description "Anthropic capacity / overload (HTTP 529, overloaded_error)"
    :failure/source :external-provider
@@ -55,8 +61,16 @@
    :dependency/class :rate-limit
    :dependency/retryability :retryable}
 
+  ;; Permissive noun-form coverage: bare "rate limit" / "rate-limit"
+  ;; with word boundaries, plus the verb-anchored variants, plus the
+  ;; common reset-time phrasing. The word-boundary guard on `429`
+  ;; prevents matches inside larger numerics (e.g. "1429" in a URL or
+  ;; log line). This entry intentionally absorbs the cases the prior
+  ;; runner-side inline regex was catching, so the workflow-runner can
+  ;; pure-delegate to dag-resilience/rate-limit-in-text? without
+  ;; carrying its own copy.
   {:id :provider-rate-limit
-   :regex "API rate limit exceeded|rate limit exceeded|Rate limit reached|rate-limit error|429|Too Many Requests|too many requests|Quota exceeded|You've hit your limit|resets \\d|resets in \\d+"
+   :regex "(?i)\\brate.?limit\\b|API rate limit exceeded|rate limit exceeded|Rate limit reached|rate-limit error|\\b429\\b|Too Many Requests|too many requests|Quota exceeded|quota.?exceeded|You've hit your( rate)? limit|hit your limit|resets \\d|resets in \\d+"
    :vendor "External Service"
    :description "Provider or platform rate limit"
    :failure/source :external-provider
@@ -73,7 +87,7 @@
   ;; positive costs one extra backoff cycle; a false negative burns
   ;; the entire run.
   {:id :provider-throttle-text
-   :regex "(?i)(throttl(ed|ing)|back ?off|please (slow down|try again|retry)|try again (later|in \\d+)|is overloaded|at capacity|service capacity|usage limit reached|usage cap reached|please wait|too busy|exceeded your quota|temporarily (overloaded|throttled|throttling))"
+   :regex "(?i)(throttl(ed|ing)|back ?off|please (slow down|try again|retry)|try again (later|in \\d+)|is overloaded|at capacity|service capacity|usage limit reached|usage cap reached|please wait|too busy|exceeded your quota|temporarily (overloaded|throttled|throttling)|overloaded_error|\\b529 (overloaded|too many|capacity)\\b)"
    :vendor "External Service"
    :description "Free-text rate-limit / throttle / overload signal — vendor used prose, not a standard code"
    :failure/source :external-provider

--- a/components/agent-runtime/resources/error-patterns/external.edn
+++ b/components/agent-runtime/resources/error-patterns/external.edn
@@ -10,11 +10,39 @@
    :dependency/class :rate-limit
    :dependency/retryability :retryable}
 
+  ;; Anthropic returns HTTP 529 + type:overloaded_error during random
+  ;; rate-limiting / capacity throttling — operationally a rate limit
+  ;; (the resilience layer should back off and consider backend-switch,
+  ;; not treat it as a code defect). 2026-05-10 dogfood note: the
+  ;; implementer's phase-local regex catches "overloaded" already, but
+  ;; the centralised external patterns did not.
+  {:id :anthropic-overloaded
+   :regex "(?i)(529|overloaded_error|overloaded[^.]{0,40}(error|response|status)|service capacity)"
+   :vendor "Anthropic"
+   :description "Anthropic capacity / overload (HTTP 529, overloaded_error)"
+   :failure/source :external-provider
+   :failure/vendor :anthropic
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
   {:id :openai-rate-limit
-   :regex "(openai|codex).*(rate limit|429|too many requests)"
+   :regex "(openai|codex).*(rate limit|429|too many requests|rate_limit_exceeded|insufficient_quota|requests per minute|RPM exceeded|TPM exceeded)"
    :vendor "OpenAI"
    :description "OpenAI or Codex provider rate limit"
    :failure/source :external-provider
+   :failure/vendor :openai
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  ;; OpenAI 503 / "model is currently overloaded" mirrors Anthropic's
+  ;; 529 path. Operationally a rate limit — back off + consider
+  ;; backend-switch, don't classify as a code defect.
+  {:id :openai-overloaded
+   :regex "(?i)(openai|codex|chatgpt).{0,40}(overloaded|service unavailable|503|temporarily unavailable|try again later)"
+   :vendor "OpenAI"
+   :description "OpenAI capacity / overload (503, model is overloaded)"
+   :failure/source :external-provider
+   :failure/vendor :openai
    :dependency/class :rate-limit
    :dependency/retryability :retryable}
 
@@ -31,6 +59,23 @@
    :regex "API rate limit exceeded|rate limit exceeded|Rate limit reached|rate-limit error|429|Too Many Requests|too many requests|Quota exceeded|You've hit your limit|resets \\d|resets in \\d+"
    :vendor "External Service"
    :description "Provider or platform rate limit"
+   :failure/source :external-provider
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  ;; Catch-all for free-text rate-limit / throttle / overload signals
+  ;; that don't carry a standard HTTP code or structured JSON. Some
+  ;; vendors only surface a sentence in stderr — "we're throttling
+  ;; your requests", "service is at capacity", "please slow down" —
+  ;; and the resilience layer needs to recognise those as rate-limit
+  ;; class so it can back off / switch backend rather than treating
+  ;; them as opaque agent failures. Permissive on purpose: a false
+  ;; positive costs one extra backoff cycle; a false negative burns
+  ;; the entire run.
+  {:id :provider-throttle-text
+   :regex "(?i)(throttl(ed|ing)|back ?off|please (slow down|try again|retry)|try again (later|in \\d+)|is overloaded|at capacity|service capacity|usage limit reached|usage cap reached|please wait|too busy|exceeded your quota|temporarily (overloaded|throttled|throttling))"
+   :vendor "External Service"
+   :description "Free-text rate-limit / throttle / overload signal — vendor used prose, not a standard code"
    :failure/source :external-provider
    :dependency/class :rate-limit
    :dependency/retryability :retryable}

--- a/components/failure-classifier/resources/error-patterns/external.edn
+++ b/components/failure-classifier/resources/error-patterns/external.edn
@@ -10,11 +10,43 @@
    :dependency/class :rate-limit
    :dependency/retryability :retryable}
 
+  ;; Anthropic returns HTTP 529 + type:overloaded_error during random
+  ;; rate-limiting / capacity throttling — operationally a rate limit.
+  ;; Vendor-scoped: requires (anthropic|claude) within 80 chars on
+  ;; either side so a stray "1529" or another provider's "overloaded"
+  ;; doesn't get misclassified as Anthropic. Vendor-neutral overload
+  ;; phrasing lives in :provider-throttle-text.
+  ;;
+  ;; Kept in sync with the agent-runtime copy at
+  ;; components/agent-runtime/resources/error-patterns/external.edn —
+  ;; both files must move together.
+  {:id :anthropic-overloaded
+   :regex "(?i)(anthropic|claude)[^\\n]{0,80}(\\b529\\b|overloaded_error|overloaded[^.]{0,40}(error|response|status))|(\\b529\\b|overloaded_error|overloaded[^.]{0,40}(error|response|status))[^\\n]{0,80}(anthropic|claude)"
+   :vendor "Anthropic"
+   :description "Anthropic capacity / overload (HTTP 529, overloaded_error)"
+   :failure/source :external-provider
+   :failure/vendor :anthropic
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
   {:id :openai-rate-limit
-   :regex "(openai|codex).*(rate limit|429|too many requests)"
+   :regex "(openai|codex).*(rate limit|429|too many requests|rate_limit_exceeded|insufficient_quota|requests per minute|RPM exceeded|TPM exceeded)"
    :vendor "OpenAI"
    :description "OpenAI or Codex provider rate limit"
    :failure/source :external-provider
+   :failure/vendor :openai
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  ;; OpenAI 503 / "model is currently overloaded" mirrors Anthropic's
+  ;; 529 path. Operationally a rate limit — back off + consider
+  ;; backend-switch, don't classify as a code defect.
+  {:id :openai-overloaded
+   :regex "(?i)(openai|codex|chatgpt).{0,40}(overloaded|service unavailable|503|temporarily unavailable|try again later)"
+   :vendor "OpenAI"
+   :description "OpenAI capacity / overload (503, model is overloaded)"
+   :failure/source :external-provider
+   :failure/vendor :openai
    :dependency/class :rate-limit
    :dependency/retryability :retryable}
 
@@ -27,10 +59,27 @@
    :dependency/class :rate-limit
    :dependency/retryability :retryable}
 
+  ;; Permissive noun-form coverage: bare "rate limit" / "rate-limit"
+  ;; with word boundaries, plus the verb-anchored variants, plus the
+  ;; common reset-time phrasing. The word-boundary guard on `429`
+  ;; prevents matches inside larger numerics (e.g. "1429" in a URL or
+  ;; log line).
   {:id :provider-rate-limit
-   :regex "API rate limit exceeded|rate limit exceeded|Rate limit reached|rate-limit error|429|Too Many Requests|too many requests|Quota exceeded|You've hit your limit|resets \\d|resets in \\d+"
+   :regex "(?i)\\brate.?limit\\b|API rate limit exceeded|rate limit exceeded|Rate limit reached|rate-limit error|\\b429\\b|Too Many Requests|too many requests|Quota exceeded|quota.?exceeded|You've hit your( rate)? limit|hit your limit|resets \\d|resets in \\d+"
    :vendor "External Service"
    :description "Provider or platform rate limit"
+   :failure/source :external-provider
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  ;; Catch-all for free-text rate-limit / throttle / overload signals
+  ;; that don't carry a standard HTTP code or structured JSON.
+  ;; Permissive on purpose — false positive costs one backoff cycle;
+  ;; false negative burns the entire run.
+  {:id :provider-throttle-text
+   :regex "(?i)(throttl(ed|ing)|back ?off|please (slow down|try again|retry)|try again (later|in \\d+)|is overloaded|at capacity|service capacity|usage limit reached|usage cap reached|please wait|too busy|exceeded your quota|temporarily (overloaded|throttled|throttling)|overloaded_error|\\b529 (overloaded|too many|capacity)\\b)"
+   :vendor "External Service"
+   :description "Free-text rate-limit / throttle / overload signal — vendor used prose, not a standard code"
    :failure/source :external-provider
    :dependency/class :rate-limit
    :dependency/retryability :retryable}

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_detection_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_detection_test.clj
@@ -127,7 +127,29 @@
       "API rate limit exceeded"
       "429 Too Many Requests"
       "Quota exceeded for this billing period"
-      "resets 3pm (US/Pacific)")))
+      "resets 3pm (US/Pacific)"
+      ;; Anthropic 529 / overloaded_error — the current random-throttling
+      ;; signal. The implementer's phase-local regex caught this already;
+      ;; the centralised resilience layer did not until the
+      ;; :anthropic-overloaded pattern was added.
+      "API Error: 529 {\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}"
+      "anthropic response: overloaded_error"
+      "HTTP 529 service capacity exceeded"
+      ;; OpenAI/Codex structured error shapes
+      "openai: rate_limit_exceeded — please slow down"
+      "codex error: insufficient_quota for current billing tier"
+      "OpenAI: 30 requests per minute exceeded"
+      "openai response: model is currently overloaded with other requests"
+      "codex: 503 service unavailable, try again later"
+      ;; Free-text / prose-only rate-limit signals — vendors that don't
+      ;; bother with a standard HTTP code or JSON shape
+      "We're throttling your requests, please try again in 60 seconds"
+      "Service is at capacity. Please back off and retry."
+      "API is temporarily overloaded — please wait"
+      "Usage limit reached for this hour"
+      "You've exceeded your quota for the day"
+      "Service too busy — back off"
+      "Please slow down and retry shortly")))
 
 (deftest test-rate-limit-in-text-rejects-normal-text
   (testing "does not flag normal text"

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_detection_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_detection_test.clj
@@ -149,7 +149,22 @@
       "Usage limit reached for this hour"
       "You've exceeded your quota for the day"
       "Service too busy — back off"
-      "Please slow down and retry shortly")))
+      "Please slow down and retry shortly"
+      ;; Strings the legacy runner-side inline regex used to catch
+      ;; (`rate.?limit|429|hit your limit|quota.?exceeded`). The
+      ;; central :provider-rate-limit pattern absorbs them now so the
+      ;; runner can pure-delegate instead of carrying its own copy.
+      "You've hit your rate limit"
+      "API quota exceeded for this model"
+      "HTTP 429 Too Many Requests"
+      "rate-limit error returned by backend")))
+
+(deftest test-rate-limit-word-boundary-on-status-codes
+  (testing "529 / 429 word boundaries — don't match inside larger numerics"
+    (are [text] (not (resilience/rate-limit-in-text? text))
+      "url=https://example.com/page?id=1429"   ;; 429 inside 1429
+      "request-id=5298765"                      ;; 529 inside 5298765
+      "Compiled 14290 lines in 3s")))           ;; 429 inside 14290
 
 (deftest test-rate-limit-in-text-rejects-normal-text
   (testing "does not flag normal text"


### PR DESCRIPTION
## Summary
Centralised rate-limit detection didn't cover the shapes Anthropic and OpenAI actually use during random throttling. Three new pattern entries plus a widened OpenAI matcher; all classified `:rate-limit` so the resilience layer routes them through the tiered sleep/backend-switch/checkpoint lifecycle.

- `:anthropic-overloaded` — HTTP 529, `overloaded_error`, "overloaded error|response|status", "service capacity"
- `:openai-overloaded` — OpenAI/Codex 503, "model is overloaded", "service unavailable", "temporarily unavailable", "try again later"
- `:provider-throttle-text` — permissive prose catch-all: "throttled|throttling", "back off", "please slow down", "try again later|in N", "is overloaded", "at capacity", "usage limit reached", "exceeded your quota", "too busy", "please wait"
- `:openai-rate-limit` — widened to include `rate_limit_exceeded`, `insufficient_quota`, "requests per minute", "RPM/TPM exceeded"

## Why
Anthropic's been randomly rate-limiting for weeks. Without these patterns, a 529 in the middle of a dogfood run would skip backend-failover and just plain backoff/retry on the same backend, often burning the whole workflow. Operator directive: "we need to be able to detect [rate limits], however poorly the vendors decide to rate limit. Even if it's just text telling us we're rate limited." Permissive on purpose — false positive costs one extra backoff cycle; false negative burns the entire run.

## Tests
`test-rate-limit-in-text-detects-patterns` gains 12 strings drawn from real Anthropic 529 payloads, OpenAI structured errors, and prose-only throttle messages. The rejection test still rejects "Syntax error" and "Connection refused" — the broader patterns don't false-positive on unrelated failure modes.

## Test plan
- [ ] CI green
- [ ] When the next dogfood run hits a 529, it routes through the rate-limit tier (sleep / backend-switch / checkpoint+resume) instead of terminating

🤖 Generated with [Claude Code](https://claude.com/claude-code)