### PR TITLE
feat(knowledge): :zettel/trust-level — per-revision trust attached to immutable revisions

### DIFF
--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -58,6 +58,10 @@
 ;; `knowledge.schema` directly (Polylith dependency rule).
 (def ShareScope     schema/ShareScope)
 (def Classification schema/Classification)
+;; Per-revision trust enum (closes #836). Surfaced here so fleet's
+;; producer-side share-learning gate can reference it without
+;; reaching into `knowledge.schema` directly.
+(def TrustLevel     schema/TrustLevel)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Store creation

--- a/components/knowledge/src/ai/miniforge/knowledge/learning.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/learning.clj
@@ -143,18 +143,28 @@
 (defn promote-learning
   "Promote a learning to a rule after validation.
 
-   This upgrades the zettel type from :learning to :rule,
-   indicating it has been validated and should be treated as authoritative.
+   This upgrades the zettel type from `:learning` to `:rule` AND
+   stamps `:zettel/trust-level :trusted` on the promoted revision
+   (Decision 6 + 8; closes #836). The trust attaches to the
+   IMMUTABLE revision: a subsequent `update-zettel` that rotates
+   any content-bearing field resets `:zettel/trust-level` back to
+   `:untrusted`. Re-promotion is the only path back to `:trusted`.
+
+   The store path bypasses `update-zettel` on purpose — `:zettel/
+   trust-level` is in the updater's `derived-fields` set, so a
+   producer can't ride trust onto a new revision through the edit
+   path. Promotion remains an explicit, store-direct gesture.
 
    Arguments:
    - store       - Knowledge store
    - learning-id - UUID of the learning to promote
    - opts        - Optional map:
-     - :new-uid   - New UID for the rule (generates one if not provided)
-     - :dewey     - Assign Dewey classification
+     - :new-uid     - New UID for the rule (generates one if not provided)
+     - :dewey       - Assign Dewey classification
      - :reviewed-by - Who reviewed/approved this
 
-   Returns the updated zettel as a rule."
+   Returns the updated zettel as a rule (with `:zettel/trust-level
+   :trusted`)."
   [knowledge-store learning-id & [{:keys [new-uid dewey reviewed-by]}]]
   (when-let [learning (store/get-zettel-by-id knowledge-store learning-id)]
     (when (= :learning (:zettel/type learning))
@@ -173,13 +183,22 @@
                                       :source/promoted-from (:zettel/uid learning))
                                (cond-> reviewed-by (assoc :source/reviewed-by reviewed-by)))
 
-            ;; Create updated zettel
+            ;; Build the change set the rotation engine needs and
+            ;; route through `zettel/update-zettel` so the digest +
+            ;; revision-id re-stamp on the new content shape (type
+            ;; flip + uid + source + optional dewey are all
+            ;; content-bearing). Then assoc `:trusted` AFTER
+            ;; update-zettel returns — update-zettel resets trust
+            ;; to `:untrusted` on rotation by design (#836); the
+            ;; promotion gesture is the one path allowed to
+            ;; override that on the new revision.
+            changes (cond-> {:zettel/type   :rule
+                             :zettel/uid    rule-uid
+                             :zettel/source updated-source}
+                      dewey (assoc :zettel/dewey dewey))
             rule (-> learning
-                     (assoc :zettel/type :rule
-                            :zettel/uid rule-uid
-                            :zettel/source updated-source
-                            :zettel/modified (java.util.Date.))
-                     (cond-> dewey (assoc :zettel/dewey dewey)))]
+                     (zettel/update-zettel changes)
+                     (assoc :zettel/trust-level :trusted))]
 
         ;; Delete old learning and store as rule
         (store/delete-zettel knowledge-store learning-id)

--- a/components/knowledge/src/ai/miniforge/knowledge/learning.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/learning.clj
@@ -150,10 +150,17 @@
    any content-bearing field resets `:zettel/trust-level` back to
    `:untrusted`. Re-promotion is the only path back to `:trusted`.
 
-   The store path bypasses `update-zettel` on purpose — `:zettel/
-   trust-level` is in the updater's `derived-fields` set, so a
-   producer can't ride trust onto a new revision through the edit
-   path. Promotion remains an explicit, store-direct gesture.
+   Flow: routes the type / uid / source / dewey transition through
+   `zettel/update-zettel` so the digest + revision-id re-stamp
+   happens in the canonical place (the type flip alone rotates
+   the revision since `:zettel/type` is content-bearing), then
+   asserts `:zettel/trust-level :trusted` on the returned value
+   AFTER the update. The post-assoc is the one path allowed to
+   override `update-zettel`'s reset-on-rotation default — promotion
+   is the explicit gesture that grants trust on the new revision.
+   `:zettel/trust-level` is in `update-zettel`'s `derived-fields`
+   set, so producers cannot reach this state through the edit
+   path on their own.
 
    Arguments:
    - store       - Knowledge store

--- a/components/knowledge/src/ai/miniforge/knowledge/schema.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/schema.clj
@@ -108,6 +108,27 @@
                     (`:fleet/shareable true` is a hard reject upstream)."
   [:enum :public-org :internal :restricted :secret])
 
+(def TrustLevel
+  "Trust attached to a specific zettel revision (Decision 6 + 8 of
+   miniforge-fleet's Phase E plan; closes the gap filed at
+   miniforge-ai/miniforge#836).
+
+     :untrusted — default. Has not passed (or no longer passes)
+                  the promotion review.
+     :trusted   — set by `knowledge.learning/promote-learning` on the
+                  promoted revision. RESET to `:untrusted`
+                  automatically by `knowledge.zettel/update-zettel`
+                  whenever a content-bearing field rotates the
+                  revision-id, so a content-edit on a trusted zettel
+                  cannot ride the prior revision's trust onto new
+                  content. Operational-metadata-only updates
+                  preserve the existing trust value (revision-id
+                  doesn't rotate).
+
+   Fleet's producer-side `share-learning` gate keys off this rather
+   than the looser `:zettel/type :rule` proxy."
+  [:enum :untrusted :trusted])
+
 ;; ----------------------------------------------------------------------------
 
 (def Zettel
@@ -152,6 +173,13 @@
    [:fleet/shareable        {:optional true} boolean?]
    [:fleet/share-scope      {:optional true} ShareScope]
    [:privacy/classification {:optional true} Classification]
+
+   ;; Per-revision trust (Decision 6 + 8; closes #836). Optional
+   ;; for legacy-zettel round-trip; new zettels get `:untrusted` by
+   ;; default at `create-zettel`, and `update-zettel` resets to
+   ;; `:untrusted` on any content rotation. Only
+   ;; `learning/promote-learning` stamps `:trusted`.
+   [:zettel/trust-level {:optional true} TrustLevel]
 
    ;; Version provenance (Decision 13). Pin to the OSS version that
    ;; produced the zettel; Fleet's E.4 quarantine gate + E.9 migration

--- a/components/knowledge/src/ai/miniforge/knowledge/zettel.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/zettel.clj
@@ -89,17 +89,26 @@
 
 (def ^:private derived-fields
   "Fields the constructor / updater own — callers cannot override them
-   directly. They're recomputed from `content-projection` so the
-   relationship between content and revision identity stays
-   tamper-evident.
+   directly via `update-zettel`'s `changes` map; they're recomputed
+   from `content-projection` so the relationship between content
+   and revision identity stays tamper-evident.
 
-   `:zettel/trust-level` is owned by the constructor (defaults to
-   `:untrusted`) + `update-zettel` (resets to `:untrusted` on
-   revision rotation). Only `knowledge.learning/promote-learning`
-   stamps `:trusted`, and it does so via `store/put-zettel`
-   directly — bypassing this updater on purpose, which is what
-   makes a re-promotion an explicit step rather than a side
-   effect of an edit."
+   `:zettel/trust-level` joins `:zettel/digest` + `:zettel/revision-id`
+   for the same reason: the constructor stamps `:untrusted`,
+   `update-zettel` resets to `:untrusted` whenever a content-bearing
+   rotation happens, and `knowledge.learning/promote-learning` is
+   the one path that may post-assoc `:trusted` on the freshly
+   re-stamped revision (it routes through `update-zettel` first
+   for the canonical content re-stamp, then asserts `:trusted`
+   on the result before persisting).
+
+   Note: enforcement here is at the EDIT path. The lower-level
+   `store/put-zettel` is intentionally permissive — it persists
+   whatever map it's given so load-from-disk paths can round-trip
+   legacy stores. Trust-sensitive consumers (e.g., miniforge-fleet's
+   `share-learning` producer-side gate) re-validate at THEIR
+   boundary; the knowledge component supplies the field, the
+   consumer enforces its meaning."
   #{:zettel/digest :zettel/revision-id :zettel/trust-level})
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -152,10 +161,20 @@
                         :zettel/type        type
                         :zettel/created     now
                         :zettel/author      author
-                        ;; Decision 6 + 8 (#836) — every fresh zettel
-                        ;; starts untrusted. Only `learning/promote-
-                        ;; learning` stamps `:trusted`; bypassing
-                        ;; create-zettel doesn't grant trust.
+                        ;; Decision 6 + 8 (#836) — every zettel
+                        ;; minted via this constructor starts
+                        ;; untrusted; `update-zettel` preserves
+                        ;; trust on operational edits and resets
+                        ;; on content rotation; only
+                        ;; `learning/promote-learning` post-asserts
+                        ;; `:trusted` on a freshly re-stamped
+                        ;; revision. The lower-level
+                        ;; `store/put-zettel` persists whatever
+                        ;; it's handed (legacy round-trip path),
+                        ;; so security-sensitive consumers
+                        ;; (fleet's `share-learning` producer
+                        ;; gate) re-validate at their own
+                        ;; boundary — see `derived-fields`.
                         :zettel/trust-level :untrusted}
                  dewey      (assoc :zettel/dewey dewey)
                  (seq tags) (assoc :zettel/tags (vec tags))

--- a/components/knowledge/src/ai/miniforge/knowledge/zettel.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/zettel.clj
@@ -91,8 +91,16 @@
   "Fields the constructor / updater own — callers cannot override them
    directly. They're recomputed from `content-projection` so the
    relationship between content and revision identity stays
-   tamper-evident."
-  #{:zettel/digest :zettel/revision-id})
+   tamper-evident.
+
+   `:zettel/trust-level` is owned by the constructor (defaults to
+   `:untrusted`) + `update-zettel` (resets to `:untrusted` on
+   revision rotation). Only `knowledge.learning/promote-learning`
+   stamps `:trusted`, and it does so via `store/put-zettel`
+   directly — bypassing this updater on purpose, which is what
+   makes a re-promotion an explicit step rather than a side
+   effect of an edit."
+  #{:zettel/digest :zettel/revision-id :zettel/trust-level})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Zettel creation and manipulation
@@ -137,13 +145,18 @@
              fleet/oss-version]
       :or   {author "user"}}]
   (let [now    (java.util.Date.)
-        zettel (cond-> {:zettel/id      (random-uuid)
-                        :zettel/uid     uid
-                        :zettel/title   title
-                        :zettel/content content
-                        :zettel/type    type
-                        :zettel/created now
-                        :zettel/author  author}
+        zettel (cond-> {:zettel/id          (random-uuid)
+                        :zettel/uid         uid
+                        :zettel/title       title
+                        :zettel/content     content
+                        :zettel/type        type
+                        :zettel/created     now
+                        :zettel/author      author
+                        ;; Decision 6 + 8 (#836) — every fresh zettel
+                        ;; starts untrusted. Only `learning/promote-
+                        ;; learning` stamps `:trusted`; bypassing
+                        ;; create-zettel doesn't grant trust.
+                        :zettel/trust-level :untrusted}
                  dewey      (assoc :zettel/dewey dewey)
                  (seq tags) (assoc :zettel/tags (vec tags))
                  (seq links) (assoc :zettel/links (vec links))
@@ -157,32 +170,56 @@
 (defn update-zettel
   "Update a zettel with new values, setting modified timestamp.
 
-   `:zettel/digest` and `:zettel/revision-id` are DERIVED — any value
-   the caller supplies for either is dropped before the merge.
-   `update-zettel` always re-stamps the result via `stamp-revision`,
-   which is idempotent on unchanged content (same content → same
-   digest → same revision-id) and rotates the revision when a
-   content-bearing field changes (`:zettel/uid` / `:zettel/title` /
-   `:zettel/content` / `:zettel/type` / `:zettel/dewey` /
-   `:zettel/tags` / `:zettel/links` / `:zettel/source`). Two
-   consequences worth pinning:
+   `:zettel/digest`, `:zettel/revision-id`, and `:zettel/trust-level`
+   are DERIVED — any value the caller supplies for any of them is
+   dropped before the merge. `update-zettel` always re-stamps the
+   result via `stamp-revision`, which is idempotent on unchanged
+   content (same content → same digest → same revision-id) and
+   rotates the revision when a content-bearing field changes
+   (`:zettel/uid` / `:zettel/title` / `:zettel/content` /
+   `:zettel/type` / `:zettel/dewey` / `:zettel/tags` /
+   `:zettel/links` / `:zettel/source`). Three consequences worth
+   pinning:
 
      - Operational-metadata-only changes (privacy classification,
        share scope, oss-version, etc.) leave the revision identity
-       intact. Decision 6 attaches trust to the immutable revision,
-       so changing operational policy must NOT silently migrate
-       trust onto a new revision.
+       intact AND preserve the existing `:zettel/trust-level`.
+       Decision 6 attaches trust to the immutable revision, so
+       changing operational policy must NOT silently migrate trust
+       onto a new revision — and must not drop trust on the
+       current revision either.
+
+     - When a content-bearing field rotates the revision-id,
+       `:zettel/trust-level` resets to `:untrusted`. The new
+       revision was never reviewed, so no trust attaches to it.
+       Re-promoting (`learning/promote-learning`) is the only path
+       back to `:trusted`, and it operates via `store/put-zettel`
+       directly so the producer can't smuggle trust through this
+       updater (#836).
 
      - A legacy zettel without `:zettel/digest` / `:zettel/revision-id`
-       receives the stamped fields on its first update — the system
-       converges on a fully-stamped state without an explicit
-       backfill pass."
+       receives the stamped fields on its first update; legacy
+       zettels also receive `:zettel/trust-level :untrusted` on
+       first update, so the system converges on a fully-stamped
+       state without an explicit backfill pass."
   [zettel changes]
-  (let [sanitised (apply dissoc changes derived-fields)
+  (let [old-rev   (:zettel/revision-id zettel)
+        old-trust (:zettel/trust-level zettel)
+        sanitised (apply dissoc changes derived-fields)
         merged    (-> zettel
                       (merge sanitised)
-                      (assoc :zettel/modified (java.util.Date.)))]
-    (stamp-revision merged)))
+                      (assoc :zettel/modified (java.util.Date.)))
+        stamped   (stamp-revision merged)
+        new-rev   (:zettel/revision-id stamped)
+        ;; Trust default for legacy zettels (no :zettel/trust-level
+        ;; field present yet) is :untrusted — same convergence
+        ;; behaviour the digest/revision-id backfill already has.
+        ;; Content rotation always resets to :untrusted.
+        next-trust (cond
+                     (and (some? old-rev) (not= old-rev new-rev)) :untrusted
+                     (some? old-trust)                            old-trust
+                     :else                                        :untrusted)]
+    (assoc stamped :zettel/trust-level next-trust)))
 
 (defn zettel-summary
   "Extract a lightweight summary from a zettel."

--- a/components/knowledge/test/ai/miniforge/knowledge/learning_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/learning_test.clj
@@ -1,0 +1,112 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+
+(ns ai.miniforge.knowledge.learning-test
+  "Tests for the learning lifecycle — capture and promotion.
+
+   The first cluster covers `promote-learning`'s contract around the
+   per-revision trust stamp added in #836:
+
+     - A `:learning` zettel goes into the store untrusted (the
+       constructor default).
+     - `promote-learning` flips the type to `:rule` AND stamps
+       `:zettel/trust-level :trusted` on the promoted revision.
+     - Trying to promote a non-`:learning` zettel returns nil
+       (existing behaviour, pinned).
+
+   The second cluster pins the rotation interaction: after promotion,
+   editing the rule's content via `update-zettel` MUST reset trust to
+   `:untrusted` (closes the gap that motivated #836)."
+  (:require
+   [ai.miniforge.knowledge.interface :as knowledge]
+   [ai.miniforge.knowledge.zettel    :as zettel]
+   [clojure.test :refer [deftest is testing use-fixtures]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Fixtures.
+
+(def ^:dynamic *store* nil)
+
+(defn- with-store [f]
+  (binding [*store* (knowledge/create-store)]
+    (f)))
+
+(use-fixtures :each with-store)
+
+(defn- new-learning
+  "Build + persist a fresh `:learning` zettel; return the persisted
+   value so callers can drive `promote-learning` against its id."
+  []
+  (let [z (knowledge/create-zettel
+           "auto-captured-learning"
+           "Captured learning"
+           "# Body\n\nA pattern observed during execution."
+           :learning)]
+    (knowledge/put-zettel *store* z)
+    (knowledge/get-zettel *store* (:zettel/id z))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; promote-learning trust stamp.
+
+(deftest test-fresh-learning-defaults-to-untrusted
+  (testing "create-zettel + put → the persisted :learning carries :zettel/trust-level :untrusted"
+    (let [l (new-learning)]
+      (is (= :learning  (:zettel/type l)))
+      (is (= :untrusted (:zettel/trust-level l))))))
+
+(deftest test-promote-learning-stamps-trusted-on-promoted-revision
+  (testing "promote-learning flips type to :rule AND stamps :zettel/trust-level :trusted"
+    (let [l        (new-learning)
+          promoted (knowledge/promote-learning *store* (:zettel/id l)
+                                               {:dewey "210"
+                                                :reviewed-by "agent:reviewer"})]
+      (is (= :rule    (:zettel/type promoted)))
+      (is (= :trusted (:zettel/trust-level promoted))
+          "promotion is the only path that grants :trusted"))))
+
+(deftest test-promote-learning-on-non-learning-returns-nil
+  (testing "promote-learning is a no-op on a non-:learning zettel — existing contract"
+    (let [rule (knowledge/create-zettel "200-already-a-rule" "Already a Rule"
+                                        "Body." :rule)
+          _    (knowledge/put-zettel *store* rule)
+          r    (knowledge/promote-learning *store* (:zettel/id rule))]
+      (is (nil? r)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Trust drops on a content edit AFTER promotion (the closure of #836).
+
+(deftest test-content-edit-on-promoted-rule-drops-trust
+  (testing "update-zettel on a content-bearing field of a :trusted rule resets to :untrusted"
+    ;; The gap #836 closes: a promoted-and-trusted rule must NOT
+    ;; carry trust onto a new revision when its content rotates.
+    ;; Re-promotion is the only path back.
+    (let [l        (new-learning)
+          promoted (knowledge/promote-learning *store* (:zettel/id l))
+          edited   (zettel/update-zettel promoted
+                                         {:zettel/content "# Edited body"})]
+      (is (= :trusted   (:zettel/trust-level promoted))
+          "the original promotion stamped :trusted")
+      (is (not= (:zettel/revision-id promoted) (:zettel/revision-id edited))
+          "content edit rotated revision-id")
+      (is (= :untrusted (:zettel/trust-level edited))
+          "rotation reset trust on the new revision"))))
+
+(deftest test-operational-edit-on-promoted-rule-preserves-trust
+  (testing "update-zettel on operational metadata only preserves the :trusted stamp"
+    (let [l        (new-learning)
+          promoted (knowledge/promote-learning *store* (:zettel/id l))
+          edited   (zettel/update-zettel promoted
+                                         {:fleet/share-scope :team})]
+      (is (= (:zettel/revision-id promoted) (:zettel/revision-id edited))
+          "operational edit did not rotate revision-id")
+      (is (= :trusted (:zettel/trust-level edited))
+          "trust preserved across operational-only edit"))))

--- a/components/knowledge/test/ai/miniforge/knowledge/zettel_revision_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/zettel_revision_test.clj
@@ -248,9 +248,12 @@
 
 (deftest test-create-zettel-defaults-trust-level-untrusted
   (testing "every fresh zettel starts with :zettel/trust-level :untrusted"
-    ;; Bypassing create-zettel doesn't grant trust — only
-    ;; learning/promote-learning stamps :trusted, and it does so via
-    ;; store/put-zettel (not update-zettel).
+    ;; Constructor default. learning/promote-learning is the only
+    ;; path that post-asserts :trusted; it routes through
+    ;; update-zettel for the canonical content re-stamp first
+    ;; (since `:zettel/type` flipping :learning → :rule rotates
+    ;; the revision), then assoc's :trusted on the returned
+    ;; value before persisting via store/put-zettel.
     (let [z (new-z)]
       (is (= :untrusted (:zettel/trust-level z))))))
 

--- a/components/knowledge/test/ai/miniforge/knowledge/zettel_revision_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/zettel_revision_test.clj
@@ -242,3 +242,95 @@
                   :zettel/created (java.util.Date.)
                   :zettel/author  "user"}]
       (is (m/validate schema/Zettel legacy)))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; :zettel/trust-level — per-revision trust (Decision 6 + 8; closes #836).
+
+(deftest test-create-zettel-defaults-trust-level-untrusted
+  (testing "every fresh zettel starts with :zettel/trust-level :untrusted"
+    ;; Bypassing create-zettel doesn't grant trust — only
+    ;; learning/promote-learning stamps :trusted, and it does so via
+    ;; store/put-zettel (not update-zettel).
+    (let [z (new-z)]
+      (is (= :untrusted (:zettel/trust-level z))))))
+
+(deftest test-trust-level-resets-on-content-rotation
+  (testing "editing :zettel/content rotates revision-id AND resets trust to :untrusted"
+    ;; The gap #836 closes: a producer who has already promoted a
+    ;; zettel to :trusted and then edits its content must NOT
+    ;; carry trust onto the new revision. update-zettel detects
+    ;; the rotation (new revision-id != old) and forces
+    ;; :untrusted on the result.
+    (let [z1     (-> (new-z) (assoc :zettel/trust-level :trusted))
+          z2     (zettel/update-zettel z1 {:zettel/content "# Brand new content"})]
+      (is (not= (:zettel/revision-id z1) (:zettel/revision-id z2))
+          "revision rotated")
+      (is (= :untrusted (:zettel/trust-level z2))
+          "trust reset on content rotation"))))
+
+(deftest test-trust-level-resets-on-tag-rotation
+  (testing "any content-bearing rotation resets trust — not just :zettel/content"
+    (let [z1 (-> (new-z :tags [:a]) (assoc :zettel/trust-level :trusted))
+          z2 (zettel/update-zettel z1 {:zettel/tags [:a :b]})]
+      (is (not= (:zettel/revision-id z1) (:zettel/revision-id z2)))
+      (is (= :untrusted (:zettel/trust-level z2))))))
+
+(deftest test-trust-level-preserved-on-operational-only-update
+  (testing "operational-metadata-only updates preserve trust (no revision rotation)"
+    ;; Decision 6: changing operational policy must NOT silently
+    ;; downgrade trust either. The current revision is still the
+    ;; one that was reviewed.
+    (let [z1 (-> (new-z) (assoc :zettel/trust-level :trusted))
+          z2 (zettel/update-zettel z1 {:privacy/classification :restricted})
+          z3 (zettel/update-zettel z2 {:fleet/share-scope :team})
+          z4 (zettel/update-zettel z3 {:fleet/oss-version "1.0.1"})]
+      (is (= (:zettel/revision-id z1) (:zettel/revision-id z4))
+          "revision identity intact across operational updates")
+      (is (= :trusted (:zettel/trust-level z2)))
+      (is (= :trusted (:zettel/trust-level z3)))
+      (is (= :trusted (:zettel/trust-level z4))))))
+
+(deftest test-update-zettel-ignores-caller-supplied-trust-level
+  (testing "callers cannot stamp :zettel/trust-level via update-zettel changes"
+    ;; The full closure: even if a producer attempts to override
+    ;; trust through the edit path, update-zettel drops it from
+    ;; the merge (it's in derived-fields), then the
+    ;; rotation/preserve logic recomputes the right value.
+    (let [z1 (new-z)
+          ;; Caller tries to stamp :trusted on an untrusted zettel
+          ;; with no content change at all
+          z2 (zettel/update-zettel z1 {:zettel/trust-level :trusted})]
+      (is (= :untrusted (:zettel/trust-level z2))
+          "caller-supplied :trusted dropped; trust stays at the previous value"))
+
+    (testing "and the same lock holds when combined with a content edit"
+      (let [z1 (-> (new-z) (assoc :zettel/trust-level :trusted))
+            z2 (zettel/update-zettel z1 {:zettel/content     "# Edited"
+                                         :zettel/trust-level :trusted})]
+        (is (= :untrusted (:zettel/trust-level z2))
+            "content edit forces :untrusted; spoof attempt at :trusted ignored")))))
+
+(deftest test-update-zettel-backfills-trust-level-on-legacy-zettel
+  (testing "a legacy zettel (no :zettel/trust-level) gets :untrusted on first update"
+    ;; Same convergence pattern the digest/revision-id backfill uses
+    ;; — no explicit migration needed.
+    (let [legacy  {:zettel/id      (java.util.UUID/randomUUID)
+                   :zettel/uid     "legacy-trust"
+                   :zettel/title   "Legacy"
+                   :zettel/content "Body."
+                   :zettel/type    :rule
+                   :zettel/created (java.util.Date.)
+                   :zettel/author  "user"}
+          updated (zettel/update-zettel legacy {:fleet/oss-version "1.0.0"})]
+      (is (= :untrusted (:zettel/trust-level updated))))))
+
+(deftest test-trust-level-schema-rejects-bad-value
+  (testing ":zettel/trust-level outside the closed enum fails schema validation"
+    (let [z (assoc (new-z) :zettel/trust-level :very-trusted)]
+      (is (false? (m/validate schema/Zettel z))))))
+
+(deftest test-trust-level-schema-accepts-both-values
+  (testing ":zettel/trust-level :trusted and :untrusted both validate"
+    (doseq [t [:trusted :untrusted]]
+      (let [z (assoc (new-z) :zettel/trust-level t)]
+        (is (m/validate schema/Zettel z))))))


### PR DESCRIPTION
Closes #836.

## Context

Phase E.3 of miniforge-fleet ships a producer-side trust gate in
`share-learning` that uses `:zettel/type :rule` as a trust proxy: only
zettels promoted from `:learning` to `:rule` are eligible to share. The
proxy has a known gap — `:zettel/type` itself only rotates when the
type changes, so editing a `:rule` zettel's `:zettel/content` rotates
`:zettel/revision-id` but does NOT downgrade the type. The fleet gate
then accepts the edited revision unchanged, even if the new content
would never have passed the original promotion review.

This change adds an explicit `:zettel/trust-level` field that attaches
trust to the IMMUTABLE revision rather than to the mutable type,
closing the gap mechanically.

## Design

1. **`schema/TrustLevel`** — new closed enum
   `[:enum :untrusted :trusted]`. Surfaced via
   `knowledge.interface/TrustLevel` so downstream components reference
   it without reaching into `knowledge.schema` directly.

2. **`zettel/create-zettel`** — every fresh zettel starts at
   `:zettel/trust-level :untrusted`. Bypassing the constructor does
   not grant trust.

3. **`zettel/derived-fields`** — `:zettel/trust-level` joins
   `:zettel/digest` + `:zettel/revision-id` as constructor /
   updater-owned. `update-zettel` strips any caller-supplied
   `:zettel/trust-level` from `changes` before merging.

4. **`zettel/update-zettel`** — recomputes the next trust value from
   the rotation outcome:
   - Old revision-id present AND differs from new → reset to
     `:untrusted` (content rotated; the new revision was never
     reviewed).
   - Otherwise (no rotation OR legacy backfill case) → preserve the
     existing trust value, defaulting legacy zettels to `:untrusted`.
   - Operational-metadata-only edits leave the revision-id intact AND
     preserve the existing trust stamp.

5. **`learning/promote-learning`** — routes its content transition
   through `zettel/update-zettel` so the digest + revision-id re-stamp
   happens in the canonical place, then asserts
   `:zettel/trust-level :trusted` on the returned value AFTER the
   update. The post-assoc is the one path allowed to override
   update-zettel's reset-on-rotation default; promotion is intentional
   and store-direct, not reachable through the edit path.

## Acceptance (from #836)

- [x] New zettel: `:zettel/trust-level` defaults to `:untrusted`
- [x] `promote-learning` rotates revision-id + digest + sets
      `:zettel/trust-level :trusted`
- [x] Editing any content-bearing field on a trusted zettel rotates
      revision-id + digest AND resets `:zettel/trust-level` to
      `:untrusted`
- [x] Schema rejects non-enum values
- [ ] Fleet-side test
      `test-share-learning-rotates-revision-on-content-edit` rotates
      from "second share succeeds" to "second share rejects unless
      re-promoted" — separate fleet PR after this lands + the OSS sha
      bump

## Test plan

- [x] `clj-kondo --lint components/knowledge components/knowledge-pack
      components/event-stream` — 0 errors
- [x] `bb poly:check` — clean (only pre-existing warning 207s)
- [x] Brick test sweep on Temurin 21 — knowledge / knowledge-pack /
      event-stream all green
- [ ] CI green
- [ ] Copilot / human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)