### PR TITLE
fix(workflow): unify runner.clj rate-limit detection with dag-resilience patterns

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -36,6 +36,7 @@
             [ai.miniforge.supervisory-state.interface :as supervisory]
             [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
             [ai.miniforge.workflow.context :as ctx]
+            [ai.miniforge.workflow.dag-resilience :as resilience]
             [ai.miniforge.workflow.execution :as exec]
             [ai.miniforge.workflow.fsm :as workflow-fsm]
             [ai.miniforge.workflow.messages :as messages]
@@ -126,12 +127,33 @@
 
 ;------------------------------------------------------------------------------ Layer 1: Iteration helpers
 
+(def ^:private inline-rate-limit-pattern
+  "Permissive noun-form fallback (`rate limit`, `429`, `hit your
+   limit`, `quota exceeded`) the central error-patterns table doesn't
+   carry — those patterns are vendor-scoped or anchored on verbs
+   (`exceeded`, `reached`). Both matchers union so the workflow-phase
+   path catches everything either side knows."
+  #"(?i)rate.?limit|429|hit your limit|quota.?exceeded")
+
 (defn- rate-limited?
-  "True when a phase error message indicates API rate limiting."
+  "True when a phase error message indicates API rate limiting.
+
+   Union of two matchers:
+   - `dag-resilience/rate-limit-in-text?` — loads per-provider patterns
+     from `error-patterns/external.edn`, so the workflow-phase path
+     catches the same shapes the DAG-batch resilience layer does
+     (Anthropic 529, OpenAI 503 / `model overloaded`, free-text
+     throttle prose, etc.).
+   - `inline-rate-limit-pattern` — permissive noun-form fallback.
+
+   Without this matcher unification a 529 in mid-implement would fall
+   through to plain backoff instead of `apply-rate-limit-failure`
+   (which writes a typed terminal so the workflow can be resumed
+   cleanly via `mf resume`)."
   [error-msg]
-  (boolean
-   (re-find #"(?i)rate.?limit|429|hit your limit|quota.?exceeded"
-            (str error-msg))))
+  (let [s (str error-msg)]
+    (boolean (or (re-find inline-rate-limit-pattern s)
+                 (resilience/rate-limit-in-text? s)))))
 
 (defn- backoff-ms
   "Exponential backoff duration for retry iteration, capped."

--- a/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
@@ -77,6 +77,26 @@
   (testing "handles nil input"
     (is (false? (rate-limited? nil)))))
 
+(deftest rate-limited-recognises-shapes-the-resilience-layer-knows-test
+  (testing "Runner's rate-limited? now delegates to dag-resilience/rate-limit-in-text?,
+            so the workflow-phase path catches every shape the resilience layer
+            knows — not just the narrow set the prior inline regex covered. The
+            patterns themselves live in error-patterns/external.edn and can be
+            extended without touching runner.clj. Without this unification a
+            vendor-prose throttle signal (e.g. 'resets 2pm') in mid-implement
+            would fall through to plain backoff instead of routing through
+            apply-rate-limit-failure (which writes a typed terminal so the
+            workflow can be resumed cleanly via `mf resume`)."
+    ;; Reset-time phrasing without the word "rate" — covered by
+    ;; :provider-rate-limit via "resets \\d", NOT by the prior inline
+    ;; regex (`rate.?limit|429|hit your limit|quota.?exceeded`). This is
+    ;; the marker assertion that proves the delegation went through.
+    (is (true? (rate-limited? "Claude CLI exhausted: resets 2pm (America/Los_Angeles)")))
+    (is (true? (rate-limited? "exhausted — resets in 30 minutes")))
+    ;; Still rejects non-rate-limit errors
+    (is (false? (rate-limited? "Syntax error in foo.clj")))
+    (is (false? (rate-limited? "Connection refused")))))
+
 ;; ============================================================================
 ;; backoff-ms
 ;; ============================================================================


### PR DESCRIPTION
## Summary
The workflow-runner had its own inline rate-limit regex (`rate.?limit|429|hit your limit|quota.?exceeded`) and `dag-resilience` had a richer per-provider pattern table loaded from `error-patterns/external.edn`. The two had no overlap by design — the inline regex matches noun-form phrases (`rate limit`, `quota exceeded`) while the central patterns are vendor-anchored or verb-anchored (`rate limit exceeded`, `rate limit reached`).

So a vendor-prose throttle signal like "resets 2pm" or the broader Anthropic 529 / OpenAI 503 shapes (added in #849) in mid-implement would fall through the inline regex and never reach `apply-rate-limit-failure` — which writes a typed terminal so the workflow can be resumed cleanly via `mf resume`.

`rate-limited?` now unions both: inline noun-form pattern kept as fallback (so existing matches don't regress), `resilience/rate-limit-in-text?` consulted for the vendor-scoped / verb-anchored / prose patterns the central table carries.

## Why
Anthropic's been randomly rate-limiting for weeks. We need the workflow-phase path to catch every signal the resilience layer knows about so backoff + checkpoint + resume kicks in instead of plain retry.

## Tests
`rate-limited-recognises-shapes-the-resilience-layer-knows-test` asserts "resets 2pm" and "resets in 30 minutes" now match (covered by `:provider-rate-limit` via `resets \d`, NOT by the inline regex). Existing detection cases for "429", "rate limit", "quota exceeded" still pass via the inline path; rejection cases for "Syntax error" and "Connection refused" still hold.

## Stack
Independently mergeable from #849. Together they ensure every vendor rate-limit shape — 429, 529, 503, structured JSON, prose — reaches the rich tiered lifecycle.

## Test plan
- [ ] CI green
- [ ] When a 529 or other vendor-prose throttle hits mid-implement, `runner/rate-limited?` returns true → `apply-rate-limit-failure` writes typed terminal → `mf resume` recovers cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)