### PR TITLE
feat(agent): emit :implementer/response-rejected event with reject reason

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -439,32 +439,63 @@
      :code/summary "Implementation from code blocks"
      :code/created-at (java.util.Date.)}))
 
+(defn- log-implementer-rejection
+  "Emit a structured :implementer/response-rejected event when the
+   implementer can't build a success response from the LLM turn.
+   Surfaces WHY each iteration failed so the next dogfood reads the
+   reject pattern (parse-failed, unverified-already-implemented,
+   etc.) inline instead of forcing a deep-dive through the trace.
+
+   Two reject paths today; both wrap response/error. The reject
+   reason is a keyword the caller picks before invoking — keeps
+   the event taxonomy stable as new reject paths get added."
+  [logger reason context input artifact-source content tools]
+  (when logger
+    (log/warn logger :implementer :implementer/response-rejected
+              {:data {:reject/reason reason
+                      :artifact-source artifact-source
+                      :tools-called tools
+                      :content-length (count (or content ""))
+                      :repair-attempt? (boolean (repair-attempt? input))}})))
+
 (defn- process-llm-response
   "Normalize structured implementer outputs from any submission channel:
-   worktree metadata, MCP artifact, file fallback, or parseable stdout."
+   worktree metadata, MCP artifact, file fallback, or parseable stdout.
+
+   When no channel yields a usable artifact, emits a structured
+   :implementer/response-rejected event with `:reject/reason` so the
+   next dogfood surfaces WHY each iteration failed without forcing
+   the operator into a deep-dive trace read."
   [{:keys [content structured-artifact parsed-content derived-artifact
            artifact-source tokens cost-usd tools-called]}
    context logger input]
-  (let [parsed (or structured-artifact parsed-content)]
-    (let [tools tools-called]
-      (when (nil? artifact-source)
-        (log/warn logger :implementer :implementer/mcp-tool-not-called
-                  {:data {:content-length (count (or content ""))
-                          :tools-called tools
-                          :has-code-blocks? (boolean (re-find #"```" (or content "")))}})))
+  (let [parsed (or structured-artifact parsed-content)
+        tools tools-called]
+    (when (nil? artifact-source)
+      (log/warn logger :implementer :implementer/mcp-tool-not-called
+                {:data {:content-length (count (or content ""))
+                        :tools-called tools
+                        :has-code-blocks? (boolean (re-find #"```" (or content "")))}}))
     (cond
       (code-artifact? structured-artifact)
       (build-code-response structured-artifact context tokens cost-usd)
 
       (= :already-implemented (:status parsed))
       (if (repair-attempt? input)
-        (unverified-already-implemented-response input tokens)
+        (do (log-implementer-rejection
+             logger :unverified-already-implemented
+             context input artifact-source content tools)
+            (unverified-already-implemented-response input tokens))
         (build-already-implemented-response parsed tokens cost-usd))
 
       :else
       (if-let [code (or parsed derived-artifact)]
         (build-code-response code context tokens cost-usd)
-        (response/error (messages/t :error/parse-failed) {:tokens tokens})))))
+        (do (log-implementer-rejection
+             logger :parse-failed
+             context input artifact-source content tools)
+            (response/error (messages/t :error/parse-failed)
+                            {:tokens tokens}))))))
 
 (def ^:private session-checkpoint-filename ".miniforge/session-id")
 

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -448,8 +448,12 @@
 
    Two reject paths today; both wrap response/error. The reject
    reason is a keyword the caller picks before invoking — keeps
-   the event taxonomy stable as new reject paths get added."
-  [logger reason context input artifact-source content tools]
+   the event taxonomy stable as new reject paths get added.
+
+   `input` is read for :repair-attempt? — that's the strongest
+   signal for distinguishing 'agent stalled mid-narration' from
+   'agent retried after rejection and still didn't ship.'"
+  [logger reason input artifact-source content tools]
   (when logger
     (log/warn logger :implementer :implementer/response-rejected
               {:data {:reject/reason reason
@@ -462,10 +466,13 @@
   "Normalize structured implementer outputs from any submission channel:
    worktree metadata, MCP artifact, file fallback, or parseable stdout.
 
-   When no channel yields a usable artifact, emits a structured
-   :implementer/response-rejected event with `:reject/reason` so the
-   next dogfood surfaces WHY each iteration failed without forcing
-   the operator into a deep-dive trace read."
+   Emits a structured :implementer/response-rejected event with
+   `:reject/reason` on both reject paths — when no channel yields a
+   usable artifact (:parse-failed) AND when a repair attempt's
+   `:already-implemented` claim lacks artifact evidence
+   (:unverified-already-implemented). Surfaces WHY each iteration
+   failed so the next dogfood reads the reject pattern inline
+   instead of forcing a deep-dive trace read."
   [{:keys [content structured-artifact parsed-content derived-artifact
            artifact-source tokens cost-usd tools-called]}
    context logger input]
@@ -484,7 +491,7 @@
       (if (repair-attempt? input)
         (do (log-implementer-rejection
              logger :unverified-already-implemented
-             context input artifact-source content tools)
+             input artifact-source content tools)
             (unverified-already-implemented-response input tokens))
         (build-already-implemented-response parsed tokens cost-usd))
 
@@ -493,7 +500,7 @@
         (build-code-response code context tokens cost-usd)
         (do (log-implementer-rejection
              logger :parse-failed
-             context input artifact-source content tools)
+             input artifact-source content tools)
             (response/error (messages/t :error/parse-failed)
                             {:tokens tokens}))))))
 

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -274,7 +274,7 @@
              (get-in result [:output :code/files])))))
 
   (testing "already-implemented fails closed on a repair attempt without artifact evidence"
-    (let [[logger _] (log/collecting-logger {:min-level :trace})
+    (let [[logger entries] (log/collecting-logger {:min-level :trace})
           response (llm-response :content "{:status :already-implemented :summary \"done\"}"
                                  :tokens 11
                                  :cost-usd 0.01)
@@ -300,10 +300,21 @@
                                (fn [_ _] nil)]
                    (@#'implementer/invoke-with-llm
                     nil "prompt" "system" {} {} nil logger []
-                    {:task/review-feedback ["Fix the blocking issues"]}))]
+                    {:task/review-feedback ["Fix the blocking issues"]}))
+          rejected-log (find-log-entry entries :implementer/response-rejected)]
       (is (response/error? result))
       (is (= :implementer/unverified-already-implemented
-             (get-in result [:error :data :code])))))
+             (get-in result [:error :data :code])))
+      ;; Observability: the reject reason must surface as a structured
+      ;; event so dogfood runs read WHY each iteration failed inline
+      ;; instead of forcing a deep-dive trace read. Pin the new event
+      ;; shape + the :reject/reason keyword the caller picks.
+      (is (some? rejected-log)
+          ":implementer/response-rejected event emitted on the
+           unverified-already-implemented reject path")
+      (is (= :unverified-already-implemented
+             (get-in rejected-log [:data :reject/reason])))
+      (is (true? (get-in rejected-log [:data :repair-attempt?])))))
 
   (testing "parseable already-implemented content survives an unsuccessful backend wrapper"
     (let [[logger _] (log/collecting-logger {:min-level :trace})


### PR DESCRIPTION
## Summary

Observability follow-on to the 2026-05-10 dogfood. Two paths in \`implementer/process-llm-response\` return \`response/error\` without naming WHY the iteration failed: \`:unverified-already-implemented\` (repair attempt + no artifact evidence) and \`:parse-failed\` (no structured-artifact, no parseable content, no derived code blocks).

Dogfood reads today require a deep-dive trace to figure out which branch fired. With these events, the operator (or future automation) reads the reject pattern inline from \`mf events show\`.

- **Helper**: private \`log-implementer-rejection\` emits \`:implementer/response-rejected\` with structured data: \`:reject/reason\`, \`:artifact-source\`, \`:tools-called\`, \`:content-length\`, \`:repair-attempt?\`. Reason keyword is picked at the call site so the event taxonomy stays stable as new reject paths get added.
- **No behaviour change**: purely additive logging. Both reject paths still return the same \`response/error\` shapes.
- **Exceptions-as-data**: helper guards on \`(when logger ...)\` so absent-logger callers don't NPE. Data flow only, no try/catch.

## Test plan

- [x] Existing "already-implemented fails closed on a repair attempt without artifact evidence" test now also asserts the new event fires with \`:reject/reason :unverified-already-implemented\` and \`:repair-attempt? true\`.
- [x] 13 / 81 / 0 / 0 across \`agent.implementer-test\`.
- [x] Full pre-commit changed-bricks suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)