### PR TITLE
refactor: exceptions-as-data tail bundle (policy-pack + tool-registry)

### DIFF
--- a/components/policy-pack/deps.edn
+++ b/components/policy-pack/deps.edn
@@ -1,7 +1,9 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/coerce {:local/root "../coerce"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/coerce {:local/root "../coerce"}
         ai.miniforge/algorithms {:local/root "../algorithms"}
         ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/response {:local/root "../response"}
         metosin/malli {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
@@ -25,6 +25,7 @@
   (:require
    [ai.miniforge.policy-pack.crypto :as crypto]
    [ai.miniforge.policy-pack.schema :as schema]
+   [ai.miniforge.response.interface :as response]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -198,9 +199,10 @@
               version (:pack/version pack)]
           (swap! state assoc-in [:packs pack-id version] pack)
           pack)
-        (throw (ex-info "Invalid pack schema"
-                        {:errors errors
-                         :pack-id (:pack/id pack)})))))
+        (response/throw-anomaly! :anomalies/incorrect
+                                 "Invalid pack schema"
+                                 {:errors errors
+                                  :pack-id (:pack/id pack)}))))
 
   (get-pack [this pack-id]
     (let [versions (get-in @state [:packs pack-id])]
@@ -256,20 +258,28 @@
       ;; Assume source is already a pack map
       (register-pack this source)
       ;; String path - would need loader integration
-      (throw (ex-info "File/URL import not implemented in registry"
-                      {:source source
-                       :hint "Use loader/load-pack-from-file instead"}))))
+      (response/throw-anomaly! :anomalies/unsupported
+                               "File/URL import not implemented in registry"
+                               {:source source
+                                :hint "Use loader/load-pack-from-file instead"})))
 
   (export-pack [_this pack-id version format]
     (if-let [pack (get-in @state [:packs pack-id version])]
       (case format
         :edn (pr-str pack)
-        :json (throw (ex-info "JSON export not implemented" {:format format}))
-        :directory (throw (ex-info "Directory export not implemented" {:format format}))
-        (throw (ex-info "Unknown export format" {:format format})))
-      (throw (ex-info "Pack not found"
-                      {:pack-id pack-id
-                       :version version}))))
+        :json (response/throw-anomaly! :anomalies/unsupported
+                                       "JSON export not implemented"
+                                       {:format format})
+        :directory (response/throw-anomaly! :anomalies/unsupported
+                                            "Directory export not implemented"
+                                            {:format format})
+        (response/throw-anomaly! :anomalies/incorrect
+                                 "Unknown export format"
+                                 {:format format}))
+      (response/throw-anomaly! :anomalies/not-found
+                               "Pack not found"
+                               {:pack-id pack-id
+                                :version version})))
 
   (validate-pack [_this pack]
     (schema/validate-pack pack))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/anomaly/registry_anomaly_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/anomaly/registry_anomaly_test.clj
@@ -1,0 +1,122 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.anomaly.registry-anomaly-test
+  "Coverage for `policy-pack/registry` boundary escalation via
+   `response/throw-anomaly!`.
+
+   Pre-cleanup, each site was a raw `(throw (ex-info ...))`. Post-
+   cleanup, throws route through the canonical
+   `response/throw-anomaly!` carrying typed anomaly categories
+   (`:anomalies/incorrect`, `:anomalies/unsupported`,
+   `:anomalies/not-found`)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.policy-pack.registry :as registry])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+(defn- new-registry []
+  (registry/->InMemoryPackRegistry (atom {:packs {}})))
+
+;------------------------------------------------------------------------------ register-pack — invalid schema
+
+(deftest register-pack-invalid-schema-throws-anomaly
+  (testing "schema-invalid pack raises :anomalies/incorrect"
+    (let [reg (new-registry)]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Invalid pack schema"
+           (registry/register-pack reg {:pack/id :bad-pack}))))))
+
+(deftest register-pack-anomaly-carries-pack-id
+  (testing "anomaly ex-data carries :pack-id and :errors"
+    (let [reg (new-registry)
+          thrown (try
+                   (registry/register-pack reg {:pack/id :bad})
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (= :bad (:pack-id (ex-data thrown)))))))
+
+;------------------------------------------------------------------------------ import-pack — unsupported source
+
+(deftest import-pack-string-source-throws-unsupported
+  (testing "string source raises :anomalies/unsupported"
+    (let [reg (new-registry)]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"File/URL import not implemented"
+           (registry/import-pack reg "/path/to/pack.edn"))))))
+
+;------------------------------------------------------------------------------ export-pack — pack not found
+
+(deftest export-pack-not-found-throws-anomaly
+  (testing "missing pack raises :anomalies/not-found"
+    (let [reg (new-registry)]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Pack not found"
+           (registry/export-pack reg :missing "1.0.0" :edn))))))
+
+;------------------------------------------------------------------------------ export-pack — unsupported / unknown formats
+
+(deftest export-pack-json-unsupported
+  (testing "JSON export raises :anomalies/unsupported for present pack"
+    (let [reg (new-registry)
+          pack {:pack/id :p1
+                :pack/version "1.0.0"
+                :pack/name "p"
+                :pack/description "d"
+                :pack/author "a"
+                :pack/rules []}]
+      (swap! (.state reg) assoc-in [:packs :p1 "1.0.0"] pack)
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"JSON export not implemented"
+           (registry/export-pack reg :p1 "1.0.0" :json))))))
+
+(deftest export-pack-directory-unsupported
+  (testing "directory export raises :anomalies/unsupported for present pack"
+    (let [reg (new-registry)
+          pack {:pack/id :p1
+                :pack/version "1.0.0"
+                :pack/name "p"
+                :pack/description "d"
+                :pack/author "a"
+                :pack/rules []}]
+      (swap! (.state reg) assoc-in [:packs :p1 "1.0.0"] pack)
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Directory export not implemented"
+           (registry/export-pack reg :p1 "1.0.0" :directory))))))
+
+(deftest export-pack-unknown-format-incorrect
+  (testing "unknown format raises :anomalies/incorrect for present pack"
+    (let [reg (new-registry)
+          pack {:pack/id :p1
+                :pack/version "1.0.0"
+                :pack/name "p"
+                :pack/description "d"
+                :pack/author "a"
+                :pack/rules []}]
+      (swap! (.state reg) assoc-in [:packs :p1 "1.0.0"] pack)
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Unknown export format"
+           (registry/export-pack reg :p1 "1.0.0" :bogus))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/anomaly/registry_anomaly_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/anomaly/registry_anomaly_test.clj
@@ -38,41 +38,43 @@
 
 (deftest register-pack-invalid-schema-throws-anomaly
   (testing "schema-invalid pack raises :anomalies/incorrect"
-    (let [reg (new-registry)]
-      (is (thrown-with-msg?
-           ExceptionInfo
-           #"Invalid pack schema"
-           (registry/register-pack reg {:pack/id :bad-pack}))))))
+    (let [reg    (new-registry)
+          thrown (try (registry/register-pack reg {:pack/id :bad-pack}) nil (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"Invalid pack schema" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
 (deftest register-pack-anomaly-carries-pack-id
-  (testing "anomaly ex-data carries :pack-id and :errors"
+  (testing "anomaly ex-data carries :pack-id, :errors, and :anomalies/incorrect category"
     (let [reg (new-registry)
           thrown (try
                    (registry/register-pack reg {:pack/id :bad})
                    nil
                    (catch ExceptionInfo e e))]
       (is (some? thrown))
-      (is (= :bad (:pack-id (ex-data thrown)))))))
+      (is (= :bad (:pack-id (ex-data thrown))))
+      (is (contains? (ex-data thrown) :errors))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
 ;------------------------------------------------------------------------------ import-pack — unsupported source
 
 (deftest import-pack-string-source-throws-unsupported
   (testing "string source raises :anomalies/unsupported"
-    (let [reg (new-registry)]
-      (is (thrown-with-msg?
-           ExceptionInfo
-           #"File/URL import not implemented"
-           (registry/import-pack reg "/path/to/pack.edn"))))))
+    (let [reg    (new-registry)
+          thrown (try (registry/import-pack reg "/path/to/pack.edn") nil (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"File/URL import not implemented" (.getMessage thrown)))
+      (is (= :anomalies/unsupported (:anomaly/category (ex-data thrown)))))))
 
 ;------------------------------------------------------------------------------ export-pack — pack not found
 
 (deftest export-pack-not-found-throws-anomaly
   (testing "missing pack raises :anomalies/not-found"
-    (let [reg (new-registry)]
-      (is (thrown-with-msg?
-           ExceptionInfo
-           #"Pack not found"
-           (registry/export-pack reg :missing "1.0.0" :edn))))))
+    (let [reg    (new-registry)
+          thrown (try (registry/export-pack reg :missing "1.0.0" :edn) nil (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"Pack not found" (.getMessage thrown)))
+      (is (= :anomalies/not-found (:anomaly/category (ex-data thrown)))))))
 
 ;------------------------------------------------------------------------------ export-pack — unsupported / unknown formats
 

--- a/components/tool-registry/deps.edn
+++ b/components/tool-registry/deps.edn
@@ -1,6 +1,8 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/config {:local/root "../config"}
         ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/response {:local/root "../response"}
         ai.miniforge/schema {:local/root "../schema"}
         metosin/malli {:mvn/version "0.16.4"}
         org.clojure/core.async {:mvn/version "1.6.681"}

--- a/components/tool-registry/src/ai/miniforge/tool_registry/registry.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/registry.clj
@@ -24,6 +24,7 @@
    Layer 2: Query and filter operations
    Layer 3: Status and statistics"
   (:require
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.tool-registry.schema :as schema]
    [ai.miniforge.logging.interface :as log]
    [clojure.string :as str]))
@@ -50,12 +51,14 @@
   (register-tool [_this tool]
     (let [{:keys [valid? errors]} (schema/validate-tool tool)]
       (when-not valid?
-        (throw (ex-info "Invalid tool configuration"
-                        {:tool-id (:tool/id tool)
-                         :errors errors})))
+        (response/throw-anomaly! :anomalies/incorrect
+                                 "Invalid tool configuration"
+                                 {:tool-id (:tool/id tool)
+                                  :errors errors}))
       (when-not (schema/valid-tool-id? (:tool/id tool))
-        (throw (ex-info "Tool ID must be a namespaced keyword"
-                        {:tool-id (:tool/id tool)})))
+        (response/throw-anomaly! :anomalies/incorrect
+                                 "Tool ID must be a namespaced keyword"
+                                 {:tool-id (:tool/id tool)}))
       (let [normalized (schema/normalize-tool tool)
             tool-id (:tool/id normalized)
             logger (:logger @state)]
@@ -111,11 +114,15 @@
   (update-tool [_this tool-id updates]
     (let [current (get @(:tools @state) tool-id)]
       (when-not current
-        (throw (ex-info "Tool not found" {:tool-id tool-id})))
+        (response/throw-anomaly! :anomalies/not-found
+                                 "Tool not found"
+                                 {:tool-id tool-id}))
       (let [updated (merge current updates)
             {:keys [valid? errors]} (schema/validate-tool updated)]
         (when-not valid?
-          (throw (ex-info "Invalid update" {:tool-id tool-id :errors errors})))
+          (response/throw-anomaly! :anomalies/incorrect
+                                   "Invalid update"
+                                   {:tool-id tool-id :errors errors}))
         (swap! (:tools @state) assoc tool-id updated)
         updated)))
 

--- a/components/tool-registry/test/ai/miniforge/tool_registry/anomaly/registry_anomaly_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/anomaly/registry_anomaly_test.clj
@@ -1,0 +1,87 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.anomaly.registry-anomaly-test
+  "Coverage for `tool-registry/registry` boundary escalation via
+   `response/throw-anomaly!`.
+
+   Pre-cleanup, each site was a raw `(throw (ex-info ...))`. Post-
+   cleanup, throws route through the canonical
+   `response/throw-anomaly!` carrying typed anomaly categories
+   (`:anomalies/incorrect`, `:anomalies/not-found`)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tool-registry.registry :as registry])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+(defn- new-registry []
+  (registry/->AtomToolRegistry (atom {:tools (atom {}) :logger nil})))
+
+;------------------------------------------------------------------------------ register-tool — invalid configuration
+
+(deftest register-tool-invalid-config-throws-anomaly
+  (testing "schema-invalid tool raises :anomalies/incorrect"
+    (let [reg (new-registry)]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Invalid tool configuration"
+           (registry/register-tool reg {}))))))
+
+(deftest register-tool-invalid-config-carries-errors
+  (testing "anomaly ex-data carries :tool-id and :errors"
+    (let [reg (new-registry)
+          thrown (try
+                   (registry/register-tool reg {:tool/id :no/such-tool})
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (contains? (ex-data thrown) :errors)))))
+
+;------------------------------------------------------------------------------ register-tool — invalid tool id shape
+
+(deftest register-tool-invalid-id-shape-throws-anomaly
+  (testing "non-namespaced tool-id raises :anomalies/incorrect"
+    ;; Construct a tool that passes schema/validate-tool but fails
+    ;; the id-shape guard. The cleanest direct test is the message;
+    ;; depending on schema, the schema check may also reject — the
+    ;; key invariant is that an ExceptionInfo is raised with a
+    ;; meaningful message.
+    (let [reg (new-registry)]
+      (is (thrown? ExceptionInfo
+                   (registry/register-tool reg {:tool/id :not-namespaced}))))))
+
+;------------------------------------------------------------------------------ update-tool — tool not found
+
+(deftest update-tool-not-found-throws-anomaly
+  (testing "missing tool raises :anomalies/not-found"
+    (let [reg (new-registry)]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Tool not found"
+           (registry/update-tool reg :missing/tool {:tool/name "x"}))))))
+
+(deftest update-tool-not-found-carries-tool-id
+  (testing "anomaly ex-data carries :tool-id"
+    (let [reg (new-registry)
+          thrown (try
+                   (registry/update-tool reg :missing/tool {:tool/name "x"})
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (= :missing/tool (:tool-id (ex-data thrown)))))))

--- a/components/tool-registry/test/ai/miniforge/tool_registry/anomaly/registry_anomaly_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/anomaly/registry_anomaly_test.clj
@@ -37,11 +37,11 @@
 
 (deftest register-tool-invalid-config-throws-anomaly
   (testing "schema-invalid tool raises :anomalies/incorrect"
-    (let [reg (new-registry)]
-      (is (thrown-with-msg?
-           ExceptionInfo
-           #"Invalid tool configuration"
-           (registry/register-tool reg {}))))))
+    (let [reg    (new-registry)
+          thrown (try (registry/register-tool reg {}) nil (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"Invalid tool configuration" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
 (deftest register-tool-invalid-config-carries-errors
   (testing "anomaly ex-data carries :tool-id and :errors"
@@ -51,20 +51,22 @@
                    nil
                    (catch ExceptionInfo e e))]
       (is (some? thrown))
-      (is (contains? (ex-data thrown) :errors)))))
+      (is (= :no/such-tool (:tool-id (ex-data thrown))))
+      (is (contains? (ex-data thrown) :errors))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
 ;------------------------------------------------------------------------------ register-tool — invalid tool id shape
 
 (deftest register-tool-invalid-id-shape-throws-anomaly
   (testing "non-namespaced tool-id raises :anomalies/incorrect"
-    ;; Construct a tool that passes schema/validate-tool but fails
-    ;; the id-shape guard. The cleanest direct test is the message;
-    ;; depending on schema, the schema check may also reject — the
-    ;; key invariant is that an ExceptionInfo is raised with a
-    ;; meaningful message.
-    (let [reg (new-registry)]
-      (is (thrown? ExceptionInfo
-                   (registry/register-tool reg {:tool/id :not-namespaced}))))))
+    ;; Provide a minimally schema-valid tool so schema/validate-tool
+    ;; passes and the id-shape guard is what fires.
+    (let [reg    (new-registry)
+          tool   {:tool/id :not-namespaced :tool/type :function :tool/name "test"}
+          thrown (try (registry/register-tool reg tool) nil (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"Tool ID must be a namespaced keyword" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
 ;------------------------------------------------------------------------------ update-tool — tool not found
 
@@ -77,11 +79,12 @@
            (registry/update-tool reg :missing/tool {:tool/name "x"}))))))
 
 (deftest update-tool-not-found-carries-tool-id
-  (testing "anomaly ex-data carries :tool-id"
+  (testing "anomaly ex-data carries :tool-id and :anomalies/not-found category"
     (let [reg (new-registry)
           thrown (try
                    (registry/update-tool reg :missing/tool {:tool/name "x"})
                    nil
                    (catch ExceptionInfo e e))]
       (is (some? thrown))
-      (is (= :missing/tool (:tool-id (ex-data thrown)))))))
+      (is (= :missing/tool (:tool-id (ex-data thrown))))
+      (is (= :anomalies/not-found (:anomaly/category (ex-data thrown)))))))

--- a/docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md
@@ -1,0 +1,154 @@
+# refactor: exceptions-as-data cleanup tail bundle (policy-pack + tool-registry)
+
+## Overview
+
+Migrates the remaining `:cleanup-needed` throw sites in two small
+components into a single PR — bundled because per-component count
+(6 + 4) is too small to justify two separate PRs and they share no
+coupling.
+
+- `policy-pack/registry.clj` — 6 sites (validation, import,
+  export-pack)
+- `tool-registry/registry.clj` — 4 sites (register, update)
+
+## Motivation
+
+Per `work/exception-cleanup-inventory.md`, `policy-pack` and
+`tool-registry` carried the remaining concentrated `:cleanup-needed`
+clusters in the < 5-site tier. Bundling matches the kill-the-deprecation
+pattern (PRs #777, #797, #799, #800, #801, #846, #854) — same shape,
+applied without redesign.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary
+- `ai.miniforge.response` (merged) — slingshot `throw-anomaly!`
+
+## Layer
+
+Refactor / per-component cleanup tier.
+
+## Scope decision: bb-data-plane-http excluded
+
+The audit also listed `bb-data-plane-http/core.clj` (4 sites) under
+`:cleanup-needed`. That component lives in the `bb-utils` GraalVM-
+compiled project, where pulling `ai.miniforge/anomaly` (depends on
+malli) and `ai.miniforge/response` (depends on slingshot) into the
+classpath isn't free — both deps carry transitive weight that would
+need explicit GraalVM-compat validation. The 4 sites there are
+boundary-shaped already (data-plane process death, HTTP failures
+surfacing to a CLI). Reclassifying as `:fatal-only` for now and
+deferring the proper migration to a follow-up that does the GraalVM
+work properly.
+
+## What This Adds / Changes
+
+`components/policy-pack/deps.edn`:
+
+- Adds `:local/root` deps on `ai.miniforge/anomaly` and
+  `ai.miniforge/response`.
+
+`components/policy-pack/src/.../registry.clj`:
+
+- 6 throw sites migrated to `response/throw-anomaly!`:
+  - `register-pack` — schema invalid → `:anomalies/incorrect`
+  - `import-pack` — string source not implemented →
+    `:anomalies/unsupported`
+  - `export-pack` — JSON format → `:anomalies/unsupported`
+  - `export-pack` — directory format → `:anomalies/unsupported`
+  - `export-pack` — unknown format → `:anomalies/incorrect`
+  - `export-pack` — pack not found → `:anomalies/not-found`
+
+`components/tool-registry/deps.edn`:
+
+- Adds `:local/root` deps on `ai.miniforge/anomaly` and
+  `ai.miniforge/response`.
+
+`components/tool-registry/src/.../registry.clj`:
+
+- 4 throw sites migrated to `response/throw-anomaly!`:
+  - `register-tool` — schema invalid → `:anomalies/incorrect`
+  - `register-tool` — id shape invalid → `:anomalies/incorrect`
+  - `update-tool` — tool not found → `:anomalies/not-found`
+  - `update-tool` — schema invalid on update → `:anomalies/incorrect`
+
+`components/policy-pack/test/.../anomaly/` (new):
+
+- `registry_anomaly_test.clj` — 7 tests across the 6 boundary sites
+  (register-pack, import-pack, export-pack × 4 formats).
+
+`components/tool-registry/test/.../anomaly/` (new):
+
+- `registry_anomaly_test.clj` — 5 tests across the 4 boundary sites
+  (register-tool, update-tool, ex-data shape).
+
+## Per-site classification
+
+### `policy-pack/registry.clj`
+
+| Site (line) | Fn | Anomaly category |
+|------------:|----|------------------|
+| 201 | `register-pack` (schema invalid) | `:anomalies/incorrect` |
+| 259 | `import-pack` (string source) | `:anomalies/unsupported` |
+| 267 | `export-pack` (:json) | `:anomalies/unsupported` |
+| 268 | `export-pack` (:directory) | `:anomalies/unsupported` |
+| 269 | `export-pack` (unknown format) | `:anomalies/incorrect` |
+| 270 | `export-pack` (pack missing) | `:anomalies/not-found` |
+
+### `tool-registry/registry.clj`
+
+| Site (line) | Fn | Anomaly category |
+|------------:|----|------------------|
+| 53 | `register-tool` (schema invalid) | `:anomalies/incorrect` |
+| 57 | `register-tool` (bad id shape) | `:anomalies/incorrect` |
+| 114 | `update-tool` (tool not found) | `:anomalies/not-found` |
+| 118 | `update-tool` (schema invalid) | `:anomalies/incorrect` |
+
+## Strata Affected
+
+- `ai.miniforge.policy-pack.registry` — registry CRUD cleanup
+- `ai.miniforge.tool-registry.registry` — registry CRUD cleanup
+- New `ai.miniforge.policy-pack.anomaly.*` test namespace
+- New `ai.miniforge.tool-registry.anomaly.*` test namespace
+
+## Testing Plan
+
+- New `anomaly.*` test files: 12 tests across the two components.
+- Existing component tests retained — `ExceptionInfo`-matching tests
+  continue to pass because `response/throw-anomaly!` raises
+  `ExceptionInfo` with the canonical message preserved.
+
+## Deployment Plan
+
+No migration. External callers continue to see the same
+`ExceptionInfo` shape via boundary throws.
+
+## Notes
+
+- **No drive-by refactors.** Other patterns flagged in the audit
+  (e.g. `requiring-resolve` smells elsewhere) are out of scope.
+- **bb-data-plane-http deferred.** Documented above — the 4 sites
+  there require GraalVM-compat work that's a separate cleanup pass.
+
+## Related Issues/PRs
+
+- Built on PR #777 (kill-the-deprecation precedent)
+- Companion to Wave 7 + 8 cleanup PRs — operator (#797),
+  spec-parser (#799), agent (#800), task (#801), pr-lifecycle
+  (#846), event-stream (#854)
+- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
+
+## Checklist
+
+- [x] All 10 in-scope `:cleanup-needed` sites retired
+- [x] bb-data-plane-http deferral documented and rationalized
+- [x] Single API per site (`response/throw-anomaly!`)
+- [x] Decomposed test files (two)
+- [x] No new throws in anomaly-returning code paths
+- [x] External caller contracts preserved
+- [x] Apache 2 license headers preserved
+- [x] `deps.edn` additions explicit and minimal


### PR DESCRIPTION
## Summary

Migrates 10 `:cleanup-needed` throw sites across two small components in one PR. Per-component count (6 + 4) too small for separate PRs; no coupling between them.

- `policy-pack/registry.clj` (6 sites)
- `tool-registry/registry.clj` (4 sites)

bb-data-plane-http (4 sites) deferred — bb-utils GraalVM project requires explicit compat validation on the malli + slingshot transitive deps. Documented in the PR doc.

Full PR doc: `docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md`

## Test plan

- [x] 12 new decomposed anomaly tests (7 + 5)
- [x] All in-scope throw sites collapsed (verified by grep — 0 raw `(throw (ex-info ...))` in target files)
- [ ] CI to confirm full suites green for both components

🤖 Generated with [Claude Code](https://claude.com/claude-code)