### PR TITLE
feat(scripts): cost-table refresh ETL — transform + tests + mapping

### DIFF
--- a/components/llm/resources/llm/cost-source-mapping.edn
+++ b/components/llm/resources/llm/cost-source-mapping.edn
@@ -1,0 +1,52 @@
+;; Mapping from our `cost-table.edn` model-id strings to the keys
+;; used by the canonical upstream pricing source (BerriAI/litellm's
+;; model_prices_and_context_window.json). Used by the
+;; refresh-cost-table ETL workflow to look up each priced model
+;; in the upstream JSON without depending on string-matching luck.
+;;
+;; Schema: {our-model-id-string upstream-litellm-key-string}
+;;
+;; When our model-id matches the upstream key directly (newer model
+;; names usually do), the mapping entry is optional — the ETL
+;; falls back to (= our-id upstream-id) and only warns when both
+;; lookups miss.
+;;
+;; To add a new priced model:
+;;   1. Add the model to cost-table.edn with a placeholder estimate.
+;;   2. Add the upstream key to this mapping (or omit if names
+;;      match).
+;;   3. Run `bb scripts/refresh-cost-table.bb` locally to verify
+;;      the lookup resolves and the prices match what you expect.
+;;   4. The next scheduled ETL run will keep it fresh.
+;;
+;; Source: https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
+
+{:mapping/by-model-id
+ {;; Anthropic Claude. Upstream uses date-stamped ids for the
+  ;; latest revision; our table uses the friendly tier-name ids.
+  "claude-opus-4-7"           "claude-opus-4-1-20250805"
+  "claude-opus-4-6"           "claude-opus-4-20250514"
+  "claude-opus-4"             "claude-opus-4-20250514"
+  "claude-sonnet-4-6"         "claude-sonnet-4-5"
+  "claude-sonnet-4-5-20250929" "claude-sonnet-4-5"
+  "claude-sonnet-4"           "claude-sonnet-4-20250514"
+  "claude-haiku-4-5-20251001" "claude-haiku-4-5"
+  "claude-haiku"              "claude-haiku-4-5"
+
+  ;; OpenAI GPT-5 family. Codex-suffixed ids in our table map to
+  ;; the base gpt-5 pricing upstream (codex is a finetune, same
+  ;; price tier). When upstream introduces a separately-priced
+  ;; codex-mini etc., update the mapping.
+  "gpt-5.4-pro"               "gpt-5-pro"
+  "gpt-5.4"                   "gpt-5"
+  "gpt-5.3-codex"             "gpt-5"
+  "gpt-5.2-codex"             "gpt-5-mini"
+  "gpt-5.1-codex-max"         "gpt-5-mini"
+  "gpt-5.2"                   "gpt-5-mini"
+
+  ;; Google Gemini — friendly ids match upstream directly, so no
+  ;; mapping is required. Listed here for documentation:
+  ;;   "gemini-2.5-pro"        => "gemini-2.5-pro"
+  ;;   "gemini-2.5-flash"      => "gemini-2.5-flash"
+  ;;   "gemini-2.5-flash-lite" => "gemini-2.5-flash-lite"
+  }}

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -422,13 +422,24 @@
    files have landed on the task branch and `git status --porcelain`
    reports nothing. Asserting cleanliness here means the regression
    test cannot accidentally pass via the legacy `git-dirty-files`
-   path — it forces the rehydrate-from-paths code under test."
+   path — it forces the rehydrate-from-paths code under test.
+
+   Defeats global GPG / signing configuration (1Password, GPG agents)
+   that would otherwise intercept the commit and intermittently fail
+   with `error: <agent> returned an error` — the same pattern the
+   v2 multi-parent merge fixtures had to solve. With
+   commit.gpgsign=false locally on this repo AND --no-gpg-sign
+   --no-verify on the commit itself, the fixture runs hermetically
+   regardless of the dev machine's signing setup."
   [worktree]
   (write-mock-files-to-worktree! worktree)
   (sh-must-succeed! worktree ["git" "config" "user.email" "test@example.com"])
   (sh-must-succeed! worktree ["git" "config" "user.name" "Test"])
+  (sh-must-succeed! worktree ["git" "config" "commit.gpgsign" "false"])
+  (sh-must-succeed! worktree ["git" "config" "tag.gpgsign" "false"])
   (sh-must-succeed! worktree ["git" "add" "."])
-  (sh-must-succeed! worktree ["git" "commit" "-m" "implement-phase-boundary commit"])
+  (sh-must-succeed! worktree ["git" "commit" "--no-gpg-sign" "--no-verify"
+                              "-m" "implement-phase-boundary commit"])
   (let [{:keys [out]} (sh-must-succeed! worktree ["git" "status" "--porcelain"])]
     (when-not (str/blank? out)
       (throw (ex-info "fixture left worktree dirty after commit"

--- a/scripts/refresh-cost-table-test.bb
+++ b/scripts/refresh-cost-table-test.bb
@@ -1,0 +1,128 @@
+#!/usr/bin/env bb
+;; Unit-test the pure-data layer of refresh-cost-table.bb:
+;; transform + upstream-pricing. Network fetch isn't tested here
+;; (CI smoke-runs the live fetch via the actual workflow run);
+;; this test pins the math + the unmatched-falls-back-to-current
+;; behaviour.
+
+(load-file "scripts/refresh-cost-table.bb")
+
+(require '[clojure.test :as test :refer [deftest is testing]])
+
+(def synthetic-upstream
+  "Subset of what litellm's JSON looks like; only the fields the
+   transform actually reads. Cheshire parses with keyword keys
+   when the script does — mirror that here."
+  {:claude-sonnet-4-5
+   {:input_cost_per_token 0.000003   ; $3.00 / 1M
+    :output_cost_per_token 0.000015} ; $15.00 / 1M
+   :claude-opus-4-1-20250805
+   {:input_cost_per_token 0.000005   ; $5.00 / 1M
+    :output_cost_per_token 0.000025} ; $25.00 / 1M
+   :gpt-5-pro
+   {:input_cost_per_token 0.000015   ; $15.00 / 1M
+    :output_cost_per_token 0.000075} ; $75.00 / 1M
+   :gemini-2.5-flash
+   {:input_cost_per_token 0.0000003  ; $0.30 / 1M
+    :output_cost_per_token 0.0000025} ; $2.50 / 1M
+   :a-model-with-no-price-fields
+   {:context_window 200000}})
+
+(def synthetic-mapping
+  {"claude-sonnet-4-6"   "claude-sonnet-4-5"
+   "claude-opus-4-7"     "claude-opus-4-1-20250805"
+   "gpt-5.4-pro"         "gpt-5-pro"})
+
+;; ----------------------------------------------------------------- upstream-pricing
+
+(deftest upstream-pricing-via-mapping-test
+  (testing "Model lookup goes through the mapping table when present
+            and resolves the upstream entry's cost-per-token fields."
+    (is (= {:input-per-1m 3.0 :output-per-1m 15.0}
+           (upstream-pricing synthetic-upstream synthetic-mapping
+                             "claude-sonnet-4-6"))
+        "sonnet-4-6 -> sonnet-4-5 via mapping -> $3/$15 per 1M")))
+
+(deftest upstream-pricing-falls-back-to-direct-key-test
+  (testing "When no mapping entry exists, the transform tries the
+            our-id as the upstream key directly. Gemini ids match
+            upstream verbatim — no mapping needed."
+    (is (= {:input-per-1m 0.3 :output-per-1m 2.5}
+           (upstream-pricing synthetic-upstream {}
+                             "gemini-2.5-flash"))
+        "direct-key fallback resolves gemini-2.5-flash")))
+
+(deftest upstream-pricing-nil-when-no-match-test
+  (testing "Neither mapping NOR direct-key hit returns nil so the
+            caller can fold the miss into the unmatched bucket."
+    (is (nil? (upstream-pricing synthetic-upstream synthetic-mapping
+                                "completely-unknown-model")))))
+
+(deftest upstream-pricing-nil-when-entry-missing-prices-test
+  (testing "Upstream may list a model with no cost-per-token fields
+            (research previews, deprecated entries). Treat the
+            same as no match — never emit a {0.0 0.0} bogus price."
+    (is (nil? (upstream-pricing synthetic-upstream {}
+                                "a-model-with-no-price-fields")))))
+
+;; ----------------------------------------------------------------- transform
+
+(deftest transform-refreshes-matched-and-preserves-unmatched-test
+  (testing "Each entry in the current table is refreshed against
+            upstream OR kept at its current price if upstream
+            doesn't cover it. Unmatched ids surface in :unmatched
+            so the operator can update the mapping or accept the
+            stale price."
+    (let [current {:pricing/by-model-id
+                   {"claude-sonnet-4-6"     {:input-per-1m 999 :output-per-1m 999}
+                    "gemini-2.5-flash"      {:input-per-1m 999 :output-per-1m 999}
+                    "free-local-model"      {:input-per-1m 0.0 :output-per-1m 0.0}}}
+          {:keys [refreshed unmatched changed]}
+          (transform current synthetic-mapping synthetic-upstream)]
+      (is (= {:input-per-1m 3.0 :output-per-1m 15.0}
+             (get refreshed "claude-sonnet-4-6"))
+          "claude-sonnet-4-6 refreshed via mapping")
+      (is (= {:input-per-1m 0.3 :output-per-1m 2.5}
+             (get refreshed "gemini-2.5-flash"))
+          "gemini refreshed via direct key")
+      (is (= {:input-per-1m 0.0 :output-per-1m 0.0}
+             (get refreshed "free-local-model"))
+          "free-local-model has no upstream match — kept verbatim")
+      (is (= ["free-local-model"] unmatched)
+          ":unmatched names what kept its prior price")
+      (is (= 2 (count changed))
+          "two models had refreshed prices; one unchanged stays out
+           of :changed even though it WAS refreshed (same value)"))))
+
+(deftest transform-only-flags-actual-value-changes-test
+  (testing ":changed only lists entries whose price actually moved.
+            Re-running the ETL when nothing upstream changed must
+            be a no-op — otherwise the auto-PR workflow opens
+            empty PRs every cycle."
+    (let [;; Current prices already match what upstream says.
+          current {:pricing/by-model-id
+                   {"claude-sonnet-4-6" {:input-per-1m 3.0 :output-per-1m 15.0}
+                    "gemini-2.5-flash"  {:input-per-1m 0.3 :output-per-1m 2.5}}}
+          {:keys [changed unmatched]}
+          (transform current synthetic-mapping synthetic-upstream)]
+      (is (empty? changed)
+          "no price moved → :changed is empty")
+      (is (empty? unmatched)
+          "all entries matched upstream"))))
+
+(deftest transform-empty-current-table-test
+  (testing "Empty cost-table → empty refresh (no work). Defensive
+            shape — operator may have wiped the table to start
+            fresh; ETL should handle it without throwing."
+    (let [{:keys [refreshed unmatched changed]}
+          (transform {:pricing/by-model-id {}}
+                     synthetic-mapping
+                     synthetic-upstream)]
+      (is (empty? refreshed))
+      (is (empty? unmatched))
+      (is (empty? changed)))))
+
+;; ----------------------------------------------------------------- Driver
+
+(let [{:keys [fail error]} (test/run-tests 'user)]
+  (System/exit (if (zero? (+ (or fail 0) (or error 0))) 0 1)))

--- a/scripts/refresh-cost-table-test.bb
+++ b/scripts/refresh-cost-table-test.bb
@@ -122,6 +122,44 @@
       (is (empty? unmatched))
       (is (empty? changed)))))
 
+;; ----------------------------------------------------------------- extract-preamble
+
+(deftest extract-preamble-pulls-text-before-first-brace-test
+  (testing "Pre-map text is the file's comment header — license,
+            documentation, provider-group dividers. extract-preamble
+            grabs everything up to (but not including) the first `{`.
+            Real cost-table.edn shape: many comment lines, then the
+            map opener — comments must round-trip across rewrites."
+    (let [raw (str ";; License header line 1\n"
+                   ";; License header line 2\n"
+                   ";;\n"
+                   ";; Documentation block\n"
+                   "\n"
+                   "{:pricing/by-model-id {\"a\" {:input-per-1m 1}}}\n")]
+      (is (= (str ";; License header line 1\n"
+                  ";; License header line 2\n"
+                  ";;\n"
+                  ";; Documentation block\n"
+                  "\n")
+             (extract-preamble raw))
+          "everything up to the first `{` is preserved verbatim"))))
+
+(deftest extract-preamble-empty-when-no-comments-test
+  (testing "EDN file with no pre-map content (the file starts with
+            `{` directly) yields an empty preamble — preserves the
+            existing behaviour of writing a clean EDN map without
+            phantom leading whitespace."
+    (is (= "" (extract-preamble "{:pricing/by-model-id {}}\n")))))
+
+(deftest extract-preamble-handles-nil-and-no-brace-test
+  (testing "Defensive: nil input (missing file) and brace-less
+            input (corrupted file) both return empty string so the
+            caller still produces a well-formed EDN map."
+    (is (= "" (extract-preamble nil))
+        "nil → empty preamble, no NPE")
+    (is (= "" (extract-preamble ";; comment with no map content\n"))
+        "no `{` → empty preamble, caller's data block still writes")))
+
 ;; ----------------------------------------------------------------- Driver
 
 (let [{:keys [fail error]} (test/run-tests 'user)]

--- a/scripts/refresh-cost-table.bb
+++ b/scripts/refresh-cost-table.bb
@@ -1,0 +1,204 @@
+#!/usr/bin/env bb
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Refresh `components/llm/resources/llm/cost-table.edn` from the
+;; canonical upstream pricing source (BerriAI/litellm's
+;; `model_prices_and_context_window.json`).
+;;
+;; Run locally:
+;;
+;;     bb scripts/refresh-cost-table.bb
+;;
+;; Run in CI:
+;;
+;;     `.github/workflows/refresh-cost-table.yml` invokes this on
+;;     schedule (weekly) and on workflow_dispatch, then opens a PR
+;;     if the EDN changed.
+;;
+;; The transform is keyed by the ids already in cost-table.edn —
+;; this ETL refreshes *existing* prices, it does NOT add new models.
+;; To track a new model, hand-edit cost-table.edn first (and
+;; cost-source-mapping.edn if upstream's id differs from ours),
+;; then the next refresh keeps it current.
+;;
+;; Exit code:
+;;   0 — cost-table is current OR was refreshed successfully
+;;   2 — upstream JSON couldn't be fetched / parsed
+;;   3 — one or more priced models had no upstream match
+
+(require '[babashka.curl :as curl]
+         '[babashka.fs :as fs]
+         '[cheshire.core :as json]
+         '[clojure.edn :as edn]
+         '[clojure.pprint :as pprint]
+         '[clojure.string :as str])
+
+;; ----------------------------------------------------------------- Constants
+;; Named here so the script doesn't carry magic strings/numbers and a
+;; future audit can find the source URL + paths in one place.
+
+(def cost-table-path
+  "components/llm/resources/llm/cost-table.edn")
+
+(def mapping-path
+  "components/llm/resources/llm/cost-source-mapping.edn")
+
+(def upstream-json-url
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json")
+
+(def tokens-per-million
+  "Same constant as ai.miniforge.llm.cost/tokens-per-million —
+   denominator for the per-1M-token shape our cost-table uses.
+   Duplicated here because bb scripts run outside the JVM classpath
+   and re-requiring the clojure namespace would pull in the whole
+   llm component for a single number."
+  1000000.0)
+
+(def exit-codes
+  {:ok                        0
+   :upstream-fetch-failed     2
+   :upstream-coverage-missing 3})
+
+;; ----------------------------------------------------------------- IO helpers
+
+(defn- read-edn-file
+  [path]
+  (-> path slurp edn/read-string))
+
+(defn- write-edn-file
+  "Write `data` as pretty-printed EDN to `path`. The output is hand-
+   readable: each model-id gets its own line, with `:input-per-1m`
+   and `:output-per-1m` columns aligned for visual diff. Sticks to
+   the same shape `cost-table.edn` is hand-edited as, so a
+   refresh PR reads as a per-cell update rather than a wholesale
+   reformat."
+  [path data]
+  (let [models  (:pricing/by-model-id data)
+        ordered (->> models (sort-by key))
+        key-width (->> ordered (map (comp count pr-str key))
+                       (reduce max 0))
+        rows (->> ordered
+                  (map (fn [[k {:keys [input-per-1m output-per-1m]}]]
+                         (format "  %s {:input-per-1m %6.2f :output-per-1m %6.2f}"
+                                 (format (str "%-" key-width "s") (pr-str k))
+                                 (double input-per-1m)
+                                 (double output-per-1m)))))]
+    (spit path
+          (str "{:pricing/by-model-id\n"
+               " {"
+               (->> rows (str/join "\n") (str/triml))
+               "}}\n"))))
+
+;; ----------------------------------------------------------------- Fetch + transform
+
+(defn fetch-upstream-json
+  "GET the litellm JSON and parse it. Returns `{:ok true :body parsed}`
+   or `{:ok false :error <message>}`. Anomaly-style return; no
+   throws — caller branches on `:ok` to decide exit code."
+  []
+  (try
+    (let [{:keys [status body]} (curl/get upstream-json-url
+                                          {:throw false})]
+      (if (= 200 status)
+        {:ok true :body (json/parse-string body true)}
+        {:ok false :error (str "HTTP " status " from " upstream-json-url)}))
+    (catch Exception e
+      {:ok false :error (.getMessage e)})))
+
+(defn upstream-pricing
+  "Look up our `model-id` in the upstream JSON via `mapping`.
+   Falls through to the direct upstream key if no mapping entry
+   AND the upstream JSON has our id verbatim — handles the case
+   where upstream and our naming line up.
+   Returns `{:input-per-1m :output-per-1m}` or nil."
+  [upstream-json mapping model-id]
+  (let [upstream-key (get mapping model-id model-id)
+        entry        (get upstream-json (keyword upstream-key))]
+    (when entry
+      (let [in  (:input_cost_per_token entry)
+            out (:output_cost_per_token entry)]
+        (when (and (number? in) (number? out))
+          {:input-per-1m  (* in  tokens-per-million)
+           :output-per-1m (* out tokens-per-million)})))))
+
+(defn transform
+  "Refresh each entry in `current` against `upstream` via `mapping`.
+   Returns `{:refreshed <new-table> :unmatched [...] :changed
+   [{:model :before :after}]}`. Unmatched models keep their existing
+   prices — operator-curated entries don't get silently zeroed out
+   when upstream renames or drops them."
+  [current-table mapping upstream]
+  (let [current (:pricing/by-model-id current-table)]
+    (reduce
+      (fn [acc [model-id current-price]]
+        (if-let [fresh (upstream-pricing upstream mapping model-id)]
+          (cond-> (update acc :refreshed assoc model-id fresh)
+            (not= fresh current-price)
+            (update :changed conj {:model model-id
+                                   :before current-price
+                                   :after  fresh}))
+          (-> acc
+              (update :refreshed assoc model-id current-price)
+              (update :unmatched conj model-id))))
+      {:refreshed {} :unmatched [] :changed []}
+      current)))
+
+;; ----------------------------------------------------------------- Report
+
+(defn- format-price [{:keys [input-per-1m output-per-1m]}]
+  (format "$%.2f in / $%.2f out per 1M" (double input-per-1m) (double output-per-1m)))
+
+(defn print-summary
+  "Human-readable change summary. Used as the GitHub Action's job
+   output AND as the PR body when the script lands changes."
+  [{:keys [refreshed unmatched changed]}]
+  (println (format "Models in cost-table: %d" (count refreshed)))
+  (println (format "Models updated:       %d" (count changed)))
+  (println (format "Models unmatched:     %d" (count unmatched)))
+  (when (seq changed)
+    (println "\nChanges:")
+    (doseq [{:keys [model before after]} changed]
+      (println (format "  %s: %s -> %s"
+                       model
+                       (format-price before)
+                       (format-price after)))))
+  (when (seq unmatched)
+    (println "\nUnmatched models (kept existing prices):")
+    (doseq [m unmatched]
+      (println (format "  %s" m)))))
+
+;; ----------------------------------------------------------------- Main
+
+(defn -main
+  [& _args]
+  (let [current  (read-edn-file cost-table-path)
+        mapping  (-> mapping-path read-edn-file :mapping/by-model-id)
+        fetch    (fetch-upstream-json)]
+    (cond
+      (not (:ok fetch))
+      (do (println "ERROR: upstream fetch failed:" (:error fetch))
+          (System/exit (:upstream-fetch-failed exit-codes)))
+
+      :else
+      (let [{:keys [refreshed unmatched changed] :as result}
+            (transform current mapping (:body fetch))]
+        (write-edn-file cost-table-path
+                        {:pricing/by-model-id refreshed})
+        (print-summary result)
+        (System/exit
+          (if (seq unmatched)
+            (:upstream-coverage-missing exit-codes)
+            (:ok exit-codes)))))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))

--- a/scripts/refresh-cost-table.bb
+++ b/scripts/refresh-cost-table.bb
@@ -40,7 +40,6 @@
          '[babashka.fs :as fs]
          '[cheshire.core :as json]
          '[clojure.edn :as edn]
-         '[clojure.pprint :as pprint]
          '[clojure.string :as str])
 
 ;; ----------------------------------------------------------------- Constants
@@ -75,16 +74,33 @@
   [path]
   (-> path slurp edn/read-string))
 
+(defn- extract-preamble
+  "Pull everything before the first `{` out of an EDN file's raw text.
+   That's the comment header (license + documentation) the
+   refresh-cost-table flow must preserve across rewrites — EDN
+   parsing strips comments, so the structured data round-trip can't
+   carry them forward on its own.
+
+   Returns the preamble string (may include trailing whitespace
+   before the `{`) or an empty string if the file has no
+   pre-map content. Defensive: a missing file or one without `{`
+   yields `\"\"` so the caller still produces valid EDN."
+  [raw-text]
+  (if-let [open-idx (str/index-of (or raw-text "") "{")]
+    (subs raw-text 0 open-idx)
+    ""))
+
 (defn- write-edn-file
-  "Write `data` as pretty-printed EDN to `path`. The output is hand-
-   readable: each model-id gets its own line, with `:input-per-1m`
-   and `:output-per-1m` columns aligned for visual diff. Sticks to
-   the same shape `cost-table.edn` is hand-edited as, so a
-   refresh PR reads as a per-cell update rather than a wholesale
-   reformat."
+  "Write `data` as pretty-readable EDN to `path`, preserving the
+   existing file's header comments (license + docs) so a refresh
+   doesn't permanently lose the documentation. Each model-id gets
+   its own line, with `:input-per-1m` and `:output-per-1m` columns
+   aligned for visual diff. Sticks to the same shape
+   `cost-table.edn` is hand-edited as, so a refresh PR reads as a
+   per-cell update rather than a wholesale reformat."
   [path data]
-  (let [models  (:pricing/by-model-id data)
-        ordered (->> models (sort-by key))
+  (let [models    (:pricing/by-model-id data)
+        ordered   (->> models (sort-by key))
         key-width (->> ordered (map (comp count pr-str key))
                        (reduce max 0))
         rows (->> ordered
@@ -92,11 +108,13 @@
                          (format "  %s {:input-per-1m %6.2f :output-per-1m %6.2f}"
                                  (format (str "%-" key-width "s") (pr-str k))
                                  (double input-per-1m)
-                                 (double output-per-1m)))))]
+                                 (double output-per-1m)))))
+        preamble (extract-preamble (when (fs/exists? path) (slurp path)))]
     (spit path
-          (str "{:pricing/by-model-id\n"
-               " {"
-               (->> rows (str/join "\n") (str/triml))
+          (str preamble
+               "{:pricing/by-model-id\n"
+               " {\n"
+               (->> rows (str/join "\n"))
                "}}\n"))))
 
 ;; ----------------------------------------------------------------- Fetch + transform
@@ -108,7 +126,9 @@
   []
   (try
     (let [{:keys [status body]} (curl/get upstream-json-url
-                                          {:throw false})]
+                                          {:throw false
+                                           :connect-timeout 30
+                                           :max-time 30})]
       (if (= 200 status)
         {:ok true :body (json/parse-string body true)}
         {:ok false :error (str "HTTP " status " from " upstream-json-url)}))
@@ -182,7 +202,11 @@
 (defn -main
   [& _args]
   (let [current  (read-edn-file cost-table-path)
-        mapping  (-> mapping-path read-edn-file :mapping/by-model-id)
+        mapping  (if (fs/exists? mapping-path)
+                   (-> mapping-path read-edn-file :mapping/by-model-id)
+                   (do (println "WARN: mapping file not found, defaulting to identity mapping:"
+                                mapping-path)
+                       {}))
         fetch    (fetch-upstream-json)]
     (cond
       (not (:ok fetch))


### PR DESCRIPTION
## Summary

Data layer for a scheduled ETL that refreshes `components/llm/resources/llm/cost-table.edn` from the canonical upstream pricing source (BerriAI/litellm's `model_prices_and_context_window.json`). Frames the LLM-cost refresh as an ETL — same delivery shape as the rest of Thesium's data sources — so it stops being a sneakernet "someone remember to update prices" chore and becomes scheduled-and-auditable.

> **Note on splitting**: the matching `.github/workflows/refresh-cost-table.yml` is in the worktree but couldn't be pushed by the ambient OAuth token (workflow files need `workflow` scope). Content is included at the bottom of this PR body — apply locally with a workflow-scoped token (e.g. `gh auth refresh -s workflow` then push), or paste-and-commit yourself.

## Components in this commit

- **`scripts/refresh-cost-table.bb`** — Babashka script. Fetches the upstream JSON, looks each model up via the our-id → upstream-id mapping (with direct-key fallback when names match), and rewrites `cost-table.edn` with refreshed prices. Exit codes: 0 clean / 2 upstream fetch failed / 3 some priced models had no upstream match (kept verbatim, surfaced in summary).
- **`scripts/refresh-cost-table-test.bb`** — 7 tests / 14 assertions pinning the pure-data transform: mapping lookups, direct-key fallback, no-match-returns-nil, missing-price-fields returns nil, unmatched models keep existing values, no-op when upstream matches current.
- **`components/llm/resources/llm/cost-source-mapping.edn`** — table mapping our friendly ids (`claude-sonnet-4-6`) to upstream litellm keys (`claude-sonnet-4-5`). Optional — direct-key fallback covers ids that already match (`gemini-2.5-flash` etc.).

## Design choices

- **Refresh existing, don't expand**: ETL keys off the model-ids already in `cost-table.edn`. To track a new model, hand-edit the table first (and the mapping if upstream's id differs), then the next refresh keeps it current. Prevents surprise-pricing of models we never intended to track.
- **Auto-PR rather than auto-commit** (workflow will do this): an LLM cost is a financial fact, not an operational config. Human reviews the diff, confirms upstream moved (and didn't get vandalised), merges.
- **Magic-number discipline**: named constants for paths, URL, tokens-per-million, exit-codes. Pricing values live in EDN.
- **Exceptions-as-data**: `fetch-upstream-json` returns `{:ok bool :error ...}`; `upstream-pricing` returns nil on miss; `transform` never throws. `System/exit` only at the top-level driver.

## Test plan

- [x] `bb scripts/refresh-cost-table-test.bb` — 7 / 14 / 0 / 0 on the pure-data transform.
- [x] `bb scripts/refresh-cost-table.bb` parses + loads (smoke).
- [x] Full pre-commit changed-bricks suite green.
- [ ] First scheduled run after the workflow file lands will be the live integration smoke.

## Workflow file (paste into `.github/workflows/refresh-cost-table.yml`)

```yaml
name: Refresh cost-table

# Refresh `components/llm/resources/llm/cost-table.edn` from the
# canonical upstream pricing source (BerriAI/litellm's
# `model_prices_and_context_window.json`) and open a PR if the
# refreshed prices differ from what we have committed.

on:
  schedule:
    - cron: '0 6 * * 1'
  workflow_dispatch:
    inputs:
      reason:
        description: 'Why are you triggering this manually? (recorded in the PR body)'
        required: false
        default: 'Manual refresh'

permissions:
  contents: write
  pull-requests: write

jobs:
  refresh:
    name: Refresh cost-table from upstream
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Install Babashka
        uses: DeLaGuardo/setup-clojure@12.5
        with:
          bb: latest

      - name: Run cost-table ETL
        id: etl
        run: |
          set +e
          bb scripts/refresh-cost-table.bb | tee /tmp/etl-summary.txt
          rc=$?
          set -e
          {
            echo "exit_code=$rc"
            echo 'summary<<EOF_SUMMARY'
            cat /tmp/etl-summary.txt
            echo 'EOF_SUMMARY'
          } >> "$GITHUB_OUTPUT"
          if [ "$rc" -eq 2 ]; then
            echo "::error::Upstream fetch failed — investigate before retrying."
            exit 2
          fi

      - name: Check for diff
        id: diff
        run: |
          if git diff --quiet components/llm/resources/llm/cost-table.edn; then
            echo "changed=false" >> "$GITHUB_OUTPUT"
          else
            echo "changed=true"  >> "$GITHUB_OUTPUT"
          fi

      - name: Prepare PR body
        if: steps.diff.outputs.changed == 'true'
        env:
          EVENT_NAME: ${{ github.event_name }}
          REASON: ${{ inputs.reason }}
          ETL_SUMMARY: ${{ steps.etl.outputs.summary }}
        run: |
          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
            TRIGGER="manual ($REASON)"
          else
            TRIGGER="scheduled weekly Monday 06:00 UTC"
          fi
          {
            echo "## Summary"
            echo ""
            echo "Auto-refresh of \`components/llm/resources/llm/cost-table.edn\` from BerriAI/litellm's \`model_prices_and_context_window.json\`."
            echo ""
            echo "**Trigger**: $TRIGGER"
            echo ""
            echo "## ETL summary"
            echo '```'
            printf '%s\n' "$ETL_SUMMARY"
            echo '```'
            echo ""
            echo "## Review checklist"
            echo "- [ ] Diff matches what the upstream source actually says"
            echo "- [ ] No provider listed a price decrease — warrants a double-check"
            echo "- [ ] Unmatched models in the ETL summary still have plausible curated prices"
          } > /tmp/pr-body.md

      - name: Open pull request
        if: steps.diff.outputs.changed == 'true'
        uses: peter-evans/create-pull-request@v7
        with:
          branch: bot/cost-table-refresh
          base: main
          commit-message: 'chore(llm): refresh cost-table from upstream pricing source'
          title: 'chore(llm): refresh cost-table from upstream pricing source'
          body-path: /tmp/pr-body.md
          delete-branch: true
          labels: |
            automated
            dependencies
            cost-table

      - name: Annotate run summary
        if: always()
        env:
          ETL_EXIT_CODE: ${{ steps.etl.outputs.exit_code }}
          DIFF_PRESENT: ${{ steps.diff.outputs.changed }}
          ETL_SUMMARY: ${{ steps.etl.outputs.summary }}
        run: |
          {
            echo "### ETL exit code: ${ETL_EXIT_CODE:-unknown}"
            echo ""
            echo "### Diff present: ${DIFF_PRESENT:-unknown}"
            echo ""
            echo "### ETL output"
            echo '```'
            printf '%s\n' "${ETL_SUMMARY:-}"
            echo '```'
          } >> "$GITHUB_STEP_SUMMARY"
```

Security note: all `${{ }}` interpolations that feed `run:` blocks go through `env:` so the `workflow_dispatch.reason` input can't shell-inject. PR body is built in a file + handed to `peter-evans/create-pull-request` via `body-path:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
