### PR TITLE
refactor(cli): exceptions-as-data cleanup of cli base

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
@@ -37,6 +37,7 @@
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -88,13 +89,17 @@
       (fs/directory? f)
       (if-let [p (single-file-under f "pipelines")]
         [(str (fs/absolutize f)) (str (fs/absolutize p))]
-        (throw (ex-info (str "Could not find a single pipelines/*.edn under " f) {})))
+        (response/throw-anomaly! :anomalies/not-found
+                                 (str "Could not find a single pipelines/*.edn under " f)
+                                 {:pack-dir (str f)}))
 
       (and (fs/regular-file? f) (str/ends-with? (str f) ".edn"))
       [nil (str (fs/absolutize f))]
 
       :else
-      (throw (ex-info (str "Not a pack directory or pipeline EDN: " pack-or-pipeline) {})))))
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Not a pack directory or pipeline EDN: " pack-or-pipeline)
+                               {:input pack-or-pipeline}))))
 
 (defn- resolve-env-path
   "Resolve `--env`, which may be a `.edn` path or a bare env name that
@@ -103,7 +108,9 @@
   [env pack-dir]
   (cond
     (nil? env)
-    (throw (ex-info "missing --env <env.edn|name>" {}))
+    (response/throw-anomaly! :anomalies/incorrect
+                             "missing --env <env.edn|name>"
+                             {})
 
     (str/ends-with? env ".edn")
     (str (fs/absolutize env))
@@ -112,10 +119,14 @@
     (let [candidate (fs/file pack-dir "envs" (str env ".edn"))]
       (if (fs/regular-file? candidate)
         (str (fs/absolutize candidate))
-        (throw (ex-info (str "env not found: " candidate) {}))))
+        (response/throw-anomaly! :anomalies/not-found
+                                 (str "env not found: " candidate)
+                                 {:env env :candidate (str candidate)})))
 
     :else
-    (throw (ex-info (str "--env was a name but pipeline was given directly; pass a .edn path instead: " env) {}))))
+    (response/throw-anomaly! :anomalies/incorrect
+                             (str "--env was a name but pipeline was given directly; pass a .edn path instead: " env)
+                             {:env env})))
 
 (defn- resolve-pack-paths
   "Given the positional arg to `etl run` / `etl validate` and the `--env`

--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
@@ -91,7 +91,7 @@
         [(str (fs/absolutize f)) (str (fs/absolutize p))]
         (response/throw-anomaly! :anomalies/not-found
                                  (str "Could not find a single pipelines/*.edn under " f)
-                                 {:pack-dir (str f)}))
+                                 {:pack-dir (str (fs/absolutize f))}))
 
       (and (fs/regular-file? f) (str/ends-with? (str f) ".edn"))
       [nil (str (fs/absolutize f))]

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -837,8 +837,10 @@
                        (not quiet) (->> (display/colorize :yellow))
                        best-effort? (str " [MINIFORGE_BEST_EFFORT_SHUTDOWN=1, continuing]"))))
           (when-not best-effort?
-            (throw (ex-info msg {:reason :event-stream-drain-failed
-                                 :drain-result drain-result})))))
+            (response/throw-anomaly! :anomalies/fault
+                                     msg
+                                     {:reason :event-stream-drain-failed
+                                      :drain-result drain-result}))))
       drain-result)))
 
 (defn run-workflow! [workflow-id {:keys [version output quiet event-stream dashboard-url]

--- a/bases/cli/test/ai/miniforge/cli/anomaly/etl_anomaly_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/anomaly/etl_anomaly_test.clj
@@ -37,19 +37,28 @@
   (testing "empty pack dir with no pipelines/*.edn raises :anomalies/not-found"
     (let [tmp (fs/create-temp-dir {:prefix "cli-etl-test-"})]
       (try
-        (is (thrown-with-msg?
-             ExceptionInfo
-             #"Could not find a single pipelines/\*\.edn"
-             (@#'etl/resolve-pipeline-path (str tmp))))
+        (let [thrown (try (@#'etl/resolve-pipeline-path (str tmp))
+                          nil
+                          (catch ExceptionInfo e e))]
+          (is (some? thrown))
+          (is (re-find #"Could not find a single pipelines/\*\.edn"
+                       (.getMessage thrown)))
+          (is (= :anomalies/not-found
+                 (:anomaly/category (ex-data thrown))))
+          (is (= (str (fs/absolutize tmp))
+                 (:pack-dir (ex-data thrown)))))
         (finally
           (fs/delete-tree tmp))))))
 
 (deftest resolve-pipeline-path-nonexistent-path-throws-incorrect
   (testing "non-dir non-edn path raises :anomalies/incorrect"
-    (is (thrown-with-msg?
-         ExceptionInfo
-         #"Not a pack directory or pipeline EDN"
-         (@#'etl/resolve-pipeline-path "/no/such/thing")))))
+    (let [thrown (try (@#'etl/resolve-pipeline-path "/no/such/thing")
+                      nil
+                      (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"Not a pack directory or pipeline EDN" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
+      (is (= "/no/such/thing" (:input (ex-data thrown)))))))
 
 (deftest resolve-pipeline-path-valid-edn-returns-path
   (testing "direct pipeline EDN file returns [nil <abs-path>]"
@@ -64,26 +73,34 @@
 
 (deftest resolve-env-path-nil-throws-incorrect
   (testing "nil env raises :anomalies/incorrect"
-    (is (thrown-with-msg?
-         ExceptionInfo
-         #"missing --env"
-         (@#'etl/resolve-env-path nil nil)))))
+    (let [thrown (try (@#'etl/resolve-env-path nil nil)
+                      nil
+                      (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"missing --env" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
 (deftest resolve-env-path-name-without-pack-dir-throws-incorrect
   (testing "env name without pack-dir raises :anomalies/incorrect"
-    (is (thrown-with-msg?
-         ExceptionInfo
-         #"pass a \.edn path instead"
-         (@#'etl/resolve-env-path "prod" nil)))))
+    (let [thrown (try (@#'etl/resolve-env-path "prod" nil)
+                      nil
+                      (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"pass a \.edn path instead" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
+      (is (= "prod" (:env (ex-data thrown)))))))
 
 (deftest resolve-env-path-name-missing-in-pack-throws-not-found
   (testing "env name not found under pack-dir/envs raises :anomalies/not-found"
     (let [tmp (fs/create-temp-dir {:prefix "cli-etl-pack-"})]
       (try
-        (is (thrown-with-msg?
-             ExceptionInfo
-             #"env not found"
-             (@#'etl/resolve-env-path "prod" (str tmp))))
+        (let [thrown (try (@#'etl/resolve-env-path "prod" (str tmp))
+                          nil
+                          (catch ExceptionInfo e e))]
+          (is (some? thrown))
+          (is (re-find #"env not found" (.getMessage thrown)))
+          (is (= :anomalies/not-found (:anomaly/category (ex-data thrown))))
+          (is (= "prod" (:env (ex-data thrown)))))
         (finally
           (fs/delete-tree tmp))))))
 

--- a/bases/cli/test/ai/miniforge/cli/anomaly/etl_anomaly_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/anomaly/etl_anomaly_test.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.anomaly.etl-anomaly-test
+  "Coverage for `cli.main.commands.etl` boundary escalation via
+   `response/throw-anomaly!`.
+
+   Pre-cleanup, each site was a raw `(throw (ex-info ...))`. Post-
+   cleanup, throws route through the canonical
+   `response/throw-anomaly!` so CLI argument-validation failures
+   surface as typed anomaly categories instead of opaque ex-info."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [babashka.fs :as fs]
+   [ai.miniforge.cli.main.commands.etl :as etl])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+;------------------------------------------------------------------------------ resolve-pipeline-path (private)
+
+(deftest resolve-pipeline-path-empty-dir-throws-not-found
+  (testing "empty pack dir with no pipelines/*.edn raises :anomalies/not-found"
+    (let [tmp (fs/create-temp-dir {:prefix "cli-etl-test-"})]
+      (try
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Could not find a single pipelines/\*\.edn"
+             (@#'etl/resolve-pipeline-path (str tmp))))
+        (finally
+          (fs/delete-tree tmp))))))
+
+(deftest resolve-pipeline-path-nonexistent-path-throws-incorrect
+  (testing "non-dir non-edn path raises :anomalies/incorrect"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Not a pack directory or pipeline EDN"
+         (@#'etl/resolve-pipeline-path "/no/such/thing")))))
+
+(deftest resolve-pipeline-path-valid-edn-returns-path
+  (testing "direct pipeline EDN file returns [nil <abs-path>]"
+    (let [tmp (fs/create-temp-file {:suffix ".edn"})]
+      (try
+        (let [result (@#'etl/resolve-pipeline-path (str tmp))]
+          (is (= [nil (str (fs/absolutize tmp))] result)))
+        (finally
+          (fs/delete-if-exists tmp))))))
+
+;------------------------------------------------------------------------------ resolve-env-path (private)
+
+(deftest resolve-env-path-nil-throws-incorrect
+  (testing "nil env raises :anomalies/incorrect"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"missing --env"
+         (@#'etl/resolve-env-path nil nil)))))
+
+(deftest resolve-env-path-name-without-pack-dir-throws-incorrect
+  (testing "env name without pack-dir raises :anomalies/incorrect"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"pass a \.edn path instead"
+         (@#'etl/resolve-env-path "prod" nil)))))
+
+(deftest resolve-env-path-name-missing-in-pack-throws-not-found
+  (testing "env name not found under pack-dir/envs raises :anomalies/not-found"
+    (let [tmp (fs/create-temp-dir {:prefix "cli-etl-pack-"})]
+      (try
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"env not found"
+             (@#'etl/resolve-env-path "prod" (str tmp))))
+        (finally
+          (fs/delete-tree tmp))))))
+
+(deftest resolve-env-path-valid-edn-returns-abs
+  (testing "env .edn path returns absolutized path"
+    (let [tmp (fs/create-temp-file {:suffix ".edn"})]
+      (try
+        (let [result (@#'etl/resolve-env-path (str tmp) nil)]
+          (is (= (str (fs/absolutize tmp)) result)))
+        (finally
+          (fs/delete-if-exists tmp))))))

--- a/docs/pull-requests/2026-05-09-refactor-cli-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-cli-cleanup.md
@@ -1,0 +1,116 @@
+# refactor: exceptions-as-data cleanup of cli base
+
+## Overview
+
+Migrates the remaining `:cleanup-needed` throw sites in `bases/cli`:
+5 sites in `cli/main/commands/etl.clj` (argument validation) and
+1 site in `cli/workflow_runner.clj` (event-stream drain failure).
+`workflow_runner.clj` and `workflow_runner/context.clj` were already
+substantially migrated to `response/throw-anomaly!` in prior PRs —
+only the 1 residual site remained.
+
+## Motivation
+
+Per `work/exception-cleanup-inventory.md` (audit dated 2026-04-23),
+`bases/cli` carried 14 `:cleanup-needed` sites. Intervening work (most
+of the workflow_runner cleanup) closed 8 of those; the remaining 6 are
+addressed here in one PR.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary
+- `ai.miniforge.response` (merged) — slingshot `throw-anomaly!`
+
+## Layer
+
+Refactor / per-component cleanup tier.
+
+## What This Adds / Changes
+
+`bases/cli/src/.../main/commands/etl.clj`:
+
+- Adds `ai.miniforge.response.interface` require.
+- 5 throw sites migrated to `response/throw-anomaly!`:
+  - `resolve-pipeline-path` — empty pack dir (no `pipelines/*.edn`)
+    → `:anomalies/not-found`
+  - `resolve-pipeline-path` — non-dir non-edn input →
+    `:anomalies/incorrect`
+  - `resolve-env-path` — missing `--env` arg → `:anomalies/incorrect`
+  - `resolve-env-path` — env name not found under `<pack>/envs/`
+    → `:anomalies/not-found`
+  - `resolve-env-path` — env was a name but pipeline was given
+    directly → `:anomalies/incorrect`
+
+`bases/cli/src/.../workflow_runner.clj`:
+
+- 1 throw site migrated. The shutdown-drain failure path (line 840)
+  now routes through `response/throw-anomaly!` with `:anomalies/fault`
+  carrying `:reason :event-stream-drain-failed` and the full
+  `:drain-result` in `:anomaly/data`. The user-facing stderr message
+  remains identical.
+
+`bases/cli/test/.../anomaly/` (new):
+
+- `etl_anomaly_test.clj` — 7 tests covering all 5 etl.clj escalation
+  paths plus two happy-path returns through the private fns.
+
+## Per-site classification
+
+| Site (line) | Fn | Anomaly category |
+|------------:|----|------------------|
+| etl.clj:91 | `resolve-pipeline-path` (empty pack dir) | `:anomalies/not-found` |
+| etl.clj:97 | `resolve-pipeline-path` (non-dir non-edn input) | `:anomalies/incorrect` |
+| etl.clj:106 | `resolve-env-path` (nil `--env`) | `:anomalies/incorrect` |
+| etl.clj:115 | `resolve-env-path` (env name not under pack/envs) | `:anomalies/not-found` |
+| etl.clj:118 | `resolve-env-path` (name without pack-dir) | `:anomalies/incorrect` |
+| workflow_runner.clj:840 | shutdown drain failure | `:anomalies/fault` |
+
+## Strata Affected
+
+- `ai.miniforge.cli.main.commands.etl` — CLI arg validation
+- `ai.miniforge.cli.workflow-runner` — shutdown drain cleanup
+- New `ai.miniforge.cli.anomaly.*` test namespace
+
+## Testing Plan
+
+- New `anomaly.*` tests: 7 tests covering both fns' escalation paths
+  + happy-path returns.
+- CI to confirm full cli suite still green.
+
+## Deployment Plan
+
+No migration. CLI top-level catches both the legacy
+`clojure.lang.ExceptionInfo` shape and the new slingshot anomaly
+shape uniformly (both surface as `ExceptionInfo`).
+
+## Notes
+
+- **No bb-data-plane-http migration.** Out of scope for this PR — see
+  the companion `tail-bundle` PR for the rationale.
+- **`bases/cli/deps.edn` not modified.** The cli base sources
+  `ai.miniforge/response` and `ai.miniforge/anomaly` transitively
+  through the parent projects (`miniforge`, `miniforge-core`,
+  `miniforge-tui`, `data-foundry` — all explicitly declare both).
+  Same pattern as the existing `response/throw-anomaly!` calls in
+  `workflow_runner.clj` already in place pre-PR.
+
+## Related Issues/PRs
+
+- Built on PR #777 (kill-the-deprecation precedent)
+- Companion to Wave 7 + 8 cleanup PRs — operator (#797), spec-parser
+  (#799), agent (#800), task (#801), pr-lifecycle (#846),
+  event-stream (#854), tail-bundle (#855)
+- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
+
+## Checklist
+
+- [x] All 6 in-scope `:cleanup-needed` cli base sites retired
+- [x] Single API per site (`response/throw-anomaly!`)
+- [x] Decomposed test file (one — etl.clj surface is small)
+- [x] No new throws in anomaly-returning code paths
+- [x] External caller contracts preserved
+- [x] Apache 2 license headers preserved

--- a/docs/pull-requests/2026-05-09-refactor-cli-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-cli-cleanup.md
@@ -48,10 +48,12 @@ Refactor / per-component cleanup tier.
 `bases/cli/src/.../workflow_runner.clj`:
 
 - 1 throw site migrated. The shutdown-drain failure path (line 840)
-  now routes through `response/throw-anomaly!` with `:anomalies/fault`
-  carrying `:reason :event-stream-drain-failed` and the full
-  `:drain-result` in `:anomaly/data`. The user-facing stderr message
-  remains identical.
+  now routes through `response/throw-anomaly!` with `:anomalies/fault`.
+  Per `response/anomaly`'s contract, the context map is merged onto
+  the thrown anomaly map at the top level (not nested under
+  `:anomaly/data`) — so `:reason :event-stream-drain-failed` and the
+  full `:drain-result` are top-level keys in `ex-data`. The
+  user-facing stderr message remains identical.
 
 `bases/cli/test/.../anomaly/` (new):
 


### PR DESCRIPTION
## Summary

Migrates the remaining 6 `:cleanup-needed` throw sites in `bases/cli`. workflow_runner.clj + workflow_runner/context.clj were largely migrated in prior PRs — only the residual drain-failure site at workflow_runner.clj:840 remained. Bulk of this PR: 5 etl.clj CLI arg-validation sites.

- `etl.clj` (5 sites) — `resolve-pipeline-path` × 2, `resolve-env-path` × 3
- `workflow_runner.clj` (1 site) — shutdown drain failure

Full PR doc: `docs/pull-requests/2026-05-09-refactor-cli-cleanup.md`

## Test plan

- [x] 7 new decomposed anomaly tests covering all 5 etl escalations + 2 happy paths
- [x] All 6 in-scope throw sites collapsed (0 raw \`(throw (ex-info ...))\` remain in the three target files)
- [ ] CI to confirm full cli suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)