### PR TITLE
GROUP 3b — runner_events stop_reason in phase-completed events

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -498,7 +498,8 @@
           transition-request (assoc :phase/transition-request transition-request)
           redirect-to (assoc :phase/redirect-to redirect-to)
           (:tokens result) (assoc :phase/tokens (:tokens result))
-          (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))))))
+          (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))
+          (:meta result) (assoc :phase/meta (:meta result))))))
 
 (defn workspace-persisted
   "Build a :workspace/persisted event recording that a phase's worktree was

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -154,10 +154,23 @@
         cost-usd (get-in result [:metrics :cost-usd]
                    (get-in result [:phase/metrics :cost-usd]))
         diagnostic-fields (when-not succeeded?
-                            (let [stop-reason           (get-in result [:result :stop-reason])
-                                  final-message-preview (get-in result [:result :final-message-preview])
-                                  turn-count            (get-in result [:result :num-turns])
-                                  tool-call-count       (get-in result [:result :tool-call-count])]
+                            (let [;; Agent failures go through result-boundary/error-response →
+                                  ;; response/error, which nests stop-reason and num-turns under
+                                  ;; [:result :error :data ...].  Success paths (planner) surface
+                                  ;; the same fields under [:result :metrics ...].  Fall back to
+                                  ;; [:result ...] for any legacy shapes that set them top-level.
+                                  stop-reason           (or (get-in result [:result :error :data :stop-reason])
+                                                            (get-in result [:result :metrics :stop-reason])
+                                                            (get-in result [:result :stop-reason]))
+                                  final-message-preview (or (get-in result [:result :error :data :final-message-preview])
+                                                            (get-in result [:result :metrics :final-message-preview])
+                                                            (get-in result [:result :final-message-preview]))
+                                  turn-count            (or (get-in result [:result :error :data :num-turns])
+                                                            (get-in result [:result :metrics :num-turns])
+                                                            (get-in result [:result :num-turns]))
+                                  tool-call-count       (or (get-in result [:result :error :data :tool-call-count])
+                                                            (get-in result [:result :metrics :tool-call-count])
+                                                            (get-in result [:result :tool-call-count]))]
                               (cond-> {}
                                 stop-reason           (assoc :stop-reason stop-reason)
                                 final-message-preview (assoc :final-message-preview final-message-preview)

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -153,22 +153,22 @@
                    (get-in result [:phase/metrics :tokens]))
         cost-usd (get-in result [:metrics :cost-usd]
                    (get-in result [:phase/metrics :cost-usd]))
-        meta-data (when-not succeeded?
-                    (let [stop-reason           (get-in result [:result :stop-reason])
-                          final-message-preview (get-in result [:result :final-message-preview])
-                          turn-count            (get-in result [:result :num-turns])
-                          tool-call-count       (get-in result [:result :tool-call-count])]
-                      (cond-> {}
-                        stop-reason           (assoc :stop-reason stop-reason)
-                        final-message-preview (assoc :final-message-preview final-message-preview)
-                        turn-count            (assoc :turn-count turn-count)
-                        tool-call-count       (assoc :tool-call-count tool-call-count))))]
+        diagnostic-fields (when-not succeeded?
+                            (let [stop-reason           (get-in result [:result :stop-reason])
+                                  final-message-preview (get-in result [:result :final-message-preview])
+                                  turn-count            (get-in result [:result :num-turns])
+                                  tool-call-count       (get-in result [:result :tool-call-count])]
+                              (cond-> {}
+                                stop-reason           (assoc :stop-reason stop-reason)
+                                final-message-preview (assoc :final-message-preview final-message-preview)
+                                turn-count            (assoc :turn-count turn-count)
+                                tool-call-count       (assoc :tool-call-count tool-call-count))))]
     (cond-> {:outcome outcome :duration-ms duration-ms}
-      error-info         (assoc :error error-info)
-      transition-request (assoc :phase/transition-request transition-request)
-      tokens             (assoc :tokens tokens)
-      cost-usd           (assoc :cost-usd cost-usd)
-      (seq meta-data)    (assoc :meta meta-data))))
+      error-info              (assoc :error error-info)
+      transition-request      (assoc :phase/transition-request transition-request)
+      tokens                  (assoc :tokens tokens)
+      cost-usd                (assoc :cost-usd cost-usd)
+      (seq diagnostic-fields) (assoc :meta diagnostic-fields))))
 
 ;------------------------------------------------------------------------------ Layer 1.5
 ;; Supervisory entity builders

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -121,7 +121,18 @@
                                    events with no payload because of this
                                    missing branch)
    4. `:phase/gate-errors`       — gate validation failures
-   5. `(:message result)`        — last-resort string message"
+   5. `(:message result)`        — last-resort string message
+
+   On failure events, `:meta` is populated with LLM diagnostic fields
+   propagated from the agent response:
+
+   - `:stop-reason`           — why the LLM stopped (e.g. :end-turn, :max-tokens)
+   - `:final-message-preview` — truncated final assistant message for post-mortem
+   - `:turn-count`            — number of turns the agent ran (from :num-turns)
+   - `:tool-call-count`       — total tool calls made during the phase
+
+   All fields are optional; `:meta` is omitted entirely on success events
+   and on failures where none of the fields are present."
   [result]
   (let [succeeded? (and (get result :success? (phase/succeeded-or-done? result))
                         (not (inner-result-failed? result)))
@@ -141,12 +152,23 @@
         tokens   (get-in result [:metrics :tokens]
                    (get-in result [:phase/metrics :tokens]))
         cost-usd (get-in result [:metrics :cost-usd]
-                   (get-in result [:phase/metrics :cost-usd]))]
+                   (get-in result [:phase/metrics :cost-usd]))
+        meta-data (when-not succeeded?
+                    (let [stop-reason           (get-in result [:result :stop-reason])
+                          final-message-preview (get-in result [:result :final-message-preview])
+                          turn-count            (get-in result [:result :num-turns])
+                          tool-call-count       (get-in result [:result :tool-call-count])]
+                      (cond-> {}
+                        stop-reason           (assoc :stop-reason stop-reason)
+                        final-message-preview (assoc :final-message-preview final-message-preview)
+                        turn-count            (assoc :turn-count turn-count)
+                        tool-call-count       (assoc :tool-call-count tool-call-count))))]
     (cond-> {:outcome outcome :duration-ms duration-ms}
-      error-info    (assoc :error error-info)
+      error-info         (assoc :error error-info)
       transition-request (assoc :phase/transition-request transition-request)
-      tokens        (assoc :tokens tokens)
-      cost-usd      (assoc :cost-usd cost-usd))))
+      tokens             (assoc :tokens tokens)
+      cost-usd           (assoc :cost-usd cost-usd)
+      (seq meta-data)    (assoc :meta meta-data))))
 
 ;------------------------------------------------------------------------------ Layer 1.5
 ;; Supervisory entity builders

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -157,16 +157,21 @@
 ;;   :meta    → :phase/meta   (added by this PR to core.clj)
 
 (deftest phase-completed-failure-includes-meta-stop-reason-test
-  (testing "failure events carry :phase/meta with stop-reason and other LLM diagnostics"
+  (testing "failure events carry :phase/meta with stop-reason and num-turns from error-data"
+    ;; result-boundary/error-response → response/error produces:
+    ;;   {:status :error
+    ;;    :error  {:message "..." :data {:stop-reason X :num-turns N}}
+    ;;    :metrics {:tokens N :duration-ms 0}}
+    ;; That whole map is what lands under :result in the phase-result.
     (let [stream (create-stream)
           ctx    (test-context)
           phase-result {:status   :failed
                         :success? false
-                        :result   {:status                :failed
-                                   :stop-reason           :max-tokens
-                                   :final-message-preview "Sorry, I ran out of tokens mid-"
-                                   :num-turns             12
-                                   :tool-call-count       37}}]
+                        :result   {:status  :error
+                                   :error   {:message "LLM call failed"
+                                             :data    {:stop-reason :max-tokens
+                                                       :num-turns   12}}
+                                   :metrics {:tokens 0 :duration-ms 0}}}]
       (events/publish-phase-completed! stream ctx :implement phase-result)
       (let [event (first-event stream)
             meta  (:phase/meta event)]
@@ -174,9 +179,7 @@
         (is (= :failure (:phase/outcome event)))
         (is (some? meta) ":phase/meta must be present on failure events with LLM diagnostics")
         (is (= :max-tokens (:stop-reason meta)))
-        (is (= "Sorry, I ran out of tokens mid-" (:final-message-preview meta)))
-        (is (= 12 (:turn-count meta)))
-        (is (= 37 (:tool-call-count meta)))))))
+        (is (= 12 (:turn-count meta)))))))
 
 (deftest phase-completed-failure-meta-omitted-when-no-diagnostic-fields-test
   (testing "failure events without LLM diagnostic fields do not carry :phase/meta"
@@ -193,15 +196,18 @@
 
 (deftest phase-completed-success-has-no-meta-test
   (testing "success events do not carry :phase/meta diagnostic fields"
+    ;; Planner success shape (response/success) puts stop-reason under :metrics.
+    ;; Even with diagnostics present, :phase/meta must be absent on success.
     (let [stream (create-stream)
           ctx    (test-context)
           phase-result {:status   :completed
                         :success? true
-                        :result   {:status                :completed
-                                   :stop-reason           :end-turn
-                                   :final-message-preview "Done."
-                                   :num-turns             5
-                                   :tool-call-count       10}}]
+                        :result   {:status  :success
+                                   :output  {}
+                                   :metrics {:tokens      500
+                                             :duration-ms 3000
+                                             :stop-reason :end-turn
+                                             :num-turns   5}}}]
       (events/publish-phase-completed! stream ctx :plan phase-result)
       (let [event (first-event stream)]
         (is (some? event) "event must be published — stream must be non-empty")
@@ -209,13 +215,17 @@
         (is (nil? (:phase/meta event)) ":phase/meta must not appear on success events")))))
 
 (deftest phase-completed-failure-partial-meta-fields-test
-  (testing "partial LLM diagnostic fields yield partial :phase/meta"
+  (testing "partial LLM diagnostic fields (only stop-reason) yield partial :phase/meta"
+    ;; When only stop-reason made it into the error data (num-turns absent),
+    ;; :phase/meta should carry :stop-reason but no :turn-count.
     (let [stream (create-stream)
           ctx    (test-context)
           phase-result {:status   :failed
                         :success? false
-                        :result   {:status      :failed
-                                   :stop-reason :end-turn}}]
+                        :result   {:status  :error
+                                   :error   {:message "LLM call failed"
+                                             :data    {:stop-reason :end-turn}}
+                                   :metrics {:tokens 0 :duration-ms 0}}}]
       (events/publish-phase-completed! stream ctx :review phase-result)
       (let [event (first-event stream)
             meta  (:phase/meta event)]

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -152,68 +152,75 @@
         (is (= :implement (get-in event [:phase/transition-request :transition/target])))))))
 
 ;------------------------------------------------------------------------------ :meta diagnostic fields
+;; es/phase-completed stores data under namespaced keys:
+;;   :outcome → :phase/outcome
+;;   :meta    → :phase/meta   (added by this PR to core.clj)
 
 (deftest phase-completed-failure-includes-meta-stop-reason-test
-  (testing "failure events carry :meta with stop-reason and other LLM diagnostics"
+  (testing "failure events carry :phase/meta with stop-reason and other LLM diagnostics"
     (let [stream (create-stream)
           ctx    (test-context)
-          phase-result {:status  :failed
+          phase-result {:status   :failed
                         :success? false
-                        :result  {:status               :failed
-                                  :stop-reason          :max-tokens
-                                  :final-message-preview "Sorry, I ran out of tokens mid-"
-                                  :num-turns            12
-                                  :tool-call-count      37}}]
+                        :result   {:status                :failed
+                                   :stop-reason           :max-tokens
+                                   :final-message-preview "Sorry, I ran out of tokens mid-"
+                                   :num-turns             12
+                                   :tool-call-count       37}}]
       (events/publish-phase-completed! stream ctx :implement phase-result)
       (let [event (first-event stream)
-            meta  (:meta event)]
-        (is (= :failure (:outcome event)))
-        (is (some? meta) ":meta must be present on failure events with LLM diagnostics")
+            meta  (:phase/meta event)]
+        (is (some? event) "event must be published — stream must be non-empty")
+        (is (= :failure (:phase/outcome event)))
+        (is (some? meta) ":phase/meta must be present on failure events with LLM diagnostics")
         (is (= :max-tokens (:stop-reason meta)))
         (is (= "Sorry, I ran out of tokens mid-" (:final-message-preview meta)))
         (is (= 12 (:turn-count meta)))
         (is (= 37 (:tool-call-count meta)))))))
 
 (deftest phase-completed-failure-meta-omitted-when-no-diagnostic-fields-test
-  (testing "failure events without LLM diagnostic fields do not carry :meta"
+  (testing "failure events without LLM diagnostic fields do not carry :phase/meta"
     (let [stream (create-stream)
           ctx    (test-context)
-          phase-result {:status  :failed
+          phase-result {:status   :failed
                         :success? false
-                        :error   {:message "network timeout"}}]
+                        :error    {:message "network timeout"}}]
       (events/publish-phase-completed! stream ctx :implement phase-result)
       (let [event (first-event stream)]
-        (is (= :failure (:outcome event)))
-        (is (nil? (:meta event)) ":meta must be absent when no diagnostic fields are present")))))
+        (is (some? event) "event must be published — stream must be non-empty")
+        (is (= :failure (:phase/outcome event)))
+        (is (nil? (:phase/meta event)) ":phase/meta must be absent when no diagnostic fields are present")))))
 
 (deftest phase-completed-success-has-no-meta-test
-  (testing "success events do not carry :meta diagnostic fields"
+  (testing "success events do not carry :phase/meta diagnostic fields"
     (let [stream (create-stream)
           ctx    (test-context)
-          phase-result {:status  :completed
+          phase-result {:status   :completed
                         :success? true
-                        :result  {:status               :completed
-                                  :stop-reason          :end-turn
-                                  :final-message-preview "Done."
-                                  :num-turns            5
-                                  :tool-call-count      10}}]
+                        :result   {:status                :completed
+                                   :stop-reason           :end-turn
+                                   :final-message-preview "Done."
+                                   :num-turns             5
+                                   :tool-call-count       10}}]
       (events/publish-phase-completed! stream ctx :plan phase-result)
       (let [event (first-event stream)]
-        (is (= :success (:outcome event)))
-        (is (nil? (:meta event)) ":meta must not appear on success events")))))
+        (is (some? event) "event must be published — stream must be non-empty")
+        (is (= :success (:phase/outcome event)))
+        (is (nil? (:phase/meta event)) ":phase/meta must not appear on success events")))))
 
 (deftest phase-completed-failure-partial-meta-fields-test
-  (testing "partial LLM diagnostic fields yield partial :meta"
+  (testing "partial LLM diagnostic fields yield partial :phase/meta"
     (let [stream (create-stream)
           ctx    (test-context)
-          phase-result {:status  :failed
+          phase-result {:status   :failed
                         :success? false
-                        :result  {:status      :failed
-                                  :stop-reason :end-turn}}]
+                        :result   {:status      :failed
+                                   :stop-reason :end-turn}}]
       (events/publish-phase-completed! stream ctx :review phase-result)
       (let [event (first-event stream)
-            meta  (:meta event)]
-        (is (= :failure (:outcome event)))
+            meta  (:phase/meta event)]
+        (is (some? event) "event must be published — stream must be non-empty")
+        (is (= :failure (:phase/outcome event)))
         (is (= :end-turn (:stop-reason meta)))
         (is (nil? (:final-message-preview meta)))
         (is (nil? (:turn-count meta)))

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -150,3 +150,71 @@
       (let [event (first-event stream)]
         (is (= :workflow/phase-completed (:event/type event)))
         (is (= :implement (get-in event [:phase/transition-request :transition/target])))))))
+
+;------------------------------------------------------------------------------ :meta diagnostic fields
+
+(deftest phase-completed-failure-includes-meta-stop-reason-test
+  (testing "failure events carry :meta with stop-reason and other LLM diagnostics"
+    (let [stream (create-stream)
+          ctx    (test-context)
+          phase-result {:status  :failed
+                        :success? false
+                        :result  {:status               :failed
+                                  :stop-reason          :max-tokens
+                                  :final-message-preview "Sorry, I ran out of tokens mid-"
+                                  :num-turns            12
+                                  :tool-call-count      37}}]
+      (events/publish-phase-completed! stream ctx :implement phase-result)
+      (let [event (first-event stream)
+            meta  (:meta event)]
+        (is (= :failure (:outcome event)))
+        (is (some? meta) ":meta must be present on failure events with LLM diagnostics")
+        (is (= :max-tokens (:stop-reason meta)))
+        (is (= "Sorry, I ran out of tokens mid-" (:final-message-preview meta)))
+        (is (= 12 (:turn-count meta)))
+        (is (= 37 (:tool-call-count meta)))))))
+
+(deftest phase-completed-failure-meta-omitted-when-no-diagnostic-fields-test
+  (testing "failure events without LLM diagnostic fields do not carry :meta"
+    (let [stream (create-stream)
+          ctx    (test-context)
+          phase-result {:status  :failed
+                        :success? false
+                        :error   {:message "network timeout"}}]
+      (events/publish-phase-completed! stream ctx :implement phase-result)
+      (let [event (first-event stream)]
+        (is (= :failure (:outcome event)))
+        (is (nil? (:meta event)) ":meta must be absent when no diagnostic fields are present")))))
+
+(deftest phase-completed-success-has-no-meta-test
+  (testing "success events do not carry :meta diagnostic fields"
+    (let [stream (create-stream)
+          ctx    (test-context)
+          phase-result {:status  :completed
+                        :success? true
+                        :result  {:status               :completed
+                                  :stop-reason          :end-turn
+                                  :final-message-preview "Done."
+                                  :num-turns            5
+                                  :tool-call-count      10}}]
+      (events/publish-phase-completed! stream ctx :plan phase-result)
+      (let [event (first-event stream)]
+        (is (= :success (:outcome event)))
+        (is (nil? (:meta event)) ":meta must not appear on success events")))))
+
+(deftest phase-completed-failure-partial-meta-fields-test
+  (testing "partial LLM diagnostic fields yield partial :meta"
+    (let [stream (create-stream)
+          ctx    (test-context)
+          phase-result {:status  :failed
+                        :success? false
+                        :result  {:status      :failed
+                                  :stop-reason :end-turn}}]
+      (events/publish-phase-completed! stream ctx :review phase-result)
+      (let [event (first-event stream)
+            meta  (:meta event)]
+        (is (= :failure (:outcome event)))
+        (is (= :end-turn (:stop-reason meta)))
+        (is (nil? (:final-message-preview meta)))
+        (is (nil? (:turn-count meta)))
+        (is (nil? (:tool-call-count meta)))))))

--- a/docs/pull-requests/2026-05-12-group-3b-runner-events-stop-reason-in-phase-completed-events.md
+++ b/docs/pull-requests/2026-05-12-group-3b-runner-events-stop-reason-in-phase-completed-events.md
@@ -1,0 +1,28 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 3b — runner_events stop_reason in phase-completed events
+
+**PR:** [#861](https://github.com/miniforge-ai/miniforge/pull/861)
+**Branch:** `mf/group-3b-runnerevents-stopreason-in-phas-096758b4`
+
+## Summary
+
+GROUP 3b — runner_events stop_reason in phase-completed events
+
+## Files Changed
+
+- `components/event-stream/src/ai/miniforge/event_stream/core.clj` (modify)
+- `components/workflow/src/ai/miniforge/workflow/runner_events.clj` (modify)
+- `components/workflow/test/ai/miniforge/workflow/runner_events_test.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# GROUP 3b — runner_events stop_reason in phase-completed events

**PR:** [#861](https://github.com/miniforge-ai/miniforge/pull/861)
**Branch:** `mf/group-3b-runnerevents-stopreason-in-phas-096758b4`

## Summary

GROUP 3b — runner_events stop_reason in phase-completed events

## Files Changed

- `components/event-stream/src/ai/miniforge/event_stream/core.clj` (modify)
- `components/workflow/src/ai/miniforge/workflow/runner_events.clj` (modify)
- `components/workflow/test/ai/miniforge/workflow/runner_events_test.clj` (modify)

## Test Results

_No test artifacts available._

## Review Decision

_No review artifacts available._
