### PR TITLE
feat(workflow): emit :dag/task-failed so failed tasks are visible to post-mortems

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -1488,14 +1488,30 @@
   (doseq [tid completed-task-ids]
     (resilience/emit-dag-task-completed! event-stream workflow-id tid (get results tid))))
 
+(defn emit-failed-checkpoints!
+  "Emit :dag/task-failed diagnostic events for failed results in a batch.
+   Mirrors emit-completed-checkpoints! on the failure path so dogfood
+   post-mortems can see WHY individual tasks died — :dag-result aggregates
+   tasks-failed counts but without per-task events those failures are
+   invisible to tooling that scans the event stream."
+  [failed-task-ids results event-stream workflow-id]
+  (doseq [tid failed-task-ids]
+    (resilience/emit-dag-task-failed! event-stream workflow-id tid (get results tid))))
+
 (defn emit-batch-events!
-  "Emit checkpointing events for successful results in a completed batch.
+  "Emit checkpointing + diagnostic events for a completed batch.
+   Successful results get :dag/task-completed; failed results get
+   :dag/task-failed. Both paths emit so dogfood and TUI can see the
+   full task disposition without grepping trace logs.
    Returns nil to keep event emission side-effect only."
   [results event-stream workflow-id]
-  (let [completed-task-ids (->> results
-                                (filter (fn [[_task-id result]] (dag/ok? result)))
-                                (map first))]
+  (let [grouped (group-by (fn [[_task-id result]]
+                            (if (dag/ok? result) :completed :failed))
+                          results)
+        completed-task-ids (map first (:completed grouped))
+        failed-task-ids    (map first (:failed grouped))]
     (emit-completed-checkpoints! completed-task-ids results event-stream workflow-id)
+    (emit-failed-checkpoints! failed-task-ids results event-stream workflow-id)
     nil))
 
 (defn find-unreached-tasks

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -1619,6 +1619,11 @@
             ;; alongside :dag/task-completed.
             (register-batch-branches! registry-atom results)
             (emit-completed-checkpoints! completed results event-stream workflow-id)
+            ;; Emit :dag/task-failed for non-rate-limited failures only.
+            ;; Rate-limited tasks will be retried after the cooldown — emitting
+            ;; a failure event for them would be premature and would lie about
+            ;; the run's actual state.
+            (emit-failed-checkpoints! other-failed-ids results event-stream workflow-id)
 
             (if (seq rate-limited-ids)
               (let [decision (handle-rate-limit-in-batch

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -226,6 +226,24 @@
                    :dag/result (select-keys result [:data :status])}))
       (catch Exception _ nil))))
 
+(defn emit-dag-task-failed!
+  "Publish :dag/task-failed event for diagnostics.
+   Mirrors emit-dag-task-completed! on the failure path so post-mortems
+   can see WHY a task died without trace-grepping. Selects :error +
+   :status from the dag/err result so the event carries the anomaly
+   shape (category, message, data) without the full agent transcript."
+  [event-stream workflow-id task-id result]
+  (when event-stream
+    (try
+      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
+        (publish! event-stream
+                  {:event/type :dag/task-failed
+                   :event/timestamp (str (java.time.Instant/now))
+                   :workflow/id workflow-id
+                   :dag/task-id task-id
+                   :dag/result (select-keys result [:error :status])}))
+      (catch Exception _ nil))))
+
 (defn emit-dag-paused!
   "Publish :dag/paused event with completed task IDs for resume."
   [event-stream workflow-id completed-ids reason]

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -230,8 +230,9 @@
   "Publish :dag/task-failed event for diagnostics.
    Mirrors emit-dag-task-completed! on the failure path so post-mortems
    can see WHY a task died without trace-grepping. Selects :error +
-   :status from the dag/err result so the event carries the anomaly
-   shape (category, message, data) without the full agent transcript."
+   :status from the dag/err result so the event carries the err shape
+   `{:error {:code <kw> :message <str> :data <map>}}` without the full
+   agent transcript."
   [event-stream workflow-id task-id result]
   (when event-stream
     (try

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -19,13 +19,15 @@
 (ns ai.miniforge.workflow.dag-orchestrator-test
   "Tests for DAG orchestrator: stratum wiring, conflict-aware batching,
    plan-to-DAG conversion with new decomposition fields, per-task base
-   branch chaining, forest validation at plan time, and artifact-of-record
-   selection across multi-iteration repair cycles."
+   branch chaining, forest validation at plan time, artifact-of-record
+   selection across multi-iteration repair cycles, and per-task event
+   emission on both success and failure paths."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.workflow.dag-orchestrator :as dag-orch]))
+   [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
+   [ai.miniforge.workflow.dag-resilience :as resilience]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -433,6 +435,72 @@
       (is (:success? wf-result))
       (is (= only-artifact (:artifact wf-result))
           "single-artifact case still works"))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; emit-batch-events! per-task event emission
+;;
+;; Stub at the resilience emit fns rather than the event-stream
+;; interface — the orchestrator's contract is "call the right emit
+;; fn with the right args"; what those fns do with publish! is the
+;; resilience namespace's concern.
+
+;; Number of tasks in the all-success and all-failure emit-batch test fixtures.
+;; Both tests build a results map of {id-a ..., id-b ...} — two tasks — so
+;; "all tasks completed" and "all tasks failed" both expect this count.
+(def ^:private emit-batch-task-count 2)
+
+;; Sentinel for the complementary side of a one-sided batch (i.e. when all
+;; tasks succeed the failure count is zero, and vice-versa).
+(def ^:private emit-batch-no-calls 0)
+
+(deftest emit-batch-events-emits-task-completed-for-success-test
+  (testing ":dag/task-completed fires for every dag/ok? result in batch"
+    (let [completed-calls (atom [])
+          failed-calls    (atom [])]
+      (with-redefs [resilience/emit-dag-task-completed!
+                    (fn [_es _wf tid result] (swap! completed-calls conj [tid result]))
+                    resilience/emit-dag-task-failed!
+                    (fn [_es _wf tid result] (swap! failed-calls conj [tid result]))]
+        (let [results {id-a {:ok? true :data {:summary "done a"}}
+                       id-b {:ok? true :data {:summary "done b"}}}]
+          (dag-orch/emit-batch-events! results ::stream "wf-1")
+          (is (= emit-batch-task-count (count @completed-calls)))
+          (is (= emit-batch-no-calls (count @failed-calls)))
+          (is (= #{id-a id-b} (set (map first @completed-calls)))))))))
+
+(deftest emit-batch-events-emits-task-failed-for-failures-test
+  (testing ":dag/task-failed fires for every dag/err? result in batch"
+    (let [completed-calls (atom [])
+          failed-calls    (atom [])]
+      (with-redefs [resilience/emit-dag-task-completed!
+                    (fn [_es _wf tid result] (swap! completed-calls conj [tid result]))
+                    resilience/emit-dag-task-failed!
+                    (fn [_es _wf tid result] (swap! failed-calls conj [tid result]))]
+        (let [results {id-a {:ok? false :error {:code :ci-failed :message "boom a"}}
+                       id-b {:ok? false :error {:code :ci-failed :message "boom b"}}}]
+          (dag-orch/emit-batch-events! results ::stream "wf-1")
+          (is (= emit-batch-no-calls (count @completed-calls)))
+          (is (= emit-batch-task-count (count @failed-calls)))
+          (is (= #{id-a id-b} (set (map first @failed-calls))))
+          (is (= #{"boom a" "boom b"}
+                 (set (map #(get-in (second %) [:error :message]) @failed-calls)))))))))
+
+(deftest emit-batch-events-emits-both-events-for-mixed-batch-test
+  (testing "mixed batch produces completed for ok and failed for err.
+            Asserts set membership not vector order — results is a hash-map
+            and iteration order is not guaranteed across JVM / Clojure
+            implementations."
+    (let [completed-calls (atom [])
+          failed-calls    (atom [])]
+      (with-redefs [resilience/emit-dag-task-completed!
+                    (fn [_es _wf tid _result] (swap! completed-calls conj tid))
+                    resilience/emit-dag-task-failed!
+                    (fn [_es _wf tid _result] (swap! failed-calls conj tid))]
+        (let [results {id-a {:ok? true :data {:summary "ok"}}
+                       id-b {:ok? false :error {:code :timeout :message "fail"}}}]
+          (dag-orch/emit-batch-events! results ::stream "wf-1")
+          (is (= #{id-a} (set @completed-calls)))
+          (is (= #{id-b} (set @failed-calls))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment


### PR DESCRIPTION
## Summary

- New `:dag/task-failed` event mirrors `:dag/task-completed` on the failure path. Pre-fix, `emit-batch-events!` only emitted the completed-side event, so failed tasks left no per-task trace.
- 2026-05-12 dogfood lost 4 of 7 sub-workflows silently — the aggregate said `tasks-failed 4` but no `:dag/task-failed` event existed for tooling to pick up.
- This is a diagnostics-only change; DAG completion logic is unchanged.

## Trigger

From `project_dogfood_findings_2026_05_12.md`:

> 4 of 7 tasks failed with zero `:dag/task-failed` events emitted. Event taxonomy asymmetry — only `:dag/task-completed` fires. Without a failed-sibling event, post-mortems can't see why most tasks died.

## Change shape

| File | Change |
|---|---|
| `dag-resilience.clj` | New `emit-dag-task-failed!` (mirrors `emit-dag-task-completed!`); event carries `{:error {:code :message :data}}` shape via `select-keys [:error :status]` — no agent transcript. |
| `dag-orchestrator.clj` | `emit-batch-events!` now groups by `dag/ok?` and emits completed-event for ok results, failed-event for err results. Extracted `emit-failed-checkpoints!` for symmetry. |
| `dag-orchestrator-test.clj` | Three new tests: all-success, all-failure, mixed batch. Tests stub at the resilience emit-fn level (orchestrator contract) rather than the event-stream interface (resilience namespace's concern). |

## Test plan

- [x] `bb test workflow` — 3386 tests / 15038 assertions, 0 failures
- [x] `bb lint:clj` — 0 errors / 0 warnings on the 3 changed files
- [x] `dag-orchestrator-test` ran 14 tests / 29 assertions (was 11/20 before)
- [ ] Next dogfood run should emit `:dag/task-failed` events for any failed sub-workflows, with per-task `:error` payloads visible in the event trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)