### PR TITLE
fix(workflow): pick LAST artifact so task-completed reflects shipped iteration

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -1229,8 +1229,20 @@
             metrics      (:execution/metrics result)
             pr-info      (extract-pr-info-from-result result task-def)
             task-branch  (task-result-branch result)]
+        ;; `:execution/artifacts` accumulates across phases AND across repair
+        ;; iterations (each `update :execution/artifacts into ...` in state.clj
+        ;; / execution.clj appends). When a task succeeds after one or more
+        ;; review:changes-requested cycles, the vector ends up holding the
+        ;; failing-iteration verifier output AHEAD of the succeeding one's.
+        ;; Picking `(first artifacts)` would make the task-completed event
+        ;; report the EARLIEST iteration as the artifact-of-record — that's
+        ;; what the 2026-05-12 dogfood showed for PR #861 (verifier said
+        ;; "core change is absent" while the merged diff was correct).
+        ;; `(last artifacts)` picks the artifact from the final iteration
+        ;; that actually shipped the work. See
+        ;; project_dogfood_findings_2026_05_12.md → "Stale verifier feedback".
         (if (phase/succeeded? result)
-          (cond-> (workflow-success (first artifacts) metrics)
+          (cond-> (workflow-success (last artifacts) metrics)
             pr-info (assoc :pr-info pr-info)
             ;; Carry sub-workflow's worktree path so apply-dag-success can
             ;; merge changes back into the parent worktree for release.

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -19,7 +19,8 @@
 (ns ai.miniforge.workflow.dag-orchestrator-test
   "Tests for DAG orchestrator: stratum wiring, conflict-aware batching,
    plan-to-DAG conversion with new decomposition fields, per-task base
-   branch chaining, and forest validation at plan time."
+   branch chaining, forest validation at plan time, and artifact-of-record
+   selection across multi-iteration repair cycles."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.dag-executor.interface :as dag]
@@ -368,6 +369,70 @@
       (is (= 0 (:total-tokens agg)))
       (is (= 0.0 (:total-cost agg)))
       (is (= 0 (:total-duration agg))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Artifact-of-record selection across repair iterations.
+;;
+;; `:execution/artifacts` accumulates across every phase invocation
+;; (state.clj:186 `update :execution/artifacts into ...`). When a task
+;; succeeds after one or more review:changes-requested cycles, the
+;; vector ends up holding the failing-iteration artifacts AHEAD of
+;; the succeeding ones'. `run-mini-workflow` must pick the LAST
+;; entry so the `:dag/task-completed` event reports the artifact
+;; that actually shipped — not an early failing iteration that was
+;; later repaired. Bug observed 2026-05-12 on PR #861.
+
+(deftest run-mini-workflow-selects-last-artifact-test
+  (testing "When :execution/artifacts has multiple entries from repair
+            iterations, the wf-result :artifact must be the LAST entry
+            (the final iteration's), not the first (an earlier failing
+            iteration's). See project_dogfood_findings_2026_05_12.md
+            → 'Stale verifier feedback'."
+    (let [early-artifact  {:status :success
+                           :summary "iter 1 — runner_events.clj modified but core change is absent"}
+          middle-artifact {:status :success
+                           :summary "iter 2 — still broken"}
+          final-artifact  {:status :success
+                           :environment-id "task-7bedbf77"
+                           :summary "iter 3 — :meta diagnostic block added, tests pass"}
+          stub-result     {:execution/status :completed
+                           :execution/artifacts [early-artifact middle-artifact final-artifact]
+                           :execution/metrics {:tokens 100 :cost-usd 0.05 :duration-ms 1000}
+                           :execution/phase-results {}}
+          context         {:execution/run-pipeline-fn (fn [_sw _in _opts] stub-result)
+                           :execution/workflow {:workflow/pipeline []}
+                           :execution/opts {:branch "main"}}
+          task-def        {:task/id id-a
+                           :task/description "Test multi-iter task"
+                           :task/deps #{}}
+          wf-result       (dag-orch/run-mini-workflow task-def context)]
+      (is (:success? wf-result)
+          "phase/succeeded? recognizes :execution/status :completed")
+      (is (= final-artifact (:artifact wf-result))
+          "artifact-of-record is the LAST entry, not the first — picking
+           `(first artifacts)` would surface the iter-1 'core change is absent'
+           summary even though iter 3 shipped the fix"))))
+
+(deftest run-mini-workflow-single-artifact-still-selected-test
+  (testing "Single-iteration happy path: with exactly one artifact in the
+            vector, `(last artifacts)` selects it just as `(first artifacts)`
+            would. Confirms the fix doesn't regress the no-repair case."
+    (let [only-artifact {:status :success
+                         :summary "shipped first time"}
+          stub-result   {:execution/status :completed
+                         :execution/artifacts [only-artifact]
+                         :execution/metrics {:tokens 50 :cost-usd 0.02 :duration-ms 500}
+                         :execution/phase-results {}}
+          context       {:execution/run-pipeline-fn (fn [_sw _in _opts] stub-result)
+                         :execution/workflow {:workflow/pipeline []}
+                         :execution/opts {:branch "main"}}
+          task-def      {:task/id id-a
+                         :task/description "Happy path task"
+                         :task/deps #{}}
+          wf-result     (dag-orch/run-mini-workflow task-def context)]
+      (is (:success? wf-result))
+      (is (= only-artifact (:artifact wf-result))
+          "single-artifact case still works"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment


### PR DESCRIPTION
## Summary

One-line fix in `run-mini-workflow`: `(first artifacts)` → `(last artifacts)`. With two regression tests.

## The bug

`:execution/artifacts` accumulates across phases AND across repair iterations — every `update :execution/artifacts into ...` in `state.clj`, `execution.clj`, and `configurable.clj` appends to the vector. When a task succeeds after one or more `review:changes-requested` cycles, the vector ends up holding the failing-iteration verifier output AHEAD of the succeeding one's.

`run-mini-workflow` then called `(workflow-success (first artifacts) ...)` which made `:dag/task-completed` events carry the EARLIEST iteration's summary as the task's artifact-of-record.

## Concrete evidence

The 2026-05-12 dogfood (PR #861, GROUP 3b runner_events) showed this loud and clear. The merged PR diff was correct:

- `:phase/meta` assoc on failure events ✓
- 4 new tests in `runner_events_test.clj` ✓

But the task-completed event's `:artifacts` payload carried:

> ""runner_events.clj and its test file were modified, but the spec's core change — conditionally assoc-ing a :meta diagnostic block ... onto failure events inside build-phase-event-data — is absent from both files.""

That's the **iter-1 verifier output**, frozen on the artifact even though iter-3 shipped the fix. Anyone reading the events trace would think the run failed; the PR diff disproves it.

See `project_dogfood_findings_2026_05_12.md` → ""Stale verifier feedback"" for the full diagnosis.

## Behavior

| artifacts | `(first ...)` | `(last ...)` |
|---|---|---|
| `[]` | nil | nil — no regression |
| `[a]` | a | a — no regression |
| `[early ... final]` | early (wrong) | final (correct) |

## Test plan

- [x] `bb lint:clj` — 0 errors / 0 warnings
- [x] Pre-commit hook ran full stable-derived test plan (60 workflow-resume tests + others) — all passed
- [x] GraalVM/Babashka compat — 6 tests / 499 assertions, 0 failures
- [x] Two new regression tests in `dag_orchestrator_test.clj`:
  - `run-mini-workflow-selects-last-artifact-test` — 3-iteration case asserts the last artifact is the artifact-of-record
  - `run-mini-workflow-single-artifact-still-selected-test` — 1-artifact happy path still works

## Stacked / orthogonal to PR #862

Both PRs touch `dag_orchestrator_test.clj` but in different sections (separated by Layer headers), so whichever lands first will rebase cleanly. #862 adds `Layer 4: emit-batch-events!` tests; this PR adds `Layer 4: artifact-of-record selection`. The naming collision should be resolved during rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)