### PR TITLE
feat(supervisory-state): N14 — long-lived Spec entity

### DIFF
--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -168,6 +168,87 @@
             intent      (assoc :spec/intent intent))]
     (when (seq m) m)))
 
+(defn- derive-spec-id-from-title
+  "Deterministic UUIDv3 (name-based) keyed on the spec title.
+
+   The same title always produces the same UUID, so two `:workflow/started`
+   events citing the same spec link to the same `Spec` entity without any
+   producer-side coordination (N5-delta-3 §3.2). This is the v1 mechanism
+   for `Spec` identity — explicit `:spec/id` on the producer's `:workflow/spec`
+   payload, when it lands later, overrides this derived value via
+   [[extract-long-lived-spec-identity]]."
+  [title]
+  (when title
+    (java.util.UUID/nameUUIDFromBytes (.getBytes ^String title "UTF-8"))))
+
+(defn- extract-long-lived-spec-identity
+  "Pull a long-lived `Spec` entity identity from a workflow event. Returns
+   nil when the event carries no derivable identity.
+
+   Distinct from [[extract-spec-identity]] above — that builds the per-run
+   `:workflow-run/spec` snapshot (BD-1). This builds the parent `Spec`
+   entity (N14, N5-delta-3 §5.1). Both can populate from the same event;
+   the snapshot captures point-in-time spec metadata, the entity links N
+   runs to one long-lived identity.
+
+   `:spec/id` is sourced as:
+   1. Producer-supplied `:spec/id` on `:workflow/spec` (preferred; future).
+   2. Deterministic UUIDv3 from the trimmed `:spec/title` (v1 fallback).
+
+   Other entity fields (`:spec/title`, `:spec/description`, `:spec/intent`,
+   `:spec/repo-url`, `:spec/tags`, `:spec/origin`) are lifted from the
+   `:workflow/spec` payload when present."
+  [event]
+  (let [spec        (:workflow/spec event)
+        clean       (fn [v] (when (string? v) (not-empty (str/trim v))))
+        title       (or (clean (:spec/title spec))       (clean (:title spec)))
+        explicit-id (:spec/id spec)
+        spec-id     (or explicit-id (derive-spec-id-from-title title))]
+    (when (and spec-id title)
+      (cond-> {:spec/id    spec-id
+               :spec/title title}
+        (clean (:spec/description spec)) (assoc :spec/description (clean (:spec/description spec)))
+        (clean (:description spec))      (assoc :spec/description (clean (:description spec)))
+        (:spec/intent spec)              (assoc :spec/intent (:spec/intent spec))
+        (clean (:spec/repo-url spec))    (assoc :spec/repo-url (clean (:spec/repo-url spec)))
+        (seq (:spec/tags spec))          (assoc :spec/tags (vec (:spec/tags spec)))
+        (:spec/origin spec)              (assoc :spec/origin (:spec/origin spec))))))
+
+(defn- upsert-spec
+  "Insert or update a `Spec` entry in `:specs` keyed by `:spec/id`.
+
+   On first observation: creates a `Spec` with `:status :active` and
+   `:created-at`/`:updated-at` set to the event timestamp. Defaults
+   `:spec/origin :miniforge` so the entity reads as upstream-known
+   (the Rust core uses `:local-synthetic` for its locally-created Specs
+   per N5-delta-3 §5.3).
+
+   On re-observation (same `:spec/id` already in the table): merges new
+   metadata fields onto the existing entity and bumps `:updated-at`.
+   `:created-at` is preserved. Status transitions are NOT performed here
+   — that's the job of explicit `:spec/updated` / `:spec/archived`
+   handlers (N14-5, deferred)."
+  [table spec-identity ts]
+  (let [spec-id  (:spec/id spec-identity)
+        existing (get-in table [:specs spec-id])
+        entity   (cond
+                   ;; First observation
+                   (nil? existing)
+                   (merge {:spec/status     :active
+                           :spec/origin     :miniforge
+                           :spec/created-at ts
+                           :spec/updated-at ts}
+                          spec-identity)
+
+                   ;; Re-observation — merge new metadata, bump updated-at,
+                   ;; preserve created-at + status + origin.
+                   :else
+                   (merge existing
+                          (dissoc spec-identity :spec/id)
+                          {:spec/updated-at ts}))]
+    (cond-> table
+      spec-id (assoc-in [:specs spec-id] entity))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; WorkflowRun handlers
 
@@ -182,7 +263,8 @@
         wf-key   (or (:workflow/key spec)
                      (some-> spec :workflow/spec name)
                      (workflow-key-fallback id))
-        spec-identity (extract-spec-identity event)
+        spec-identity     (extract-spec-identity event)
+        long-spec-identity (extract-long-lived-spec-identity event)
         run      (cond-> (merge {:workflow-run/id              id
                                  :workflow-run/workflow-key    wf-key
                                  :workflow-run/intent          intent
@@ -194,16 +276,25 @@
                                  :workflow-run/correlation-id  id}
                                 ;; Preserve fields from a prior phase-* event that
                                 ;; arrived before workflow/started. `:workflow-run/spec`
-                                ;; is preserved here too so a placeholder set by an
-                                ;; earlier spec-bearing event survives if this event
-                                ;; has none; an event-derived identity overrides it
-                                ;; below.
+                                ;; and `:workflow-run/spec-id` are preserved too so a
+                                ;; placeholder set by an earlier spec-bearing event
+                                ;; survives if this event has none; an event-derived
+                                ;; identity overrides them below.
                                 (select-keys existing
                                              [:workflow-run/current-phase
                                               :workflow-run/workflow-key
-                                              :workflow-run/spec]))
-                   spec-identity (assoc :workflow-run/spec spec-identity))]
-    (assoc-in table [:workflows id] run)))
+                                              :workflow-run/spec
+                                              :workflow-run/spec-id]))
+                   spec-identity      (assoc :workflow-run/spec spec-identity)
+                   ;; N14: link this WorkflowRun to the long-lived Spec entity.
+                   long-spec-identity (assoc :workflow-run/spec-id
+                                             (:spec/id long-spec-identity)))]
+    (cond-> (assoc-in table [:workflows id] run)
+      ;; N14: upsert the long-lived Spec entity into `:specs` keyed by
+      ;; `:spec/id`. Idempotent on re-observation; status transitions
+      ;; (`:completed`, `:archived`) are out of scope for N14 and land in
+      ;; N14-5 via explicit `:spec/*` events.
+      long-spec-identity (upsert-spec long-spec-identity ts))))
 
 (defn- ensure-workflow
   "Create a placeholder WorkflowRun if we see a phase event before
@@ -573,6 +664,12 @@
 ;; A `:supervisory/*-upserted` event carries the canonical entity in
 ;; :supervisory/entity; we trust it as the baseline state.
 
+(defn supervisory-spec-upserted
+  [table event]
+  (let [entity (:supervisory/entity event)]
+    (cond-> table
+      entity (assoc-in [:specs (:spec/id entity)] entity))))
+
 (defn supervisory-workflow-upserted
   [table event]
   (let [entity (:supervisory/entity event)]
@@ -860,6 +957,7 @@
    :gate/passed                            gate-passed
    :gate/failed                            gate-failed
    ;; Snapshot events (used during replay)
+   :supervisory/spec-upserted              supervisory-spec-upserted
    :supervisory/workflow-upserted          supervisory-workflow-upserted
    :supervisory/agent-upserted             supervisory-agent-upserted
    :supervisory/pr-upserted                supervisory-pr-upserted

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -217,22 +217,28 @@
 (defn- upsert-spec
   "Insert or update a `Spec` entry in `:specs` keyed by `:spec/id`.
 
-   On first observation: creates a `Spec` with `:status :active` and
-   `:created-at`/`:updated-at` set to the event timestamp. Defaults
-   `:spec/origin :miniforge` so the entity reads as upstream-known
-   (the Rust core uses `:local-synthetic` for its locally-created Specs
-   per N5-delta-3 §5.3).
+   On first observation: creates a `Spec` with `:spec/status :active`
+   and `:spec/created-at`/`:spec/updated-at` set to the event timestamp.
+   Defaults `:spec/origin :miniforge` so the entity reads as upstream-
+   known (the Rust core uses `:local-synthetic` for its locally-created
+   Specs per N5-delta-3 §5.3).
 
    On re-observation (same `:spec/id` already in the table): merges new
-   metadata fields onto the existing entity and bumps `:updated-at`.
-   `:created-at` is preserved. Status transitions are NOT performed here
-   — that's the job of explicit `:spec/updated` / `:spec/archived`
-   handlers (N14-5, deferred)."
+   *mutable metadata* fields onto the existing entity and bumps
+   `:spec/updated-at`. The following fields are **immutable after first
+   observation** and are NOT overwritten by subsequent events: `:spec/id`
+   (key), `:spec/origin` (provenance — set once when the entity is born),
+   `:spec/created-at`, `:spec/status` (status transitions are explicit
+   `:spec/updated` / `:spec/archived` events, N14-5, deferred)."
   [table spec-identity ts]
-  (let [spec-id  (:spec/id spec-identity)
-        existing (get-in table [:specs spec-id])
+  (let [spec-id           (:spec/id spec-identity)
+        existing          (get-in table [:specs spec-id])
+        ;; Fields the producer-side identity must NOT clobber on
+        ;; re-observation. `:spec/id` is the key (never merged anyway);
+        ;; `:spec/origin` is set once at first observation and stays.
+        immutable-on-merge #{:spec/id :spec/origin}
         entity   (cond
-                   ;; First observation
+                   ;; First observation — full construction with defaults.
                    (nil? existing)
                    (merge {:spec/status     :active
                            :spec/origin     :miniforge
@@ -240,11 +246,11 @@
                            :spec/updated-at ts}
                           spec-identity)
 
-                   ;; Re-observation — merge new metadata, bump updated-at,
-                   ;; preserve created-at + status + origin.
+                   ;; Re-observation — merge mutable metadata only, bump
+                   ;; updated-at, preserve created-at + status + origin.
                    :else
                    (merge existing
-                          (dissoc spec-identity :spec/id)
+                          (apply dissoc spec-identity immutable-on-merge)
                           {:spec/updated-at ts}))]
     (cond-> table
       spec-id (assoc-in [:specs spec-id] entity))))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -151,6 +151,7 @@
   [component]
   (:table @component))
 
+(defn specs       [component] (vals (get-in @component [:table :specs])))
 (defn workflows   [component] (vals (get-in @component [:table :workflows])))
 (defn agents      [component] (vals (get-in @component [:table :agents])))
 (defn prs         [component] (vals (get-in @component [:table :prs])))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -82,7 +82,8 @@
 (defn- handle-event!
   [component event]
   ;; Ignore our own snapshot events to prevent re-emit loops.
-  (when-not (#{:supervisory/workflow-upserted
+  (when-not (#{:supervisory/spec-upserted
+               :supervisory/workflow-upserted
                :supervisory/agent-upserted
                :supervisory/pr-upserted
                :supervisory/policy-evaluated

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
@@ -33,6 +33,14 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event constructors (match N3 §3.19 schemas)
 
+(defn spec-upserted
+  [stream spec-entity]
+  (-> (es/create-envelope stream
+                          :supervisory/spec-upserted
+                          nil
+                          (str "Spec " (:spec/title spec-entity) " upserted"))
+      (assoc :supervisory/entity spec-entity)))
+
 (defn workflow-upserted
   [stream workflow-entity]
   (-> (es/create-envelope stream
@@ -130,6 +138,7 @@
    Returns the number of events published, mainly for testing."
   [stream old-table new-table]
   (let [before (count (es/get-events stream))]
+    (emit-diff! stream spec-upserted      (:specs        old-table) (:specs        new-table))
     (emit-diff! stream workflow-upserted  (:workflows    old-table) (:workflows    new-table))
     (emit-diff! stream agent-upserted     (:agents       old-table) (:agents       new-table))
     (emit-diff! stream pr-upserted        (:prs          old-table) (:prs          new-table))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
@@ -31,6 +31,7 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schemas (re-exports)
 
+(def Spec             schema/Spec)
 (def WorkflowRun      schema/WorkflowRun)
 (def AgentSession     schema/AgentSession)
 (def PrFleetEntry     schema/PrFleetEntry)
@@ -54,6 +55,7 @@
 ;; `:supervisory/*-upserted` events on the event stream)
 
 (def table         core/table)
+(def specs         core/specs)
 (def workflows     core/workflows)
 (def agents        core/agents)
 (def prs           core/prs)

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -110,6 +110,19 @@
 (def dependency-statuses
   [:healthy :degraded :unavailable :misconfigured :operator-action-required])
 
+(def spec-statuses
+  "Lifecycle states a long-lived Spec passes through (N5-delta-3 §5.1).
+
+   - :draft     — created, no MiniforgeRun yet
+   - :active    — at least one WorkflowRun in flight (or recently completed)
+   - :completed — operator-marked done; no future runs expected
+   - :archived  — operator-archived; suppressed from default UI surfaces
+
+   Vector (not set) for deterministic enum ordering in malli printed
+   schemas / error messages, matching `workflow-run-statuses` /
+   `pr-statuses` / etc. throughout this namespace."
+  [:draft :active :completed :archived])
+
 ;------------------------------------------------------------------------------ Layer 0a
 ;; Registry extensions for supervisory v1
 
@@ -179,7 +192,14 @@
    ;; DependencyHealth
    :dependency/id                keyword?
    :dependency/kind              (into [:enum] dependency-kinds)
-   :dependency/status            (into [:enum] dependency-statuses)})
+   :dependency/status            (into [:enum] dependency-statuses)
+
+   ;; Spec (N5-delta-3 §3.1, §5.1). Long-lived supervisory entity that
+   ;; owns N WorkflowRuns over its lifetime. Distinct from the per-run
+   ;; `:workflow-run/spec` snapshot (BD-1, miniforge#793) which captures
+   ;; spec identity at run-start time only.
+   :spec/id                      :id/uuid
+   :spec/status                  (into [:enum] spec-statuses)})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Entity schemas — open maps, mirror N5-delta-1 §3.1
@@ -209,6 +229,12 @@
      [:spec/title       {:optional true} [:string {:min 1}]]
      [:spec/description {:optional true} [:string {:min 1}]]
      [:spec/intent      {:optional true} map?]]]
+   ;; N14: foreign key to the long-lived `Spec` entity that owns this
+   ;; run. Optional — runs without a derivable spec identity (no title
+   ;; on the snapshot) remain Specless. Distinct from
+   ;; `:workflow-run/spec` (the per-run snapshot above) and stable
+   ;; across re-executions of the same spec.
+   [:workflow-run/spec-id {:optional true} :spec/id]
    [:workflow-run/prs {:optional true}
     [:vector
      [:map
@@ -219,6 +245,37 @@
       [:pr/title {:optional true} [:maybe string?]]
       [:pr/author {:optional true} [:maybe string?]]
       [:pr/merge-order {:optional true} [:maybe :common/non-neg-int]]]]]])
+
+(def Spec
+  "A long-lived supervisory entity representing the operator's
+   top-level unit of work (N5-delta-3 §3.1, §5.1). One Spec owns N
+   WorkflowRuns over its lifetime.
+
+   Open map: additional keys pass through validation. Field types
+   chosen to be compatible with the existing per-run snapshot
+   (`:workflow-run/spec` above) and the spec-parser's `SpecIntent`
+   shape:
+
+   - `:spec/intent` is a structured map (per `SpecIntent` in
+     `spec-parser/.../schema.clj`); kept as open `map?` here so we
+     don't re-validate against the producer-side schema.
+   - `:spec/tags` accepts strings OR keywords (existing tag
+     conventions elsewhere in the codebase).
+   - `:spec/origin` discriminates `:miniforge` (specs known to this
+     runtime) from `:local-synthetic` (the Rust-core consumer
+     creates these ahead of upstream knowing about them, per
+     N5-delta-3 §5.3 reconciliation)."
+  [:map {:registry registry}
+   [:spec/id         :spec/id]
+   [:spec/title      [:string {:min 1}]]
+   [:spec/status     :spec/status]
+   [:spec/created-at :common/timestamp]
+   [:spec/updated-at :common/timestamp]
+   [:spec/description {:optional true} :string]
+   [:spec/intent      {:optional true} map?]
+   [:spec/repo-url    {:optional true} :string]
+   [:spec/tags        {:optional true} [:vector [:or :string :keyword]]]
+   [:spec/origin      {:optional true} keyword?]])
 
 (def AgentSession
   "An external or internal agent observable to the supervisory plane.
@@ -468,6 +525,7 @@
 (def EntityTable
   "Aggregate state held by the supervisory-state component."
   [:map
+   [:specs         [:map-of :id/uuid Spec]]
    [:workflows     [:map-of :id/uuid WorkflowRun]]
    [:agents        [:map-of :id/uuid AgentSession]]
    [:prs           [:map-of [:tuple string? :common/non-neg-int] PrFleetEntry]]
@@ -480,7 +538,8 @@
 
 (def empty-table
   "Initial empty entity table."
-  {:workflows {}
+  {:specs {}
+   :workflows {}
    :agents {}
    :prs {}
    :policy-evals {}

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -203,6 +203,25 @@
         "new metadata merged on re-observation")
     (is (= :active (:spec/status s)) "status preserved")))
 
+(deftest workflow-started-second-observation-preserves-origin
+  ;; `:spec/origin` is set once at first observation and MUST NOT be
+  ;; overwritten by subsequent events — origin is provenance, not
+  ;; mutable metadata. Regression for the Copilot-flagged bug.
+  (let [spec-with-origin {:spec/title "Provenance Test"
+                          :spec/origin :local-synthetic}
+        spec-with-different-origin {:spec/title "Provenance Test"
+                                    :spec/origin :miniforge}
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started
+                                       {:workflow/id   (random-uuid)
+                                        :workflow/spec spec-with-origin}))
+                  (acc/apply-event (ev :workflow/started
+                                       {:workflow/id   (random-uuid)
+                                        :workflow/spec spec-with-different-origin})))
+        s     (first (vals (:specs table)))]
+    (is (= :local-synthetic (:spec/origin s))
+        "origin from first observation preserved across re-observation")))
+
 (deftest supervisory-spec-upserted-replay-populates-specs
   ;; Snapshot-event replay path: a `:supervisory/spec-upserted` event
   ;; carries the canonical Spec entity in `:supervisory/entity`.

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -103,6 +103,122 @@
     (is (= "Bare Title" (get-in run [:workflow-run/spec :spec/title])))
     (is (= "raw" (get-in run [:workflow-run/spec :spec/description])))))
 
+;------------------------------------------------------------------------------ Spec (N14)
+;; The long-lived `Spec` entity (N5-delta-3 §5.1) is derived from
+;; `:workflow/started` events. `:spec/id` is computed deterministically
+;; from the trimmed `:spec/title` so two runs citing the same spec link
+;; to one `Spec` row without producer-side coordination.
+
+(deftest workflow-started-upserts-spec-on-first-observation
+  (let [wf-id (random-uuid)
+        spec  {:spec/title "N13 Closed-Loop PR Pipeline"
+               :spec/description "Eliminate the operator-as-message-bus role"
+               :spec/intent {:type :feature}}
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started
+                                   {:workflow/id   wf-id
+                                    :workflow/spec spec}))
+        specs (vals (:specs table))]
+    (is (= 1 (count specs))
+        "first observation creates exactly one Spec entry")
+    (let [s (first specs)]
+      (is (= "N13 Closed-Loop PR Pipeline" (:spec/title s)))
+      (is (= :active (:spec/status s)))
+      (is (= :miniforge (:spec/origin s)))
+      (is (some? (:spec/created-at s)))
+      (is (some? (:spec/updated-at s)))
+      (is (= "Eliminate the operator-as-message-bus role" (:spec/description s)))
+      (is (= {:type :feature} (:spec/intent s))))))
+
+(deftest workflow-started-links-workflow-run-to-spec-id
+  (let [wf-id (random-uuid)
+        spec  {:spec/title "Some Spec"}
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started
+                                   {:workflow/id wf-id :workflow/spec spec}))
+        run   (get-in table [:workflows wf-id])
+        spec-id (first (keys (:specs table)))]
+    (is (some? spec-id))
+    (is (= spec-id (:workflow-run/spec-id run))
+        "the WorkflowRun.spec-id points at the upserted Spec")))
+
+(deftest workflow-started-reuses-spec-id-on-second-observation
+  (let [spec  {:spec/title "Same Title"}
+        wf-a  (random-uuid)
+        wf-b  (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started
+                                       {:workflow/id wf-a :workflow/spec spec}))
+                  (acc/apply-event (ev :workflow/started
+                                       {:workflow/id wf-b :workflow/spec spec})))]
+    (is (= 1 (count (:specs table)))
+        "two runs citing the same title collapse to one Spec entity")
+    (is (= (get-in table [:workflows wf-a :workflow-run/spec-id])
+           (get-in table [:workflows wf-b :workflow-run/spec-id]))
+        "both runs point at the same spec-id")))
+
+(deftest workflow-started-omits-spec-id-when-no-spec
+  (let [wf-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started {:workflow/id wf-id}))
+        run   (get-in table [:workflows wf-id])]
+    (is (empty? (:specs table))
+        "no Spec entity is created when the event carries none")
+    (is (nil? (:workflow-run/spec-id run))
+        "WorkflowRun stays Specless when no spec identity is derivable")))
+
+(deftest workflow-started-omits-spec-id-when-only-blank-title
+  ;; Whitespace-only title should not produce a Spec — same discipline as
+  ;; the run-owned snapshot in `workflow-started-omits-blank-spec-fields`.
+  (let [wf-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started
+                                   {:workflow/id wf-id
+                                    :workflow/spec {:spec/title "   "}}))
+        run   (get-in table [:workflows wf-id])]
+    (is (empty? (:specs table)))
+    (is (nil? (:workflow-run/spec-id run)))))
+
+(deftest workflow-started-second-observation-bumps-updated-at-only
+  ;; Re-observing the same Spec preserves :spec/created-at + :spec/status
+  ;; + :spec/origin but bumps :spec/updated-at and merges new metadata.
+  (let [t1    (java.util.Date. 1700000000000)
+        t2    (java.util.Date. 1800000000000)
+        spec1 {:spec/title "Evolving Spec"}
+        spec2 {:spec/title "Evolving Spec"
+               :spec/repo-url "https://example.com/repo"}
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started
+                                       {:workflow/id     (random-uuid)
+                                        :workflow/spec   spec1
+                                        :event/timestamp t1}))
+                  (acc/apply-event (ev :workflow/started
+                                       {:workflow/id     (random-uuid)
+                                        :workflow/spec   spec2
+                                        :event/timestamp t2})))
+        s     (first (vals (:specs table)))]
+    (is (= t1 (:spec/created-at s)) "created-at preserved from first observation")
+    (is (= t2 (:spec/updated-at s)) "updated-at bumped to second observation")
+    (is (= "https://example.com/repo" (:spec/repo-url s))
+        "new metadata merged on re-observation")
+    (is (= :active (:spec/status s)) "status preserved")))
+
+(deftest supervisory-spec-upserted-replay-populates-specs
+  ;; Snapshot-event replay path: a `:supervisory/spec-upserted` event
+  ;; carries the canonical Spec entity in `:supervisory/entity`.
+  (let [spec-id (random-uuid)
+        entity  {:spec/id         spec-id
+                 :spec/title      "Replayed Spec"
+                 :spec/status     :active
+                 :spec/origin     :miniforge
+                 :spec/created-at (java.util.Date.)
+                 :spec/updated-at (java.util.Date.)}
+        table   (acc/apply-event schema/empty-table
+                                 (ev :supervisory/spec-upserted
+                                     {:supervisory/entity entity}))]
+    (is (= entity (get-in table [:specs spec-id]))
+        "replay populates :specs from the snapshot envelope")))
+
 (deftest workflow-phase-started-updates-phase
   (let [wf-id (random-uuid)
         table (-> schema/empty-table

--- a/docs/design/supervisory-spec-entity.md
+++ b/docs/design/supervisory-spec-entity.md
@@ -221,25 +221,33 @@ tooling or by the Rust-core consumer's
 them is out of scope for this RFC; the accumulator should be
 ready to handle them when they arrive.
 
-## Migration / back-compat
+## Data-model semantics
 
-- **Existing WorkflowRuns without `:workflow-run/spec-id`:**
-  valid. Consumer projects to Specless bucket. No data migration
-  required.
-- **Pre-existing `~/.miniforge/events/` event files:** consumed
-  by `event-client` on replay; new `:supervisory/spec-upserted`
-  events arrive in chronological order alongside existing
-  `:supervisory/workflow-upserted` events. No retroactive
-  emission of Spec snapshots for historical WorkflowRuns — they
-  remain Specless until the operator classifies them via the
-  Rust-core path.
-- **In-memory supervisory state:** `supervisory-state/core` is
-  an in-memory view cache with no across-restart persistence;
-  the new `:specs` table key joins the other top-level table
-  keys via the existing accumulator initialization path
-  (`empty-table` extended to include `:specs {}`). No
-  deserialization-of-old-snapshots concern — there is no
-  snapshot format to migrate.
+Miniforge is unreleased; there is no installed base to be
+backward-compatible *with*. The discipline is "skip all backward-
+compat shims and transition periods" (operator policy). This
+section therefore documents the **v1 data-model semantics**, not a
+migration story.
+
+- **Specless workflows are a first-class state, not a carve-out.**
+  `:workflow-run/spec-id` is genuinely optional because some
+  `:workflow/started` events don't carry a `:workflow/spec`
+  payload at all (exploratory runs, runs whose spec identity the
+  operator hasn't classified yet). Such runs project into the
+  Specless bucket per N5-delta-3 §3.3. The optional schema marker
+  reflects this data-model truth — it is NOT a kindness to
+  pre-existing data shapes.
+- **Event-stream ordering.** New `:supervisory/spec-upserted`
+  events interleave with existing `:supervisory/workflow-upserted`
+  events in chronological order on the same event-client channel.
+  Producers emit the spec snapshot the first time a workflow
+  cites a fresh spec identity; consumers see it before the
+  workflow upsert that links to it.
+- **In-memory supervisory state.** `supervisory-state/core` is an
+  in-memory view cache with no across-restart persistence. The new
+  `:specs` table key joins the other top-level table keys via the
+  accumulator's `empty-table` initialization — no separate
+  snapshot format to think about.
 
 ## Sequencing (the burndown)
 


### PR DESCRIPTION
## Summary

Implements the full N14 burndown (steps 1-4) per the design RFC landed in [#865](https://github.com/miniforge-ai/miniforge/pull/865) + miniforge-control [N5-delta-3 §3.1, §5.1, §6.1](https://github.com/miniforge-ai/miniforge-control/blob/main/specs/normative/N5-delta-3-bare-agent-supervision.md). The Rust core's AA-2 projection ([miniforge-control PR #57](https://github.com/miniforge-ai/miniforge-control/pull/57)) now has real `:supervisory/spec-upserted` events to consume.

Single PR (4 logical pieces fused) — schema + emitter + accumulator + interface + tests are tightly coupled and individually non-shippable.

## What's in

- **`Spec` entity** — long-lived; one Spec owns N WorkflowRuns over its lifetime; distinct from BD-1's per-run `:workflow-run/spec` snapshot.
- **`:workflow-run/spec-id` foreign key** — optional because **Specless workflows are a first-class data-model state** (N5-delta-3 §3.3): some `:workflow/started` events legitimately don't carry a `:workflow/spec` payload, and those runs project into the Specless bucket. The `{:optional true}` is justified by the data model, not back-compat. Per operator policy `feedback_no_backwards_compat.md`, Miniforge is unreleased and there is no installed base to be backward-compatible with.
- **Deterministic spec-id derivation** — `UUID/nameUUIDFromBytes` keyed on trimmed `:spec/title`. Two `:workflow/started` events citing the same spec link to one `Spec` without producer-side coordination. Explicit `:spec/id` on the producer payload overrides when it lands later.
- **`upsert-spec` accumulator handler** — first-observation creates `:active` + `:origin :miniforge`; re-observation preserves `:created-at` + status + origin, bumps `:updated-at`, merges new mutable metadata only. `:spec/origin` is immutable provenance (regression-tested).
- **`:supervisory/spec-upserted` event** — emitter + replay handler + `core/handle-event!` self-ignore set.
- **`specs` reader on the public interface.**

## Verification

- `clj-kondo`: clean (0 errors, 0 warnings).
- `accumulator-test`: 57 tests / 166 assertions pass (was 49 / 143 on main; +8 tests / +23 assertions).
- `attention-test`: 11 tests / 17 assertions pass.
- `bb poly:check`: clean for touched code (pre-existing 207 warnings only, unrelated).

## Deferred (N14-5)

`:spec/updated` / `:spec/archived` event handlers for operator-driven status transitions — separate PR once the Rust-core consumer's `:spec/archive` intervention is wired through MCP round-trip.

## Test plan

- [ ] Spot-check the deterministic spec-id derivation against the operator's intuition — two `:workflow/started` events for the same conceptual spec should collapse to one entity
- [ ] Confirm the `Spec` entity shape is acceptable for the Rust-core projection (`AgentSession.spec_id` cross-references this entity's `:spec/id`)
- [ ] Confirm the `:miniforge` default for `:spec/origin` is right (vs `:upstream` or similar)
- [ ] Spot-check that `:specs` is keyed correctly in `EntityTable` + `empty-table`
- [ ] Verify the v1 data-model semantics section in the RFC (post-728183d3) reads correctly — Specless workflows are a first-class state, not a back-compat carve-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)