### PR TITLE
fix(gate): use passed? predicate in check-gates to handle response-shaped results

### DIFF
--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -189,8 +189,8 @@
      {:passed? bool :results [...]}"
   [gate-kws artifact ctx]
   (let [results (mapv #(check-gate % artifact ctx) gate-kws)
-        passed? (every? passed? results)]
-    {:passed? passed?
+        all-passed? (every? passed? results)]
+    {:passed? all-passed?
      :results results
      :failed-gates (filterv failed? results)}))
 

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -189,7 +189,7 @@
      {:passed? bool :results [...]}"
   [gate-kws artifact ctx]
   (let [results (mapv #(check-gate % artifact ctx) gate-kws)
-        passed? (every? :passed? results)]
+        passed? (every? passed? results)]
     {:passed? passed?
      :results results
      :failed-gates (filterv failed? results)}))

--- a/components/gate/test/ai/miniforge/gate/interface_test.clj
+++ b/components/gate/test/ai/miniforge/gate/interface_test.clj
@@ -27,7 +27,8 @@
    [ai.miniforge.gate.syntax]
    [ai.miniforge.gate.lint]
    [ai.miniforge.gate.test]
-   [ai.miniforge.gate.policy]))
+   [ai.miniforge.gate.policy]
+   [ai.miniforge.gate.format]))
 
 ;; ============================================================================
 ;; Registry tests
@@ -153,6 +154,18 @@
   (testing "check-gates passes for empty gate list"
     (let [result (gate/check-gates [] {} {})]
       (is (:passed? result)))))
+
+(deftest check-gates-response-shaped-gate-test
+  (testing "check-gates correctly handles gates that return response/success shape"
+    ;; The format gate returns response/success (no :passed? key) — always passes.
+    ;; Before the fix, (every? :passed? results) saw nil for response-shaped results
+    ;; and declared overall :passed? false despite the gate passing.
+    (let [artifact {:code/files [{:path "src/foo.clj" :content "(+ 1 2)" :action :create}]}
+          result   (gate/check-gates [:format] artifact {})]
+      (is (true? (:passed? result))
+          "check-gates must return :passed? true when gate passes via response/success shape")
+      (is (empty? (:failed-gates result))
+          "failed-gates must be empty when gate passes"))))
 
 ;; ============================================================================
 ;; Repair gate tests


### PR DESCRIPTION
## Summary

- `check-gates` computed aggregate pass status via `(every? :passed? results)` — the raw keyword accessor. Gates returning `response/success` shape (no `:passed?` key, e.g. the format gate) had `(:passed? result) = nil` (falsy), so `every?` declared the aggregate `:passed? false` even when those gates passed.
- `(filterv failed? results)` used the correct `gate/passed?` predicate (which handles both `{:passed? bool}` and `response/success?` shapes), producing `failed-gates = []`.
- Net: `check-gates` returned `{:passed? false :failed-gates []}` for any artifact that ran the format gate — `apply-gate-validation` set `:phase/status :failed` with `:phase/gate-errors []`, `gate-failed? = true` in `leave-implement`, phase marked `:failed` despite zero gate errors.

**Root cause of classification dogfood all-tasks-failed** (2026-05-13): implementer wrote 5 correct classification component files, file-artifact-fallback collected them, curated artifact was valid — but the format gate in the `[:syntax :format :lint]` gate suite silently failed `check-gates` with `{:passed? false :failed-gates []}`, causing every task to report `:phase/status :failed` with `:phase/gate-errors []`.

## Changes

- `gate/interface.clj`: `(every? :passed? results)` → `(every? passed? results)` (uses the same `passed?` predicate already defined in the same namespace)
- `gate/interface-test.clj`: regression test `check-gates-response-shaped-gate-test` using the format gate (which always returns `response/success`)

## Test plan

- [ ] `check-gates-response-shaped-gate-test` passes: `check-gates [:format]` returns `{:passed? true :failed-gates []}` for any artifact
- [ ] All existing gate tests pass
- [ ] Pre-commit hook passes (ran 73 bricks, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)