### PR TITLE
Fix submit MCP artifact tool for dogfood runs

### DIFF
--- a/bases/mcp-context-server/resources/mcp-context-server/tool-registry.edn
+++ b/bases/mcp-context-server/resources/mcp-context-server/tool-registry.edn
@@ -53,4 +53,21 @@
     :properties
     {"pattern" {:type "string" :description "Glob pattern to match files (e.g. \"**/*.clj\", \"src/**/*.ts\")"}}}}
   :required-params
-  {"pattern" {:check :non-blank :msg "pattern is required"}}}}
+  {"pattern" {:check :non-blank :msg "pattern is required"}}}
+
+ "submit"
+ {:handler :submit
+  :tool-def
+  {:name "submit"
+   :description "Submit structured phase artifact metadata. Use after writing files with Write/Edit. The runtime derives file contents from the working tree and reads this metadata from artifact.edn."
+   :inputSchema
+   {:type "object"
+    :properties
+    {"code/summary" {:type "string" :description "Brief summary of changes made"}
+     "code/tests-needed?" {:type "boolean" :description "Whether tests should be run for the changes"}
+     "code/dependencies-added" {:type "array"
+                                :items {:type "string"}
+                                :description "Dependency coordinates added by the change"}
+     "status" {:type "string" :description "Status for non-code submissions, for example already-implemented"}
+     "summary" {:type "string" :description "Summary for non-code submissions"}}}}
+  :required-params {}}}

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -29,7 +29,8 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.java.shell :as shell]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.walk :as walk]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure helpers
@@ -148,12 +149,12 @@
 
 ;; Cache atom holding :files (path → content) and :misses (recorded cache misses).
 (defonce cache-state
-  (atom {:files {} :misses [] :source-root nil}))
+  (atom {:files {} :misses [] :source-root nil :artifact-dir nil}))
 
 (defn reset-state!
   "Reset cache state. Intended for test isolation."
   []
-  (reset! cache-state {:files {} :misses [] :source-root nil}))
+  (reset! cache-state {:files {} :misses [] :source-root nil :artifact-dir nil}))
 
 (defn- source-root
   []
@@ -172,7 +173,9 @@
   ([artifact-dir source-root]
    (let [path (str artifact-dir "/context-cache.edn")
          f (io/file path)]
-     (swap! cache-state assoc :source-root source-root)
+     (swap! cache-state assoc
+            :source-root source-root
+            :artifact-dir artifact-dir)
      (when (.exists f)
        (try
          (let [data (edn/read-string (slurp f))]
@@ -192,6 +195,49 @@
         (spit path (pr-str misses))
         (binding [*out* *err*]
           (println (msg/t :cache/misses-written {:count (count misses) :path path})))))))
+
+(defn- artifact-dir
+  []
+  (:artifact-dir @cache-state))
+
+(defn- string-key->keyword
+  "Convert JSON object keys into EDN keywords, preserving namespaces."
+  [k]
+  (cond
+    (keyword? k) k
+    (and (string? k) (str/includes? k "/"))
+    (let [[ns n] (str/split k #"/" 2)]
+      (keyword ns n))
+
+    (string? k) (keyword k)
+    :else k))
+
+(defn- keywordize-artifact-keys
+  "Keywordize MCP JSON arguments before persisting them as EDN."
+  [artifact]
+  (walk/postwalk
+   (fn [v]
+     (if (map-entry? v)
+       [(string-key->keyword (key v)) (val v)]
+       v))
+   artifact))
+
+(defn handle-submit
+  "Persist a structured artifact payload to artifact.edn.
+
+   Agents use this tool as the structured confirmation channel. The runtime
+   may still derive file contents from the working tree; this payload carries
+   metadata such as :code/summary and :code/tests-needed?."
+  [params]
+  (let [dir (artifact-dir)]
+    (when (str/blank? dir)
+      (throw (ex-info "artifact-dir is not configured" {:code -32603})))
+    (let [artifact (keywordize-artifact-keys params)
+          path (str dir "/artifact.edn")]
+      (io/make-parents path)
+      (spit path (pr-str artifact))
+      {:content [{:type "text"
+                  :text (str "Artifact submitted to " path)}]})))
 
 (defn- record-miss!
   "Record a cache miss for meta-loop learning."

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
@@ -112,7 +112,8 @@
   []
   (tools/register-handler! :context-read  context-cache/handle-context-read)
   (tools/register-handler! :context-grep  context-cache/handle-context-grep)
-  (tools/register-handler! :context-glob  context-cache/handle-context-glob))
+  (tools/register-handler! :context-glob  context-cache/handle-context-glob)
+  (tools/register-handler! :submit        context-cache/handle-submit))
 
 (defn run-server
   "Run the MCP context server loop, reading JSON-RPC messages from stdin.

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -211,6 +211,22 @@
         (is (= "(ns b)" (get-in @cache/cache-state [:files "src/b.clj"])))
         (is (= "/tmp/repo-root" (:source-root @cache/cache-state)))))))
 
+(deftest handle-submit-writes-artifact-test
+  (testing "submit persists keywordized artifact metadata"
+    (with-temp-dir
+      (fn [dir]
+        (cache/load-cache! dir "/tmp/repo-root")
+        (let [result (cache/handle-submit {"code/summary" "Added event tools"
+                                           "code/tests-needed?" true
+                                           "code/dependencies-added" ["org/example"]})
+              artifact-file (io/file dir "artifact.edn")
+              artifact (edn/read-string (slurp artifact-file))]
+          (is (re-find #"Artifact submitted" (get-in result [:content 0 :text])))
+          (is (= {:code/summary "Added event tools"
+                  :code/tests-needed? true
+                  :code/dependencies-added ["org/example"]}
+                 artifact)))))))
+
 (deftest handle-context-read-source-root-fallback-test
   (testing "relative file reads resolve from source-root when cache is empty"
     (with-temp-dir

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -262,39 +262,6 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; MCP config generation
 
-(def ^:private codex-artifact-table-pattern
-  #"^\[mcp_servers\.artifact(?:\..+)?\]\s*$")
-
-(def ^:private toml-table-pattern
-  #"^\[[^]]+\]\s*$")
-
-(defn- strip-codex-artifact-config
-  "Remove the full mcp_servers.artifact subtree from a Codex TOML config.
-
-   This strips both the root server block and any nested tables such as
-   [mcp_servers.artifact.tools.context_read], which newer Codex builds treat
-   as invalid if the parent server definition has already been removed."
-  [content]
-  (let [lines (str/split-lines content)]
-    (loop [remaining lines
-           cleaned []
-           skipping? false]
-      (if-let [line (first remaining)]
-        (let [trimmed (str/trim line)]
-          (cond
-            (re-matches codex-artifact-table-pattern trimmed)
-            (recur (rest remaining) cleaned true)
-
-            (and skipping? (re-matches toml-table-pattern trimmed))
-            (recur remaining cleaned false)
-
-            skipping?
-            (recur (rest remaining) cleaned true)
-
-            :else
-            (recur (rest remaining) (conj cleaned line) false)))
-        (str/join "\n" cleaned)))))
-
 (defn write-codex-mcp-config!
   "Write or update .codex/config.toml with [mcp_servers.artifact] block.
 
@@ -398,6 +365,7 @@
   [{:mcp/server :context :mcp/tool :context_read}
    {:mcp/server :context :mcp/tool :context_grep}
    {:mcp/server :context :mcp/tool :context_glob}
+   {:mcp/server :context :mcp/tool :submit}
    ;; Native write tools: implementer needs all three patch shapes.
    ;; `Write` for full-file rewrites (planner's plan.edn, implementer
    ;; new files, releaser PR drafts). `Edit` for single-region patches.

--- a/components/agent/src/ai/miniforge/agent/result_boundary.clj
+++ b/components/agent/src/ai/miniforge/agent/result_boundary.clj
@@ -32,12 +32,21 @@
         content (or (extract-content response) "")
         worktree-artifact (when role
                             (get worktree-artifacts role))
+        artifact-with-fallback (when (and artifact
+                                          fallback-artifact
+                                          (map? artifact)
+                                          (map? fallback-artifact)
+                                          (contains? fallback-artifact :code/files)
+                                          (not (contains? artifact :code/files)))
+                                 (merge fallback-artifact artifact))
         artifact-source (cond
                           worktree-artifact :worktree-metadata
+                          artifact-with-fallback :mcp-with-file-fallback
                           artifact :mcp
                           fallback-artifact :file-fallback
                           :else nil)
-        structured-artifact (or worktree-artifact artifact fallback-artifact)
+        structured-artifact (or worktree-artifact artifact-with-fallback
+                                artifact fallback-artifact)
         parsed-content (when parse-response
                          (parse-response content))
         derived-artifact (when derive-artifact

--- a/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
@@ -285,7 +285,7 @@
   (testing "context-server MCP tools are present"
     (let [mcp-entries (filter map? session/mcp-tools)]
       (is (every? #(= :context (:mcp/server %)) mcp-entries))
-      (is (= #{:context_read :context_grep :context_glob}
+      (is (= #{:context_read :context_grep :context_glob :submit}
              (into #{} (map :mcp/tool) mcp-entries)))))
 
   (testing "native Write is auto-approved — plan.edn submission path"

--- a/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
+++ b/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
@@ -48,6 +48,26 @@
       (is (= :already-implemented (:status (:parsed-content normalized))))
       (is (true? (sut/usable-content? normalized))))))
 
+(deftest normalize-llm-result-merges-submit-metadata-with-file-fallback
+  (testing "MCP submit metadata does not hide files collected from Write/Edit"
+    (let [normalized (sut/normalize-llm-result
+                      {:role :implement
+                       :response {:success true :content ""}
+                       :artifact {:code/summary "Added tool-call events"
+                                  :code/tests-needed? true}
+                       :fallback-artifact {:code/files [{:path "src/core.clj"
+                                                         :content "(ns core)"
+                                                         :action :modify}]
+                                           :code/summary "fallback summary"
+                                           :code/language "clojure"}})
+          payload (sut/authoritative-payload normalized)]
+      (is (= :mcp-with-file-fallback (:artifact-source normalized)))
+      (is (= "Added tool-call events" (:code/summary payload)))
+      (is (true? (:code/tests-needed? payload)))
+      (is (= [{:path "src/core.clj" :content "(ns core)" :action :modify}]
+             (:code/files payload)))
+      (is (= "clojure" (:code/language payload))))))
+
 (deftest error-response-preserves-backend-error-shape
   (testing "error-response carries raw backend data and response metadata through"
     (let [normalized {:llm-error {:message "Adaptive timeout"

--- a/work/QUEUE.md
+++ b/work/QUEUE.md
@@ -16,6 +16,7 @@ Make miniforge capable of running miniforge without paying for
 | tier | r | theme | spec | axes |
 |---|---|---|---|---|
 | blocker | ● | dogfood-resilience | `event-log-tool-visibility.spec.edn` — Event log — capture tool name / args / result on every agent tool call | observation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `planner-convergence-and-artifact-submission.spec.edn` — Planner convergence — container-promoted plan artifact + forced context-MCP usage | correctness+observation+tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `worktree-persistence-scratch-branch.spec.edn` — Persist worktrees outside /tmp + scratch-branch commits on every write | dogfoodenabler |
 | high | ● | dogfood-resilience | `pedestal-interceptor-chain.spec.edn` — Pedestal-style interceptor chain for phase lifecycle | correctness+dogfoodenabler |
 | high | ● | dogfood-resilience | `tech-registry-doctor-repo-scoped-bootstrap.spec.edn` — Tech-registry-driven runtime bootstrap — repo-scoped, print-don't-install | correctness+ux+dogfoodenabler |
@@ -39,6 +40,19 @@ Miniforge is an agent-CLI-agnostic platform. Every supported CLI
 |---|---|---|---|---|
 | blocker | ● | multi-backend-parity | `multi-backend-cli-parity.spec.edn` — Multi-backend CLI parity — make codex / cursor-agent / copilot / open-codex first-class planners and implementers | correctness+scale+dogfoodenabler |
 
+## Theme — Operational Policy Synthesis (OPSV) (`operational-policy-synthesis`, status: planned)
+
+Discover scaling + budget signals via governed experiments, synthesize
+   operational policies, verify against acceptance criteria, and emit
+   them as auditable artifacts. Any numeric knob whose optimal value we
+   currently guess — agent max-tokens, tool-call caps, timeouts, K8s
+   container CPU/memory, I/O bandwidth — is an OPSV target.
+
+| tier | r | theme | spec | axes |
+|---|---|---|---|---|
+| high | ○ | operational-policy-synthesis | `n07-opsv-agent-budgets.spec.edn` — OPSV: converge agent max-tokens + phase-iteration budgets | observation+tokenconservation+dogfoodenabler |
+| medium | ○ | operational-policy-synthesis | `workflow-policy-convergence.spec.edn` — Workflow Policy Convergence: learned workflow selection | workfloworchestration+governance+reliability |
+
 ## Theme — DAG orchestration (`dag-orchestration`, status: in-flight)
 
 Miniforge's DAG executor exists and is wired but never fires for
@@ -52,18 +66,7 @@ Miniforge's DAG executor exists and is wired but never fires for
 | tier | r | theme | spec | axes |
 |---|---|---|---|---|
 | blocker | ● | dag-orchestration | `plan-from-agent-dag-wiring.spec.edn` — plan-from-agent must emit :plan/id so the DAG orchestrator activates | observation+tokenconservation+dogfoodenabler |
-
-## Theme — Operational Policy Synthesis (OPSV) (`operational-policy-synthesis`, status: planned)
-
-Discover scaling + budget signals via governed experiments, synthesize
-   operational policies, verify against acceptance criteria, and emit
-   them as auditable artifacts. Any numeric knob whose optimal value we
-   currently guess — agent max-tokens, tool-call caps, timeouts, K8s
-   container CPU/memory, I/O bandwidth — is an OPSV target.
-
-| tier | r | theme | spec | axes |
-|---|---|---|---|---|
-| high | ○ | operational-policy-synthesis | `n07-opsv-agent-budgets.spec.edn` — OPSV: converge agent max-tokens + phase-iteration budgets | observation+tokenconservation+dogfoodenabler |
+| high | ● | dag-orchestration | `per-task-base-chaining.spec.edn` — Per-Task Base Chaining for DAG Sub-Workflows | workfloworchestration+dagexecution+localmodefidelity |
 
 ## Theme — unassigned (`unassigned`, status: planned)
 
@@ -79,6 +82,7 @@ Discover scaling + budget signals via governed experiments, synthesize
 | medium | ● | unassigned | `control-plane-completion.spec.edn` — Control Plane Completion — Decision Wiring, Events, and Dashboard | - |
 | medium | ● | unassigned | `dashboard-production-ready.spec.edn` — Build Production-Ready Web Dashboard with High Fidelity | - |
 | medium | ● | unassigned | `environment-promotion-pipeline.spec.edn` — Environment Promotion Pipeline | - |
+| medium | ● | unassigned | `external-dependency-health-and-failure-attribution.spec.edn` — External dependency health and failure attribution | - |
 | medium | ● | unassigned | `fleet-supervisory-deferred.spec.edn` —  | - |
 | medium | ● | unassigned | `gitlab-support-tasks.spec.edn` — GitLab Support — Detailed Implementation Tasks | - |
 | medium | ● | unassigned | `gitlab-support.spec.edn` — Add GitLab Support for MR Lifecycle Management | - |
@@ -127,3 +131,13 @@ Discover scaling + budget signals via governed experiments, synthesize
 | medium | ● | unassigned | `tui-ws5-attention-intervention.spec.edn` — WS5: Attention and Bounded Intervention | - |
 | medium | ● | unassigned | `wire-self-repair-chain.spec.edn` — Wire Self-Repair Chain Into Workflow Execution | - |
 | medium | ● | unassigned | `workflow-redesign-use-case-targeted.spec.edn` — Redesign Workflows: Use-Case Targeted with Safety by Default | - |
+
+## Theme — semantic-supervision (`semantic-supervision`, status: planned)
+
+(no theme description)
+
+| tier | r | theme | spec | axes |
+|---|---|---|---|---|
+| critical | ● | semantic-supervision | `progress-detector-semantic-loop-detection.spec.edn` — Progress detector stage 1 — tool-loop and repair-loop anomaly detection | agentquality+supervision+dogfoodenabler |
+| critical | ○ | semantic-supervision | `progress-detector-stage-2.spec.edn` — Progress detector stage 2 — event envelope + tool-loop + repair-loop + supervisor wiring | agentquality+supervision+dogfoodenabler |
+| critical | ○ | semantic-supervision | `progress-detector-stage-3.spec.edn` — Progress detector stage 3 — agent.invoke runtime wiring + per-category :on-anomaly policy | agentquality+supervision+dogfoodenabler |


### PR DESCRIPTION
## Summary
- Add the missing context MCP submit tool and register it in the context server.
- Persist submitted artifact metadata to artifact.edn with JSON keys converted to EDN keywords.
- Preserve Write/Edit-derived file artifacts when submit metadata omits :code/files.
- Refresh work/QUEUE.md from bb work:queue.

## Dogfood finding
While resuming event-log-tool-visibility.spec.edn from checkpoint 3927baf8-c9db-44d3-b5fb-5a1552dbe554, the implementer prompt required a submit MCP tool, but the MCP context server only exposed context read/grep/glob tools. The run repeatedly logged missing artifact.edn errors and eventually rejected otherwise-written work as implementer/mcp-tool-not-called.

## Verification
- clj-kondo focused lint for mcp-context-server and agent files
- clojure -M:poly test brick:agent
- clojure -M:test context-cache-test one-off run
- bb pre-commit
