### PR TITLE
fix: resume failed workflow checkpoints

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -102,7 +102,8 @@
             {:keys [workflow]} (load-workflow workflow-type workflow-version {})
 
             machine-snapshot (:machine-snapshot reconstructed)
-            resume-workflow (if machine-snapshot
+            failed-checkpoint? (and machine-snapshot (:failed? reconstructed))
+            resume-workflow (if (and machine-snapshot (not failed-checkpoint?))
                               workflow
                               (wr/trim-pipeline workflow completed-phases))
             remaining-pipeline (:workflow/pipeline resume-workflow)
@@ -115,7 +116,7 @@
                   (display/print-info
                     (messages/t :resume/new-workflow-id
                                 {:workflow-id resume-run-id})))
-                (if (and (not machine-snapshot) (seq remaining-pipeline))
+                (if (seq remaining-pipeline)
                   (display/print-info
                     (messages/t :resume/resuming-from-phase
                                 {:phase (name (:phase (first remaining-pipeline)))
@@ -133,9 +134,10 @@
           (let [result (run-pipeline resume-workflow
                                      {}
                                      {:llm-backend llm-client
-                                      :event-stream event-stream
-                                      :control-state control-state
+                                     :event-stream event-stream
+                                     :control-state control-state
                                      :resume-machine-snapshot machine-snapshot
+                                     :resume-reset-terminal? failed-checkpoint?
                                      :resume-phase-results (:phase-results reconstructed)
                                      :skip-lifecycle-events false
                                      :pre-completed-dag-tasks (:completed-dag-tasks reconstructed)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -134,19 +134,19 @@
           (let [result (run-pipeline resume-workflow
                                      {}
                                      {:llm-backend llm-client
-                                     :event-stream event-stream
-                                     :control-state control-state
-                                     :resume-machine-snapshot machine-snapshot
-                                     :resume-reset-terminal? failed-checkpoint?
-                                     :resume-phase-results (:phase-results reconstructed)
-                                     :skip-lifecycle-events false
-                                     :pre-completed-dag-tasks (:completed-dag-tasks reconstructed)
-                                     :pre-completed-artifacts (:completed-dag-artifacts reconstructed)
-                                     :on-phase-start (fn [_ctx interceptor]
-                                                       (when-not quiet
-                                                         (display/print-info
-                                                            (messages/t :resume/phase-starting
-                                                                        {:phase (get-in interceptor [:config :phase])}))))
+                                      :event-stream event-stream
+                                      :control-state control-state
+                                      :resume-machine-snapshot machine-snapshot
+                                      :resume-reset-terminal? failed-checkpoint?
+                                      :resume-phase-results (:phase-results reconstructed)
+                                      :skip-lifecycle-events false
+                                      :pre-completed-dag-tasks (:completed-dag-tasks reconstructed)
+                                      :pre-completed-artifacts (:completed-dag-artifacts reconstructed)
+                                      :on-phase-start (fn [_ctx interceptor]
+                                                        (when-not quiet
+                                                          (display/print-info
+                                                           (messages/t :resume/phase-starting
+                                                                       {:phase (get-in interceptor [:config :phase])}))))
                                       :on-phase-complete (fn [_ctx _interceptor _result] nil)})]
             (when-not quiet
               (display/print-info

--- a/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
@@ -111,6 +111,7 @@
 (deftest resume-workflow-passes-dag-recovery-data-test
   (let [workflow-id (random-uuid)
         run-pipeline-opts (atom nil)
+        run-pipeline-workflow (atom nil)
         reconstructed {:completed-phases [:plan]
                        :event-count 0
                        :completed-dag-tasks #{:task-a}
@@ -139,12 +140,65 @@
                                     :workflow/pipeline [{:phase :verify}]}})
 
                       (= sym 'ai.miniforge.workflow.interface/run-pipeline)
-                      (fn [_workflow _input opts]
+                      (fn [workflow _input opts]
+                        (reset! run-pipeline-workflow workflow)
                         (reset! run-pipeline-opts opts)
                         {:execution/status :completed})))]
       (let [result (sut/resume-workflow workflow-id {:quiet true})]
         (is (= :completed (:execution/status result)))
+        (is (= [{:phase :verify}]
+               (:workflow/pipeline @run-pipeline-workflow)))
+        (is (nil? (:resume-reset-terminal? @run-pipeline-opts)))
         (is (= #{:task-a}
                (:pre-completed-dag-tasks @run-pipeline-opts)))
         (is (= [{:artifact/id "art-1"}]
                (:pre-completed-artifacts @run-pipeline-opts)))))))
+
+(deftest resume-workflow-trims-failed-checkpoint-before-running-test
+  (let [workflow-id (random-uuid)
+        run-pipeline-opts (atom nil)
+        run-pipeline-workflow (atom nil)
+        reconstructed {:completed-phases [:plan]
+                       :event-count 0
+                       :failed? true
+                       :completed-dag-tasks #{}
+                       :completed-dag-artifacts []
+                       :phase-results {:plan {:status :completed}}
+                       :machine-snapshot {:execution/id workflow-id
+                                          :execution/status :failed
+                                          :execution/fsm-state {:_state :failed}}
+                       :workflow-spec {:name "canonical-sdlc"
+                                       :version "1.0.0"}}]
+    (with-redefs [wr/reconstruct-context (fn [_events-dir _workflow-id] reconstructed)
+                  sut/resolve-resume-workflow (fn [_] {:workflow-type :canonical-sdlc
+                                                       :workflow-version "1.0.0"})
+                  context/create-llm-client (fn [_workflow _provider _quiet] :llm-client)
+                  es/create-event-stream (fn [] :event-stream)
+                  supervisory/attach! (fn [_event-stream] nil)
+                  dashboard/start-command-poller! (fn [_workflow-id _control-state]
+                                                    (fn [] nil))
+                  main-display/print-info (fn [& _] nil)
+                  main-display/print-error (fn [& _] nil)
+                  clojure.core/requiring-resolve
+                  (fn [sym]
+                    (cond
+                      (= sym 'ai.miniforge.workflow.interface/load-workflow)
+                      (fn [_workflow-type _workflow-version _opts]
+                        {:workflow {:workflow/id :canonical-sdlc
+                                    :workflow/version "1.0.0"
+                                    :workflow/pipeline [{:phase :plan}
+                                                        {:phase :implement}
+                                                        {:phase :verify}]}})
+
+                      (= sym 'ai.miniforge.workflow.interface/run-pipeline)
+                      (fn [workflow _input opts]
+                        (reset! run-pipeline-workflow workflow)
+                        (reset! run-pipeline-opts opts)
+                        {:execution/status :completed})))]
+      (let [result (sut/resume-workflow workflow-id {:quiet true})]
+        (is (= :completed (:execution/status result)))
+        (is (= [{:phase :implement} {:phase :verify}]
+               (:workflow/pipeline @run-pipeline-workflow)))
+        (is (true? (:resume-reset-terminal? @run-pipeline-opts)))
+        (is (= workflow-id
+               (get-in @run-pipeline-opts [:resume-machine-snapshot :execution/id])))))))

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -224,6 +224,10 @@
   "Restore execution context from a durable machine snapshot and phase checkpoints."
   [workflow input machine-snapshot phase-results opts]
   (let [execution-machine (fsm/compile-execution-machine workflow)
+        fsm-state (if (:resume-reset-terminal? opts)
+                    (->> (fsm/initialize-execution execution-machine)
+                         (fsm/start-execution execution-machine))
+                    (:execution/fsm-state machine-snapshot))
         checkpoint-root (checkpoint-store/resolve-checkpoint-root
                          (merge opts machine-snapshot))]
     (sync-machine-projections
@@ -233,7 +237,7 @@
        :execution/workflow-id (:workflow/id workflow)
        :execution/workflow-version (:workflow/version workflow)
        :execution/fsm-machine execution-machine
-       :execution/fsm-state (:execution/fsm-state machine-snapshot)
+       :execution/fsm-state fsm-state
        :execution/input (get machine-snapshot :execution/input input)
        :execution/phase-results phase-results
        :execution/opts opts

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -140,6 +140,17 @@
      :execution/streaming-activity []
      :execution/files-written #{}}))
 
+(defn- reset-terminal-snapshot-fields
+  [machine-snapshot workflow]
+  (-> machine-snapshot
+      (dissoc :execution/ended-at
+              :execution/output
+              :execution/completed-with-warnings?)
+      (assoc :execution/errors []
+             :execution/response-chain (response/create (:workflow/id workflow))
+             :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+             :execution/started-at (System/currentTimeMillis))))
+
 (defn sync-machine-projections
   "Project workflow fields from the authoritative machine snapshot."
   [ctx]
@@ -224,6 +235,9 @@
   "Restore execution context from a durable machine snapshot and phase checkpoints."
   [workflow input machine-snapshot phase-results opts]
   (let [execution-machine (fsm/compile-execution-machine workflow)
+        machine-snapshot (cond-> machine-snapshot
+                           (:resume-reset-terminal? opts)
+                           (reset-terminal-snapshot-fields workflow))
         fsm-state (if (:resume-reset-terminal? opts)
                     (->> (fsm/initialize-execution execution-machine)
                          (fsm/start-execution execution-machine))

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -91,17 +91,35 @@
                     :workflow/pipeline [{:phase :implement}
                                         {:phase :verify}]}
           workflow-id (random-uuid)
+          failed-started-at 1000
           restored (ctx/restore-context
                     workflow
                     {:task "Test"}
                     {:execution/id workflow-id
+                     :execution/input {:task "From snapshot"}
                      :execution/status :failed
-                     :execution/fsm-state {:_state :failed}}
+                     :execution/fsm-state {:_state :failed}
+                     :execution/started-at failed-started-at
+                     :execution/ended-at 2000
+                     :execution/output {:status :failed}
+                     :execution/errors [{:type :boom}]
+                     :execution/response-chain {:old :failure}
+                     :execution/metrics {:tokens 9
+                                         :cost-usd 1.2
+                                         :duration-ms 1000}}
                     {:plan {:status :completed}}
                     {:resume-reset-terminal? true})]
       (is (= workflow-id (:execution/id restored)))
+      (is (= {:task "From snapshot"} (:execution/input restored)))
       (is (= :running (:execution/status restored)))
       (is (= :implement (:execution/current-phase restored)))
+      (is (nil? (:execution/ended-at restored)))
+      (is (nil? (:execution/output restored)))
+      (is (= [] (:execution/errors restored)))
+      (is (= {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+             (:execution/metrics restored)))
+      (is (not= failed-started-at (:execution/started-at restored)))
+      (is (not= {:old :failure} (:execution/response-chain restored)))
       (is (= {:plan {:status :completed}}
              (:execution/phase-results restored))))))
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -84,6 +84,27 @@
           ctx (ctx/create-context workflow {:task "Test"} {:source-root source-root})]
       (is (= source-root (:source-root ctx))))))
 
+(deftest restore-context-can-reset-terminal-snapshot-test
+  (testing "failed checkpoint snapshots can resume a trimmed workflow"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :implement}
+                                        {:phase :verify}]}
+          workflow-id (random-uuid)
+          restored (ctx/restore-context
+                    workflow
+                    {:task "Test"}
+                    {:execution/id workflow-id
+                     :execution/status :failed
+                     :execution/fsm-state {:_state :failed}}
+                    {:plan {:status :completed}}
+                    {:resume-reset-terminal? true})]
+      (is (= workflow-id (:execution/id restored)))
+      (is (= :running (:execution/status restored)))
+      (is (= :implement (:execution/current-phase restored)))
+      (is (= {:plan {:status :completed}}
+             (:execution/phase-results restored))))))
+
 ;; ============================================================================
 ;; Pipeline building tests
 ;; ============================================================================


### PR DESCRIPTION
## Summary
- trim failed checkpoint resumes to the remaining pipeline instead of reusing a terminal failed machine state
- reset restored FSM state only for terminal failed checkpoint resumes while preserving execution id and phase results
- add CLI and workflow tests for failed-checkpoint resume behavior

## Validation
- clojure -M:dev:test -e resume-test
- clojure -M:poly test brick:workflow
- bb miniforge resume 3927baf8-c9db-44d3-b5fb-5a1552dbe554
- bb pre-commit
- git commit hook passed with budget 90 / 200

## Dogfood notes
- Resume now advances past the failed checkpoint and ran explore, implement, verify, review, then looped back to implement.
- Remaining next bug: status still reports stale failed checkpoint state during an active resumed run, and the event-log implementation still fails review / artifact submission in that stale workflow context.