### PR TITLE
fix: repair dogfood resume checkpoint handling

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -229,7 +229,8 @@
           files          (or (not-empty committed)
                              (not-empty dirty)
                              (throw (ex-info (messages/t :release/zero-files)
-                                             {:phase          :release
+                                             {:type           :release/zero-files
+                                              :phase          :release
                                               :environment-id (:environment-id impl-result)
                                               :worktree-path  worktree-path})))
           code-artifacts [{:artifact/type    :code
@@ -415,9 +416,8 @@
         iterations (get-in ctx [:phase :iterations] 1)
         max-iterations (get-in ctx [:phase :budget :iterations]
                                (get-in default-config [:budget :iterations]))
-        zero-files? (and (= (messages/t :release/zero-files)
-                            (get-in result [:error :message]))
-                         (= :release (get-in result [:error :data :phase])))
+        zero-files? (= :release/zero-files
+                       (get-in result [:error :data :type]))
         phase-status (if zero-files?
                        :failed
                        (phase/determine-phase-status

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -415,8 +415,13 @@
         iterations (get-in ctx [:phase :iterations] 1)
         max-iterations (get-in ctx [:phase :budget :iterations]
                                (get-in default-config [:budget :iterations]))
-        phase-status (phase/determine-phase-status
-                       agent-status iterations max-iterations)
+        zero-files? (and (= (messages/t :release/zero-files)
+                            (get-in result [:error :message]))
+                         (= :release (get-in result [:error :data :phase])))
+        phase-status (if zero-files?
+                       :failed
+                       (phase/determine-phase-status
+                        agent-status iterations max-iterations))
         pr-info (get-in ctx [:workflow/pr-info])
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -634,6 +634,20 @@
       (is (= 0 (get-in result [:phase :duration-ms]))
           "Duration should default to 0 when start-time is nil"))))
 
+(deftest leave-release-detects-zero-files-by-error-type-test
+  (testing "zero-files failures do not depend on localized error text"
+    (let [interceptor (phase/get-phase-interceptor {:phase :release})
+          ctx {:phase {:started-at (System/currentTimeMillis)
+                       :result {:status :success
+                                :error {:message "translated message"
+                                        :data {:type :release/zero-files
+                                               :phase :release}}}
+                       :budget {:iterations 2}
+                       :iterations 1}
+               :execution/metrics {:tokens 0 :duration-ms 0}}
+          result ((:leave interceptor) ctx)]
+      (is (= :failed (get-in result [:phase :status]))))))
+
 ;------------------------------------------------------------------------------ Layer 2: Interceptor Leave Tests
 
 (deftest leave-release-records-metrics-test

--- a/components/workflow-resume/resources/config/workflow-resume/resume.edn
+++ b/components/workflow-resume/resources/config/workflow-resume/resume.edn
@@ -1,0 +1,8 @@
+{:workflow-resume/resume
+ {:completed-phase-statuses #{:completed
+                              :success
+                              :succeeded
+                              :already-implemented
+                              :already-satisfied}
+  :blocking-review-decisions #{:changes-requested
+                               :rejected}}}

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -310,11 +310,12 @@
 ;; Pipeline trimming
 
 (defn trim-pipeline
-  "Drop already-completed phases from a workflow's pipeline.
+  "Drop the already-completed prefix from a workflow's pipeline.
 
    Pure: takes a workflow map with `:workflow/pipeline` and a
-   collection of completed phase keywords; returns the workflow with
-   its pipeline reduced to only the remaining phases."
+   collection of completed phase keywords; returns the workflow with only
+   leading completed phases removed. Completed phases after the first
+   incomplete phase are preserved."
   [workflow completed-phases]
   (schema/validate! schema/TrimPipelineInput
                     {:workflow workflow :completed-phases completed-phases}

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -142,10 +142,73 @@
   (or (boolean (seq (get by-type :workflow/failed)))
       (= :failed (checkpoint-status checkpoint-data))))
 
+(def completed-phase-statuses
+  "Phase result statuses that are safe to skip on resume."
+  #{:completed :success :succeeded :already-implemented :already-satisfied})
+
+(def blocking-review-decisions
+  "Review decisions that must resume the repair path."
+  #{:changes-requested :rejected})
+
+(defn- phase-result-status
+  [phase-result]
+  (or (:status phase-result)
+      (:phase/status phase-result)
+      (:outcome phase-result)
+      (:phase/outcome phase-result)
+      (get-in phase-result [:result :status])
+      (get-in phase-result [:phase/result :status])))
+
+(defn- review-blocked?
+  [phase-id phase-result]
+  (and (= :review phase-id)
+       (contains? blocking-review-decisions
+                  (or (:review/decision phase-result)
+                      (get-in phase-result [:result :review/decision])
+                      (get-in phase-result [:result :output :review/decision])
+                      (get-in phase-result [:phase/result :review/decision])
+                      (get-in phase-result [:phase/result :output :review/decision])
+                      (get-in phase-result [:result :decision])
+                      (:decision phase-result)))))
+
+(defn- completed-phase-result?
+  [phase-id phase-result]
+  (and phase-result
+       (not (review-blocked? phase-id phase-result))
+       (contains? completed-phase-statuses
+                  (phase-result-status phase-result))))
+
+(defn- checkpoint-phase-order
+  [checkpoint-data phase-results]
+  (let [manifest-order (get-in checkpoint-data [:manifest :workflow/phases-completed])]
+    (vec (concat manifest-order
+                 (remove (set manifest-order) (keys phase-results))))))
+
+(defn- event-phase-order
+  [events]
+  (->> events
+       (filter #(= :workflow/phase-completed (:event/type %)))
+       (map :workflow/phase)
+       distinct
+       vec))
+
+(defn- completed-checkpoint-phases
+  [checkpoint-data phase-results]
+  (->> (checkpoint-phase-order checkpoint-data phase-results)
+       (filter #(completed-phase-result? % (get phase-results %)))))
+
+(defn- completed-event-phases
+  [events]
+  (let [event-results (extract-phase-results events)]
+    (->> (event-phase-order events)
+         (filter #(completed-phase-result? % (get event-results %))))))
+
 (defn- restored-completed-phases
-  [checkpoint-data events]
-  (or (some-> checkpoint-data :manifest :workflow/phases-completed)
-      (extract-completed-phases events)))
+  [checkpoint-data events phase-results]
+  (->> (concat (completed-event-phases events)
+               (completed-checkpoint-phases checkpoint-data phase-results))
+       distinct
+       vec))
 
 (defn- restored-phase-results
   [checkpoint-data events]
@@ -217,8 +280,8 @@
         events (vec (filter schema/valid-event? raw-events))
         _ (ensure-reconstruction-source! checkpoint-data events-dir workflow-id raw-events)
         by-type (group-by :event/type events)
-        completed-phases (restored-completed-phases checkpoint-data events)
         phase-results (restored-phase-results checkpoint-data events)
+        completed-phases (restored-completed-phases checkpoint-data events phase-results)
         workflow-spec (find-workflow-spec events)
         started-event (first (get by-type :workflow/started))
         machine-snapshot (:machine-snapshot checkpoint-data)
@@ -257,8 +320,8 @@
                     {:workflow workflow :completed-phases completed-phases}
                     {:message "Invalid trim-pipeline input"})
   (let [completed-set (set completed-phases)
-        remaining (vec (remove #(completed-set (:phase %))
-                               (get workflow :workflow/pipeline [])))]
+        remaining (vec (drop-while #(completed-set (:phase %))
+                                   (get workflow :workflow/pipeline [])))]
     (assoc workflow :workflow/pipeline remaining)))
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -39,6 +39,8 @@
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.workflow-resume.schema :as schema]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -142,13 +144,31 @@
   (or (boolean (seq (get by-type :workflow/failed)))
       (= :failed (checkpoint-status checkpoint-data))))
 
+(def ^:private resume-config-resource
+  "config/workflow-resume/resume.edn")
+
+(defn- read-resume-config
+  []
+  (if-let [resource (io/resource resume-config-resource)]
+    (:workflow-resume/resume (edn/read-string (slurp resource)))
+    (response/throw-anomaly! :anomalies/not-found
+                             "Workflow resume config resource not found"
+                             {:resource resume-config-resource})))
+
+(def ^:private resume-config
+  (delay (read-resume-config)))
+
+(defn- config-set
+  [k]
+  (set (get @resume-config k)))
+
 (def completed-phase-statuses
   "Phase result statuses that are safe to skip on resume."
-  #{:completed :success :succeeded :already-implemented :already-satisfied})
+  (config-set :completed-phase-statuses))
 
 (def blocking-review-decisions
   "Review decisions that must resume the repair path."
-  #{:changes-requested :rejected})
+  (config-set :blocking-review-decisions))
 
 (defn- phase-result-status
   [phase-result]

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -132,7 +132,21 @@
 
   (testing "all phases completed → empty pipeline"
     (let [wf {:workflow/pipeline [{:phase :a} {:phase :b}]}]
-      (is (= [] (:workflow/pipeline (core/trim-pipeline wf [:a :b])))))))
+      (is (= [] (:workflow/pipeline (core/trim-pipeline wf [:a :b]))))))
+
+  (testing "non-contiguous completed phases do not skip phases after the first gap"
+    (let [wf {:workflow/pipeline [{:phase :explore}
+                                  {:phase :plan}
+                                  {:phase :implement}
+                                  {:phase :verify}
+                                  {:phase :review}
+                                  {:phase :release}]}
+          trimmed (core/trim-pipeline wf [:explore :plan :verify])]
+      (is (= [{:phase :implement}
+              {:phase :verify}
+              {:phase :review}
+              {:phase :release}]
+             (:workflow/pipeline trimmed))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; resolve-workflow-identity
@@ -272,6 +286,49 @@
           (is (true? (:dag-paused? ctx)))
           (is (= :rate-limit (:dag-pause-reason ctx)))
           (is (= 0 (:event-count ctx))))))))
+
+(deftest reconstruct-context-trims-only-completed-checkpoint-phases-test
+  (testing "checkpoint manifests may list failed/retrying phases; resume skips only completed results"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/id workflow-id
+                                             :execution/workflow-id :canonical-sdlc
+                                             :execution/workflow-version "1.0.0"
+                                             :execution/status :failed}
+                           :manifest {:workflow/phases-completed [:explore :plan :implement :review :release]}
+                           :phase-results {:explore {:status :completed}
+                                           :plan {:status :completed}
+                                           :implement {:status :completed}
+                                           :review {:status :completed
+                                                    :review/decision :changes-requested}
+                                           :release {:status :retrying}}}]
+      (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (= [:explore :plan :implement] (:completed-phases ctx))))))))
+
+(deftest reconstruct-context-merges-latest-successful-events-with-checkpoint-test
+  (testing "a damaged manifest can still resume from successful event history"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/id workflow-id
+                                             :execution/workflow-id :canonical-sdlc
+                                             :execution/workflow-version "1.0.0"
+                                             :execution/status :failed}
+                           :manifest {:workflow/phases-completed [:release :plan]}
+                           :phase-results {:release {:status :retrying}
+                                           :plan {:status :completed}}}
+          events [{:event/type :workflow/phase-completed
+                   :workflow/phase :explore
+                   :phase/outcome :success}
+                  {:event/type :workflow/phase-completed
+                   :workflow/phase :implement
+                   :phase/outcome :failure}
+                  {:event/type :workflow/phase-completed
+                   :workflow/phase :verify
+                   :phase/outcome :success}]]
+      (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] events)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (= [:explore :verify :plan] (:completed-phases ctx))))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Interface re-exports

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -211,6 +211,32 @@
 (defn- write-event! [^java.io.File dir filename event-map]
   (spit (io/file dir filename) (json/generate-string event-map)))
 
+(def resume-checkpoint-config
+  {:base-machine-snapshot {:execution/workflow-id :canonical-sdlc
+                           :execution/workflow-version "1.0.0"
+                           :execution/status :failed}
+   :blocked-review {:manifest {:workflow/phases-completed [:explore
+                                                           :plan
+                                                           :implement
+                                                           :review
+                                                           :release]}
+                    :phase-results {:explore {:status :completed}
+                                    :plan {:status :completed}
+                                    :implement {:status :completed}
+                                    :review {:status :completed
+                                             :review/decision :changes-requested}
+                                    :release {:status :retrying}}}
+   :damaged-manifest {:manifest {:workflow/phases-completed [:release :plan]}
+                      :phase-results {:release {:status :retrying}
+                                      :plan {:status :completed}}}})
+
+(defn- configured-checkpoint-data
+  [config-key workflow-id]
+  (let [checkpoint (get resume-checkpoint-config config-key)]
+    (assoc checkpoint :machine-snapshot
+           (assoc (:base-machine-snapshot resume-checkpoint-config)
+                  :execution/id workflow-id))))
+
 (deftest reconstruct-context-integration-test
   (with-temp-events-dir
     (fn [base-dir]
@@ -290,17 +316,8 @@
 (deftest reconstruct-context-trims-only-completed-checkpoint-phases-test
   (testing "checkpoint manifests may list failed/retrying phases; resume skips only completed results"
     (let [workflow-id (str (random-uuid))
-          checkpoint-data {:machine-snapshot {:execution/id workflow-id
-                                             :execution/workflow-id :canonical-sdlc
-                                             :execution/workflow-version "1.0.0"
-                                             :execution/status :failed}
-                           :manifest {:workflow/phases-completed [:explore :plan :implement :review :release]}
-                           :phase-results {:explore {:status :completed}
-                                           :plan {:status :completed}
-                                           :implement {:status :completed}
-                                           :review {:status :completed
-                                                    :review/decision :changes-requested}
-                                           :release {:status :retrying}}}]
+          checkpoint-data (configured-checkpoint-data :blocked-review
+                                                      workflow-id)]
       (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
                     es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
         (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
@@ -309,13 +326,8 @@
 (deftest reconstruct-context-merges-latest-successful-events-with-checkpoint-test
   (testing "a damaged manifest can still resume from successful event history"
     (let [workflow-id (str (random-uuid))
-          checkpoint-data {:machine-snapshot {:execution/id workflow-id
-                                             :execution/workflow-id :canonical-sdlc
-                                             :execution/workflow-version "1.0.0"
-                                             :execution/status :failed}
-                           :manifest {:workflow/phases-completed [:release :plan]}
-                           :phase-results {:release {:status :retrying}
-                                           :plan {:status :completed}}}
+          checkpoint-data (configured-checkpoint-data :damaged-manifest
+                                                      workflow-id)
           events [{:event/type :workflow/phase-completed
                    :workflow/phase :explore
                    :phase/outcome :success}

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -191,14 +191,23 @@
 
 (defn build-manifest
   "Build the durable checkpoint manifest for an execution context."
-  [ctx checkpoint-root]
+  ([ctx checkpoint-root]
+   (build-manifest ctx checkpoint-root nil))
+  ([ctx checkpoint-root existing-manifest]
   (let [workflow-run-id (:execution/id ctx)
-        phase-ids (ordered-phase-ids ctx)
-        phase-paths (into {}
-                          (map (fn [phase-id]
-                                 [phase-id
-                                  (phase-checkpoint-path checkpoint-root workflow-run-id phase-id)]))
-                          phase-ids)]
+        current-phase-ids (ordered-phase-ids ctx)
+        existing-phase-paths (:workflow/phase-checkpoints existing-manifest)
+        phase-ids (vec (concat (keys existing-phase-paths)
+                               (remove (set (keys existing-phase-paths))
+                                       current-phase-ids)))
+        current-phase-paths (into {}
+                                  (map (fn [phase-id]
+                                         [phase-id
+                                          (phase-checkpoint-path checkpoint-root
+                                                                 workflow-run-id
+                                                                 phase-id)]))
+                                  current-phase-ids)
+        phase-paths (merge existing-phase-paths current-phase-paths)]
     (serialize-checkpoint-value
      {:workflow/id workflow-run-id
       :workflow/workflow-id (:execution/workflow-id ctx)
@@ -207,7 +216,7 @@
       :workflow/machine-snapshot-path
       (machine-snapshot-path checkpoint-root workflow-run-id)
       :workflow/phase-checkpoints phase-paths
-      :workflow/last-checkpoint-at (current-checkpoint-timestamp)})))
+      :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Persistence and restore inputs
@@ -221,8 +230,9 @@
           phase-result (get-in ctx [:execution/phase-results phase-name])
           snapshot-path' (machine-snapshot-path checkpoint-root workflow-run-id)
           manifest-path' (manifest-path checkpoint-root workflow-run-id)
+          existing-manifest (read-edn-file manifest-path')
           snapshot (build-machine-snapshot ctx)
-          manifest (build-manifest ctx checkpoint-root)
+          manifest (build-manifest ctx checkpoint-root existing-manifest)
           checkpoint-data {:checkpoint/root checkpoint-root
                            :manifest manifest
                            :machine-snapshot snapshot

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -194,29 +194,31 @@
   ([ctx checkpoint-root]
    (build-manifest ctx checkpoint-root nil))
   ([ctx checkpoint-root existing-manifest]
-  (let [workflow-run-id (:execution/id ctx)
-        current-phase-ids (ordered-phase-ids ctx)
-        existing-phase-paths (:workflow/phase-checkpoints existing-manifest)
-        phase-ids (vec (concat (keys existing-phase-paths)
-                               (remove (set (keys existing-phase-paths))
-                                       current-phase-ids)))
-        current-phase-paths (into {}
-                                  (map (fn [phase-id]
-                                         [phase-id
-                                          (phase-checkpoint-path checkpoint-root
-                                                                 workflow-run-id
-                                                                 phase-id)]))
-                                  current-phase-ids)
-        phase-paths (merge existing-phase-paths current-phase-paths)]
-    (serialize-checkpoint-value
-     {:workflow/id workflow-run-id
-      :workflow/workflow-id (:execution/workflow-id ctx)
-      :workflow/workflow-version (:execution/workflow-version ctx)
-      :workflow/phases-completed phase-ids
-      :workflow/machine-snapshot-path
-      (machine-snapshot-path checkpoint-root workflow-run-id)
-      :workflow/phase-checkpoints phase-paths
-      :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))
+   (let [workflow-run-id (:execution/id ctx)
+         current-phase-ids (ordered-phase-ids ctx)
+         existing-phase-paths (or (:workflow/phase-checkpoints existing-manifest) {})
+         existing-phase-ids (or (not-empty (:workflow/phases-completed existing-manifest))
+                                (sort-by name (keys existing-phase-paths)))
+         phase-ids (vec (concat existing-phase-ids
+                                (remove (set existing-phase-ids)
+                                        current-phase-ids)))
+         current-phase-paths (into {}
+                                   (map (fn [phase-id]
+                                          [phase-id
+                                           (phase-checkpoint-path checkpoint-root
+                                                                  workflow-run-id
+                                                                  phase-id)]))
+                                   current-phase-ids)
+         phase-paths (merge existing-phase-paths current-phase-paths)]
+     (serialize-checkpoint-value
+      {:workflow/id workflow-run-id
+       :workflow/workflow-id (:execution/workflow-id ctx)
+       :workflow/workflow-version (:execution/workflow-version ctx)
+       :workflow/phases-completed phase-ids
+       :workflow/machine-snapshot-path
+       (machine-snapshot-path checkpoint-root workflow-run-id)
+       :workflow/phase-checkpoints phase-paths
+       :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Persistence and restore inputs

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -475,6 +475,7 @@
                                  (ctx/transition-to-failed)))))
              output-ctx (-> final-ctx validate-completion extract-output)]
          (vreset! output-ctx-vol output-ctx)
+         (checkpoint-store/persist-execution-state! output-ctx)
          (when-not skip-lifecycle?
            (events/publish-workflow-completed! event-stream output-ctx))
          output-ctx)

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -95,6 +95,48 @@
                               #"Invalid checkpoint data"
                               (checkpoint-store/persist-execution-state! invalid-ctx)))))))
 
+(deftest persist-execution-state-preserves-existing-phase-checkpoints-test
+  (testing "a resumed partial pipeline does not shrink the checkpoint manifest"
+    (with-temp-checkpoint-root
+      (fn [checkpoint-root]
+        (let [workflow-id (random-uuid)
+              initial-workflow {:workflow/id :test
+                                :workflow/version "1.0.0"
+                                :workflow/pipeline [{:phase :explore}
+                                                    {:phase :plan}
+                                                    {:phase :implement}
+                                                    {:phase :review}]}
+              resumed-workflow {:workflow/id :test
+                                :workflow/version "1.0.0"
+                                :workflow/pipeline [{:phase :release}]}
+              initial-ctx (-> (ctx/create-context initial-workflow {:task "Test"}
+                                                  {:checkpoint/root checkpoint-root})
+                              (assoc :execution/id workflow-id)
+                              (assoc :execution/phase-results
+                                     {:explore {:status :completed}
+                                      :plan {:status :completed}
+                                      :implement {:status :completed}
+                                      :review {:status :completed}}))
+              resumed-ctx (-> (ctx/create-context resumed-workflow {:task "Test"}
+                                                  {:checkpoint/root checkpoint-root})
+                              (assoc :execution/id workflow-id)
+                              (assoc :execution/phase-results
+                                     {:plan {:status :completed}
+                                      :implement {:status :completed}
+                                      :release {:status :failed}})
+                              (assoc :execution/current-phase :release))]
+          (checkpoint-store/persist-execution-state! initial-ctx)
+          (checkpoint-store/persist-execution-state! resumed-ctx)
+          (let [checkpoint-data (checkpoint-store/load-checkpoint-data
+                                 workflow-id
+                                 {:checkpoint/root checkpoint-root})]
+            (is (= #{:explore :plan :implement :review :release}
+                   (set (get-in checkpoint-data [:manifest :workflow/phases-completed]))))
+            (is (= {:status :completed}
+                   (get-in checkpoint-data [:phase-results :explore])))
+            (is (= {:status :failed}
+                   (get-in checkpoint-data [:phase-results :release])))))))))
+
 (deftest load-checkpoint-data-validates-at-interface-boundary-test
   (testing "invalid checkpoint payloads are rejected at the public interface"
     (with-redefs [checkpoint-store/load-checkpoint-data

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -130,8 +130,8 @@
           (let [checkpoint-data (checkpoint-store/load-checkpoint-data
                                  workflow-id
                                  {:checkpoint/root checkpoint-root})]
-            (is (= #{:explore :plan :implement :review :release}
-                   (set (get-in checkpoint-data [:manifest :workflow/phases-completed]))))
+            (is (= [:explore :plan :implement :review :release]
+                   (get-in checkpoint-data [:manifest :workflow/phases-completed])))
             (is (= {:status :completed}
                    (get-in checkpoint-data [:phase-results :explore])))
             (is (= {:status :failed}

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -84,6 +84,25 @@
           ctx (ctx/create-context workflow {:task "Test"} {:source-root source-root})]
       (is (= source-root (:source-root ctx))))))
 
+(deftest run-pipeline-persists-final-terminal-snapshot-test
+  (testing "terminal failures produced after the loop overwrite the running checkpoint"
+    (with-temp-checkpoint-root
+      (fn [checkpoint-root]
+        (let [workflow {:workflow/id :empty-test
+                        :workflow/version "1.0.0"
+                        :workflow/pipeline []}
+              result (runner/run-pipeline workflow {:task "Test"}
+                                          {:checkpoint/root checkpoint-root
+                                           :skip-lifecycle-events true})
+              checkpoint-data (checkpoint-store/load-checkpoint-data
+                               (:execution/id result)
+                               {:checkpoint/root checkpoint-root})]
+          (is (= :failed (:execution/status result)))
+          (is (= :failed (get-in checkpoint-data
+                                 [:machine-snapshot :execution/status])))
+          (is (seq (get-in checkpoint-data
+                           [:machine-snapshot :execution/errors]))))))))
+
 (deftest restore-context-can-reset-terminal-snapshot-test
   (testing "failed checkpoint snapshots can resume a trimmed workflow"
     (let [workflow {:workflow/id :test

--- a/docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md
+++ b/docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md
@@ -1,0 +1,65 @@
+# Fix: Dogfood Resume Checkpoint Repair
+
+## Overview
+
+This PR fixes resume behavior discovered while dogfooding the highest-priority
+event-log tool visibility spec. Resumed software-factory runs now restart from
+the first unfinished or repair-required phase instead of treating stale manifest
+entries as authoritative completion.
+
+## Motivation
+
+Dogfood run `3927baf8-c9db-44d3-b5fb-5a1552dbe554` repeatedly resumed into the
+wrong phase after review-driven repair and terminal release failure. The
+checkpoint manifest could preserve failed or stale phase names, and the resume
+trimmer removed completed phases globally rather than only trimming the completed
+prefix.
+
+## Changes in Detail
+
+- Resume now treats only successful phase results as completed.
+- Review `changes-requested` and rejected decisions block completion so repair
+  resumes at `implement`.
+- Pipeline trimming now removes only the leading completed prefix, preserving
+  later phases after the first incomplete phase.
+- Checkpoint manifest persistence now merges existing phase checkpoint paths so
+  partial resumed pipelines do not shrink historical checkpoint metadata.
+- Runner now persists the terminal execution snapshot before publishing the
+  completed workflow event.
+- Release `zero-files` responses now fail deterministically instead of entering
+  a retry loop.
+
+## Dogfood Notes
+
+- Resumed checkpoint: `3927baf8-c9db-44d3-b5fb-5a1552dbe554`
+- After these fixes, the run resumed from `implement`, advanced through
+  `verify` and `review`, and correctly returned to `implement` after review
+  changes were requested.
+- The next blocker is artifact extraction when agents do not submit
+  `artifact.edn`; the worktree/container contents should be valid provenance.
+
+## Testing Plan
+
+- `clojure -M:dev:test -e ...` for workflow resume, checkpoint store, and runner
+  tests: 51 tests, 155 assertions, 0 failures, 0 errors.
+- `bb test` passed before the final narrow runner test addition and after the
+  resume trim correction.
+
+## Deployment Plan
+
+Merge normally after review. These changes affect resume/checkpoint behavior and
+software-factory release failure classification only.
+
+## Related Issues/PRs
+
+- Dogfood target: `work/event-log-tool-visibility.spec.edn`
+- Follow-up bug: file-on-disk artifact provenance when MCP artifact submission is
+  missing.
+
+## Checklist
+
+- [x] Resume from checkpoint restarts at the correct repair phase.
+- [x] Failed or review-blocked phases are not treated as complete.
+- [x] Partial resumed pipeline manifests preserve prior checkpoint paths.
+- [x] Terminal workflow snapshots are persisted.
+- [ ] File-on-disk artifact provenance follow-up is fixed.


### PR DESCRIPTION
# Fix: Dogfood Resume Checkpoint Repair

## Overview

This PR fixes resume behavior discovered while dogfooding the highest-priority
event-log tool visibility spec. Resumed software-factory runs now restart from
the first unfinished or repair-required phase instead of treating stale manifest
entries as authoritative completion.

## Motivation

Dogfood run `3927baf8-c9db-44d3-b5fb-5a1552dbe554` repeatedly resumed into the
wrong phase after review-driven repair and terminal release failure. The
checkpoint manifest could preserve failed or stale phase names, and the resume
trimmer removed completed phases globally rather than only trimming the completed
prefix.

## Changes in Detail

- Resume now treats only successful phase results as completed.
- Review `changes-requested` and rejected decisions block completion so repair
  resumes at `implement`.
- Pipeline trimming now removes only the leading completed prefix, preserving
  later phases after the first incomplete phase.
- Checkpoint manifest persistence now merges existing phase checkpoint paths so
  partial resumed pipelines do not shrink historical checkpoint metadata.
- Runner now persists the terminal execution snapshot before publishing the
  completed workflow event.
- Release `zero-files` responses now fail deterministically instead of entering
  a retry loop.

## Dogfood Notes

- Resumed checkpoint: `3927baf8-c9db-44d3-b5fb-5a1552dbe554`
- After these fixes, the run resumed from `implement`, advanced through
  `verify` and `review`, and correctly returned to `implement` after review
  changes were requested.
- The next blocker is artifact extraction when agents do not submit
  `artifact.edn`; the worktree/container contents should be valid provenance.

## Testing Plan

- `clojure -M:dev:test -e ...` for workflow resume, checkpoint store, and runner
  tests: 51 tests, 155 assertions, 0 failures, 0 errors.
- `bb test` passed before the final narrow runner test addition and after the
  resume trim correction.

## Deployment Plan

Merge normally after review. These changes affect resume/checkpoint behavior and
software-factory release failure classification only.

## Related Issues/PRs

- Dogfood target: `work/event-log-tool-visibility.spec.edn`
- Follow-up bug: file-on-disk artifact provenance when MCP artifact submission is
  missing.

## Checklist

- [x] Resume from checkpoint restarts at the correct repair phase.
- [x] Failed or review-blocked phases are not treated as complete.
- [x] Partial resumed pipeline manifests preserve prior checkpoint paths.
- [x] Terminal workflow snapshots are persisted.
- [ ] File-on-disk artifact provenance follow-up is fixed.
