### PR TITLE
fix: derive artifacts from promoted worktree

### DIFF
--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -189,16 +189,37 @@
   [implementer-result]
   (get-in implementer-result [:output :code/files]))
 
+(defn- artifact-files
+  [artifact]
+  (:code/files artifact))
+
+(defn- executor-worktree-artifact
+  [{:keys [executor execute-fn env-id worktree-path base-refs]}]
+  (file-artifacts/collect-worktree-files-via-executor
+   execute-fn executor env-id worktree-path base-refs))
+
+(defn- executor-session-artifact
+  [{:keys [pre-session-snapshot executor execute-fn env-id worktree-path]}]
+  (when pre-session-snapshot
+    (file-artifacts/collect-written-files-via-executor
+     pre-session-snapshot execute-fn executor env-id worktree-path)))
+
 (defn- files-via-executor
   "Collect files via capsule executor (governed mode)."
-  [{:keys [pre-session-snapshot executor execute-fn env-id worktree-path base-refs]}]
+  [{:keys [executor execute-fn env-id worktree-path] :as input}]
   (when (and executor execute-fn env-id worktree-path)
-    (get (or (file-artifacts/collect-worktree-files-via-executor
-              execute-fn executor env-id worktree-path base-refs)
-             (when pre-session-snapshot
-               (file-artifacts/collect-written-files-via-executor
-                pre-session-snapshot execute-fn executor env-id worktree-path)))
-         :code/files)))
+    (artifact-files (or (executor-worktree-artifact input)
+                        (executor-session-artifact input)))))
+
+(defn- local-worktree-artifact
+  [{:keys [worktree-path base-refs]}]
+  (file-artifacts/collect-worktree-files worktree-path base-refs))
+
+(defn- local-session-artifact
+  [{:keys [pre-session-snapshot worktree-path]}]
+  (file-artifacts/collect-written-files
+   (or pre-session-snapshot (file-artifacts/empty-snapshot))
+   worktree-path))
 
 (defn- files-via-local-snapshot
   "Collect files via local git status (non-capsule fallback).
@@ -211,13 +232,10 @@
    the implementer wrote substantive files before the throw — observed
    in the 2026-05-08 dogfood (Run 7 produced 285 LOC that the curator
    rejected because the snapshot path short-circuited)."
-  [{:keys [pre-session-snapshot worktree-path base-refs]}]
+  [{:keys [worktree-path] :as input}]
   (when worktree-path
-    (get (or (file-artifacts/collect-worktree-files worktree-path base-refs)
-             (file-artifacts/collect-written-files
-              (or pre-session-snapshot (file-artifacts/empty-snapshot))
-              worktree-path))
-         :code/files)))
+    (artifact-files (or (local-worktree-artifact input)
+                        (local-session-artifact input)))))
 
 (def non-substantive-paths
   "Paths the curator drops before assessing 'files written.'

--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -191,10 +191,13 @@
 
 (defn- files-via-executor
   "Collect files via capsule executor (governed mode)."
-  [{:keys [pre-session-snapshot executor execute-fn env-id worktree-path]}]
-  (when (and pre-session-snapshot executor execute-fn env-id worktree-path)
-    (get (file-artifacts/collect-written-files-via-executor
-          pre-session-snapshot execute-fn executor env-id worktree-path)
+  [{:keys [pre-session-snapshot executor execute-fn env-id worktree-path base-refs]}]
+  (when (and executor execute-fn env-id worktree-path)
+    (get (or (file-artifacts/collect-worktree-files-via-executor
+              execute-fn executor env-id worktree-path base-refs)
+             (when pre-session-snapshot
+               (file-artifacts/collect-written-files-via-executor
+                pre-session-snapshot execute-fn executor env-id worktree-path)))
          :code/files)))
 
 (defn- files-via-local-snapshot
@@ -208,11 +211,12 @@
    the implementer wrote substantive files before the throw — observed
    in the 2026-05-08 dogfood (Run 7 produced 285 LOC that the curator
    rejected because the snapshot path short-circuited)."
-  [{:keys [pre-session-snapshot worktree-path]}]
+  [{:keys [pre-session-snapshot worktree-path base-refs]}]
   (when worktree-path
-    (get (file-artifacts/collect-written-files
-          (or pre-session-snapshot (file-artifacts/empty-snapshot))
-          worktree-path)
+    (get (or (file-artifacts/collect-worktree-files worktree-path base-refs)
+             (file-artifacts/collect-written-files
+              (or pre-session-snapshot (file-artifacts/empty-snapshot))
+              worktree-path))
          :code/files)))
 
 (def non-substantive-paths
@@ -555,8 +559,7 @@
            :conflicted-paths (vec (sort paths))}}))
 
 (defmethod curate :merge-resolution
-  [{:keys [worktree-path prior-conflicted-paths]
-    :as input}]
+  [{:keys [worktree-path prior-conflicted-paths]}]
   (let [current-paths (scan-conflicted-paths worktree-path)
         ;; Coerce prior-conflicted-paths to a set so callers can feed
         ;; the previous iteration's :conflicted-paths (a sorted vector

--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -74,6 +74,20 @@
       (modified? status) {:bucket :modified :path path}
       :else nil))))
 
+(defn- name-status-entry
+  "Parse one `git diff --name-status` line into an action/path pair."
+  [line]
+  (let [[status old-path new-path] (str/split line #"\t")
+        code (some-> status first)]
+    (case code
+      \A {:action :create :path old-path}
+      \D {:action :delete :path old-path}
+      \R {:action :modify :path new-path}
+      \C {:action :create :path new-path}
+      \M {:action :modify :path old-path}
+      \T {:action :modify :path old-path}
+      nil)))
+
 (defn empty-snapshot
   "Return an empty working tree snapshot."
   []
@@ -125,6 +139,43 @@
     {:create (disj created artifact-manifest-name)
      :modify (disj modified artifact-manifest-name)
      :delete (disj deleted artifact-manifest-name)}))
+
+(defn- add-diff-entry
+  "Add a parsed name-status entry into changed path sets."
+  [changed {:keys [action path]}]
+  (if (and action path)
+    (update changed action conj path)
+    changed))
+
+(defn- merge-changed
+  "Union changed path maps."
+  [& changeds]
+  (apply merge-with set/union changeds))
+
+(defn- snapshot->changed-paths
+  "Convert a current dirty snapshot into changed path sets."
+  [snapshot]
+  {:create (disj (set/union (:untracked snapshot #{})
+                            (:added snapshot #{}))
+                 artifact-manifest-name)
+   :modify (disj (:modified snapshot #{}) artifact-manifest-name)
+   :delete (disj (:deleted snapshot #{}) artifact-manifest-name)})
+
+(defn- diff-against-ref
+  "Return changed paths between `base-ref` and the current working tree."
+  [working-dir base-ref]
+  (when (and working-dir (string? base-ref) (not (str/blank? base-ref)))
+    (let [{:keys [exit out]} (shell/sh "git" "-C" working-dir
+                                       "diff" "--name-status" base-ref "--")]
+      (when (zero? exit)
+        (reduce add-diff-entry
+                {:create #{} :modify #{} :delete #{}}
+                (keep name-status-entry (str/split-lines out)))))))
+
+(defn- first-diff-against-ref
+  "Try base refs in order and return the first successful diff."
+  [working-dir base-refs]
+  (some #(diff-against-ref working-dir %) (filter some? base-refs)))
 
 (defn- synthetic-artifact
   "Build a synthetic code artifact from written file sets."
@@ -214,6 +265,33 @@
                (synthetic-artifact working-dir))))
       (catch Exception _
         nil))))
+
+(defn collect-worktree-files
+  "Collect the promoted worktree artifact.
+
+   Unlike `collect-written-files`, this is not limited to the current
+   LLM session. It compares the current worktree against the task base
+   ref when one is known, then merges in untracked dirty files. This is
+   the environment-promotion path: previously committed repair work is
+   still part of the artifact even when the current session only touched
+   one follow-up file or wrote nothing new."
+  ([working-dir]
+   (collect-worktree-files working-dir nil))
+  ([working-dir base-refs]
+   (when working-dir
+     (try
+       (let [snap (snapshot-working-dir working-dir)]
+         (when-not (anomaly/anomaly? snap)
+           (let [changed (merge-changed
+                          (or (first-diff-against-ref working-dir
+                                                      (if (sequential? base-refs)
+                                                        base-refs
+                                                        [base-refs]))
+                              {:create #{} :modify #{} :delete #{}})
+                          (snapshot->changed-paths snap))]
+             (synthetic-artifact working-dir changed))))
+       (catch Exception _
+         nil)))))
 
 (defn- safe-resolve
   "Resolve `path` under `working-dir` defensively. Returns a regular-file
@@ -335,6 +413,25 @@
                       (sort paths))))
        vec))
 
+(defn- diff-against-ref-via-executor
+  "Return changed paths between `base-ref` and the capsule working tree."
+  [exec! executor env-id working-dir base-ref]
+  (when (and base-ref (not (str/blank? base-ref)))
+    (let [result (exec! executor env-id
+                        (str "git diff --name-status " (pr-str base-ref) " --")
+                        {:workdir working-dir})]
+      (when (and (:ok? result) (zero? (get-in result [:data :exit-code] 1)))
+        (reduce add-diff-entry
+                {:create #{} :modify #{} :delete #{}}
+                (keep name-status-entry
+                      (str/split-lines (get-in result [:data :stdout] ""))))))))
+
+(defn- first-diff-against-ref-via-executor
+  "Try base refs in order inside the capsule."
+  [exec! executor env-id working-dir base-refs]
+  (some #(diff-against-ref-via-executor exec! executor env-id working-dir %)
+        (filter some? base-refs)))
+
 (defn collect-written-files-via-executor
   "Like collect-written-files but runs git status inside a capsule via executor.
    Reads file contents from the capsule for the synthetic artifact."
@@ -352,6 +449,30 @@
                  (read-manifest-via-executor exec! executor env-id working-dir))))
       (catch Exception _
         nil))))
+
+(defn collect-worktree-files-via-executor
+  "Like collect-worktree-files but reads git state and content in a capsule."
+  ([exec! executor env-id working-dir]
+   (collect-worktree-files-via-executor exec! executor env-id working-dir nil))
+  ([exec! executor env-id working-dir base-refs]
+   (when working-dir
+     (try
+       (let [snap (snapshot-via-executor exec! executor env-id working-dir)
+             changed (merge-changed
+                      (or (first-diff-against-ref-via-executor
+                           exec! executor env-id working-dir
+                           (if (sequential? base-refs) base-refs [base-refs]))
+                          {:create #{} :modify #{} :delete #{}})
+                      (snapshot->changed-paths snap))
+             files (changed-paths->file-entries changed exec! executor env-id working-dir)]
+         (when (seq files)
+           (merge {:code/files files
+                   :code/summary (str (count files)
+                                      " files collected from capsule working directory (no MCP submit)")
+                   :code/tests-needed? true}
+                  (read-manifest-via-executor exec! executor env-id working-dir))))
+       (catch Exception _
+         nil)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -33,6 +33,36 @@
   "Optional metadata manifest written by the agent."
   "miniforge-artifact.edn")
 
+(def ^:private failed-exit-code
+  "Default process exit code for missing executor status."
+  1)
+
+(def ^:private empty-changed-paths
+  {:create #{} :modify #{} :delete #{}})
+
+(defn- shell-quote
+  "Quote a value for a POSIX shell command string."
+  [value]
+  (str "'" (str/replace (str value) #"'" "'\"'\"'") "'"))
+
+(defn- valid-base-ref?
+  "True when `base-ref` can be used as a git diff base candidate."
+  [base-ref]
+  (and (string? base-ref) (not (str/blank? base-ref))))
+
+(defn- successful-exec?
+  "True when executor result reports success and a zero exit code."
+  [result]
+  (let [exit-code (get-in result [:data :exit-code] failed-exit-code)]
+    (and (:ok? result)
+         (zero? exit-code))))
+
+(defn- normalize-base-refs
+  [base-refs]
+  (if (sequential? base-refs)
+    base-refs
+    [base-refs]))
+
 (defn- tracked-addition?
   "Return true when the porcelain status indicates a newly added tracked file."
   [status]
@@ -63,30 +93,31 @@
   [line]
   (when (>= (count line) 3)
     (let [status (subs line 0 2)
-        raw-path (subs line 3)
-        path (if (str/includes? raw-path " -> ")
-               (second (str/split raw-path #" -> " 2))
-               raw-path)]
-    (cond
-      (= status "??") {:bucket :untracked :path path}
-      (deleted? status) {:bucket :deleted :path path}
-      (tracked-addition? status) {:bucket :added :path path}
-      (modified? status) {:bucket :modified :path path}
-      :else nil))))
+          raw-path (subs line 3)
+          path (if (str/includes? raw-path " -> ")
+                 (second (str/split raw-path #" -> " 2))
+                 raw-path)]
+      (cond
+        (= status "??") {:bucket :untracked :path path}
+        (deleted? status) {:bucket :deleted :path path}
+        (tracked-addition? status) {:bucket :added :path path}
+        (modified? status) {:bucket :modified :path path}
+        :else nil))))
 
-(defn- name-status-entry
-  "Parse one `git diff --name-status` line into an action/path pair."
+(defn- name-status-entries
+  "Parse one `git diff --name-status` line into action/path entries."
   [line]
   (let [[status old-path new-path] (str/split line #"\t")
         code (some-> status first)]
     (case code
-      \A {:action :create :path old-path}
-      \D {:action :delete :path old-path}
-      \R {:action :modify :path new-path}
-      \C {:action :create :path new-path}
-      \M {:action :modify :path old-path}
-      \T {:action :modify :path old-path}
-      nil)))
+      \A [{:action :create :path old-path}]
+      \D [{:action :delete :path old-path}]
+      \R [{:action :delete :path old-path}
+          {:action :create :path new-path}]
+      \C [{:action :create :path new-path}]
+      \M [{:action :modify :path old-path}]
+      \T [{:action :modify :path old-path}]
+      [])))
 
 (defn empty-snapshot
   "Return an empty working tree snapshot."
@@ -164,18 +195,27 @@
 (defn- diff-against-ref
   "Return changed paths between `base-ref` and the current working tree."
   [working-dir base-ref]
-  (when (and working-dir (string? base-ref) (not (str/blank? base-ref)))
+  (when (and working-dir (valid-base-ref? base-ref))
     (let [{:keys [exit out]} (shell/sh "git" "-C" working-dir
                                        "diff" "--name-status" base-ref "--")]
       (when (zero? exit)
         (reduce add-diff-entry
-                {:create #{} :modify #{} :delete #{}}
-                (keep name-status-entry (str/split-lines out)))))))
+                empty-changed-paths
+                (mapcat name-status-entries (str/split-lines out)))))))
 
 (defn- first-diff-against-ref
   "Try base refs in order and return the first successful diff."
   [working-dir base-refs]
-  (some #(diff-against-ref working-dir %) (filter some? base-refs)))
+  (some #(diff-against-ref working-dir %)
+        (filter valid-base-ref? base-refs)))
+
+(defn- worktree-changed-paths
+  "Merge committed task diff and current dirty snapshot paths."
+  [working-dir base-refs snapshot]
+  (merge-changed
+   (or (first-diff-against-ref working-dir (normalize-base-refs base-refs))
+       empty-changed-paths)
+   (snapshot->changed-paths snapshot)))
 
 (defn- synthetic-artifact
   "Build a synthetic code artifact from written file sets."
@@ -238,7 +278,7 @@
   (let [result (exec! executor env-id
                       "git status --porcelain=v1 --untracked-files=all --ignored=no -- ."
                       {:workdir working-dir})]
-    (if (and (:ok? result) (zero? (get-in result [:data :exit-code] 1)))
+    (if (successful-exec? result)
       (reduce add-entry
               (empty-snapshot)
               (keep porcelain-entry (str/split-lines (get-in result [:data :stdout] ""))))
@@ -282,14 +322,10 @@
      (try
        (let [snap (snapshot-working-dir working-dir)]
          (when-not (anomaly/anomaly? snap)
-           (let [changed (merge-changed
-                          (or (first-diff-against-ref working-dir
-                                                      (if (sequential? base-refs)
-                                                        base-refs
-                                                        [base-refs]))
-                              {:create #{} :modify #{} :delete #{}})
-                          (snapshot->changed-paths snap))]
-             (synthetic-artifact working-dir changed))))
+           (synthetic-artifact working-dir
+                               (worktree-changed-paths working-dir
+                                                       base-refs
+                                                       snap))))
        (catch Exception _
          nil)))))
 
@@ -378,16 +414,16 @@
 (defn- read-file-via-executor
   "Read a file's content from the capsule. Returns empty string on failure."
   [exec! executor env-id working-dir path]
-  (let [r (exec! executor env-id (str "cat " (pr-str path)) {:workdir working-dir})]
+  (let [r (exec! executor env-id (str "cat " (shell-quote path)) {:workdir working-dir})]
     (get-in r [:data :stdout] "")))
 
 (defn- read-manifest-via-executor
   "Read the artifact manifest from the capsule, if present."
   [exec! executor env-id working-dir]
   (let [r (exec! executor env-id
-                 (str "cat " (pr-str artifact-manifest-name))
+                 (str "cat " (shell-quote artifact-manifest-name))
                  {:workdir working-dir})]
-    (when (and (:ok? r) (zero? (get-in r [:data :exit-code] 1)))
+    (when (successful-exec? r)
       (try (-> (get-in r [:data :stdout])
                edn/read-string
                (select-keys [:code/summary :code/tests-needed?]))
@@ -416,21 +452,42 @@
 (defn- diff-against-ref-via-executor
   "Return changed paths between `base-ref` and the capsule working tree."
   [exec! executor env-id working-dir base-ref]
-  (when (and base-ref (not (str/blank? base-ref)))
+  (when (valid-base-ref? base-ref)
     (let [result (exec! executor env-id
-                        (str "git diff --name-status " (pr-str base-ref) " --")
+                        (str "git diff --name-status "
+                             (shell-quote base-ref)
+                             " --")
                         {:workdir working-dir})]
-      (when (and (:ok? result) (zero? (get-in result [:data :exit-code] 1)))
+      (when (successful-exec? result)
         (reduce add-diff-entry
-                {:create #{} :modify #{} :delete #{}}
-                (keep name-status-entry
-                      (str/split-lines (get-in result [:data :stdout] ""))))))))
+                empty-changed-paths
+                (mapcat name-status-entries
+                        (str/split-lines (get-in result [:data :stdout] ""))))))))
 
 (defn- first-diff-against-ref-via-executor
   "Try base refs in order inside the capsule."
   [exec! executor env-id working-dir base-refs]
   (some #(diff-against-ref-via-executor exec! executor env-id working-dir %)
-        (filter some? base-refs)))
+        (filter valid-base-ref? base-refs)))
+
+(defn- worktree-changed-paths-via-executor
+  "Merge committed task diff and current dirty snapshot paths in a capsule."
+  [exec! executor env-id working-dir base-refs snapshot]
+  (merge-changed
+   (or (first-diff-against-ref-via-executor
+        exec! executor env-id working-dir (normalize-base-refs base-refs))
+       empty-changed-paths)
+   (snapshot->changed-paths snapshot)))
+
+(defn- worktree-artifact-via-executor
+  [exec! executor env-id working-dir changed]
+  (let [files (changed-paths->file-entries changed exec! executor env-id working-dir)]
+    (when (seq files)
+      (merge {:code/files files
+              :code/summary (str (count files)
+                                 " files collected from capsule working directory (no MCP submit)")
+              :code/tests-needed? true}
+             (read-manifest-via-executor exec! executor env-id working-dir)))))
 
 (defn collect-written-files-via-executor
   "Like collect-written-files but runs git status inside a capsule via executor.
@@ -458,19 +515,9 @@
    (when working-dir
      (try
        (let [snap (snapshot-via-executor exec! executor env-id working-dir)
-             changed (merge-changed
-                      (or (first-diff-against-ref-via-executor
-                           exec! executor env-id working-dir
-                           (if (sequential? base-refs) base-refs [base-refs]))
-                          {:create #{} :modify #{} :delete #{}})
-                      (snapshot->changed-paths snap))
-             files (changed-paths->file-entries changed exec! executor env-id working-dir)]
-         (when (seq files)
-           (merge {:code/files files
-                   :code/summary (str (count files)
-                                      " files collected from capsule working directory (no MCP submit)")
-                   :code/tests-needed? true}
-                  (read-manifest-via-executor exec! executor env-id working-dir))))
+             changed (worktree-changed-paths-via-executor
+                      exec! executor env-id working-dir base-refs snap)]
+         (worktree-artifact-via-executor exec! executor env-id working-dir changed))
        (catch Exception _
          nil)))))
 

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -590,6 +590,20 @@
          base-refs))
       (file-artifacts/collect-worktree-files working-dir base-refs))))
 
+(defn- collect-session-artifact
+  "Collect a file artifact when the agent did not submit one explicitly."
+  [context session-mode working-dir pre-session-snapshot]
+  (or (collect-promoted-artifact context session-mode working-dir)
+      (if (= :capsule session-mode)
+        (file-artifacts/collect-written-files-via-executor
+         pre-session-snapshot
+         @(requiring-resolve 'ai.miniforge.dag-executor.executor/execute!)
+         (:execution/executor context)
+         (:execution/environment-id context)
+         working-dir)
+        (file-artifacts/collect-written-files pre-session-snapshot
+                                              working-dir))))
+
 (defn- invoke-with-llm
   "Invoke the implementer via the LLM backend."
   [llm-client user-prompt effective-system-prompt config context on-chunk logger
@@ -603,16 +617,10 @@
                                        config context on-chunk existing-files working-dir))
         response llm-result
         file-artifact (when-not artifact
-                        (or (collect-promoted-artifact context session-mode working-dir)
-                            (if (= :capsule session-mode)
-                              (file-artifacts/collect-written-files-via-executor
-                               pre-session-snapshot
-                               @(requiring-resolve 'ai.miniforge.dag-executor.executor/execute!)
-                               (:execution/executor context)
-                               (:execution/environment-id context)
-                               working-dir)
-                              (file-artifacts/collect-written-files pre-session-snapshot
-                                                                    working-dir))))
+                        (collect-session-artifact context
+                                                  session-mode
+                                                  working-dir
+                                                  pre-session-snapshot))
         normalized (result-boundary/normalize-llm-result
                     {:role :implement
                      :response response

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -564,6 +564,32 @@
       (write-session-checkpoint! working-dir new-session-id))
     result))
 
+(defn- base-ref-candidates
+  "Return candidate refs for computing the promoted task diff."
+  [context]
+  (let [base-sha (get-in context [:execution/environment-metadata :base-sha])
+        base-branch (or (get-in context [:execution/environment-metadata :base-branch])
+                        (get-in context [:execution/opts :branch])
+                        (get-in context [:execution/input :branch]))]
+    (cond-> []
+      base-sha (conj base-sha)
+      base-branch (conj (str "origin/" base-branch) base-branch))))
+
+(defn- collect-promoted-artifact
+  "Collect code files from the current promoted worktree/container state."
+  [context session-mode working-dir]
+  (let [base-refs (base-ref-candidates context)]
+    (if (= :capsule session-mode)
+      (when-let [exec! (or (:execution/execute-fn context)
+                           @(requiring-resolve 'ai.miniforge.dag-executor.executor/execute!))]
+        (file-artifacts/collect-worktree-files-via-executor
+         exec!
+         (:execution/executor context)
+         (:execution/environment-id context)
+         working-dir
+         base-refs))
+      (file-artifacts/collect-worktree-files working-dir base-refs))))
+
 (defn- invoke-with-llm
   "Invoke the implementer via the LLM backend."
   [llm-client user-prompt effective-system-prompt config context on-chunk logger
@@ -577,15 +603,16 @@
                                        config context on-chunk existing-files working-dir))
         response llm-result
         file-artifact (when-not artifact
-                        (if (= :capsule session-mode)
-                          (file-artifacts/collect-written-files-via-executor
-                           pre-session-snapshot
-                           @(requiring-resolve 'ai.miniforge.dag-executor.executor/execute!)
-                           (:execution/executor context)
-                           (:execution/environment-id context)
-                           working-dir)
-                          (file-artifacts/collect-written-files pre-session-snapshot
-                                                                working-dir)))
+                        (or (collect-promoted-artifact context session-mode working-dir)
+                            (if (= :capsule session-mode)
+                              (file-artifacts/collect-written-files-via-executor
+                               pre-session-snapshot
+                               @(requiring-resolve 'ai.miniforge.dag-executor.executor/execute!)
+                               (:execution/executor context)
+                               (:execution/environment-id context)
+                               working-dir)
+                              (file-artifacts/collect-written-files pre-session-snapshot
+                                                                    working-dir))))
         normalized (result-boundary/normalize-llm-result
                     {:role :implement
                      :response response

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -187,6 +187,10 @@
   "Collect files written during the agent session into a synthetic code artifact."
   file-artifacts/collect-written-files)
 
+(def collect-worktree-files
+  "Collect the promoted task artifact from the current worktree."
+  file-artifacts/collect-worktree-files)
+
 (def rehydrate-files
   "Reconstitute :code/files from recorded paths by reading the worktree.
    Used by downstream phases when the implement phase persisted only

--- a/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
@@ -26,6 +26,12 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test helpers
 
+(def success-exit-code
+  0)
+
+(def missing-base-exit-code
+  128)
+
 (defn- temp-dir
   "Create a temp directory for file artifact tests."
   []
@@ -65,7 +71,7 @@
   (testing "parses git porcelain output into working tree buckets"
     (with-redefs [clojure.java.shell/sh
                   (fn [& _]
-                    {:exit 0
+                    {:exit success-exit-code
                      :out (str "?? src/new_file.clj\n"
                                " M src/changed.clj\n"
                                "D  src/deleted.clj\n"
@@ -152,7 +158,7 @@
                         (make-snapshot :modified #{"src/dirty.clj"}))
                       clojure.java.shell/sh
                       (fn [& _]
-                        {:exit 0
+                        {:exit success-exit-code
                          :out "M\tsrc/committed.clj\n"
                          :err ""})]
           (let [artifact (sut/collect-worktree-files dir ["base-sha"])
@@ -171,13 +177,36 @@
                         (make-snapshot :modified #{"src/dirty.clj"}))
                       clojure.java.shell/sh
                       (fn [& _]
-                        {:exit 128
+                        {:exit missing-base-exit-code
                          :out ""
                          :err "bad revision"})]
           (is (= [{:path "src/dirty.clj"
                    :content "(ns dirty)"
                    :action :modify}]
                  (:code/files (sut/collect-worktree-files dir ["missing-base"])))))
+        (finally
+          (delete-tree! dir))))))
+
+(deftest collect-worktree-files-rename-test
+  (testing "diff renames delete the old path and create the new path"
+    (let [dir (temp-dir)]
+      (try
+        (write-file! dir "src/new.clj" "(ns new)")
+        (with-redefs [ai.miniforge.agent.file-artifacts/snapshot-working-dir
+                      (fn [_]
+                        (sut/empty-snapshot))
+                      clojure.java.shell/sh
+                      (fn [& _]
+                        {:exit success-exit-code
+                         :out "R100\tsrc/old.clj\tsrc/new.clj\n"
+                         :err ""})]
+          (is (= [{:path "src/new.clj"
+                   :content "(ns new)"
+                   :action :create}
+                  {:path "src/old.clj"
+                   :content ""
+                   :action :delete}]
+                 (:code/files (sut/collect-worktree-files dir ["base-sha"])))))
         (finally
           (delete-tree! dir))))))
 

--- a/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
@@ -141,6 +141,46 @@
         (finally
           (delete-tree! dir))))))
 
+(deftest collect-worktree-files-test
+  (testing "collects committed task diff plus current dirty files"
+    (let [dir (temp-dir)]
+      (try
+        (write-file! dir "src/committed.clj" "(ns committed)")
+        (write-file! dir "src/dirty.clj" "(ns dirty)")
+        (with-redefs [ai.miniforge.agent.file-artifacts/snapshot-working-dir
+                      (fn [_]
+                        (make-snapshot :modified #{"src/dirty.clj"}))
+                      clojure.java.shell/sh
+                      (fn [& _]
+                        {:exit 0
+                         :out "M\tsrc/committed.clj\n"
+                         :err ""})]
+          (let [artifact (sut/collect-worktree-files dir ["base-sha"])
+                paths (mapv :path (:code/files artifact))]
+            (is (= ["src/committed.clj" "src/dirty.clj"] paths))
+            (is (= #{:modify} (set (map :action (:code/files artifact)))))))
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "falls back to dirty worktree when base ref cannot be diffed"
+    (let [dir (temp-dir)]
+      (try
+        (write-file! dir "src/dirty.clj" "(ns dirty)")
+        (with-redefs [ai.miniforge.agent.file-artifacts/snapshot-working-dir
+                      (fn [_]
+                        (make-snapshot :modified #{"src/dirty.clj"}))
+                      clojure.java.shell/sh
+                      (fn [& _]
+                        {:exit 128
+                         :out ""
+                         :err "bad revision"})]
+          (is (= [{:path "src/dirty.clj"
+                   :content "(ns dirty)"
+                   :action :modify}]
+                 (:code/files (sut/collect-worktree-files dir ["missing-base"])))))
+        (finally
+          (delete-tree! dir))))))
+
 (deftest rehydrate-files-test
   (testing "reads file content from disk for each recorded path"
     (let [dir (temp-dir)]

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
@@ -589,7 +589,11 @@
       ;; Set push URL with token so persist-workspace! can push
       (when token
         (exec! (str "git -C " workdir " remote set-url --push origin "
-                    (authenticated-https-url https-url token host-kind)))))))
+                    (authenticated-https-url https-url token host-kind))))
+      (let [sha-r (exec! (str "git -C " workdir " rev-parse HEAD"))
+            base-sha (str/trim (get-in sha-r [:data :stdout] ""))]
+        (cond-> {:base-branch branch}
+          (seq base-sha) (assoc :base-sha base-sha))))))
 
 ;; ============================================================================
 ;; OciCliExecutor Record
@@ -627,16 +631,16 @@
                                           (:resources env-config)
                                           network)]
       (if (result/ok? create-result)
-        (do
-          ;; Bootstrap workspace: clone repo into container if repo-url provided (N11 §4.2)
-          (bootstrap-workspace! descriptor container-name workdir env-config)
-          ;; Capture image SHA256 digest for evidence record (N11 §11 SHOULD)
-          (let [image-digest (container-image-digest descriptor container-name)
-                metadata (cond-> (get create-result :data {})
-                           image-digest (assoc :image-digest image-digest))]
-            (result/ok (proto/create-environment-record
-                        container-name (descriptor/kind descriptor) task-id workdir
-                        (assoc env-config :metadata metadata)))))
+        ;; Bootstrap workspace: clone repo into container if repo-url provided (N11 §4.2)
+        (let [bootstrap-metadata (bootstrap-workspace! descriptor container-name workdir env-config)
+              ;; Capture image SHA256 digest for evidence record (N11 §11 SHOULD)
+              image-digest (container-image-digest descriptor container-name)
+              metadata (cond-> (merge (get create-result :data {})
+                                       bootstrap-metadata)
+                         image-digest (assoc :image-digest image-digest))]
+          (result/ok (proto/create-environment-record
+                      container-name (descriptor/kind descriptor) task-id workdir
+                      (assoc env-config :metadata metadata))))
         create-result)))
 
   (execute! [_this environment-id command opts]

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -136,13 +136,16 @@
   [base-path repo-path worktree-name branch]
   (locking worktree-lock
     (let [worktree-path (str base-path "/" worktree-name)
-          base-ref      (or (resolve-branch-sha repo-path branch) branch)]
+          base-sha      (resolve-branch-sha repo-path branch)
+          base-ref      (or base-sha branch)]
       (ensure-directory base-path)
       (let [result (run-git "-C" repo-path
                             "worktree" "add" "-b" worktree-name
                             worktree-path base-ref)]
         (if (zero? (:exit result))
-          (result/ok {:worktree-path worktree-path})
+          (result/ok {:worktree-path worktree-path
+                      :base-sha base-sha
+                      :base-ref branch})
           ;; Failed — clean up stale branch/directory from a prior run and retry
           (do
             (run-shell "rm" "-rf" worktree-path)
@@ -152,13 +155,17 @@
                                    "worktree" "add" "-b" worktree-name
                                    worktree-path base-ref)]
               (if (zero? (:exit result2))
-                (result/ok {:worktree-path worktree-path})
+                (result/ok {:worktree-path worktree-path
+                            :base-sha base-sha
+                            :base-ref branch})
                 ;; Still failing — detached HEAD as last resort
                 (let [result3 (run-git "-C" repo-path
                                        "worktree" "add" "--detach"
                                        worktree-path)]
                   (if (zero? (:exit result3))
-                    (result/ok {:worktree-path worktree-path})
+                    (result/ok {:worktree-path worktree-path
+                                :base-sha base-sha
+                                :base-ref branch})
                     (result/err :worktree-create-failed (:err result3))))))))))))
 
 (defn remove-worktree
@@ -568,12 +575,14 @@
           branch (get env-config :branch "main")
           create-result (create-worktree base-path repo-path worktree-name branch)]
       (if (result/ok? create-result)
-        (let [worktree-path (:worktree-path (:data create-result))]
+        (let [data (:data create-result)
+              worktree-path (:worktree-path data)]
           (result/ok (proto/create-environment-record
                       worktree-name :worktree task-id worktree-path
                       (assoc env-config
                              :metadata {:worktree-path worktree-path
                                         :repo-path repo-path
+                                        :base-sha (:base-sha data)
                                         ;; Stored so persist-workspace! can bundle
                                         ;; the right base..HEAD range without
                                         ;; guessing the parent branch.

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -105,6 +105,17 @@
       (throw (ex-info (messages/t :implement/no-worktree)
                       {:ctx-keys (keys ctx)}))))
 
+(defn- base-ref-candidates
+  "Return candidate refs for collecting the promoted task artifact."
+  [ctx]
+  (let [base-sha (get-in ctx [:execution/environment-metadata :base-sha])
+        base-branch (or (get-in ctx [:execution/environment-metadata :base-branch])
+                        (get-in ctx [:execution/opts :branch])
+                        (get-in ctx [:execution/input :branch]))]
+    (cond-> []
+      base-sha (conj base-sha)
+      base-branch (conj (str "origin/" base-branch) base-branch))))
+
 (defn- resolve-files-in-scope
   "Resolve files-in-scope from input, checking context and intent."
   [input]
@@ -267,6 +278,7 @@
             :executor (get ctx :execution/executor)
             :execute-fn (get ctx :execution/execute-fn)
             :pre-session-snapshot (get ctx :execution/pre-session-snapshot)
+            :base-refs (base-ref-candidates ctx)
             :intent-scope (get-in ctx [:execution/input :intent :scope])
             :spec-description (get-in ctx [:execution/input :description])
             :llm-client (get ctx :llm-backend)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -229,7 +229,8 @@
           files          (or (not-empty committed)
                              (not-empty dirty)
                              (throw (ex-info (messages/t :release/zero-files)
-                                             {:phase          :release
+                                             {:type           :release/zero-files
+                                              :phase          :release
                                               :environment-id (:environment-id impl-result)
                                               :worktree-path  worktree-path})))
           code-artifacts [{:artifact/type    :code
@@ -415,9 +416,8 @@
         iterations (get-in ctx [:phase :iterations] 1)
         max-iterations (get-in ctx [:phase :budget :iterations]
                                (get-in default-config [:budget :iterations]))
-        zero-files? (and (= (messages/t :release/zero-files)
-                            (get-in result [:error :message]))
-                         (= :release (get-in result [:error :data :phase])))
+        zero-files? (= :release/zero-files
+                       (get-in result [:error :data :type]))
         phase-status (if zero-files?
                        :failed
                        (phase/determine-phase-status

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -415,8 +415,13 @@
         iterations (get-in ctx [:phase :iterations] 1)
         max-iterations (get-in ctx [:phase :budget :iterations]
                                (get-in default-config [:budget :iterations]))
-        phase-status (phase/determine-phase-status
-                       agent-status iterations max-iterations)
+        zero-files? (and (= (messages/t :release/zero-files)
+                            (get-in result [:error :message]))
+                         (= :release (get-in result [:error :data :phase])))
+        phase-status (if zero-files?
+                       :failed
+                       (phase/determine-phase-status
+                        agent-status iterations max-iterations))
         pr-info (get-in ctx [:workflow/pr-info])
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -95,9 +95,18 @@
         inner-output       (get-in implement-phase-result [:result :output])
         worktree-path      (or (get ctx :execution/worktree-path)
                                (get ctx :worktree-path))
+        base-branch        (or (get-in ctx [:execution/environment-metadata :base-branch])
+                               (get-in ctx [:execution/opts :branch])
+                               (get-in ctx [:execution/input :branch]))
+        base-refs          (cond-> []
+                             (get-in ctx [:execution/environment-metadata :base-sha])
+                             (conj (get-in ctx [:execution/environment-metadata :base-sha]))
+                             base-branch
+                             (conj (str "origin/" base-branch) base-branch))
         worktree-artifact  (when worktree-path
-                             (agent/collect-written-files (agent/empty-snapshot)
-                                                          worktree-path))]
+                             (or (agent/collect-worktree-files worktree-path base-refs)
+                                 (agent/collect-written-files (agent/empty-snapshot)
+                                                              worktree-path)))]
     (or
      (when (:code/files outer-artifact)        outer-artifact)
      (when (:code/files inner-artifact)        inner-artifact)

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -634,6 +634,20 @@
       (is (= 0 (get-in result [:phase :duration-ms]))
           "Duration should default to 0 when start-time is nil"))))
 
+(deftest leave-release-detects-zero-files-by-error-type-test
+  (testing "zero-files failures do not depend on localized error text"
+    (let [interceptor (phase/get-phase-interceptor {:phase :release})
+          ctx {:phase {:started-at (System/currentTimeMillis)
+                       :result {:status :success
+                                :error {:message "translated message"
+                                        :data {:type :release/zero-files
+                                               :phase :release}}}
+                       :budget {:iterations 2}
+                       :iterations 1}
+               :execution/metrics {:tokens 0 :duration-ms 0}}
+          result ((:leave interceptor) ctx)]
+      (is (= :failed (get-in result [:phase :status]))))))
+
 ;------------------------------------------------------------------------------ Layer 2: Interceptor Leave Tests
 
 (deftest leave-release-records-metrics-test

--- a/components/workflow-resume/resources/config/workflow-resume/resume.edn
+++ b/components/workflow-resume/resources/config/workflow-resume/resume.edn
@@ -1,0 +1,8 @@
+{:workflow-resume/resume
+ {:completed-phase-statuses #{:completed
+                              :success
+                              :succeeded
+                              :already-implemented
+                              :already-satisfied}
+  :blocking-review-decisions #{:changes-requested
+                               :rejected}}}

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -310,11 +310,12 @@
 ;; Pipeline trimming
 
 (defn trim-pipeline
-  "Drop already-completed phases from a workflow's pipeline.
+  "Drop the already-completed prefix from a workflow's pipeline.
 
    Pure: takes a workflow map with `:workflow/pipeline` and a
-   collection of completed phase keywords; returns the workflow with
-   its pipeline reduced to only the remaining phases."
+   collection of completed phase keywords; returns the workflow with only
+   leading completed phases removed. Completed phases after the first
+   incomplete phase are preserved."
   [workflow completed-phases]
   (schema/validate! schema/TrimPipelineInput
                     {:workflow workflow :completed-phases completed-phases}

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -142,10 +142,73 @@
   (or (boolean (seq (get by-type :workflow/failed)))
       (= :failed (checkpoint-status checkpoint-data))))
 
+(def completed-phase-statuses
+  "Phase result statuses that are safe to skip on resume."
+  #{:completed :success :succeeded :already-implemented :already-satisfied})
+
+(def blocking-review-decisions
+  "Review decisions that must resume the repair path."
+  #{:changes-requested :rejected})
+
+(defn- phase-result-status
+  [phase-result]
+  (or (:status phase-result)
+      (:phase/status phase-result)
+      (:outcome phase-result)
+      (:phase/outcome phase-result)
+      (get-in phase-result [:result :status])
+      (get-in phase-result [:phase/result :status])))
+
+(defn- review-blocked?
+  [phase-id phase-result]
+  (and (= :review phase-id)
+       (contains? blocking-review-decisions
+                  (or (:review/decision phase-result)
+                      (get-in phase-result [:result :review/decision])
+                      (get-in phase-result [:result :output :review/decision])
+                      (get-in phase-result [:phase/result :review/decision])
+                      (get-in phase-result [:phase/result :output :review/decision])
+                      (get-in phase-result [:result :decision])
+                      (:decision phase-result)))))
+
+(defn- completed-phase-result?
+  [phase-id phase-result]
+  (and phase-result
+       (not (review-blocked? phase-id phase-result))
+       (contains? completed-phase-statuses
+                  (phase-result-status phase-result))))
+
+(defn- checkpoint-phase-order
+  [checkpoint-data phase-results]
+  (let [manifest-order (get-in checkpoint-data [:manifest :workflow/phases-completed])]
+    (vec (concat manifest-order
+                 (remove (set manifest-order) (keys phase-results))))))
+
+(defn- event-phase-order
+  [events]
+  (->> events
+       (filter #(= :workflow/phase-completed (:event/type %)))
+       (map :workflow/phase)
+       distinct
+       vec))
+
+(defn- completed-checkpoint-phases
+  [checkpoint-data phase-results]
+  (->> (checkpoint-phase-order checkpoint-data phase-results)
+       (filter #(completed-phase-result? % (get phase-results %)))))
+
+(defn- completed-event-phases
+  [events]
+  (let [event-results (extract-phase-results events)]
+    (->> (event-phase-order events)
+         (filter #(completed-phase-result? % (get event-results %))))))
+
 (defn- restored-completed-phases
-  [checkpoint-data events]
-  (or (some-> checkpoint-data :manifest :workflow/phases-completed)
-      (extract-completed-phases events)))
+  [checkpoint-data events phase-results]
+  (->> (concat (completed-event-phases events)
+               (completed-checkpoint-phases checkpoint-data phase-results))
+       distinct
+       vec))
 
 (defn- restored-phase-results
   [checkpoint-data events]
@@ -217,8 +280,8 @@
         events (vec (filter schema/valid-event? raw-events))
         _ (ensure-reconstruction-source! checkpoint-data events-dir workflow-id raw-events)
         by-type (group-by :event/type events)
-        completed-phases (restored-completed-phases checkpoint-data events)
         phase-results (restored-phase-results checkpoint-data events)
+        completed-phases (restored-completed-phases checkpoint-data events phase-results)
         workflow-spec (find-workflow-spec events)
         started-event (first (get by-type :workflow/started))
         machine-snapshot (:machine-snapshot checkpoint-data)
@@ -257,8 +320,8 @@
                     {:workflow workflow :completed-phases completed-phases}
                     {:message "Invalid trim-pipeline input"})
   (let [completed-set (set completed-phases)
-        remaining (vec (remove #(completed-set (:phase %))
-                               (get workflow :workflow/pipeline [])))]
+        remaining (vec (drop-while #(completed-set (:phase %))
+                                   (get workflow :workflow/pipeline [])))]
     (assoc workflow :workflow/pipeline remaining)))
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -39,6 +39,8 @@
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.workflow-resume.schema :as schema]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -142,13 +144,31 @@
   (or (boolean (seq (get by-type :workflow/failed)))
       (= :failed (checkpoint-status checkpoint-data))))
 
+(def ^:private resume-config-resource
+  "config/workflow-resume/resume.edn")
+
+(defn- read-resume-config
+  []
+  (if-let [resource (io/resource resume-config-resource)]
+    (:workflow-resume/resume (edn/read-string (slurp resource)))
+    (response/throw-anomaly! :anomalies/not-found
+                             "Workflow resume config resource not found"
+                             {:resource resume-config-resource})))
+
+(def ^:private resume-config
+  (delay (read-resume-config)))
+
+(defn- config-set
+  [k]
+  (set (get @resume-config k)))
+
 (def completed-phase-statuses
   "Phase result statuses that are safe to skip on resume."
-  #{:completed :success :succeeded :already-implemented :already-satisfied})
+  (config-set :completed-phase-statuses))
 
 (def blocking-review-decisions
   "Review decisions that must resume the repair path."
-  #{:changes-requested :rejected})
+  (config-set :blocking-review-decisions))
 
 (defn- phase-result-status
   [phase-result]

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -132,7 +132,21 @@
 
   (testing "all phases completed → empty pipeline"
     (let [wf {:workflow/pipeline [{:phase :a} {:phase :b}]}]
-      (is (= [] (:workflow/pipeline (core/trim-pipeline wf [:a :b])))))))
+      (is (= [] (:workflow/pipeline (core/trim-pipeline wf [:a :b]))))))
+
+  (testing "non-contiguous completed phases do not skip phases after the first gap"
+    (let [wf {:workflow/pipeline [{:phase :explore}
+                                  {:phase :plan}
+                                  {:phase :implement}
+                                  {:phase :verify}
+                                  {:phase :review}
+                                  {:phase :release}]}
+          trimmed (core/trim-pipeline wf [:explore :plan :verify])]
+      (is (= [{:phase :implement}
+              {:phase :verify}
+              {:phase :review}
+              {:phase :release}]
+             (:workflow/pipeline trimmed))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; resolve-workflow-identity
@@ -272,6 +286,49 @@
           (is (true? (:dag-paused? ctx)))
           (is (= :rate-limit (:dag-pause-reason ctx)))
           (is (= 0 (:event-count ctx))))))))
+
+(deftest reconstruct-context-trims-only-completed-checkpoint-phases-test
+  (testing "checkpoint manifests may list failed/retrying phases; resume skips only completed results"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/id workflow-id
+                                             :execution/workflow-id :canonical-sdlc
+                                             :execution/workflow-version "1.0.0"
+                                             :execution/status :failed}
+                           :manifest {:workflow/phases-completed [:explore :plan :implement :review :release]}
+                           :phase-results {:explore {:status :completed}
+                                           :plan {:status :completed}
+                                           :implement {:status :completed}
+                                           :review {:status :completed
+                                                    :review/decision :changes-requested}
+                                           :release {:status :retrying}}}]
+      (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (= [:explore :plan :implement] (:completed-phases ctx))))))))
+
+(deftest reconstruct-context-merges-latest-successful-events-with-checkpoint-test
+  (testing "a damaged manifest can still resume from successful event history"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/id workflow-id
+                                             :execution/workflow-id :canonical-sdlc
+                                             :execution/workflow-version "1.0.0"
+                                             :execution/status :failed}
+                           :manifest {:workflow/phases-completed [:release :plan]}
+                           :phase-results {:release {:status :retrying}
+                                           :plan {:status :completed}}}
+          events [{:event/type :workflow/phase-completed
+                   :workflow/phase :explore
+                   :phase/outcome :success}
+                  {:event/type :workflow/phase-completed
+                   :workflow/phase :implement
+                   :phase/outcome :failure}
+                  {:event/type :workflow/phase-completed
+                   :workflow/phase :verify
+                   :phase/outcome :success}]]
+      (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] events)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (= [:explore :verify :plan] (:completed-phases ctx))))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Interface re-exports

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -211,6 +211,32 @@
 (defn- write-event! [^java.io.File dir filename event-map]
   (spit (io/file dir filename) (json/generate-string event-map)))
 
+(def resume-checkpoint-config
+  {:base-machine-snapshot {:execution/workflow-id :canonical-sdlc
+                           :execution/workflow-version "1.0.0"
+                           :execution/status :failed}
+   :blocked-review {:manifest {:workflow/phases-completed [:explore
+                                                           :plan
+                                                           :implement
+                                                           :review
+                                                           :release]}
+                    :phase-results {:explore {:status :completed}
+                                    :plan {:status :completed}
+                                    :implement {:status :completed}
+                                    :review {:status :completed
+                                             :review/decision :changes-requested}
+                                    :release {:status :retrying}}}
+   :damaged-manifest {:manifest {:workflow/phases-completed [:release :plan]}
+                      :phase-results {:release {:status :retrying}
+                                      :plan {:status :completed}}}})
+
+(defn- configured-checkpoint-data
+  [config-key workflow-id]
+  (let [checkpoint (get resume-checkpoint-config config-key)]
+    (assoc checkpoint :machine-snapshot
+           (assoc (:base-machine-snapshot resume-checkpoint-config)
+                  :execution/id workflow-id))))
+
 (deftest reconstruct-context-integration-test
   (with-temp-events-dir
     (fn [base-dir]
@@ -290,17 +316,8 @@
 (deftest reconstruct-context-trims-only-completed-checkpoint-phases-test
   (testing "checkpoint manifests may list failed/retrying phases; resume skips only completed results"
     (let [workflow-id (str (random-uuid))
-          checkpoint-data {:machine-snapshot {:execution/id workflow-id
-                                             :execution/workflow-id :canonical-sdlc
-                                             :execution/workflow-version "1.0.0"
-                                             :execution/status :failed}
-                           :manifest {:workflow/phases-completed [:explore :plan :implement :review :release]}
-                           :phase-results {:explore {:status :completed}
-                                           :plan {:status :completed}
-                                           :implement {:status :completed}
-                                           :review {:status :completed
-                                                    :review/decision :changes-requested}
-                                           :release {:status :retrying}}}]
+          checkpoint-data (configured-checkpoint-data :blocked-review
+                                                      workflow-id)]
       (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
                     es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
         (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
@@ -309,13 +326,8 @@
 (deftest reconstruct-context-merges-latest-successful-events-with-checkpoint-test
   (testing "a damaged manifest can still resume from successful event history"
     (let [workflow-id (str (random-uuid))
-          checkpoint-data {:machine-snapshot {:execution/id workflow-id
-                                             :execution/workflow-id :canonical-sdlc
-                                             :execution/workflow-version "1.0.0"
-                                             :execution/status :failed}
-                           :manifest {:workflow/phases-completed [:release :plan]}
-                           :phase-results {:release {:status :retrying}
-                                           :plan {:status :completed}}}
+          checkpoint-data (configured-checkpoint-data :damaged-manifest
+                                                      workflow-id)
           events [{:event/type :workflow/phase-completed
                    :workflow/phase :explore
                    :phase/outcome :success}

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -191,14 +191,23 @@
 
 (defn build-manifest
   "Build the durable checkpoint manifest for an execution context."
-  [ctx checkpoint-root]
+  ([ctx checkpoint-root]
+   (build-manifest ctx checkpoint-root nil))
+  ([ctx checkpoint-root existing-manifest]
   (let [workflow-run-id (:execution/id ctx)
-        phase-ids (ordered-phase-ids ctx)
-        phase-paths (into {}
-                          (map (fn [phase-id]
-                                 [phase-id
-                                  (phase-checkpoint-path checkpoint-root workflow-run-id phase-id)]))
-                          phase-ids)]
+        current-phase-ids (ordered-phase-ids ctx)
+        existing-phase-paths (:workflow/phase-checkpoints existing-manifest)
+        phase-ids (vec (concat (keys existing-phase-paths)
+                               (remove (set (keys existing-phase-paths))
+                                       current-phase-ids)))
+        current-phase-paths (into {}
+                                  (map (fn [phase-id]
+                                         [phase-id
+                                          (phase-checkpoint-path checkpoint-root
+                                                                 workflow-run-id
+                                                                 phase-id)]))
+                                  current-phase-ids)
+        phase-paths (merge existing-phase-paths current-phase-paths)]
     (serialize-checkpoint-value
      {:workflow/id workflow-run-id
       :workflow/workflow-id (:execution/workflow-id ctx)
@@ -207,7 +216,7 @@
       :workflow/machine-snapshot-path
       (machine-snapshot-path checkpoint-root workflow-run-id)
       :workflow/phase-checkpoints phase-paths
-      :workflow/last-checkpoint-at (current-checkpoint-timestamp)})))
+      :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Persistence and restore inputs
@@ -221,8 +230,9 @@
           phase-result (get-in ctx [:execution/phase-results phase-name])
           snapshot-path' (machine-snapshot-path checkpoint-root workflow-run-id)
           manifest-path' (manifest-path checkpoint-root workflow-run-id)
+          existing-manifest (read-edn-file manifest-path')
           snapshot (build-machine-snapshot ctx)
-          manifest (build-manifest ctx checkpoint-root)
+          manifest (build-manifest ctx checkpoint-root existing-manifest)
           checkpoint-data {:checkpoint/root checkpoint-root
                            :manifest manifest
                            :machine-snapshot snapshot

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -194,29 +194,31 @@
   ([ctx checkpoint-root]
    (build-manifest ctx checkpoint-root nil))
   ([ctx checkpoint-root existing-manifest]
-  (let [workflow-run-id (:execution/id ctx)
-        current-phase-ids (ordered-phase-ids ctx)
-        existing-phase-paths (:workflow/phase-checkpoints existing-manifest)
-        phase-ids (vec (concat (keys existing-phase-paths)
-                               (remove (set (keys existing-phase-paths))
-                                       current-phase-ids)))
-        current-phase-paths (into {}
-                                  (map (fn [phase-id]
-                                         [phase-id
-                                          (phase-checkpoint-path checkpoint-root
-                                                                 workflow-run-id
-                                                                 phase-id)]))
-                                  current-phase-ids)
-        phase-paths (merge existing-phase-paths current-phase-paths)]
-    (serialize-checkpoint-value
-     {:workflow/id workflow-run-id
-      :workflow/workflow-id (:execution/workflow-id ctx)
-      :workflow/workflow-version (:execution/workflow-version ctx)
-      :workflow/phases-completed phase-ids
-      :workflow/machine-snapshot-path
-      (machine-snapshot-path checkpoint-root workflow-run-id)
-      :workflow/phase-checkpoints phase-paths
-      :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))
+   (let [workflow-run-id (:execution/id ctx)
+         current-phase-ids (ordered-phase-ids ctx)
+         existing-phase-paths (or (:workflow/phase-checkpoints existing-manifest) {})
+         existing-phase-ids (or (not-empty (:workflow/phases-completed existing-manifest))
+                                (sort-by name (keys existing-phase-paths)))
+         phase-ids (vec (concat existing-phase-ids
+                                (remove (set existing-phase-ids)
+                                        current-phase-ids)))
+         current-phase-paths (into {}
+                                   (map (fn [phase-id]
+                                          [phase-id
+                                           (phase-checkpoint-path checkpoint-root
+                                                                  workflow-run-id
+                                                                  phase-id)]))
+                                   current-phase-ids)
+         phase-paths (merge existing-phase-paths current-phase-paths)]
+     (serialize-checkpoint-value
+      {:workflow/id workflow-run-id
+       :workflow/workflow-id (:execution/workflow-id ctx)
+       :workflow/workflow-version (:execution/workflow-version ctx)
+       :workflow/phases-completed phase-ids
+       :workflow/machine-snapshot-path
+       (machine-snapshot-path checkpoint-root workflow-run-id)
+       :workflow/phase-checkpoints phase-paths
+       :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Persistence and restore inputs

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -475,6 +475,7 @@
                                  (ctx/transition-to-failed)))))
              output-ctx (-> final-ctx validate-completion extract-output)]
          (vreset! output-ctx-vol output-ctx)
+         (checkpoint-store/persist-execution-state! output-ctx)
          (when-not skip-lifecycle?
            (events/publish-workflow-completed! event-stream output-ctx))
          output-ctx)

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -95,6 +95,48 @@
                               #"Invalid checkpoint data"
                               (checkpoint-store/persist-execution-state! invalid-ctx)))))))
 
+(deftest persist-execution-state-preserves-existing-phase-checkpoints-test
+  (testing "a resumed partial pipeline does not shrink the checkpoint manifest"
+    (with-temp-checkpoint-root
+      (fn [checkpoint-root]
+        (let [workflow-id (random-uuid)
+              initial-workflow {:workflow/id :test
+                                :workflow/version "1.0.0"
+                                :workflow/pipeline [{:phase :explore}
+                                                    {:phase :plan}
+                                                    {:phase :implement}
+                                                    {:phase :review}]}
+              resumed-workflow {:workflow/id :test
+                                :workflow/version "1.0.0"
+                                :workflow/pipeline [{:phase :release}]}
+              initial-ctx (-> (ctx/create-context initial-workflow {:task "Test"}
+                                                  {:checkpoint/root checkpoint-root})
+                              (assoc :execution/id workflow-id)
+                              (assoc :execution/phase-results
+                                     {:explore {:status :completed}
+                                      :plan {:status :completed}
+                                      :implement {:status :completed}
+                                      :review {:status :completed}}))
+              resumed-ctx (-> (ctx/create-context resumed-workflow {:task "Test"}
+                                                  {:checkpoint/root checkpoint-root})
+                              (assoc :execution/id workflow-id)
+                              (assoc :execution/phase-results
+                                     {:plan {:status :completed}
+                                      :implement {:status :completed}
+                                      :release {:status :failed}})
+                              (assoc :execution/current-phase :release))]
+          (checkpoint-store/persist-execution-state! initial-ctx)
+          (checkpoint-store/persist-execution-state! resumed-ctx)
+          (let [checkpoint-data (checkpoint-store/load-checkpoint-data
+                                 workflow-id
+                                 {:checkpoint/root checkpoint-root})]
+            (is (= #{:explore :plan :implement :review :release}
+                   (set (get-in checkpoint-data [:manifest :workflow/phases-completed]))))
+            (is (= {:status :completed}
+                   (get-in checkpoint-data [:phase-results :explore])))
+            (is (= {:status :failed}
+                   (get-in checkpoint-data [:phase-results :release])))))))))
+
 (deftest load-checkpoint-data-validates-at-interface-boundary-test
   (testing "invalid checkpoint payloads are rejected at the public interface"
     (with-redefs [checkpoint-store/load-checkpoint-data

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -130,8 +130,8 @@
           (let [checkpoint-data (checkpoint-store/load-checkpoint-data
                                  workflow-id
                                  {:checkpoint/root checkpoint-root})]
-            (is (= #{:explore :plan :implement :review :release}
-                   (set (get-in checkpoint-data [:manifest :workflow/phases-completed]))))
+            (is (= [:explore :plan :implement :review :release]
+                   (get-in checkpoint-data [:manifest :workflow/phases-completed])))
             (is (= {:status :completed}
                    (get-in checkpoint-data [:phase-results :explore])))
             (is (= {:status :failed}

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -84,6 +84,25 @@
           ctx (ctx/create-context workflow {:task "Test"} {:source-root source-root})]
       (is (= source-root (:source-root ctx))))))
 
+(deftest run-pipeline-persists-final-terminal-snapshot-test
+  (testing "terminal failures produced after the loop overwrite the running checkpoint"
+    (with-temp-checkpoint-root
+      (fn [checkpoint-root]
+        (let [workflow {:workflow/id :empty-test
+                        :workflow/version "1.0.0"
+                        :workflow/pipeline []}
+              result (runner/run-pipeline workflow {:task "Test"}
+                                          {:checkpoint/root checkpoint-root
+                                           :skip-lifecycle-events true})
+              checkpoint-data (checkpoint-store/load-checkpoint-data
+                               (:execution/id result)
+                               {:checkpoint/root checkpoint-root})]
+          (is (= :failed (:execution/status result)))
+          (is (= :failed (get-in checkpoint-data
+                                 [:machine-snapshot :execution/status])))
+          (is (seq (get-in checkpoint-data
+                           [:machine-snapshot :execution/errors]))))))))
+
 (deftest restore-context-can-reset-terminal-snapshot-test
   (testing "failed checkpoint snapshots can resume a trimmed workflow"
     (let [workflow {:workflow/id :test

--- a/docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md
+++ b/docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md
@@ -1,0 +1,63 @@
+# Fix: Dogfood Artifact Provenance
+
+## Overview
+
+This stacked PR fixes the artifact extraction failure that surfaced after the
+checkpoint resume repair. When agents do not submit `artifact.edn`, Miniforge now
+treats the promoted worktree or container workspace as valid artifact
+provenance.
+
+## Motivation
+
+Dogfood resume reached implement/review correctly, then failed again because the
+fallback artifact collector only looked at the latest agent-session delta. In
+repair loops, the relevant implementation can already be committed or otherwise
+present in the promoted worktree, while the latest turn may touch only one file
+or no files. That made valid task output look like `:curator/no-files-written`.
+
+Agents still should submit artifacts explicitly when they can, but file state in
+the task worktree/container is authoritative enough for code artifacts because
+the environment itself is what Miniforge promotes.
+
+## Changes in Detail
+
+- Added promoted-worktree artifact collection that diffs the task workspace
+  against captured base refs and merges current dirty or untracked files.
+- Captured base SHA metadata when creating local worktree and OCI container
+  execution environments.
+- Updated implementer and curator fallback extraction to prefer promoted
+  worktree/container artifacts before using the old per-session delta fallback.
+- Updated review artifact resolution so downstream phases can recover file
+  artifacts from the worktree even when the implement phase missed explicit
+  artifact submission.
+- Covered committed task diff plus dirty-file fallback behavior.
+
+## Stacking
+
+This PR is stacked on:
+
+- `fix/dogfood-resume-checkpoint-repair`
+- PR #875
+
+The resume/checkpoint repair should merge first. This PR addresses the next
+blocker discovered by that dogfood pass.
+
+## Testing Plan
+
+- Targeted artifact/review tests: 14 tests, 45 assertions, 0 failures, 0 errors.
+- Broader agent/factory/executor targeted tests: 123 tests, 377 assertions, 0
+  failures, 0 errors.
+- `bb test` passed across the stable-derived test plan with only existing
+  unresolved-var warnings.
+
+## Deployment Plan
+
+Merge after PR #875. No migration is required. The change only broadens fallback
+artifact extraction when explicit MCP artifact submission is missing.
+
+## Checklist
+
+- [x] Explicit artifacts still win when present.
+- [x] Files on disk are treated as valid fallback artifacts.
+- [x] Container/worktree base refs are captured for task diffing.
+- [x] Dirty and untracked files remain included when base diffing fails.

--- a/docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md
+++ b/docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md
@@ -1,0 +1,65 @@
+# Fix: Dogfood Resume Checkpoint Repair
+
+## Overview
+
+This PR fixes resume behavior discovered while dogfooding the highest-priority
+event-log tool visibility spec. Resumed software-factory runs now restart from
+the first unfinished or repair-required phase instead of treating stale manifest
+entries as authoritative completion.
+
+## Motivation
+
+Dogfood run `3927baf8-c9db-44d3-b5fb-5a1552dbe554` repeatedly resumed into the
+wrong phase after review-driven repair and terminal release failure. The
+checkpoint manifest could preserve failed or stale phase names, and the resume
+trimmer removed completed phases globally rather than only trimming the completed
+prefix.
+
+## Changes in Detail
+
+- Resume now treats only successful phase results as completed.
+- Review `changes-requested` and rejected decisions block completion so repair
+  resumes at `implement`.
+- Pipeline trimming now removes only the leading completed prefix, preserving
+  later phases after the first incomplete phase.
+- Checkpoint manifest persistence now merges existing phase checkpoint paths so
+  partial resumed pipelines do not shrink historical checkpoint metadata.
+- Runner now persists the terminal execution snapshot before publishing the
+  completed workflow event.
+- Release `zero-files` responses now fail deterministically instead of entering
+  a retry loop.
+
+## Dogfood Notes
+
+- Resumed checkpoint: `3927baf8-c9db-44d3-b5fb-5a1552dbe554`
+- After these fixes, the run resumed from `implement`, advanced through
+  `verify` and `review`, and correctly returned to `implement` after review
+  changes were requested.
+- The next blocker is artifact extraction when agents do not submit
+  `artifact.edn`; the worktree/container contents should be valid provenance.
+
+## Testing Plan
+
+- `clojure -M:dev:test -e ...` for workflow resume, checkpoint store, and runner
+  tests: 51 tests, 155 assertions, 0 failures, 0 errors.
+- `bb test` passed before the final narrow runner test addition and after the
+  resume trim correction.
+
+## Deployment Plan
+
+Merge normally after review. These changes affect resume/checkpoint behavior and
+software-factory release failure classification only.
+
+## Related Issues/PRs
+
+- Dogfood target: `work/event-log-tool-visibility.spec.edn`
+- Follow-up bug: file-on-disk artifact provenance when MCP artifact submission is
+  missing.
+
+## Checklist
+
+- [x] Resume from checkpoint restarts at the correct repair phase.
+- [x] Failed or review-blocked phases are not treated as complete.
+- [x] Partial resumed pipeline manifests preserve prior checkpoint paths.
+- [x] Terminal workflow snapshots are persisted.
+- [ ] File-on-disk artifact provenance follow-up is fixed.


### PR DESCRIPTION
# Fix: Dogfood Artifact Provenance

## Overview

This stacked PR fixes the artifact extraction failure that surfaced after the
checkpoint resume repair. When agents do not submit `artifact.edn`, Miniforge now
treats the promoted worktree or container workspace as valid artifact
provenance.

## Motivation

Dogfood resume reached implement/review correctly, then failed again because the
fallback artifact collector only looked at the latest agent-session delta. In
repair loops, the relevant implementation can already be committed or otherwise
present in the promoted worktree, while the latest turn may touch only one file
or no files. That made valid task output look like `:curator/no-files-written`.

Agents still should submit artifacts explicitly when they can, but file state in
the task worktree/container is authoritative enough for code artifacts because
the environment itself is what Miniforge promotes.

## Changes in Detail

- Added promoted-worktree artifact collection that diffs the task workspace
  against captured base refs and merges current dirty or untracked files.
- Captured base SHA metadata when creating local worktree and OCI container
  execution environments.
- Updated implementer and curator fallback extraction to prefer promoted
  worktree/container artifacts before using the old per-session delta fallback.
- Updated review artifact resolution so downstream phases can recover file
  artifacts from the worktree even when the implement phase missed explicit
  artifact submission.
- Covered committed task diff plus dirty-file fallback behavior.

## Stacking

This PR is stacked on:

- `fix/dogfood-resume-checkpoint-repair`
- PR #875

The resume/checkpoint repair should merge first. This PR addresses the next
blocker discovered by that dogfood pass.

## Testing Plan

- Targeted artifact/review tests: 14 tests, 45 assertions, 0 failures, 0 errors.
- Broader agent/factory/executor targeted tests: 123 tests, 377 assertions, 0
  failures, 0 errors.
- `bb test` passed across the stable-derived test plan with only existing
  unresolved-var warnings.

## Deployment Plan

Merge after PR #875. No migration is required. The change only broadens fallback
artifact extraction when explicit MCP artifact submission is missing.

## Checklist

- [x] Explicit artifacts still win when present.
- [x] Files on disk are treated as valid fallback artifacts.
- [x] Container/worktree base refs are captured for task diffing.
- [x] Dirty and untracked files remain included when base diffing fails.
