### PR TITLE
fix: include workflow resume resources in dev cli

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -577,6 +577,7 @@
                  "components/event-stream/resources"
                  "components/supervisory-state/src"
                  "components/workflow-resume/src"
+                 "components/workflow-resume/resources"
                  "components/dag-primitives/src"
                  "components/dag-executor/src"
                  "components/dag-executor/resources"

--- a/deps.edn
+++ b/deps.edn
@@ -84,6 +84,7 @@
                        "components/supervisory-state/src"
                        "components/pr-scoring/src"
                        "components/workflow-resume/src"
+                       "components/workflow-resume/resources"
                        "components/tui-engine/src"
                        "components/tui-engine/resources"
                        "components/tui-views/src"


### PR DESCRIPTION
## Summary
- add workflow-resume resources to the dev CLI classpaths in `deps.edn` and `bb.edn`
- restores `bb miniforge status/resume` access to `config/workflow-resume/resume.edn`

## Verification
- `bb miniforge status 3927baf8-c9db-44d3-b5fb-5a1552dbe554`
- `clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.workflow-resume.core-test) (let [r (clojure.test/run-tests 'ai.miniforge.workflow-resume.core-test)] (when (or (pos? (:fail r)) (pos? (:error r))) (System/exit 1)))"`
- commit hook / pre-commit checks