### PR TITLE
test: cover connector boundary paths flagged in #871 review

### DIFF
--- a/components/connector-edgar/test/ai/miniforge/connector_edgar/anomaly/edgar_anomaly_test.clj
+++ b/components/connector-edgar/test/ai/miniforge/connector_edgar/anomaly/edgar_anomaly_test.clj
@@ -17,10 +17,11 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.connector-edgar.anomaly.edgar-anomaly-test
-  "Coverage for `impl/do-connect` boundary escalation via
-   `response/throw-anomaly!`.
+  "Coverage for `impl/do-connect` and `impl/do-extract` boundary
+   escalation via `response/throw-anomaly!`.
 
-   Missing config keys → `:anomalies/incorrect`."
+   Missing config keys → `:anomalies/incorrect`. Unknown aggregation at
+   extract time → `:anomalies/unsupported`."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-edgar.impl :as impl])
   (:import (clojure.lang ExceptionInfo)))
@@ -49,3 +50,20 @@
       (is false "should have thrown")
       (catch ExceptionInfo e
         (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+
+(deftest do-extract-unknown-aggregation-throws-anomaly
+  (testing "do-extract with unknown :edgar/aggregation raises :anomalies/unsupported"
+    (let [connect-result (impl/do-connect
+                          {:edgar/form-type "10-K"
+                           :edgar/user-agent "ua"
+                           :edgar/aggregation :bogus-thing}
+                          nil)
+          handle (:connection/handle connect-result)]
+      (try
+        (impl/do-extract handle {})
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (is (= :anomalies/unsupported (:anomaly/category (ex-data e))))
+          (is (= :bogus-thing (:aggregation (ex-data e)))))
+        (finally
+          (impl/do-close handle))))))

--- a/components/connector-excel/test/ai/miniforge/connector_excel/anomaly/excel_anomaly_test.clj
+++ b/components/connector-excel/test/ai/miniforge/connector_excel/anomaly/excel_anomaly_test.clj
@@ -17,11 +17,15 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.connector-excel.anomaly.excel-anomaly-test
-  "Coverage for `impl/do-connect` config-validation paths. Boundary throws
-   route through `response/throw-anomaly!`."
+  "Coverage for `impl/do-connect` config-validation paths,
+   `impl/parse-sheet` sheet-not-found, and the non-2xx download path
+   exercised through `impl/do-connect`. Boundary throws route through
+   `response/throw-anomaly!`."
   (:require [clojure.test :refer [deftest is testing]]
-            [ai.miniforge.connector-excel.impl :as impl])
-  (:import (clojure.lang ExceptionInfo)))
+            [ai.miniforge.connector-excel.impl :as impl]
+            [babashka.http-client :as http])
+  (:import (clojure.lang ExceptionInfo)
+           (org.apache.poi.xssf.usermodel XSSFWorkbook)))
 
 (deftest do-connect-missing-url-throws-anomaly
   (testing "missing :excel/url raises :anomalies/incorrect"
@@ -46,3 +50,30 @@
       (is false "should have thrown")
       (catch ExceptionInfo e
         (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+
+(deftest parse-sheet-missing-sheet-throws-anomaly
+  (testing "requesting a sheet absent from the workbook raises :anomalies/not-found"
+    (let [wb (XSSFWorkbook.)]
+      (try
+        (.createSheet wb "Existing")
+        (try
+          (impl/parse-sheet wb "Missing" {0 :a} 0 nil)
+          (is false "should have thrown")
+          (catch ExceptionInfo e
+            (is (= :anomalies/not-found (:anomaly/category (ex-data e))))
+            (is (= "Missing" (:sheet (ex-data e))))))
+        (finally
+          (.close wb))))))
+
+(deftest do-connect-non-2xx-download-throws-anomaly
+  (testing "non-2xx HTTP response while downloading raises :anomalies/unavailable"
+    (with-redefs [http/get (fn [_url _opts] {:status 503 :body (byte-array 0)})]
+      (try
+        (impl/do-connect {:excel/url "http://x/y.xls"
+                          :excel/sheet-name "Sheet1"
+                          :excel/columns {0 :a}}
+                         nil)
+        (is false "should have thrown")
+        (catch ExceptionInfo e
+          (is (= :anomalies/unavailable (:anomaly/category (ex-data e))))
+          (is (= 503 (:status (ex-data e)))))))))

--- a/components/connector-http/test/ai/miniforge/connector_http/anomaly/http_anomaly_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/anomaly/http_anomaly_test.clj
@@ -76,3 +76,22 @@
   (testing "successful result passes through unchanged"
     (let [success {:success? true :body :data}]
       (is (= success (request/throw-on-failure! success))))))
+
+(deftest fetch-single-request-failure-throws-anomaly
+  (testing "do-extract propagates fetch-single request failure as :anomalies/unavailable"
+    (let [{:keys [connection/handle]} (impl/do-connect {:http/base-url "https://example.test"
+                                                        :http/endpoint "/items"}
+                                                       nil)]
+      (with-redefs [impl/do-request
+                    (fn [_url _headers _query-params]
+                      {:success? false
+                       :error "upstream down"
+                       :error-type :transient})]
+        (try
+          (impl/do-extract handle {})
+          (is false "should have thrown")
+          (catch ExceptionInfo e
+            (is (= :anomalies/unavailable (:anomaly/category (ex-data e))))
+            (is (= :transient (:error-type (ex-data e)))))
+          (finally
+            (impl/do-close handle)))))))

--- a/docs/pull-requests/2026-05-15-refactor-connector-test-followups.md
+++ b/docs/pull-requests/2026-05-15-refactor-connector-test-followups.md
@@ -1,0 +1,65 @@
+# refactor: connector cleanup test coverage follow-ups
+
+## Overview
+
+Adds the test coverage that PRs #871 (data-source connectors) and #874
+(VCS connectors) review flagged as missing. The migrated throw sites
+were correct but lacked direct test coverage, so a future regression
+could go undetected.
+
+## What This Adds
+
+`components/connector-excel/test/.../anomaly/excel_anomaly_test.clj`:
+
+- `parse-sheet-missing-sheet-throws-anomaly` — constructs an
+  `XSSFWorkbook` with one sheet, asks for a different one, asserts
+  `:anomalies/not-found` and `:sheet` in ex-data.
+- `do-connect-non-2xx-download-throws-anomaly` — redefs
+  `babashka.http-client/get` to return `:status 503`, asserts
+  `:anomalies/unavailable` and `:status 503` in ex-data.
+
+`components/connector-edgar/test/.../anomaly/edgar_anomaly_test.clj`:
+
+- `do-extract-unknown-aggregation-throws-anomaly` — connects with a
+  bogus `:edgar/aggregation` value, calls `do-extract`, asserts
+  `:anomalies/unsupported` and the aggregation value in ex-data.
+
+`components/connector-http/test/.../anomaly/http_anomaly_test.clj`:
+
+- `fetch-single-request-failure-throws-anomaly` — connects, redefs
+  `impl/do-request` to return a failure result, asserts
+  `:anomalies/unavailable` and `:error-type :transient` in ex-data.
+
+## Why
+
+PRs #871 and #874 received review feedback that several escalation
+paths listed in the per-site classification tables had no direct test
+coverage. Specifically:
+
+- excel `parse-sheet` not-found path
+- excel `download-to-temp` non-2xx path
+- edgar `do-extract` unknown-aggregation path
+- http `fetch-single` request-failure path
+
+The PR docs claimed "every escalation path" was covered, which wasn't
+strictly true for these four sites. This PR closes those gaps and
+removes the regression-risk window.
+
+## Testing Plan
+
+- 4 new test cases, each asserting `:anomaly/category` and a key
+  context field on the migrated throw path.
+- Existing test suites unaffected.
+
+## Related Issues/PRs
+
+- Follow-up to PR #871 (data-source connectors)
+- Follow-up to PR #874 (VCS connectors)
+- Part of the exceptions-as-data cleanup tracked in PR #691
+
+## Checklist
+
+- [x] Each previously-flagged escalation path now has a direct test
+- [x] Tests assert `:anomaly/category` + key context field, not just
+      message
+- [x] Apache 2 license headers preserved on all edited files

--- a/docs/pull-requests/2026-05-15-refactor-connector-test-followups.md
+++ b/docs/pull-requests/2026-05-15-refactor-connector-test-followups.md
@@ -2,10 +2,15 @@
 
 ## Overview
 
-Adds the test coverage that PRs #871 (data-source connectors) and #874
-(VCS connectors) review flagged as missing. The migrated throw sites
-were correct but lacked direct test coverage, so a future regression
-could go undetected.
+Adds the test coverage that PR #871 (data-source connectors) review
+flagged as missing. The migrated throw sites were correct but lacked
+direct test coverage, so a future regression could go undetected.
+
+Scope note: #874 (VCS connectors) had similar review feedback, but the
+auto-fix pass that landed before #874 merged already added direct tests
+for every flagged VCS path (`do-connect-invalid-schema-throws-anomaly`,
+`load-resources-missing-edn-throws-anomaly` × 3, etc.). The remaining
+gaps are #871-only.
 
 ## What This Adds
 
@@ -32,18 +37,21 @@ could go undetected.
 
 ## Why
 
-PRs #871 and #874 received review feedback that several escalation
-paths listed in the per-site classification tables had no direct test
-coverage. Specifically:
+PR #871 received review feedback that several escalation paths listed
+in the per-site classification table had no direct test coverage.
+Specifically:
 
 - excel `parse-sheet` not-found path
 - excel `download-to-temp` non-2xx path
 - edgar `do-extract` unknown-aggregation path
 - http `fetch-single` request-failure path
 
-The PR docs claimed "every escalation path" was covered, which wasn't
-strictly true for these four sites. This PR closes those gaps and
-removes the regression-risk window.
+The #871 PR doc claimed "every escalation path" was covered, which
+wasn't strictly true for these four sites. This PR closes those gaps
+and removes the regression-risk window.
+
+PR #874 had similar feedback but the auto-fix pass already added the
+missing VCS tests pre-merge; no additional VCS coverage is needed.
 
 ## Testing Plan
 
@@ -54,7 +62,8 @@ removes the regression-risk window.
 ## Related Issues/PRs
 
 - Follow-up to PR #871 (data-source connectors)
-- Follow-up to PR #874 (VCS connectors)
+- PR #874 (VCS connectors) gaps were closed by the pre-merge auto-fix
+  pass; referenced here for completeness only
 - Part of the exceptions-as-data cleanup tracked in PR #691
 
 ## Checklist


### PR DESCRIPTION
## Summary

Adds the test coverage that PR #871 (data-source connectors) reviewers flagged as missing. The migrated throw sites were correct but lacked direct tests, so a future regression could go undetected.

Scope: #874 (VCS connectors) had similar feedback, but the auto-fix pass that landed before #874 merged already added direct tests for every flagged VCS path. The remaining gaps were #871-only.

- excel `parse-sheet` not-found (`:anomalies/not-found`)
- excel `download-to-temp` non-2xx (`:anomalies/unavailable`)
- edgar `do-extract` unknown-aggregation (`:anomalies/unsupported`)
- http `fetch-single` request-failure (`:anomalies/unavailable`)

Full PR doc: `docs/pull-requests/2026-05-15-refactor-connector-test-followups.md`

## Test plan

- [x] 4 new test cases, each asserting `:anomaly/category` + key context field
- [ ] CI to confirm full suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)