### PR TITLE
Fix LLM fallback workdir propagation

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1087,7 +1087,8 @@
                                      :prompt prompt
                                      :prompt-via prompt-via))
             full-cmd (into [cmd] args)
-            opts     (exec-opts-for-prompt-via prompt-via prompt)
+            opts     (cond-> (exec-opts-for-prompt-via prompt-via prompt)
+                       (:workdir request) (assoc :workdir (:workdir request)))
             result   (run-cli-exec exec-fn full-cmd opts)
             response (parse-cli-output (:out result) (:exit result) (:err result))]
         (log-response logger response)
@@ -1386,15 +1387,17 @@
 (defn default-exec-fn
   "Run `cmd` with `p/shell`, capturing :out / :err / :exit.
 
-   2-arity opts map supports `:stdin` — a string piped to the
-   subprocess's stdin. Absent or blank => zero-length stdin (legacy)."
+   2-arity opts map supports:
+   - `:stdin`  — string piped to the subprocess's stdin
+   - `:workdir` — directory where the subprocess runs"
   ([cmd] (default-exec-fn cmd {}))
-  ([cmd {:keys [stdin]}]
+  ([cmd {:keys [stdin workdir]}]
    (let [timeout-ms 600000
          in-stream  (->stdin-stream stdin)
          result (apply p/shell (cond-> {:out :string :err :string :continue true
                                         :in in-stream :timeout timeout-ms}
-                                 (clean-env) (assoc :env (clean-env))) cmd)]
+                                 (clean-env) (assoc :env (clean-env))
+                                 workdir     (assoc :dir workdir)) cmd)]
      {:out (:out result)
       :err (:err result)
       :exit (:exit result)})))

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -927,6 +927,29 @@
       (is (zero? exit))
       (is (= "" out)))))
 
+(deftest default-exec-fn-honors-workdir-test
+  (testing ":workdir opt becomes the subprocess working directory"
+    (let [workdir (.getCanonicalPath (java.io.File. (System/getProperty "java.io.tmpdir")))
+          {:keys [out exit]} (impl/default-exec-fn ["pwd"] {:workdir workdir})
+          actual (.getCanonicalPath (java.io.File. (str/trim out)))]
+      (is (zero? exit))
+      (is (= workdir actual)))))
+
+(deftest complete-impl-passes-workdir-to-exec-fn-test
+  (testing "non-streaming CLI completion runs in the requested workdir"
+    (let [seen-opts (atom nil)
+          exec-fn   (fn
+                      ([_cmd] {:out "ok" :err "" :exit 0})
+                      ([_cmd opts]
+                       (reset! seen-opts opts)
+                       {:out "ok" :err "" :exit 0}))
+          client    (ai.miniforge.llm.protocols.records.llm-client/create-client
+                     {:backend :echo :exec-fn exec-fn})
+          resp      (llm/complete client {:prompt "hello" :workdir "/tmp/task-worktree"})]
+      (is (llm/success? resp))
+      (is (= "/tmp/task-worktree" (:workdir @seen-opts))
+          "fallback/non-streaming calls must not run in the host checkout"))))
+
 (deftest legacy-1-arity-exec-fn-survives-stdin-path-test
   (testing "1-arity user-supplied :exec-fn keeps working when impl invokes 2-arity"
     ;; Backward-compat guard: PR #798 review pointed out that callers
@@ -951,7 +974,7 @@
     (let [seen-opts (atom nil)
           two-arity (fn
                       ([cmd] {:out "" :err "" :exit 0 :seen-cmd cmd})
-                      ([cmd opts]
+                      ([_cmd opts]
                        (reset! seen-opts opts)
                        {:out "ok" :err "" :exit 0}))
           wrapped (impl/normalize-exec-fn two-arity)]


### PR DESCRIPTION
## Summary
- carry :workdir into non-streaming CLI completion and stream fallback execution
- make the default CLI exec runner honor :workdir
- add regression coverage for fallback/non-streaming workdir handling

## Verification
- clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.llm.interface-test) (let [r (clojure.test/run-tests 'ai.miniforge.llm.interface-test)] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))"
- clj-kondo --lint components/llm/src/ai/miniforge/llm/progress_monitor.clj components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj components/llm/test/ai/miniforge/llm/interface_test.clj
- bb test brick:llm
- bb pre-commit