### PR TITLE
Fix artifact provenance base refs

### DIFF
--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -183,6 +183,11 @@
   [& changeds]
   (apply merge-with set/union changeds))
 
+(defn- has-changed-paths?
+  "True when a diff changed-path map contains at least one path."
+  [changed]
+  (boolean (some seq (vals changed))))
+
 (defn- snapshot->changed-paths
   "Convert a current dirty snapshot into changed path sets."
   [snapshot]
@@ -204,10 +209,17 @@
                 (mapcat name-status-entries (str/split-lines out)))))))
 
 (defn- first-diff-against-ref
-  "Try base refs in order and return the first successful diff."
+  "Try base refs in order and return the first non-empty successful diff."
   [working-dir base-refs]
-  (some #(diff-against-ref working-dir %)
-        (filter valid-base-ref? base-refs)))
+  (loop [[base-ref & remaining] (filter valid-base-ref? base-refs)
+         empty-diff nil]
+    (if base-ref
+      (if-let [changed (diff-against-ref working-dir base-ref)]
+        (if (has-changed-paths? changed)
+          changed
+          (recur remaining changed))
+        (recur remaining empty-diff))
+      empty-diff)))
 
 (defn- worktree-changed-paths
   "Merge committed task diff and current dirty snapshot paths."
@@ -467,8 +479,16 @@
 (defn- first-diff-against-ref-via-executor
   "Try base refs in order inside the capsule."
   [exec! executor env-id working-dir base-refs]
-  (some #(diff-against-ref-via-executor exec! executor env-id working-dir %)
-        (filter valid-base-ref? base-refs)))
+  (loop [[base-ref & remaining] (filter valid-base-ref? base-refs)
+         empty-diff nil]
+    (if base-ref
+      (if-let [changed (diff-against-ref-via-executor
+                        exec! executor env-id working-dir base-ref)]
+        (if (has-changed-paths? changed)
+          changed
+          (recur remaining changed))
+        (recur remaining empty-diff))
+      empty-diff)))
 
 (defn- worktree-changed-paths-via-executor
   "Merge committed task diff and current dirty snapshot paths in a capsule."

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -571,9 +571,16 @@
         base-branch (or (get-in context [:execution/environment-metadata :base-branch])
                         (get-in context [:execution/opts :branch])
                         (get-in context [:execution/input :branch]))]
-    (cond-> []
-      base-sha (conj base-sha)
-      base-branch (conj (str "origin/" base-branch) base-branch))))
+    (into []
+          (distinct)
+          (cond-> []
+            (and base-sha (not (str/blank? base-sha)))
+            (conj base-sha)
+
+            (and base-branch (not (str/blank? base-branch)))
+            (into [(str "refs/remotes/origin/" base-branch)
+                   (str "origin/" base-branch)
+                   (str "refs/heads/" base-branch)])))))
 
 (defn- collect-promoted-artifact
   "Collect code files from the current promoted worktree/container state."

--- a/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
@@ -21,6 +21,7 @@
    [ai.miniforge.agent.file-artifacts :as sut]
    [clojure.java.io :as io]
    [clojure.java.shell]
+   [clojure.string :as str]
    [clojure.test :as test :refer [deftest testing is]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -185,7 +186,63 @@
                    :action :modify}]
                  (:code/files (sut/collect-worktree-files dir ["missing-base"])))))
         (finally
-          (delete-tree! dir))))))
+          (delete-tree! dir)))))
+
+  (testing "skips empty base diffs so a later base can recover committed work"
+    (let [dir (temp-dir)]
+      (try
+        (write-file! dir "src/committed.clj" "(ns committed)")
+        (with-redefs [ai.miniforge.agent.file-artifacts/snapshot-working-dir
+                      (fn [_]
+                        (sut/empty-snapshot))
+                      clojure.java.shell/sh
+                      (fn [& args]
+                        (let [base-ref (nth args 5 nil)]
+                          {:exit success-exit-code
+                           :out (if (= "head-alias" base-ref)
+                                  ""
+                                  "M\tsrc/committed.clj\n")
+                           :err ""}))]
+          (is (= [{:path "src/committed.clj"
+                   :content "(ns committed)"
+                   :action :modify}]
+                 (:code/files (sut/collect-worktree-files
+                               dir
+                               ["head-alias" "base-sha"])))))
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "executor worktree collection also skips empty base diffs"
+    (let [commands (atom [])]
+      (letfn [(exec! [_ _ command _]
+                (swap! commands conj command)
+                (cond
+                  (str/starts-with? command "git status")
+                  {:ok? true :data {:exit-code success-exit-code :stdout ""}}
+
+                  (str/includes? command "'head-alias'")
+                  {:ok? true :data {:exit-code success-exit-code :stdout ""}}
+
+                  (str/includes? command "'base-sha'")
+                  {:ok? true :data {:exit-code success-exit-code
+                                    :stdout "M\tsrc/committed.clj\n"}}
+
+                  (str/starts-with? command "cat ")
+                  {:ok? true :data {:exit-code success-exit-code
+                                    :stdout "(ns committed)"}}
+
+                  :else
+                  {:ok? false :data {:exit-code missing-base-exit-code :stdout ""}}))]
+        (is (= [{:path "src/committed.clj"
+                 :content "(ns committed)"
+                 :action :modify}]
+               (:code/files (sut/collect-worktree-files-via-executor
+                             exec!
+                             :executor
+                             :env
+                             "/work"
+                             ["head-alias" "base-sha"]))))
+        (is (some #(str/includes? % "'base-sha'") @commands))))))
 
 (deftest collect-worktree-files-rename-test
   (testing "diff renames delete the old path and create the new path"

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -465,6 +465,18 @@
             (io/file tmp ".miniforge") true)
           (.delete tmp))))))
 
+(deftest base-ref-candidates-avoid-ambiguous-branch-names
+  (testing "bare branch names are not used as diff bases"
+    (let [candidates (@#'implementer/base-ref-candidates
+                      {:execution/environment-metadata {:base-sha "abc123"
+                                                        :base-branch "main"}})]
+      (is (= ["abc123"
+              "refs/remotes/origin/main"
+              "origin/main"
+              "refs/heads/main"]
+             candidates))
+      (is (not (contains? (set candidates) "main"))))))
+
 ;------------------------------------------------------------------------------ Layer 4
 ;; Utility tests
 

--- a/docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md
+++ b/docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md
@@ -2,10 +2,9 @@
 
 ## Overview
 
-This stacked PR fixes the artifact extraction failure that surfaced after the
-checkpoint resume repair. When agents do not submit `artifact.edn`, Miniforge now
-treats the promoted worktree or container workspace as valid artifact
-provenance.
+This PR fixes the artifact extraction failure that surfaced after checkpoint
+resume repair. When agents do not submit `artifact.edn`, Miniforge treats the
+promoted worktree or container workspace as valid artifact provenance.
 
 ## Motivation
 
@@ -30,30 +29,24 @@ the environment itself is what Miniforge promotes.
 - Updated review artifact resolution so downstream phases can recover file
   artifacts from the worktree even when the implement phase missed explicit
   artifact submission.
+- Made promoted artifact diffing skip empty successful base diffs when later
+  base refs can still recover committed work.
+- Stopped using bare branch names such as `main` as promoted-artifact diff bases;
+  fully qualified refs avoid collisions with tags and stale local branches.
 - Covered committed task diff plus dirty-file fallback behavior.
-
-## Stacking
-
-This PR is stacked on:
-
-- `fix/dogfood-resume-checkpoint-repair`
-- PR #875
-
-The resume/checkpoint repair should merge first. This PR addresses the next
-blocker discovered by that dogfood pass.
 
 ## Testing Plan
 
-- Targeted artifact/review tests: 14 tests, 45 assertions, 0 failures, 0 errors.
-- Broader agent/factory/executor targeted tests: 123 tests, 377 assertions, 0
+- `clj-kondo --lint` on changed source and test namespaces passed.
+- Focused file artifact and implementer tests: 19 tests, 105 assertions, 0
   failures, 0 errors.
-- `bb test` passed across the stable-derived test plan with only existing
-  unresolved-var warnings.
+- `bb test brick:agent` passed across the stable-derived test plan with existing
+  warning 207 only.
 
 ## Deployment Plan
 
-Merge after PR #875. No migration is required. The change only broadens fallback
-artifact extraction when explicit MCP artifact submission is missing.
+No migration is required. The change only broadens fallback artifact extraction
+when explicit MCP artifact submission is missing.
 
 ## Checklist
 
@@ -61,3 +54,4 @@ artifact extraction when explicit MCP artifact submission is missing.
 - [x] Files on disk are treated as valid fallback artifacts.
 - [x] Container/worktree base refs are captured for task diffing.
 - [x] Dirty and untracked files remain included when base diffing fails.
+- [x] Ambiguous branch refs do not mask valid promoted worktree artifacts.


### PR DESCRIPTION
# Fix: Dogfood Artifact Provenance

## Overview

This PR fixes the artifact extraction failure that surfaced after checkpoint
resume repair. When agents do not submit `artifact.edn`, Miniforge treats the
promoted worktree or container workspace as valid artifact provenance.

## Motivation

Dogfood resume reached implement/review correctly, then failed again because the
fallback artifact collector only looked at the latest agent-session delta. In
repair loops, the relevant implementation can already be committed or otherwise
present in the promoted worktree, while the latest turn may touch only one file
or no files. That made valid task output look like `:curator/no-files-written`.

Agents still should submit artifacts explicitly when they can, but file state in
the task worktree/container is authoritative enough for code artifacts because
the environment itself is what Miniforge promotes.

## Changes in Detail

- Added promoted-worktree artifact collection that diffs the task workspace
  against captured base refs and merges current dirty or untracked files.
- Captured base SHA metadata when creating local worktree and OCI container
  execution environments.
- Updated implementer and curator fallback extraction to prefer promoted
  worktree/container artifacts before using the old per-session delta fallback.
- Updated review artifact resolution so downstream phases can recover file
  artifacts from the worktree even when the implement phase missed explicit
  artifact submission.
- Made promoted artifact diffing skip empty successful base diffs when later
  base refs can still recover committed work.
- Stopped using bare branch names such as `main` as promoted-artifact diff bases;
  fully qualified refs avoid collisions with tags and stale local branches.
- Covered committed task diff plus dirty-file fallback behavior.

## Testing Plan

- `clj-kondo --lint` on changed source and test namespaces passed.
- Focused file artifact and implementer tests: 19 tests, 105 assertions, 0
  failures, 0 errors.
- `bb test brick:agent` passed across the stable-derived test plan with existing
  warning 207 only.

## Deployment Plan

No migration is required. The change only broadens fallback artifact extraction
when explicit MCP artifact submission is missing.

## Checklist

- [x] Explicit artifacts still win when present.
- [x] Files on disk are treated as valid fallback artifacts.
- [x] Container/worktree base refs are captured for task diffing.
- [x] Dirty and untracked files remain included when base diffing fails.
- [x] Ambiguous branch refs do not mask valid promoted worktree artifacts.
