### PR TITLE
fix: preserve resume artifact base metadata

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -82,6 +82,7 @@
    :execution/started-at
    :execution/ended-at
    :execution/environment-id
+   :execution/environment-metadata
    :execution/worktree-path
    :execution/mode
    :execution/completed-with-warnings?])

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -283,7 +283,9 @@
                      :branch          branch
                      :execution-mode  (:execution-mode opts)
                      :executor-config (:executor-config opts)})]
-      [acquired (if acquired (merge opts acquired) opts)])))
+      [acquired (if acquired
+                  (merge opts {:branch branch} acquired)
+                  opts)])))
 
 (defn- wrap-phase-callbacks
   "Wrap caller callbacks with event publishing."
@@ -339,20 +341,23 @@
                            dag-exec/execute!
                            (get opts :executor)
                            (get opts :environment-id)
-                           (get opts :worktree-path (defaults/default-workdir))))]
-    (-> (if (and resume-machine-snapshot resume-phase-results)
-          (ctx/restore-context workflow input
-                               resume-machine-snapshot
-                               resume-phase-results
-                               opts)
-          (ctx/create-context workflow input opts))
+                           (get opts :worktree-path (defaults/default-workdir))))
+        base-context (if (and resume-machine-snapshot resume-phase-results)
+                       (ctx/restore-context workflow input
+                                            resume-machine-snapshot
+                                            resume-phase-results
+                                            opts)
+                       (ctx/create-context workflow input opts))
+        environment-metadata (or (get opts :environment-metadata)
+                                 (:execution/environment-metadata base-context))]
+    (-> base-context
         (assoc :execution/executor (get opts :executor)
                :execution/environment-id (get opts :environment-id)
                :execution/worktree-path (get opts :worktree-path
                                              (get opts :sandbox-workdir))
                :execution/mode mode
                :execution/started-at (java.time.Instant/now)
-               :execution/environment-metadata (get opts :environment-metadata)
+               :execution/environment-metadata environment-metadata
                :execution/execute-fn (when governed? dag-exec/execute!)
                :execution/exec-fn capsule-exec-fn
                :execution/task-branch (when governed?

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -413,6 +413,44 @@
       (is (= env-id (:execution/environment-id result)))
       (is (= "/tmp/worktree" (:execution/worktree-path result))))))
 
+(deftest run-pipeline-threads-acquired-default-branch-test
+  (testing "the branch used to acquire a worktree is kept in execution opts"
+    (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)]
+      (with-redefs-fn
+        {acquire-var (fn [_workflow-id env-config]
+                       {:executor ::stub-executor
+                        :environment-id "task-branch-test"
+                        :worktree-path "/tmp/task-branch-test"
+                        :execution-mode :local
+                        :environment-metadata {:base-branch (:branch env-config)}})}
+        (fn []
+          (let [workflow {:workflow/id :test
+                          :workflow/version "1.0.0"
+                          :workflow/pipeline [{:phase test-done-phase}]}
+                result (runner/run-pipeline workflow {:task "Test"} {})]
+            (is (= "main" (get-in result [:execution/opts :branch])))
+            (is (= {:base-branch "main"}
+                   (:execution/environment-metadata result)))))))))
+
+(deftest run-pipeline-resume-preserves-checkpoint-metadata-test
+  (testing "resume keeps checkpoint metadata when no fresh environment metadata is supplied"
+    (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)
+          workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase test-done-phase}]}
+          metadata {:base-branch "trunk"}
+          resume-ctx (assoc (ctx/create-context workflow {:task "Test"} {})
+                            :execution/environment-metadata metadata)]
+      (with-redefs-fn
+        {acquire-var (fn [& _] nil)}
+        (fn []
+          (let [result (runner/run-pipeline workflow
+                                            {:task "Ignored"}
+                                            {:resume-machine-snapshot
+                                             (checkpoint-store/build-machine-snapshot resume-ctx)
+                                             :resume-phase-results {}})]
+            (is (= metadata (:execution/environment-metadata result)))))))))
+
 (deftest run-pipeline-without-executor-skips-env-keys-test
   (testing "when no executor in opts and acquisition yields nil, env keys are absent"
     ;; Force acquisition to return nil for deterministic test isolation.

--- a/docs/pull-requests/2026-05-15-fix-resume-artifact-base-metadata.md
+++ b/docs/pull-requests/2026-05-15-fix-resume-artifact-base-metadata.md
@@ -1,0 +1,47 @@
+# Fix: Resume Artifact Base Metadata
+
+## Overview
+
+This PR fixes a dogfood resume failure where a restarted local worktree could
+produce a clean committed task state, but artifact fallback still reported that
+the implementer wrote no files.
+
+## Motivation
+
+Checkpoint `3927baf8-c9db-44d3-b5fb-5a1552dbe554` resumed into `implement` and
+failed with `Curator: implementer wrote no files to the environment`. The task
+worktree fallback depends on a base ref so it can diff committed task work
+against the branch it was created from. Resumed snapshots were not persisting
+environment metadata, and freshly acquired default-branch worktrees did not
+thread the resolved branch into execution opts.
+
+## Changes in Detail
+
+- Persist `:execution/environment-metadata` in durable machine snapshots.
+- Preserve checkpoint environment metadata when resume does not supply fresh
+  metadata.
+- Thread the branch used for worktree acquisition into `:execution/opts`.
+- Enable clj-kondo cache lookups for staged-file lint so local namespace vars are
+  resolved without inline suppressions.
+- Cover default-branch threading and checkpoint metadata preservation in runner
+  tests.
+
+## Testing Plan
+
+- `clj-kondo --lint` on changed workflow source and tests: 0 warnings.
+- `bb lint:clj` on staged source and tests: 0 warnings.
+- Focused runner tests: 27 tests, 84 assertions, 0 failures, 0 errors.
+- `bb test` stable-derived plan across 4 projects: passed.
+
+## Deployment Plan
+
+No migration is required. Existing checkpoints without environment metadata will
+continue to resume as before; new checkpoints retain the metadata needed for
+artifact diff fallback.
+
+## Checklist
+
+- [x] Checkpoint snapshots retain environment metadata.
+- [x] Resume preserves checkpoint metadata when fresh metadata is absent.
+- [x] Default local worktree branches are available to artifact recovery.
+- [x] Stable-derived tests passed.

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -44,7 +44,7 @@
       (let [_ (println "🔍 Linting" (count clj-files) "Clojure file(s)...")
             _ (println "Files:" (str/join ", " clj-files))
             {:keys [exit out err]} (apply p/sh {:out :string :err :string}
-                                         "clj-kondo" "--lint" clj-files)]
+                                         "clj-kondo" "--cache" "true" "--lint" clj-files)]
         (when-not (str/blank? out) (println out))
         (when-not (str/blank? err) (binding [*out* *err*] (println err)))
         ;; Exit 0 = success, 2 = warnings only, 3 = errors


### PR DESCRIPTION
# Fix: Resume Artifact Base Metadata

## Overview

This PR fixes a dogfood resume failure where a restarted local worktree could
produce a clean committed task state, but artifact fallback still reported that
the implementer wrote no files.

## Motivation

Checkpoint `3927baf8-c9db-44d3-b5fb-5a1552dbe554` resumed into `implement` and
failed with `Curator: implementer wrote no files to the environment`. The task
worktree fallback depends on a base ref so it can diff committed task work
against the branch it was created from. Resumed snapshots were not persisting
environment metadata, and freshly acquired default-branch worktrees did not
thread the resolved branch into execution opts.

## Changes in Detail

- Persist `:execution/environment-metadata` in durable machine snapshots.
- Preserve checkpoint environment metadata when resume does not supply fresh
  metadata.
- Thread the branch used for worktree acquisition into `:execution/opts`.
- Cover default-branch threading and checkpoint metadata preservation in runner
  tests.

## Testing Plan

- `clj-kondo --lint` on changed workflow source and tests: 0 warnings.
- Focused runner tests: 27 tests, 84 assertions, 0 failures, 0 errors.
- `bb test` stable-derived plan across 4 projects: passed.

## Deployment Plan

No migration is required. Existing checkpoints without environment metadata will
continue to resume as before; new checkpoints retain the metadata needed for
artifact diff fallback.

## Checklist

- [x] Checkpoint snapshots retain environment metadata.
- [x] Resume preserves checkpoint metadata when fresh metadata is absent.
- [x] Default local worktree branches are available to artifact recovery.
- [x] Stable-derived tests passed.
