### PR TITLE
fix: prefer checkpoint status on resume

### DIFF
--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -135,14 +135,17 @@
 
 (defn- reconstructed-completed?
   [by-type checkpoint-data]
-  (or (boolean (seq (get by-type :workflow/completed)))
-      (= :completed (checkpoint-status checkpoint-data))
-      (= :completed-with-warnings (checkpoint-status checkpoint-data))))
+  (let [status (checkpoint-status checkpoint-data)]
+    (if (some? status)
+      (contains? #{:completed :completed-with-warnings} status)
+      (boolean (seq (get by-type :workflow/completed))))))
 
 (defn- reconstructed-failed?
   [by-type checkpoint-data]
-  (or (boolean (seq (get by-type :workflow/failed)))
-      (= :failed (checkpoint-status checkpoint-data))))
+  (let [status (checkpoint-status checkpoint-data)]
+    (if (some? status)
+      (= :failed status)
+      (boolean (seq (get by-type :workflow/failed))))))
 
 (def ^:private resume-config-resource
   "config/workflow-resume/resume.edn")

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -313,6 +313,22 @@
           (is (= :rate-limit (:dag-pause-reason ctx)))
           (is (= 0 (:event-count ctx))))))))
 
+(deftest reconstruct-context-uses-checkpoint-status-over-stale-terminal-events-test
+  (testing "a resumed running checkpoint overrides older failed events"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/id workflow-id
+                                             :execution/workflow-id :canonical-sdlc
+                                             :execution/workflow-version "1.0.0"
+                                             :execution/status :running}
+                           :manifest {:workflow/phases-completed [:plan]}
+                           :phase-results {:plan {:status :completed}}}
+          events [{:event/type :workflow/failed}]]
+      (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] events)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (false? (:failed? ctx)))
+          (is (false? (:completed? ctx))))))))
+
 (deftest reconstruct-context-trims-only-completed-checkpoint-phases-test
   (testing "checkpoint manifests may list failed/retrying phases; resume skips only completed results"
     (let [workflow-id (str (random-uuid))

--- a/docs/pull-requests/2026-05-15-fix-resume-status-stale-failure.md
+++ b/docs/pull-requests/2026-05-15-fix-resume-status-stale-failure.md
@@ -1,0 +1,22 @@
+# Fix Resume Status Stale Failure
+
+## Summary
+
+`miniforge status <workflow-id>` reported `failed` for an actively resumed
+workflow if the event stream still contained a historical `:workflow/failed`
+event from an earlier attempt. Checkpoint state already records the current
+execution status, so resume reconstruction now treats a checkpoint status as
+authoritative when present.
+
+## Changes
+
+- Make workflow resume reconstruction prefer checkpoint `:execution/status`
+  over historical terminal events.
+- Add regression coverage for a running checkpoint with stale failure events.
+
+## Verification
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.workflow-resume.core-test 'clojure.test) (clojure.test/run-tests
+  'ai.miniforge.workflow-resume.core-test)"`
+- `bb miniforge status 3927baf8-c9db-44d3-b5fb-5a1552dbe554`
+- `bb pre-commit`


### PR DESCRIPTION
# Fix Resume Status Stale Failure

## Summary

`miniforge status <workflow-id>` reported `failed` for an actively resumed
workflow if the event stream still contained a historical `:workflow/failed`
event from an earlier attempt. Checkpoint state already records the current
execution status, so resume reconstruction now treats a checkpoint status as
authoritative when present.

## Changes

- Make workflow resume reconstruction prefer checkpoint `:execution/status`
  over historical terminal events.
- Add regression coverage for a running checkpoint with stale failure events.

## Verification

- `clojure -M:dev:test -e "(require 'ai.miniforge.workflow-resume.core-test 'clojure.test) (clojure.test/run-tests
  'ai.miniforge.workflow-resume.core-test)"`
- `bb miniforge status 3927baf8-c9db-44d3-b5fb-5a1552dbe554`
- `bb pre-commit`
