### PR TITLE
fix: validate reviewer issue shapes

### DIFF
--- a/components/agent/resources/config/agent/test-fixtures/en-US.edn
+++ b/components/agent/resources/config/agent/test-fixtures/en-US.edn
@@ -1,0 +1,21 @@
+{:agent-reviewer-test/fixtures
+ {:reviewer-test/valid-review-blocking-description "Needs changes"
+  :reviewer-test/valid-review-content
+  "```clojure
+{:review/decision :changes-requested
+ :review/issues [{:severity :blocking :description \"Needs changes\"}]}
+```"
+
+  :reviewer-test/malformed-review-issue-content
+  "```clojure
+{:review/decision :changes-requested
+ :review/issues [{:severity :warning
+                  :description \"ToolCallCompleted omits agent id. Queries like \"
+                  failed tool
+                  show all
+                  :file \"components/event-stream/src/ai/miniforge/event_stream/schema.clj\"
+                  :suggestion \"Add agent id\"
+                  :line 313
+                  the implement
+                  agent \" require joining\"}]}
+```"}}

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -98,6 +98,10 @@
    resources."
   20)
 
+(def ^:private review-issue-keys
+  "Canonical keys accepted in LLM review issue maps."
+  #{:severity :file :line :description :suggestion})
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Gate running and feedback
 
@@ -322,6 +326,23 @@
                 (if (string? tests) tests (pr-str tests))))
          "\n\nOutput your review as a Clojure map inside a ```clojure code block.")))
 
+(defn- valid-review-issue-map?
+  "True when an LLM-supplied issue has the canonical ReviewIssue shape.
+   Malli map schemas are intentionally open, so reject extra keys here to
+   catch EDN that parsed only because quoted prose was read as symbols."
+  [issue]
+  (and (map? issue)
+       (every? review-issue-keys (keys issue))
+       (m/validate ReviewIssue issue)))
+
+(defn- valid-review-issues?
+  "True when parsed LLM review issues are absent or structurally canonical."
+  [parsed]
+  (let [issues (find parsed :review/issues)]
+    (or (nil? issues)
+        (and (vector? (val issues))
+             (every? valid-review-issue-map? (val issues))))))
+
 (defn parse-review-response
   "Parse the LLM response to extract review feedback.
    Handles EDN in code blocks and plain EDN."
@@ -330,7 +351,8 @@
     (let [parsed (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
                    (edn/read-string (second match))
                    (edn/read-string response-content))]
-      (when (map? parsed)
+      (when (and (map? parsed)
+                 (valid-review-issues? parsed))
         parsed))
     (catch Exception _
       nil)))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -26,6 +26,7 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.loop.interface :as loop]
+   [ai.miniforge.messages.interface :as messages]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Regression-floor constants
@@ -71,22 +72,18 @@
 (def ^:private backend-timeout-type
   "adaptive_timeout")
 
+(def ^:private test-t
+  (messages/create-translator "config/agent/test-fixtures/en-US.edn"
+                              :agent-reviewer-test/fixtures))
+
+(def ^:private valid-review-blocking-description
+  (test-t :reviewer-test/valid-review-blocking-description))
+
 (def ^:private valid-review-content
-  "```clojure\n{:review/decision :changes-requested\n :review/issues [{:severity :blocking :description \"Needs changes\"}]}\n```")
+  (test-t :reviewer-test/valid-review-content))
 
 (def ^:private malformed-review-issue-content
-  "```clojure
-{:review/decision :changes-requested
- :review/issues [{:severity :warning
-                  :description \"ToolCallCompleted omits agent id. Queries like \"
-                  failed tool
-                  show all
-                  :file \"components/event-stream/src/ai/miniforge/event_stream/schema.clj\"
-                  :suggestion \"Add agent id\"
-                  :line 313
-                  the implement
-                  agent \" require joining\"}]}
-```")
+  (test-t :reviewer-test/malformed-review-issue-content))
 
 ;------------------------------------------------------------------------------ Test fixtures
 
@@ -325,7 +322,7 @@
             result (core/invoke reviewer {} sample-artifact)
             review (:artifact result)]
         (is (= :changes-requested (:review/decision review)))
-        (is (some #{"Needs changes"} (:review/blocking-issues review)))
+        (is (some #{valid-review-blocking-description} (:review/blocking-issues review)))
         (is (= parseable-backend-failure-token-count
                (get-in result [:metrics :tokens])))))))
 

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -71,6 +71,23 @@
 (def ^:private backend-timeout-type
   "adaptive_timeout")
 
+(def ^:private valid-review-content
+  "```clojure\n{:review/decision :changes-requested\n :review/issues [{:severity :blocking :description \"Needs changes\"}]}\n```")
+
+(def ^:private malformed-review-issue-content
+  "```clojure
+{:review/decision :changes-requested
+ :review/issues [{:severity :warning
+                  :description \"ToolCallCompleted omits agent id. Queries like \"
+                  failed tool
+                  show all
+                  :file \"components/event-stream/src/ai/miniforge/event_stream/schema.clj\"
+                  :suggestion \"Add agent id\"
+                  :line 313
+                  the implement
+                  agent \" require joining\"}]}
+```")
+
 ;------------------------------------------------------------------------------ Test fixtures
 
 (defn passing-gate
@@ -296,7 +313,7 @@
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
                   llm/chat (fn [_client _prompt _opts]
                              (mock-llm-response
-                              "```clojure\n{:review/decision :changes-requested\n :review/issues [{:severity :blocking :description \"Needs changes\"}]}\n```"
+                              valid-review-content
                               :success? false
                               :tokens parseable-backend-failure-token-count
                               :error {:message "artifact file not found"}))
@@ -311,6 +328,10 @@
         (is (some #{"Needs changes"} (:review/blocking-issues review)))
         (is (= parseable-backend-failure-token-count
                (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-rejects-structurally-corrupt-llm-issues
+  (testing "valid EDN with malformed issue maps is treated as unparseable"
+    (is (nil? (reviewer/parse-review-response malformed-review-issue-content)))))
 
 (deftest test-reviewer-timeout-only-parseable-failure-is-agent-error
   (testing "timeout-only parsed review failures do not become rejected code-review artifacts"

--- a/docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md
+++ b/docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md
@@ -22,5 +22,6 @@ recognized issue keys.
 
 ## Verification
 
-- `clojure -M:dev:test -e "(require 'ai.miniforge.agent.reviewer-test 'clojure.test) (clojure.test/run-tests
-  'ai.miniforge.agent.reviewer-test)"`
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.agent.reviewer-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.agent.reviewer-test)"
+```

--- a/docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md
+++ b/docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md
@@ -1,0 +1,26 @@
+# Fix Reviewer Issue Shape Validation
+
+## Summary
+
+Dogfood exposed a reviewer parse failure mode where malformed LLM EDN still read
+successfully because unescaped quoted prose became extra symbol keys inside a
+`:review/issues` map. The review artifact then carried structurally corrupt
+issue data into checkpoint feedback instead of failing closed.
+
+This change validates parsed LLM review issues before accepting a review map.
+Issue maps must now match the canonical `ReviewIssue` shape and only contain
+recognized issue keys.
+
+## Changes
+
+- Reject parsed LLM review maps whose `:review/issues` value is not a vector of
+  canonical issue maps.
+- Add a regression test for the dogfood failure shape where quoted prose is
+  parsed as stray EDN symbols.
+- Keep valid parseable review content working even when the backend wrapper
+  reports failure.
+
+## Verification
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.agent.reviewer-test 'clojure.test) (clojure.test/run-tests
+  'ai.miniforge.agent.reviewer-test)"`


### PR DESCRIPTION
## Summary
- reject parsed reviewer LLM issue maps with non-canonical keys or invalid ReviewIssue shape
- fail closed on the dogfood malformed-EDN case where quoted prose becomes stray symbol keys
- add PR documentation for the dogfood parser fix

## Verification
- clojure -M:dev:test -e "(require 'ai.miniforge.agent.reviewer-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.agent.reviewer-test)"
- bb pre-commit