### PR TITLE
fix: resume from persisted workspace checkpoints

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -139,6 +139,7 @@
                                       :resume-machine-snapshot machine-snapshot
                                       :resume-reset-terminal? failed-checkpoint?
                                       :resume-phase-results (:phase-results reconstructed)
+                                      :resume-workspace (:workspace-checkpoint reconstructed)
                                       :skip-lifecycle-events false
                                       :pre-completed-dag-tasks (:completed-dag-tasks reconstructed)
                                       :pre-completed-artifacts (:completed-dag-artifacts reconstructed)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
@@ -116,6 +116,8 @@
                        :event-count 0
                        :completed-dag-tasks #{:task-a}
                        :completed-dag-artifacts [{:artifact/id "art-1"}]
+                       :workspace-checkpoint {:branch "task-a"
+                                              :bundle-path "/tmp/task-a.bundle"}
                        :phase-results {:plan {:status :completed}}
                        :machine-snapshot {:execution/id workflow-id}
                        :workflow-spec {:name "canonical-sdlc"
@@ -152,7 +154,10 @@
         (is (= #{:task-a}
                (:pre-completed-dag-tasks @run-pipeline-opts)))
         (is (= [{:artifact/id "art-1"}]
-               (:pre-completed-artifacts @run-pipeline-opts)))))))
+               (:pre-completed-artifacts @run-pipeline-opts)))
+        (is (= {:branch "task-a"
+                :bundle-path "/tmp/task-a.bundle"}
+               (:resume-workspace @run-pipeline-opts)))))))
 
 (deftest resume-workflow-trims-failed-checkpoint-before-running-test
   (let [workflow-id (random-uuid)

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -74,6 +74,10 @@
 
 (def ^:private impl-config-path "config/repo-index/implementer.edn")
 
+(def ^:private current-head-ref
+  "Git ref for the currently acquired promoted workspace."
+  "HEAD")
+
 (defn- load-ext->language []
   (if-let [res (io/resource impl-config-path)]
     (get-in (edn/read-string (slurp res)) [:repo-index/implementer :extension->language] {})
@@ -570,10 +574,23 @@
   (let [base-sha (get-in context [:execution/environment-metadata :base-sha])
         base-branch (or (get-in context [:execution/environment-metadata :base-branch])
                         (get-in context [:execution/opts :branch])
-                        (get-in context [:execution/input :branch]))]
+                        (get-in context [:execution/input :branch]))
+        resume-workspace (get-in context [:execution/opts :resume-workspace])
+        original-commit (get-in context [:execution/input :context :git-commit])
+        original-branch (get-in context [:execution/input :context :git-branch])
+        original-refs (concat (when (and original-commit
+                                         (not (str/blank? original-commit)))
+                                [original-commit])
+                              (when (and original-branch
+                                         (not (str/blank? original-branch)))
+                                [(str "refs/remotes/origin/" original-branch)
+                                 (str "origin/" original-branch)
+                                 (str "refs/heads/" original-branch)]))
+        resume-ranges (when resume-workspace
+                        (map #(str % "..." current-head-ref) original-refs))]
     (into []
           (distinct)
-          (cond-> []
+          (cond-> (vec resume-ranges)
             (and base-sha (not (str/blank? base-sha)))
             (conj base-sha)
 

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -477,6 +477,24 @@
              candidates))
       (is (not (contains? (set candidates) "main"))))))
 
+(deftest base-ref-candidates-use-resume-merge-base-ranges
+  (testing "resumed workspaces compare the original spec base to restored HEAD"
+    (let [candidates (@#'implementer/base-ref-candidates
+                      {:execution/environment-metadata {:base-sha "task-sha"
+                                                        :base-branch "task-restored"}
+                       :execution/opts {:resume-workspace {:branch "task-restored"}}
+                       :execution/input {:context {:git-commit "spec-sha"
+                                                   :git-branch "dogfood/source"}}})]
+      (is (= ["spec-sha...HEAD"
+              "refs/remotes/origin/dogfood/source...HEAD"
+              "origin/dogfood/source...HEAD"
+              "refs/heads/dogfood/source...HEAD"
+              "task-sha"
+              "refs/remotes/origin/task-restored"
+              "origin/task-restored"
+              "refs/heads/task-restored"]
+             candidates)))))
+
 ;------------------------------------------------------------------------------ Layer 4
 ;; Utility tests
 

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -53,6 +53,10 @@
    Failure summaries are typically in the first/last 30 lines."
   60)
 
+(def ^:private current-head-ref
+  "Git ref for the currently acquired promoted workspace."
+  "HEAD")
+
 (defn- truncate-test-output
   "Truncate test output to max-test-output-lines, keeping head and tail."
   [output]
@@ -108,13 +112,30 @@
 (defn- base-ref-candidates
   "Return candidate refs for collecting the promoted task artifact."
   [ctx]
-  (let [base-sha (get-in ctx [:execution/environment-metadata :base-sha])
-        base-branch (or (get-in ctx [:execution/environment-metadata :base-branch])
-                        (get-in ctx [:execution/opts :branch])
-                        (get-in ctx [:execution/input :branch]))]
-    (cond-> []
-      base-sha (conj base-sha)
-      base-branch (conj (str "origin/" base-branch) base-branch))))
+  (letfn [(present-string? [value]
+            (and (string? value) (not (str/blank? value))))
+          (branch-refs [branch]
+            (when (present-string? branch)
+              [(str "refs/remotes/origin/" branch)
+               (str "origin/" branch)
+               (str "refs/heads/" branch)]))]
+    (let [base-sha (get-in ctx [:execution/environment-metadata :base-sha])
+          base-branch (or (get-in ctx [:execution/environment-metadata :base-branch])
+                          (get-in ctx [:execution/opts :branch])
+                          (get-in ctx [:execution/input :branch]))
+          resume-workspace (get-in ctx [:execution/opts :resume-workspace])
+          original-commit (get-in ctx [:execution/input :context :git-commit])
+          original-branch (get-in ctx [:execution/input :context :git-branch])
+          original-refs (concat (when (present-string? original-commit)
+                                  [original-commit])
+                                (branch-refs original-branch))
+          resume-ranges (when resume-workspace
+                          (map #(str % "..." current-head-ref) original-refs))]
+      (into []
+            (comp (filter present-string?) (distinct))
+            (concat resume-ranges
+                    [base-sha]
+                    (branch-refs base-branch))))))
 
 (defn- resolve-files-in-scope
   "Resolve files-in-scope from input, checking context and intent."

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -110,6 +110,24 @@
       (is (= :implementer (:agent defaults)))
       (is (= [:syntax :format :lint] (:gates defaults))))))
 
+(deftest base-ref-candidates-include-resume-merge-base-ranges-test
+  (testing "resumed workspaces diff from the original spec base to restored HEAD"
+    (let [candidates (#'implement/base-ref-candidates
+                      {:execution/environment-metadata {:base-sha "task-sha"
+                                                        :base-branch "task-restored"}
+                       :execution/opts {:resume-workspace {:branch "task-restored"}}
+                       :execution/input {:context {:git-commit "spec-sha"
+                                                   :git-branch "dogfood/source"}}})]
+      (is (= ["spec-sha...HEAD"
+              "refs/remotes/origin/dogfood/source...HEAD"
+              "origin/dogfood/source...HEAD"
+              "refs/heads/dogfood/source...HEAD"
+              "task-sha"
+              "refs/remotes/origin/task-restored"
+              "origin/task-restored"
+              "refs/heads/task-restored"]
+             candidates)))))
+
 ;------------------------------------------------------------------------------ Layer 1: Interceptor Enter Tests
 
 (deftest enter-implement-sets-phase-metadata-test

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -77,6 +77,31 @@
        (mapcat #(get-in % [:dag/result :data :artifacts] []))
        vec))
 
+(defn extract-workspace-checkpoints
+  "Workspace persistence records emitted at phase boundaries.
+
+   These are the container/worktree provenance records that survive when
+   a DAG task eventually fails. Completed-DAG artifacts only exist for
+   successful tasks; failed repair loops still need the latest persisted
+   branch or bundle so resume continues from the last real workspace
+   state instead of starting from the spec base again."
+  [events]
+  (->> events
+       (filter #(= :workspace/persisted (:event/type %)))
+       (keep (fn [event]
+               (let [checkpoint {:branch (:workspace/branch event)
+                                 :bundle-path (:workspace/bundle-path event)
+                                 :commit-sha (:workspace/commit-sha event)
+                                 :persist-tier (:workspace/persist-tier event)
+                                 :env-id (:workspace/env-id event)
+                                 :phase (:workflow/phase event)
+                                 :timestamp (:event/timestamp event)}]
+                 (when (and (:branch checkpoint)
+                            (or (:bundle-path checkpoint)
+                                (:commit-sha checkpoint)))
+                   checkpoint))))
+       vec))
+
 (defn extract-dag-pause-info
   "Find the last `:dag/paused` event and extract completed task IDs + reason."
   [events]
@@ -267,6 +292,10 @@
       checkpoint-artifacts
       event-artifacts)))
 
+(defn- restored-workspace-checkpoint
+  [events]
+  (last (extract-workspace-checkpoints events)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Context reconstruction
 
@@ -312,6 +341,7 @@
         failed? (reconstructed-failed? by-type checkpoint-data)
         completed-dag-tasks (restored-completed-dag-tasks checkpoint-data events)
         completed-dag-artifacts (restored-completed-dag-artifacts checkpoint-data events)
+        workspace-checkpoint (restored-workspace-checkpoint events)
         dag-pause-info (restored-dag-pause-info checkpoint-data events)]
     {:phase-results phase-results
      :completed-phases completed-phases
@@ -324,6 +354,7 @@
      :event-count (count events)
      :completed-dag-tasks completed-dag-tasks
      :completed-dag-artifacts completed-dag-artifacts
+     :workspace-checkpoint workspace-checkpoint
      :dag-paused? (boolean dag-pause-info)
      :dag-pause-reason (:pause-reason dag-pause-info)
      :machine-snapshot machine-snapshot

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
@@ -46,6 +46,7 @@
 (def paused?                     core/paused?)
 (def extract-completed-dag-tasks core/extract-completed-dag-tasks)
 (def extract-completed-dag-artifacts core/extract-completed-dag-artifacts)
+(def extract-workspace-checkpoints core/extract-workspace-checkpoints)
 (def extract-dag-pause-info      core/extract-dag-pause-info)
 (def extract-completed-phases    core/extract-completed-phases)
 (def extract-phase-results       core/extract-phase-results)

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -84,6 +84,27 @@
       (is (= [{:artifact/id "a"} {:artifact/id "b"} {:artifact/id "c"}]
              (core/extract-completed-dag-artifacts events))))))
 
+(deftest extract-workspace-checkpoints-test
+  (testing "collects persisted workspace provenance for failed-task resume"
+    (let [events [{:event/type :workspace/persisted
+                   :workspace/branch "task-a"
+                   :workspace/bundle-path "/tmp/task-a.bundle"
+                   :workspace/commit-sha "abc"
+                   :workspace/env-id "task-a"
+                   :workflow/phase :review
+                   :event/timestamp "2026-05-16T00:00:00Z"}
+                  {:event/type :workspace/persisted
+                   :workspace/branch "task-b"
+                   :workspace/bundle-path "/tmp/task-b.bundle"
+                   :workspace/commit-sha "def"}
+                  {:event/type :workspace/persisted
+                   :workspace/branch nil
+                   :workspace/bundle-path "/tmp/ignored.bundle"}]
+          checkpoints (core/extract-workspace-checkpoints events)]
+      (is (= 2 (count checkpoints)))
+      (is (= "task-a" (:branch (first checkpoints))))
+      (is (= "/tmp/task-b.bundle" (:bundle-path (second checkpoints)))))))
+
 (deftest extract-dag-pause-info-last-pause-wins-test
   (testing "multiple pause events — latest one wins"
     (let [events [{:event/type :dag/paused
@@ -265,17 +286,32 @@
                       {"~:event/type" "~:workflow/phase-completed"
                        "~:workflow/phase" "~:implement"
                        "~:phase/outcome" "~:failure"})
+        (write-event! wf-dir "20260421T000004Z-w.json"
+                      {"~:event/type" "~:workspace/persisted"
+                       "~:workspace/branch" "task-resume"
+                       "~:workspace/bundle-path" "/tmp/task-resume.bundle"
+                       "~:workspace/commit-sha" "abc123"
+                       "~:workspace/env-id" "task-resume"
+                       "~:workflow/phase" "~:review"})
         (testing "reconstructs context from per-event JSON files"
           (let [ctx (core/reconstruct-context base-dir wf-id)]
             (is (= [:explore :plan] (:completed-phases ctx)))
-            (is (= 4 (:event-count ctx)))
+            (is (= 5 (:event-count ctx)))
             (is (false? (:completed? ctx)))
             (is (false? (:failed? ctx)))
             (is (= wf-id (:workflow-id ctx)))
             (is (= {"name" "resumable" "version" "2.0"}
                    (:workflow-spec ctx)))
             (is (= 123 (get-in ctx [:phase-results :explore :duration-ms])))
-            (is (= :success (get-in ctx [:phase-results :plan :outcome])))))))))
+            (is (= :success (get-in ctx [:phase-results :plan :outcome])))
+            (is (= {:branch "task-resume"
+                    :bundle-path "/tmp/task-resume.bundle"
+                    :commit-sha "abc123"
+                    :persist-tier nil
+                    :env-id "task-resume"
+                    :phase :review
+                    :timestamp nil}
+                   (:workspace-checkpoint ctx)))))))))
 
 (deftest reconstruct-context-missing-workflow-test
   (with-temp-events-dir
@@ -368,6 +404,7 @@
     (is (= core/paused? wr/paused?))
     (is (= core/extract-completed-dag-tasks wr/extract-completed-dag-tasks))
     (is (= core/extract-completed-dag-artifacts wr/extract-completed-dag-artifacts))
+    (is (= core/extract-workspace-checkpoints wr/extract-workspace-checkpoints))
     (is (= core/extract-completed-phases wr/extract-completed-phases))
     (is (= core/reconstruct-context wr/reconstruct-context))
     (is (= core/trim-pipeline wr/trim-pipeline))

--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -76,6 +76,7 @@
   :env/release-failed       "Environment release failed: {error}"
   :env/persist-message      "{phase} phase completed"
   :env/persist-failed       "Workspace persist failed: {error}"
+  :env/restore-failed       "Workspace restore failed: {error}"
 
   ;; v2 multi-parent merge (DAG orchestrator) — anomaly + log messages
   :dag.merge/branch-unresolvable     "Parent branch could not be resolved to a commit"

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -277,12 +277,15 @@
     [nil opts]
     (let [repo-url (get opts :repo-url (get input :repo-url))
           branch   (get opts :branch (get input :branch "main"))
+          repo-path (get opts :repo-path (get input :repo-path "."))
           acquired (env/acquire-execution-environment!
                     (:workflow/id workflow)
                     {:repo-url        repo-url
                      :branch          branch
+                     :repo-path       repo-path
                      :execution-mode  (:execution-mode opts)
-                     :executor-config (:executor-config opts)})]
+                     :executor-config (:executor-config opts)
+                     :resume-workspace (:resume-workspace opts)})]
       [acquired (if acquired
                   (merge opts {:branch branch} acquired)
                   opts)])))

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -105,6 +105,34 @@
          :execution-mode       mode
          :environment-metadata (:metadata env)}))))
 
+(defn- restore-local-workspace-checkpoint!
+  "Restore a persisted local workspace branch before acquiring a worktree.
+
+   Local resume must make the last persisted branch visible before
+   `git worktree add` runs. Governed runtimes restore inside the capsule;
+   local worktrees are acquired from a host ref, so the host ref has to
+   exist first."
+  [executor repo-path {:keys [bundle-path branch] :as checkpoint}]
+  (when (and executor bundle-path branch)
+    (try
+      (let [result (dag/restore-workspace! executor nil
+                                           {:host-repo-path (or repo-path ".")
+                                            :workdir (or repo-path ".")
+                                            :bundle-path bundle-path
+                                            :branch branch})]
+        (when-not (dag/ok? result)
+          (log/warn env-logger :workflow :workflow/restore-failed
+                    {:message (messages/t :env/restore-failed
+                                          {:error (str result)})
+                     :data checkpoint}))
+        result)
+      (catch Exception e
+        (log/warn env-logger :workflow :workflow/restore-failed
+                  {:message (messages/t :env/restore-failed
+                                        {:error (ex-message e)})
+                   :data checkpoint})
+        nil))))
+
 (defn- acquire-worktree-and-capsule
   "Acquire both a host worktree and a capsule for governed mode."
   [executor workflow-id mode env-config fns]
@@ -125,16 +153,19 @@
 (defn acquire-execution-environment!
   "Acquire an isolated execution environment before pipeline starts.
    Returns env map, or nil (local) / throws (governed) on failure."
-  [workflow-id {:keys [repo-url branch execution-mode executor-config]}]
+  [workflow-id {:keys [repo-url branch repo-path execution-mode executor-config
+                       resume-workspace]}]
   (let [mode (get {:governed :governed} execution-mode :local)]
     (try
       (let [fns      (dag-executor-fns)
             config   (registry-config-for-mode mode executor-config)
             registry ((:create-registry fns) config)
             executor (select-capsule-executor registry mode fns)
+            branch   (or (:branch resume-workspace) branch)
             env-config (cond-> {}
                          repo-url (assoc :repo-url repo-url)
-                         branch   (assoc :branch branch))]
+                         branch   (assoc :branch branch)
+                         repo-path (assoc :repo-path repo-path))]
         (when-let [a (check-executor-for-mode executor mode)]
           ;; Boundary throw: acquire-execution-environment! is the
           ;; runner's escalation point for governed-mode unavailability.
@@ -144,6 +175,8 @@
                                    (:anomaly/message a)
                                    {:anomaly.executor/mode (get-in a [:anomaly/data :mode])
                                     :hint (get-in a [:anomaly/data :hint])}))
+        (when (= :local mode)
+          (restore-local-workspace-checkpoint! executor repo-path resume-workspace))
         (when executor
           (if (= :governed mode)
             (acquire-worktree-and-capsule executor workflow-id mode env-config fns)

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -432,6 +432,30 @@
             (is (= {:base-branch "main"}
                    (:execution/environment-metadata result)))))))))
 
+(deftest run-pipeline-threads-resume-workspace-to-acquisition-test
+  (testing "resume workspace checkpoint reaches environment acquisition"
+    (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)
+          env-config-seen (atom nil)
+          resume-workspace {:branch "task-resume"
+                            :bundle-path "/tmp/task-resume.bundle"}]
+      (with-redefs-fn
+        {acquire-var (fn [_workflow-id env-config]
+                       (reset! env-config-seen env-config)
+                       {:executor ::stub-executor
+                        :environment-id "task-resume"
+                        :worktree-path "/tmp/task-resume"
+                        :execution-mode :local
+                        :environment-metadata {:base-branch (:branch env-config)}})}
+        (fn []
+          (let [workflow {:workflow/id :test
+                          :workflow/version "1.0.0"
+                          :workflow/pipeline [{:phase test-done-phase}]}
+                result (runner/run-pipeline workflow
+                                            {:task "Test"}
+                                            {:resume-workspace resume-workspace})]
+            (is (= resume-workspace (:resume-workspace @env-config-seen)))
+            (is (= :completed (:execution/status result)))))))))
+
 (deftest run-pipeline-resume-preserves-checkpoint-metadata-test
   (testing "resume keeps checkpoint metadata when no fresh environment metadata is supplied"
     (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)

--- a/docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md
+++ b/docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md
@@ -23,6 +23,9 @@ inside a repair loop, there were no completed DAG artifacts, so the next
 - Local environment acquisition restores the checkpoint bundle into the host
   repo before acquiring a worktree and prefers the persisted task branch as the
   acquisition branch.
+- Implement artifact collection adds resume-specific merge-base diff candidates
+  from the original spec commit or branch to the restored workspace `HEAD`, so
+  files already present in the promoted workspace remain valid provenance.
 - Workflow messages now include a localized workspace restore failure message.
 
 ## Dogfood Notes
@@ -33,12 +36,18 @@ inside a repair loop, there were no completed DAG artifacts, so the next
   failed with `:curator/no-files-written`.
 - With this change, resume has enough provenance to continue from the last
   promoted workspace state.
+- A follow-up dogfood resume restored `task-79ca5c82` but failed because
+  artifact collection compared the new worktree against the restored task
+  branch itself. The corrected diff base is the merge-base between the original
+  spec ref and the restored `HEAD`.
 
 ## Testing Plan
 
 - `clojure -M:dev:test -e ... workflow-resume.core-test`
 - `clojure -M:dev:test -e ... cli.main.commands.resume-test`
 - `clojure -M:dev:test -e ... workflow.runner-test`
+- `clojure -M:dev:test -e ... phase-software-factory.implement-test`
+- `clojure -M:dev:test -e ... agent.implementer-test`
 - `bb pre-commit`
 
 ## Deployment Plan
@@ -56,4 +65,6 @@ acquisition.
 - [x] Resume records workspace provenance from persisted events.
 - [x] CLI resume threads workspace checkpoint data into the next run.
 - [x] Local worktree acquisition can start from the persisted task branch.
+- [x] Resumed artifact collection compares restored workspaces against the
+      original spec base via merge-base ranges.
 - [x] Focused tests cover reconstruction, CLI plumbing, and runner plumbing.

--- a/docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md
+++ b/docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md
@@ -1,0 +1,59 @@
+# Fix: Resume From Workspace Checkpoints
+
+## Overview
+
+This PR fixes checkpoint resume so failed dogfood runs continue from the latest
+persisted workspace branch or bundle instead of reacquiring a fresh worktree
+from the original spec base.
+
+## Motivation
+
+Dogfood run `3927baf8-c9db-44d3-b5fb-5a1552dbe554` had 59
+`:workspace/persisted` events and durable task bundles, but resume only
+threaded completed-DAG artifacts into the next run. When the checkpoint failed
+inside a repair loop, there were no completed DAG artifacts, so the next
+`implement` attempt started from a clean base and failed with
+`:curator/no-files-written`.
+
+## Changes in Detail
+
+- Resume reconstruction now extracts persisted workspace checkpoints from
+  `:workspace/persisted` events.
+- CLI resume passes the latest workspace checkpoint into `run-pipeline`.
+- Local environment acquisition restores the checkpoint bundle into the host
+  repo before acquiring a worktree and prefers the persisted task branch as the
+  acquisition branch.
+- Workflow messages now include a localized workspace restore failure message.
+
+## Dogfood Notes
+
+- The failing resume had a latest persisted branch of `task-79ca5c82` at
+  commit `2a8f7e6ac8963e71e60e1c6c4f18f3ff3923f5c5`.
+- The failed retry acquired a new clean worktree `task-cbe8110c` and then
+  failed with `:curator/no-files-written`.
+- With this change, resume has enough provenance to continue from the last
+  promoted workspace state.
+
+## Testing Plan
+
+- `clojure -M:dev:test -e ... workflow-resume.core-test`
+- `clojure -M:dev:test -e ... cli.main.commands.resume-test`
+- `clojure -M:dev:test -e ... workflow.runner-test`
+- `bb pre-commit`
+
+## Deployment Plan
+
+Merge after review. This is scoped to checkpoint resume and local worktree
+acquisition.
+
+## Related Issues/PRs
+
+- Dogfood target: `work/event-log-tool-visibility.spec.edn`
+- Follow-up from the artifact provenance work in the May 15 dogfood PR.
+
+## Checklist
+
+- [x] Resume records workspace provenance from persisted events.
+- [x] CLI resume threads workspace checkpoint data into the next run.
+- [x] Local worktree acquisition can start from the persisted task branch.
+- [x] Focused tests cover reconstruction, CLI plumbing, and runner plumbing.


### PR DESCRIPTION
# Fix: Resume From Workspace Checkpoints

## Overview

This PR fixes checkpoint resume so failed dogfood runs continue from the latest
persisted workspace branch or bundle instead of reacquiring a fresh worktree
from the original spec base.

## Motivation

Dogfood run `3927baf8-c9db-44d3-b5fb-5a1552dbe554` had 59
`:workspace/persisted` events and durable task bundles, but resume only
threaded completed-DAG artifacts into the next run. When the checkpoint failed
inside a repair loop, there were no completed DAG artifacts, so the next
`implement` attempt started from a clean base and failed with
`:curator/no-files-written`.

## Changes in Detail

- Resume reconstruction now extracts persisted workspace checkpoints from
  `:workspace/persisted` events.
- CLI resume passes the latest workspace checkpoint into `run-pipeline`.
- Local environment acquisition restores the checkpoint bundle into the host
  repo before acquiring a worktree and prefers the persisted task branch as the
  acquisition branch.
- Workflow messages now include a localized workspace restore failure message.

## Dogfood Notes

- The failing resume had a latest persisted branch of `task-79ca5c82` at
  commit `2a8f7e6ac8963e71e60e1c6c4f18f3ff3923f5c5`.
- The failed retry acquired a new clean worktree `task-cbe8110c` and then
  failed with `:curator/no-files-written`.
- With this change, resume has enough provenance to continue from the last
  promoted workspace state.

## Testing Plan

- `clojure -M:dev:test -e ... workflow-resume.core-test`
- `clojure -M:dev:test -e ... cli.main.commands.resume-test`
- `clojure -M:dev:test -e ... workflow.runner-test`
- `bb pre-commit`

## Deployment Plan

Merge after review. This is scoped to checkpoint resume and local worktree
acquisition.

## Related Issues/PRs

- Dogfood target: `work/event-log-tool-visibility.spec.edn`
- Follow-up from the artifact provenance work in the May 15 dogfood PR.

## Checklist

- [x] Resume records workspace provenance from persisted events.
- [x] CLI resume threads workspace checkpoint data into the next run.
- [x] Local worktree acquisition can start from the persisted task branch.
- [x] Focused tests cover reconstruction, CLI plumbing, and runner plumbing.
