### PR TITLE
Fix implement leave nil start time

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -492,7 +492,7 @@
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
-        duration-ms (- end-time start-time)
+        duration-ms (if start-time (- end-time start-time) 0)
         result (get-in ctx [:phase :result])
         agent-status (:status result)
         rate-limited? (and (= :error agent-status) (rate-limit-in-result? result))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -341,6 +341,19 @@
         (is (= :implement (first (get-in final-result [:execution :phases-completed])))
             "Implement should be added to phases-completed")))))
 
+(deftest leave-implement-handles-nil-start-time-test
+  (testing "leave-implement does not NPE when :started-at is nil"
+    (let [interceptor (phase/get-phase-interceptor {:phase :implement})
+          ctx {:phase {:result {:status :error
+                                :error {:message "agent failed"}}
+                       :budget {:iterations 2}
+                       :iterations 1}
+               :execution/metrics {:tokens 0 :duration-ms 0}}
+          result ((:leave interceptor) ctx)]
+      (is (some? result) "leave-implement should not throw")
+      (is (= 0 (get-in result [:phase :duration-ms]))
+          "Duration should default to 0 when start-time is nil"))))
+
 (deftest leave-implement-preserves-curated-artifact-test
   (testing "successful implement preserves curated artifact on the outer phase map for downstream review"
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})

--- a/docs/pull-requests/2026-05-16-fix-implement-leave-nil-start-time.md
+++ b/docs/pull-requests/2026-05-16-fix-implement-leave-nil-start-time.md
@@ -1,0 +1,24 @@
+<!--
+  Title: Fix Implement Leave Nil Start Time
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix Implement Leave Nil Start Time
+
+## Summary
+
+Dogfood resume run `3927baf8-c9db-44d3-b5fb-5a1552dbe554` repeatedly recorded
+`:leave-error` anomalies in the implement phase with a null-pointer exception
+and no useful message. The run continued through checkpoint persistence, but the
+error history made the eventual workflow failure harder to understand.
+
+`leave-implement` assumed `[:phase :started-at]` was always present and computed
+duration with `(- end-time start-time)`. Other leave handlers already tolerate a
+missing start time; implement now follows that same pattern and records duration
+`0` when the enter context did not establish a start timestamp.
+
+## Validation
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.implement-test 'clojure.test)
+  (clojure.test/run-tests 'ai.miniforge.phase-software-factory.implement-test)"`


### PR DESCRIPTION
<!--
  Title: Fix Implement Leave Nil Start Time
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Fix Implement Leave Nil Start Time

## Summary

Dogfood resume run `3927baf8-c9db-44d3-b5fb-5a1552dbe554` repeatedly recorded
`:leave-error` anomalies in the implement phase with a null-pointer exception
and no useful message. The run continued through checkpoint persistence, but the
error history made the eventual workflow failure harder to understand.

`leave-implement` assumed `[:phase :started-at]` was always present and computed
duration with `(- end-time start-time)`. Other leave handlers already tolerate a
missing start time; implement now follows that same pattern and records duration
`0` when the enter context did not establish a start timestamp.

## Validation

- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.implement-test 'clojure.test)
  (clojure.test/run-tests 'ai.miniforge.phase-software-factory.implement-test)"`
