### PR TITLE
Fix implement leave nil iterations

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -505,7 +505,7 @@
         ;; are a first-class concept.
         curator-empty-diff? (= :curator/no-files-written
                                (get-in result [:error :data :code]))
-        iterations (get-in ctx [:phase :iterations] 1)
+        iterations (or (get-in ctx [:phase :iterations]) 1)
         max-iterations (get-in ctx [:phase :budget :iterations]
                                (get-in default-config [:budget :iterations]))
         ;; In the environment promotion model the agent writes files directly to

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -342,17 +342,19 @@
             "Implement should be added to phases-completed")))))
 
 (deftest leave-implement-handles-nil-start-time-test
-  (testing "leave-implement does not NPE when :started-at is nil"
+  (testing "leave-implement does not NPE when resume left timing or iteration fields nil"
     (let [interceptor (phase/get-phase-interceptor {:phase :implement})
           ctx {:phase {:result {:status :error
                                 :error {:message "agent failed"}}
                        :budget {:iterations 2}
-                       :iterations 1}
+                       :iterations nil}
                :execution/metrics {:tokens 0 :duration-ms 0}}
           result ((:leave interceptor) ctx)]
       (is (some? result) "leave-implement should not throw")
       (is (= 0 (get-in result [:phase :duration-ms]))
-          "Duration should default to 0 when start-time is nil"))))
+          "Duration should default to 0 when start-time is nil")
+      (is (= 0 (get-in result [:metrics :implementation :repair-cycles]))
+          "Nil iterations should fall back to first-attempt metrics"))))
 
 (deftest leave-implement-preserves-curated-artifact-test
   (testing "successful implement preserves curated artifact on the outer phase map for downstream review"

--- a/docs/pull-requests/2026-05-16-fix-implement-leave-nil-iterations.md
+++ b/docs/pull-requests/2026-05-16-fix-implement-leave-nil-iterations.md
@@ -1,0 +1,24 @@
+<!--
+  Title: Fix Implement Leave Nil Iterations
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix Implement Leave Nil Iterations
+
+## Summary
+
+After PR #889, dogfood resume no longer failed on a missing implement
+`:started-at`, but the same workflow still recorded `:implement` leave NPEs.
+The remaining nil path was `[:phase :iterations]`: resumed or redirected phase
+state can carry the key with a nil value, and `get-in` defaults do not apply when
+the value is present-but-nil.
+
+`leave-implement` now treats nil iterations as the first attempt. The regression
+test covers both nil timing and nil iteration state so future checkpoint resumes
+do not reintroduce this failure mode.
+
+## Validation
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.implement-test 'clojure.test)
+  (clojure.test/run-tests 'ai.miniforge.phase-software-factory.implement-test)"`


### PR DESCRIPTION
<!--
  Title: Fix Implement Leave Nil Iterations
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Fix Implement Leave Nil Iterations

## Summary

After PR #889, dogfood resume no longer failed on a missing implement
`:started-at`, but the same workflow still recorded `:implement` leave NPEs.
The remaining nil path was `[:phase :iterations]`: resumed or redirected phase
state can carry the key with a nil value, and `get-in` defaults do not apply when
the value is present-but-nil.

`leave-implement` now treats nil iterations as the first attempt. The regression
test covers both nil timing and nil iteration state so future checkpoint resumes
do not reintroduce this failure mode.

## Validation

- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.implement-test 'clojure.test)
  (clojure.test/run-tests 'ai.miniforge.phase-software-factory.implement-test)"`
