### PR TITLE
Fix verify parse error feedback

### DIFF
--- a/components/phase-software-factory/resources/config/phase/messages/en-US.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/en-US.edn
@@ -22,6 +22,7 @@
   :verify/no-environment-hint "Workflow runner must acquire an execution environment before verify phase"
   :verify/tests-passed        "All {pass-count} test(s) passed"
   :verify/tests-failed        "Tests failed: {fail-count} failure(s), {error-count} error(s)"
+  :verify/output-unparseable  "Test output could not be parsed"
   :verify/gate-failed         "Gate validation failed"
   :verify/failed              "Verification failed"
 

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -50,6 +50,10 @@
   "Maximum test-runner output included in the verify phase error message."
   2000)
 
+(def ^:private truncated-output-suffix
+  "Suffix appended when test-runner output is truncated for display."
+  "\n...")
+
 ;; Register defaults on load
 (phase/register-phase-defaults! :verify default-config)
 
@@ -107,7 +111,7 @@
   (let [trimmed (str/trim (str output))]
     (cond-> (subs trimmed 0 (min (count trimmed) verify-error-preview-limit))
       (> (count trimmed) verify-error-preview-limit)
-      (str "\n..."))))
+      (str truncated-output-suffix))))
 
 (defn- verify-failure-message
   "Build the user-facing verify failure message from parsed test results."
@@ -209,7 +213,11 @@
         pass-count (get test-results :test-count 0)
         raw-fails  (get test-results :fail-count 0)
         raw-errors (get test-results :error-count 0)
-        metrics    (phase/test-metrics pass-count (+ raw-fails raw-errors) (get test-results :output ""))
+        metrics    (cond-> (phase/test-metrics pass-count
+                                                (+ raw-fails raw-errors)
+                                                (get test-results :output ""))
+                     (:parse-error? test-results)
+                     (assoc :parse-error? true))
         summary    (if passed?
                      (messages/t :verify/tests-passed {:pass-count pass-count})
                      (verify-failure-message test-results raw-fails raw-errors))
@@ -232,10 +240,13 @@
         result (get-in ctx [:phase :result])
         agent-status (:status result)
         gate-failed? (= :failed (:phase/status (get-in ctx [:phase])))
+        parse-error? (true? (get-in result [:metrics :parse-error?]))
         timeout? (and (= :error agent-status)
+                      (not parse-error?)
                       (some-> (get-in result [:error :message])
                               (str/includes? timeout-message-fragment)))
         rate-limited? (and (= :error agent-status)
+                           (not parse-error?)
                            (let [msg (str (get-in result [:error :message]))]
                              (re-find verify-rate-limit-pattern msg)))
         phase-status (cond

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -46,6 +46,10 @@
   "Pattern for non-actionable verify failures caused by provider throttling."
   #"(?i)rate.?limit|429|you've hit your limit|quota.?exceeded")
 
+(def ^:private verify-error-preview-limit
+  "Maximum test-runner output included in the verify phase error message."
+  2000)
+
 ;; Register defaults on load
 (phase/register-phase-defaults! :verify default-config)
 
@@ -95,7 +99,24 @@
            :fail-count fail-count
            :error-count error-count
            :output output})
-        (assoc (test-error-result output) :error-count 0 :parse-error? true)))))
+        (assoc (test-error-result output) :parse-error? true)))))
+
+(defn- bounded-output-preview
+  "Return a bounded, trimmed preview of test runner output."
+  [output]
+  (let [trimmed (str/trim (str output))]
+    (cond-> (subs trimmed 0 (min (count trimmed) verify-error-preview-limit))
+      (> (count trimmed) verify-error-preview-limit)
+      (str "\n..."))))
+
+(defn- verify-failure-message
+  "Build the user-facing verify failure message from parsed test results."
+  [test-results raw-fails raw-errors]
+  (if (:parse-error? test-results)
+    (str (messages/t :verify/output-unparseable)
+         (when-let [preview (not-empty (bounded-output-preview (:output test-results)))]
+           (str "\n" preview)))
+    (messages/t :verify/tests-failed {:fail-count raw-fails :error-count raw-errors})))
 
 (defn infer-test-command
   "Infer the test command from the repo structure.
@@ -191,7 +212,7 @@
         metrics    (phase/test-metrics pass-count (+ raw-fails raw-errors) (get test-results :output ""))
         summary    (if passed?
                      (messages/t :verify/tests-passed {:pass-count pass-count})
-                     (messages/t :verify/tests-failed {:fail-count raw-fails :error-count raw-errors}))
+                     (verify-failure-message test-results raw-fails raw-errors))
         result     (if passed?
                      (phase/success env-id summary metrics)
                      (phase/error   env-id summary summary metrics))]

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
@@ -23,6 +23,7 @@
    test runner errors, and leave-verify redirect suppression."
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.string :as str]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.phase-software-factory.verify :as verify]))
@@ -130,6 +131,26 @@
                 "Runner error should produce :error result")
             (is (some? (get-in result [:phase :result :metrics :test-output]))
                 "Test output captured in metrics even on runner error")))))))
+
+(deftest verify-preserves-unparseable-test-output-test
+  (testing "unparseable test output is surfaced as actionable verify feedback"
+    (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
+      (with-redefs-fn
+        {run-var (fn [_ & _opts] {:passed? false
+                                  :test-count 0
+                                  :assertion-count 0
+                                  :fail-count 0
+                                  :error-count 1
+                                  :parse-error? true
+                                  :output "Syntax error compiling at src/example.clj:12:3"})}
+        (fn []
+          (let [ctx (-> (create-base-context)
+                        (assoc :phase-config {:phase :verify}))
+                interceptor (phase/get-phase-interceptor {:phase :verify})
+                result ((:enter interceptor) ctx)
+                message (get-in result [:phase :result :error :message])]
+            (is (str/includes? message "Test output could not be parsed"))
+            (is (str/includes? message "Syntax error compiling"))))))))
 
 ;------------------------------------------------------------------------------ Leave-verify redirect suppression tests (PR #288)
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
@@ -26,6 +26,7 @@
    [clojure.string :as str]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
+   [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.verify :as verify]))
 
 (def phase-test-config-resource
@@ -149,8 +150,42 @@
                 interceptor (phase/get-phase-interceptor {:phase :verify})
                 result ((:enter interceptor) ctx)
                 message (get-in result [:phase :result :error :message])]
-            (is (str/includes? message "Test output could not be parsed"))
+            (is (str/includes? message (messages/t :verify/output-unparseable)))
             (is (str/includes? message "Syntax error compiling"))))))))
+
+(deftest parse-test-output-marks-unparseable-output-test
+  (testing "the real parser treats unparseable output as one actionable error"
+    (let [result (verify/parse-test-output "Syntax error compiling at src/example.clj:12:3"
+                                           1)]
+      (is (false? (:passed? result)))
+      (is (true? (:parse-error? result)))
+      (is (= 1 (:error-count result)))
+      (is (= 0 (:fail-count result))))))
+
+(deftest verify-bounds-unparseable-output-preview-test
+  (testing "long unparseable output is bounded in the verify error message"
+    (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)
+          preview-limit @#'verify/verify-error-preview-limit
+          suffix @#'verify/truncated-output-suffix
+          output (apply str (repeat (+ preview-limit 50) "x"))]
+      (with-redefs-fn
+        {run-var (fn [_ & _opts] {:passed? false
+                                  :test-count 0
+                                  :assertion-count 0
+                                  :fail-count 0
+                                  :error-count 1
+                                  :parse-error? true
+                                  :output output})}
+        (fn []
+          (let [ctx (-> (create-base-context)
+                        (assoc :phase-config {:phase :verify}))
+                interceptor (phase/get-phase-interceptor {:phase :verify})
+                result ((:enter interceptor) ctx)
+                message (get-in result [:phase :result :error :message])
+                prefix (messages/t :verify/output-unparseable)]
+            (is (str/ends-with? message suffix))
+            (is (= (+ (count prefix) 1 preview-limit (count suffix))
+                   (count message)))))))))
 
 ;------------------------------------------------------------------------------ Leave-verify redirect suppression tests (PR #288)
 
@@ -168,6 +203,17 @@
   (testing "normal verify failure with :on-fail configured requests a redirect"
     (let [ctx (make-leave-ctx {:status :error
                                :error {:message "Tests failed: 3 assertions"}}
+                              :implement)
+          result (verify/leave-verify ctx)]
+      (is (= :implement (phase/transition-target (get result :phase))))
+      (is (phase/failed? (get result :phase))))))
+
+(deftest leave-verify-redirects-parse-error-output-with-provider-words-test
+  (testing "parse-error previews are actionable even when test output contains provider-like fragments"
+    (let [ctx (make-leave-ctx {:status :error
+                               :error {:message (str (messages/t :verify/output-unparseable)
+                                                     "\nHTTP 429 from project test output timed out")}
+                               :metrics {:parse-error? true}}
                               :implement)
           result (verify/leave-verify ctx)]
       (is (= :implement (phase/transition-target (get result :phase))))

--- a/docs/pull-requests/2026-05-16-fix-verify-parse-error-feedback.md
+++ b/docs/pull-requests/2026-05-16-fix-verify-parse-error-feedback.md
@@ -1,0 +1,29 @@
+<!--
+  Title: Fix Verify Parse Error Feedback
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix Verify Parse Error Feedback
+
+## Summary
+
+Dogfood resume showed repeated `verify -> implement` redirects with the message:
+
+```text
+Tests failed: 0 failure(s), 0 error(s)
+```
+
+That message is internally contradictory and gives the implementer nothing to
+repair. The actual condition was an unparseable test runner output: Verify was
+setting `:parse-error? true`, but then formatting the failure with zero failures
+and zero errors.
+
+Verify now treats parse errors as test-runner errors and includes a bounded
+preview of the raw output in the phase error. Repair prompts should now carry
+the compiler/test output that caused Verify to redirect.
+
+## Validation
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.verify-failure-modes-test 'clojure.test)
+  (clojure.test/run-tests 'ai.miniforge.phase-software-factory.verify-failure-modes-test)"`


### PR DESCRIPTION
<!--
  Title: Fix Verify Parse Error Feedback
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Fix Verify Parse Error Feedback

## Summary

Dogfood resume showed repeated `verify -> implement` redirects with the message:

```text
Tests failed: 0 failure(s), 0 error(s)
```

That message is internally contradictory and gives the implementer nothing to
repair. The actual condition was an unparseable test runner output: Verify was
setting `:parse-error? true`, but then formatting the failure with zero failures
and zero errors.

Verify now treats parse errors as test-runner errors and includes a bounded
preview of the raw output in the phase error. Repair prompts should now carry
the compiler/test output that caused Verify to redirect.

## Validation

- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.verify-failure-modes-test 'clojure.test)
  (clojure.test/run-tests 'ai.miniforge.phase-software-factory.verify-failure-modes-test)"`
