### PR TITLE
fix(reviewer): accept explicit nil on optional :review/issues fields (+ pre-commit hang fix)

### DIFF
--- a/components/agent/resources/config/agent/test-fixtures/en-US.edn
+++ b/components/agent/resources/config/agent/test-fixtures/en-US.edn
@@ -18,4 +18,32 @@
                   :line 313
                   the implement
                   agent \" require joining\"}]}
+```"
+
+  :reviewer-test/approved-with-nil-line-content
+  "```clojure
+{:review/decision :approved
+ :review/issues [{:severity :warning
+                  :file \"components/event-stream/src/ai/miniforge/event_stream/callbacks_test.clj\"
+                  :line nil
+                  :description \"No test covers the case where tool-result arrives with a call-id that was never registered in the SAME callback instance.\"
+                  :suggestion \"Add a test for the unmatched call-id path.\"}
+                 {:severity :nit
+                  :file \"components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj\"
+                  :line 115
+                  :description \"(not (empty? delta)) is less idiomatic than (seq delta).\"
+                  :suggestion \"Use (seq delta).\"}]
+ :review/summary \"Implementation correct. Spec fully satisfied.\"
+ :review/strengths [\"Per-instance atom scoping prevents cross-callback state leakage.\"]}
+```"
+
+  :reviewer-test/approved-with-nil-optional-fields-content
+  "```clojure
+{:review/decision :approved
+ :review/issues [{:severity :nit
+                  :file nil
+                  :line nil
+                  :description \"Overall architecture looks clean.\"
+                  :suggestion nil}]
+ :review/summary \"Approved with one architectural nit.\"}
 ```"}}

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -48,13 +48,25 @@
    [:duration-ms {:optional true} [:int {:min 0}]]])
 
 (def ReviewIssue
-  "Schema for a single review issue from LLM analysis."
+  "Schema for a single review issue from LLM analysis.
+
+   Optional fields are wrapped in `:maybe` because the LLM frequently
+   emits explicit `nil` for fields that don't apply to a given issue
+   (e.g. `:line nil` on a file-level concern). Bare `{:optional true}`
+   only permits the key to be absent, not present-but-nil — a strict
+   read of the schema would silently reject an otherwise-fine review
+   and cascade through `parse-review-response` → `llm-review = nil`
+   → `llm-decision = :rejected`, flipping a real :approved verdict
+   into a rejected one. The 2026-05-16 event-log-tool-visibility
+   dogfood (see project_dogfood_findings_2026_05_16) shipped a
+   verifier-pass + LLM-:approved build that the gate refused for
+   exactly this reason."
   [:map
    [:severity [:enum :blocking :warning :nit]]
-   [:file {:optional true} [:string {:min 1}]]
-   [:line {:optional true} [:int {:min 1}]]
+   [:file {:optional true} [:maybe [:string {:min 1}]]]
+   [:line {:optional true} [:maybe [:int {:min 1}]]]
    [:description [:string {:min 1}]]
-   [:suggestion {:optional true} [:string {:min 1}]]])
+   [:suggestion {:optional true} [:maybe [:string {:min 1}]]]])
 
 (def ReviewArtifact
   "Schema for the reviewer's output."

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -58,9 +58,9 @@
    and cascade through `parse-review-response` → `llm-review = nil`
    → `llm-decision = :rejected`, flipping a real :approved verdict
    into a rejected one. The 2026-05-16 event-log-tool-visibility
-   dogfood (see project_dogfood_findings_2026_05_16) shipped a
-   verifier-pass + LLM-:approved build that the gate refused for
-   exactly this reason."
+   dogfood shipped a verifier-pass + LLM-:approved build that the
+   gate refused for exactly this reason; the root-cause trace lives
+   in `docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md`."
   [:map
    [:severity [:enum :blocking :warning :nit]]
    [:file {:optional true} [:maybe [:string {:min 1}]]]

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -85,6 +85,12 @@
 (def ^:private malformed-review-issue-content
   (test-t :reviewer-test/malformed-review-issue-content))
 
+(def ^:private approved-with-nil-line-content
+  (test-t :reviewer-test/approved-with-nil-line-content))
+
+(def ^:private approved-with-nil-optional-fields-content
+  (test-t :reviewer-test/approved-with-nil-optional-fields-content))
+
 ;------------------------------------------------------------------------------ Test fixtures
 
 (defn passing-gate
@@ -329,6 +335,29 @@
 (deftest test-reviewer-rejects-structurally-corrupt-llm-issues
   (testing "valid EDN with malformed issue maps is treated as unparseable"
     (is (nil? (reviewer/parse-review-response malformed-review-issue-content)))))
+
+(deftest test-reviewer-accepts-issues-with-nil-line
+  ;; Reproduces the 2026-05-16 event-log-tool-visibility dogfood
+  ;; gate-vs-verdict mismatch: the LLM emitted :line nil on a
+  ;; file-level issue. The schema's pre-fix shape
+  ;; (`{:optional true} [:int {:min 1}]`) silently rejected the issue,
+  ;; parser returned nil, parse-failed? flipped llm-decision to
+  ;; :rejected, and the :review-approved gate correctly rejected a
+  ;; decision that should have been :approved. With :line wrapped in
+  ;; :maybe, explicit nil now round-trips through the parser.
+  (testing "issue with :line nil parses with :review/decision intact"
+    (let [parsed (reviewer/parse-review-response approved-with-nil-line-content)]
+      (is (some? parsed) "parser must not return nil for a nil-line issue")
+      (is (= :approved (:review/decision parsed)))
+      (is (= 2 (count (:review/issues parsed))))
+      (is (nil? (:line (first (:review/issues parsed))))
+          ":line nil must round-trip through the parser, not get dropped"))))
+
+(deftest test-reviewer-accepts-issues-with-all-optional-fields-nil
+  (testing "issue with :file nil, :line nil, :suggestion nil parses cleanly"
+    (let [parsed (reviewer/parse-review-response approved-with-nil-optional-fields-content)]
+      (is (some? parsed))
+      (is (= :approved (:review/decision parsed))))))
 
 (deftest test-reviewer-timeout-only-parseable-failure-is-agent-error
   (testing "timeout-only parsed review failures do not become rejected code-review artifacts"

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -6,6 +6,15 @@
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 
 (ns ai.miniforge.gate.policy-test
   (:require [clojure.test :refer [deftest is testing]]
@@ -14,12 +23,13 @@
 ;; -------------------------------------------------------------------------- check-review-approved
 ;; Cross-component contract: the reviewer agent (components/agent) produces an
 ;; artifact shaped like `build-review-artifact`'s output, with `:review/decision`
-;; at the top level. The 2026-05-16 event-log-tool-visibility dogfood
-;; (see project_dogfood_findings_2026_05_16) ran end-to-end and the reviewer
-;; emitted :approved, but a strict ReviewIssue schema upstream silently
-;; flipped the decision to :rejected. The gate side has always been correct;
-;; pin the contract from this side so a future "fix" can't loosen
-;; check-review-approved into a false positive.
+;; at the top level. The 2026-05-16 event-log-tool-visibility dogfood (root-
+;; cause walk in docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-
+;; tolerance.md) ran end-to-end and the reviewer emitted :approved, but a
+;; strict ReviewIssue schema upstream silently flipped the decision to
+;; :rejected. The gate side has always been correct; pin the contract from
+;; this side so a future "fix" can't loosen check-review-approved into a
+;; false positive.
 
 (deftest check-review-approved-passes-on-explicit-approved
   (testing ":review/decision :approved → :passed? true"

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -1,0 +1,65 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+
+(ns ai.miniforge.gate.policy-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.gate.policy :as policy]))
+
+;; -------------------------------------------------------------------------- check-review-approved
+;; Cross-component contract: the reviewer agent (components/agent) produces an
+;; artifact shaped like `build-review-artifact`'s output, with `:review/decision`
+;; at the top level. The 2026-05-16 event-log-tool-visibility dogfood
+;; (see project_dogfood_findings_2026_05_16) ran end-to-end and the reviewer
+;; emitted :approved, but a strict ReviewIssue schema upstream silently
+;; flipped the decision to :rejected. The gate side has always been correct;
+;; pin the contract from this side so a future "fix" can't loosen
+;; check-review-approved into a false positive.
+
+(deftest check-review-approved-passes-on-explicit-approved
+  (testing ":review/decision :approved → :passed? true"
+    (is (= {:passed? true}
+           (policy/check-review-approved
+             {:review/decision :approved
+              :review/summary "ok"
+              :review/issues []}
+             {})))))
+
+(deftest check-review-approved-passes-on-conditionally-approved
+  (testing ":review/decision :conditionally-approved → :passed? true"
+    (is (= {:passed? true}
+           (policy/check-review-approved
+             {:review/decision :conditionally-approved}
+             {})))))
+
+(deftest check-review-approved-fails-on-changes-requested
+  (let [result (policy/check-review-approved
+                 {:review/decision :changes-requested}
+                 {})]
+    (is (false? (:passed? result)))
+    (is (= :not-approved (-> result :errors first :type)))))
+
+(deftest check-review-approved-fails-on-rejected
+  (let [result (policy/check-review-approved
+                 {:review/decision :rejected}
+                 {})]
+    (is (false? (:passed? result)))))
+
+(deftest check-review-approved-fallback-paths-still-honored
+  (testing "legacy artifact shapes without :review/decision fall back to metadata flags"
+    (is (= {:passed? true}
+           (policy/check-review-approved {:metadata {:approved true}} {})))
+    (is (= {:passed? true}
+           (policy/check-review-approved {:artifact/metadata {:approved true}} {})))
+    (is (= {:passed? true}
+           (policy/check-review-approved {:review {:approved true}} {})))))
+
+(deftest check-review-approved-no-signal-fails-closed
+  (testing "artifact with no decision and no metadata flag → :passed? false"
+    (let [result (policy/check-review-approved {} {})]
+      (is (false? (:passed? result))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -30,6 +30,64 @@
    [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.workflow.phase-test-support :as phase-test-support]))
 
+;; ---------------------------------------------------------------------------- mock capsule executor
+;; The governed-mode tests below assert that run-pipeline routes mode/worktree
+;; metadata correctly. They should never touch a real Docker daemon —
+;; create-executor-registry's Docker branch can block indefinitely when the
+;; daemon is busy or stuck (which is exactly the hang documented in PR #893's
+;; PR doc, where bb pre-commit's stable-derived sweep stalled here for 300s+).
+;; Mock the dag-executor surface so these tests stay deterministic.
+
+(defn- mock-capsule-registry
+  "Drop-in for `dag-exec/create-executor-registry` that returns a synthetic
+   capsule executor without ever talking to Docker."
+  [_config]
+  {:docker   ::mock-capsule
+   :worktree ::mock-worktree})
+
+(defn- mock-capsule-select
+  "Drop-in for `dag-exec/select-executor` — returns the stub capsule
+   under governed mode and the stub worktree otherwise."
+  ([registry] (:docker registry))
+  ([registry & opts]
+   (let [{:keys [preferred]} (apply hash-map opts)]
+     (case preferred
+       :worktree (:worktree registry)
+       (:docker registry)))))
+
+(defn- mock-capsule-acquire
+  "Drop-in for `dag-exec/acquire-environment!`. Returns a host-path
+   environment record so :execution/worktree-path looks like a real
+   host worktree, not the container-internal /workspace."
+  [_executor task-id _config]
+  (dag-exec/ok {:environment-id (str "mock-env-" task-id)
+                :workdir        "/tmp/mock-host-worktree"
+                :metadata       {:base-branch "main"}}))
+
+(defn- mock-capsule-type
+  "Drop-in for `dag-exec/executor-type`. The capsule stub is :docker,
+   the worktree stub is :worktree — matches what the runner expects so
+   N11 §7.4's no-silent-downgrade check still discriminates."
+  [executor]
+  (case executor
+    ::mock-capsule  :docker
+    ::mock-worktree :worktree
+    :unknown))
+
+(defmacro ^:private with-mock-capsule-executor
+  "Run body with the dag-executor surface mocked out so governed-mode
+   path doesn't reach a real Docker daemon. Also no-ops release and
+   persist so the cleanup path doesn't log protocol-mismatch warnings
+   against the stub keyword executor."
+  [& body]
+  `(with-redefs [dag-exec/create-executor-registry mock-capsule-registry
+                 dag-exec/select-executor          mock-capsule-select
+                 dag-exec/acquire-environment!     mock-capsule-acquire
+                 dag-exec/executor-type            mock-capsule-type
+                 dag-exec/release-environment!     (fn [& _#] (dag-exec/ok {}))
+                 dag-exec/persist-workspace!       (fn [& _#] (dag-exec/ok {}))]
+     ~@body))
+
 (use-fixtures :each phase-test-support/with-workflow-phase-test-support)
 
 (def ^:private runner-test-plan
@@ -264,29 +322,22 @@
 
 (deftest run-pipeline-governed-mode-sets-execution-mode-test
   (testing ":governed mode sets :execution/mode :governed on context"
-    ;; Governed mode requires Docker or K8s. This test verifies the mode is
-    ;; propagated to the context regardless of which executor is selected.
-    ;; In environments without Docker/K8s, governed mode throws instead
-    ;; (N11 §7 no-silent-downgrade) — tested separately via mock.
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
               :workflow/pipeline [{:phase runner-test-done}]}]
-      (try
-        (let [result (runner/run-pipeline wf {:task "Test"} {:execution-mode :governed})]
-          ;; Docker was available — mode should be :governed on context
-          (is (= :governed (:execution/mode result))))
-        (catch Exception e
-          ;; Docker unavailable — exception message should match N11 spec language
-          (is (re-find #"(?i)No capsule executor" (ex-message e))))))))
+      (with-mock-capsule-executor
+        (let [result (runner/run-pipeline wf {:task "Test"}
+                                          {:execution-mode :governed})]
+          (is (= :governed (:execution/mode result))))))))
 
 (deftest run-pipeline-governed-mode-has-host-worktree-test
   (testing ":governed mode provides a host-accessible worktree-path (not /workspace)"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
               :workflow/pipeline [{:phase runner-test-done}]}]
-      (try
-        (let [result (runner/run-pipeline wf {:task "Test"} {:execution-mode :governed})]
-          ;; worktree-path should be a host path, not the container-internal /workspace
+      (with-mock-capsule-executor
+        (let [result (runner/run-pipeline wf {:task "Test"}
+                                          {:execution-mode :governed})]
           (is (some? (:execution/worktree-path result))
               "Should have a worktree path")
           (is (not= "/workspace" (:execution/worktree-path result))
@@ -294,10 +345,7 @@
           (is (some? (:execution/executor result))
               "Should have a capsule executor")
           (is (some? (:execution/environment-id result))
-              "Should have a capsule environment-id"))
-        (catch Exception _e
-          ;; Docker unavailable — skip test
-          nil)))))
+              "Should have a capsule environment-id"))))))
 
 (deftest run-pipeline-governed-mode-rejects-worktree-fallback-test
   (testing ":governed mode does not fall through to worktree (N11 §7.4 no-silent-downgrade)"
@@ -306,7 +354,9 @@
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
               :workflow/pipeline [{:phase runner-test-done}]}]
-      (with-redefs [dag-exec/executor-type (constantly :worktree)]
+      (with-redefs [dag-exec/create-executor-registry mock-capsule-registry
+                    dag-exec/select-executor          mock-capsule-select
+                    dag-exec/executor-type            (constantly :worktree)]
         (is (thrown-with-msg?
              Exception #"(?i)No capsule executor available"
              (runner/run-pipeline wf {:task "Test"}

--- a/docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md
+++ b/docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md
@@ -1,0 +1,159 @@
+# Fix: Reviewer issue schema rejected explicit nils, flipping :approved to :rejected silently
+
+## Overview
+
+The 2026-05-16 event-log-tool-visibility dogfood (see
+[project_dogfood_findings_2026_05_16](../../.claude/projects/-Users-chris-ws-miniforge-ai-miniforge/memory/project_dogfood_findings_2026_05_16.md))
+walked plan → implement → verify (78m, all 35 tests passed) → reviewer-emits
+`:review/decision :approved` on a real GROUP 1 build. The `:review-approved`
+gate then failed and the workflow died. The gate was right; the artifact
+that reached it had `:review/decision :rejected`, not `:approved`. A strict
+`ReviewIssue` schema in the parser cascade flipped the verdict before the
+gate ever saw it.
+
+## Motivation
+
+Same shape as the PR #867 `:passed?` gate bug — strict reading of an
+upstream contract silently flipping a downstream verdict. The
+`ReviewIssue` Malli schema declared `:line`, `:file`, and `:suggestion`
+as `{:optional true} [:int {:min 1}]` / `[:string {:min 1}]`. In Malli,
+`{:optional true}` means "the key may be ABSENT," NOT "the key may be
+present-but-nil." The reviewer LLM routinely emits `:line nil` on
+file-level concerns (e.g., "no test covers the case where..."). Each
+such issue failed `m/validate`, `valid-review-issues?` cascaded to
+`false`, `parse-review-response` returned `nil`,
+`parse-failed?` flipped `llm-decision` to `:rejected`, and an
+actually-`:approved` review came through as rejected. The gate then
+correctly rejected `:rejected`.
+
+The dogfood post-mortem made this visible because the run printed the
+LLM's raw `:approved` output to the chat log before the parser's silent
+rejection. Without that print, the bug would have read as
+"the reviewer never approves anything."
+
+## Changes in Detail
+
+### Schema: wrap optional fields in `:maybe`
+
+`components/agent/src/ai/miniforge/agent/reviewer.clj` — `ReviewIssue`
+schema now reads:
+
+```clojure
+[:map
+ [:severity [:enum :blocking :warning :nit]]
+ [:file {:optional true} [:maybe [:string {:min 1}]]]
+ [:line {:optional true} [:maybe [:int {:min 1}]]]
+ [:description [:string {:min 1}]]
+ [:suggestion {:optional true} [:maybe [:string {:min 1}]]]]
+```
+
+Plus a docstring that explains *why* — so the next person who tries to
+tighten this back doesn't reintroduce the bug.
+
+### Parser regression tests (dogfood-shape EDN)
+
+Two new tests in `reviewer_test.clj` pinned to fixtures that reproduce
+the dogfood's exact LLM output:
+
+- `test-reviewer-accepts-issues-with-nil-line` — issue with `:line nil`
+  parses and `:review/decision :approved` survives.
+- `test-reviewer-accepts-issues-with-all-optional-fields-nil` — issue
+  with `:file nil`, `:line nil`, `:suggestion nil` parses cleanly.
+
+### Gate-side contract pin
+
+New `components/gate/test/ai/miniforge/gate/policy_test.clj`. The
+`check-review-approved` gate had zero direct test coverage despite being
+the load-bearing check between the reviewer and release. Pin the contract
+from this side too:
+
+- `:approved` and `:conditionally-approved` → `:passed? true`
+- `:changes-requested` and `:rejected` → `:passed? false`
+- Legacy `[:metadata :approved]`, `[:artifact/metadata :approved]`,
+  `[:review :approved]` fallback paths still honored
+- Empty artifact → fails closed
+
+A future "tighten the approval check" can't loosen this back into a
+false positive without flipping a red test.
+
+### Scope check — is the same shape hiding elsewhere?
+
+The "shape" is: an LLM-output parser calling `m/validate` inline on
+an LLM-emitted map, with optional fields declared `{:optional true} T`
+instead of `{:optional true} [:maybe T]`. Surveyed every
+`parse-*-response` in the agent component:
+
+- `parse-review-response` — affected (fixed here).
+- `parse-code-response` (implementer) — only checks `(map? parsed)`;
+  schema validation happens later in `:validate-fn` during the repair
+  cycle, where rejection routes to repair, not to a verdict-flip.
+- `parse-release-response` (releaser) — same as above.
+- `parse-plan-response` (planner) — only checks `(map? parsed)`.
+- `parse-eval-response` (meta-evaluator) — JSON path, no Malli.
+
+So the bug is contained to reviewer. The cross-component contract test
+in `policy_test` guards the gate side regardless.
+
+## Testing Plan
+
+- [x] `clojure -A:test:dev -M -e "(require 'clojure.test
+  '[ai.miniforge.agent.reviewer-test] '[ai.miniforge.gate.policy-test])
+  (clojure.test/run-tests 'ai.miniforge.agent.reviewer-test
+                          'ai.miniforge.gate.policy-test)"`
+  → 35 tests, 111 assertions, 0 failures.
+- [x] `bb lint:clj` — clean on touched files (one pre-existing
+  `prompts/load-progress-monitor` warning, unrelated).
+- [x] `bb pre-commit` — passed cleanly on both commits in this PR.
+  PR #893's PR doc reported a `workflow.runner-extended-test` stall in
+  the stable-derived sweep; the first commit on this branch
+  (`test(workflow): stub dag executor in governed-mode runner tests`)
+  bisected and resolved that hang, so `bb pre-commit` is now reliably
+  green again.
+- [ ] Manual: rerun the dogfood after merge; expect the GROUP 1 build
+  that previously got an LLM-`:approved` to now also pass the gate and
+  proceed to release.
+
+## Deployment Plan
+
+Merge normally. Backwards compatible: `[:maybe T]` accepts both nil
+and a valid T value, so any existing valid review still parses.
+
+## Related Issues/PRs
+
+- Same shape as PR #867 (`:passed?` predicate gate bug).
+- Dogfood checkpoint: `c1abda63-3072-4f57-9871-6c177384968e`.
+- Spec: `work/event-log-tool-visibility.spec.edn`.
+- Memory: `project_dogfood_findings_2026_05_16.md` — full root-cause trace.
+
+## Bonus: pre-commit hang fix
+
+The first commit on this branch
+(`ea751fd9 test(workflow): stub dag executor in governed-mode runner
+tests so they don't hit Docker`) resolves the
+`workflow.runner-extended-test` hang documented in PR #893's PR doc.
+
+Chased via `bb test:since-stable:bisect` + a 20s-per-deftest
+watchdog. Three tests hang:
+`run-pipeline-governed-mode-{has-host-worktree,sets-execution-mode,rejects-worktree-fallback}-test`.
+All three call `run-pipeline ... {:execution-mode :governed}` →
+`create-docker-executor`, which blocks indefinitely when the local
+Docker daemon is busy. The tests are unit tests of run-pipeline mode
+propagation, not Docker integration tests, so stubbing the
+dag-executor surface in a `with-mock-capsule-executor` macro is the
+right scope. Each test now completes in ~200ms instead of hanging
+past 20s.
+
+Follow-up: a separate spec should add a configurable acquisition
+timeout to `acquire-environment!` so production callers also fail
+fast when Docker stalls (currently captured as a TODO in the commit
+trailer; will file as a work spec once the supervisor for this
+codebase merges this PR).
+
+## Checklist
+
+- [x] ReviewIssue schema accepts explicit `nil` on optional fields.
+- [x] Parser regression tests pinned to dogfood-shape EDN.
+- [x] Cross-component contract test for `check-review-approved`.
+- [x] Surveyed peer LLM parsers for the same shape; confirmed contained.
+- [x] `bb pre-commit` green on both commits in the branch.
+- [x] Resolved the `workflow.runner-extended-test` hang from PR #893's PR doc.

--- a/docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md
+++ b/docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md
@@ -2,8 +2,9 @@
 
 ## Overview
 
-The 2026-05-16 event-log-tool-visibility dogfood (see
-[project_dogfood_findings_2026_05_16](../../.claude/projects/-Users-chris-ws-miniforge-ai-miniforge/memory/project_dogfood_findings_2026_05_16.md))
+The 2026-05-16 event-log-tool-visibility dogfood (full root-cause trace
+in this PR doc; the run's spec lives at
+`work/event-log-tool-visibility.spec.edn`)
 walked plan → implement → verify (78m, all 35 tests passed) → reviewer-emits
 `:review/decision :approved` on a real GROUP 1 build. The `:review-approved`
 gate then failed and the workflow died. The gate was right; the artifact
@@ -123,7 +124,8 @@ and a valid T value, so any existing valid review still parses.
 - Same shape as PR #867 (`:passed?` predicate gate bug).
 - Dogfood checkpoint: `c1abda63-3072-4f57-9871-6c177384968e`.
 - Spec: `work/event-log-tool-visibility.spec.edn`.
-- Memory: `project_dogfood_findings_2026_05_16.md` — full root-cause trace.
+- Full root-cause trace: this PR doc (above), under "Motivation" and
+  "Changes in Detail" — no external memory link needed.
 
 ## Bonus: pre-commit hang fix
 


### PR DESCRIPTION
## Summary

The 2026-05-16 event-log-tool-visibility dogfood walked plan → implement →
verify (78m, 35 tests passed) → reviewer-emits `{:review/decision :approved}`
on a real GROUP 1 build. The `:review-approved` gate then failed and the
workflow died. The gate was right; the artifact reaching it had
`:review/decision :rejected`, not `:approved`. A strict `ReviewIssue`
schema flipped the verdict before the gate ever saw it. Same shape as the
PR #867 `:passed?` gate bug — strict reading of an upstream contract
silently flipping a downstream verdict.

Plus a bonus fix for the `workflow.runner-extended-test` hang that
PR #893's PR doc flagged as blocking `bb pre-commit`.

## Commits

- `ea751fd9` — `test(workflow): stub dag executor in governed-mode runner
  tests so they don't hit Docker` — three governed-mode tests routed
  through `create-docker-executor` and blocked indefinitely. Stubbed the
  dag-executor surface so the tests stay deterministic. Each test now
  completes in ~200ms instead of hanging past 20s.
- `6462023d` — `fix(reviewer): accept explicit nil on optional
  :review/issues fields` — wrap `:line`, `:file`, `:suggestion` in
  `[:maybe T]` so the LLM's explicit `nil` round-trips. New parser tests
  pinned to dogfood-shape EDN, plus a new `gate/policy_test` namespace
  pinning `check-review-approved`'s contract from the gate side so a
  future tightening can't loosen this back into a false positive.
- `0c11956e` — PR doc.

See [docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md](docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md)
for the full motivation, root-cause trace, and scope check (surveyed peer
LLM parsers; only the reviewer's path called `m/validate` inline in the
parse cascade, so the bug is contained).

## Test plan

- [x] Focused tests on touched namespaces — 35 reviewer/policy tests +
  33 runner-extended tests, all green (200 assertions).
- [x] `bb pre-commit` ran cleanly on both code commits in this branch —
  the runner-extended hang from PR #893's PR doc is resolved.
- [x] `bb lint:clj` clean.
- [ ] Manual: rerun the event-log-tool-visibility dogfood after merge;
  expect the GROUP 1 build that previously got LLM-`:approved` to now
  also pass the gate and proceed to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)