### PR TITLE
test(workflow): pin mid-snapshot resume contract + file FSM-advance investigation spec

### DIFF
--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -31,7 +31,33 @@
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]))
 
-(use-fixtures :each phase-test-support/with-workflow-phase-test-support)
+(defn- with-stubbed-acquire-environment
+  "Force `acquire-execution-environment!` to return nil for every test
+   in this namespace.
+
+   Why: many tests below call `runner/run-pipeline` without a
+   pre-acquired executor. Default :local mode would otherwise acquire
+   a real worktree at System/getProperty user.dir, and the workflow-
+   tester phases (which call persist-workspace-at-phase-boundary!)
+   would commit phase-completion messages into the test runner's own
+   git checkout. The 2026-05-16 pre-commit-smoke rollout caught this
+   leaking real commits onto active branches; the fix lives once
+   here so individual tests don't have to remember the with-redefs
+   dance, and so any future test that calls run-pipeline inherits
+   the safe default. Tests that genuinely need a real acquired env
+   override with their own with-redefs."
+  [f]
+  (let [acquire-var (requiring-resolve
+                      'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)]
+    (with-redefs-fn {acquire-var (fn [& _] nil)}
+      f)))
+
+;; Compose phase-test-support's loader setup with the acquire-environment
+;; stub. clojure.test/use-fixtures REPLACES prior :each fixtures, so both
+;; must be registered in a single call.
+(use-fixtures :each
+  phase-test-support/with-workflow-phase-test-support
+  with-stubbed-acquire-environment)
 
 (def test-plan-phase
   phase-test-support/runner-test-plan)
@@ -290,43 +316,32 @@
   ;; this test pins the underlying "must actually advance" contract so a
   ;; regression in the FSM/snapshot path doesn't silently re-introduce
   ;; `:running` returns from completed runs.
-  ;;
-  ;; CRITICAL: mock acquire-execution-environment! to return nil so the
-  ;; runner never tries to acquire a real worktree from the host repo.
-  ;; Without this mock the workflow-tester phases trigger
-  ;; persist-workspace-at-phase-boundary! against the test runner's own
-  ;; git worktree, which produced rogue "runner-test-done phase completed"
-  ;; commits on the active branch during the smoke-test rollout.
   (testing "snapshot captured after phase-1 completes resumes through remaining phases to :completed"
-    (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)
-          workflow {:workflow/id :test-multi-phase
+    (let [workflow {:workflow/id :test-multi-phase
                     :workflow/version "1.0.0"
                     :workflow/pipeline [{:phase test-plan-phase}
                                         {:phase test-implement-phase}
                                         {:phase test-verify-phase}
-                                        {:phase test-done-phase}]}]
-      (with-redefs-fn
-        {acquire-var (fn [& _] nil)}
-        (fn []
-          (let [full-result (runner/run-pipeline workflow {:task "Test"} {})
-                _ (is (= :completed (:execution/status full-result))
-                      "baseline: full run must reach :completed")
-                mid-snapshot (-> (checkpoint-store/build-machine-snapshot full-result)
-                                 (assoc :execution/status :running
-                                        :execution/phase-index 1
-                                        :execution/current-phase test-implement-phase))
-                phase-results {test-plan-phase
-                               (get-in full-result [:execution/phase-results test-plan-phase])}
-                resumed (runner/run-pipeline workflow
-                                             {:task "Ignored on resume"}
-                                             {:resume-machine-snapshot mid-snapshot
-                                              :resume-phase-results phase-results})]
-            (is (contains? #{:completed :completed-with-warnings :failed :aborted :cancelled}
-                           (:execution/status resumed))
-                (str "resume must reach a terminal status, got "
-                     (pr-str (:execution/status resumed))))
-            (is (not= :running (:execution/status resumed))
-                ":running is the silent-fast-fail signature — resume must not return it")))))))
+                                        {:phase test-done-phase}]}
+          full-result (runner/run-pipeline workflow {:task "Test"} {})
+          _ (is (= :completed (:execution/status full-result))
+                "baseline: full run must reach :completed")
+          mid-snapshot (-> (checkpoint-store/build-machine-snapshot full-result)
+                           (assoc :execution/status :running
+                                  :execution/phase-index 1
+                                  :execution/current-phase test-implement-phase))
+          phase-results {test-plan-phase
+                         (get-in full-result [:execution/phase-results test-plan-phase])}
+          resumed (runner/run-pipeline workflow
+                                       {:task "Ignored on resume"}
+                                       {:resume-machine-snapshot mid-snapshot
+                                        :resume-phase-results phase-results})]
+      (is (contains? #{:completed :completed-with-warnings :failed :aborted :cancelled}
+                     (:execution/status resumed))
+          (str "resume must reach a terminal status, got "
+               (pr-str (:execution/status resumed))))
+      (is (not= :running (:execution/status resumed))
+          ":running is the silent-fast-fail signature — resume must not return it"))))
 
 ;; ============================================================================
 ;; Phase result recording tests

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -283,6 +283,47 @@
       (is (= :completed (:execution/status result)))
       (is (= (:execution/id resume-ctx) (:execution/id result))))))
 
+(deftest run-pipeline-resume-from-mid-workflow-snapshot-advances-test
+  ;; Regression for the dogfood-2026-05-16 silent fast-fail: resume from a
+  ;; snapshot taken after phase 1 completed must advance through phases 2..N
+  ;; and reach a terminal status. The bug fix lives in PR #896 (loud-fail);
+  ;; this test pins the underlying "must actually advance" contract so a
+  ;; regression in the FSM/snapshot path doesn't silently re-introduce
+  ;; `:running` returns from completed runs.
+  (testing "snapshot captured after phase-1 completes resumes through remaining phases to :completed"
+    (let [workflow {:workflow/id :test-multi-phase
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase test-plan-phase}
+                                        {:phase test-implement-phase}
+                                        {:phase test-verify-phase}
+                                        {:phase test-done-phase}]}
+          ;; First run — let plan phase complete, capture mid-run snapshot.
+          full-result (runner/run-pipeline workflow {:task "Test"} {})
+          ;; The full run completes; assert that as a sanity baseline.
+          _ (is (= :completed (:execution/status full-result))
+                "baseline: full run must reach :completed")
+          ;; Now build a snapshot that looks like a checkpoint taken AFTER
+          ;; phase 1 (plan) completed. We use the full-result minus the
+          ;; later phases as a stand-in for that mid-run state.
+          mid-snapshot (-> (checkpoint-store/build-machine-snapshot full-result)
+                           (assoc :execution/status :running
+                                  :execution/phase-index 1
+                                  :execution/current-phase test-implement-phase))
+          ;; Phase-results carrying plan's completion are required so
+          ;; restore-context wires up the run from the snapshot path.
+          phase-results {test-plan-phase
+                         (get-in full-result [:execution/phase-results test-plan-phase])}
+          resumed (runner/run-pipeline workflow
+                                       {:task "Ignored on resume"}
+                                       {:resume-machine-snapshot mid-snapshot
+                                        :resume-phase-results phase-results})]
+      (is (contains? #{:completed :completed-with-warnings :failed :aborted :cancelled}
+                     (:execution/status resumed))
+          (str "resume must reach a terminal status, got "
+               (pr-str (:execution/status resumed))))
+      (is (not= :running (:execution/status resumed))
+          ":running is the silent-fast-fail signature — resume must not return it"))))
+
 ;; ============================================================================
 ;; Phase result recording tests
 ;; ============================================================================

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.phase.interface]
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
+   [ai.miniforge.workflow.fsm :as workflow-fsm]
    [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]))
@@ -311,37 +312,59 @@
 
 (deftest run-pipeline-resume-from-mid-workflow-snapshot-advances-test
   ;; Regression for the dogfood-2026-05-16 silent fast-fail: resume from a
-  ;; snapshot taken after phase 1 completed must advance through phases 2..N
-  ;; and reach a terminal status. The bug fix lives in PR #896 (loud-fail);
-  ;; this test pins the underlying "must actually advance" contract so a
-  ;; regression in the FSM/snapshot path doesn't silently re-introduce
+  ;; snapshot whose FSM is actually parked at an intermediate phase must
+  ;; advance through the remaining phases and reach `:completed` (not just
+  ;; any terminal state). The bug fix lives in PR #896 (loud-fail); this
+  ;; test pins the underlying "must actually advance" contract so a
+  ;; regression in the FSM/snapshot path can't silently re-introduce
   ;; `:running` returns from completed runs.
-  (testing "snapshot captured after phase-1 completes resumes through remaining phases to :completed"
+  ;;
+  ;; The snapshot is constructed by driving the execution machine
+  ;; manually from :pending → plan-active → (succeed) → implement-active,
+  ;; so the resumed runner has real remaining work to do.
+  (testing "snapshot parked at implement-active resumes through implement→verify→done to :completed"
     (let [workflow {:workflow/id :test-multi-phase
                     :workflow/version "1.0.0"
                     :workflow/pipeline [{:phase test-plan-phase}
                                         {:phase test-implement-phase}
                                         {:phase test-verify-phase}
                                         {:phase test-done-phase}]}
-          full-result (runner/run-pipeline workflow {:task "Test"} {})
-          _ (is (= :completed (:execution/status full-result))
-                "baseline: full run must reach :completed")
-          mid-snapshot (-> (checkpoint-store/build-machine-snapshot full-result)
-                           (assoc :execution/status :running
-                                  :execution/phase-index 1
-                                  :execution/current-phase test-implement-phase))
-          phase-results {test-plan-phase
-                         (get-in full-result [:execution/phase-results test-plan-phase])}
+          machine (workflow-fsm/compile-execution-machine workflow)
+          ;; Drive the machine from :pending → plan-active → implement-active
+          ;; so the snapshot has real remaining work.
+          initial-state (workflow-fsm/initialize-execution machine)
+          plan-state (workflow-fsm/start-execution machine initial-state)
+          fsm-at-implement (workflow-fsm/transition-execution machine plan-state :phase/succeed)
+          response-chain (requiring-resolve 'ai.miniforge.response.interface/create)
+          mid-snapshot {:execution/id (random-uuid)
+                        :execution/workflow-id (:workflow/id workflow)
+                        :execution/workflow-version (:workflow/version workflow)
+                        :execution/input {:task "Original"}
+                        :execution/status :running
+                        :execution/fsm-state fsm-at-implement
+                        :execution/response-chain (response-chain (:workflow/id workflow))
+                        :execution/phase-results {}
+                        :execution/artifacts []
+                        :execution/errors []
+                        :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+                        :execution/started-at (System/currentTimeMillis)}
+          seeded-plan-result {:status :success :outcome :success
+                              :summary "plan completed before checkpoint"
+                              :metrics {:tokens 0 :duration-ms 0}}
+          phase-results {test-plan-phase seeded-plan-result}
           resumed (runner/run-pipeline workflow
                                        {:task "Ignored on resume"}
                                        {:resume-machine-snapshot mid-snapshot
                                         :resume-phase-results phase-results})]
-      (is (contains? #{:completed :completed-with-warnings :failed :aborted :cancelled}
-                     (:execution/status resumed))
-          (str "resume must reach a terminal status, got "
+      (is (= :completed (:execution/status resumed))
+          (str "resume must complete the remaining pipeline, got "
                (pr-str (:execution/status resumed))))
-      (is (not= :running (:execution/status resumed))
-          ":running is the silent-fast-fail signature — resume must not return it"))))
+      (is (every? (:execution/phase-results resumed)
+                  [test-implement-phase test-verify-phase test-done-phase])
+          "implement, verify, and done phases must have phase-results recorded after resume")
+      (is (= "plan completed before checkpoint"
+             (get-in resumed [:execution/phase-results test-plan-phase :summary]))
+          "plan phase was already complete in the snapshot — resume must preserve the seeded result, not re-run it"))))
 
 ;; ============================================================================
 ;; Phase result recording tests

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -290,39 +290,43 @@
   ;; this test pins the underlying "must actually advance" contract so a
   ;; regression in the FSM/snapshot path doesn't silently re-introduce
   ;; `:running` returns from completed runs.
+  ;;
+  ;; CRITICAL: mock acquire-execution-environment! to return nil so the
+  ;; runner never tries to acquire a real worktree from the host repo.
+  ;; Without this mock the workflow-tester phases trigger
+  ;; persist-workspace-at-phase-boundary! against the test runner's own
+  ;; git worktree, which produced rogue "runner-test-done phase completed"
+  ;; commits on the active branch during the smoke-test rollout.
   (testing "snapshot captured after phase-1 completes resumes through remaining phases to :completed"
-    (let [workflow {:workflow/id :test-multi-phase
+    (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)
+          workflow {:workflow/id :test-multi-phase
                     :workflow/version "1.0.0"
                     :workflow/pipeline [{:phase test-plan-phase}
                                         {:phase test-implement-phase}
                                         {:phase test-verify-phase}
-                                        {:phase test-done-phase}]}
-          ;; First run — let plan phase complete, capture mid-run snapshot.
-          full-result (runner/run-pipeline workflow {:task "Test"} {})
-          ;; The full run completes; assert that as a sanity baseline.
-          _ (is (= :completed (:execution/status full-result))
-                "baseline: full run must reach :completed")
-          ;; Now build a snapshot that looks like a checkpoint taken AFTER
-          ;; phase 1 (plan) completed. We use the full-result minus the
-          ;; later phases as a stand-in for that mid-run state.
-          mid-snapshot (-> (checkpoint-store/build-machine-snapshot full-result)
-                           (assoc :execution/status :running
-                                  :execution/phase-index 1
-                                  :execution/current-phase test-implement-phase))
-          ;; Phase-results carrying plan's completion are required so
-          ;; restore-context wires up the run from the snapshot path.
-          phase-results {test-plan-phase
-                         (get-in full-result [:execution/phase-results test-plan-phase])}
-          resumed (runner/run-pipeline workflow
-                                       {:task "Ignored on resume"}
-                                       {:resume-machine-snapshot mid-snapshot
-                                        :resume-phase-results phase-results})]
-      (is (contains? #{:completed :completed-with-warnings :failed :aborted :cancelled}
-                     (:execution/status resumed))
-          (str "resume must reach a terminal status, got "
-               (pr-str (:execution/status resumed))))
-      (is (not= :running (:execution/status resumed))
-          ":running is the silent-fast-fail signature — resume must not return it"))))
+                                        {:phase test-done-phase}]}]
+      (with-redefs-fn
+        {acquire-var (fn [& _] nil)}
+        (fn []
+          (let [full-result (runner/run-pipeline workflow {:task "Test"} {})
+                _ (is (= :completed (:execution/status full-result))
+                      "baseline: full run must reach :completed")
+                mid-snapshot (-> (checkpoint-store/build-machine-snapshot full-result)
+                                 (assoc :execution/status :running
+                                        :execution/phase-index 1
+                                        :execution/current-phase test-implement-phase))
+                phase-results {test-plan-phase
+                               (get-in full-result [:execution/phase-results test-plan-phase])}
+                resumed (runner/run-pipeline workflow
+                                             {:task "Ignored on resume"}
+                                             {:resume-machine-snapshot mid-snapshot
+                                              :resume-phase-results phase-results})]
+            (is (contains? #{:completed :completed-with-warnings :failed :aborted :cancelled}
+                           (:execution/status resumed))
+                (str "resume must reach a terminal status, got "
+                     (pr-str (:execution/status resumed))))
+            (is (not= :running (:execution/status resumed))
+                ":running is the silent-fast-fail signature — resume must not return it")))))))
 
 ;; ============================================================================
 ;; Phase result recording tests

--- a/work/workflow-resume-fsm-advance-investigation.spec.edn
+++ b/work/workflow-resume-fsm-advance-investigation.spec.edn
@@ -9,10 +9,13 @@
 ;;
 ;; The synthetic test in runner-test
 ;; (`run-pipeline-resume-from-mid-workflow-snapshot-advances-test`,
-;; added alongside this spec) demonstrates that resume from a mid-workflow
-;; snapshot DOES advance to :completed when the snapshot is built in-process.
-;; That test passes. So the production failure mode has at least one of
-;; these extra ingredients:
+;; added alongside this spec) constructs an FSM state parked at
+;; implement-active by driving the execution machine manually
+;; (initialize → start → :phase/succeed), feeds that snapshot through
+;; run-pipeline, and asserts the remaining phases (implement → verify →
+;; done) execute and the run reaches `:completed` with the seeded plan
+;; result preserved. That test passes. So the production failure mode
+;; has at least one of these extra ingredients:
 ;;
 ;;   (a) Workspace restore failure cascade. Production resumes hit
 ;;       `workflow/restore-failed` when the task branch is already checked

--- a/work/workflow-resume-fsm-advance-investigation.spec.edn
+++ b/work/workflow-resume-fsm-advance-investigation.spec.edn
@@ -1,0 +1,91 @@
+;; =============================================================================
+;; Spec: Workflow resume — investigate why FSM doesn't advance from production snapshots
+;; =============================================================================
+;;
+;; Status: PR #896 made resume FAIL LOUD on non-terminal status — operators
+;; now see "resume returned :running" instead of silent exit 0. But the
+;; underlying question — why does run-pipeline return :running when handed
+;; a snapshot from a real dogfood run — is still open.
+;;
+;; The synthetic test in runner-test
+;; (`run-pipeline-resume-from-mid-workflow-snapshot-advances-test`,
+;; added alongside this spec) demonstrates that resume from a mid-workflow
+;; snapshot DOES advance to :completed when the snapshot is built in-process.
+;; That test passes. So the production failure mode has at least one of
+;; these extra ingredients:
+;;
+;;   (a) Workspace restore failure cascade. Production resumes hit
+;;       `workflow/restore-failed` when the task branch is already checked
+;;       out at /private/tmp/miniforge-worktrees/task-XXX. `acquire-
+;;       execution-environment!` swallows the failure, returns nil for the
+;;       env, and run-pipeline proceeds with no executor. Phase interceptors
+;;       then fail silently and run-pipeline returns :running.
+;;
+;;   (b) Checkpoint shape drift. Snapshots written by an older miniforge
+;;       commit may not round-trip cleanly into a newer fsm/restore-context.
+;;       The persisted-execution-keys list excludes :execution/fsm-machine
+;;       (rebuilt from the workflow at restore time), so a workflow whose
+;;       state IDs changed between persist and restore would produce a
+;;       fsm-state that points at nothing in the rebuilt machine.
+;;
+;;   (c) DAG sub-workflow snapshots. The dogfood spec triggers DAG
+;;       fan-out; a snapshot taken mid-DAG may not have the right
+;;       :execution/dag-result shape for the restored runner to recognise.
+
+{:spec/title "Workflow resume — make FSM advance from production checkpoints, not just synthetic ones"
+
+ :spec/description
+ "Reproduce the 2026-05-16 dogfood production resume failure inside a
+  unit/integration test, then fix the root cause. Approach:
+
+  1. Pull the actual checkpoint for `c1abda63-3072-4f57-9871-6c177384968e`
+     or a fresh dogfood run from `~/.miniforge/checkpoints/`. Load it
+     into the runner under test and assert the resume reaches a terminal
+     status. The synthetic test in runner-test already covers the happy
+     path; the missing coverage is real-checkpoint-shape.
+
+  2. Investigate the three candidate causes (a)/(b)/(c) above. (a) is the
+     most likely — restore-local-workspace-checkpoint! logs but doesn't
+     escalate, and acquire-execution-environment! treats nil env as
+     'continue without one' for :local mode.
+
+  3. Fix the root cause. Likely shapes:
+     - acquire-execution-environment! escalates workspace-restore failure
+       to a thrown anomaly so the CLI sees a real error instead of
+       :running.
+     - restore-context detects an fsm-state that points at no state in
+       the rebuilt machine and falls back to pipeline-trim resume.
+     - DAG-mid-resume gets its own snapshot shape and code path.
+
+  4. Add the production-checkpoint replay as a permanent regression test
+     so the next FSM/snapshot drift fails at test time."
+
+ :spec/intent
+ {:type :fix
+  :scope ["components/workflow/src/ai/miniforge/workflow/runner_environment.clj"
+          "components/workflow/src/ai/miniforge/workflow/context.clj"
+          "components/workflow/src/ai/miniforge/workflow/runner.clj"
+          "components/workflow-resume/src"
+          "components/workflow/test"]}
+
+ :spec/constraints
+ ["Production checkpoint must round-trip through resume to a terminal status"
+  "Workspace-restore failures must propagate as a thrown error, not a silent log + nil-env continue"
+  "Backwards-compatible — existing successful resumes (synthetic + production) still complete"
+  "Regression test must load a real checkpoint EDN file, not just build snapshots in-process"]
+
+ :spec/acceptance-criteria
+ ["bb miniforge resume on a known-good production checkpoint reaches :completed or :failed (terminal)"
+  "bb miniforge resume on a checkpoint with workspace-restore-failed produces a clear error before run-pipeline"
+  "New replay test in components/workflow/test loads a fixture checkpoint and asserts terminal status"
+  "Existing run-pipeline-resume-* tests in runner-test still pass"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:tokenconservation :dogfoodenabler :observation}
+  :theme :dogfood-resilience
+  :rationale "PR #896 makes resume fail loud, but resume still doesn't work — every dogfood loss still costs the full plan/explore/verify token spend on re-run. This spec makes resume actually save tokens, which is the dogfood-resilience theme's primary goal."
+  :blocks []
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
## Summary

Captures the open question left after PR #896 (resume fails loud on
non-terminal status but doesn't actually advance from the dogfood's
production snapshots).

- Adds `run-pipeline-resume-from-mid-workflow-snapshot-advances-test`
  that builds a snapshot mid-workflow and asserts the resume reaches
  a terminal status. The test PASSES against current code — which is
  itself the finding: the basic FSM/snapshot path works in isolation,
  so the production failure mode has additional ingredients.
- Files `work/workflow-resume-fsm-advance-investigation.spec.edn`
  enumerating the three candidate causes:
  (a) workspace-restore-failure cascade,
  (b) checkpoint shape drift across miniforge commits,
  (c) DAG sub-workflow snapshots.

This is intentionally a small ship — pins the contract from the
synthetic side, leaves the production-checkpoint replay test + root-
cause fix as the next spec for the dogfood-resilience theme.

## Test plan

- [x] 29 tests, 89 assertions, 0 failures in workflow runner-test.
- [x] `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)