### PR TITLE
chore(pre-commit): replace stable-derived sweep with curated smoke set

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -156,13 +156,18 @@
    :requires ([test-runner])
    :task (test-runner/graalvm)}
 
+  test:precommit
+  {:doc  "Run the hand-curated pre-commit smoke set (resources/precommit-smoke-tests.edn)"
+   :requires ([test-runner])
+   :task (test-runner/precommit-smoke)}
+
   ;; ──────────────────────────────────────────────────────────────────────────
   ;; Pre-commit
   ;; ──────────────────────────────────────────────────────────────────────────
 
   pre-commit
-  {:doc     "Run all pre-commit checks (commit budget, structure, lint, format, test, graalvm)"
-   :depends [commit-budget poly:check lint:clj fmt:md test test:graalvm]
+  {:doc     "Run pre-commit checks (commit budget, structure, lint, format, smoke tests, graalvm). Full test suite runs in CI."
+   :depends [commit-budget poly:check lint:clj fmt:md test:precommit test:graalvm]
    :task    (println "\n✅ ALL PRE-COMMIT CHECKS PASSED\n")}
 
   ;; ──────────────────────────────────────────────────────────────────────────

--- a/docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md
+++ b/docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md
@@ -3,7 +3,7 @@
 Replaces `bb test` (stable-derived sweep) in the `bb pre-commit` chain
 with a hand-curated `bb test:precommit` smoke set. Goal: drop the dev
 loop's commit cost from "potentially hangs past 30 min" (PR #893's
-recurring nightmare) to "13 namespaces, ~110 s wall, deterministic." CI
+recurring nightmare) to "12 namespaces, ~110 s wall, deterministic." CI
 still runs `bb test:all` on every PR, so coverage is unchanged.
 
 ## Motivation
@@ -87,8 +87,10 @@ filtering the smoke set by `git diff`-derived component touch.
 
 ## Test plan
 
-- [x] `bb test:precommit` — 270 tests, 964 assertions, 0 failures,
-  ~110 s wall.
+- [x] `bb test:precommit` — 12 namespaces, ~110 s wall, 0 failures.
+  (The historical 13-namespace baseline with runner-test included was
+  270 tests / 964 assertions; the 12-namespace set is similar minus
+  runner-test's count.)
 - [ ] `bb pre-commit` on this branch — runs commit-budget, poly:check,
   lint:clj, fmt:md, test:precommit, test:graalvm. Expected green.
 

--- a/docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md
+++ b/docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md
@@ -1,0 +1,100 @@
+## Overview
+
+Replaces `bb test` (stable-derived sweep) in the `bb pre-commit` chain
+with a hand-curated `bb test:precommit` smoke set. Goal: drop the dev
+loop's commit cost from "potentially hangs past 30 min" (PR #893's
+recurring nightmare) to "13 namespaces, ~110 s wall, deterministic." CI
+still runs `bb test:all` on every PR, so coverage is unchanged.
+
+## Motivation
+
+The recent dogfood/PR cycle showed two recurring failure modes in the
+existing pre-commit:
+
+- The stable-derived sweep can hang on a single bad test (PR #895
+  bisected `workflow.runner-extended-test` after a 33-minute stall in
+  the governed-mode Docker path).
+- "Affected" projects can balloon when a load-bearing component
+  changes, so a small fix routinely paid the full project-level test
+  cost.
+
+Both push agents toward `--no-verify`, which defeats the gate. A small,
+fast, hand-picked smoke set is a better commitment: every line in the
+allow-list is a deliberate choice, and CI still gates on the full
+suite.
+
+## Selection criteria
+
+Documented inline in `resources/precommit-smoke-tests.edn`:
+
+1. Load-bearing infrastructure — break this, half the codebase breaks
+   (response, anomaly, schema, event-stream).
+2. Cross-component boundary contracts — recent regressions pinned
+   here: PR #867 (gate `:passed?`), PR #872/#894 (Anthropic property
+   keys), PR #895 (`ReviewIssue` schema), PR #896 (resume terminal
+   status).
+3. Fast — sub-second per namespace, no Docker, no network.
+4. Deterministic — never depends on worktree state.
+
+Initial set (12 namespaces, ~250 tests):
+
+- `ai.miniforge.response.interface-test`
+- `ai.miniforge.anomaly.interface.schema-test`
+- `ai.miniforge.event-stream.interface-test`
+- `ai.miniforge.event-stream.core-test`
+- `ai.miniforge.gate.interface-test`
+- `ai.miniforge.gate.policy-test`
+- `ai.miniforge.mcp-context-server.tools-test`
+- `ai.miniforge.mcp-context-server.context-cache-test`
+- `ai.miniforge.cli.main.commands.resume-test`
+- `ai.miniforge.cli.workflow-runner.display-output-test`
+- `ai.miniforge.agent.reviewer-test`
+- `ai.miniforge.phase.interface-test`
+
+**Deliberately excluded until PR #897 merges:**
+`ai.miniforge.workflow.runner-test`. Its tests acquire a real
+worktree at `System/getProperty "user.dir"` without the
+fixture-level acquire mock (added in PR #897), and would commit
+phase-completion messages into the active branch. The rogue commits
+were caught during this PR's own pre-commit run — same shape as
+[[feedback_runtime_state_never_git_tracked]]. Re-add in a follow-up
+once #897 lands.
+
+## Changes
+
+- New `bb test:precommit` task in `bb.edn` that delegates to
+  `test-runner/precommit-smoke`.
+- `test-runner/precommit-smoke` loads
+  `resources/precommit-smoke-tests.edn`, requires every namespace, and
+  runs `clojure.test/run-tests` in one JVM invocation. Non-zero on any
+  failure.
+- `pre-commit` task's `:depends` flips `test` → `test:precommit`. The
+  full suite (`bb test:all`, `bb test:since-stable`) remains
+  unchanged and continues to be how CI runs.
+
+## What CI still does
+
+`.github/workflows/ci.yml` already runs `bb test:all` for every PR
+(see the `Run tests` step in the Test job). Nothing changes for CI
+coverage; only the pre-commit hook gets fast.
+
+## Future optimization (not in this PR)
+
+110 s is much faster than the prior 30+ min, but still longer than the
+< 30 s target. The dominant cost is JVM startup per namespace cohort.
+Candidates for a follow-up: a persistent test-runner REPL, or
+filtering the smoke set by `git diff`-derived component touch.
+
+## Test plan
+
+- [x] `bb test:precommit` — 270 tests, 964 assertions, 0 failures,
+  ~110 s wall.
+- [ ] `bb pre-commit` on this branch — runs commit-budget, poly:check,
+  lint:clj, fmt:md, test:precommit, test:graalvm. Expected green.
+
+## Related
+
+- PR #893 — first documented the `bb pre-commit` hang in
+  `workflow.runner-extended-test`.
+- PR #895 — fixed the hang via the dag-executor mock; this PR locks
+  in the fast loop so we don't regress.

--- a/resources/precommit-smoke-tests.edn
+++ b/resources/precommit-smoke-tests.edn
@@ -1,0 +1,48 @@
+;; -----------------------------------------------------------------------------
+;; Pre-commit smoke test surface
+;; -----------------------------------------------------------------------------
+;;
+;; A small, hand-curated set of test namespaces that pre-commit runs on every
+;; commit. The goal is < 30 seconds total so the agent dev loop doesn't pay
+;; the full stable-derived sweep cost on every iteration. CI still runs the
+;; full suite (`bb test:all`) on every PR — this file is the FAST GATE, not
+;; the SOLE GATE.
+;;
+;; Selection criteria for inclusion:
+;;
+;;  1. Load-bearing infrastructure — if this namespace's contract breaks,
+;;     half the codebase breaks (response/anomaly/schema/event-stream).
+;;
+;;  2. Cross-component boundary contracts — when one side of a contract
+;;     changes silently, the dogfood findings file fills up. Recent
+;;     examples pinned here: PR #867 (gate :passed?), PR #872/894
+;;     (Anthropic property keys), PR #895 (reviewer ReviewIssue schema),
+;;     PR #896 (resume terminal-status).
+;;
+;;  3. Fast — sub-second per namespace, no Docker, no network, no large
+;;     fixtures.
+;;
+;;  4. Deterministic — never flaky, never depends on worktree state
+;;     (the runner-extended-test fix in PR #895 was a hard lesson).
+;;
+;; Adding to this list is a deliberate choice — it adds dev-loop time for
+;; every commit. Prefer fixing the test to be fast over keeping it out.
+
+;; ai.miniforge.workflow.runner-test deliberately excluded until PR #897
+;; merges — its tests acquire a real worktree at System/getProperty user.dir
+;; without the fixture-level acquire mock, and would commit phase-completion
+;; messages into the active branch. Re-add once #897 lands.
+
+{:smoke/namespaces
+ ["ai.miniforge.response.interface-test"
+  "ai.miniforge.anomaly.interface.schema-test"
+  "ai.miniforge.event-stream.interface-test"
+  "ai.miniforge.event-stream.core-test"
+  "ai.miniforge.gate.interface-test"
+  "ai.miniforge.gate.policy-test"
+  "ai.miniforge.mcp-context-server.tools-test"
+  "ai.miniforge.mcp-context-server.context-cache-test"
+  "ai.miniforge.cli.main.commands.resume-test"
+  "ai.miniforge.cli.workflow-runner.display-output-test"
+  "ai.miniforge.agent.reviewer-test"
+  "ai.miniforge.phase.interface-test"]}

--- a/tasks/test_runner.clj
+++ b/tasks/test_runner.clj
@@ -104,35 +104,54 @@
       (println "❌ Conformance tests failed with exit code:" exit)
       (System/exit exit))))
 
-(def ^:private precommit-smoke-config-resource
+(def ^:private precommit-smoke-config-path
+  "Working-directory-relative filesystem path to the smoke-set config.
+   Not loaded via `io/resource` because bb tasks already run from the
+   repo root by convention; if that ever changes the `(.exists f)` guard
+   surfaces the misconfiguration loudly."
   "resources/precommit-smoke-tests.edn")
+
+(defn- valid-namespace-token?
+  "Conservative check: namespace entries in the EDN must look like
+   period-separated, dash-segmented symbol tokens. Rejects strings with
+   whitespace, quotes, comment chars, or any non-symbol character so a
+   typo in the config doesn't silently break the generated -e form."
+  [s]
+  (and (string? s) (re-matches #"[a-zA-Z][a-zA-Z0-9.\-_?!]*" s)))
 
 (defn- read-precommit-smoke-nses!
   []
-  (let [f (io/file precommit-smoke-config-resource)]
+  (let [f (io/file precommit-smoke-config-path)]
     (when-not (.exists f)
-      (println "❌ Pre-commit smoke config not found:" precommit-smoke-config-resource)
+      (println "❌ Pre-commit smoke config not found:" precommit-smoke-config-path)
       (System/exit 1))
     (let [{:keys [smoke/namespaces]} (edn/read-string (slurp f))]
       (when (empty? namespaces)
         (println "❌ Pre-commit smoke config has no :smoke/namespaces")
+        (System/exit 1))
+      (when-let [bad (seq (remove valid-namespace-token? namespaces))]
+        (println "❌ Pre-commit smoke config has invalid namespace tokens:"
+                 (pr-str bad))
         (System/exit 1))
       namespaces)))
 
 (defn precommit-smoke
   "Run the hand-curated pre-commit smoke set.
 
-   Source of truth: resources/precommit-smoke-tests.edn. Goal is
-   < 30 seconds total so the dev loop stays cheap. CI runs
+   Source of truth: resources/precommit-smoke-tests.edn. Aspirational
+   target is <30 s; current realised wall time is ~110 s (dominated by
+   JVM startup, see the PR doc's future-optimisation section). CI runs
    `bb test:all` for full coverage."
   []
   (println "🧪 Running pre-commit smoke tests...")
   (let [nses (read-precommit-smoke-nses!)
         clojure-cmd (proc/clojure-command)
-        require-expr (apply str (map (fn [n] (str " '" n)) nses))
-        run-expr (apply str (map (fn [n] (str " '" n)) nses))
-        expr (str "(require 'clojure.test" require-expr ") "
-                  "(let [r (clojure.test/run-tests" run-expr ")] "
+        ;; The same space-prefixed quoted-namespace string drives both
+        ;; (require …) and (clojure.test/run-tests …) — one expression,
+        ;; one source of truth.
+        ns-args (apply str (map (fn [n] (str " '" n)) nses))
+        expr (str "(require 'clojure.test" ns-args ") "
+                  "(let [r (clojure.test/run-tests" ns-args ")] "
                   "  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))")
         exit (run-stream! clojure-cmd "-M:test:dev" "-e" expr)]
     (when-not (zero? exit)

--- a/tasks/test_runner.clj
+++ b/tasks/test_runner.clj
@@ -20,6 +20,8 @@
   (:require
    [ai.miniforge.bb-proc.interface :as proc]
    [babashka.process :as p]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.string :as str]))
 
 (defn run-stream! [& args]
@@ -101,6 +103,42 @@
     (when-not (zero? exit)
       (println "❌ Conformance tests failed with exit code:" exit)
       (System/exit exit))))
+
+(def ^:private precommit-smoke-config-resource
+  "resources/precommit-smoke-tests.edn")
+
+(defn- read-precommit-smoke-nses!
+  []
+  (let [f (io/file precommit-smoke-config-resource)]
+    (when-not (.exists f)
+      (println "❌ Pre-commit smoke config not found:" precommit-smoke-config-resource)
+      (System/exit 1))
+    (let [{:keys [smoke/namespaces]} (edn/read-string (slurp f))]
+      (when (empty? namespaces)
+        (println "❌ Pre-commit smoke config has no :smoke/namespaces")
+        (System/exit 1))
+      namespaces)))
+
+(defn precommit-smoke
+  "Run the hand-curated pre-commit smoke set.
+
+   Source of truth: resources/precommit-smoke-tests.edn. Goal is
+   < 30 seconds total so the dev loop stays cheap. CI runs
+   `bb test:all` for full coverage."
+  []
+  (println "🧪 Running pre-commit smoke tests...")
+  (let [nses (read-precommit-smoke-nses!)
+        clojure-cmd (proc/clojure-command)
+        require-expr (apply str (map (fn [n] (str " '" n)) nses))
+        run-expr (apply str (map (fn [n] (str " '" n)) nses))
+        expr (str "(require 'clojure.test" require-expr ") "
+                  "(let [r (clojure.test/run-tests" run-expr ")] "
+                  "  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))")
+        exit (run-stream! clojure-cmd "-M:test:dev" "-e" expr)]
+    (when-not (zero? exit)
+      (println "❌ Pre-commit smoke tests failed with exit code:" exit)
+      (System/exit exit))
+    (println (format "✓ Pre-commit smoke (%d namespaces) passed" (count nses)))))
 
 (defn graalvm []
   (println "🧪 Testing GraalVM/Babashka compatibility...")


### PR DESCRIPTION
## Summary

Replaces `bb test` (stable-derived sweep) in the `bb pre-commit` chain
with a hand-curated `bb test:precommit` smoke set. Goal: drop the dev
loop's commit cost from "potentially hangs past 30 min" (PR #893's
recurring nightmare) to "12 namespaces, ~110 s wall, deterministic."
CI still runs `bb test:all` on every PR, so coverage is unchanged.

See [docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md](docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md)
for selection criteria, recent regressions pinned by the set, and
future optimization paths.

## Note on workflow.runner-test

Deliberately excluded until PR #897 merges. Its tests acquire a real
worktree at `user.dir` without the fixture-level acquire mock and
would commit phase-completion messages into the active branch
(caught during this PR's own pre-commit run — same shape as
[[feedback_runtime_state_never_git_tracked]]). #897 adds the fixture;
re-add in a follow-up after that lands.

## Test plan

- [x] `bb test:precommit` — 12 namespaces, 0 failures.
- [x] `bb pre-commit` on this branch — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)