### PR TITLE
feat(automation-edge-correlator): N15-1 scaffold — schema + trigger classification

### DIFF
--- a/components/automation-edge-correlator/deps.edn
+++ b/components/automation-edge-correlator/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/event-stream {:local/root "../event-stream"}
+        ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/schema {:local/root "../schema"}
+        metosin/malli {:mvn/version "0.16.4"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {io.github.cognitect-labs/test-runner
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/automation-edge-correlator/deps.edn
+++ b/components/automation-edge-correlator/deps.edn
@@ -1,8 +1,10 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/event-stream {:local/root "../event-stream"}
-        ai.miniforge/logging {:local/root "../logging"}
-        ai.miniforge/schema {:local/root "../schema"}
-        metosin/malli {:mvn/version "0.16.4"}}
+ ;; N15-1 source surface is pure schema + trigger classification — only malli
+ ;; is consumed.  Cross-component deps (event-stream / logging / schema) are
+ ;; added in N15-3 when `core.clj` + `emitter.clj` start the lifecycle and
+ ;; subscribe to the event stream.  Declaring them prematurely would
+ ;; mis-state the brick's current boundary surface.
+ :deps {metosin/malli {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/interface.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/interface.clj
@@ -28,11 +28,16 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
+;;
+;; `schema/registry` is intentionally NOT re-exported: it is an internal
+;; implementation detail that inlines primitive keyword types to avoid a
+;; cross-boundary reach into `ai.miniforge.schema.core/registry`. Exposing it
+;; would invite downstream callers to depend on its exact key set, turning
+;; later consolidation into a breaking change.
 
 (def AutomationEdge          schema/AutomationEdge)
 (def routing-trigger-kinds   schema/routing-trigger-kinds)
 (def automation-edge-statuses schema/automation-edge-statuses)
-(def registry                schema/registry)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Trigger classification

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/interface.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/interface.clj
@@ -1,0 +1,40 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.interface
+  "Public API for the automation-edge-correlator component.
+
+   N15-1 exposes schema and trigger-classification helpers only.
+   Lifecycle (`start!` / `stop!` / `attach!`) lands in N15-3 once
+   `core.clj` and `emitter.clj` are in place."
+  (:require
+   [ai.miniforge.automation-edge-correlator.schema :as schema]
+   [ai.miniforge.automation-edge-correlator.triggers :as triggers]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema re-exports
+
+(def AutomationEdge          schema/AutomationEdge)
+(def routing-trigger-kinds   schema/routing-trigger-kinds)
+(def automation-edge-statuses schema/automation-edge-statuses)
+(def registry                schema/registry)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Trigger classification
+
+(def classify-trigger triggers/classify-trigger)

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/schema.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/schema.clj
@@ -1,0 +1,114 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.schema
+  "Open Malli schemas for the AutomationEdge wire form.
+
+   Mirrors the Rust contract in
+   `miniforge-control/contracts/crates/supervisory-entities/src/entities.rs`
+   (`AutomationEdge` struct) and the RFC at
+   `docs/design/automation-edge-correlator.md` §Schema.
+
+   All maps are open (additional keys pass through) per the supervisory-state
+   convention from N5-delta-1 §12.4. Enums are closed sets expressed as
+   `[:enum ...]`.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Closed enums — match Rust RoutingTriggerKind and AutomationEdgeStatus variants
+
+(def routing-trigger-kinds
+  "All recognised RoutingTriggerKind values, matching the Rust enum in
+   `miniforge-control/contracts/crates/supervisory-entities/src/entities.rs`.
+   Vector for deterministic ordering in malli error messages."
+  [:pr-merged
+   :review-comments-arrived
+   :ci-failed
+   :standards-review-arrived
+   :workflow-completed
+   :gate-fired])
+
+(def automation-edge-statuses
+  "All recognised AutomationEdge status values, matching the Rust enum.
+   Vector for deterministic ordering."
+  [:observed
+   :handled
+   :failed
+   :needs-operator
+   :suppressed])
+
+;------------------------------------------------------------------------------ Layer 0a
+;; Registry — minimal primitives, no cross-boundary reach into schema/core
+
+(def registry
+  "Malli registry for automation-edge-correlator keyword types.
+
+   Inlines the base keyword types (`id/uuid`, `:common/timestamp`,
+   `:common/non-neg-int`) rather than depending on
+   `ai.miniforge.schema.core/registry` — keeps the component from reaching
+   across a Polylith boundary, matching supervisory-state convention."
+  {;; Primitives
+   :id/uuid            uuid?
+   :common/timestamp   inst?
+   :common/non-neg-int [:int {:min 0}]
+
+   ;; AutomationEdge sub-types
+   :edge/id                 :id/uuid
+   :edge/trigger-event-id   :id/uuid
+   :edge/trigger-kind       (into [:enum] routing-trigger-kinds)
+   :edge/status             (into [:enum] automation-edge-statuses)})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Entity schema
+
+(def AutomationEdge
+  "Wire form for a single automation causality edge emitted as
+   `:supervisory/automation-edge-upserted`.
+
+   Mirrors the Rust `AutomationEdge` struct one-to-one. Open map: additional
+   keys pass through validation. Each field corresponds to the RFC §Schema
+   definition.
+
+   Idempotency key: `:edge/id` is a deterministic UUIDv5 derived from
+   `:edge/trigger-event-id` alone — not from the handler workflow id — so
+   status transitions upsert the same row. See RFC §Idempotency."
+  [:map {:registry registry}
+   ;; Required identity fields
+   [:edge/id                :edge/id]
+   [:edge/trigger-event-id  :edge/trigger-event-id]
+   [:edge/trigger-kind      :edge/trigger-kind]
+   [:edge/status            :edge/status]
+   [:edge/idempotency-key   string?]
+   [:edge/occurred-at       :common/timestamp]
+   [:edge/updated-at        :common/timestamp]
+
+   ;; Optional — populated once a handler workflow is correlated
+   [:edge/spec-id {:optional true}
+    [:maybe :id/uuid]]
+   [:edge/handled-by-workflow-run-id {:optional true}
+    [:maybe :id/uuid]]
+
+   ;; Optional — derived from trigger payload; may be empty vectors when
+   ;; trigger doesn't carry sufficient payload (RFC §Affected PRs and agents)
+   [:edge/affected-pr-ids {:optional true}
+    [:vector [:tuple :string :common/non-neg-int]]]
+   [:edge/affected-agent-session-ids {:optional true}
+    [:vector :id/uuid]]
+
+   ;; Optional — populated on :needs-operator or :failed transitions
+   [:edge/operator-action-required {:optional true} boolean?]
+   [:edge/fallback-intervention    {:optional true} [:maybe keyword?]]])

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/schema.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/schema.clj
@@ -92,7 +92,12 @@
    [:edge/trigger-event-id  :edge/trigger-event-id]
    [:edge/trigger-kind      :edge/trigger-kind]
    [:edge/status            :edge/status]
-   [:edge/idempotency-key   string?]
+   ;; Per RFC §Idempotency the key is the canonical UUID-string form of
+   ;; `:edge/trigger-event-id`. Validate the canonical form here so malformed
+   ;; producers are rejected at the wire boundary rather than at the Rust
+   ;; consumer (where the error blames the deserializer, not the source).
+   [:edge/idempotency-key
+    [:re #"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"]]
    [:edge/occurred-at       :common/timestamp]
    [:edge/updated-at        :common/timestamp]
 

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/triggers.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/triggers.clj
@@ -1,0 +1,62 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.triggers
+  "Pure trigger-event classification.
+
+   Maps incoming event-stream events to the correlator's RoutingTriggerKind
+   taxonomy per the RFC at `docs/design/automation-edge-correlator.md`
+   §RoutingTriggerKind taxonomy.
+
+   No side effects. No state. All functions are pure.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Classification table — event-type → RoutingTriggerKind
+
+(def ^:private trigger-table
+  "Lookup map from event-stream `:type` keyword to RoutingTriggerKind.
+
+   Mirrors the RFC §RoutingTriggerKind taxonomy table exactly:
+
+   | Trigger event type                      | RoutingTriggerKind        |
+   |-----------------------------------------|---------------------------|
+   | :pr/merged                              | :pr-merged                |
+   | :pr-monitor/review-comments-arrived     | :review-comments-arrived  |
+   | :pr-monitor/ci-failed                   | :ci-failed                |
+   | :standards-review/posted                | :standards-review-arrived |
+   | :workflow/completed                     | :workflow-completed       |
+   | :gate/passed                            | :gate-fired               |
+   | :gate/failed                            | :gate-fired               |"
+  {:pr/merged                              :pr-merged
+   :pr-monitor/review-comments-arrived     :review-comments-arrived
+   :pr-monitor/ci-failed                   :ci-failed
+   :standards-review/posted                :standards-review-arrived
+   :workflow/completed                     :workflow-completed
+   :gate/passed                            :gate-fired
+   :gate/failed                            :gate-fired})
+
+(defn classify-trigger
+  "Classify an event-stream event into a RoutingTriggerKind keyword.
+
+   Accepts any map with a `:type` key (the standard event-stream envelope
+   shape). Returns the matching RoutingTriggerKind keyword, or `nil` if the
+   event type is not a routing trigger.
+
+   Pure function. No side effects. No state."
+  [event]
+  (get trigger-table (:type event)))

--- a/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/schema_test.clj
+++ b/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/schema_test.clj
@@ -96,3 +96,13 @@
 (deftest open-map-allows-extra-keys
   (testing "extra keys pass through (open map per N5-delta-1 §12.4)"
     (is (validate (assoc observed-edge :some/future-key "value")))))
+
+(deftest idempotency-key-rejects-non-uuid-strings
+  (testing "empty string is rejected — catches mis-stringified producers"
+    (is (false? (validate (assoc observed-edge :edge/idempotency-key "")))))
+  (testing "free-form string is rejected — must be canonical UUIDv5 form"
+    (is (false? (validate (assoc observed-edge :edge/idempotency-key "not-a-uuid")))))
+  (testing "uppercase UUID is rejected — RFC fixes the canonical form as lowercase"
+    (is (false? (validate (assoc observed-edge
+                                 :edge/idempotency-key
+                                 "00000000-0000-0000-0000-00000000000A"))))))

--- a/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/schema_test.clj
+++ b/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/schema_test.clj
@@ -43,31 +43,35 @@
 ;------------------------------------------------------------------------------ Fixtures
 
 (def ^:private observed-edge
-  "Synthetic :observed edge — trigger seen, no handler correlated yet."
-  {:edge/id              (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001")
-   :edge/trigger-event-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000002")
-   :edge/trigger-kind    :pr-merged
-   :edge/status          :observed
-   :edge/idempotency-key "00000000-0000-0000-0000-000000000002"
-   :edge/occurred-at     (now)
-   :edge/updated-at      (now)
-   ;; Optional payload fields present on :observed
-   :edge/affected-pr-ids [["miniforge-ai/miniforge" 999]]
-   :edge/affected-agent-session-ids []})
+  "Synthetic :observed edge — trigger seen, no handler correlated yet.
+   `:edge/idempotency-key` is the string form of `:edge/trigger-event-id`
+   per RFC §Idempotency."
+  (let [trigger-id (random-uuid)]
+    {:edge/id              (random-uuid)
+     :edge/trigger-event-id trigger-id
+     :edge/trigger-kind    :pr-merged
+     :edge/status          :observed
+     :edge/idempotency-key (str trigger-id)
+     :edge/occurred-at     (now)
+     :edge/updated-at      (now)
+     ;; Optional payload fields present on :observed
+     :edge/affected-pr-ids [["miniforge-ai/miniforge" 999]]
+     :edge/affected-agent-session-ids []}))
 
 (def ^:private handled-edge
   "Synthetic :handled edge — handler workflow correlated and completed."
-  {:edge/id              (java.util.UUID/fromString "00000000-0000-0000-0000-000000000010")
-   :edge/trigger-event-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000011")
-   :edge/trigger-kind    :workflow-completed
-   :edge/status          :handled
-   :edge/idempotency-key "00000000-0000-0000-0000-000000000011"
-   :edge/occurred-at     (now)
-   :edge/updated-at      (now)
-   ;; Handler correlation fields populated on :handled
-   :edge/handled-by-workflow-run-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000012")
-   :edge/affected-pr-ids []
-   :edge/affected-agent-session-ids [(java.util.UUID/fromString "00000000-0000-0000-0000-000000000013")]})
+  (let [trigger-id (random-uuid)]
+    {:edge/id              (random-uuid)
+     :edge/trigger-event-id trigger-id
+     :edge/trigger-kind    :workflow-completed
+     :edge/status          :handled
+     :edge/idempotency-key (str trigger-id)
+     :edge/occurred-at     (now)
+     :edge/updated-at      (now)
+     ;; Handler correlation fields populated on :handled
+     :edge/handled-by-workflow-run-id (random-uuid)
+     :edge/affected-pr-ids []
+     :edge/affected-agent-session-ids [(random-uuid)]}))
 
 ;------------------------------------------------------------------------------ Tests
 

--- a/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/schema_test.clj
+++ b/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/schema_test.clj
@@ -1,0 +1,98 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.schema-test
+  "Unit tests for AutomationEdge schema validation.
+
+   Fixtures are obviously synthetic (random UUIDs, synthetic PR numbers).
+   One fixture per representative status: :observed and :handled."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
+   [ai.miniforge.automation-edge-correlator.schema :as schema]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- validate
+  "Returns true if `data` satisfies `AutomationEdge` schema."
+  [data]
+  (m/validate schema/AutomationEdge data))
+
+(defn- explain
+  "Returns malli explain map for debugging failures."
+  [data]
+  (m/explain schema/AutomationEdge data))
+
+(defn- now [] (java.util.Date.))
+
+;------------------------------------------------------------------------------ Fixtures
+
+(def ^:private observed-edge
+  "Synthetic :observed edge — trigger seen, no handler correlated yet."
+  {:edge/id              (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001")
+   :edge/trigger-event-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000002")
+   :edge/trigger-kind    :pr-merged
+   :edge/status          :observed
+   :edge/idempotency-key "00000000-0000-0000-0000-000000000002"
+   :edge/occurred-at     (now)
+   :edge/updated-at      (now)
+   ;; Optional payload fields present on :observed
+   :edge/affected-pr-ids [["miniforge-ai/miniforge" 999]]
+   :edge/affected-agent-session-ids []})
+
+(def ^:private handled-edge
+  "Synthetic :handled edge — handler workflow correlated and completed."
+  {:edge/id              (java.util.UUID/fromString "00000000-0000-0000-0000-000000000010")
+   :edge/trigger-event-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000011")
+   :edge/trigger-kind    :workflow-completed
+   :edge/status          :handled
+   :edge/idempotency-key "00000000-0000-0000-0000-000000000011"
+   :edge/occurred-at     (now)
+   :edge/updated-at      (now)
+   ;; Handler correlation fields populated on :handled
+   :edge/handled-by-workflow-run-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000012")
+   :edge/affected-pr-ids []
+   :edge/affected-agent-session-ids [(java.util.UUID/fromString "00000000-0000-0000-0000-000000000013")]})
+
+;------------------------------------------------------------------------------ Tests
+
+(deftest observed-edge-validates
+  (testing ":observed edge fixture satisfies AutomationEdge schema"
+    (is (validate observed-edge)
+        (str "explain: " (explain observed-edge)))))
+
+(deftest handled-edge-validates
+  (testing ":handled edge fixture satisfies AutomationEdge schema"
+    (is (validate handled-edge)
+        (str "explain: " (explain handled-edge)))))
+
+(deftest missing-required-field-fails
+  (testing "edge without :edge/id fails validation"
+    (is (false? (validate (dissoc observed-edge :edge/id))))))
+
+(deftest invalid-status-fails
+  (testing "edge with unknown :edge/status fails validation"
+    (is (false? (validate (assoc observed-edge :edge/status :flying))))))
+
+(deftest invalid-trigger-kind-fails
+  (testing "edge with unknown :edge/trigger-kind fails validation"
+    (is (false? (validate (assoc observed-edge :edge/trigger-kind :made-up))))))
+
+(deftest open-map-allows-extra-keys
+  (testing "extra keys pass through (open map per N5-delta-1 §12.4)"
+    (is (validate (assoc observed-edge :some/future-key "value")))))

--- a/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/triggers_test.clj
+++ b/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/triggers_test.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.triggers-test
+  "Unit tests for trigger-event classification.
+
+   Covers every entry in the RFC §RoutingTriggerKind taxonomy table, plus
+   a nil-returning case for an event-type that is not a routing trigger."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.automation-edge-correlator.triggers :as triggers]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- event
+  "Minimal event-stream envelope with the given `:type` keyword."
+  [t]
+  {:type t :event/id (random-uuid)})
+
+;------------------------------------------------------------------------------ Tests — positive classification
+
+(deftest pr-merged-classifies-to-pr-merged
+  (is (= :pr-merged (triggers/classify-trigger (event :pr/merged)))))
+
+(deftest review-comments-arrived-classifies-correctly
+  (is (= :review-comments-arrived
+         (triggers/classify-trigger (event :pr-monitor/review-comments-arrived)))))
+
+(deftest ci-failed-classifies-correctly
+  (is (= :ci-failed
+         (triggers/classify-trigger (event :pr-monitor/ci-failed)))))
+
+(deftest standards-review-posted-classifies-to-standards-review-arrived
+  (is (= :standards-review-arrived
+         (triggers/classify-trigger (event :standards-review/posted)))))
+
+(deftest workflow-completed-classifies-correctly
+  (is (= :workflow-completed
+         (triggers/classify-trigger (event :workflow/completed)))))
+
+(deftest gate-passed-classifies-to-gate-fired
+  (is (= :gate-fired (triggers/classify-trigger (event :gate/passed)))))
+
+(deftest gate-failed-classifies-to-gate-fired
+  (is (= :gate-fired (triggers/classify-trigger (event :gate/failed)))))
+
+;------------------------------------------------------------------------------ Tests — nil for non-trigger events
+
+(deftest non-trigger-event-returns-nil
+  (testing "event types that are not routing triggers return nil"
+    (is (nil? (triggers/classify-trigger (event :workflow/started))))
+    (is (nil? (triggers/classify-trigger (event :pr/opened))))
+    (is (nil? (triggers/classify-trigger (event :agent/heartbeat))))
+    (is (nil? (triggers/classify-trigger (event :unknown/event-type))))))
+
+(deftest nil-type-returns-nil
+  (testing "event with nil :type does not throw; returns nil"
+    (is (nil? (triggers/classify-trigger {:type nil})))))
+
+(deftest missing-type-returns-nil
+  (testing "event with no :type key does not throw; returns nil"
+    (is (nil? (triggers/classify-trigger {})))))

--- a/deps.edn
+++ b/deps.edn
@@ -82,6 +82,7 @@
                        "components/repo-dag/src"
                        "components/event-stream/src"
                        "components/supervisory-state/src"
+                       "components/automation-edge-correlator/src"
                        "components/pr-scoring/src"
                        "components/workflow-resume/src"
                        "components/workflow-resume/resources"
@@ -237,6 +238,7 @@
                      ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                      ai.miniforge/event-stream {:local/root "components/event-stream"}
                      ai.miniforge/supervisory-state {:local/root "components/supervisory-state"}
+                     ai.miniforge/automation-edge-correlator {:local/root "components/automation-edge-correlator"}
                      ai.miniforge/pr-scoring {:local/root "components/pr-scoring"}
                      ai.miniforge/workflow-resume {:local/root "components/workflow-resume"}
                      ai.miniforge/tui-engine {:local/root "components/tui-engine"}
@@ -355,6 +357,7 @@
                        "components/repo-dag/test"
                        "components/event-stream/test"
                        "components/supervisory-state/test"
+                       "components/automation-edge-correlator/test"
                        "components/pr-scoring/test"
                        "components/workflow-resume/test"
                        "components/tui-engine/test"
@@ -477,6 +480,7 @@
                       ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                       ai.miniforge/event-stream {:local/root "components/event-stream"}
                       ai.miniforge/supervisory-state {:local/root "components/supervisory-state"}
+                      ai.miniforge/automation-edge-correlator {:local/root "components/automation-edge-correlator"}
                       ai.miniforge/pr-scoring {:local/root "components/pr-scoring"}
                       ai.miniforge/workflow-resume {:local/root "components/workflow-resume"}
                       ai.miniforge/tui-engine {:local/root "components/tui-engine"}


### PR DESCRIPTION
## Summary

N15-1 of the N15 burndown from PR #901 (`docs/design/automation-edge-correlator.md`).

**In scope (this PR):**
- New Polylith brick at `components/automation-edge-correlator/` — sibling to `supervisory-state`, not a subsystem
- `schema.clj` — malli `AutomationEdge` wire form, `routing-trigger-kinds` vector, `automation-edge-statuses` vector, inline registry (no cross-boundary reach). Mirrors Rust contract in `miniforge-control/contracts/crates/supervisory-entities/src/entities.rs` one-to-one. Open maps per N5-delta-1 §12.4.
- `triggers.clj` — pure `classify-trigger` function; maps `:type` keyword to `RoutingTriggerKind` per RFC §RoutingTriggerKind taxonomy table. No side effects, no state.
- `interface.clj` — Layer 0 public API re-exporting schema and `classify-trigger` only
- `deps.edn` — minimal brick deps (event-stream, logging, schema, malli 0.16.4)
- Root `deps.edn` updated: component registered in `:dev :extra-paths` (src + test) and `:extra-deps` (both dev and test aliases)

**NOT in scope yet:**
- `correlator.clj` — pure state-machine logic (`:observed → :handled`, timeout → `:needs-operator`, etc.) — **N15-2**
- `emitter.clj` + `core.clj` — event-stream subscription, lifecycle `start!`/`stop!`/`attach!` — **N15-3**
- `:routing/trigger-event-id` field on handler-workflow `:workflow/started` emissions — **N15-4**
- New trigger event-type declarations in `event-stream/schema.clj` — **N15-5**
- Interface lifecycle re-export + canonical attach wiring — **N15-6**

## Tests

| Namespace | Tests | Assertions | Result |
|---|---|---|---|
| `triggers-test` | 10 | 13 | green |
| `schema-test` | 6 | 6 | green |

`triggers-test` covers every row in the RFC §RoutingTriggerKind table plus nil-returning cases (non-trigger event types, nil `:type`, missing `:type` key).

`schema-test` validates hand-rolled `:observed` and `:handled` fixtures; also confirms invalid status/kind reject and open-map allows extra keys.

## Verification

- `clj-kondo --lint components/automation-edge-correlator/src components/automation-edge-correlator/test` — **0 errors, 0 warnings**
- `clojure -M:test -m cognitect.test-runner -d test -n ai.miniforge.automation-edge-correlator.triggers-test` — **10 tests, 13 assertions, 0 failures**
- `clojure -M:test -m cognitect.test-runner -d test -n ai.miniforge.automation-edge-correlator.schema-test` — **6 tests, 6 assertions, 0 failures**
- `bb poly:check` — **new brick clean**; only pre-existing Warning 207s for `boundary`/`knowledge-pack`/`phase-software-factory` in existing projects
- Pre-commit hook suite: 242 smoke tests + 6 GraalVM-compat tests — all green

## Commit budget

Override applied: new brick scaffold — all 7 files logically inseparable (schema, triggers, interface, deps.edn, 2 test files, root registration). Test files account for 101 of 227 reportable lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)