### PR TITLE
chore(pre-commit): add workflow.runner-test back to smoke set

### DIFF
--- a/resources/precommit-smoke-tests.edn
+++ b/resources/precommit-smoke-tests.edn
@@ -28,11 +28,6 @@
 ;; Adding to this list is a deliberate choice — it adds dev-loop time for
 ;; every commit. Prefer fixing the test to be fast over keeping it out.
 
-;; ai.miniforge.workflow.runner-test deliberately excluded until PR #897
-;; merges — its tests acquire a real worktree at System/getProperty user.dir
-;; without the fixture-level acquire mock, and would commit phase-completion
-;; messages into the active branch. Re-add once #897 lands.
-
 {:smoke/namespaces
  ["ai.miniforge.response.interface-test"
   "ai.miniforge.anomaly.interface.schema-test"
@@ -45,4 +40,8 @@
   "ai.miniforge.cli.main.commands.resume-test"
   "ai.miniforge.cli.workflow-runner.display-output-test"
   "ai.miniforge.agent.reviewer-test"
+  ;; Safe to include now that PR #897 landed the namespace-level
+  ;; acquire-environment! mock — runner-test tests no longer commit
+  ;; phase-completion messages into the host worktree.
+  "ai.miniforge.workflow.runner-test"
   "ai.miniforge.phase.interface-test"]}


### PR DESCRIPTION
## Summary

Re-add `ai.miniforge.workflow.runner-test` to the smoke set,
deferred at PR #898 ship time pending PR #897's fixture-level
acquire-environment! mock (now merged as `c7e5a76a`).

Re-measured: 13 namespaces, 271 tests, 967 assertions, 0 failures.
Wall time unchanged in practice (~110 s).

## Test plan

- [x] `bb test:precommit` — green.
- [x] `bb pre-commit` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)