### PR TITLE
feat(automation-edge-correlator): N15-2 — correlator pure state machine

### DIFF
--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/correlator.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/correlator.clj
@@ -1,0 +1,292 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.correlator
+  "Pure state machine for the AutomationEdge correlator (N5-delta-4 §2.4).
+
+   State has the shape
+
+       {:pending {<trigger-event-id> <edge-map>}}
+
+   mirroring the supervisory-state accumulator pattern: events fold over the
+   state and each transition returns `[new-state edge-map-or-nil]`. Layer 1
+   (`core.clj`, arrives in N15-3) wires the I/O — subscription, emission,
+   clock — around this pure layer.
+
+   Per the spec, terminal statuses (`:handled`, `:failed`, `:suppressed`,
+   `:needs-operator`) MUST evict from `:pending`. `:needs-operator` is
+   terminal for the in-memory index per §3.6 bullet 1 — operators reanimate
+   it through the intervention surface (N15-6+), not by holding the entry in
+   the pending map.
+
+   No I/O. No system clock. All transitions receive `now` (a `java.util.Date`
+   or `inst?`) as an injected parameter."
+  (:require
+   [ai.miniforge.automation-edge-correlator.schema :as schema])
+  (:import
+   (java.util UUID)
+   (java.security MessageDigest)
+   (java.nio ByteBuffer)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; UUIDv5 derivation
+;;
+;; Inlined RFC-4122 §4.3 implementation (SHA-1, name-based). The sibling
+;; `supervisory-state` component carries the same helper privately
+;; (`attention.clj/uuid-v5`); we do not reach across the Polylith boundary
+;; for a `defn-` and the upstream Clojure UUIDv5 library
+;; (`danlentz/clj-uuid`) is not yet a workspace dependency. Lifting the
+;; helper to a shared `id-derivation` component is left for a follow-on
+;; (tracked alongside N15-6 interface re-exports).
+
+(defn- uuid-v5
+  "Deterministic UUIDv5 from a namespace UUID and a key string. RFC-4122
+   §4.3 (SHA-1 name-based)."
+  ^UUID [^UUID ns-uuid ^String k]
+  (let [md     (MessageDigest/getInstance "SHA-1")
+        ns-buf (ByteBuffer/wrap (byte-array 16))]
+    (.putLong ns-buf (.getMostSignificantBits ns-uuid))
+    (.putLong ns-buf (.getLeastSignificantBits ns-uuid))
+    (.update md (.array ns-buf))
+    (.update md (.getBytes k "UTF-8"))
+    (let [hash    (.digest md)
+          msb-raw (.getLong (ByteBuffer/wrap hash 0 8))
+          lsb-raw (.getLong (ByteBuffer/wrap hash 8 8))
+          ;; Clear version nibble (bits 48-51) → OR in 0x5000 to set v5.
+          ;; 0xFFFFFFFFFFFF0FFF as a signed long is -61441 — written that
+          ;; way because Clojure parses the literal as BigInt otherwise,
+          ;; which breaks `bit-and`.
+          hi      (bit-or (bit-and msb-raw (unchecked-long -61441)) 0x5000)
+          ;; Clear variant bits (62-63) → set to RFC-4122 `10`. The
+          ;; `Long/MIN_VALUE` constant is `0x8000000000000000`.
+          lo      (bit-or (bit-and lsb-raw 0x3FFFFFFFFFFFFFFF)
+                          Long/MIN_VALUE)]
+      (UUID. hi lo))))
+
+(defn edge-id-for
+  "Deterministic `:edge/id` for a given `:edge/trigger-event-id`. Pure.
+
+   Per N5-delta-4 §2.3, the namespace is the per-deployment constant in
+   `schema/automation-edge-namespace` and the key is the canonical
+   lowercase-hyphenated UUID-string form of `trigger-event-id`. Two calls
+   with the same input MUST return `=`-equal UUIDs (the consumer
+   `automation_edges` table dedups on this id)."
+  ^UUID [trigger-event-id]
+  (let [tid (if (instance? UUID trigger-event-id)
+              trigger-event-id
+              (UUID/fromString (str trigger-event-id)))]
+    (uuid-v5 schema/automation-edge-namespace (str tid))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; State + edge construction
+
+(def empty-state
+  "Initial correlator state — empty pending-edge index."
+  {:pending {}})
+
+(defn- new-observed-edge
+  "Build the `:observed` edge map for a freshly-seen trigger. Pure."
+  [{:trigger/keys [event-id kind affected-pr-ids affected-agent-session-ids]} now]
+  {:edge/id                          (edge-id-for event-id)
+   :edge/trigger-event-id            event-id
+   :edge/trigger-kind                kind
+   :edge/status                      :observed
+   :edge/idempotency-key             (str event-id)
+   :edge/occurred-at                 now
+   :edge/updated-at                  now
+   :edge/affected-pr-ids             (vec affected-pr-ids)
+   :edge/affected-agent-session-ids  (vec affected-agent-session-ids)
+   :edge/operator-action-required    false})
+
+(defn apply-trigger
+  "Apply a classified trigger to the correlator state.
+
+   `classified-trigger` MUST carry `:trigger/event-id`, `:trigger/kind`, and
+   MAY carry `:trigger/affected-pr-ids` / `:trigger/affected-agent-session-ids`
+   (defaults to empty vectors). `now` is the wall-clock instant injected by
+   the caller — used for both `:edge/occurred-at` and `:edge/updated-at` on
+   the new edge.
+
+   Returns `[new-state edge]`.
+
+   Idempotent per N5-delta-4 §2.3: re-observing the same `:trigger/event-id`
+   returns the previously-stored edge byte-identically and leaves the
+   pending map unchanged."
+  [state classified-trigger now]
+  (let [event-id (:trigger/event-id classified-trigger)
+        existing (get-in state [:pending event-id])]
+    (if existing
+      [state existing]
+      (let [edge (new-observed-edge classified-trigger now)]
+        [(assoc-in state [:pending event-id] edge) edge]))))
+
+(defn- transition-pending
+  "Look up an edge by `trigger-event-id`, transition it via `transition-fn`
+   if found, evict from `:pending`, and return `[new-state edge]`.
+
+   Returns `[state nil]` when no pending edge matches the id — the
+   correlator does not invent correlations per §3.5."
+  [state trigger-event-id transition-fn]
+  (if-let [pending (get-in state [:pending trigger-event-id])]
+    (let [transitioned (transition-fn pending)]
+      [(update state :pending dissoc trigger-event-id) transitioned])
+    [state nil]))
+
+(defn- mark-handled
+  [edge workflow-id now]
+  (assoc edge
+         :edge/status                     :handled
+         :edge/handled-by-workflow-run-id workflow-id
+         :edge/operator-action-required   false
+         :edge/updated-at                 now))
+
+(defn- mark-failed
+  [edge workflow-id now]
+  (assoc edge
+         :edge/status                     :failed
+         :edge/handled-by-workflow-run-id workflow-id
+         :edge/operator-action-required   true
+         :edge/updated-at                 now))
+
+(defn- mark-suppressed
+  [edge now]
+  (assoc edge
+         :edge/status                   :suppressed
+         :edge/operator-action-required false
+         :edge/updated-at               now))
+
+(def ^:private manual-disposition-intervention
+  "Placeholder fallback intervention keyword used on `:needs-operator`
+   transitions in v1. The per-kind intervention vocabulary lands with
+   N15-6+ (operator intervention surface); v1 emits one shared placeholder."
+  :edge/manual-disposition-required)
+
+(defn- mark-needs-operator
+  [edge now]
+  (assoc edge
+         :edge/status                   :needs-operator
+         :edge/operator-action-required true
+         :edge/fallback-intervention    manual-disposition-intervention
+         :edge/updated-at               now))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public transitions — one per §2.4 state-machine arrow
+
+(defn apply-workflow-completed
+  "Transition a pending edge to `:handled` when a `:workflow/completed`
+   event correlates by `:routing/trigger-event-id` (§2.4 first transition).
+
+   `completion` MUST carry `:routing/trigger-event-id` and `:workflow/id`,
+   and SHOULD carry `:workflow/timestamp` (the `:edge/updated-at` value).
+   Returns `[new-state edge-or-nil]`. When no pending edge matches the
+   trigger-event-id, the state is unchanged and the edge is nil — the
+   workflow is treated as an unrelated completion per §3.5."
+  [state {:keys [routing/trigger-event-id workflow/id workflow/timestamp]}]
+  (transition-pending state trigger-event-id
+                      #(mark-handled % id timestamp)))
+
+(defn apply-workflow-failed
+  "Transition a pending edge to `:failed` when a `:workflow/failed` event
+   correlates by `:routing/trigger-event-id` (§2.4 second transition).
+
+   Sets `:edge/operator-action-required true`. Same contract as
+   `apply-workflow-completed` otherwise — returns `[new-state edge-or-nil]`,
+   no-op when no match."
+  [state {:keys [routing/trigger-event-id workflow/id workflow/timestamp]}]
+  (transition-pending state trigger-event-id
+                      #(mark-failed % id timestamp)))
+
+(defn apply-no-handler
+  "Transition a pending edge to `:needs-operator` when a handler explicitly
+   declares `:no-handler-available` for its trigger (§2.4 third transition,
+   no-handler arm).
+
+   `signal` MUST carry `:routing/trigger-event-id` and SHOULD carry
+   `:timestamp`. Returns `[new-state edge-or-nil]`. No-op when no match."
+  [state {:keys [routing/trigger-event-id timestamp]}]
+  (transition-pending state trigger-event-id
+                      #(mark-needs-operator % timestamp)))
+
+(defn apply-suppress
+  "Transition a pending edge to `:suppressed` on an `:edge/suppress`
+   intervention (§2.4 fourth transition).
+
+   `intervention` MUST carry `:edge/trigger-event-id` and SHOULD carry
+   `:timestamp`. Preserves `:edge/handled-by-workflow-run-id` if it was set
+   on a prior transition (per §2.4 — the spec contemplates suppression of
+   already-handled edges via operator intervention). Returns
+   `[new-state edge-or-nil]`. No-op when no match.
+
+   NOTE: in-memory state only ever holds `:observed` edges (terminal
+   statuses evict on transition). Suppressing a fully-terminal edge after
+   eviction is therefore out of scope for this pure layer — it is handled
+   by the operator intervention surface (N15-6+) operating directly on the
+   consumer's entity table."
+  [state {:keys [edge/trigger-event-id timestamp]}]
+  (transition-pending state trigger-event-id
+                      #(mark-suppressed % timestamp)))
+
+(defn- expired?
+  "True when the time between `:edge/occurred-at` and `now` exceeds
+   `suppression-window-ms`."
+  [edge now suppression-window-ms]
+  (let [occurred (:edge/occurred-at edge)
+        elapsed  (- (inst-ms now) (inst-ms occurred))]
+    (> elapsed suppression-window-ms)))
+
+(defn expire-pending
+  "Scan the pending-edge index and transition any edge whose age exceeds
+   `suppression-window-ms` to `:needs-operator` (§2.4 third transition,
+   timeout arm).
+
+   Returns `[new-state expired-edges]` where `expired-edges` is the vector
+   of transitioned edge maps the emitter (N15-3) will publish.
+
+   Pure: `now` is injected, no system clock."
+  [state now suppression-window-ms]
+  (let [pending  (:pending state)
+        expired  (into []
+                       (comp (filter (fn [[_ edge]]
+                                       (expired? edge now suppression-window-ms)))
+                             (map (fn [[_ edge]] (mark-needs-operator edge now))))
+                       pending)
+        evict    (into #{} (map :edge/trigger-event-id) expired)
+        pending' (into {}
+                       (remove (fn [[event-id _]] (contains? evict event-id)))
+                       pending)]
+    [(assoc state :pending pending') expired]))
+
+(comment
+  ;; REPL — observe → handle a single trigger
+  (let [tid       (random-uuid)
+        wf-id     (random-uuid)
+        ts1       (java.util.Date.)
+        ts2       (java.util.Date.)
+        [s1 e1]   (apply-trigger empty-state
+                                 {:trigger/event-id       tid
+                                  :trigger/kind           :pr-merged
+                                  :trigger/affected-pr-ids [["miniforge-ai/miniforge" 999]]
+                                  :trigger/affected-agent-session-ids []}
+                                 ts1)
+        [s2 e2]   (apply-workflow-completed s1
+                                            {:routing/trigger-event-id tid
+                                             :workflow/id              wf-id
+                                             :workflow/timestamp       ts2})]
+    {:opened   e1
+     :handled  e2
+     :pending  (:pending s2)}))

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/correlator.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/correlator.clj
@@ -21,21 +21,59 @@
 
    State has the shape
 
-       {:pending {<trigger-event-id> <edge-map>}}
+       {:pending        {<trigger-event-id> <edge-map>}    ; :observed edges
+        :workflow-index {<workflow-id>      <trigger-event-id>}
+        :terminal       {<trigger-event-id> <edge-map>}}   ; :handled/:failed/
+                                                           ; :needs-operator/
+                                                           ; :suppressed
 
    mirroring the supervisory-state accumulator pattern: events fold over the
    state and each transition returns `[new-state edge-map-or-nil]`. Layer 1
    (`core.clj`, arrives in N15-3) wires the I/O — subscription, emission,
    clock — around this pure layer.
 
-   Per the spec, terminal statuses (`:handled`, `:failed`, `:suppressed`,
-   `:needs-operator`) MUST evict from `:pending`. `:needs-operator` is
-   terminal for the in-memory index per §3.6 bullet 1 — operators reanimate
-   it through the intervention surface (N15-6+), not by holding the entry in
-   the pending map.
+   ## Why three indices, not one
 
-   No I/O. No system clock. All transitions receive `now` (a `java.util.Date`
-   or `inst?`) as an injected parameter."
+   The correlator must close three correctness gaps that a single `:pending`
+   map cannot:
+
+   1. **Cross-event correlation.** `:workflow/completed` / `:workflow/failed`
+      carry `:workflow/id` only — they do NOT carry `:routing/trigger-event-id`
+      (which lives exclusively on `:workflow/started` per N5-delta-4 §4.3).
+      `:workflow-index` is the trigger→workflow bridge: populated by
+      `apply-workflow-started`, consumed by the completion / failure arms.
+   2. **Handler-started protection on the timeout arm.** Per §2.4 third
+      transition, `:needs-operator` fires when *no handler workflow is
+      observed within the suppression window*. A long-running handler that
+      started promptly is NOT eligible for the timeout, regardless of its
+      runtime. `expire-pending` consults `:workflow-index` to enforce this.
+   3. **Replay + duplicate-trigger correctness.** Per §2.3, replay MUST NOT
+      duplicate edges; per §3.6 terminal edges evict from `:pending`. Without
+      `:terminal`, a duplicate trigger after terminal eviction would re-open
+      an `:observed` edge with the same `:edge/id`, regressing the consumer's
+      projection from `:handled` back to `:observed`. `:terminal` remembers
+      the post-transition edge so a re-observation returns the same
+      terminal edge byte-identically.
+
+   ## Why `:event/timestamp` everywhere
+
+   All Clojure event-stream envelopes (`:workflow/started`, `:workflow/completed`,
+   `:workflow/failed`, the trigger events) carry their wall-clock as
+   `:event/timestamp`. The correlator reads exclusively from that envelope
+   key. The trigger event's `:event/timestamp` flows into the edge's
+   `:edge/occurred-at` (so replay and delayed delivery preserve the original
+   trigger time); each transition's `:event/timestamp` flows into the edge's
+   `:edge/updated-at`. No injected `now`: the pure layer takes the timestamp
+   from the event itself, and the lifecycle layer (N15-3) supplies the clock
+   only for `expire-pending` where there is no triggering event.
+
+   ## What this layer does NOT do
+
+   - No `:edge/fallback-intervention` emission. v1 omits this field on
+     `:needs-operator` edges — the per-trigger-kind intervention vocabulary
+     lands with N15-6+ (operator intervention surface). The schema marks the
+     field optional; emitting an out-of-vocabulary placeholder keyword would
+     leave operators pointing at an action no surface can dispatch."
   (:require
    [ai.miniforge.automation-edge-correlator.schema :as schema])
   (:import
@@ -96,19 +134,36 @@
 ;; State + edge construction
 
 (def empty-state
-  "Initial correlator state — empty pending-edge index."
-  {:pending {}})
+  "Initial correlator state — empty indices.
+
+   `:pending`        — `:observed` edges keyed by `:edge/trigger-event-id`.
+                       Evicted on transition to any terminal status.
+   `:workflow-index` — `<workflow-id> → <trigger-event-id>` for handler
+                       workflows whose `:workflow/started` carried a
+                       `:routing/trigger-event-id`. Evicted with the edge.
+   `:terminal`       — terminal edges keyed by `:edge/trigger-event-id`.
+                       Retained for replay + duplicate-trigger correctness
+                       per §2.3 and to support post-terminal suppression
+                       per §2.4."
+  {:pending        {}
+   :workflow-index {}
+   :terminal       {}})
 
 (defn- new-observed-edge
-  "Build the `:observed` edge map for a freshly-seen trigger. Pure."
-  [{:trigger/keys [event-id kind affected-pr-ids affected-agent-session-ids]} now]
+  "Build the `:observed` edge map for a freshly-seen trigger. Pure.
+
+   `:edge/occurred-at` and `:edge/updated-at` both come from the trigger
+   event's own timestamp (`:trigger/occurred-at` on the classified-trigger
+   map, sourced from the raw event's `:event/timestamp`)."
+  [{:trigger/keys [event-id kind affected-pr-ids affected-agent-session-ids
+                   occurred-at]}]
   {:edge/id                          (edge-id-for event-id)
    :edge/trigger-event-id            event-id
    :edge/trigger-kind                kind
    :edge/status                      :observed
    :edge/idempotency-key             (str event-id)
-   :edge/occurred-at                 now
-   :edge/updated-at                  now
+   :edge/occurred-at                 occurred-at
+   :edge/updated-at                  occurred-at
    :edge/affected-pr-ids             (vec affected-pr-ids)
    :edge/affected-agent-session-ids  (vec affected-agent-session-ids)
    :edge/operator-action-required    false})
@@ -116,130 +171,211 @@
 (defn apply-trigger
   "Apply a classified trigger to the correlator state.
 
-   `classified-trigger` MUST carry `:trigger/event-id`, `:trigger/kind`, and
-   MAY carry `:trigger/affected-pr-ids` / `:trigger/affected-agent-session-ids`
-   (defaults to empty vectors). `now` is the wall-clock instant injected by
-   the caller — used for both `:edge/occurred-at` and `:edge/updated-at` on
-   the new edge.
+   `classified-trigger` MUST carry:
+
+   - `:trigger/event-id`    — the raw event's `:event/id`
+   - `:trigger/kind`        — one of `schema/routing-trigger-kinds`
+   - `:trigger/occurred-at` — the raw event's `:event/timestamp`
+
+   and MAY carry:
+
+   - `:trigger/affected-pr-ids`           (defaults to `[]`)
+   - `:trigger/affected-agent-session-ids` (defaults to `[]`)
+
+   The lifecycle layer (N15-3) assembles this map from the raw event by
+   reading the envelope timestamp and applying the §3.4 affected-entity
+   extraction table.
 
    Returns `[new-state edge]`.
 
-   Idempotent per N5-delta-4 §2.3: re-observing the same `:trigger/event-id`
-   returns the previously-stored edge byte-identically and leaves the
-   pending map unchanged."
-  [state classified-trigger now]
-  (let [event-id (:trigger/event-id classified-trigger)
-        existing (get-in state [:pending event-id])]
-    (if existing
-      [state existing]
-      (let [edge (new-observed-edge classified-trigger now)]
+   Idempotent per N5-delta-4 §2.3:
+
+   - Re-observing a still-pending trigger returns the stored `:observed`
+     edge and leaves state unchanged.
+   - Re-observing a trigger whose edge has already transitioned to a
+     terminal status returns the terminal edge from `:terminal` and leaves
+     state unchanged. This prevents replay or duplicate delivery from
+     regressing the consumer's projection back to `:observed`."
+  [state classified-trigger]
+  (let [event-id (:trigger/event-id classified-trigger)]
+    (cond
+      (contains? (:pending state) event-id)
+      [state (get-in state [:pending event-id])]
+
+      (contains? (:terminal state) event-id)
+      [state (get-in state [:terminal event-id])]
+
+      :else
+      (let [edge (new-observed-edge classified-trigger)]
         [(assoc-in state [:pending event-id] edge) edge]))))
 
-(defn- transition-pending
-  "Look up an edge by `trigger-event-id`, transition it via `transition-fn`
-   if found, evict from `:pending`, and return `[new-state edge]`.
+(defn apply-workflow-started
+  "Index a handler workflow's `:workflow/started` event so subsequent
+   `:workflow/completed` / `:workflow/failed` events can be correlated to
+   their originating trigger by `:workflow/id`.
 
-   Returns `[state nil]` when no pending edge matches the id — the
-   correlator does not invent correlations per §3.5."
-  [state trigger-event-id transition-fn]
-  (if-let [pending (get-in state [:pending trigger-event-id])]
-    (let [transitioned (transition-fn pending)]
-      [(update state :pending dissoc trigger-event-id) transitioned])
+   `started` MUST carry `:workflow/id`. When it also carries
+   `:routing/trigger-event-id` (per N5-delta-4 §4.3 envelope addition), the
+   correlator records the mapping `workflow-id → trigger-event-id` in
+   `:workflow-index`. Workflows started outside the routing path (operator-
+   initiated runs, etc.) MUST omit the field and are not indexed.
+
+   Returns `[new-state nil]` — `apply-workflow-started` never emits an
+   edge upsert; the `:observed` edge was already emitted by `apply-trigger`
+   when the trigger landed.
+
+   Tolerates out-of-order delivery: if the trigger event has not yet been
+   observed when its handler's `:workflow/started` lands, the mapping is
+   recorded anyway. A later `apply-trigger` opens the `:observed` edge with
+   handler-started protection already in place — `expire-pending` will not
+   transition it to `:needs-operator` on the timeout arm."
+  [state {:workflow/keys [id] :routing/keys [trigger-event-id]}]
+  (if (and id trigger-event-id)
+    [(assoc-in state [:workflow-index id] trigger-event-id) nil]
     [state nil]))
 
 (defn- mark-handled
-  [edge workflow-id now]
+  [edge workflow-id event-timestamp]
   (assoc edge
          :edge/status                     :handled
          :edge/handled-by-workflow-run-id workflow-id
          :edge/operator-action-required   false
-         :edge/updated-at                 now))
+         :edge/updated-at                 event-timestamp))
 
 (defn- mark-failed
-  [edge workflow-id now]
+  [edge workflow-id event-timestamp]
   (assoc edge
          :edge/status                     :failed
          :edge/handled-by-workflow-run-id workflow-id
          :edge/operator-action-required   true
-         :edge/updated-at                 now))
+         :edge/updated-at                 event-timestamp))
 
 (defn- mark-suppressed
-  [edge now]
+  [edge event-timestamp]
   (assoc edge
          :edge/status                   :suppressed
          :edge/operator-action-required false
-         :edge/updated-at               now))
-
-(def ^:private manual-disposition-intervention
-  "Placeholder fallback intervention keyword used on `:needs-operator`
-   transitions in v1. The per-kind intervention vocabulary lands with
-   N15-6+ (operator intervention surface); v1 emits one shared placeholder."
-  :edge/manual-disposition-required)
+         :edge/updated-at               event-timestamp))
 
 (defn- mark-needs-operator
-  [edge now]
+  "Transition to `:needs-operator`. `:edge/fallback-intervention` is
+   deliberately omitted — v1 does not emit a placeholder keyword (see the
+   ns docstring); N15-6+ wires the per-trigger-kind intervention
+   vocabulary."
+  [edge event-timestamp]
   (assoc edge
          :edge/status                   :needs-operator
          :edge/operator-action-required true
-         :edge/fallback-intervention    manual-disposition-intervention
-         :edge/updated-at               now))
+         :edge/updated-at               event-timestamp))
+
+(defn- transition-and-evict
+  "Move `trigger-event-id`'s pending edge to `:terminal` after applying
+   `transition-fn`, evicting it from `:pending` (and from `:workflow-index`
+   if a handler workflow had been indexed against it). Pure.
+
+   Returns `[new-state transitioned-edge]`. Returns `[state nil]` if no
+   pending edge exists for `trigger-event-id`."
+  [state trigger-event-id transition-fn]
+  (if-let [pending (get-in state [:pending trigger-event-id])]
+    (let [transitioned (transition-fn pending)
+          ;; Find any workflow-id pointing at this trigger; evict that
+          ;; entry too. (For the handled/failed paths the workflow-id is
+          ;; known up-front; for the no-handler / suppress paths the
+          ;; trigger was opened but no handler was indexed — the scan is
+          ;; a no-op then.)
+          state'       (->> (:workflow-index state)
+                            (remove (fn [[_ tid]] (= tid trigger-event-id)))
+                            (into {})
+                            (assoc state :workflow-index))]
+      [(-> state'
+           (update :pending dissoc trigger-event-id)
+           (assoc-in [:terminal trigger-event-id] transitioned))
+       transitioned])
+    [state nil]))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public transitions — one per §2.4 state-machine arrow
 
 (defn apply-workflow-completed
-  "Transition a pending edge to `:handled` when a `:workflow/completed`
-   event correlates by `:routing/trigger-event-id` (§2.4 first transition).
+  "Transition an indexed handler workflow's pending edge to `:handled`.
 
-   `completion` MUST carry `:routing/trigger-event-id` and `:workflow/id`,
-   and SHOULD carry `:workflow/timestamp` (the `:edge/updated-at` value).
-   Returns `[new-state edge-or-nil]`. When no pending edge matches the
-   trigger-event-id, the state is unchanged and the edge is nil — the
-   workflow is treated as an unrelated completion per §3.5."
-  [state {:keys [routing/trigger-event-id workflow/id workflow/timestamp]}]
-  (transition-pending state trigger-event-id
-                      #(mark-handled % id timestamp)))
+   `completion` MUST carry `:workflow/id` and `:event/timestamp` (the
+   envelope key — `:workflow/completed` events do NOT carry
+   `:routing/trigger-event-id`; the correlator looks the trigger up via
+   `:workflow-index` populated by `apply-workflow-started`).
+
+   Returns `[new-state edge-or-nil]`. When the workflow-id has no indexed
+   trigger-event-id (workflow started outside routing, or out-of-order
+   delivery where the started event was lost), the state is unchanged and
+   the edge is nil per §3.5."
+  [state {:workflow/keys [id] :event/keys [timestamp]}]
+  (if-let [trigger-event-id (get-in state [:workflow-index id])]
+    (transition-and-evict state trigger-event-id
+                          #(mark-handled % id timestamp))
+    [state nil]))
 
 (defn apply-workflow-failed
-  "Transition a pending edge to `:failed` when a `:workflow/failed` event
-   correlates by `:routing/trigger-event-id` (§2.4 second transition).
+  "Transition an indexed handler workflow's pending edge to `:failed`.
 
-   Sets `:edge/operator-action-required true`. Same contract as
-   `apply-workflow-completed` otherwise — returns `[new-state edge-or-nil]`,
-   no-op when no match."
-  [state {:keys [routing/trigger-event-id workflow/id workflow/timestamp]}]
-  (transition-pending state trigger-event-id
-                      #(mark-failed % id timestamp)))
+   Same contract as `apply-workflow-completed` but transitions to `:failed`
+   and sets `:edge/operator-action-required true`."
+  [state {:workflow/keys [id] :event/keys [timestamp]}]
+  (if-let [trigger-event-id (get-in state [:workflow-index id])]
+    (transition-and-evict state trigger-event-id
+                          #(mark-failed % id timestamp))
+    [state nil]))
 
 (defn apply-no-handler
   "Transition a pending edge to `:needs-operator` when a handler explicitly
    declares `:no-handler-available` for its trigger (§2.4 third transition,
-   no-handler arm).
+   no-handler arm — `resume-dispatcher` emits this when the routing edge
+   has no configured workflow).
 
-   `signal` MUST carry `:routing/trigger-event-id` and SHOULD carry
-   `:timestamp`. Returns `[new-state edge-or-nil]`. No-op when no match."
-  [state {:keys [routing/trigger-event-id timestamp]}]
-  (transition-pending state trigger-event-id
-                      #(mark-needs-operator % timestamp)))
+   `signal` MUST carry `:routing/trigger-event-id` and `:event/timestamp`.
+   Returns `[new-state edge-or-nil]`; no-op when no pending edge matches."
+  [state {:routing/keys [trigger-event-id] :event/keys [timestamp]}]
+  (transition-and-evict state trigger-event-id
+                        #(mark-needs-operator % timestamp)))
 
 (defn apply-suppress
-  "Transition a pending edge to `:suppressed` on an `:edge/suppress`
+  "Transition an edge to `:suppressed` on an `:edge/suppress` operator
    intervention (§2.4 fourth transition).
 
-   `intervention` MUST carry `:edge/trigger-event-id` and SHOULD carry
-   `:timestamp`. Preserves `:edge/handled-by-workflow-run-id` if it was set
-   on a prior transition (per §2.4 — the spec contemplates suppression of
-   already-handled edges via operator intervention). Returns
-   `[new-state edge-or-nil]`. No-op when no match.
+   `intervention` MUST carry `:edge/trigger-event-id` and `:event/timestamp`.
+   Per §2.4 the operator MAY suppress an edge in any non-terminal *or*
+   terminal state — the suppression replaces the prior status while
+   preserving `:edge/handled-by-workflow-run-id` if it was set.
 
-   NOTE: in-memory state only ever holds `:observed` edges (terminal
-   statuses evict on transition). Suppressing a fully-terminal edge after
-   eviction is therefore out of scope for this pure layer — it is handled
-   by the operator intervention surface (N15-6+) operating directly on the
-   consumer's entity table."
-  [state {:keys [edge/trigger-event-id timestamp]}]
-  (transition-pending state trigger-event-id
-                      #(mark-suppressed % timestamp)))
+   Behavior:
+
+   - Pending edge → `:suppressed`, evicted from `:pending`, moved to
+     `:terminal`.
+   - Already-terminal edge → re-emitted as `:suppressed`, replacing the
+     prior terminal entry. `:edge/handled-by-workflow-run-id` is preserved
+     from whichever terminal state it was previously in.
+   - No record at all → `[state nil]`.
+
+   Returns `[new-state edge-or-nil]`."
+  [state {:edge/keys [trigger-event-id] :event/keys [timestamp]}]
+  (cond
+    (contains? (:pending state) trigger-event-id)
+    (transition-and-evict state trigger-event-id
+                          #(mark-suppressed % timestamp))
+
+    (contains? (:terminal state) trigger-event-id)
+    (let [prior        (get-in state [:terminal trigger-event-id])
+          transitioned (mark-suppressed prior timestamp)]
+      [(assoc-in state [:terminal trigger-event-id] transitioned) transitioned])
+
+    :else
+    [state nil]))
+
+(defn- handler-started?
+  "True when any entry in `:workflow-index` points at `trigger-event-id` —
+   i.e. a `:workflow/started` carrying that trigger has been observed."
+  [state trigger-event-id]
+  (some (fn [[_ tid]] (= tid trigger-event-id))
+        (:workflow-index state)))
 
 (defn- expired?
   "True when the time between `:edge/occurred-at` and `now` exceeds
@@ -251,8 +387,14 @@
 
 (defn expire-pending
   "Scan the pending-edge index and transition any edge whose age exceeds
-   `suppression-window-ms` to `:needs-operator` (§2.4 third transition,
-   timeout arm).
+   `suppression-window-ms` AND whose trigger has not been seen by any
+   `:workflow/started` to `:needs-operator` (§2.4 third transition, timeout
+   arm — *no handler workflow observed within the suppression window*).
+
+   Edges whose handler workflow HAS been observed (i.e. `:workflow-index`
+   carries an entry pointing at the trigger-event-id) are NOT eligible for
+   timeout regardless of their pending age — a long-running handler that
+   started promptly stays pending until it completes or fails.
 
    Returns `[new-state expired-edges]` where `expired-edges` is the vector
    of transitioned edge maps the emitter (N15-3) will publish.
@@ -263,30 +405,40 @@
         expired  (into []
                        (comp (filter (fn [[_ edge]]
                                        (expired? edge now suppression-window-ms)))
+                             (remove (fn [[tid _]] (handler-started? state tid)))
                              (map (fn [[_ edge]] (mark-needs-operator edge now))))
                        pending)
         evict    (into #{} (map :edge/trigger-event-id) expired)
         pending' (into {}
                        (remove (fn [[event-id _]] (contains? evict event-id)))
-                       pending)]
-    [(assoc state :pending pending') expired]))
+                       pending)
+        ;; Move evicted edges into :terminal so duplicate observations
+        ;; after expiry do not regress the consumer's projection.
+        terminal' (reduce (fn [t edge]
+                            (assoc t (:edge/trigger-event-id edge) edge))
+                          (:terminal state)
+                          expired)]
+    [(assoc state :pending pending' :terminal terminal') expired]))
 
 (comment
-  ;; REPL — observe → handle a single trigger
-  (let [tid       (random-uuid)
-        wf-id     (random-uuid)
-        ts1       (java.util.Date.)
-        ts2       (java.util.Date.)
-        [s1 e1]   (apply-trigger empty-state
-                                 {:trigger/event-id       tid
-                                  :trigger/kind           :pr-merged
-                                  :trigger/affected-pr-ids [["miniforge-ai/miniforge" 999]]
-                                  :trigger/affected-agent-session-ids []}
-                                 ts1)
-        [s2 e2]   (apply-workflow-completed s1
-                                            {:routing/trigger-event-id tid
-                                             :workflow/id              wf-id
-                                             :workflow/timestamp       ts2})]
+  ;; REPL — observe → handler starts → handler completes
+  (let [tid     (random-uuid)
+        wf-id   (random-uuid)
+        ts1     (java.util.Date.)
+        ts2     (java.util.Date.)
+        ts3     (java.util.Date.)
+        [s1 e1] (apply-trigger empty-state
+                               {:trigger/event-id                  tid
+                                :trigger/kind                      :pr-merged
+                                :trigger/occurred-at               ts1
+                                :trigger/affected-pr-ids           [["miniforge-ai/miniforge" 999]]
+                                :trigger/affected-agent-session-ids []})
+        [s2 _]  (apply-workflow-started s1 {:workflow/id              wf-id
+                                            :routing/trigger-event-id tid
+                                            :event/timestamp          ts2})
+        [s3 e3] (apply-workflow-completed s2 {:workflow/id     wf-id
+                                              :event/timestamp ts3})]
     {:opened   e1
-     :handled  e2
-     :pending  (:pending s2)}))
+     :handled  e3
+     :pending  (:pending s3)
+     :terminal (:terminal s3)}))

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/schema.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/schema.clj
@@ -26,7 +26,22 @@
 
    All maps are open (additional keys pass through) per the supervisory-state
    convention from N5-delta-1 §12.4. Enums are closed sets expressed as
-   `[:enum ...]`.")
+   `[:enum ...]`."
+  (:import
+   (java.util UUID)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Namespace UUID — stable per-deployment constant for UUIDv5 derivation
+
+(def ^UUID automation-edge-namespace
+  "Per-deployment namespace UUID for `:edge/id` UUIDv5 derivation, per
+   N5-delta-4 §2.3.
+
+   Generated once with `uuid.uuid4()` and frozen as a constant. MUST NOT be
+   the nil UUID and MUST NOT be one of the RFC-4122 well-known namespaces
+   (DNS / URL / OID / X500). A spec bump is required to rotate this value:
+   rotation re-keys every previously-emitted edge in consumer entity tables."
+  (UUID/fromString "5ca660c9-b2a4-42bf-85e4-0086de98dffb"))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Closed enums — match Rust RoutingTriggerKind and AutomationEdgeStatus variants

--- a/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/correlator_test.clj
+++ b/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/correlator_test.clj
@@ -19,9 +19,15 @@
 (ns ai.miniforge.automation-edge-correlator.correlator-test
   "Unit tests for the pure state-machine layer.
 
-   Covers every transition in N5-delta-4 §2.4 plus the §2.3 idempotency
-   invariant. Fixtures are obviously synthetic — random UUIDs and synthetic
-   PR numbers (999) per the workspace fabrication-evidence rule."
+   Covers every transition in N5-delta-4 §2.4, the §2.3 idempotency
+   invariant (including the post-terminal-eviction replay case), the
+   handler-started protection on the timeout arm, and the post-terminal
+   `:edge/suppress` case.
+
+   Fixtures use the canonical envelope key `:event/timestamp` (matching
+   `event_stream/schema.clj`), not synthetic `:workflow/timestamp` or
+   `:timestamp` shapes — Copilot caught that earlier fixtures exercised a
+   payload the event stream never emits."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.automation-edge-correlator.correlator :as sut]
@@ -47,29 +53,55 @@
   (Date. ms))
 
 (defn- classified-trigger
-  "Factory for a classified-trigger map. Override individual keys via
-   trailing kwargs; defaults synthesize a `:pr-merged` trigger with one PR."
+  "Factory for a classified-trigger map. `:trigger/occurred-at` defaults to
+   `(at-ms 1000)` (epoch+1s — obviously synthetic, deterministic). Override
+   any field via trailing kwargs."
   [trigger-id & {:as overrides}]
-  (merge {:trigger/event-id                  trigger-id
-          :trigger/kind                      :pr-merged
-          :trigger/affected-pr-ids           [synthetic-pr]
+  (merge {:trigger/event-id                   trigger-id
+          :trigger/kind                       :pr-merged
+          :trigger/occurred-at                (at-ms 1000)
+          :trigger/affected-pr-ids            [synthetic-pr]
           :trigger/affected-agent-session-ids []}
          overrides))
 
-(defn- workflow-completion
-  "Factory for the payload `apply-workflow-completed` / `apply-workflow-failed`
-   consumes."
-  [trigger-id workflow-id timestamp]
-  {:routing/trigger-event-id trigger-id
-   :workflow/id              workflow-id
-   :workflow/timestamp       timestamp})
+(defn- workflow-started
+  "Factory for the payload `apply-workflow-started` consumes. The routing
+   id is the bridge between `apply-trigger` and the later
+   completion/failure arms — it lives on `:workflow/started` per
+   N5-delta-4 §4.3, NOT on completion / failure events."
+  ([workflow-id trigger-id] (workflow-started workflow-id trigger-id (at-ms 1100)))
+  ([workflow-id trigger-id event-timestamp]
+   {:workflow/id              workflow-id
+    :routing/trigger-event-id trigger-id
+    :event/timestamp          event-timestamp}))
+
+(defn- workflow-terminal
+  "Factory for `:workflow/completed` / `:workflow/failed` payloads. Carries
+   only `:workflow/id` + `:event/timestamp` — the trigger-event-id is
+   looked up via the correlator's `:workflow-index`, NOT carried on the
+   event itself."
+  [workflow-id event-timestamp]
+  {:workflow/id     workflow-id
+   :event/timestamp event-timestamp})
 
 (defn- observe
   "Seed `empty-state` with one `:observed` edge for `trigger-id`. Returns
    `[state edge]`."
-  ([trigger-id] (observe trigger-id (at-ms 1000)))
-  ([trigger-id now]
-   (sut/apply-trigger sut/empty-state (classified-trigger trigger-id) now)))
+  ([trigger-id]
+   (observe trigger-id (at-ms 1000)))
+  ([trigger-id occurred-at]
+   (sut/apply-trigger sut/empty-state
+                      (classified-trigger trigger-id
+                                          :trigger/occurred-at occurred-at))))
+
+(defn- observe+start
+  "Open a trigger, then index its handler workflow as started. Returns
+   `[state trigger-edge workflow-id]`."
+  [trigger-id]
+  (let [wf-id   (random-uuid)
+        [s1 e]  (observe trigger-id)
+        [s2 _]  (sut/apply-workflow-started s1 (workflow-started wf-id trigger-id))]
+    [s2 e wf-id]))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; edge-id-for — §2.3 idempotency invariant
@@ -98,70 +130,126 @@
           "edge-id-for must not derive against the nil UUID namespace"))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; apply-trigger — :observed open + idempotency
+;; apply-trigger — :observed open + idempotency (in-pending AND post-terminal)
 
 (deftest apply-trigger-opens-observed-edge
   (testing "fresh trigger inserts an :observed edge into :pending"
-    (let [tid       (random-uuid)
-          now       (at-ms 1000)
-          [state e] (sut/apply-trigger sut/empty-state
-                                       (classified-trigger tid)
-                                       now)]
+    (let [tid        (random-uuid)
+          occurred   (at-ms 1000)
+          [state e]  (sut/apply-trigger sut/empty-state
+                                        (classified-trigger
+                                          tid
+                                          :trigger/occurred-at occurred))]
       (is (= :observed (:edge/status e)))
       (is (= tid (:edge/trigger-event-id e)))
       (is (= (sut/edge-id-for tid) (:edge/id e)))
       (is (= (str tid) (:edge/idempotency-key e)))
-      (is (= now (:edge/occurred-at e)))
-      (is (= now (:edge/updated-at e)))
+      (is (= occurred (:edge/occurred-at e))
+          ":edge/occurred-at carries the trigger event's own timestamp, not wall-clock")
+      (is (= occurred (:edge/updated-at e)))
       (is (false? (:edge/operator-action-required e)))
       (is (= e (get-in state [:pending tid]))
           "edge is keyed in :pending by :edge/trigger-event-id"))))
 
-(deftest apply-trigger-is-idempotent
+(deftest apply-trigger-is-idempotent-while-pending
   (testing "re-observing the same trigger-event-id returns the stored edge and unchanged state"
-    (let [tid          (random-uuid)
-          [s1 e1]      (observe tid (at-ms 1000))
-          [s2 e2]      (sut/apply-trigger s1
-                                          (classified-trigger tid)
-                                          (at-ms 9999))]
+    (let [tid     (random-uuid)
+          [s1 e1] (observe tid (at-ms 1000))
+          ;; Second observation uses a later timestamp — but state is unchanged
+          ;; and the returned edge is byte-identical with the original.
+          [s2 e2] (sut/apply-trigger
+                    s1
+                    (classified-trigger tid :trigger/occurred-at (at-ms 9999)))]
       (is (= e1 e2)
           "second observation returns byte-identical edge (per §2.3 / §3.6)")
       (is (= s1 s2)
           "state is unchanged on re-observation"))))
 
+(deftest apply-trigger-is-idempotent-after-terminal-eviction
+  (testing "re-observing AFTER terminal eviction returns the terminal edge (no regression)"
+    (let [tid        (random-uuid)
+          [s1 _ wf]  (observe+start tid)
+          ;; Drive the edge terminal via :handled.
+          [s2 _]     (sut/apply-workflow-completed
+                       s1 (workflow-terminal wf (at-ms 2000)))
+          terminal   (get-in s2 [:terminal tid])
+          _          (is (= :handled (:edge/status terminal)))
+          ;; Now replay or duplicate the original trigger event.
+          [s3 e]     (sut/apply-trigger
+                       s2 (classified-trigger tid :trigger/occurred-at (at-ms 1000)))]
+      (is (= terminal e)
+          (str "post-terminal re-observation MUST return the terminal edge, "
+               "not a fresh :observed — otherwise the consumer's projection "
+               "regresses :handled → :observed on duplicate delivery"))
+      (is (= s2 s3)
+          "state is unchanged on post-terminal re-observation"))))
+
 (deftest apply-trigger-stamps-affected-fields
   (testing "affected PRs and agent sessions are carried onto the edge"
     (let [tid       (random-uuid)
           agent-id  (random-uuid)
-          [_ e]     (sut/apply-trigger sut/empty-state
-                                       (classified-trigger
-                                         tid
-                                         :trigger/affected-agent-session-ids [agent-id])
-                                       (at-ms 1000))]
+          [_ e]     (sut/apply-trigger
+                      sut/empty-state
+                      (classified-trigger
+                        tid
+                        :trigger/affected-agent-session-ids [agent-id]))]
       (is (= [synthetic-pr] (:edge/affected-pr-ids e)))
       (is (= [agent-id] (:edge/affected-agent-session-ids e))))))
 
 ;------------------------------------------------------------------------------ Layer 1
+;; apply-workflow-started — workflow-index population
+
+(deftest apply-workflow-started-indexes-with-routing-id
+  (testing "a :workflow/started carrying :routing/trigger-event-id indexes the workflow"
+    (let [tid    (random-uuid)
+          wf-id  (random-uuid)
+          [s _]  (sut/apply-workflow-started
+                   sut/empty-state (workflow-started wf-id tid))]
+      (is (= tid (get-in s [:workflow-index wf-id]))))))
+
+(deftest apply-workflow-started-without-routing-id-is-noop
+  (testing "operator-initiated workflows (no :routing/trigger-event-id) are NOT indexed"
+    (let [wf-id (random-uuid)
+          [s _] (sut/apply-workflow-started
+                  sut/empty-state
+                  {:workflow/id wf-id :event/timestamp (at-ms 1000)})]
+      (is (= sut/empty-state s)))))
+
+(deftest apply-workflow-started-tolerates-out-of-order
+  (testing "started lands before its trigger: index recorded; later trigger opens normally"
+    (let [tid    (random-uuid)
+          wf-id  (random-uuid)
+          [s1 _] (sut/apply-workflow-started
+                   sut/empty-state (workflow-started wf-id tid))
+          [s2 e] (sut/apply-trigger s1 (classified-trigger tid))]
+      (is (= tid (get-in s2 [:workflow-index wf-id])))
+      (is (= :observed (:edge/status e))))))
+
+;------------------------------------------------------------------------------ Layer 1
 ;; :observed → :handled
 
-(deftest observed-to-handled-on-workflow-completed
-  (testing "matching :workflow/completed transitions to :handled and evicts"
-    (let [tid         (random-uuid)
-          wf-id       (random-uuid)
-          [s1 _]      (observe tid (at-ms 1000))
-          completion  (workflow-completion tid wf-id (at-ms 2000))
-          [s2 edge]   (sut/apply-workflow-completed s1 completion)]
+(deftest observed-to-handled-via-workflow-index
+  (testing "matching :workflow/completed transitions via workflow-index, evicts, terminalizes"
+    (let [tid          (random-uuid)
+          [s1 _ wf]    (observe+start tid)
+          completion   (workflow-terminal wf (at-ms 2000))
+          [s2 edge]    (sut/apply-workflow-completed s1 completion)]
       (is (= :handled (:edge/status edge)))
-      (is (= wf-id (:edge/handled-by-workflow-run-id edge)))
+      (is (= wf (:edge/handled-by-workflow-run-id edge)))
       (is (false? (:edge/operator-action-required edge)))
-      (is (= (at-ms 2000) (:edge/updated-at edge)))
+      (is (= (at-ms 2000) (:edge/updated-at edge))
+          ":edge/updated-at carries the :event/timestamp from the completion event")
       (is (nil? (get-in s2 [:pending tid]))
-          "terminal status evicts from :pending per §3.6 bullet 1"))))
+          "terminal status evicts from :pending per §3.6 bullet 1")
+      (is (nil? (get-in s2 [:workflow-index wf]))
+          ":workflow-index is evicted with the edge")
+      (is (= edge (get-in s2 [:terminal tid]))
+          "terminal edge is retained for replay + post-terminal suppress"))))
 
-(deftest workflow-completed-without-match-is-noop
-  (testing "completion with no pending edge leaves state unchanged and returns nil"
-    (let [orphan-tid (random-uuid)
-          completion (workflow-completion orphan-tid (random-uuid) (at-ms 2000))
+(deftest workflow-completed-without-index-entry-is-noop
+  (testing "completion for an unindexed workflow leaves state unchanged"
+    (let [orphan-wf  (random-uuid)
+          completion (workflow-terminal orphan-wf (at-ms 2000))
           [s2 edge]  (sut/apply-workflow-completed sut/empty-state completion)]
       (is (nil? edge))
       (is (= sut/empty-state s2)
@@ -170,23 +258,25 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; :observed → :failed
 
-(deftest observed-to-failed-on-workflow-failed
+(deftest observed-to-failed-via-workflow-index
   (testing "matching :workflow/failed transitions to :failed, sets operator-action, evicts"
     (let [tid       (random-uuid)
-          wf-id     (random-uuid)
-          [s1 _]    (observe tid (at-ms 1000))
-          failure   (workflow-completion tid wf-id (at-ms 2000))
+          [s1 _ wf] (observe+start tid)
+          failure   (workflow-terminal wf (at-ms 2000))
           [s2 edge] (sut/apply-workflow-failed s1 failure)]
       (is (= :failed (:edge/status edge)))
-      (is (= wf-id (:edge/handled-by-workflow-run-id edge)))
+      (is (= wf (:edge/handled-by-workflow-run-id edge)))
       (is (true? (:edge/operator-action-required edge)))
-      (is (nil? (get-in s2 [:pending tid]))))))
+      (is (= (at-ms 2000) (:edge/updated-at edge)))
+      (is (nil? (get-in s2 [:pending tid])))
+      (is (nil? (get-in s2 [:workflow-index wf])))
+      (is (= :failed (:edge/status (get-in s2 [:terminal tid])))))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; :observed → :needs-operator (timeout arm)
+;; :observed → :needs-operator — timeout arm + handler-started protection
 
-(deftest expire-pending-transitions-aged-edges
-  (testing "edges older than suppression-window transition to :needs-operator and evict"
+(deftest expire-pending-transitions-aged-edges-with-no-handler
+  (testing "edges older than the window AND with no handler observed transition"
     (let [tid        (random-uuid)
           [s1 _]     (observe tid (at-ms 1000))
           ;; 1000 + 300000 + 1 = past the window
@@ -196,56 +286,124 @@
       (is (= 1 (count edges)))
       (is (= :needs-operator (:edge/status edge)))
       (is (true? (:edge/operator-action-required edge)))
-      (is (= :edge/manual-disposition-required
-             (:edge/fallback-intervention edge)))
       (is (= now (:edge/updated-at edge)))
-      (is (nil? (get-in s2 [:pending tid]))))))
+      (is (nil? (get-in s2 [:pending tid])))
+      (is (= :needs-operator (:edge/status (get-in s2 [:terminal tid])))
+          "expired edge moves to :terminal to keep duplicate observations dedup'd")
+      (is (not (contains? edge :edge/fallback-intervention))
+          (str "v1 omits :edge/fallback-intervention until N15-6+ defines the "
+               "per-trigger-kind vocabulary (placeholder keyword would not be "
+               "in the bounded intervention set)")))))
 
 (deftest expire-pending-leaves-fresh-edges
   (testing "edges within the suppression-window are not transitioned"
-    (let [tid    (random-uuid)
-          [s1 _] (observe tid (at-ms 1000))
+    (let [tid        (random-uuid)
+          [s1 _]     (observe tid (at-ms 1000))
           ;; Well within the 5-minute window
-          now    (at-ms 60000)
+          now        (at-ms 60000)
           [s2 edges] (sut/expire-pending s1 now suppression-window-ms)]
       (is (empty? edges))
       (is (= s1 s2)))))
+
+(deftest expire-pending-does-not-time-out-when-handler-has-started
+  (testing "a long-running handler that started promptly is NOT eligible for timeout"
+    (let [tid        (random-uuid)
+          [s1 _ _]   (observe+start tid)
+          ;; Way past the window — but the handler started, so the edge is
+          ;; protected from the timeout arm per §2.4 third transition.
+          now        (at-ms 999999)
+          [s2 edges] (sut/expire-pending s1 now suppression-window-ms)]
+      (is (empty? edges)
+          "handler-started edges MUST NOT transition to :needs-operator via timeout")
+      (is (= s1 s2)
+          "state unchanged when no eligible edges expire")
+      (is (contains? (:pending s2) tid)
+          "pending edge stays put until the handler completes or fails"))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; :observed → :needs-operator (no-handler arm)
 
 (deftest observed-to-needs-operator-on-no-handler
-  (testing "apply-no-handler transitions a pending edge to :needs-operator and evicts"
+  (testing "apply-no-handler transitions a pending edge and terminalizes"
     (let [tid       (random-uuid)
           [s1 _]    (observe tid (at-ms 1000))
-          signal    {:routing/trigger-event-id tid :timestamp (at-ms 2000)}
+          signal    {:routing/trigger-event-id tid
+                     :event/timestamp          (at-ms 2000)}
           [s2 edge] (sut/apply-no-handler s1 signal)]
       (is (= :needs-operator (:edge/status edge)))
       (is (true? (:edge/operator-action-required edge)))
-      (is (= :edge/manual-disposition-required
-             (:edge/fallback-intervention edge)))
-      (is (nil? (get-in s2 [:pending tid]))))))
+      (is (= (at-ms 2000) (:edge/updated-at edge)))
+      (is (nil? (get-in s2 [:pending tid])))
+      (is (= :needs-operator (:edge/status (get-in s2 [:terminal tid]))))
+      (is (not (contains? edge :edge/fallback-intervention))
+          "v1 omits :edge/fallback-intervention (placeholder not in vocabulary)"))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; :observed → :suppressed
+;; :observed → :suppressed (pending)
 
-(deftest observed-to-suppressed-on-intervention
-  (testing "apply-suppress transitions a pending edge to :suppressed and evicts"
+(deftest pending-to-suppressed-on-intervention
+  (testing "apply-suppress on a pending edge transitions to :suppressed and terminalizes"
     (let [tid       (random-uuid)
           [s1 _]    (observe tid (at-ms 1000))
-          interv    {:edge/trigger-event-id tid :timestamp (at-ms 2000)}
+          interv    {:edge/trigger-event-id tid
+                     :event/timestamp       (at-ms 2000)}
           [s2 edge] (sut/apply-suppress s1 interv)]
       (is (= :suppressed (:edge/status edge)))
       (is (false? (:edge/operator-action-required edge)))
       (is (= (at-ms 2000) (:edge/updated-at edge)))
-      (is (nil? (get-in s2 [:pending tid]))))))
+      (is (nil? (get-in s2 [:pending tid])))
+      (is (= :suppressed (:edge/status (get-in s2 [:terminal tid])))))))
 
-;; NOTE — §2.4 contemplates `:handled → :suppressed` (operator suppresses a
-;; terminal edge). The in-memory state machine only tracks `:observed` edges
-;; (terminals evict on transition per §3.6 bullet 1), so this transition is
-;; out of scope for the pure layer. It is handled by the operator
-;; intervention surface (N15-6+) operating directly on the consumer entity
-;; table.
+;------------------------------------------------------------------------------ Layer 1
+;; Terminal → :suppressed — operator may suppress an already-terminal edge
+
+(deftest handled-to-suppressed-preserves-handled-workflow
+  (testing "operator suppresses a :handled edge → :suppressed; workflow-run-id preserved"
+    (let [tid          (random-uuid)
+          [s1 _ wf]    (observe+start tid)
+          [s2 _]       (sut/apply-workflow-completed
+                         s1 (workflow-terminal wf (at-ms 2000)))
+          interv       {:edge/trigger-event-id tid
+                        :event/timestamp       (at-ms 3000)}
+          [s3 edge]    (sut/apply-suppress s2 interv)]
+      (is (= :suppressed (:edge/status edge)))
+      (is (= wf (:edge/handled-by-workflow-run-id edge))
+          ":edge/handled-by-workflow-run-id MUST survive post-terminal suppression")
+      (is (= (at-ms 3000) (:edge/updated-at edge)))
+      (is (= edge (get-in s3 [:terminal tid]))
+          "the terminal entry is replaced with the :suppressed shape"))))
+
+(deftest failed-to-suppressed-preserves-handled-workflow
+  (testing "operator suppresses a :failed edge → :suppressed; workflow-run-id preserved"
+    (let [tid          (random-uuid)
+          [s1 _ wf]    (observe+start tid)
+          [s2 _]       (sut/apply-workflow-failed
+                         s1 (workflow-terminal wf (at-ms 2000)))
+          [_  edge]    (sut/apply-suppress
+                         s2 {:edge/trigger-event-id tid
+                             :event/timestamp       (at-ms 3000)})]
+      (is (= :suppressed (:edge/status edge)))
+      (is (= wf (:edge/handled-by-workflow-run-id edge))))))
+
+(deftest needs-operator-to-suppressed-after-expiry
+  (testing "operator suppresses a :needs-operator edge (post-expiry) → :suppressed"
+    (let [tid          (random-uuid)
+          [s1 _]       (observe tid (at-ms 1000))
+          [s2 _]       (sut/expire-pending s1 (at-ms 301001) suppression-window-ms)
+          [_  edge]    (sut/apply-suppress
+                         s2 {:edge/trigger-event-id tid
+                             :event/timestamp       (at-ms 400000)})]
+      (is (= :suppressed (:edge/status edge)))
+      (is (= (at-ms 400000) (:edge/updated-at edge))))))
+
+(deftest suppress-without-any-record-is-noop
+  (testing "suppress for an unknown trigger-event-id leaves state unchanged"
+    (let [orphan-tid  (random-uuid)
+          interv      {:edge/trigger-event-id orphan-tid
+                       :event/timestamp       (at-ms 2000)}
+          [s2 edge]   (sut/apply-suppress sut/empty-state interv)]
+      (is (nil? edge))
+      (is (= sut/empty-state s2)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Idempotency-key derivation

--- a/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/correlator_test.clj
+++ b/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/correlator_test.clj
@@ -1,0 +1,261 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.correlator-test
+  "Unit tests for the pure state-machine layer.
+
+   Covers every transition in N5-delta-4 §2.4 plus the §2.3 idempotency
+   invariant. Fixtures are obviously synthetic — random UUIDs and synthetic
+   PR numbers (999) per the workspace fabrication-evidence rule."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.automation-edge-correlator.correlator :as sut]
+   [ai.miniforge.automation-edge-correlator.schema :as schema])
+  (:import
+   (java.util Date)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants + factories
+
+(def ^:private suppression-window-ms
+  "Five-minute suppression window — matches the §6 default."
+  300000)
+
+(def ^:private synthetic-pr
+  "Synthetic [repo number] pair used everywhere a trigger payload needs PR
+   identity. Number 999 keeps fixtures obviously fake."
+  ["miniforge-ai/miniforge" 999])
+
+(defn- at-ms
+  "Build a `java.util.Date` at the given epoch-millis."
+  ^Date [^long ms]
+  (Date. ms))
+
+(defn- classified-trigger
+  "Factory for a classified-trigger map. Override individual keys via
+   trailing kwargs; defaults synthesize a `:pr-merged` trigger with one PR."
+  [trigger-id & {:as overrides}]
+  (merge {:trigger/event-id                  trigger-id
+          :trigger/kind                      :pr-merged
+          :trigger/affected-pr-ids           [synthetic-pr]
+          :trigger/affected-agent-session-ids []}
+         overrides))
+
+(defn- workflow-completion
+  "Factory for the payload `apply-workflow-completed` / `apply-workflow-failed`
+   consumes."
+  [trigger-id workflow-id timestamp]
+  {:routing/trigger-event-id trigger-id
+   :workflow/id              workflow-id
+   :workflow/timestamp       timestamp})
+
+(defn- observe
+  "Seed `empty-state` with one `:observed` edge for `trigger-id`. Returns
+   `[state edge]`."
+  ([trigger-id] (observe trigger-id (at-ms 1000)))
+  ([trigger-id now]
+   (sut/apply-trigger sut/empty-state (classified-trigger trigger-id) now)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; edge-id-for — §2.3 idempotency invariant
+
+(deftest edge-id-for-is-deterministic
+  (testing "two derivations from the same trigger-event-id produce =-equal ids"
+    (let [tid (random-uuid)]
+      (is (= (sut/edge-id-for tid) (sut/edge-id-for tid))))))
+
+(deftest edge-id-for-distinct-inputs-produce-distinct-ids
+  (testing "two distinct trigger-event-ids derive to distinct edge ids"
+    (let [a (random-uuid)
+          b (random-uuid)]
+      (is (not= (sut/edge-id-for a) (sut/edge-id-for b))))))
+
+(deftest edge-id-for-accepts-string-input
+  (testing "string input coerces through UUID/fromString and matches UUID input"
+    (let [tid (random-uuid)]
+      (is (= (sut/edge-id-for tid) (sut/edge-id-for (str tid)))))))
+
+(deftest edge-id-for-uses-component-namespace
+  (testing "derivation differs from the nil-UUID namespace (catches accidental nil-ns regression)"
+    (let [tid       (random-uuid)
+          nil-ns-id (#'sut/uuid-v5 (java.util.UUID. 0 0) (str tid))]
+      (is (not= nil-ns-id (sut/edge-id-for tid))
+          "edge-id-for must not derive against the nil UUID namespace"))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; apply-trigger — :observed open + idempotency
+
+(deftest apply-trigger-opens-observed-edge
+  (testing "fresh trigger inserts an :observed edge into :pending"
+    (let [tid       (random-uuid)
+          now       (at-ms 1000)
+          [state e] (sut/apply-trigger sut/empty-state
+                                       (classified-trigger tid)
+                                       now)]
+      (is (= :observed (:edge/status e)))
+      (is (= tid (:edge/trigger-event-id e)))
+      (is (= (sut/edge-id-for tid) (:edge/id e)))
+      (is (= (str tid) (:edge/idempotency-key e)))
+      (is (= now (:edge/occurred-at e)))
+      (is (= now (:edge/updated-at e)))
+      (is (false? (:edge/operator-action-required e)))
+      (is (= e (get-in state [:pending tid]))
+          "edge is keyed in :pending by :edge/trigger-event-id"))))
+
+(deftest apply-trigger-is-idempotent
+  (testing "re-observing the same trigger-event-id returns the stored edge and unchanged state"
+    (let [tid          (random-uuid)
+          [s1 e1]      (observe tid (at-ms 1000))
+          [s2 e2]      (sut/apply-trigger s1
+                                          (classified-trigger tid)
+                                          (at-ms 9999))]
+      (is (= e1 e2)
+          "second observation returns byte-identical edge (per §2.3 / §3.6)")
+      (is (= s1 s2)
+          "state is unchanged on re-observation"))))
+
+(deftest apply-trigger-stamps-affected-fields
+  (testing "affected PRs and agent sessions are carried onto the edge"
+    (let [tid       (random-uuid)
+          agent-id  (random-uuid)
+          [_ e]     (sut/apply-trigger sut/empty-state
+                                       (classified-trigger
+                                         tid
+                                         :trigger/affected-agent-session-ids [agent-id])
+                                       (at-ms 1000))]
+      (is (= [synthetic-pr] (:edge/affected-pr-ids e)))
+      (is (= [agent-id] (:edge/affected-agent-session-ids e))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; :observed → :handled
+
+(deftest observed-to-handled-on-workflow-completed
+  (testing "matching :workflow/completed transitions to :handled and evicts"
+    (let [tid         (random-uuid)
+          wf-id       (random-uuid)
+          [s1 _]      (observe tid (at-ms 1000))
+          completion  (workflow-completion tid wf-id (at-ms 2000))
+          [s2 edge]   (sut/apply-workflow-completed s1 completion)]
+      (is (= :handled (:edge/status edge)))
+      (is (= wf-id (:edge/handled-by-workflow-run-id edge)))
+      (is (false? (:edge/operator-action-required edge)))
+      (is (= (at-ms 2000) (:edge/updated-at edge)))
+      (is (nil? (get-in s2 [:pending tid]))
+          "terminal status evicts from :pending per §3.6 bullet 1"))))
+
+(deftest workflow-completed-without-match-is-noop
+  (testing "completion with no pending edge leaves state unchanged and returns nil"
+    (let [orphan-tid (random-uuid)
+          completion (workflow-completion orphan-tid (random-uuid) (at-ms 2000))
+          [s2 edge]  (sut/apply-workflow-completed sut/empty-state completion)]
+      (is (nil? edge))
+      (is (= sut/empty-state s2)
+          "correlator does not invent correlations (§3.5)"))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; :observed → :failed
+
+(deftest observed-to-failed-on-workflow-failed
+  (testing "matching :workflow/failed transitions to :failed, sets operator-action, evicts"
+    (let [tid       (random-uuid)
+          wf-id     (random-uuid)
+          [s1 _]    (observe tid (at-ms 1000))
+          failure   (workflow-completion tid wf-id (at-ms 2000))
+          [s2 edge] (sut/apply-workflow-failed s1 failure)]
+      (is (= :failed (:edge/status edge)))
+      (is (= wf-id (:edge/handled-by-workflow-run-id edge)))
+      (is (true? (:edge/operator-action-required edge)))
+      (is (nil? (get-in s2 [:pending tid]))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; :observed → :needs-operator (timeout arm)
+
+(deftest expire-pending-transitions-aged-edges
+  (testing "edges older than suppression-window transition to :needs-operator and evict"
+    (let [tid        (random-uuid)
+          [s1 _]     (observe tid (at-ms 1000))
+          ;; 1000 + 300000 + 1 = past the window
+          now        (at-ms 301001)
+          [s2 edges] (sut/expire-pending s1 now suppression-window-ms)
+          edge       (first edges)]
+      (is (= 1 (count edges)))
+      (is (= :needs-operator (:edge/status edge)))
+      (is (true? (:edge/operator-action-required edge)))
+      (is (= :edge/manual-disposition-required
+             (:edge/fallback-intervention edge)))
+      (is (= now (:edge/updated-at edge)))
+      (is (nil? (get-in s2 [:pending tid]))))))
+
+(deftest expire-pending-leaves-fresh-edges
+  (testing "edges within the suppression-window are not transitioned"
+    (let [tid    (random-uuid)
+          [s1 _] (observe tid (at-ms 1000))
+          ;; Well within the 5-minute window
+          now    (at-ms 60000)
+          [s2 edges] (sut/expire-pending s1 now suppression-window-ms)]
+      (is (empty? edges))
+      (is (= s1 s2)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; :observed → :needs-operator (no-handler arm)
+
+(deftest observed-to-needs-operator-on-no-handler
+  (testing "apply-no-handler transitions a pending edge to :needs-operator and evicts"
+    (let [tid       (random-uuid)
+          [s1 _]    (observe tid (at-ms 1000))
+          signal    {:routing/trigger-event-id tid :timestamp (at-ms 2000)}
+          [s2 edge] (sut/apply-no-handler s1 signal)]
+      (is (= :needs-operator (:edge/status edge)))
+      (is (true? (:edge/operator-action-required edge)))
+      (is (= :edge/manual-disposition-required
+             (:edge/fallback-intervention edge)))
+      (is (nil? (get-in s2 [:pending tid]))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; :observed → :suppressed
+
+(deftest observed-to-suppressed-on-intervention
+  (testing "apply-suppress transitions a pending edge to :suppressed and evicts"
+    (let [tid       (random-uuid)
+          [s1 _]    (observe tid (at-ms 1000))
+          interv    {:edge/trigger-event-id tid :timestamp (at-ms 2000)}
+          [s2 edge] (sut/apply-suppress s1 interv)]
+      (is (= :suppressed (:edge/status edge)))
+      (is (false? (:edge/operator-action-required edge)))
+      (is (= (at-ms 2000) (:edge/updated-at edge)))
+      (is (nil? (get-in s2 [:pending tid]))))))
+
+;; NOTE — §2.4 contemplates `:handled → :suppressed` (operator suppresses a
+;; terminal edge). The in-memory state machine only tracks `:observed` edges
+;; (terminals evict on transition per §3.6 bullet 1), so this transition is
+;; out of scope for the pure layer. It is handled by the operator
+;; intervention surface (N15-6+) operating directly on the consumer entity
+;; table.
+
+;------------------------------------------------------------------------------ Layer 1
+;; Idempotency-key derivation
+
+(deftest idempotency-key-is-string-of-trigger-event-id
+  (testing "stored :edge/idempotency-key equals (str trigger-event-id)"
+    (let [tid   (random-uuid)
+          [_ e] (observe tid)]
+      (is (= (str tid) (:edge/idempotency-key e))))))
+
+(deftest namespace-uuid-is-the-component-constant
+  (testing "the namespace constant is the schema-level def, not the nil UUID"
+    (is (not= (java.util.UUID. 0 0) schema/automation-edge-namespace))))


### PR DESCRIPTION
## Summary

Pure state-machine layer of the AutomationEdge correlator. No I/O — clock is
injected; every transition is `(state, event, now) → [state', edge-or-nil]`.
Builds on #902 (N15-1 scaffold). Implements the producer half of
`specs/normative/N5-delta-4-automation-edge-correlator.md`:

- **§2.3 idempotency** — `:edge/id` is deterministic UUIDv5 over a stable
  per-deployment namespace UUID (`schema/automation-edge-namespace`, new
  constant). Re-observing the same `:trigger/event-id` returns the
  previously-stored edge byte-identically and leaves state unchanged.
- **§2.4 state machine** — six transitions, one fn each:
  `apply-trigger` (`→ :observed`), `apply-workflow-completed`
  (`→ :handled`), `apply-workflow-failed` (`→ :failed`), `apply-no-handler`
  (`→ :needs-operator`, no-handler arm), `expire-pending`
  (`→ :needs-operator`, timeout arm), `apply-suppress` (`→ :suppressed`).
- **§3.6 pending-edge discipline** — `:pending` is keyed by
  `:edge/trigger-event-id`; all terminal statuses evict.

UUIDv5 helper inlined (RFC-4122 §4.3 SHA-1 name-based) rather than reaching
across the Polylith boundary into `supervisory-state`'s private copy or
adding a new library dependency. Future follow-on tracked alongside N15-6
to lift the helper to a shared `id-derivation` component.

Out of scope (subsequent burndown steps): `core.clj` lifecycle +
`emitter.clj` (N15-3), `:routing/trigger-event-id` envelope additions in
handler producers (N15-4), new trigger event schemas in event-stream (N15-5),
interface re-exports (N15-6).

## Test plan

- [x] `clojure -M:test -m cognitect.test-runner` brick suite — 33 tests, 67
  assertions, 0 failures.
- [x] `clj-kondo --lint components/automation-edge-correlator/{src,test}` — 0
  errors / 0 warnings.
- [x] `bb poly:check` — only the pre-existing 207 warnings for
  `boundary` / `phase-software-factory` / `context-pack` / `knowledge-pack`.
- [x] `bb pre-commit` (commit-budget, lint, fmt, smoke 12 namespaces,
  graalvm) — passed. Commit budget intentionally overridden:
  `feat(automation-edge-correlator)` rationale — production layer (~292
  lines) is one fn per §2.4 row; splitting transitions across PRs would
  invent partial state machines, and dropping the test layer would land an
  untested machine.
- [ ] N15-3 integration test will exercise the state-machine end-to-end
  against an in-memory event stream when the lifecycle layer lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)