### PR TITLE
feat(pr-label-actions): M1 — labels in :pr/merged + registry resource + base-sha capture

### DIFF
--- a/components/pr-lifecycle/resources/config/pr-lifecycle/label-actions.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/label-actions.edn
@@ -1,0 +1,39 @@
+;; -----------------------------------------------------------------------------
+;; PR-label-triggered actions on in-flight workflows
+;; -----------------------------------------------------------------------------
+;;
+;; Source of truth for which PR labels trigger which workflow-runtime
+;; actions when a PR merges to main. See
+;; docs/design/labeled-pr-actions-plan.md for the architecture.
+;;
+;; Keys are STRINGS to match GitHub's native label shape — labels are
+;; normalized at creation time by the GitHub project, and this lookup
+;; is a literal compare (no case-folding, no whitespace stripping).
+;;
+;; Match semantics:
+;;
+;;   :applies-when {:workflow.base-sha/not-ancestor-of-merge true}
+;;
+;; The watcher (M2) resolves "applies?" by running
+;; `git merge-base --is-ancestor base-sha merge-sha` against each
+;; active workflow's recorded base SHA. Exit 0 → ancestor (workflow
+;; already includes the fix) → skip. Exit 1 → not ancestor (workflow
+;; predates the fix) → match. Git SHAs are not orderable; ancestry
+;; is the only correct test.
+;;
+;; This file is the M1 contract. The watcher (M2), meta-agent
+;; (M2b), and rebase actuator (M3) consume but do not modify it.
+
+{:pr-label-actions/registry
+ {"dogfood-fix"
+  {:action       :rebase-and-resume
+   :description  "Pause, rebase the task worktree onto post-merge main, resume from the next phase boundary"
+   :on-conflict  :attention-required
+   :applies-when {:workflow.base-sha/not-ancestor-of-merge true}}
+
+  ;; Future label-action pairs are added here without code edits.
+  ;; Examples from the design plan that may land later:
+  ;;
+  ;;   "hot-config-reload" {:action :reload-runtime-config ...}
+  ;;   "budget-pause"      {:action :pause-until-human-review ...}
+  }}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/events.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/events.clj
@@ -135,14 +135,24 @@
                  :comment comment-data}))
 
 (defn merged
-  "Create a merged event."
-  [dag-id run-id task-id pr-id merge-sha]
-  (create-event :pr/merged
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :pr/merge-sha merge-sha}))
+  "Create a merged event.
+
+   `labels` is an optional set of strings — the GitHub-native label
+   names attached to the PR at merge time. Carrying them here lets
+   downstream watchers (e.g. the pr-label-actions M2 brick) match
+   without re-querying GitHub. The 5-arity preserves backward
+   compatibility for callers that don't have label data on hand;
+   they default to an empty set."
+  ([dag-id run-id task-id pr-id merge-sha]
+   (merged dag-id run-id task-id pr-id merge-sha #{}))
+  ([dag-id run-id task-id pr-id merge-sha labels]
+   (create-event :pr/merged
+                 {:dag/id dag-id
+                  :run/id run-id
+                  :task/id task-id
+                  :pr/id pr-id
+                  :pr/merge-sha merge-sha
+                  :pr/labels (set labels)})))
 
 (defn closed
   "Create a closed (without merge) event."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -375,6 +375,26 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Merge orchestration
 
+(defn fetch-pr-labels!
+  "Fetch the label names attached to a PR via `gh pr view --json labels`.
+
+   Returns a `#{}` of label-name strings (GitHub-native, literal,
+   no case-folding). Returns `#{}` on any failure — label fetch is
+   best-effort and never blocks the merge-event publish path. The
+   first downstream consumer is the M2 pr-label-actions watcher."
+  [worktree-path pr-number]
+  (try
+    (let [result (run-gh-command
+                  ["gh" "pr" "view" (str pr-number) "--json" "labels"]
+                  worktree-path)]
+      (if (dag/ok? result)
+        (let [body (json/parse-string (:output (:data result)) true)]
+          (->> (:labels body)
+               (keep :name)
+               set))
+        #{}))
+    (catch Exception _ #{})))
+
 (defn attempt-merge
   "Attempt to merge a PR, handling common failure cases.
 
@@ -402,15 +422,20 @@
         (let [merge-result (merge-pr! worktree-path pr-number :policy policy)]
           (if (dag/ok? merge-result)
             (do
-              ;; Publish merged event
+              ;; Publish merged event with the PR's labels so downstream
+              ;; watchers (label-actions M2) can match without re-querying
+              ;; GitHub. Label fetch is best-effort — missing labels
+              ;; default to #{}, never block the merge event.
               (when event-bus
                 (let [sha-result (run-gh-command
                                   ["git" "rev-parse" "HEAD"]
                                   worktree-path)
                       merge-sha (when (dag/ok? sha-result)
-                                  (:output (:data sha-result)))]
+                                  (:output (:data sha-result)))
+                      labels (fetch-pr-labels! worktree-path pr-number)]
                   (events/publish! event-bus
-                                   (events/merged dag-id run-id task-id pr-id merge-sha)
+                                   (events/merged dag-id run-id task-id pr-id
+                                                  merge-sha labels)
                                    logger)))
               (when logger
                 (log/info logger :pr-lifecycle :merge/success

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/events_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/events_test.clj
@@ -117,7 +117,21 @@
   (testing "merged creates event with merge SHA"
     (let [event (events/merged dag-id run-id task-id 123 "merge-sha-abc")]
       (is (= :pr/merged (:event/type event)))
-      (is (= "merge-sha-abc" (:pr/merge-sha event))))))
+      (is (= "merge-sha-abc" (:pr/merge-sha event)))
+      (is (= #{} (:pr/labels event))
+          "5-arity defaults labels to empty set for backward compatibility")))
+
+  (testing "6-arity merged carries the PR's labels for downstream watchers"
+    (let [labels ["dogfood-fix" "infrastructure"]
+          event  (events/merged dag-id run-id task-id 123 "merge-sha-abc" labels)]
+      (is (= :pr/merged (:event/type event)))
+      (is (= "merge-sha-abc" (:pr/merge-sha event)))
+      (is (= #{"dogfood-fix" "infrastructure"} (:pr/labels event))
+          "labels are coerced to a set so downstream membership checks are O(1)")))
+
+  (testing "labels passed as a set round-trip unchanged"
+    (let [event (events/merged dag-id run-id task-id 123 "abc" #{"dogfood-fix"})]
+      (is (= #{"dogfood-fix"} (:pr/labels event))))))
 
 (deftest closed-constructor-test
   (testing "closed creates event with reason"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/label_actions_config_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/label_actions_config_test.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.label-actions-config-test
+  "Structural validity tests for the M1 PR-label-actions registry EDN.
+
+   The watcher (M2) consumes this file. Pinning the shape here means a
+   typo in the registry surfaces at test time, not at first-merge time."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.test :refer [deftest is testing]]))
+
+(def ^:private config-path
+  "config/pr-lifecycle/label-actions.edn")
+
+(defn- load-registry []
+  (-> (io/resource config-path)
+      slurp
+      edn/read-string
+      :pr-label-actions/registry))
+
+(deftest registry-resource-loads
+  (testing "the registry resource exists on the classpath and parses as EDN"
+    (let [r (io/resource config-path)]
+      (is (some? r)
+          (str "Registry resource missing at " config-path)))
+    (let [registry (load-registry)]
+      (is (map? registry) "Registry must be a map keyed by label string"))))
+
+(deftest registry-keys-are-strings
+  (testing "label keys are STRINGS (GitHub-native), never keywords or symbols"
+    (let [registry (load-registry)]
+      (doseq [[k _] registry]
+        (is (string? k)
+            (str "Label registry key " (pr-str k)
+                 " must be a string — GitHub labels are not keywords"))))))
+
+(deftest dogfood-fix-entry-shape
+  (testing "the seed dogfood-fix entry has the canonical M1 shape"
+    (let [entry (get (load-registry) "dogfood-fix")]
+      (is (some? entry) "dogfood-fix entry must be present in the registry")
+      (is (= :rebase-and-resume (:action entry))
+          ":action must be :rebase-and-resume per the design plan")
+      (is (string? (:description entry))
+          ":description must be a human-readable string")
+      (is (= :attention-required (:on-conflict entry))
+          ":on-conflict must route to :attention-required (no silent loss)")
+      (let [applies (:applies-when entry)]
+        (is (map? applies))
+        (is (= true (:workflow.base-sha/not-ancestor-of-merge applies))
+            ":applies-when must declare the not-ancestor-of-merge predicate")))))
+
+(deftest every-entry-has-required-keys
+  (testing "every registry entry declares :action, :description, :on-conflict, :applies-when"
+    (let [registry (load-registry)
+          required #{:action :description :on-conflict :applies-when}]
+      (doseq [[label entry] registry]
+        (let [missing (set/difference required (set (keys entry)))]
+          (is (empty? missing)
+              (str "Entry " (pr-str label)
+                   " is missing required keys: " (pr-str missing))))))))

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -29,7 +29,9 @@
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.context :as context]
    [ai.miniforge.workflow.messages :as messages]
-   [ai.miniforge.workflow.runner-defaults :as defaults]))
+   [ai.miniforge.workflow.runner-defaults :as defaults]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]))
 
 (defonce ^:private env-logger
   (log/create-logger {:min-level :debug :output :human}))
@@ -92,18 +94,40 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Environment record construction
 
+(defn- read-head-sha
+  "Return the current HEAD SHA of `working-dir` as a string, or nil
+   when the directory is missing, not a git repo, or `git rev-parse`
+   exits non-zero. Best-effort — never throws."
+  [working-dir]
+  (when working-dir
+    (try
+      (let [{:keys [exit out]} (shell/sh "git" "-C" (str working-dir)
+                                         "rev-parse" "HEAD")]
+        (when (zero? exit) (str/trim out)))
+      (catch Exception _ nil))))
+
 (defn build-env-record
-  "Acquire environment from executor and build the result map."
+  "Acquire environment from executor and build the result map.
+
+   Records the acquired worktree's HEAD SHA under
+   `[:environment-metadata :base-sha]` so downstream consumers
+   (M1 of the labeled-PR-actions plan: the watcher ancestry-check
+   via `git merge-base --is-ancestor base merge`) can tell whether
+   a workflow predates a given fix without reconstructing history."
   [executor workflow-id mode env-config {:keys [acquire-env! result-ok? result-unwrap]}]
   (let [task-id    (if (uuid? workflow-id) workflow-id (random-uuid))
         env-result (acquire-env! executor task-id env-config)]
     (when (result-ok? env-result)
-      (let [env (result-unwrap env-result)]
+      (let [env       (result-unwrap env-result)
+            workdir   (:workdir env)
+            base-sha  (read-head-sha workdir)
+            metadata  (cond-> (or (:metadata env) {})
+                        base-sha (assoc :base-sha base-sha))]
         {:executor             executor
          :environment-id       (:environment-id env)
-         :worktree-path        (:workdir env)
+         :worktree-path        workdir
          :execution-mode       mode
-         :environment-metadata (:metadata env)}))))
+         :environment-metadata metadata}))))
 
 (defn- restore-local-workspace-checkpoint!
   "Restore a persisted local workspace branch before acquiring a worktree.

--- a/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.runner-environment-test
+  "Tests for runner-environment — specifically the M1 base-sha
+   capture path that future label-action watchers consume."
+  (:require [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.dag-executor.result :as result]
+            [ai.miniforge.workflow.runner-environment :as env]))
+
+(defn- with-temp-git-repo
+  "Initialise a temp git repo with one commit and pass its path to f."
+  [f]
+  (let [dir (str (System/getProperty "java.io.tmpdir") "/m1-base-sha-"
+                 (random-uuid))]
+    (.mkdirs (io/file dir))
+    (try
+      (shell/sh "git" "init" "-q" :dir dir)
+      (shell/sh "git" "-C" dir "config" "user.email" "test@local")
+      (shell/sh "git" "-C" dir "config" "user.name" "Test")
+      (shell/sh "git" "-C" dir "commit" "--allow-empty" "-m" "seed")
+      (f dir)
+      (finally
+        (doseq [^java.io.File fp (reverse (file-seq (io/file dir)))]
+          (.delete fp))))))
+
+(deftest build-env-record-captures-base-sha-test
+  ;; The watcher in M2 needs to know what SHA each in-flight workflow
+  ;; was acquired at to run the `git merge-base --is-ancestor` ancestry
+  ;; check against a freshly-merged PR's SHA. Pin the capture here so
+  ;; a regression that drops the field surfaces at test time.
+  (testing "[:environment-metadata :base-sha] is populated from worktree HEAD"
+    (with-temp-git-repo
+      (fn [dir]
+        (let [expected-sha (-> (shell/sh "git" "-C" dir "rev-parse" "HEAD")
+                               :out
+                               str/trim)
+              fns {:create-registry (constantly {})
+                   :select-exec     (constantly ::stub-executor)
+                   :acquire-env!    (fn [_ task-id _]
+                                      (result/ok {:environment-id (str "env-" task-id)
+                                                  :workdir dir
+                                                  :metadata {:base-branch "main"}}))
+                   :result-ok?      result/ok?
+                   :result-unwrap   :data
+                   :executor-type   (constantly :worktree)}
+              record (env/build-env-record ::stub-executor
+                                            (random-uuid)
+                                            :local
+                                            {}
+                                            fns)]
+          (is (some? record))
+          (is (= dir (:worktree-path record)))
+          (is (= expected-sha (get-in record [:environment-metadata :base-sha]))
+              "base-sha must match the worktree's HEAD at acquire time")
+          (is (= "main" (get-in record [:environment-metadata :base-branch]))
+              "pre-existing metadata fields must survive the merge"))))))
+
+(deftest build-env-record-omits-base-sha-when-no-git-test
+  (testing "non-git worktree → :base-sha absent, no crash"
+    (let [non-git-dir (str (System/getProperty "java.io.tmpdir") "/m1-no-git-"
+                           (random-uuid))]
+      (.mkdirs (io/file non-git-dir))
+      (try
+        (let [fns {:create-registry (constantly {})
+                   :select-exec     (constantly ::stub)
+                   :acquire-env!    (fn [_ _ _]
+                                      (result/ok {:environment-id "e"
+                                                  :workdir non-git-dir
+                                                  :metadata {}}))
+                   :result-ok?      result/ok?
+                   :result-unwrap   :data
+                   :executor-type   (constantly :worktree)}
+              record (env/build-env-record ::stub (random-uuid) :local {} fns)]
+          (is (some? record))
+          (is (not (contains? (:environment-metadata record) :base-sha))
+              ":base-sha must be absent (not nil) when HEAD can't be read"))
+        (finally
+          (.delete (io/file non-git-dir)))))))


### PR DESCRIPTION
## Summary

M1 of the labeled-PR-actions plan (`docs/design/labeled-pr-actions-plan.md`).
Ships the three data-plumbing pieces the watcher (M2), meta-agent
(M2b), and rebase actuator (M3) all consume. No watcher / actuator
yet — those land in M2/M2b/M3.

Three commits, each a clean slice under the budget:

- `a0e0771e` feat(pr-lifecycle): `:pr/merged` carries the PR's labels
  via a new 6-arity on `events/merged` + `fetch-pr-labels!` in
  `merge.clj` (best-effort, never blocks the publish path).
- `fcdd4cc2` feat(pr-lifecycle): label-actions registry resource at
  `resources/config/pr-lifecycle/label-actions.edn`, seeded with the
  `"dogfood-fix" → :rebase-and-resume` entry. Five shape tests pin
  the contract for M2's loader.
- `a33cad73` feat(workflow): capture base-sha at `acquire-environment!`
  time under `[:execution/environment-metadata :base-sha]`
  (already-persisted parent key, no schema-key addition). Two tests
  cover happy path + non-git omit-on-failure.

## Test plan

- [x] 27 tests, 89 assertions, 0 failures across the three new test
  namespaces (events-test extension, label-actions-config-test,
  runner-environment-test).
- [x] `bb pre-commit` green on every slice.

## Follow-ups

- **M2**: new `pr-label-watcher` brick that subscribes to `:pr/merged`,
  loads the registry, joins with supervisory-state, runs the
  `git merge-base --is-ancestor` ancestry check, emits a match payload.
- **M2b**: meta-agent invoked on hit, decides stagger order, emits
  `:workflow/inject` commands.
- **M3**: `rebase-onto!` in `dag-executor/workspace.clj`, runner hook
  at the `await-resume!` seam, conflict → `:attention-required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)