### PR TITLE
feat(dag-executor): worktrees default to ~/.miniforge/worktrees instead of /tmp

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
@@ -100,7 +100,11 @@
   "Create a worktree-based executor (fallback).
 
    Config:
-   - :base-path - Base directory for worktrees (default: /tmp/miniforge-worktrees)
+   - :base-path - Base directory for worktrees (default:
+     `~/.miniforge/worktrees`). The old `/tmp/miniforge-worktrees`
+     default was removed after the 2026-04-17 gates-workflow lost
+     8+ minutes of working code to a tmpfs cleanup. Opt in via this
+     key for ephemeral runs.
    - :max-concurrent - Max concurrent worktrees (default: 4)"
   worktree/create-worktree-executor)
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -35,7 +35,22 @@
 ;; Configuration
 ;; ============================================================================
 
-(def default-base-path "/tmp/miniforge-worktrees")
+(defn default-base-path
+  "Default location for git worktrees acquired by the worktree executor.
+
+   Lives under `~/.miniforge/worktrees/` rather than `/tmp` so the
+   worktree (and any uncommitted implementer file writes living in it)
+   survives reboots and macOS-tmpfs cleanups. The 2026-04-17 gates
+   workflow lost 8+ minutes of working code when its `/tmp` worktree
+   was GC'd on process-tree restart; persistence outside `/tmp` is the
+   foundation for the broader work in
+   `work/worktree-persistence-scratch-branch.spec.edn`.
+
+   Callers that need an ephemeral location (CI runs, sandbox tests)
+   can override via the `:base-path` config arg."
+  []
+  (str (System/getProperty "user.home") "/.miniforge/worktrees"))
+
 (def default-max-concurrent 4)
 
 (defn default-archive-dir
@@ -665,10 +680,15 @@
   "Create a worktree-based executor (fallback).
 
    Config:
-   - :base-path - Base directory for worktrees (default: /tmp/miniforge-worktrees)
+   - :base-path - Base directory for worktrees (default:
+     `~/.miniforge/worktrees`). The previous `/tmp/miniforge-worktrees`
+     default was changed after the 2026-04-17 gates-workflow lost
+     8+ minutes of working code to a macOS tmpfs cleanup. Ephemeral
+     `/tmp`-rooted runs (CI, sandbox tests) opt in explicitly via
+     this key.
    - :max-concurrent - Max concurrent worktrees (default: 4)"
   [config]
   (map->WorktreeExecutor
    {:config config
-    :base-path (get config :base-path default-base-path)
+    :base-path (get config :base-path (default-base-path))
     :max-concurrent (get config :max-concurrent default-max-concurrent)}))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -430,3 +430,33 @@
                                          :base-ref    "main"})]
         (is (result/err? r))
         (is (= :archive-bundle-failed (get-in r [:error :code])))))))
+
+;; ============================================================================
+;; default-base-path — survives reboots
+;; ============================================================================
+
+(deftest default-base-path-lives-under-home-not-tmp-test
+  ;; Regression for the 2026-04-17 gates-workflow data-loss incident:
+  ;; the old `/tmp/miniforge-worktrees` default got wiped on macOS
+  ;; tmpfs cleanup, taking 8+ minutes of working code with it. Pin
+  ;; the new default to a path that survives reboots.
+  (testing "default-base-path is rooted at the user's home directory"
+    (let [p (worktree/default-base-path)
+          home (System/getProperty "user.home")]
+      (is (.startsWith ^String p home)
+          (str "default-base-path " (pr-str p)
+               " must live under user.home (" home ")"))
+      (is (.endsWith ^String p "/.miniforge/worktrees")
+          "must end with `.miniforge/worktrees` so it sits next to checkpoints")
+      (is (not (.startsWith ^String p "/tmp"))
+          "must NOT be /tmp-rooted — that's the regression we're guarding"))))
+
+(deftest create-worktree-executor-uses-new-default-test
+  (testing "create-worktree-executor with no :base-path picks up the home default"
+    (let [exec (worktree/create-worktree-executor {})]
+      (is (= (worktree/default-base-path) (:base-path exec)))))
+
+  (testing "explicit :base-path override still works (CI ephemeral runs opt in)"
+    (let [exec (worktree/create-worktree-executor
+                {:base-path "/tmp/miniforge-worktrees-ci"})]
+      (is (= "/tmp/miniforge-worktrees-ci" (:base-path exec))))))


### PR DESCRIPTION
## Summary

Group 1 of `work/worktree-persistence-scratch-branch.spec.edn` —
the foundational dogfood-resilience fix. The 2026-04-17 gates
workflow lost 8+ minutes of working code when its `/tmp/miniforge-
worktrees/<id>` was wiped on the next process-tree restart
(macOS tmpfs cleanup). Move the worktree-executor's default base
path to `~/.miniforge/worktrees/`, alongside the existing
`default-archive-dir` which already lives there for the same
reason.

## Changes

- `default-base-path` is now a function (parallel to
  `default-archive-dir`) returning `~/.miniforge/worktrees`.
- `create-worktree-executor`'s `:base-path` fallback uses the fn.
- Explicit `:base-path` override still works — CI / sandbox tests
  that want ephemeral `/tmp` storage opt in via config.
- Two tests pin the new behaviour + the override path.

## Follow-ups (other groups from the same spec)

- Group 2: scratch-branch commit on every file write
- Group 3: `miniforge recover <workflow-id>` CLI
- Group 4: worktree-lifecycle hooks

Each will be its own PR.

## Test plan

- [x] `clojure -A:test:dev -M -e "(require 'clojure.test
  '[ai.miniforge.dag-executor.protocols.impl.worktree-test])
  (clojure.test/run-tests
    'ai.miniforge.dag-executor.protocols.impl.worktree-test)"`
  → 17 tests, 42 assertions, 0 failures.
- [x] `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)