### PR TITLE
feat(automation-edge-correlator): N15-3 — core lifecycle + emitter + event-stream wiring

### DIFF
--- a/components/automation-edge-correlator/deps.edn
+++ b/components/automation-edge-correlator/deps.edn
@@ -1,10 +1,11 @@
 {:paths ["src" "resources"]
- ;; N15-1 source surface is pure schema + trigger classification — only malli
- ;; is consumed.  Cross-component deps (event-stream / logging / schema) are
- ;; added in N15-3 when `core.clj` + `emitter.clj` start the lifecycle and
- ;; subscribe to the event stream.  Declaring them prematurely would
- ;; mis-state the brick's current boundary surface.
- :deps {metosin/malli {:mvn/version "0.16.4"}}
+ ;; N15-3 adds the lifecycle + emitter layer; the brick now subscribes to
+ ;; the event stream and publishes `:supervisory/automation-edge-upserted`
+ ;; events on it. `ai.miniforge/event-stream` is the boundary; it was
+ ;; deliberately omitted in N15-1 (per PR #902's deps-trim discussion)
+ ;; because the brick's surface was pure schema + classification then.
+ :deps {ai.miniforge/event-stream {:local/root "../event-stream"}
+        metosin/malli {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/core.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/core.clj
@@ -1,0 +1,447 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.core
+  "Lifecycle wrapper for the AutomationEdge correlator.
+
+   Wraps the pure state machine in `correlator.clj` with I/O:
+
+   - Subscribes to the event stream, filtering `:supervisory/automation-
+     edge-upserted` out of its own input (recursion prevention per
+     N5-delta-4 §3.3).
+   - Classifies trigger events via `triggers/classify-trigger`, assembles
+     the §3.4 payload-derived `classified-trigger`, and folds it through
+     `correlator/apply-trigger`.
+   - Dispatches non-trigger events (`:workflow/started`,
+     `:workflow/completed`, `:workflow/failed`, `:edge/suppress`,
+     `:routing/no-handler`) to the matching pure transition.
+   - Emits a `:supervisory/automation-edge-upserted` envelope on the
+     stream whenever a transition returns a non-nil edge.
+   - On `start!`, replays the event-stream prefix to reconstruct state +
+     re-emit upserts (§3.6 cross-restart).
+   - Runs a periodic expire-pending tick on a `ScheduledExecutorService`
+     so `:observed` edges past the suppression window transition to
+     `:needs-operator` (§2.4 third transition, timeout arm).
+
+   Design choices recorded for review:
+
+   - `ScheduledExecutorService` rather than `core.async`: `supervisory-
+     state` carries no periodic ticker precedent, and `core.async` would
+     introduce a new dependency surface for what is fundamentally one
+     thread firing every 30 s. The executor is shut down deterministically
+     in `stop!`.
+   - State is an atom holding `{:correlator <pure-state>, :stream,
+     :subscribed?, :scheduler, :config, :clock}`. The pure-state lives
+     under a nested key so a single atomic swap can both apply a
+     transition and clear the subscription latch on shutdown.
+   - The expire tick reads the clock injected via `deps`. Tests inject a
+     fixed-time fn and drive the tick by hand via `expire-once!`."
+  (:require
+   [ai.miniforge.automation-edge-correlator.correlator :as correlator]
+   [ai.miniforge.automation-edge-correlator.emitter :as emitter]
+   [ai.miniforge.automation-edge-correlator.triggers :as triggers]
+   [ai.miniforge.event-stream.interface :as es])
+  (:import
+   (java.util.concurrent Executors
+                         ScheduledExecutorService
+                         TimeUnit)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Subscriber id + defaults
+
+(def ^:const subscriber-id ::automation-edge-correlator)
+
+(def ^:private default-config
+  "Defaults sourced from N5-delta-4 §6.
+
+   `:correlator/correlation-window-ms` is unused in v1 — included for
+   forward compatibility with the §3.5 case 2 heuristic-fallback path
+   that lands in a follow-on. The brief explicitly defers it."
+  {:correlator/suppression-window-ms 300000   ; 5 min — §6 default
+   :correlator/correlation-window-ms 60000    ; 60 s  — §6 default (v1 unused)
+   :correlator/expire-tick-ms        30000})  ; 30 s  — see expire-cadence note
+
+;; Expire-tick cadence rationale: the 30-s default is one tenth of the
+;; default 5-minute suppression window. That cadence makes worst-case
+;; timeout latency (suppression-window + one tick) at most 5m30s — well
+;; within the operator-attention budget — without spinning the scheduler
+;; pointlessly. Operators MAY override via `:correlator/expire-tick-ms`
+;; on the `deps` config map; tests drive the tick by hand via
+;; `expire-once!` and set the cadence to a no-op-large value.
+
+(def ^:private self-emitted-type
+  "The single event type this correlator emits. Filtered out of its own
+   input per §3.3."
+  :supervisory/automation-edge-upserted)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Classified-trigger assembly — lifts the §3.4 payload-derivation table
+
+(defn- one-pr-tuple
+  "Single `[repo number]` tuple from `:pr/repo` + `:pr/number`, or `[]`
+   when either is absent. Per §3.4 every PR-bearing trigger uses this
+   shape."
+  [{:pr/keys [repo number]}]
+  (if (and repo number) [[repo number]] []))
+
+(defn- ->session-vec
+  "Wrap a single optional session-id into a vector, omitting nil. §3.4
+   uses `[<id>]` when present, `[]` otherwise."
+  [maybe-id]
+  (if maybe-id [maybe-id] []))
+
+(defn- payload-pr-ids
+  "Lift `:edge/affected-pr-ids` from a raw event per §3.4. The shape is
+   the same `[[repo number]]` tuple form across every PR-bearing trigger
+   kind. Returns `[]` when the payload does not carry both fields (the
+   correlator MUST emit the edge anyway per §3.4 last paragraph — empty
+   vectors are the documented contract)."
+  [_kind event]
+  (one-pr-tuple event))
+
+(defn- payload-agent-ids
+  "Lift `:edge/affected-agent-session-ids` from a raw event per §3.4.
+   Per-kind: only `:review-comments-arrived` carries
+   `:comments/agent-session-id`, and only `:standards-review-arrived`
+   carries `:affected/workflow-run-id` (which §3.4 says MAY be mapped
+   through a workflow→agent index when one is available; v1 records the
+   workflow-run-id verbatim and leaves the mapping to consumers — the
+   field is open). All others derive `[]`."
+  [kind event]
+  (case kind
+    :review-comments-arrived
+    (->session-vec (:comments/agent-session-id event))
+
+    :standards-review-arrived
+    (->session-vec (:affected/workflow-run-id event))
+
+    []))
+
+(defn assemble-classified-trigger
+  "Lift a raw event + its classified `kind` into the map the pure layer
+   consumes (`correlator/apply-trigger`).
+
+   Pure. The lifecycle layer calls this only after
+   `triggers/classify-trigger` has confirmed the event maps to a
+   RoutingTriggerKind.
+
+   Per N5-delta-4 §3.4:
+
+   - `:trigger/event-id`    ← raw `:event/id`
+   - `:trigger/kind`        ← classified kind
+   - `:trigger/occurred-at` ← raw `:event/timestamp`
+   - `:trigger/affected-pr-ids`           ← `[[:pr/repo :pr/number]]` (one tuple)
+                                            when both fields present, else `[]`.
+   - `:trigger/affected-agent-session-ids`← per-kind: see
+                                            `payload-agent-ids`."
+  [kind event]
+  {:trigger/event-id                   (:event/id event)
+   :trigger/kind                       kind
+   :trigger/occurred-at                (:event/timestamp event)
+   :trigger/affected-pr-ids            (payload-pr-ids kind event)
+   :trigger/affected-agent-session-ids (payload-agent-ids kind event)})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Per-event dispatch
+
+(defn- emit-upsert!
+  "Build an upsert envelope via `emitter/upsert-event` and publish it on
+   the stream. Sequence-number allocation is delegated to
+   `es/create-envelope` for consistency with every other producer — the
+   pure emitter is built around an explicit sequence number, and we
+   thread the stream-allocated value through here."
+  [stream edge]
+  (let [;; Use `create-envelope` purely to allocate a sequence-number
+        ;; under the same monotonic counter every other event uses.
+        ;; The emitter then re-shapes the envelope with the correct
+        ;; timestamp (edge's `:edge/updated-at`, not wall clock) and
+        ;; payload — but the sequence-number flows through unchanged.
+        env    (es/create-envelope stream
+                                   self-emitted-type
+                                   nil
+                                   "")
+        seq-no (:event/sequence-number env)
+        event  (emitter/upsert-event edge seq-no)]
+    (es/publish! stream event)
+    event))
+
+(defn- handle-trigger
+  "Classify a raw event; if it's a trigger, fold it through the pure
+   layer and emit the resulting edge."
+  [pure-state stream event]
+  (if-let [kind (triggers/classify-trigger
+                 ;; The classify table is keyed on `:type`; the envelope
+                 ;; ships `:event/type`. Adapt here so both wire shapes
+                 ;; route correctly — keeps the pure classifier untouched.
+                 (assoc event :type (:event/type event)))]
+    (let [classified  (assemble-classified-trigger kind event)
+          [next-state edge] (correlator/apply-trigger pure-state classified)]
+      (when edge (emit-upsert! stream edge))
+      next-state)
+    pure-state))
+
+(defn- handle-workflow-started
+  [pure-state event]
+  (let [[next-state _] (correlator/apply-workflow-started pure-state event)]
+    next-state))
+
+(defn- handle-workflow-completed
+  "`:workflow/completed` plays two roles per §3.4 / §2.4: it's both a
+   handler signal (transition any indexed pending edge to `:handled`)
+   AND a routing trigger itself (opens a new `:workflow-completed`
+   edge). Apply both in order — handler first so a re-observation of
+   the same id falls into the §2.3 terminal branch."
+  [pure-state stream event]
+  (let [[after-completion handled-edge]
+        (correlator/apply-workflow-completed pure-state event)]
+    (when handled-edge (emit-upsert! stream handled-edge))
+    (handle-trigger after-completion stream event)))
+
+(defn- handle-workflow-failed
+  [pure-state stream event]
+  (let [[next-state edge] (correlator/apply-workflow-failed pure-state event)]
+    (when edge (emit-upsert! stream edge))
+    next-state))
+
+(defn- handle-no-handler
+  [pure-state stream event]
+  (let [[next-state edge] (correlator/apply-no-handler pure-state event)]
+    (when edge (emit-upsert! stream edge))
+    next-state))
+
+(defn- handle-suppress
+  [pure-state stream event]
+  (let [[next-state edge] (correlator/apply-suppress pure-state event)]
+    (when edge (emit-upsert! stream edge))
+    next-state))
+
+(defn- tick
+  "Apply one event to the correlator's pure state. Emits any resulting
+   edges on the stream. Returns the new pure state."
+  [pure-state stream event]
+  (let [event-type (:event/type event)]
+    (cond
+      ;; §3.3 recursion prevention. The subscription filter ALSO drops
+      ;; these, but we re-check here so direct callers (and the replay
+      ;; path) cannot accidentally fold a self-emission.
+      (= event-type self-emitted-type)
+      pure-state
+
+      (= event-type :workflow/started)
+      (handle-workflow-started pure-state event)
+
+      (= event-type :workflow/failed)
+      (handle-workflow-failed pure-state stream event)
+
+      (= event-type :edge/suppress)
+      (handle-suppress pure-state stream event)
+
+      (= event-type :routing/no-handler)
+      (handle-no-handler pure-state stream event)
+
+      ;; `:workflow/completed` is both a handler signal AND a routing
+      ;; trigger per §3.4. The dispatch handles both arms.
+      (= event-type :workflow/completed)
+      (handle-workflow-completed pure-state stream event)
+
+      ;; Every other classifiable event runs the trigger arm only.
+      :else
+      (handle-trigger pure-state stream event))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Lifecycle handle
+
+(defn- not-self-emit?
+  "Subscription-level filter — drops our own upsert events at the
+   subscriber boundary per §3.3."
+  [event]
+  (not= self-emitted-type (:event/type event)))
+
+(defn create
+  "Build a fresh correlator handle bound to `stream`. Does not subscribe
+   yet — call `start!` to begin consuming events.
+
+   `deps` MAY carry:
+
+   - `:clock`  — 0-arity fn returning a `java.util.Date`. Defaults to
+                 `(java.util.Date.)`. The pure state machine reads the
+                 timestamp from the event itself for trigger / workflow
+                 transitions, so the clock is consulted only by
+                 `expire-once!` (which has no triggering event).
+   - `:config` — map of `:correlator/*` overrides; see `default-config`."
+  [stream & [{:keys [clock config]}]]
+  (atom {:correlator  correlator/empty-state
+         :stream      stream
+         :subscribed? false
+         :scheduler   nil
+         :clock       (or clock #(java.util.Date.))
+         :config      (merge default-config config)}))
+
+(defn- handle-event!
+  [handle event]
+  (when (not-self-emit? event)
+    (swap! handle update :correlator tick (:stream @handle) event)))
+
+(defn- replay!
+  "Fold the event-stream's already-published prefix through the
+   correlator + re-emit upserts (§3.6 cross-restart).
+
+   `get-events` is captured at start-of-replay; concurrent publishes
+   during the fold land via the subscriber after the snapshot, so
+   ordering is preserved with no duplicate-application."
+  [handle]
+  (let [{:keys [stream]} @handle
+        snapshot (es/get-events stream)]
+    (doseq [event snapshot]
+      (when (not-self-emit? event)
+        (swap! handle update :correlator tick stream event)))))
+
+(defn expire-once!
+  "Drive one expire-pending pass. Used by the scheduled tick AND by
+   tests that need deterministic time advancement (without
+   `Thread/sleep`).
+
+   Emits a `:supervisory/automation-edge-upserted` for every edge that
+   transitions to `:needs-operator`. Idempotent: a second call with no
+   new clock advance produces no further emissions."
+  [handle]
+  (let [{:keys [clock config stream]} @handle
+        suppression-window-ms (:correlator/suppression-window-ms config)
+        now ((or clock #(java.util.Date.)))
+        ;; Pull-and-swap the new state atomically; collect the expired
+        ;; edges from the returned tuple so emission happens outside the
+        ;; swap (publish! must not run inside a `swap!` body — it can
+        ;; recur into other subscribers).
+        new-edges
+        (let [edges-ref (atom nil)]
+          (swap! handle
+                 (fn [{:keys [correlator] :as state}]
+                   (let [[next-pure expired]
+                         (correlator/expire-pending correlator now suppression-window-ms)]
+                     (reset! edges-ref expired)
+                     (assoc state :correlator next-pure))))
+          @edges-ref)]
+    (doseq [edge new-edges]
+      (emit-upsert! stream edge))
+    new-edges))
+
+(defn- start-scheduler!
+  "Spin up a single-thread `ScheduledExecutorService` that fires
+   `expire-once!` every `expire-tick-ms`. The thread is a daemon so JVM
+   shutdown is unaffected if `stop!` is missed (defensive — the
+   lifecycle contract is that callers `stop!` explicitly)."
+  ^ScheduledExecutorService [handle expire-tick-ms]
+  (let [scheduler (Executors/newSingleThreadScheduledExecutor
+                   (reify java.util.concurrent.ThreadFactory
+                     (newThread [_ r]
+                       (doto (Thread. ^Runnable r "automation-edge-correlator-expire-tick")
+                         (.setDaemon true)))))]
+    (.scheduleAtFixedRate scheduler
+                          ^Runnable (fn []
+                                      (try (expire-once! handle)
+                                           (catch Throwable _
+                                             ;; Swallow — a single tick
+                                             ;; failure must not kill the
+                                             ;; scheduler. Production
+                                             ;; wires a logger via the
+                                             ;; stream's logger; the
+                                             ;; rethrow path would leave
+                                             ;; the brick silently
+                                             ;; idle.
+                                             nil)))
+                          (long expire-tick-ms)
+                          (long expire-tick-ms)
+                          TimeUnit/MILLISECONDS)
+    scheduler))
+
+(defn start!
+  "Subscribe to the stream, replay the prefix, and start the expire
+   ticker. Idempotent — a second call on a started handle is a no-op."
+  [handle]
+  (let [{:keys [stream subscribed? config]} @handle]
+    (when-not subscribed?
+      (swap! handle assoc :subscribed? true)
+      ;; Replay BEFORE subscribing so we observe the prefix exactly
+      ;; once. A concurrent publisher between replay and subscribe
+      ;; would lose at most one event; in v1 the lifecycle is brought
+      ;; up alongside the stream, so there is no race in practice.
+      ;; Production deployments that wire a hot stream MUST replay +
+      ;; subscribe under a quiesce barrier; tracked for the operator-
+      ;; surface follow-on.
+      (replay! handle)
+      (es/subscribe! stream subscriber-id
+                     (fn [event] (handle-event! handle event))
+                     not-self-emit?)
+      (let [scheduler (start-scheduler! handle (:correlator/expire-tick-ms config))]
+        (swap! handle assoc :scheduler scheduler)))
+    handle))
+
+(defn stop!
+  "Unsubscribe from the stream and cancel the expire ticker. Idempotent.
+   Retains the in-memory pure state so post-shutdown queries can still
+   read the edge indices."
+  [handle]
+  (let [{:keys [stream subscribed? ^ScheduledExecutorService scheduler]} @handle]
+    (when subscribed?
+      (es/unsubscribe! stream subscriber-id)
+      (when scheduler
+        (.shutdownNow scheduler))
+      (swap! handle assoc :subscribed? false :scheduler nil))
+    handle))
+
+(defn attach!
+  "Convenience: `create` + `start!` in one step. Test injection point
+   for an in-memory event stream — equivalent to `start!` on a fresh
+   handle, mirroring the supervisory-state convention."
+  ([stream] (attach! stream nil))
+  ([stream deps]
+   (start! (create stream deps))))
+
+(defn attached?
+  "True when the correlator is subscribed to `stream`."
+  [stream]
+  (contains? (:subscribers @stream) subscriber-id))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Read-only query API — useful for tests and operator surfaces
+
+(defn pure-state
+  "Snapshot of the correlator's pure state (read-only)."
+  [handle]
+  (:correlator @handle))
+
+(comment
+  ;; REPL — drive the lifecycle against an in-memory stream.
+  (require '[ai.miniforge.event-stream.core :as es-core])
+  (let [stream (es-core/create-event-stream {:sinks []})
+        deps   {:clock #(java.util.Date.)}
+        handle (attach! stream deps)]
+    (es/publish! stream {:event/type      :pr/merged
+                         :event/id        (random-uuid)
+                         :event/timestamp (java.util.Date.)
+                         :event/version   "1.0.0"
+                         :event/sequence-number 0
+                         :pr/repo         "miniforge-ai/miniforge"
+                         :pr/number       999
+                         :message         "merged"})
+    (Thread/sleep 20)
+    (let [edges (filter #(= :supervisory/automation-edge-upserted (:event/type %))
+                        (es/get-events stream))]
+      (stop! handle)
+      edges))
+  :leave-this-here)

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/core.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/core.clj
@@ -161,22 +161,30 @@
 
 (defn- emit-upsert!
   "Build an upsert envelope via `emitter/upsert-event` and publish it on
-   the stream. Sequence-number allocation is delegated to
-   `es/create-envelope` for consistency with every other producer — the
-   pure emitter is built around an explicit sequence number, and we
-   thread the stream-allocated value through here."
+   the stream.
+
+   The base envelope is built via `es/create-envelope` so the
+   correlator inherits the canonical `:event/id` (Snowflake-encoded
+   when the stream is so configured), `:event/version`,
+   `:event/sequence-number`, and any identity-propagation fields the
+   stream attaches. The pure emitter then overrides only the edge-
+   specific fields (`:event/timestamp` from `:edge/updated-at`,
+   `:message`, `:supervisory/entity`).
+
+   `:workflow/id` is threaded through `create-envelope`'s positional
+   `workflow-id` arg when the edge has been correlated to a handler
+   (`:edge/handled-by-workflow-run-id` is non-nil). For pre-handler
+   edges (`:observed` with no workflow yet, or triggers like
+   `:pr/merged` that name no workflow) the value is `nil` and the
+   envelope's `:workflow/id` is left absent. Downstream filters use
+   the threaded value for workflow-scoped views."
   [stream edge]
-  (let [;; Use `create-envelope` purely to allocate a sequence-number
-        ;; under the same monotonic counter every other event uses.
-        ;; The emitter then re-shapes the envelope with the correct
-        ;; timestamp (edge's `:edge/updated-at`, not wall clock) and
-        ;; payload — but the sequence-number flows through unchanged.
-        env    (es/create-envelope stream
-                                   self-emitted-type
-                                   nil
-                                   "")
-        seq-no (:event/sequence-number env)
-        event  (emitter/upsert-event edge seq-no)]
+  (let [workflow-id  (:edge/handled-by-workflow-run-id edge)
+        base         (es/create-envelope stream
+                                         self-emitted-type
+                                         workflow-id
+                                         "")
+        event        (emitter/upsert-event base edge)]
     (es/publish! stream event)
     event))
 
@@ -353,40 +361,95 @@
                          (.setDaemon true)))))]
     (.scheduleAtFixedRate scheduler
                           ^Runnable (fn []
-                                      (try (expire-once! handle)
-                                           (catch Throwable _
-                                             ;; Swallow — a single tick
-                                             ;; failure must not kill the
-                                             ;; scheduler. Production
-                                             ;; wires a logger via the
-                                             ;; stream's logger; the
-                                             ;; rethrow path would leave
-                                             ;; the brick silently
-                                             ;; idle.
-                                             nil)))
+                                      (try
+                                        (expire-once! handle)
+                                        (catch Throwable t
+                                          ;; A single tick failure MUST
+                                          ;; NOT kill the scheduler — a
+                                          ;; thrown Throwable from a
+                                          ;; `scheduleAtFixedRate` task
+                                          ;; cancels all future runs
+                                          ;; silently per
+                                          ;; `ScheduledExecutorService`
+                                          ;; contract.  We catch, log to
+                                          ;; stderr (matching the
+                                          ;; sibling event-stream sink
+                                          ;; failure convention), and
+                                          ;; let the next tick try
+                                          ;; again. Operators tail
+                                          ;; stderr in dev; in
+                                          ;; production the journal
+                                          ;; captures it and an alert
+                                          ;; can scrape on the prefix.
+                                          (binding [*out* *err*]
+                                            (println
+                                             (str "WARNING: automation-edge-correlator "
+                                                  "expire-tick failed: "
+                                                  (.getMessage t))))
+                                          nil)))
                           (long expire-tick-ms)
                           (long expire-tick-ms)
                           TimeUnit/MILLISECONDS)
     scheduler))
 
 (defn start!
-  "Subscribe to the stream, replay the prefix, and start the expire
-   ticker. Idempotent — a second call on a started handle is a no-op."
+  "Subscribe to the stream, replay the prefix, drain anything that
+   landed during replay, then start the expire ticker. Idempotent — a
+   second call on a started handle is a no-op.
+
+   ## Race-free replay (Copilot review on PR #908)
+
+   The naïve order replay-then-subscribe loses any event published in
+   the gap between `get-events` snapshot and `subscribe!` registration.
+   Production deployments wire a hot stream where that gap can be
+   non-empty.
+
+   The barrier: subscribe FIRST with a buffering callback that
+   appends to an in-memory queue. Then replay. Then drain the queue
+   through the real handler. Then flip a `replaying?` flag and drain
+   ONE MORE TIME to catch anything that landed between the last drain
+   and the flag flip. After the second drain the buffering callback
+   sees `replaying? = false` and goes direct.
+
+   Overlap is fine: replay-folded events and any buffered events that
+   the replay snapshot already contained will be applied through the
+   pure layer twice — but the state machine is idempotent on
+   re-observation (§2.3 terminal memory; `:pending` membership check)
+   so byte-identical edges flow out either way."
   [handle]
   (let [{:keys [stream subscribed? config]} @handle]
     (when-not subscribed?
       (swap! handle assoc :subscribed? true)
-      ;; Replay BEFORE subscribing so we observe the prefix exactly
-      ;; once. A concurrent publisher between replay and subscribe
-      ;; would lose at most one event; in v1 the lifecycle is brought
-      ;; up alongside the stream, so there is no race in practice.
-      ;; Production deployments that wire a hot stream MUST replay +
-      ;; subscribe under a quiesce barrier; tracked for the operator-
-      ;; surface follow-on.
-      (replay! handle)
-      (es/subscribe! stream subscriber-id
-                     (fn [event] (handle-event! handle event))
-                     not-self-emit?)
+      (let [buffer     (java.util.concurrent.LinkedBlockingQueue.)
+            replaying? (atom true)
+            ;; Buffering subscriber: while replaying, enqueue; after,
+            ;; go direct. The flag flip below is the cutover.
+            handler    (fn [event]
+                         (if @replaying?
+                           (.add buffer event)
+                           (handle-event! handle event)))]
+        (es/subscribe! stream subscriber-id handler not-self-emit?)
+        ;; Replay reads `get-events` as a snapshot. Events that landed
+        ;; before the snapshot are folded here; events that landed
+        ;; after (i.e. concurrent publishers) are in `buffer`.
+        (replay! handle)
+        ;; Drain everything that arrived during replay. Loop until the
+        ;; queue stays empty across one full pass — concurrent
+        ;; publishers might add while we're draining.
+        (loop []
+          (let [batch (java.util.ArrayList.)]
+            (.drainTo buffer batch)
+            (when (pos? (.size batch))
+              (doseq [event batch] (handle-event! handle event))
+              (recur))))
+        ;; Flip the flag, then drain one more time. Any event that
+        ;; landed BEFORE the flip went into the buffer (drained here);
+        ;; anything AFTER goes through the direct path via the
+        ;; subscriber callback.
+        (reset! replaying? false)
+        (let [final-batch (java.util.ArrayList.)]
+          (.drainTo buffer final-batch)
+          (doseq [event final-batch] (handle-event! handle event))))
       (let [scheduler (start-scheduler! handle (:correlator/expire-tick-ms config))]
         (swap! handle assoc :scheduler scheduler)))
     handle))

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/emitter.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/emitter.clj
@@ -20,16 +20,35 @@
   "Pure envelope construction for `:supervisory/automation-edge-upserted`
    events (N5-delta-4 §4.1).
 
-   Layer 0: no I/O, no clock. Takes an edge map produced by the state
-   machine plus a sequence number allocated by the lifecycle layer and
-   returns the wire envelope per N3 §2.1.
+   Layer 0: no I/O, no clock. Takes a base envelope (already carrying the
+   stream's allocated `:event/id` / `:event/version` /
+   `:event/sequence-number` / identity-propagation fields per the
+   event-stream `create-envelope` contract) plus an edge map from the
+   state machine and layers on the edge-specific fields.
 
-   The lifecycle layer (`core.clj`) is responsible for sequence-number
-   allocation — the brick does not reach into the event-stream's internal
-   counter from here. This keeps the emitter trivially testable: given an
-   edge and a number, it produces a deterministic map."
-  (:require
-   [ai.miniforge.automation-edge-correlator.schema :as schema]))
+   The lifecycle layer (`core.clj`) is responsible for calling
+   `create-envelope`; the emitter only assoc's on top. Two reasons:
+
+   - **Identity propagation.** `create-envelope` ships `:event/id` as a
+     Snowflake-encoded UUID when the stream carries a generator (BD-2b),
+     and threads `:org/id` / `:workspace/id` / `:repo/id` / `:auth/context`
+     identity fields per Phase E Decision 14. Discarding those by
+     re-generating a `random-uuid` here would regress ordering (Snowflake
+     vs random) and lose tenancy context.
+   - **Sequence numbering.** Sequence allocation is racey-without-care;
+     `create-envelope` already wraps the swap-vals! pattern that fixed an
+     earlier race (PR #814). The emitter has no business duplicating that
+     code path.
+
+   The emitter overrides exactly three envelope fields, and only those:
+
+   - `:event/timestamp`     — replaced with the edge's `:edge/updated-at`.
+                              The state machine's transition time is the
+                              source of truth; the wall-clock value
+                              `create-envelope` stamped is discarded so
+                              replay reconstructs byte-identical envelopes.
+   - `:message`             — short human-readable summary.
+   - `:supervisory/entity`  — the full edge map.")
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Message construction
@@ -57,53 +76,41 @@
 ;; Envelope construction
 
 (defn upsert-event
-  "Build a `:supervisory/automation-edge-upserted` event envelope from an
-   `edge` map produced by the state machine. Pure.
+  "Layer the edge-specific fields onto a base envelope from
+   `event-stream/create-envelope`. Pure.
 
-   The envelope follows N3 §2.1:
+   `base-envelope` MUST already carry the stream's allocated `:event/id`
+   (Snowflake-encoded when the stream is so configured), `:event/version`,
+   `:event/sequence-number`, and any identity-propagation fields the
+   caller supplied. `:event/type` is asserted to
+   `:supervisory/automation-edge-upserted` defensively — the lifecycle
+   layer passes that type to `create-envelope` already, but assoc'ing
+   here catches accidental future regressions.
 
-   - `:event/id`              — freshly-generated `random-uuid`. Replay
-                                regenerates this; consumers dedup on
-                                `:edge/id` per N5-delta-4 §2.3.
-   - `:event/type`            — `:supervisory/automation-edge-upserted`
-   - `:event/timestamp`       — the edge's `:edge/updated-at`. Mirrors
-                                the source-of-truth discipline from the
-                                state machine: the envelope clock is the
-                                most-recent transition time, not wall
-                                clock at emission. Replay therefore
-                                reconstructs byte-identical timestamps.
-   - `:event/version`         — `\"1.0.0\"` per N5-delta-4 §4.1.
-   - `:event/sequence-number` — supplied by the lifecycle layer; the
-                                pure emitter does not allocate.
-   - `:supervisory/entity`    — the full edge map.
-   - `:message`               — short human-readable summary.
+   Three fields are overridden / set:
 
-   `:workflow/id` is left absent: the schema marks it `:optional` /
-   `:maybe`, and the edge does not always belong to a single workflow
-   (a `:pr/merged` trigger opens an edge before any handler workflow
-   exists). The downstream filter scopes on `:event/type` instead."
-  [edge sequence-number]
-  {:event/type            :supervisory/automation-edge-upserted
-   :event/id              (random-uuid)
-   :event/timestamp       (:edge/updated-at edge)
-   :event/version         "1.0.0"
-   :event/sequence-number sequence-number
-   :message               (summary-message edge)
-   :supervisory/entity    edge})
-
-;; The schema namespace is required so `clj-kondo` / cljc compilation
-;; finds the dependency even though we currently reach into it only via
-;; the validation hook in core.clj. Touch a value here so the require is
-;; not flagged as unused — `schema/automation-edge-statuses` is a stable,
-;; pure constant suitable for the compile-time anchor.
-(def ^:private referenced-statuses
-  "Compile-time anchor that keeps the `schema` require live. The vector
-   is also useful in the rich comment below for REPL exploration."
-  schema/automation-edge-statuses)
+   - `:event/timestamp`    ← `:edge/updated-at` (replay-stable transition
+                             time, not wall clock).
+   - `:message`            ← short human summary.
+   - `:supervisory/entity` ← the full edge map."
+  [base-envelope edge]
+  (assoc base-envelope
+         :event/type         :supervisory/automation-edge-upserted
+         :event/timestamp    (:edge/updated-at edge)
+         :message            (summary-message edge)
+         :supervisory/entity edge))
 
 (comment
-  ;; REPL — synthesize an edge, wrap it, inspect.
-  (let [edge {:edge/id                          (random-uuid)
+  ;; REPL — synthesize a base envelope (what create-envelope would
+  ;; produce) and an edge, wrap them, inspect.
+  (let [base {:event/type            :supervisory/automation-edge-upserted
+              :event/id              (random-uuid)
+              :event/timestamp       (java.util.Date.)
+              :event/version         "1.0.0"
+              :event/sequence-number 42
+              :workflow/id           nil
+              :message               ""}
+        edge {:edge/id                          (random-uuid)
               :edge/trigger-event-id            (random-uuid)
               :edge/trigger-kind                :pr-merged
               :edge/status                      :observed
@@ -113,8 +120,6 @@
               :edge/affected-pr-ids             [["miniforge-ai/miniforge" 999]]
               :edge/affected-agent-session-ids  []
               :edge/operator-action-required    false}]
-    (upsert-event edge 42))
-
-  referenced-statuses
+    (upsert-event base edge))
 
   :leave-this-here)

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/emitter.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/emitter.clj
@@ -1,0 +1,120 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.emitter
+  "Pure envelope construction for `:supervisory/automation-edge-upserted`
+   events (N5-delta-4 §4.1).
+
+   Layer 0: no I/O, no clock. Takes an edge map produced by the state
+   machine plus a sequence number allocated by the lifecycle layer and
+   returns the wire envelope per N3 §2.1.
+
+   The lifecycle layer (`core.clj`) is responsible for sequence-number
+   allocation — the brick does not reach into the event-stream's internal
+   counter from here. This keeps the emitter trivially testable: given an
+   edge and a number, it produces a deterministic map."
+  (:require
+   [ai.miniforge.automation-edge-correlator.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Message construction
+
+(defn- short-id
+  "First eight chars of a UUID string — keeps the human-readable
+   `:message` field bounded without being so terse as to lose the
+   ability to grep for a specific edge."
+  [u]
+  (subs (str u) 0 8))
+
+(defn- summary-message
+  "Build the human-readable `:message` field for an upsert event.
+
+   Mirrors the supervisory-state precedent (e.g. workflow-upserted uses
+   `\"Workflow <key> upserted\"`): kind, short id, status. Operators
+   reading raw event logs get enough to identify the edge without
+   reaching for `:supervisory/entity`."
+  [{:edge/keys [id trigger-kind status]}]
+  (str "AutomationEdge " (short-id id)
+       " (" (name (or trigger-kind :unknown))
+       ") → " (name (or status :unknown))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Envelope construction
+
+(defn upsert-event
+  "Build a `:supervisory/automation-edge-upserted` event envelope from an
+   `edge` map produced by the state machine. Pure.
+
+   The envelope follows N3 §2.1:
+
+   - `:event/id`              — freshly-generated `random-uuid`. Replay
+                                regenerates this; consumers dedup on
+                                `:edge/id` per N5-delta-4 §2.3.
+   - `:event/type`            — `:supervisory/automation-edge-upserted`
+   - `:event/timestamp`       — the edge's `:edge/updated-at`. Mirrors
+                                the source-of-truth discipline from the
+                                state machine: the envelope clock is the
+                                most-recent transition time, not wall
+                                clock at emission. Replay therefore
+                                reconstructs byte-identical timestamps.
+   - `:event/version`         — `\"1.0.0\"` per N5-delta-4 §4.1.
+   - `:event/sequence-number` — supplied by the lifecycle layer; the
+                                pure emitter does not allocate.
+   - `:supervisory/entity`    — the full edge map.
+   - `:message`               — short human-readable summary.
+
+   `:workflow/id` is left absent: the schema marks it `:optional` /
+   `:maybe`, and the edge does not always belong to a single workflow
+   (a `:pr/merged` trigger opens an edge before any handler workflow
+   exists). The downstream filter scopes on `:event/type` instead."
+  [edge sequence-number]
+  {:event/type            :supervisory/automation-edge-upserted
+   :event/id              (random-uuid)
+   :event/timestamp       (:edge/updated-at edge)
+   :event/version         "1.0.0"
+   :event/sequence-number sequence-number
+   :message               (summary-message edge)
+   :supervisory/entity    edge})
+
+;; The schema namespace is required so `clj-kondo` / cljc compilation
+;; finds the dependency even though we currently reach into it only via
+;; the validation hook in core.clj. Touch a value here so the require is
+;; not flagged as unused — `schema/automation-edge-statuses` is a stable,
+;; pure constant suitable for the compile-time anchor.
+(def ^:private referenced-statuses
+  "Compile-time anchor that keeps the `schema` require live. The vector
+   is also useful in the rich comment below for REPL exploration."
+  schema/automation-edge-statuses)
+
+(comment
+  ;; REPL — synthesize an edge, wrap it, inspect.
+  (let [edge {:edge/id                          (random-uuid)
+              :edge/trigger-event-id            (random-uuid)
+              :edge/trigger-kind                :pr-merged
+              :edge/status                      :observed
+              :edge/idempotency-key             "00000000-0000-0000-0000-000000000000"
+              :edge/occurred-at                 (java.util.Date.)
+              :edge/updated-at                  (java.util.Date.)
+              :edge/affected-pr-ids             [["miniforge-ai/miniforge" 999]]
+              :edge/affected-agent-session-ids  []
+              :edge/operator-action-required    false}]
+    (upsert-event edge 42))
+
+  referenced-statuses
+
+  :leave-this-here)

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/interface.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/interface.clj
@@ -19,10 +19,13 @@
 (ns ai.miniforge.automation-edge-correlator.interface
   "Public API for the automation-edge-correlator component.
 
-   N15-1 exposes schema and trigger-classification helpers only.
-   Lifecycle (`start!` / `stop!` / `attach!`) lands in N15-3 once
-   `core.clj` and `emitter.clj` are in place."
+   Exposes schemas, trigger classification (N15-1), and the lifecycle
+   surface (N15-3). The pure state-machine transitions in `correlator.clj`
+   are deliberately NOT re-exported — they are implementation details
+   behind `start!` / `stop!` / `attach!`, and surfacing them would let
+   downstream callers reach past the boundary into the fold internals."
   (:require
+   [ai.miniforge.automation-edge-correlator.core :as core]
    [ai.miniforge.automation-edge-correlator.schema :as schema]
    [ai.miniforge.automation-edge-correlator.triggers :as triggers]))
 
@@ -43,3 +46,10 @@
 ;; Trigger classification
 
 (def classify-trigger triggers/classify-trigger)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Lifecycle — the only surface the rest of the workspace should touch.
+
+(def start!  core/start!)
+(def stop!   core/stop!)
+(def attach! core/attach!)

--- a/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/integration_test.clj
+++ b/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/integration_test.clj
@@ -1,0 +1,284 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.automation-edge-correlator.integration-test
+  "End-to-end lifecycle tests for the AutomationEdge correlator —
+   subscription wiring, emission, recursion prevention, cross-restart
+   replay, and the expire-tick path (driven deterministically via
+   `expire-once!`, not `Thread/sleep`).
+
+   Uses an in-memory event stream with no sinks so test runs leave no
+   on-disk debris."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.automation-edge-correlator.core :as core]
+   [ai.miniforge.automation-edge-correlator.interface :as iface]
+   [ai.miniforge.event-stream.core :as es-core]
+   [ai.miniforge.event-stream.interface :as es])
+  (:import
+   (java.util Date)))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- in-memory-stream
+  []
+  (es-core/create-event-stream {:sinks []}))
+
+(defn- upserts
+  "All `:supervisory/automation-edge-upserted` events on the stream, in
+   publish order."
+  [stream]
+  (->> (es/get-events stream)
+       (filter #(= :supervisory/automation-edge-upserted (:event/type %)))
+       vec))
+
+(defn- at-ms ^Date [^long ms] (Date. ms))
+
+(defn- pr-merged-event
+  ([] (pr-merged-event (random-uuid) (at-ms 1000)))
+  ([event-id ts]
+   {:event/type            :pr/merged
+    :event/id              event-id
+    :event/timestamp       ts
+    :event/version         "1.0.0"
+    :event/sequence-number 0
+    :pr/repo               "miniforge-ai/miniforge"
+    :pr/number             999
+    :message               "merged"}))
+
+(defn- workflow-started-event
+  [workflow-id trigger-event-id]
+  {:event/type               :workflow/started
+   :event/id                 (random-uuid)
+   :event/timestamp          (at-ms 1100)
+   :event/version            "1.0.0"
+   :event/sequence-number    0
+   :workflow/id              workflow-id
+   :routing/trigger-event-id trigger-event-id
+   :message                  "started"})
+
+(defn- workflow-completed-event
+  [workflow-id]
+  {:event/type            :workflow/completed
+   :event/id              (random-uuid)
+   :event/timestamp       (at-ms 1200)
+   :event/version         "1.0.0"
+   :event/sequence-number 0
+   :workflow/id           workflow-id
+   :message               "completed"})
+
+(defn- fake-clock
+  "A 0-arity fn returning the value of `t-atom`. Tests drive the clock
+   forward via `(reset! t-atom new-date)` and invoke `core/expire-once!`
+   by hand — no `Thread/sleep`, fully deterministic."
+  [t-atom]
+  (fn [] @t-atom))
+
+(defn- await-upsert-count
+  "Poll up to `budget-ms` for `(count (upserts stream))` to reach `n`.
+   The subscriber callback runs synchronously under `publish!`, so this
+   spin is essentially a one-iteration check in practice — kept defensive
+   in case future executor changes make the callback async."
+  [stream n budget-ms]
+  (let [deadline (+ (System/currentTimeMillis) budget-ms)]
+    (loop []
+      (cond
+        (>= (count (upserts stream)) n) true
+        (>= (System/currentTimeMillis) deadline) false
+        :else (do (Thread/sleep 5) (recur))))))
+
+;; Cadence override that prevents the scheduled tick from firing during
+;; the tests — we drive `core/expire-once!` by hand. `Long/MAX_VALUE`
+;; effectively means "never" without disabling the scheduler entirely
+;; (which would change the `start!` code path).
+(def ^:private never-fire-ms Long/MAX_VALUE)
+
+(defn- start-with-clock
+  "Boot a correlator handle bound to `stream` with the injected clock
+   and a no-fire expire cadence so tests drive timing deterministically."
+  [stream t-atom]
+  (iface/attach! stream {:clock  (fake-clock t-atom)
+                         :config {:correlator/suppression-window-ms 300000
+                                  :correlator/expire-tick-ms        never-fire-ms}}))
+
+;------------------------------------------------------------------------------ Tests
+
+(deftest trigger-emits-observed-edge
+  (testing "A `:pr/merged` trigger lands one `:observed` upsert on the stream."
+    (let [stream (in-memory-stream)
+          t-atom (atom (at-ms 1000))
+          handle (start-with-clock stream t-atom)]
+      (try
+        (es/publish! stream (pr-merged-event))
+        (is (await-upsert-count stream 1 500))
+        (let [[ev] (upserts stream)]
+          (is (= :supervisory/automation-edge-upserted (:event/type ev)))
+          (is (= :observed (get-in ev [:supervisory/entity :edge/status])))
+          (is (= :pr-merged (get-in ev [:supervisory/entity :edge/trigger-kind]))))
+        (finally (iface/stop! handle))))))
+
+(deftest workflow-started-emits-no-upsert
+  (testing "`:workflow/started` indexes the workflow but emits no edge upsert."
+    (let [stream  (in-memory-stream)
+          t-atom  (atom (at-ms 1000))
+          handle  (start-with-clock stream t-atom)
+          trigger (pr-merged-event)]
+      (try
+        (es/publish! stream trigger)
+        (await-upsert-count stream 1 500)
+        (let [baseline (count (upserts stream))]
+          (es/publish! stream (workflow-started-event (random-uuid) (:event/id trigger)))
+          (Thread/sleep 20)
+          (is (= baseline (count (upserts stream)))
+              "workflow/started must not emit an upsert (handled-arm is a no-op for emission)"))
+        (finally (iface/stop! handle))))))
+
+(deftest workflow-completed-transitions-to-handled
+  (testing "Observed → handled flow emits two upserts sharing one `:edge/id`."
+    (let [stream      (in-memory-stream)
+          t-atom      (atom (at-ms 1000))
+          handle      (start-with-clock stream t-atom)
+          trigger     (pr-merged-event)
+          workflow-id (random-uuid)]
+      (try
+        (es/publish! stream trigger)
+        (await-upsert-count stream 1 500)
+        (es/publish! stream (workflow-started-event workflow-id (:event/id trigger)))
+        (es/publish! stream (workflow-completed-event workflow-id))
+        (is (await-upsert-count stream 2 500))
+        (let [evs (upserts stream)
+              [observed handled] evs]
+          (is (= :observed (get-in observed [:supervisory/entity :edge/status])))
+          (is (= :handled  (get-in handled  [:supervisory/entity :edge/status])))
+          (is (= (get-in observed [:supervisory/entity :edge/id])
+                 (get-in handled  [:supervisory/entity :edge/id]))
+              "Both upserts share `:edge/id` so the consumer dedups to one row."))
+        (finally (iface/stop! handle))))))
+
+(deftest recursion-prevention-drops-self-emissions
+  (testing "Synthetic `:supervisory/automation-edge-upserted` injected into the
+            stream MUST NOT be fed back through the dispatch (no emission storm)."
+    (let [stream (in-memory-stream)
+          t-atom (atom (at-ms 1000))
+          handle (start-with-clock stream t-atom)]
+      (try
+        (es/publish! stream {:event/type            :supervisory/automation-edge-upserted
+                             :event/id              (random-uuid)
+                             :event/timestamp       (at-ms 1000)
+                             :event/version         "1.0.0"
+                             :event/sequence-number 0
+                             :supervisory/entity    {:edge/id            (random-uuid)
+                                                     :edge/status        :observed
+                                                     :edge/trigger-kind  :pr-merged}
+                             :message               "synthetic"})
+        (Thread/sleep 20)
+        (is (= 1 (count (upserts stream)))
+            "The injected event is the only upsert on the stream — the
+             correlator must not have re-emitted in response.")
+        (finally (iface/stop! handle))))))
+
+(deftest replay-reconstructs-edges-byte-identically
+  (testing "On a fresh `attach!` against the same stream prefix, the
+            correlator reconstructs the same edges with byte-identical
+            `:edge/id` and `:edge/status` per §3.6."
+    (let [stream      (in-memory-stream)
+          t-atom      (atom (at-ms 1000))
+          trigger     (pr-merged-event)
+          workflow-id (random-uuid)
+          handle-1    (start-with-clock stream t-atom)]
+      (try
+        (es/publish! stream trigger)
+        (es/publish! stream (workflow-started-event workflow-id (:event/id trigger)))
+        (es/publish! stream (workflow-completed-event workflow-id))
+        (await-upsert-count stream 2 500)
+        (iface/stop! handle-1)
+
+        (let [pre-restart-edges
+              (mapv #(get % :supervisory/entity) (upserts stream))
+              ;; Filter out the just-emitted upserts so they don't get
+              ;; replayed (the recursion filter would skip them anyway,
+              ;; but we want to assert the post-replay edges came from
+              ;; folding the source events, not from a re-observation
+              ;; of our prior emission).
+              filtered-stream
+              (let [s (in-memory-stream)]
+                (doseq [e (es/get-events stream)
+                        :when (not= :supervisory/automation-edge-upserted
+                                    (:event/type e))]
+                  (es/publish! s e))
+                s)
+              handle-2 (start-with-clock filtered-stream t-atom)]
+          (try
+            (await-upsert-count filtered-stream 2 500)
+            (let [post-restart-edges
+                  (mapv #(get % :supervisory/entity) (upserts filtered-stream))]
+              (is (= (set (map :edge/id pre-restart-edges))
+                     (set (map :edge/id post-restart-edges)))
+                  "Edge ids reconstruct identically across restart (UUIDv5 is deterministic).")
+              (is (= (set (map :edge/status pre-restart-edges))
+                     (set (map :edge/status post-restart-edges)))
+                  "Edge statuses reconstruct identically across restart."))
+            (finally (iface/stop! handle-2))))
+        (finally (iface/stop! handle-1))))))
+
+(deftest expire-tick-transitions-to-needs-operator
+  (testing "After the suppression window elapses with no handler-started,
+            `expire-once!` transitions the edge to `:needs-operator` and
+            emits one upsert."
+    (let [stream  (in-memory-stream)
+          ;; Trigger occurs at 1 s past epoch; suppression window is
+          ;; 300 s in `start-with-clock` config; clock advances to 1 s
+          ;; past that window so the edge is eligible.
+          t-atom  (atom (at-ms 1000))
+          handle  (start-with-clock stream t-atom)
+          trigger (pr-merged-event (random-uuid) (at-ms 1000))]
+      (try
+        (es/publish! stream trigger)
+        (await-upsert-count stream 1 500)
+
+        ;; Advance clock past the suppression window and drive the
+        ;; expire tick by hand — no Thread/sleep on the cadence.
+        (reset! t-atom (at-ms (+ 1000 300000 1)))
+        (let [expired (core/expire-once! handle)]
+          (is (= 1 (count expired)))
+          (is (= :needs-operator (:edge/status (first expired)))))
+
+        (is (await-upsert-count stream 2 500))
+        (let [[_ needs-op] (upserts stream)]
+          (is (= :needs-operator
+                 (get-in needs-op [:supervisory/entity :edge/status]))))
+        (finally (iface/stop! handle))))))
+
+(deftest expire-tick-skips-edges-with-started-handler
+  (testing "An edge whose `:workflow/started` has been observed is NOT
+            timed out by the expire-tick — handler-started protection."
+    (let [stream      (in-memory-stream)
+          t-atom      (atom (at-ms 1000))
+          handle      (start-with-clock stream t-atom)
+          trigger     (pr-merged-event (random-uuid) (at-ms 1000))
+          workflow-id (random-uuid)]
+      (try
+        (es/publish! stream trigger)
+        (es/publish! stream (workflow-started-event workflow-id (:event/id trigger)))
+        (await-upsert-count stream 1 500)
+        (reset! t-atom (at-ms (+ 1000 300000 1)))
+        (let [expired (core/expire-once! handle)]
+          (is (empty? expired)
+              "Handler workflow already started — edge stays pending
+               regardless of age."))
+        (finally (iface/stop! handle))))))

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -763,11 +763,21 @@
     [:event/timestamp inst?]
     [:event/version string?]
     [:event/sequence-number int?]
-    ;; `:workflow/id` is :optional/:maybe — an edge MAY be opened by a
-    ;; trigger that names no workflow (e.g. `:pr/merged`), so the envelope
-    ;; field is absent then. When the trigger is workflow-scoped
-    ;; (`:workflow/completed`, `:gate/passed`) the producer threads the
-    ;; workflow id through for downstream filtering.
+    ;; `:workflow/id` is :optional/:maybe — its presence on the envelope
+    ;; tracks the edge's correlation state, not the originating trigger
+    ;; kind:
+    ;;
+    ;; - Pre-handler edges (`:observed` with no handler workflow
+    ;;   correlated yet — the typical state after a `:pr/merged` trigger
+    ;;   and before the responding workflow's `:workflow/started`) have
+    ;;   no `:edge/handled-by-workflow-run-id` yet, so the producer
+    ;;   threads `nil` and `create-envelope` omits the envelope field.
+    ;; - Post-correlation edges (`:handled`, `:failed`, and the
+    ;;   post-terminal `:suppressed` shape that preserved the prior
+    ;;   workflow id) carry `:edge/handled-by-workflow-run-id` on the
+    ;;   entity; the producer threads that value into `create-envelope`
+    ;;   so the envelope's `:workflow/id` is populated for downstream
+    ;;   workflow-scoped filters.
     [:workflow/id {:optional true} [:maybe uuid?]]
     [:supervisory/entity map?]
     [:message string?]]))

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -620,6 +620,10 @@
    :supervision/tool-use-evaluated :internal
    :supervisory/intervention-requested :confidential
    :supervisory/intervention-state-changed :confidential
+   ;; Automation-edge upserts mirror the same operator-attention shape as
+   ;; the other supervisory snapshots; default `:internal` matches the
+   ;; sibling `:supervisory/*-upserted` family.
+   :supervisory/automation-edge-upserted :internal
    :control-action/requested :confidential
    :control-action/executed  :confidential
    :annotation/created       :internal
@@ -734,6 +738,38 @@
     [:intervention/approval-required? {:optional true} boolean?]
     [:intervention/requested-at {:optional true} inst?]
     [:intervention/updated-at {:optional true} inst?]
+    [:message string?]]))
+
+;; Automation-edge correlator emission (N5-delta-4 §4.1)
+;;
+;; The correlator is the sole producer of this event per N5-delta-1 §3.4
+;; invariant 6 (extended in N5-delta-4 §4.1). Wire form mirrors the Rust
+;; `AutomationEdge` struct in `miniforge-control/contracts/crates/
+;; supervisory-entities/src/entities.rs`. The full entity malli schema lives
+;; with the producer in `components/automation-edge-correlator/.../schema.clj`;
+;; here we accept the entity as an open `map?` so that adding fields to the
+;; producer's schema does not require a wire-schema edit in lockstep — the
+;; consumer (Rust core) round-trips the open shape per §1.3.
+(def AutomationEdgeUpserted
+  "Schema for `:supervisory/automation-edge-upserted` event (N5-delta-4 §4.1).
+
+   Carries the full AutomationEdge entity in `:supervisory/entity`. The
+   correlator is the sole producer; consumers (Rust core, native app) dedup
+   on the entity's `:edge/id` so re-emission on replay is safe."
+  (with-identity
+   [:map
+    [:event/type [:= :supervisory/automation-edge-upserted]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    ;; `:workflow/id` is :optional/:maybe — an edge MAY be opened by a
+    ;; trigger that names no workflow (e.g. `:pr/merged`), so the envelope
+    ;; field is absent then. When the trigger is workflow-scoped
+    ;; (`:workflow/completed`, `:gate/passed`) the producer threads the
+    ;; workflow id through for downstream filtering.
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:supervisory/entity map?]
     [:message string?]]))
 
 ;; OCI container event schemas


### PR DESCRIPTION
## Summary

N15-3 of the AutomationEdge Correlator burndown. Wraps the merged N15-2 pure
state machine in the **lifecycle + emitter** layer so
`:supervisory/automation-edge-upserted` events land on the event stream as
triggers / handler signals / suppressions flow through it.

- **`emitter.clj`** (Layer 0, pure): layers edge-specific fields onto a base
  envelope from `event-stream/create-envelope` — preserves the stream's
  Snowflake-encoded `:event/id`, `:event/version`, `:event/sequence-number`,
  and identity-propagation fields per the BD-2b / Phase E Decision 14
  contracts. Overrides only `:event/timestamp` (to the edge's
  `:edge/updated-at`, not wall clock — replay reconstructs byte-identical
  events), `:message`, and `:supervisory/entity`. Consumers dedup on
  `:edge/id` per §2.3.
- **`core.clj`** (Layer 1): atom-wrapped lifecycle handle, subscription with
  the `:supervisory/automation-edge-upserted` self-filter (§3.3 recursion
  prevention), full per-event dispatch (`:workflow/started`,
  `:workflow/completed` as both handler-signal AND trigger, `:workflow/failed`,
  `:edge/suppress`, `:routing/no-handler`, every classifiable trigger via
  `assemble-classified-trigger` lifting the §3.4 payload-derivation table),
  **subscribe-then-replay-then-drain barrier** so events published between the
  `get-events` snapshot and the subscriber going live are NOT lost
  (buffered-handler + flag-flip + final drain pattern), replay-on-startup with
  re-emission (§3.6 cross-restart), and a `ScheduledExecutorService`
  expire-pending tick at 30 s cadence with stderr logging on Throwable
  (matches the sibling event-stream sink failure convention; a scheduled-task
  Throwable would otherwise silently cancel all future runs).
  `expire-once!` is public so tests drive the tick deterministically without
  `Thread/sleep`. Emission threads `:edge/handled-by-workflow-run-id` into
  `create-envelope`'s `workflow-id` arg so post-correlation envelopes carry
  `:workflow/id` for workflow-scoped consumers.
- **`interface.clj`**: re-exports the lifecycle surface (`start!` / `stop!` /
  `attach!`) PLUS the pre-existing N15-1 schema and trigger-classification
  surface (`AutomationEdge`, `routing-trigger-kinds`,
  `automation-edge-statuses`, `classify-trigger`) — these are useful public
  inspection points for downstream callers and remain part of the interface
  per N15-1. Implementation-private items (state-machine transitions,
  `schema/registry`, `schema/automation-edge-namespace`) are NOT re-exported.
- **`deps.edn`**: adds `ai.miniforge/event-stream` (deliberately omitted in
  N15-1 per PR #902's deps-trim discussion).
- **`event-stream/schema.clj`**: adds `AutomationEdgeUpserted` malli schema +
  `:internal` privacy default. The `:workflow/id` envelope field is now
  threaded by the correlator from the edge's
  `:edge/handled-by-workflow-run-id` when present — comment in the schema
  documents the actual emission behavior.

## Out of scope (siblings)

- `:routing/trigger-event-id` producer wiring — N15-4
- Trigger-event-type declarations — N15-5
- Heuristic-fallback correlation (§3.5 case 2) — deferred per brief

## Test plan

- [x] `bb poly:check` clean (only pre-existing warning-207 noise).
- [x] `clj-kondo --lint components/automation-edge-correlator/{src,test}` → 0 errors / 0 warnings.
- [x] Brick suite: 49 tests / 113 assertions, green
  (`correlator-test` + `schema-test` + `triggers-test` + new `integration-test`).
- [x] Event-stream suite unchanged: 264 tests / 1324 assertions, green.
- [x] Pre-commit smoke (271 tests / 967 assertions) + GraalVM (6 / 502) green.
- [x] Integration coverage:
  - trigger → `:observed` upsert
  - `:workflow/started` indexes without emitting
  - `:workflow/completed` → `:handled` with byte-identical `:edge/id`
  - synthetic self-emission does NOT loop (§3.3)
  - cross-restart replay reconstructs identical `:edge/id` + `:edge/status` (§3.6)
  - expire-tick → `:needs-operator` past suppression window

🤖 Generated with [Claude Code](https://claude.com/claude-code)