### PR TITLE
fix(reviewer): surface which internal gate flipped the LLM verdict

### DIFF
--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -120,14 +120,28 @@
 (defn gate-result->feedback
   "Convert a loop gate result to reviewer feedback format.
 
-   Gate identity is resolved from the result first (`:gate/id` /
-   `:gate/type` populated by `loop/pass-result` and `loop/fail-result`),
-   falling back to the gate defrecord's plain `id` / `type-kw` fields.
-   Both the loop's own SyntaxGate/LintGate/CustomGate records and the
-   reviewer-internal `implementation-handoff-gate` rely on this
-   fallback — without it, every gate surfaced as `:unknown` in the
-   `:failing-gate-ids` diagnostic and the 2026-05-18 dogfood couldn't
-   tell which gate flipped its LLM verdict."
+   Gate identity resolution order:
+     1. `:gate/id`   on the result   (populated by `loop/pass-result`
+                                      and `loop/fail-result`)
+     2. `:gate/id`   on the gate     (rare — not set by current records,
+                                      kept for forward-compat)
+     3. `:id`        on the gate     (the plain field on SyntaxGate /
+                                      LintGate / TestGate / PolicyGate /
+                                      CustomGate records)
+     4. `:unknown`   final fallback
+
+   Gate-type resolution differs slightly. Only `CustomGate` carries a
+   `type-kw` field on the record itself; the other gate records hard-
+   code their type at construction (e.g. `SyntaxGate` always passes
+   `:syntax` into the result via `loop/pass-result`). So:
+     1. `:gate/type` on the result
+     2. `:gate/type` on the gate
+     3. `:type-kw`   on the gate     (CustomGate only)
+     4. `:unknown`
+
+   Before this two-step resolution every failing gate surfaced as
+   `:unknown` in the `:failing-gate-ids` diagnostic and the 2026-05-18
+   dogfood couldn't tell which gate flipped its LLM verdict."
   [gate result]
   (let [gate-id   (or (:gate/id result) (:gate/id gate) (:id gate) :unknown)
         gate-type (or (:gate/type result) (:gate/type gate) (:type-kw gate) :unknown)

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -118,13 +118,22 @@
 ;; Gate running and feedback
 
 (defn gate-result->feedback
-  "Convert a loop gate result to reviewer feedback format."
+  "Convert a loop gate result to reviewer feedback format.
+
+   Gate identity is resolved from the result first (`:gate/id` /
+   `:gate/type` populated by `loop/pass-result` and `loop/fail-result`),
+   falling back to the gate defrecord's plain `id` / `type-kw` fields.
+   Both the loop's own SyntaxGate/LintGate/CustomGate records and the
+   reviewer-internal `implementation-handoff-gate` rely on this
+   fallback — without it, every gate surfaced as `:unknown` in the
+   `:failing-gate-ids` diagnostic and the 2026-05-18 dogfood couldn't
+   tell which gate flipped its LLM verdict."
   [gate result]
-  (let [gate-id (:gate/id gate :unknown)
-        gate-type (:gate/type gate :unknown)
-        passed? (:gate/passed? result true)
-        errors (:gate/errors result [])
-        warnings (:gate/warnings result [])]
+  (let [gate-id   (or (:gate/id result) (:gate/id gate) (:id gate) :unknown)
+        gate-type (or (:gate/type result) (:gate/type gate) (:type-kw gate) :unknown)
+        passed?   (:gate/passed? result true)
+        errors    (:gate/errors result [])
+        warnings  (:gate/warnings result [])]
     {:gate-id gate-id
      :gate-type gate-type
      :passed? passed?
@@ -782,15 +791,36 @@
                    logger normalized llm-review gate-result counts duration tokens cost-usd
                    timeout-failure-message)
                   (do
-                    (log/info logger :reviewer :reviewer/review-complete
-                              {:data {:decision final-decision
-                                      :llm-decision llm-decision
-                                      :llm-parse-failed? parse-failed?
-                                      :timeout-only-review? timeout-only-review?
-                                      :gates-passed (:passed counts)
-                                      :gates-failed (:failed counts)
-                                      :llm-issues (count llm-issues)
-                                      :duration-ms duration}})
+                    ;; Observability — when the deterministic gates flip
+                    ;; the LLM's verdict, the operator needs to know
+                    ;; which gate(s) caused it. Without this, the
+                    ;; downstream workflow gate just fails opaquely.
+                    ;; The 2026-05-18 agent-stream-watchdog dogfood
+                    ;; surfaced LLM :approved → final :rejected with no
+                    ;; signal in the event log about which internal gate
+                    ;; produced the override.
+                    (let [failing-gate-ids (->> gate-feedbacks
+                                                (remove :passed?)
+                                                (mapv :gate-id))
+                          gate-overrode-llm? (and (some? llm-decision)
+                                                  (not= llm-decision final-decision))]
+                      (log/info logger :reviewer :reviewer/review-complete
+                                {:data {:decision final-decision
+                                        :llm-decision llm-decision
+                                        :llm-parse-failed? parse-failed?
+                                        :timeout-only-review? timeout-only-review?
+                                        :gates-passed (:passed counts)
+                                        :gates-failed (:failed counts)
+                                        :failing-gate-ids failing-gate-ids
+                                        :gate-overrode-llm? gate-overrode-llm?
+                                        :llm-issues (count llm-issues)
+                                        :duration-ms duration}})
+                      (when gate-overrode-llm?
+                        (log/warn logger :reviewer :reviewer/gate-overrode-llm
+                                  {:data {:llm-decision llm-decision
+                                          :final-decision final-decision
+                                          :failing-gate-ids failing-gate-ids
+                                          :artifact-id artifact-id}})))
 
                     ;; Phase lifecycle: mark review exit with decision
                     (leave-review logger {:review/decision final-decision

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -575,6 +575,54 @@
         (is (= :rejected  (get-in override-entry [:data :final-decision])))
         (is (= [:always-fails] (get-in override-entry [:data :failing-gate-ids])))))))
 
+(deftest test-gate-result-feedback-resolves-real-gate-ids
+  ;; Coverage gap exposed by the 2026-05-18 dogfood: gate-result->feedback
+  ;; was reading `:gate/id` off the gate defrecord (where SyntaxGate /
+  ;; LintGate / CustomGate store `id` as a plain field), so every gate
+  ;; surfaced as `:unknown` in the failing-gate-ids diagnostic. Pin
+  ;; resolution from each shape so a regression here flips the test red
+  ;; instead of silently degrading observability.
+  (testing "CustomGate result: gate-id resolved from result's :gate/id"
+    (let [gate (loop/custom-gate :my-custom :policy
+                 (fn [_ _] (loop/pass-result :my-custom :policy)))
+          result (loop/check-gate gate {} {})
+          fb (#'reviewer/gate-result->feedback gate result)]
+      (is (= :my-custom (:gate-id fb)))
+      (is (= :policy (:gate-type fb)))
+      (is (true? (:passed? fb)))))
+
+  (testing "CustomGate result with explicit :gate/id wins over the gate's :id"
+    (let [gate (loop/custom-gate :gate-side :policy (fn [_ _] {}))
+          result {:gate/id :result-side :gate/type :other :gate/passed? false :gate/errors []}
+          fb (#'reviewer/gate-result->feedback gate result)]
+      (is (= :result-side (:gate-id fb))
+          "result's :gate/id always wins — pass-result/fail-result are authoritative")
+      (is (= :other (:gate-type fb)))))
+
+  (testing "CustomGate result without :gate/id falls back to the record's :id"
+    (let [gate (loop/custom-gate :on-the-record :policy (fn [_ _] {}))
+          result {:gate/passed? false :gate/errors [{:message "boom"}]}
+          fb (#'reviewer/gate-result->feedback gate result)]
+      (is (= :on-the-record (:gate-id fb))
+          ":id from the defrecord must surface when the result is bare")
+      (is (= :policy (:gate-type fb))
+          ":type-kw from the CustomGate record must surface when the result is bare")))
+
+  (testing "SyntaxGate result resolves to a real id even though the record has no :type-kw field"
+    (let [gate (loop/syntax-gate)
+          result {:gate/id :syntax :gate/type :syntax :gate/passed? true}
+          fb (#'reviewer/gate-result->feedback gate result)]
+      (is (= :syntax (:gate-id fb))
+          "syntax gate must NOT show as :unknown — it was the canonical regression")
+      (is (= :syntax (:gate-type fb)))))
+
+  (testing "missing-id path falls back to :unknown — keeps the existing safety net"
+    (let [gate {:not-a-record true}    ; non-record map with no id at all
+          result {:gate/passed? false :gate/errors []}
+          fb (#'reviewer/gate-result->feedback gate result)]
+      (is (= :unknown (:gate-id fb)))
+      (is (= :unknown (:gate-type fb))))))
+
 (deftest test-reviewer-no-override-warn-when-gates-and-llm-agree
   (testing "no :reviewer/gate-overrode-llm warn when LLM and gates agree on :approved"
     (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -521,6 +521,87 @@
       (is (= :rejected (:review/decision review)))
       (is (some #(re-find #"out-of-scope" %) (:review/blocking-issues review))))))
 
+;; ============================================================================
+;; LLM vs gate disagreement — observability for the 2026-05-18 dogfood
+;; finding (LLM :approved silently overridden by failing internal gates)
+;; ============================================================================
+
+(deftest test-reviewer-emits-gate-overrode-llm-warn-on-disagreement
+  ;; When the LLM emits :approved but a deterministic gate fails, the
+  ;; final decision flips and the workflow gate fails with no signal
+  ;; to the operator about which internal gate caused the override.
+  ;; Pin the diagnostic log + the :failing-gate-ids / :gate-overrode-llm?
+  ;; fields on :reviewer/review-complete, plus the dedicated
+  ;; :reviewer/gate-overrode-llm warn entry.
+  (testing ":reviewer/gate-overrode-llm warn fires when LLM :approved becomes final :rejected"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             (mock-llm-response
+                               "```clojure
+{:review/decision :approved
+ :review/issues []
+ :review/summary \"LGTM\"}
+```"))
+                  llm/success? :success?
+                  llm/get-content :content]
+      (let [[logger entries] (log/collecting-logger {:min-level :trace})
+            failing-gate (loop/custom-gate
+                           :always-fails
+                           :policy
+                           (fn [_artifact _ctx]
+                             (loop/fail-result :always-fails :policy
+                                               [(loop/make-error :failed
+                                                                 "deterministic gate")])))
+            reviewer (reviewer/create-reviewer
+                       {:llm-backend ::mock-backend
+                        :gates [failing-gate]
+                        :logger logger})
+            result (core/invoke reviewer {} sample-artifact)
+            complete-entry (some #(when (= :reviewer/review-complete (:log/event %)) %)
+                                 @entries)
+            override-entry (some #(when (= :reviewer/gate-overrode-llm (:log/event %)) %)
+                                 @entries)]
+        (is (= :rejected (:review/decision (:artifact result)))
+            "baseline: failing internal gate flips LLM :approved → :rejected")
+        (is (some? complete-entry)
+            ":reviewer/review-complete must fire")
+        (is (= [:always-fails] (get-in complete-entry [:data :failing-gate-ids]))
+            ":failing-gate-ids on the complete log must name the gate")
+        (is (true? (get-in complete-entry [:data :gate-overrode-llm?]))
+            ":gate-overrode-llm? must be true when LLM and final differ")
+        (is (some? override-entry)
+            ":reviewer/gate-overrode-llm warn must fire on disagreement")
+        (is (= :approved  (get-in override-entry [:data :llm-decision])))
+        (is (= :rejected  (get-in override-entry [:data :final-decision])))
+        (is (= [:always-fails] (get-in override-entry [:data :failing-gate-ids])))))))
+
+(deftest test-reviewer-no-override-warn-when-gates-and-llm-agree
+  (testing "no :reviewer/gate-overrode-llm warn when LLM and gates agree on :approved"
+    (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                  llm/chat (fn [_client _prompt _opts]
+                             (mock-llm-response
+                               "```clojure
+{:review/decision :approved
+ :review/issues []
+ :review/summary \"LGTM\"}
+```"))
+                  llm/success? :success?
+                  llm/get-content :content]
+      (let [[logger entries] (log/collecting-logger {:min-level :trace})
+            reviewer (reviewer/create-reviewer
+                       {:llm-backend ::mock-backend
+                        :gates []
+                        :logger logger})
+            _result (core/invoke reviewer {} sample-artifact)
+            complete-entry (some #(when (= :reviewer/review-complete (:log/event %)) %)
+                                 @entries)
+            override-entry (some #(when (= :reviewer/gate-overrode-llm (:log/event %)) %)
+                                 @entries)]
+        (is (false? (get-in complete-entry [:data :gate-overrode-llm?])))
+        (is (empty? (get-in complete-entry [:data :failing-gate-ids])))
+        (is (nil? override-entry)
+            "no warn when LLM and gates agree — keeps the signal high-value")))))
+
 ;------------------------------------------------------------------------------ Schema validation tests
 
 (deftest test-validate-review-artifact


### PR DESCRIPTION
## Summary

Observability fix for the gate-vs-LLM disagreement pattern surfaced
by the 2026-05-18 agent-stream-watchdog dogfood. The LLM emitted
`:approved` (4 issues: 2 warnings, 2 nits, 0 blocking) but the
workflow gate failed — and the operator had no way to tell which
internal gate flipped the decision.

## Root cause + two fixes

### Fix 1: `gate-result->feedback` was always returning `:unknown` gate-id

The reviewer's feedback builder read `(:gate/id gate :unknown)` from
the gate defrecord. The `CustomGate` / `SyntaxGate` / `LintGate`
records store identity as a plain `id` field, not `:gate/id`. So
every gate ID came out as `:unknown` regardless of which gate ran.

Fixed: resolve identity from the result first (`loop/pass-result` and
`loop/fail-result` set `:gate/id` on the result map), fall back to
the defrecord's plain `id`.

### Fix 2: no diagnostic event when gate flips LLM verdict

`:reviewer/review-complete` logged the COUNT of failures but not which
gates failed. Added `:failing-gate-ids` and `:gate-overrode-llm?` to
that log, plus a new `:reviewer/gate-overrode-llm` WARN that only
fires when LLM-decision and final-decision differ — high signal, no
noise on the agreement path.

## What this PR does NOT do

The underlying policy question — whether errors without an explicit
`:severity` field should default to `:blocking` (current behaviour,
which is why ANY internal gate failure flips a LLM `:approved` to
`:rejected`) or to `:warning` — is deferred. This PR is observability-
only so we can see WHICH gates trip in production before changing the
LLM-vs-gate precedence.

## Test plan

- [x] 31 reviewer tests, 113 assertions, 0 failures (2 new pins:
  disagreement path + agreement path).
- [x] `bb pre-commit` green.

## Related

- 2026-05-18 dogfood: `agent-stream-watchdog-and-resume` spec walked
  through one full cycle, hit gate-vs-verdict mismatch at review #1,
  next iteration died before completing. This PR adds the missing
  observability so the next dogfood surfaces the gate name in its
  output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)