### PR TITLE
feat(automation-edge-correlator): N15-6 — wire correlator into workspace startup

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
@@ -24,6 +24,7 @@
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.supervisory-state.interface :as supervisory]
+   [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.phase.interface :as phase])
   (:import
    [java.util UUID]))
@@ -105,6 +106,8 @@
         workflow (build-execution-workflow plan-id)
         event-stream (es/create-event-stream)
         _supervisor (supervisory/attach! event-stream)
+        ;; N15-6: route routing-causality through the witness surface.
+        _correlator (correlator/attach! event-stream)
         workflow-id (random-uuid)
         control-state (es/create-control-state)
         command-poller-cleanup (dashboard/start-command-poller! workflow-id control-state)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -38,6 +38,7 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.supervisory-state.interface :as supervisory]
+   [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.workflow-resume.interface :as wr]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -156,6 +157,11 @@
             ;; Runtime wiring (CLI concern — stays here)
             event-stream (es/create-event-stream)
             _supervisor (supervisory/attach! event-stream)
+            ;; N15-6: route routing-causality through the witness surface.
+            ;; Mirrors the meta-loop and workflow-runner attach sites; the
+            ;; correlator emits `:supervisory/automation-edge-upserted`
+            ;; alongside the supervisory snapshots.
+            _correlator (correlator/attach! event-stream)
             control-state (es/create-control-state)
             command-poller-cleanup (dashboard/start-command-poller! resume-run-id control-state)
             llm-client (context/create-llm-client workflow nil quiet)]

--- a/bases/cli/src/ai/miniforge/cli/web/sse.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/sse.clj
@@ -23,6 +23,7 @@
    [org.httpkit.server :as http]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.supervisory-state.interface :as supervisory]
+   [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.cli.web.response :as response]))
 
 (def streams (atom {}))
@@ -31,6 +32,8 @@
   (or (get @streams workflow-id)
       (let [stream (es/create-event-stream)]
         (supervisory/attach! stream)
+        ;; N15-6: route routing-causality through the witness surface.
+        (correlator/attach! stream)
         (swap! streams assoc workflow-id stream)
         stream)))
 

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.supervisory-state.interface :as supervisory]
+   [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.artifact.interface :as artifact]
    [ai.miniforge.agent.interface :as agent]
@@ -95,6 +96,11 @@
   (or @meta-loop-ctx
       (let [operator-stream (es/create-event-stream)
             _supervisor (supervisory/attach! operator-stream)
+            ;; N15-6: route routing-causality through the witness surface.
+            ;; The correlator subscribes to the same stream as
+            ;; supervisory-state and emits `:supervisory/automation-edge-upserted`
+            ;; events; consumers (Rust core, native app) dedup on `:edge/id`.
+            _correlator (correlator/attach! operator-stream)
             ctx (agent/create-meta-loop-context operator-stream)]
         (reset! meta-loop-ctx ctx)
         ctx)))
@@ -1078,6 +1084,8 @@
           artifact-store (create-artifact-store quiet)
           event-stream (es/create-event-stream)
           _supervisor (supervisory/attach! event-stream)
+          ;; N15-6: see meta-loop attach above for rationale.
+          _correlator (correlator/attach! event-stream)
           workflow-id (or (get-in enriched-spec [:spec/metadata :session-id]) (random-uuid))
           ;; Control state for dashboard commands (pause/resume/stop)
           control-state (es/create-control-state)
@@ -1237,6 +1245,8 @@
             chain-input (resolve-chain-input opts)
             event-stream (es/create-event-stream)
             _supervisor (supervisory/attach! event-stream)
+            ;; N15-6: see meta-loop attach above for rationale.
+            _correlator (correlator/attach! event-stream)
             llm-client (context/create-llm-client nil nil quiet)
             callbacks (create-phase-callbacks quiet)
             context (context/create-workflow-context {:callbacks callbacks

--- a/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.cli.workflow-selection-config :as selection-config]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.supervisory-state.interface :as supervisory]
+   [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.workflow-resume.interface :as wr]))
 
 (deftest resolve-resume-workflow-test
@@ -128,6 +129,7 @@
                   context/create-llm-client (fn [_workflow _provider _quiet] :llm-client)
                   es/create-event-stream (fn [] :event-stream)
                   supervisory/attach! (fn [_event-stream] nil)
+                  correlator/attach! (fn [_event-stream] nil)
                   dashboard/start-command-poller! (fn [_workflow-id _control-state]
                                                     (fn [] nil))
                   main-display/print-info (fn [& _] nil)
@@ -184,6 +186,7 @@
                   context/create-llm-client (fn [_ _ _] :llm-client)
                   es/create-event-stream (fn [] :event-stream)
                   supervisory/attach! (fn [_] nil)
+                  correlator/attach! (fn [_] nil)
                   dashboard/start-command-poller! (fn [_ _] (fn [] nil))
                   main-display/print-info (fn [& _] nil)
                   main-display/print-error (fn [& _] nil)
@@ -240,6 +243,7 @@
                   context/create-llm-client (fn [_workflow _provider _quiet] :llm-client)
                   es/create-event-stream (fn [] :event-stream)
                   supervisory/attach! (fn [_event-stream] nil)
+                  correlator/attach! (fn [_event-stream] nil)
                   dashboard/start-command-poller! (fn [_workflow-id _control-state]
                                                     (fn [] nil))
                   main-display/print-info (fn [& _] nil)

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -39,6 +39,7 @@
         ai.miniforge/orchestrator {:local/root "../../components/orchestrator"}
         ai.miniforge/event-stream {:local/root "../../components/event-stream"}
         ai.miniforge/supervisory-state {:local/root "../../components/supervisory-state"}
+        ai.miniforge/automation-edge-correlator {:local/root "../../components/automation-edge-correlator"}
         ai.miniforge/self-healing {:local/root "../../components/self-healing"}
 ai.miniforge/messages {:local/root "../../components/messages"}
         ai.miniforge/patterns {:local/root "../../components/patterns"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -8,6 +8,7 @@
         ;; Event streaming (TUI subscribes to workflow events)
         ai.miniforge/event-stream {:local/root "../../components/event-stream"}
         ai.miniforge/supervisory-state {:local/root "../../components/supervisory-state"}
+        ai.miniforge/automation-edge-correlator {:local/root "../../components/automation-edge-correlator"}
         ;; Core domain components needed by CLI
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -64,6 +64,7 @@
         ;; Event streaming and observability
         ai.miniforge/event-stream {:local/root "../../components/event-stream"}
         ai.miniforge/supervisory-state {:local/root "../../components/supervisory-state"}
+        ai.miniforge/automation-edge-correlator {:local/root "../../components/automation-edge-correlator"}
         ai.miniforge/workflow-resume {:local/root "../../components/workflow-resume"}
         ;; Self-healing: workaround detection, backend health tracking
         ai.miniforge/self-healing {:local/root "../../components/self-healing"}


### PR DESCRIPTION
## Summary

Final slice of the N15 burndown. Adds `correlator/attach!` alongside every
`supervisory/attach!` callsite so the AutomationEdge correlator runs in
production paths, not just integration tests.

## Attach sites

All alongside the matching `supervisory/attach!`:

- `bases/cli/.../workflow_runner.clj` — meta-loop operator stream + the
  two workflow-execution streams (single-workflow + chain).
- `bases/cli/.../main/commands/resume.clj` — resumed-workflow stream.
- `bases/cli/.../main/commands/plan_executor.clj` — plan-executor stream.
- `bases/cli/.../web/sse.clj` — per-workflow SSE streams keyed by workflow-id.

## Project deps

Adds `ai.miniforge/automation-edge-correlator` as a `:local/root` dep to
`projects/miniforge/deps.edn`, `projects/miniforge-core/deps.edn`, and
`projects/miniforge-tui/deps.edn` — mirrors the `supervisory-state` footprint
exactly on the principle that correlator and supervisory-state are siblings
on the witness surface.

## Tests

- `bases/cli/test/.../resume_test.clj` mocks `correlator/attach!` alongside
  the existing `supervisory/attach!` mock in all three `with-redefs` blocks.
  Without the mock, the real `attach!` would spawn the
  `ScheduledExecutorService` daemon thread + the buffered subscription
  pattern, leaking after the test exits.
- Brick suite: **49 tests / 113 assertions**, green.
- `resume-test`: **8 tests / 36 assertions**, green.
- `clj-kondo`: 0 errors / 0 warnings on every touched file.
- `bb poly:check`: clean (pre-existing 207 warnings only).

## Burndown status post-merge

| Step  | Status | Surface |
|-------|--------|---------|
| N15-1 | done   | Component scaffold + schema + trigger classification (PR #902) |
| N15-2 | done   | Pure state machine (PR #905) |
| N15-3 | done   | Lifecycle + emitter + event-stream wiring (PR #908) |
| N15-4 | paused | `:routing/trigger-event-id` envelope addition — deferred pending architecture call |
| N15-5 | paused | Three new trigger event types — deferred pending architecture call |
| N15-6 | here   | Workspace attach wiring |
| N15-7 | paused | Optional: dashboard / TUI rendering — deferred to native-app surface |

The correlator's heuristic-fallback path (§3.5 case 2, 60 s correlation window
plus spec match) absorbs the N15-4/5 absence in v1 — every fallback fires with
a warn log so the operator can audit migration progress once those producer
components exist.

## Test plan

- [x] `bb poly:check` clean
- [x] `clj-kondo` clean on every touched file
- [x] Brick suite 49/113 green
- [x] `resume-test` 8/36 green with new correlator mocks

Generated with [Claude Code](https://claude.com/claude-code)