### PR TITLE
i18n(cli): localize remaining English literals in config.clj

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -573,6 +573,7 @@
   :config/title "Current Configuration:"
   :config/section-llm "LLM Settings:"
   :config/llm-backend "  backend: {backend} ({provider})"
+  :config/llm-backend-provider-unknown "Unknown"
   :config/llm-model "  model: {model}"
   :config/llm-max-tokens "  max-tokens: {max-tokens}"
   :config/llm-timeout "  timeout: {minutes} minutes"
@@ -626,6 +627,7 @@
   :config/validate-valid "✅ Config file is valid"
   :config/validate-location "   Location: {path}"
   :config/validate-backend-available "   Backend {backend}: {status}"
+  :config/validate-backend-status-available "Available"
   :config/validate-invalid "Config file is invalid or unreadable"
   :config/validate-reset-hint "Try resetting: {command}"
 

--- a/bases/cli/src/ai/miniforge/cli/config.clj
+++ b/bases/cli/src/ai/miniforge/cli/config.clj
@@ -139,9 +139,9 @@
   (println (messages/t :config/section-llm))
   (println (messages/t :config/llm-backend
                        {:backend (format-config-value (get-in config [:llm :backend]))
-                        :provider (get-in backends/backend-specs
-                                          [(get-in config [:llm :backend]) :provider]
-                                          (messages/t :config/llm-backend-provider-unknown))}))
+                        :provider (or (get-in backends/backend-specs
+                                              [(get-in config [:llm :backend]) :provider])
+                                      (messages/t :config/llm-backend-provider-unknown))}))
   (println (messages/t :config/llm-model {:model (get-in config [:llm :model])}))
   (println (messages/t :config/llm-max-tokens {:max-tokens (get-in config [:llm :max-tokens])}))
   (println (messages/t :config/llm-timeout {:minutes (quot (get-in config [:llm :timeout-ms]) 60000)}))

--- a/bases/cli/src/ai/miniforge/cli/config.clj
+++ b/bases/cli/src/ai/miniforge/cli/config.clj
@@ -139,7 +139,9 @@
   (println (messages/t :config/section-llm))
   (println (messages/t :config/llm-backend
                        {:backend (format-config-value (get-in config [:llm :backend]))
-                        :provider (get-in backends/backend-specs [(get-in config [:llm :backend]) :provider] "Unknown")}))
+                        :provider (get-in backends/backend-specs
+                                          [(get-in config [:llm :backend]) :provider]
+                                          (messages/t :config/llm-backend-provider-unknown))}))
   (println (messages/t :config/llm-model {:model (get-in config [:llm :model])}))
   (println (messages/t :config/llm-max-tokens {:max-tokens (get-in config [:llm :max-tokens])}))
   (println (messages/t :config/llm-timeout {:minutes (quot (get-in config [:llm :timeout-ms]) 60000)}))
@@ -335,7 +337,7 @@
                 (if (:valid? validation)
                   (println (messages/t :config/validate-backend-available
                                        {:backend (name backend)
-                                        :status (style "Available" :green)}))
+                                        :status (style (messages/t :config/validate-backend-status-available) :green)}))
                   (println (messages/t :config/validate-backend-available
                                        {:backend (name backend)
                                         :status (style (:message validation) :yellow)}))))))


### PR DESCRIPTION
## Summary
Localize cli/config.clj per .standards/foundations/localization.mdc.
- Added 2 keys under `:config/*` in `bases/cli/resources/config/cli/messages/en-US.edn` (`:config/llm-backend-provider-unknown`, `:config/validate-backend-status-available`).
- Migrated 2 raw English literals in `bases/cli/src/ai/miniforge/cli/config.clj` to `(messages/t …)` — the `"Unknown"` provider fallback in `display-config` and the `"Available"` backend-status label in `cmd-validate`.

The rest of `config.clj` was already localized; this PR closes the two remaining gaps caught by the standards drift scan. Output of `bb config list` and `bb config validate` is byte-identical to the previous implementation (verified via REPL smoke).

Note: this branch is cut from `origin/main`, parallel to #913 (which localized `cli/backends.clj`). Both PRs touch `en-US.edn`; expected merge conflict resolves cleanly (additive in disjoint regions of the catalog).

## Test plan
- [x] `bb pre-commit` passes (lint + 289 smoke tests + GraalVM compat)
- [x] catalog entries lint clean
- [x] `config.clj` smoke test — `display-config` and `cmd-validate` render identical output to pre-change behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)