### PR TITLE
fix(verify): bound verify test runner with destroyForcibly deadline

### DIFF
--- a/components/phase-software-factory/resources/config/phase/messages/en-US.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/en-US.edn
@@ -25,6 +25,7 @@
   :verify/output-unparseable  "Test output could not be parsed"
   :verify/gate-failed         "Gate validation failed"
   :verify/failed              "Verification failed"
+  :verify/timed-out           "Verify test runner timed out after {timeout-ms}ms (cmd: {test-cmd})"
 
   ;; Release phase
   :release/zero-files                   "Release phase received code artifact with zero files"

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -39,8 +39,19 @@
   (phase-config/defaults-for :verify))
 
 (def ^:private timeout-message-fragment
-  "Substring that marks a non-actionable verify timeout."
+  "Substring that marks a non-actionable verify timeout.
+   Produced by `run-tests!` when the test command exceeds its deadline,
+   and matched by `leave-verify` to skip the redirect-to-implement path
+   (retrying implement won't fix a stalled test process)."
   "timed out")
+
+(def default-test-timeout-ms
+  "Default wall-clock budget for `run-tests!` before the test process is
+   destroyed. Picked so an absent override still bounds the verify phase:
+   30 min covers slow Polylith suites + CI cold cache, but stops the
+   ~indefinite hangs seen when bb test blocks on Docker acquire or stdin.
+   Override per spec via :spec/test-timeout-ms or per phase-config."
+  (* 30 60 1000))
 
 (def ^:private verify-rate-limit-pattern
   "Pattern for non-actionable verify failures caused by provider throttling."
@@ -116,10 +127,19 @@
 (defn- verify-failure-message
   "Build the user-facing verify failure message from parsed test results."
   [test-results raw-fails raw-errors]
-  (if (:parse-error? test-results)
+  (cond
+    ;; Timeout: surface the formatted timeout output directly so the substring
+    ;; matched by `timeout-message-fragment` lands in the phase result, which
+    ;; routes leave-verify to the non-actionable path (no redirect-to-implement).
+    (:timed-out? test-results)
+    (str (:output test-results))
+
+    (:parse-error? test-results)
     (str (messages/t :verify/output-unparseable)
          (when-let [preview (not-empty (bounded-output-preview (:output test-results)))]
            (str "\n" preview)))
+
+    :else
     (messages/t :verify/tests-failed {:fail-count raw-fails :error-count raw-errors})))
 
 (defn infer-test-command
@@ -135,16 +155,40 @@
 (defn run-tests!
   "Run tests in the worktree. Infers the test command from the repo structure
    unless test-cmd is supplied explicitly.
+
+   Bounded by :timeout-ms (default `default-test-timeout-ms`). On timeout
+   the test process and its children are destroyed forcibly and a failed
+   result is returned whose :output contains `timeout-message-fragment` so
+   leave-verify routes it as a non-actionable verify failure rather than
+   redirecting back to implement.
+
    Returns parsed test results map."
-  [worktree-path & {:keys [test-cmd]}]
-  (let [cmd (or test-cmd (infer-test-command worktree-path))]
+  [worktree-path & {:keys [test-cmd timeout-ms]}]
+  (let [cmd        (or test-cmd (infer-test-command worktree-path))
+        timeout-ms (or timeout-ms default-test-timeout-ms)]
     (try
-      (let [result (process/shell
-                     {:dir (str worktree-path)
-                      :out :string :err :string :continue true}
-                     "sh" "-c" cmd)]
-        (parse-test-output (str (:out result "") "\n" (:err result ""))
-                           (:exit result 1)))
+      ;; process/process gives us a Process handle so we can apply our own
+      ;; deadline; process/shell only returns after the child exits and
+      ;; would block here indefinitely on a hung test command.
+      (let [proc     (process/process
+                       {:dir (str worktree-path)
+                        :out :string :err :string :continue true}
+                       "sh" "-c" cmd)
+            done-fut (future @proc)
+            done?    (not= ::timeout (deref done-fut timeout-ms ::timeout))]
+        (if done?
+          (let [result @done-fut]
+            (parse-test-output (str (:out result "") "\n" (:err result ""))
+                               (:exit result 1)))
+          (do
+            (.destroyForcibly ^Process (:proc proc))
+            ;; Let the destroyed process's reader threads finish so the
+            ;; future doesn't leak — bounded wait, ignore the result.
+            (try (deref done-fut 5000 nil) (catch Exception _))
+            (assoc (test-error-result
+                     (messages/t :verify/timed-out
+                                 {:timeout-ms timeout-ms :test-cmd cmd}))
+                   :timed-out? true))))
       (catch Exception e
         (test-error-result (.getMessage e))))))
 
@@ -193,6 +237,16 @@
         test-cmd (or (get-in ctx [:execution/input :spec/test-command])
                      (get-in ctx [:execution/input :test-command]))
 
+        ;; Wall-clock deadline for the test process. Spec wins, then
+        ;; phase-config, then a phase-level default. Without this bound
+        ;; a hung `bb test` (Docker acquire, stdin block, infinite loop)
+        ;; freezes the verify phase indefinitely with zero events —
+        ;; observed 2026-05-18 on workflow aadac7ce.
+        timeout-ms (or (get-in ctx [:execution/input :spec/test-timeout-ms])
+                       (get-in ctx [:execution/input :test-timeout-ms])
+                       (get config :timeout-ms)
+                       default-test-timeout-ms)
+
         ;; Run the test suite — inside capsule for governed mode, on host otherwise
         execute-fn (get ctx :execution/execute-fn)
         test-results (if (and (= :governed (get ctx :execution/mode))
@@ -203,7 +257,9 @@
                                               (get ctx :execution/environment-id)
                                               worktree-path
                                               :test-cmd test-cmd)
-                       (run-tests! worktree-path :test-cmd test-cmd))
+                       (run-tests! worktree-path
+                                   :test-cmd test-cmd
+                                   :timeout-ms timeout-ms))
 
         ;; Phase result carries environment reference and test metrics (N6 environment model).
         ;; No serialized code — changes live in the environment's worktree.

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -152,6 +152,20 @@
     (fs/exists? (fs/path worktree-path "package.json")) "npm test"
     :else "bb test"))
 
+(defn- destroy-process-tree!
+  "Forcefully kill `proc` and all of its descendants.
+
+   `.destroyForcibly` on a parent `sh -c ...` does NOT propagate to children,
+   so the JVM running `bb test` is left orphaned after we time out. Walks the
+   descendant tree explicitly (children first, then the parent) so we don't
+   leak processes or hold file/port locks across verify runs."
+  [^Process proc]
+  (try
+    (doseq [^java.lang.ProcessHandle child (.. proc descendants (toArray))]
+      (try (.destroyForcibly child) (catch Throwable _)))
+    (catch Throwable _))
+  (try (.destroyForcibly proc) (catch Throwable _)))
+
 (defn run-tests!
   "Run tests in the worktree. Infers the test command from the repo structure
    unless test-cmd is supplied explicitly.
@@ -181,10 +195,16 @@
             (parse-test-output (str (:out result "") "\n" (:err result ""))
                                (:exit result 1)))
           (do
-            (.destroyForcibly ^Process (:proc proc))
-            ;; Let the destroyed process's reader threads finish so the
-            ;; future doesn't leak — bounded wait, ignore the result.
-            (try (deref done-fut 5000 nil) (catch Exception _))
+            ;; .destroyForcibly on the `sh` parent does NOT reliably kill the
+            ;; test runner child (the actual JVM running `bb test`). Walk the
+            ;; descendant tree first so children die before the shell does;
+            ;; this is what produced the orphan polylith poly-cli process
+            ;; observed on 2026-05-18.
+            (destroy-process-tree! (:proc proc))
+            ;; Bounded wait for the reader threads to drain; if they don't,
+            ;; cancel the future so the thread doesn't leak across verify runs.
+            (when (= ::timeout (deref done-fut 5000 ::timeout))
+              (future-cancel done-fut))
             (assoc (test-error-result
                      (messages/t :verify/timed-out
                                  {:timeout-ms timeout-ms :test-cmd cmd}))
@@ -195,14 +215,35 @@
 (defn run-tests-in-capsule!
   "Run tests inside a task capsule via execute-fn (N11 §6).
    Routes the test command through the executor instead of host process/shell.
-   execute-fn is dag-exec/execute! passed through context to avoid cross-component requires."
-  [execute-fn executor env-id worktree-path & {:keys [test-cmd]}]
-  (let [cmd (or test-cmd "bb test")]
+   execute-fn is dag-exec/execute! passed through context to avoid cross-component requires.
+
+   Bounded by :timeout-ms (default `default-test-timeout-ms`) — passed
+   through to the capsule executor's `execute!` protocol which honours
+   the option per `dag-executor.protocols.executor/TaskExecutor`. Without
+   this bound a stuck `bb test` inside the capsule produced the same
+   silent verify hang seen on the host path."
+  [execute-fn executor env-id worktree-path & {:keys [test-cmd timeout-ms]}]
+  (let [cmd        (or test-cmd "bb test")
+        timeout-ms (or timeout-ms default-test-timeout-ms)]
     (try
-      (let [result (execute-fn executor env-id cmd {:workdir worktree-path})
-            data   (:data result)]
-        (parse-test-output (str (get data :stdout "") "\n" (get data :stderr ""))
-                           (get data :exit-code 1)))
+      (let [result (execute-fn executor env-id cmd
+                               {:workdir worktree-path
+                                :timeout-ms timeout-ms})
+            data   (:data result)
+            exit   (get data :exit-code 1)
+            parsed (parse-test-output (str (get data :stdout "") "\n" (get data :stderr ""))
+                                      exit)]
+        ;; Executors signal timeout via :timed-out? (or a sentinel exit) on
+        ;; the result. Surface it on the parsed map so leave-verify routes
+        ;; through the non-actionable path and doesn't redirect to implement.
+        (if (or (:timed-out? result)
+                (:timed-out? data))
+          (assoc parsed
+                 :passed? false
+                 :timed-out? true
+                 :output (messages/t :verify/timed-out
+                                     {:timeout-ms timeout-ms :test-cmd cmd}))
+          parsed))
       (catch Exception e
         (test-error-result (.getMessage e))))))
 
@@ -256,7 +297,8 @@
                                               (get ctx :execution/executor)
                                               (get ctx :execution/environment-id)
                                               worktree-path
-                                              :test-cmd test-cmd)
+                                              :test-cmd test-cmd
+                                              :timeout-ms timeout-ms)
                        (run-tests! worktree-path
                                    :test-cmd test-cmd
                                    :timeout-ms timeout-ms))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
@@ -23,6 +23,7 @@
    no tester agent. Tests here cover: environment-based test execution,
    fail-fast on missing environment-id, and pass/fail result shapes."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [ai.miniforge.phase-software-factory.verify :as verify]
    [ai.miniforge.phase.interface :as phase]
@@ -158,6 +159,104 @@
                         (assoc :phase-config {:phase :verify}))]
             (verify/enter-verify ctx)
             (is (= "/tmp/my-worktree" @captured-path))))))))
+
+;------------------------------------------------------------------------------ Verify-stall coverage
+;;
+;; Regression coverage for the 2026-05-18 dogfood incident on workflow
+;; aadac7ce. Verify entered, emitted :phase/milestone-started, then went
+;; silent for 30+ minutes because `run-tests!` shelled out to `bb test`
+;; without a deadline. The workflow had no events, no liveness signal, no
+;; recovery — exactly the failure class the running spec was meant to
+;; address for agent streams, surfacing in a sibling code path.
+;;
+;; These tests pin the timeout contract on run-tests! and the propagation
+;; through enter-verify and verify-failure-message into the phase result
+;; (so leave-verify's existing timeout-detection path becomes reachable
+;; instead of being silently dead code).
+
+(deftest run-tests-aborts-hung-process-within-timeout-test
+  (testing "run-tests! must destroy a hung test process when :timeout-ms elapses"
+    (let [t0      (System/currentTimeMillis)
+          ;; sleep 600 = a process that would block run-tests! indefinitely.
+          ;; Before the fix this assertion timed out the entire test run;
+          ;; after the fix the deadline destroys the child within ~1s.
+          result  (verify/run-tests! "/tmp" :test-cmd "sleep 600" :timeout-ms 750)
+          elapsed (- (System/currentTimeMillis) t0)]
+      (is (false? (:passed? result))
+          "a destroyed test process must produce a failed result")
+      (is (true? (:timed-out? result))
+          ":timed-out? sentinel must be set so downstream consumers can branch on cause")
+      (is (str/includes? (str (:output result)) "timed out")
+          ":output must contain the substring `timed out` so leave-verify routes correctly")
+      (is (< elapsed 5000)
+          (str "must abort within seconds, not block the workflow indefinitely "
+               "(elapsed: " elapsed "ms)")))))
+
+(deftest run-tests-honours-default-timeout-when-not-supplied-test
+  (testing "run-tests! falls back to default-test-timeout-ms when no :timeout-ms arg given"
+    ;; Pin the default to a positive number — protects against a refactor
+    ;; that nils the default and silently restores the unbounded behaviour
+    ;; that caused the 2026-05-18 verify hang.
+    (is (pos-int? verify/default-test-timeout-ms))
+    (is (<= verify/default-test-timeout-ms (* 60 60 1000))
+        "default must stay under 1 hour — otherwise a hang still freezes the workflow for too long")))
+
+(deftest enter-verify-propagates-spec-test-timeout-test
+  (testing "enter-verify threads :spec/test-timeout-ms from :execution/input into run-tests!"
+    (let [captured-opts (atom nil)
+          run-var       (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
+      (with-redefs-fn
+        {run-var (fn [_path & opts]
+                   (reset! captured-opts (apply hash-map opts))
+                   {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
+        (fn []
+          (let [ctx (-> (create-base-context)
+                        (assoc-in [:execution/input :spec/test-timeout-ms] 12345)
+                        (assoc :phase-config {:phase :verify}))]
+            (verify/enter-verify ctx)
+            (is (= 12345 (:timeout-ms @captured-opts))
+                (str ":spec/test-timeout-ms must flow into run-tests! — "
+                     "the spec is the user-facing budget surface for the verify deadline"))))))))
+
+(deftest enter-verify-uses-default-timeout-when-no-override-test
+  (testing "enter-verify falls back to default-test-timeout-ms when neither spec nor config sets one"
+    (let [captured-opts (atom nil)
+          run-var       (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
+      (with-redefs-fn
+        {run-var (fn [_path & opts]
+                   (reset! captured-opts (apply hash-map opts))
+                   {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
+        (fn []
+          (let [ctx (-> (create-base-context)
+                        (assoc :phase-config {:phase :verify}))]
+            (verify/enter-verify ctx)
+            (is (= verify/default-test-timeout-ms (:timeout-ms @captured-opts))
+                "default deadline must be applied even when spec is silent")))))))
+
+(deftest enter-verify-timed-out-result-includes-fragment-test
+  (testing "a :timed-out? test result becomes a phase result whose summary contains `timed out`"
+    ;; This is the wiring leave-verify depends on: it scans result :error :message
+    ;; for `timeout-message-fragment` to skip the redirect-to-implement path.
+    ;; If the fragment doesn't survive into the phase result, the dead-code
+    ;; detection in leave-verify stays dead and timeouts get treated as
+    ;; ordinary test failures (and route back to implement — wasting tokens).
+    (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
+      (with-redefs-fn
+        {run-var (fn [_path & _opts]
+                   {:passed? false :test-count 0 :assertion-count 0
+                    :fail-count 0 :error-count 1
+                    :timed-out? true
+                    :output "Verify test runner timed out after 1000ms (cmd: bb test)"})}
+        (fn []
+          (let [ctx (-> (create-base-context)
+                        (assoc :phase-config {:phase :verify}))
+                ctx-after (verify/enter-verify ctx)
+                result (get-in ctx-after [:phase :result])]
+            (is (= :error (:status result)))
+            (is (str/includes? (str (:summary result)) "timed out")
+                ":summary must carry the `timed out` fragment")
+            (is (str/includes? (str (get-in result [:error :message])) "timed out")
+                ":error :message must carry the fragment — leave-verify branches on this")))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
@@ -233,6 +233,60 @@
             (is (= verify/default-test-timeout-ms (:timeout-ms @captured-opts))
                 "default deadline must be applied even when spec is silent")))))))
 
+(deftest run-tests-kills-child-process-not-just-shell-test
+  (testing "destroy-process-tree! kills `sh -c <cmd>` AND its descendant test runner"
+    ;; `sh -c "sleep 600"` forks sleep as a child; .destroyForcibly on the
+    ;; sh parent does not propagate to sleep, so the production code used
+    ;; to leak the actual test-runner process after a verify timeout.
+    ;; This is what we observed as PID 31181 still alive 30+ min after
+    ;; killing the parent. After the fix the descendant tree is walked
+    ;; first, so no PID survives.
+    (let [;; sleep 7200 in the shell so the test fails red if the tree
+          ;; isn't actually killed (CI noticing a 2h orphan process).
+          result (verify/run-tests! "/tmp" :test-cmd "sleep 7200" :timeout-ms 500)]
+      (is (true? (:timed-out? result)))
+      ;; Give the OS a beat to reap.
+      (Thread/sleep 250)
+      ;; Walk the JVM's current process descendants — no `sleep 7200` should remain.
+      (let [orphans (->> (.. (java.lang.ProcessHandle/current) descendants (toArray))
+                         (filter (fn [^java.lang.ProcessHandle ph]
+                                   (some-> ph .info .command .get
+                                           (clojure.string/includes? "sleep")))))]
+        (is (empty? orphans)
+            (str "destroy-process-tree! must reap every descendant sleep process; "
+                 "found " (count orphans) " orphan(s)"))))))
+
+(deftest run-tests-in-capsule-passes-timeout-to-execute-fn-test
+  (testing "run-tests-in-capsule! threads :timeout-ms into execute-fn opts so capsule executors honour it"
+    ;; Governed-mode parity: without this, a hung `bb test` inside a
+    ;; capsule produces the same silent verify hang we saw on the host
+    ;; path on 2026-05-18. The Copilot review on PR #915 flagged this
+    ;; explicitly.
+    (let [captured-opts (atom nil)
+          execute-fn    (fn [_executor _env-id _cmd opts]
+                          (reset! captured-opts opts)
+                          {:data {:stdout "Ran 1 tests containing 1 assertions.\n0 failures, 0 errors."
+                                  :stderr ""
+                                  :exit-code 0}})]
+      (verify/run-tests-in-capsule! execute-fn :exec :env "/tmp"
+                                    :test-cmd "bb test"
+                                    :timeout-ms 123456)
+      (is (= 123456 (:timeout-ms @captured-opts))
+          ":timeout-ms must reach the executor's execute! opts"))))
+
+(deftest run-tests-in-capsule-surfaces-executor-timeout-as-timed-out-test
+  (testing "an executor that returns :timed-out? gets routed as a timeout on the result"
+    (let [execute-fn (fn [_ _ _ _]
+                       {:data {:stdout "" :stderr "" :exit-code 124}
+                        :timed-out? true})
+          result     (verify/run-tests-in-capsule! execute-fn :exec :env "/tmp"
+                                                   :test-cmd "bb test"
+                                                   :timeout-ms 1000)]
+      (is (true? (:timed-out? result))
+          ":timed-out? from the executor must survive parsing")
+      (is (str/includes? (str (:output result)) "timed out")
+          ":output must carry the timeout fragment so leave-verify routes correctly"))))
+
 (deftest enter-verify-timed-out-result-includes-fragment-test
   (testing "a :timed-out? test result becomes a phase result whose summary contains `timed out`"
     ;; This is the wiring leave-verify depends on: it scans result :error :message


### PR DESCRIPTION
## Summary

- Adds a wall-clock deadline to `run-tests!` in the verify phase — default 30 min, overridable via `:spec/test-timeout-ms`. On timeout the test process is destroyed forcibly and a failed result is returned that surfaces the substring `timed out` for `leave-verify`'s existing non-actionable-failure path to detect.
- Wires the timeout through `enter-verify` (spec → phase-config → default).
- Updates `verify-failure-message` so `:timed-out?` results propagate the timeout substring into the phase result's `:summary` and `:error :message` (previously the substring lived only in `:output` and never reached the surface where `leave-verify` scans).
- Pinning regression tests reproduce the failure mode and pin the spec/default propagation.

## What actually happened (2026-05-18, workflow aadac7ce, DAG task-227a6b0b)

I initially told the user this was a 30-minute test run. Re-checked against file mtimes in the DAG task worktree:

| Time     | Evidence                                  |
| -------- | ----------------------------------------- |
| 10:24:08 | `:phase/milestone-started` for verify     |
| 10:24:10 | `.cpcache/{cp,basis,main}` written (~2s)  |
| 10:27:50 | `.miniforge/index/…edn` written (~3:40)   |
| 10:27:50 → 10:54+ | nothing for 26+ minutes          |

So the test runner *did* spawn, made progress for ~3:40 (Clojure deps resolved, repo indexing finished), then hung for 26 minutes on something inside the test phase — almost certainly `workflow.runner-extended-test`'s Docker acquire (the same path PR #897 mocked). The task worktree was branched from main *before* #897 landed, so the broken acquisition path was reachable.

**This was a hang inside the test runner, not a 30-min test run.** Either way, `enter-verify`'s synchronous `process/shell "bb test"` with no deadline meant the workflow had no escape: zero events after `:phase/milestone-started`, no liveness signal, no recovery.

## Why now

Same failure class as the spec we were dogfooding (agent-stream stall) — synchronous I/O wait with no telemetry — surfacing in a sibling code path. The watchdog work continues separately for the agent side; this PR closes the test-runner hole.

A second bug surfaced under investigation: `leave-verify` already has a code path for `timeout?` (line 244 of `verify.clj`) — but **nothing was producing the substring it scans for**, so the path was dead code. This PR makes it reachable.

## Tests

Five new pins in `verify_test.clj`:

- `run-tests-aborts-hung-process-within-timeout-test` — `sleep 600` with `:timeout-ms 750` must abort within seconds and set `:timed-out?` + the substring. This is the direct reproducer for the observed failure mode.
- `run-tests-honours-default-timeout-when-not-supplied-test` — `default-test-timeout-ms` must remain a positive int under 1 hour.
- `enter-verify-propagates-spec-test-timeout-test` — `:spec/test-timeout-ms` flows from spec into `run-tests!`.
- `enter-verify-uses-default-timeout-when-no-override-test` — default applies when spec is silent.
- `enter-verify-timed-out-result-includes-fragment-test` — `:timed-out?` results carry the substring all the way through into the phase result's `:summary` and `:error :message`.

## Test plan

- [x] `bb test:poly project:miniforge brick:phase-software-factory` — 132 tests, 0 failures
- [x] `bb pre-commit` — 289 tests / 1017 assertions, 0 failures
- [x] `bb lint:clj` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)