### PR TITLE
GROUP 1+4 foundation: Add new event constructors to event-stream...

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -499,7 +499,9 @@
           redirect-to (assoc :phase/redirect-to redirect-to)
           (:tokens result) (assoc :phase/tokens (:tokens result))
           (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))
-          (:meta result) (assoc :phase/meta (:meta result))))))
+          (:meta result) (assoc :phase/meta (:meta result))
+          (:phase/termination-reason result)
+          (assoc :phase/termination-reason (:phase/termination-reason result))))))
 
 (defn workspace-persisted
   "Build a :workspace/persisted event recording that a phase's worktree was
@@ -1318,6 +1320,34 @@
                        (str "Meta-loop cycle failed: " (ex-message error)))
       (assoc :meta-loop/error (ex-message error)
              :meta-loop/error-class (.getName (class error)))))
+
+;------------------------------------------------------------------------------ Layer 6.5
+;; Agent stream-stall events (GROUP 1+4)
+
+(defn agent-stream-stalled
+  "Build an :agent/stream-stalled event indicating the agent output stream
+   has gone silent beyond the configured gap threshold.
+
+   Consumed by the self-healing supervisor to decide whether to kill the
+   hung backend process and retry on the next eligible backend.
+
+   Arguments:
+   - stream:          event-stream atom
+   - workflow-id:     owning workflow UUID
+   - phase-id:        keyword identifying the current phase (e.g. :implement)
+   - gap-duration-ms: measured silence gap in milliseconds
+   - backend:         keyword identifying the backend (:codex, :claude, etc.)
+
+   Valid `:phase/termination-reason` enum values for `phase-completed`:
+     :agent-stalled, :curator-rejected, :tool-error, :normal"
+  [stream workflow-id phase-id gap-duration-ms backend]
+  (-> (create-envelope stream :agent/stream-stalled workflow-id
+                       (str "Agent stream stalled in " (name phase-id)
+                            " after " gap-duration-ms "ms"
+                            " (backend: " (name backend) ")"))
+      (assoc :phase/id phase-id
+             :stream/gap-duration-ms gap-duration-ms
+             :agent/backend backend)))
 
 ;------------------------------------------------------------------------------ Layer 7
 ;; Observer / knowledge failure events

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1345,7 +1345,7 @@
                        (str "Agent stream stalled in " (name phase-id)
                             " after " gap-duration-ms "ms"
                             " (backend: " (name backend) ")"))
-      (assoc :phase/id phase-id
+      (assoc :workflow/phase phase-id
              :stream/gap-duration-ms gap-duration-ms
              :agent/backend backend)))
 

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -353,6 +353,12 @@
    {:constructor "phase-heartbeat"
     :event-type  :workflow/phase-heartbeat
     :json-string "workflow/phase-heartbeat"
+    :browser?    false}
+
+   ;; GROUP 1+4 agent stream-stall events
+   {:constructor "agent-stream-stalled"
+    :event-type  :agent/stream-stalled
+    :json-string "agent/stream-stalled"
     :browser?    false}])
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -404,7 +410,7 @@
 ;; Audit summary (machine-readable)
 
 (def audit-summary
-  {:audit/date          "2026-03-28"
+  {:audit/date          "2026-05-19"
    :audit/source-server "components/event-stream/src/ai/miniforge/event_stream/interface/events.clj"
    :audit/source-browser "components/web-dashboard/resources/public/js/app.js"
    :audit/browser-switch "handleWorkflowEvent"

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -183,6 +183,9 @@
 (def knowledge-synthesis-failed events/knowledge-synthesis-failed)
 (def knowledge-promotion-failed events/knowledge-promotion-failed)
 
+;; Agent stream-stall events (GROUP 1+4)
+(def agent-stream-stalled events/agent-stream-stalled)
+
 ;------------------------------------------------------------------------------ Layer 4
 ;; Event-stream reader — replay events from the file-sink layout
 

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -124,3 +124,8 @@
 (def observer-signal-failed core/observer-signal-failed)
 (def knowledge-synthesis-failed core/knowledge-synthesis-failed)
 (def knowledge-promotion-failed core/knowledge-promotion-failed)
+
+;------------------------------------------------------------------------------ Layer 3.5
+;; Agent stream-stall event constructors (GROUP 1+4)
+
+(def agent-stream-stalled core/agent-stream-stalled)

--- a/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
@@ -1,0 +1,153 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.stall-events-test
+  "Tests for GROUP 1+4 foundation: agent-stream-stalled constructor and
+   phase-completed :phase/termination-reason extension."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.event-stream.interface :as events-iface]
+   [ai.miniforge.event-stream.interface.events :as events]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn no-op-stream
+  "Create a stream with no sinks — event constructors only build maps."
+  []
+  (core/create-event-stream {:sinks []}))
+
+;------------------------------------------------------------------------------ agent-stream-stalled
+
+(deftest agent-stream-stalled-type-test
+  (testing "event type is :agent/stream-stalled"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
+      (is (= :agent/stream-stalled (:event/type event))))))
+
+(deftest agent-stream-stalled-fields-test
+  (testing "carries phase-id, gap-duration-ms, and backend"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
+      (is (= :implement (:phase/id event)))
+      (is (= 95000 (:stream/gap-duration-ms event)))
+      (is (= :codex (:agent/backend event)))))
+
+  (testing "workflow-id is propagated"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :verify 120000 :claude)]
+      (is (= wf-id (:workflow/id event)))))
+
+  (testing "message includes phase-id and gap-duration"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :plan 88000 :claude)]
+      (is (string? (:message event)))
+      (is (re-find #"plan" (:message event)))
+      (is (re-find #"88000" (:message event)))))
+
+  (testing "envelope fields are present"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :implement 90001 :codex)]
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= core/event-version (:event/version event)))
+      (is (number? (:event/sequence-number event))))))
+
+(deftest agent-stream-stalled-works-with-any-backend-test
+  (testing "backend keyword is preserved as-is"
+    (doseq [backend [:codex :claude :openai :local]]
+      (let [stream (no-op-stream)
+            event  (core/agent-stream-stalled stream (random-uuid) :implement 90000 backend)]
+        (is (= backend (:agent/backend event)))))))
+
+;------------------------------------------------------------------------------ phase-completed :phase/termination-reason
+
+(deftest phase-completed-termination-reason-test
+  (testing "termination-reason :normal is passed through"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :implement
+                                       {:outcome :success
+                                        :phase/termination-reason :normal})]
+      (is (= :normal (:phase/termination-reason event)))))
+
+  (testing "termination-reason :agent-stalled is passed through"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :implement
+                                       {:outcome :failure
+                                        :phase/termination-reason :agent-stalled})]
+      (is (= :agent-stalled (:phase/termination-reason event)))))
+
+  (testing "termination-reason :curator-rejected is passed through"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :verify
+                                       {:outcome :failure
+                                        :phase/termination-reason :curator-rejected})]
+      (is (= :curator-rejected (:phase/termination-reason event)))))
+
+  (testing "termination-reason :tool-error is passed through"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :implement
+                                       {:outcome :failure
+                                        :phase/termination-reason :tool-error})]
+      (is (= :tool-error (:phase/termination-reason event)))))
+
+  (testing "absence of termination-reason leaves key absent"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :plan {:outcome :success})]
+      (is (not (contains? event :phase/termination-reason)))))
+
+  (testing "termination-reason does not displace existing result fields"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :implement
+                                       {:outcome :success
+                                        :duration-ms 4200
+                                        :phase/termination-reason :normal})]
+      (is (= :success (:phase/outcome event)))
+      (is (= 4200 (:phase/duration-ms event)))
+      (is (= :normal (:phase/termination-reason event))))))
+
+;------------------------------------------------------------------------------ Re-export verification
+
+(deftest interface-events-re-export-test
+  (testing "agent-stream-stalled is exported through interface.events"
+    (is (fn? events/agent-stream-stalled)))
+
+  (testing "agent-stream-stalled is exported through interface"
+    (is (fn? events-iface/agent-stream-stalled)))
+
+  (testing "re-exported function produces the same result as core"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          direct (core/agent-stream-stalled stream wf-id :implement 90000 :codex)
+          via-if (events/agent-stream-stalled stream wf-id :implement 90000 :codex)]
+      ;; Type, phase, gap, and backend must match; ids and timestamps differ
+      (is (= (:event/type direct) (:event/type via-if)))
+      (is (= (:phase/id direct) (:phase/id via-if)))
+      (is (= (:stream/gap-duration-ms direct) (:stream/gap-duration-ms via-if)))
+      (is (= (:agent/backend direct) (:agent/backend via-if))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
@@ -42,11 +42,11 @@
       (is (= :agent/stream-stalled (:event/type event))))))
 
 (deftest agent-stream-stalled-fields-test
-  (testing "carries phase-id, gap-duration-ms, and backend"
+  (testing "carries workflow-phase, gap-duration-ms, and backend"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
           event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
-      (is (= :implement (:phase/id event)))
+      (is (= :implement (:workflow/phase event)))
       (is (= 95000 (:stream/gap-duration-ms event)))
       (is (= :codex (:agent/backend event)))))
 
@@ -148,6 +148,6 @@
           via-if (events/agent-stream-stalled stream wf-id :implement 90000 :codex)]
       ;; Type, phase, gap, and backend must match; ids and timestamps differ
       (is (= (:event/type direct) (:event/type via-if)))
-      (is (= (:phase/id direct) (:phase/id via-if)))
+      (is (= (:workflow/phase direct) (:workflow/phase via-if)))
       (is (= (:stream/gap-duration-ms direct) (:stream/gap-duration-ms via-if)))
       (is (= (:agent/backend direct) (:agent/backend via-if))))))

--- a/docs/pull-requests/2026-05-18-group-1-4-foundation-add-new-event-constructors-to-event-stream.md
+++ b/docs/pull-requests/2026-05-18-group-1-4-foundation-add-new-event-constructors-to-event-stream.md
@@ -1,0 +1,30 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 1+4 foundation: Add new event constructors to event-stream...
+
+**PR:** [#917](https://github.com/miniforge-ai/miniforge/pull/917)
+**Branch:** `mf/group-14-foundation-add-new-event-constr-67d46e01`
+
+## Summary
+
+GROUP 1+4 foundation: Add new event constructors to event-stream component and config key.
+
+## Files Changed
+
+- `components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj` (create)
+- `components/event-stream/src/ai/miniforge/event_stream/core.clj` (modify)
+- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` (modify)
+- `components/event-stream/src/ai/miniforge/event_stream/interface/events.clj` (modify)
+- `resources/config/default-user-config.edn` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -47,8 +47,8 @@
                  :agent/stream-gap-threshold-ms 90000
                  ;; Per-backend overrides for the gap threshold. Keys are backend
                  ;; keywords; values are millisecond integers. Empty by default.
-                 ;; Example: {:codex 120000} gives Codex 2 extra minutes before
-                 ;; stall detection fires.
+                 ;; Example: {:codex 210000} gives Codex 2 extra minutes
+                 ;; (210s total) before stall detection fires.
                  :agent/per-backend-gap-thresholds {}}
   :governance {:readiness {}
                :risk {}

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -39,7 +39,17 @@
                  :backend-health-threshold 0.90
                  :backend-switch-cooldown-ms 1800000
                  :allowed-failover-backends [:claude :codex]
-                 :max-cost-per-workflow nil}
+                 :max-cost-per-workflow nil
+                 ;; Agent output-stream gap threshold. If no output line is received
+                 ;; from the backend process for this many milliseconds, a
+                 ;; :agent/stream-stalled event is emitted and self-healing may
+                 ;; terminate and retry the phase on a fallback backend.
+                 :agent/stream-gap-threshold-ms 90000
+                 ;; Per-backend overrides for the gap threshold. Keys are backend
+                 ;; keywords; values are millisecond integers. Empty by default.
+                 ;; Example: {:codex 120000} gives Codex 2 extra minutes before
+                 ;; stall detection fires.
+                 :agent/per-backend-gap-thresholds {}}
   :governance {:readiness {}
                :risk {}
                :tiers {}


### PR DESCRIPTION
## Summary

GROUP 1+4 foundation for agent stream-stall detection and self-healing. Adds the `:agent/stream-stalled` event constructor (and its `interface` + `interface/events` re-exports), extends `phase-completed` with the `:phase/termination-reason` field (`:agent-stalled` / `:curator-rejected` / `:tool-error` / `:normal`), and lands the `:agent/stream-gap-threshold-ms` + `:agent/per-backend-gap-thresholds` keys in `default-user-config.edn` so downstream GROUP 1 / GROUP 4 work can wire up the watchdog and the phase-software-factory plumbing.

- Constructor uses `:workflow/phase` (matches phase-started / phase-completed / phase-heartbeat); registered in `event_type_registry.clj`.
- Default gap threshold is 90 s, per-backend overrides default to `{}`.
- Test suite covers field shape, type tag, message format, envelope fields, all four termination-reason enum values, absence semantics, and the re-export from `interface.events`.

## Files Changed

- `components/event-stream/src/ai/miniforge/event_stream/core.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/interface/events.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj` (modify)
- `components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj` (create)
- `resources/config/default-user-config.edn` (modify)

## Test Plan

- [x] `bb pre-commit` — clean (lint, format, smoke 14ns / 289 tests / 1017 assertions, GraalVM compatibility)
- [x] `ai.miniforge.event-stream.stall-events-test` — 5 tests, 30 assertions, 0 failures
- [x] `clojure -M:poly test brick:event-stream` — clean across event-stream brick

## Review

Copilot review pass (5 inline threads) addressed in 3193adb6:

- Stall event re-keyed to `:workflow/phase` (was `:phase/id`) to match this component's existing phase-correlation convention.
- `event_type_registry.clj` extended with the new `agent-stream-stalled` row so the registry stays in sync with `interface/events.clj`.
- Default-config comment math fixed: `{:codex 120000}` is +30 s, not +2 min; example bumped to `{:codex 210000}` to actually mean +2 min.
- Stall-events tests updated to assert the new key.

## Authorship

- Generated by **Heimdall** (Miniforge phase-software-factory agent) on 2026-05-19 in its `verify` phase. Commit message and PR template are the verify-step artifacts.
- Copilot review pass + body backfill by Claude Code on behalf of @ChristopherLester. Commit `3193adb6` carries the review-pass fixes; original Heimdall verify commit is `2ab7262f`.

<details>
<summary>Original Heimdall PR template</summary>

**PR:** [#917](https://github.com/miniforge-ai/miniforge/pull/917)
**Branch:** `mf/group-14-foundation-add-new-event-constr-67d46e01`

Test Results and Review Decision sections were left as `_No * available._` placeholders by the Heimdall template; backfilled above.

</details>