### PR TITLE
GROUP 1 core: Per-phase event-gap watchdog timer in agent component.

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -31,6 +31,7 @@
    [ai.miniforge.agent.interface.runtime :as runtime]
    [ai.miniforge.agent.interface.specialized :as specialized]
    [ai.miniforge.agent.interface.supervision :as supervision]
+   [ai.miniforge.agent.interface.watchdog :as watchdog]
    [ai.miniforge.agent.tool-supervisor :as tool-supervisor]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -208,3 +209,13 @@
 (def hook-eval-stdin!
   "CLI entry point for tool-use evaluation from stdin."
   tool-supervisor/hook-eval-stdin!)
+
+;------------------------------------------------------------------------------ Layer 4
+;; Stream-gap watchdog
+
+(def resolve-gap-threshold watchdog/resolve-gap-threshold)
+(def default-gap-threshold-ms watchdog/default-gap-threshold-ms)
+(def create-watchdog watchdog/create-watchdog)
+(def reset-watchdog! watchdog/reset!)
+(def stop-watchdog! watchdog/stop!)
+(def watchdog-stalled? watchdog/stalled?)

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -198,7 +198,7 @@
    paths-as-metadata and the worktree has since been committed clean."
   file-artifacts/rehydrate-files)
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 4
 ;; Tool supervision
 
 (def evaluate-tool-use
@@ -210,12 +210,13 @@
   "CLI entry point for tool-use evaluation from stdin."
   tool-supervisor/hook-eval-stdin!)
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 5
 ;; Stream-gap watchdog
 
 (def resolve-gap-threshold watchdog/resolve-gap-threshold)
 (def default-gap-threshold-ms watchdog/default-gap-threshold-ms)
+(def default-check-interval-ms watchdog/default-check-interval-ms)
 (def create-watchdog watchdog/create-watchdog)
-(def reset-watchdog! watchdog/reset!)
+(def ping-watchdog! watchdog/ping!)
 (def stop-watchdog! watchdog/stop!)
 (def watchdog-stalled? watchdog/stalled?)

--- a/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
@@ -19,7 +19,7 @@
 (ns ai.miniforge.agent.interface.watchdog
   "Public boundary for the per-phase stream-gap watchdog.
 
-   Re-exports the four primary operations and the config helper from
+   Re-exports the five primary operations and the config helper from
    ai.miniforge.agent.stream-watchdog.
 
    Usage:
@@ -33,7 +33,7 @@
                  :workflow-id  workflow-id
                  :kill-fn      kill-subprocess!})]
        ;; on every agent event:
-       (watchdog/reset! wd)
+       (watchdog/ping! wd)
        ;; on normal completion:
        (watchdog/stop! wd)
        ;; to check for stall:
@@ -53,6 +53,10 @@
   "Default stream-gap threshold in ms (90 000)."
   watchdog/default-gap-threshold-ms)
 
+(def default-check-interval-ms
+  "Default watchdog check interval in ms (5 000)."
+  watchdog/default-check-interval-ms)
+
 ;; ---------------------------------------------------------------------------
 ;; Watchdog lifecycle
 
@@ -61,10 +65,11 @@
    See `ai.miniforge.agent.stream-watchdog/create-watchdog`."
   watchdog/create-watchdog)
 
-(def reset!
+(def ping!
   "Record a new agent event, resetting the gap timer.
-   See `ai.miniforge.agent.stream-watchdog/reset!`."
-  watchdog/reset!)
+   Named ping! (not reset!) to avoid shadowing clojure.core/reset!.
+   See `ai.miniforge.agent.stream-watchdog/ping!`."
+  watchdog/ping!)
 
 (def stop!
   "Gracefully shut down the watchdog scheduler.

--- a/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.interface.watchdog
+  "Public boundary for the per-phase stream-gap watchdog.
+
+   Re-exports the four primary operations and the config helper from
+   ai.miniforge.agent.stream-watchdog.
+
+   Usage:
+     (require '[ai.miniforge.agent.interface.watchdog :as watchdog])
+
+     (let [wd (watchdog/create-watchdog
+                {:threshold-ms (watchdog/resolve-gap-threshold config :claude-code)
+                 :phase-id     :implement
+                 :backend      :claude-code
+                 :event-stream event-stream
+                 :workflow-id  workflow-id
+                 :kill-fn      kill-subprocess!})]
+       ;; on every agent event:
+       (watchdog/reset! wd)
+       ;; on normal completion:
+       (watchdog/stop! wd)
+       ;; to check for stall:
+       (watchdog/stalled? wd))"
+  (:require
+   [ai.miniforge.agent.stream-watchdog :as watchdog]))
+
+;; ---------------------------------------------------------------------------
+;; Config helpers
+
+(def resolve-gap-threshold
+  "Resolve the stream-gap threshold (ms) for a backend.
+   See `ai.miniforge.agent.stream-watchdog/resolve-gap-threshold`."
+  watchdog/resolve-gap-threshold)
+
+(def default-gap-threshold-ms
+  "Default stream-gap threshold in ms (90 000)."
+  watchdog/default-gap-threshold-ms)
+
+;; ---------------------------------------------------------------------------
+;; Watchdog lifecycle
+
+(def create-watchdog
+  "Create and start a stream-gap watchdog.
+   See `ai.miniforge.agent.stream-watchdog/create-watchdog`."
+  watchdog/create-watchdog)
+
+(def reset!
+  "Record a new agent event, resetting the gap timer.
+   See `ai.miniforge.agent.stream-watchdog/reset!`."
+  watchdog/reset!)
+
+(def stop!
+  "Gracefully shut down the watchdog scheduler.
+   See `ai.miniforge.agent.stream-watchdog/stop!`."
+  watchdog/stop!)
+
+(def stalled?
+  "Return true if the watchdog fired and killed the agent subprocess.
+   See `ai.miniforge.agent.stream-watchdog/stalled?`."
+  watchdog/stalled?)

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -80,23 +80,27 @@
 
    nil event-stream is treated as a legal no-op (useful in tests and in early
    pipeline stages that have not yet wired an event-stream). Any emission error
-   is caught and logged so the watchdog thread cannot crash."
-  [event-stream workflow-id phase-id backend logger]
+   is caught and logged so the watchdog thread cannot crash.
+
+   Uses the `agent-stream-stalled` constructor from `event-stream.interface`
+   (added in PR #917 / GROUP 1+4 foundation) so the envelope, sequence
+   numbering, and `:workflow/phase` correlation key stay consistent with the
+   rest of the event-stream component."
+  [event-stream workflow-id phase-id gap-duration-ms backend logger]
   (if-not event-stream
-    (log/warn logger "stream-watchdog: no event-stream configured; stall event suppressed"
-              {:phase-id phase-id :backend backend})
+    (log/debug logger :stream-watchdog :stall-event/suppressed
+               {:reason :no-event-stream
+                :workflow/phase phase-id
+                :agent/backend backend})
     (try
-      (let [envelope (event-stream/create-envelope
-                      event-stream
-                      :agent/stream-stalled
-                      {:phase/id          phase-id
-                       :agent/backend     backend
-                       :event/workflow-id workflow-id}
-                      {})]
+      (let [envelope (event-stream/agent-stream-stalled
+                      event-stream workflow-id phase-id gap-duration-ms backend)]
         (event-stream/publish! event-stream envelope))
       (catch Exception ex
-        (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
-                  {:phase-id phase-id :backend backend :error (ex-message ex)})))))
+        (log/warn logger :stream-watchdog :stall-event/emit-failed
+                  {:workflow/phase phase-id
+                   :agent/backend backend
+                   :error (ex-message ex)})))))
 
 (defn- build-check-task
   "Build the Runnable that the scheduler fires every check interval.
@@ -114,22 +118,26 @@
       (when-not (.isShutdown scheduler)
         (let [gap (- (System/currentTimeMillis) (.get last-event-ts))]
           (when (> gap threshold-ms)
-            (log/warn logger "stream-watchdog: gap exceeded threshold — killing agent"
-                      {:gap-ms gap :threshold-ms threshold-ms
-                       :phase-id phase-id :backend backend})
+            (log/warn logger :stream-watchdog :stream/gap-exceeded
+                      {:stream/gap-duration-ms gap
+                       :stream/gap-threshold-ms threshold-ms
+                       :workflow/phase phase-id
+                       :agent/backend backend})
             ;; a. kill the subprocess
             (try (kill-fn)
                  (catch Exception ex
-                   (log/warn logger "stream-watchdog: kill-fn threw"
-                             {:error (ex-message ex)})))
+                   (log/warn logger :stream-watchdog :stream/kill-fn-failed
+                             {:workflow/phase phase-id
+                              :agent/backend backend
+                              :error (ex-message ex)})))
             ;; b. emit stall event (nil-safe)
-            (emit-stall-event! event-stream workflow-id phase-id backend logger)
+            (emit-stall-event! event-stream workflow-id phase-id gap backend logger)
             ;; c. mark stalled
             (clojure.core/reset! stalled-atom true)
             ;; d. shut down scheduler — non-blocking, safe from own thread
             (.shutdown scheduler))))
       (catch Exception ex
-        (log/error logger "stream-watchdog: unhandled error in check task"
+        (log/error logger :stream-watchdog :check-task/unhandled-error
                    {:error (ex-message ex)})))))
 
 (defn create-watchdog

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -1,0 +1,220 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.stream-watchdog
+  "Per-phase event-gap watchdog timer.
+
+   Detects agent stream stalls by tracking the timestamp of the most recent
+   event emission and firing a kill signal when the gap exceeds a configurable
+   threshold. Runs on a dedicated ScheduledExecutorService daemon thread — never
+   blocks event emission on the hot path.
+
+   Layer 0: Config helpers (resolve-gap-threshold)
+   Layer 1: Watchdog lifecycle (create-watchdog, reset!, stop!, stalled?)"
+  (:require
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.logging.interface :as log])
+  (:import
+   (java.util.concurrent Executors ScheduledExecutorService TimeUnit)
+   (java.util.concurrent.atomic AtomicLong)))
+
+;; ---------------------------------------------------------------------------
+;; Layer 0 — configuration helpers
+
+(def ^:const default-gap-threshold-ms
+  "Default stream-gap threshold in milliseconds (90 seconds)."
+  90000)
+
+(def ^:const check-interval-seconds
+  "How often the scheduled watcher fires, in seconds."
+  5)
+
+(defn resolve-gap-threshold
+  "Resolve the stream-gap threshold in ms for a given backend.
+
+   Precedence (highest wins):
+     1. backend-specific entry in :agent/per-backend-gap-thresholds
+     2. global :agent/stream-gap-threshold-ms in config
+     3. `default-gap-threshold-ms` (90 000 ms)
+
+   Example config:
+     {:agent/stream-gap-threshold-ms 60000
+      :agent/per-backend-gap-thresholds {:claude-code 120000}}"
+  [config backend]
+  (let [base      (get config :agent/stream-gap-threshold-ms default-gap-threshold-ms)
+        overrides (get config :agent/per-backend-gap-thresholds {})]
+    (get overrides backend base)))
+
+;; ---------------------------------------------------------------------------
+;; Layer 1 — watchdog lifecycle
+
+(defn- daemon-thread-factory
+  "Return a ThreadFactory that always produces named daemon threads."
+  [name-prefix]
+  (reify java.util.concurrent.ThreadFactory
+    (newThread [_ runnable]
+      (doto (Thread. runnable)
+        (.setName (str name-prefix "-" (System/nanoTime)))
+        (.setDaemon true)))))
+
+(defn- emit-stall-event!
+  "Publish a :agent/stream-stalled event to the event-stream.
+   Best-effort: log and swallow any emission failure so the watchdog
+   thread itself does not crash."
+  [event-stream workflow-id phase-id backend logger]
+  (try
+    (let [envelope (event-stream/create-envelope
+                    event-stream
+                    :agent/stream-stalled
+                    {:phase/id       phase-id
+                     :agent/backend  backend
+                     :event/workflow-id workflow-id}
+                    {})]
+      (event-stream/publish! event-stream envelope))
+    (catch Exception ex
+      (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
+                {:phase-id phase-id :backend backend :error (ex-message ex)}))))
+
+(defn- build-check-task
+  "Build the Runnable that the scheduler fires every `check-interval-seconds`.
+
+   When the gap between now and the last recorded event timestamp exceeds
+   threshold-ms the task:
+     a. Calls kill-fn (kills the agent subprocess).
+     b. Emits :agent/stream-stalled via event-stream.
+     c. Sets the stalled? atom to true.
+     d. Shuts down the scheduler (one-shot; idempotent via isShutdown guard)."
+  [{:keys [^AtomicLong last-event-ts stalled-atom
+           threshold-ms phase-id backend event-stream workflow-id kill-fn
+           ^ScheduledExecutorService scheduler logger]}]
+  (fn []
+    (try
+      (when-not (.isShutdown scheduler)
+        (let [gap (- (System/currentTimeMillis) (.get last-event-ts))]
+          (when (> gap threshold-ms)
+            (log/warn logger "stream-watchdog: gap exceeded threshold — killing agent"
+                      {:gap-ms gap :threshold-ms threshold-ms
+                       :phase-id phase-id :backend backend})
+            ;; a. kill the subprocess
+            (try (kill-fn)
+                 (catch Exception ex
+                   (log/warn logger "stream-watchdog: kill-fn threw"
+                             {:error (ex-message ex)})))
+            ;; b. emit stall event
+            (emit-stall-event! event-stream workflow-id phase-id backend logger)
+            ;; c. mark stalled
+            (reset! stalled-atom true)
+            ;; d. shut down scheduler (one-shot)
+            (future (.shutdown scheduler)))))
+      (catch Exception ex
+        (log/error logger "stream-watchdog: unhandled error in check task"
+                   {:error (ex-message ex)})))))
+
+(defn create-watchdog
+  "Create and start a stream-gap watchdog.
+
+   Options map:
+     :threshold-ms  — gap in ms before the kill fires (required)
+     :phase-id      — keyword or string identifying the current phase
+     :backend       — keyword identifying the agent backend (e.g. :claude-code)
+     :event-stream  — event-stream instance to publish the stall event
+     :workflow-id   — UUID or string; embedded in the stall event
+     :kill-fn       — zero-arity fn that terminates the agent subprocess
+
+   Returns a watchdog state map. Pass it to `reset!`, `stop!`, and `stalled?`.
+
+   The internal scheduler starts immediately on a daemon thread. Events must be
+   reported via `reset!` on every emission to keep the watchdog from firing."
+  [{:keys [threshold-ms phase-id backend event-stream workflow-id kill-fn]
+    :or   {threshold-ms default-gap-threshold-ms}}]
+  (let [logger       (log/create-logger {:min-level :info :output :edn})
+        last-event-ts (AtomicLong. (System/currentTimeMillis))
+        stalled-atom  (atom false)
+        scheduler     (Executors/newSingleThreadScheduledExecutor
+                       (daemon-thread-factory "stream-watchdog"))
+        ctx           {:last-event-ts last-event-ts
+                       :stalled-atom  stalled-atom
+                       :threshold-ms  threshold-ms
+                       :phase-id      phase-id
+                       :backend       backend
+                       :event-stream  event-stream
+                       :workflow-id   workflow-id
+                       :kill-fn       (or kill-fn (fn []))
+                       :scheduler     scheduler
+                       :logger        logger}
+        check-task    (build-check-task ctx)]
+    (.scheduleAtFixedRate
+     scheduler
+     check-task
+     check-interval-seconds
+     check-interval-seconds
+     TimeUnit/SECONDS)
+    ctx))
+
+(defn reset!
+  "Record that an agent event just occurred, resetting the gap timer.
+
+   Call this on every event emitted by the agent (tool-call, chunk, status, etc.).
+   Thread-safe via AtomicLong.set — never blocks."
+  [watchdog]
+  (when-let [^AtomicLong ts (:last-event-ts watchdog)]
+    (.set ts (System/currentTimeMillis)))
+  watchdog)
+
+(defn stop!
+  "Gracefully shut down the watchdog scheduler.
+
+   Call on normal phase completion. Safe to call multiple times; subsequent
+   calls are no-ops (scheduler is already shut down).
+
+   Does NOT set :stalled? — a stopped watchdog is distinct from a stalled one."
+  [watchdog]
+  (when-let [^ScheduledExecutorService sched (:scheduler watchdog)]
+    (when-not (.isShutdown sched)
+      (.shutdown sched)))
+  watchdog)
+
+(defn stalled?
+  "Return true if the watchdog fired and killed the agent subprocess.
+
+   Safe to call from any thread; reads an atom."
+  [watchdog]
+  (boolean (and watchdog @(:stalled-atom watchdog))))
+
+;; ---------------------------------------------------------------------------
+;; Rich comment — development examples
+
+(comment
+  ;; Minimal watchdog with a 5-second threshold (fires in ~5s without resets)
+  (def wd
+    (create-watchdog
+     {:threshold-ms 5000
+      :phase-id     :implement
+      :backend      :claude-code
+      :event-stream nil
+      :workflow-id  "wf-test-001"
+      :kill-fn      #(println "KILL SIGNAL")}))
+
+  ;; Simulate an event
+  (reset! wd)
+
+  ;; Check status
+  (stalled? wd)
+
+  ;; Graceful shutdown
+  (stop! wd))

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -25,7 +25,7 @@
    blocks event emission on the hot path.
 
    Layer 0: Config helpers (resolve-gap-threshold)
-   Layer 1: Watchdog lifecycle (create-watchdog, reset!, stop!, stalled?)"
+   Layer 1: Watchdog lifecycle (create-watchdog, ping!, stop!, stalled?)"
   (:require
    [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.logging.interface :as log])
@@ -34,22 +34,25 @@
    (java.util.concurrent.atomic AtomicLong)))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 0 — configuration helpers
+;; Layer 0 — module-level logger and configuration helpers
+
+(defonce ^:private module-logger
+  (log/create-logger {:min-level :info :output :edn}))
 
 (def ^:const default-gap-threshold-ms
   "Default stream-gap threshold in milliseconds (90 seconds)."
   90000)
 
-(def ^:const check-interval-seconds
-  "How often the scheduled watcher fires, in seconds."
-  5)
+(def ^:const default-check-interval-ms
+  "Default watchdog check interval in milliseconds (5 seconds)."
+  5000)
 
 (defn resolve-gap-threshold
   "Resolve the stream-gap threshold in ms for a given backend.
 
    Precedence (highest wins):
-     1. backend-specific entry in :agent/per-backend-gap-thresholds
-     2. global :agent/stream-gap-threshold-ms in config
+     1. Backend-specific entry in :agent/per-backend-gap-thresholds
+     2. Global :agent/stream-gap-threshold-ms in config
      3. `default-gap-threshold-ms` (90 000 ms)
 
    Example config:
@@ -74,15 +77,15 @@
 
 (defn- emit-stall-event!
   "Publish a :agent/stream-stalled event to the event-stream.
-   Best-effort: log and swallow any emission failure so the watchdog
+   Best-effort — logs and swallows any emission failure so the watchdog
    thread itself does not crash."
   [event-stream workflow-id phase-id backend logger]
   (try
     (let [envelope (event-stream/create-envelope
                     event-stream
                     :agent/stream-stalled
-                    {:phase/id       phase-id
-                     :agent/backend  backend
+                    {:phase/id          phase-id
+                     :agent/backend     backend
                      :event/workflow-id workflow-id}
                     {})]
       (event-stream/publish! event-stream envelope))
@@ -91,14 +94,13 @@
                 {:phase-id phase-id :backend backend :error (ex-message ex)}))))
 
 (defn- build-check-task
-  "Build the Runnable that the scheduler fires every `check-interval-seconds`.
+  "Build the Runnable that the scheduler fires every check interval.
 
-   When the gap between now and the last recorded event timestamp exceeds
-   threshold-ms the task:
+   When (now − last-event-timestamp) exceeds threshold-ms the task:
      a. Calls kill-fn (kills the agent subprocess).
      b. Emits :agent/stream-stalled via event-stream.
      c. Sets the stalled? atom to true.
-     d. Shuts down the scheduler (one-shot; idempotent via isShutdown guard)."
+     d. Shuts down the scheduler (one-shot; non-blocking from own thread)."
   [{:keys [^AtomicLong last-event-ts stalled-atom
            threshold-ms phase-id backend event-stream workflow-id kill-fn
            ^ScheduledExecutorService scheduler logger]}]
@@ -118,9 +120,9 @@
             ;; b. emit stall event
             (emit-stall-event! event-stream workflow-id phase-id backend logger)
             ;; c. mark stalled
-            (reset! stalled-atom true)
-            ;; d. shut down scheduler (one-shot)
-            (future (.shutdown scheduler)))))
+            (clojure.core/reset! stalled-atom true)
+            ;; d. shut down scheduler — safe and non-blocking from own thread
+            (.shutdown scheduler))))
       (catch Exception ex
         (log/error logger "stream-watchdog: unhandled error in check task"
                    {:error (ex-message ex)})))))
@@ -129,21 +131,25 @@
   "Create and start a stream-gap watchdog.
 
    Options map:
-     :threshold-ms  — gap in ms before the kill fires (required)
-     :phase-id      — keyword or string identifying the current phase
-     :backend       — keyword identifying the agent backend (e.g. :claude-code)
-     :event-stream  — event-stream instance to publish the stall event
-     :workflow-id   — UUID or string; embedded in the stall event
-     :kill-fn       — zero-arity fn that terminates the agent subprocess
+     :threshold-ms      — gap in ms before the kill fires (default 90 000)
+     :check-interval-ms — how often to check for a stall (default 5 000)
+     :phase-id          — keyword or string identifying the current phase
+     :backend           — keyword identifying the agent backend (e.g. :claude-code)
+     :event-stream      — event-stream instance to publish the stall event
+     :workflow-id       — UUID or string; embedded in the stall event
+     :kill-fn           — zero-arity fn that terminates the agent subprocess
+     :logger            — optional logger; defaults to the module-level logger
 
-   Returns a watchdog state map. Pass it to `reset!`, `stop!`, and `stalled?`.
+   Returns a watchdog state map. Pass it to `ping!`, `stop!`, and `stalled?`.
 
-   The internal scheduler starts immediately on a daemon thread. Events must be
-   reported via `reset!` on every emission to keep the watchdog from firing."
-  [{:keys [threshold-ms phase-id backend event-stream workflow-id kill-fn]
-    :or   {threshold-ms default-gap-threshold-ms}}]
-  (let [logger       (log/create-logger {:min-level :info :output :edn})
-        last-event-ts (AtomicLong. (System/currentTimeMillis))
+   The internal scheduler starts immediately on a daemon thread. Report every
+   agent event via `ping!` to keep the watchdog from firing."
+  [{:keys [threshold-ms check-interval-ms phase-id backend
+           event-stream workflow-id kill-fn logger]
+    :or   {threshold-ms      default-gap-threshold-ms
+           check-interval-ms default-check-interval-ms
+           logger            module-logger}}]
+  (let [last-event-ts (AtomicLong. (System/currentTimeMillis))
         stalled-atom  (atom false)
         scheduler     (Executors/newSingleThreadScheduledExecutor
                        (daemon-thread-factory "stream-watchdog"))
@@ -161,16 +167,18 @@
     (.scheduleAtFixedRate
      scheduler
      check-task
-     check-interval-seconds
-     check-interval-seconds
-     TimeUnit/SECONDS)
+     check-interval-ms
+     check-interval-ms
+     TimeUnit/MILLISECONDS)
     ctx))
 
-(defn reset!
+(defn ping!
   "Record that an agent event just occurred, resetting the gap timer.
 
    Call this on every event emitted by the agent (tool-call, chunk, status, etc.).
-   Thread-safe via AtomicLong.set — never blocks."
+   Thread-safe via AtomicLong.set — never blocks.
+
+   Named `ping!` (not `reset!`) to avoid shadowing `clojure.core/reset!`."
   [watchdog]
   (when-let [^AtomicLong ts (:last-event-ts watchdog)]
     (.set ts (System/currentTimeMillis)))
@@ -200,21 +208,22 @@
 ;; Rich comment — development examples
 
 (comment
-  ;; Minimal watchdog with a 5-second threshold (fires in ~5s without resets)
+  ;; Minimal watchdog with a 200ms threshold and 50ms check interval (for REPL)
   (def wd
     (create-watchdog
-     {:threshold-ms 5000
-      :phase-id     :implement
-      :backend      :claude-code
-      :event-stream nil
-      :workflow-id  "wf-test-001"
-      :kill-fn      #(println "KILL SIGNAL")}))
+     {:threshold-ms      200
+      :check-interval-ms 50
+      :phase-id          :implement
+      :backend           :claude-code
+      :event-stream      nil
+      :workflow-id       "wf-test-001"
+      :kill-fn           #(println "KILL SIGNAL")}))
 
-  ;; Simulate an event
-  (reset! wd)
+  ;; Simulate an event ping
+  (ping! wd)
 
   ;; Check status
   (stalled? wd)
 
-  ;; Graceful shutdown
+  ;; Graceful shutdown on normal completion
   (stop! wd))

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -76,22 +76,27 @@
         (.setDaemon true)))))
 
 (defn- emit-stall-event!
-  "Publish a :agent/stream-stalled event to the event-stream.
-   Best-effort — logs and swallows any emission failure so the watchdog
-   thread itself does not crash."
+  "Publish a :agent/stream-stalled event to event-stream.
+
+   nil event-stream is treated as a legal no-op (useful in tests and in early
+   pipeline stages that have not yet wired an event-stream). Any emission error
+   is caught and logged so the watchdog thread cannot crash."
   [event-stream workflow-id phase-id backend logger]
-  (try
-    (let [envelope (event-stream/create-envelope
-                    event-stream
-                    :agent/stream-stalled
-                    {:phase/id          phase-id
-                     :agent/backend     backend
-                     :event/workflow-id workflow-id}
-                    {})]
-      (event-stream/publish! event-stream envelope))
-    (catch Exception ex
-      (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
-                {:phase-id phase-id :backend backend :error (ex-message ex)}))))
+  (if-not event-stream
+    (log/warn logger "stream-watchdog: no event-stream configured; stall event suppressed"
+              {:phase-id phase-id :backend backend})
+    (try
+      (let [envelope (event-stream/create-envelope
+                      event-stream
+                      :agent/stream-stalled
+                      {:phase/id          phase-id
+                       :agent/backend     backend
+                       :event/workflow-id workflow-id}
+                      {})]
+        (event-stream/publish! event-stream envelope))
+      (catch Exception ex
+        (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
+                  {:phase-id phase-id :backend backend :error (ex-message ex)})))))
 
 (defn- build-check-task
   "Build the Runnable that the scheduler fires every check interval.
@@ -117,11 +122,11 @@
                  (catch Exception ex
                    (log/warn logger "stream-watchdog: kill-fn threw"
                              {:error (ex-message ex)})))
-            ;; b. emit stall event
+            ;; b. emit stall event (nil-safe)
             (emit-stall-event! event-stream workflow-id phase-id backend logger)
             ;; c. mark stalled
             (clojure.core/reset! stalled-atom true)
-            ;; d. shut down scheduler — safe and non-blocking from own thread
+            ;; d. shut down scheduler — non-blocking, safe from own thread
             (.shutdown scheduler))))
       (catch Exception ex
         (log/error logger "stream-watchdog: unhandled error in check task"
@@ -135,7 +140,8 @@
      :check-interval-ms — how often to check for a stall (default 5 000)
      :phase-id          — keyword or string identifying the current phase
      :backend           — keyword identifying the agent backend (e.g. :claude-code)
-     :event-stream      — event-stream instance to publish the stall event
+     :event-stream      — event-stream instance to publish the stall event;
+                          nil is accepted and suppresses event emission
      :workflow-id       — UUID or string; embedded in the stall event
      :kill-fn           — zero-arity fn that terminates the agent subprocess
      :logger            — optional logger; defaults to the module-level logger
@@ -153,16 +159,17 @@
         stalled-atom  (atom false)
         scheduler     (Executors/newSingleThreadScheduledExecutor
                        (daemon-thread-factory "stream-watchdog"))
-        ctx           {:last-event-ts last-event-ts
-                       :stalled-atom  stalled-atom
-                       :threshold-ms  threshold-ms
-                       :phase-id      phase-id
-                       :backend       backend
-                       :event-stream  event-stream
-                       :workflow-id   workflow-id
-                       :kill-fn       (or kill-fn (fn []))
-                       :scheduler     scheduler
-                       :logger        logger}
+        ctx           {:last-event-ts     last-event-ts
+                       :stalled-atom      stalled-atom
+                       :threshold-ms      threshold-ms
+                       :check-interval-ms check-interval-ms
+                       :phase-id          phase-id
+                       :backend           backend
+                       :event-stream      event-stream
+                       :workflow-id       workflow-id
+                       :kill-fn           (or kill-fn (fn []))
+                       :scheduler         scheduler
+                       :logger            logger}
         check-task    (build-check-task ctx)]
     (.scheduleAtFixedRate
      scheduler
@@ -208,11 +215,11 @@
 ;; Rich comment — development examples
 
 (comment
-  ;; Minimal watchdog with a 200ms threshold and 50ms check interval (for REPL)
+  ;; Minimal watchdog with fast settings for REPL experimentation
   (def wd
     (create-watchdog
-     {:threshold-ms      200
-      :check-interval-ms 50
+     {:threshold-ms      1000
+      :check-interval-ms 100
       :phase-id          :implement
       :backend           :claude-code
       :event-stream      nil

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -1,0 +1,238 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.stream-watchdog-test
+  "Tests for the per-phase stream-gap watchdog timer."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [ai.miniforge.agent.stream-watchdog :as sut])
+  (:import
+   (java.util.concurrent.atomic AtomicLong)))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+
+(defn- make-test-watchdog
+  "Create a watchdog with an artificially short threshold for testing."
+  [opts]
+  (merge {:threshold-ms 200
+          :phase-id     :test-phase
+          :backend      :mock
+          :event-stream nil
+          :workflow-id  "wf-test"
+          :kill-fn      (fn [])}
+         opts))
+
+(defn- await-condition
+  "Spin-wait up to `timeout-ms` for `pred` to return truthy.
+   Returns true when pred fires, false on timeout."
+  [pred timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (if (pred)
+        true
+        (if (> (System/currentTimeMillis) deadline)
+          false
+          (do (Thread/sleep 50) (recur)))))))
+
+;; ---------------------------------------------------------------------------
+;; resolve-gap-threshold
+
+(deftest resolve-gap-threshold-returns-default-when-no-config
+  (testing "returns default-gap-threshold-ms when config is empty"
+    (is (= sut/default-gap-threshold-ms
+           (sut/resolve-gap-threshold {} :any-backend)))))
+
+(deftest resolve-gap-threshold-returns-global-override
+  (testing "global :agent/stream-gap-threshold-ms overrides the default"
+    (is (= 60000
+           (sut/resolve-gap-threshold
+            {:agent/stream-gap-threshold-ms 60000}
+            :claude-code)))))
+
+(deftest resolve-gap-threshold-returns-backend-specific-override
+  (testing "per-backend entry overrides global threshold"
+    (let [config {:agent/stream-gap-threshold-ms      60000
+                  :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
+      (is (= 120000 (sut/resolve-gap-threshold config :claude-code)))))
+
+  (testing "falls back to global threshold for an unlisted backend"
+    (let [config {:agent/stream-gap-threshold-ms      60000
+                  :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
+      (is (= 60000 (sut/resolve-gap-threshold config :other-backend))))))
+
+(deftest resolve-gap-threshold-default-constant-is-90s
+  (testing "default constant value is 90 000 ms"
+    (is (= 90000 sut/default-gap-threshold-ms))))
+
+;; ---------------------------------------------------------------------------
+;; create-watchdog structure
+
+(deftest create-watchdog-returns-expected-keys
+  (testing "watchdog map contains required keys"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (is (contains? wd :last-event-ts))
+        (is (contains? wd :stalled-atom))
+        (is (contains? wd :scheduler))
+        (is (contains? wd :threshold-ms))
+        (is (contains? wd :phase-id))
+        (is (contains? wd :backend))
+        (is (instance? AtomicLong (:last-event-ts wd)))
+        (is (instance? clojure.lang.Atom (:stalled-atom wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest create-watchdog-starts-not-stalled
+  (testing "a freshly created watchdog is not stalled"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (is (false? (sut/stalled? wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest create-watchdog-uses-default-threshold-when-omitted
+  (testing "omitting :threshold-ms falls back to default-gap-threshold-ms"
+    (let [wd (sut/create-watchdog {:phase-id :x :backend :y
+                                   :event-stream nil :workflow-id "w"
+                                   :kill-fn (fn [])})]
+      (try
+        (is (= sut/default-gap-threshold-ms (:threshold-ms wd)))
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
+;; reset!
+
+(deftest reset-updates-timestamp
+  (testing "reset! updates the AtomicLong to current time"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (let [^AtomicLong ts (:last-event-ts wd)
+              before          (.get ts)]
+          (Thread/sleep 5)
+          (sut/reset! wd)
+          (let [after (.get ts)]
+            (is (>= after before))))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest reset-returns-the-watchdog-map
+  (testing "reset! returns the watchdog map (fluent chaining)"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (is (= wd (sut/reset! wd)))
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
+;; stop!
+
+(deftest stop-shuts-down-scheduler
+  (testing "stop! shuts down the ScheduledExecutorService"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (sut/stop! wd)
+      (is (.isShutdown (:scheduler wd))))))
+
+(deftest stop-is-idempotent
+  (testing "calling stop! multiple times does not throw"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (sut/stop! wd)
+      (is (some? (sut/stop! wd))))))
+
+(deftest stop-does-not-set-stalled
+  (testing "stop! does not mark the watchdog as stalled"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (sut/stop! wd)
+      (is (false? (sut/stalled? wd))))))
+
+;; ---------------------------------------------------------------------------
+;; stalled? predicate
+
+(deftest stalled-returns-false-initially
+  (testing "stalled? returns false before any kill"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (is (false? (sut/stalled? wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest stalled-returns-false-for-nil
+  (testing "stalled? is safe to call with nil watchdog"
+    (is (false? (sut/stalled? nil)))))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end: kill fires when threshold exceeded
+
+(deftest watchdog-fires-kill-when-gap-exceeded
+  (testing "kill-fn is called after the threshold is exceeded"
+    (let [killed? (atom false)
+          wd      (sut/create-watchdog
+                   {:threshold-ms 100          ;; 100 ms threshold
+                    :phase-id     :test
+                    :backend      :mock
+                    :event-stream nil
+                    :workflow-id  "wf-fire-test"
+                    :kill-fn      #(reset! killed? true)})]
+      ;; Wait up to 3 seconds for the kill to fire (check runs every 5s normally,
+      ;; but the threshold is 100ms so the very first check — at 5s — will exceed
+      ;; it; we wait up to 3× the check-interval-seconds window)
+      ;; Note: actual check fires at check-interval-seconds (5s). For speed in
+      ;; unit tests we manipulate the last-event timestamp directly.
+      (let [^AtomicLong ts (:last-event-ts wd)]
+        ;; Back-date the timestamp so the gap is already exceeded
+        (.set ts (- (System/currentTimeMillis) 200)))
+      (let [fired? (await-condition #(deref killed?) 12000)]
+        (sut/stop! wd)
+        (is fired? "kill-fn should have been called when the gap exceeded threshold-ms")
+        (is (sut/stalled? wd) "watchdog should be marked stalled after kill")))))
+
+(deftest watchdog-does-not-fire-when-regularly-reset
+  (testing "kill-fn is NOT called when reset! is called frequently enough"
+    (let [killed?    (atom false)
+          threshold  200
+          wd         (sut/create-watchdog
+                      {:threshold-ms threshold
+                       :phase-id     :test
+                       :backend      :mock
+                       :event-stream nil
+                       :workflow-id  "wf-no-fire"
+                       :kill-fn      #(reset! killed? true)})]
+      ;; Keep resetting every 50ms for 2 seconds (well within check interval)
+      (dotimes [_ 10]
+        (Thread/sleep 50)
+        (sut/reset! wd))
+      (sut/stop! wd)
+      ;; The scheduler fires every 5s; we stopped it cleanly before any check.
+      ;; If no check ran, kill should not have fired.
+      (is (not (sut/stalled? wd)))
+      (is (false? @killed?)))))
+
+;; ---------------------------------------------------------------------------
+;; Interface namespace re-export sanity
+
+(deftest interface-namespace-exports-same-vars
+  (testing "ai.miniforge.agent.interface.watchdog re-exports match stream-watchdog"
+    (require 'ai.miniforge.agent.interface.watchdog)
+    (let [iface (find-ns 'ai.miniforge.agent.interface.watchdog)]
+      (is (some? (ns-resolve iface 'create-watchdog)))
+      (is (some? (ns-resolve iface 'reset!)))
+      (is (some? (ns-resolve iface 'stop!)))
+      (is (some? (ns-resolve iface 'stalled?)))
+      (is (some? (ns-resolve iface 'resolve-gap-threshold)))
+      (is (some? (ns-resolve iface 'default-gap-threshold-ms))))))

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -19,7 +19,7 @@
 (ns ai.miniforge.agent.stream-watchdog-test
   "Tests for the per-phase stream-gap watchdog timer."
   (:require
-   [clojure.test :refer [deftest is testing use-fixtures]]
+   [clojure.test :refer [deftest is testing]]
    [ai.miniforge.agent.stream-watchdog :as sut])
   (:import
    (java.util.concurrent.atomic AtomicLong)))
@@ -28,14 +28,16 @@
 ;; Helpers
 
 (defn- make-test-watchdog
-  "Create a watchdog with an artificially short threshold for testing."
+  "Merge caller opts over safe defaults. Uses a fast check interval so
+   fire-on-threshold tests complete quickly without sleep gymnastics."
   [opts]
-  (merge {:threshold-ms 200
-          :phase-id     :test-phase
-          :backend      :mock
-          :event-stream nil
-          :workflow-id  "wf-test"
-          :kill-fn      (fn [])}
+  (merge {:threshold-ms      200
+          :check-interval-ms 50        ;; fast checks for test speed
+          :phase-id          :test-phase
+          :backend           :mock
+          :event-stream      nil
+          :workflow-id       "wf-test"
+          :kill-fn           (fn [])}
          opts))
 
 (defn- await-condition
@@ -48,7 +50,15 @@
         true
         (if (> (System/currentTimeMillis) deadline)
           false
-          (do (Thread/sleep 50) (recur)))))))
+          (do (Thread/sleep 10) (recur)))))))
+
+(defn- backdate!
+  "Back-date a watchdog's AtomicLong by `offset-ms` so the gap is already
+   exceeded on the next check tick."
+  [watchdog offset-ms]
+  (let [^AtomicLong ts (:last-event-ts watchdog)]
+    (.set ts (- (System/currentTimeMillis) offset-ms)))
+  watchdog)
 
 ;; ---------------------------------------------------------------------------
 ;; resolve-gap-threshold
@@ -66,18 +76,18 @@
             :claude-code)))))
 
 (deftest resolve-gap-threshold-returns-backend-specific-override
-  (testing "per-backend entry overrides global threshold"
-    (let [config {:agent/stream-gap-threshold-ms      60000
+  (testing "per-backend entry wins over global threshold"
+    (let [config {:agent/stream-gap-threshold-ms     60000
                   :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
       (is (= 120000 (sut/resolve-gap-threshold config :claude-code)))))
 
-  (testing "falls back to global threshold for an unlisted backend"
-    (let [config {:agent/stream-gap-threshold-ms      60000
+  (testing "falls back to global for an unlisted backend"
+    (let [config {:agent/stream-gap-threshold-ms     60000
                   :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
       (is (= 60000 (sut/resolve-gap-threshold config :other-backend))))))
 
 (deftest resolve-gap-threshold-default-constant-is-90s
-  (testing "default constant value is 90 000 ms"
+  (testing "default constant is 90 000 ms"
     (is (= 90000 sut/default-gap-threshold-ms))))
 
 ;; ---------------------------------------------------------------------------
@@ -116,27 +126,38 @@
         (finally
           (sut/stop! wd))))))
 
-;; ---------------------------------------------------------------------------
-;; reset!
+(deftest create-watchdog-accepts-check-interval-ms
+  (testing ":check-interval-ms is stored in the watchdog map"
+    (let [wd (sut/create-watchdog (make-test-watchdog {:check-interval-ms 100}))]
+      (try
+        ;; The scheduler is started with the custom interval; we verify it by
+        ;; checking the ctx key is absent (not stored) but the scheduler is alive.
+        ;; Structural check: scheduler is running
+        (is (not (.isShutdown (:scheduler wd))))
+        (finally
+          (sut/stop! wd))))))
 
-(deftest reset-updates-timestamp
-  (testing "reset! updates the AtomicLong to current time"
+;; ---------------------------------------------------------------------------
+;; ping!
+
+(deftest ping-updates-timestamp
+  (testing "ping! advances the AtomicLong to current time"
     (let [wd (sut/create-watchdog (make-test-watchdog {}))]
       (try
         (let [^AtomicLong ts (:last-event-ts wd)
               before          (.get ts)]
           (Thread/sleep 5)
-          (sut/reset! wd)
+          (sut/ping! wd)
           (let [after (.get ts)]
             (is (>= after before))))
         (finally
           (sut/stop! wd))))))
 
-(deftest reset-returns-the-watchdog-map
-  (testing "reset! returns the watchdog map (fluent chaining)"
+(deftest ping-returns-the-watchdog-map
+  (testing "ping! returns the watchdog map (fluent chaining)"
     (let [wd (sut/create-watchdog (make-test-watchdog {}))]
       (try
-        (is (= wd (sut/reset! wd)))
+        (is (= wd (sut/ping! wd)))
         (finally
           (sut/stop! wd))))))
 
@@ -180,48 +201,49 @@
 ;; End-to-end: kill fires when threshold exceeded
 
 (deftest watchdog-fires-kill-when-gap-exceeded
-  (testing "kill-fn is called after the threshold is exceeded"
+  (testing "kill-fn is called when the backdated gap exceeds threshold-ms"
     (let [killed? (atom false)
           wd      (sut/create-watchdog
-                   {:threshold-ms 100          ;; 100 ms threshold
-                    :phase-id     :test
-                    :backend      :mock
-                    :event-stream nil
-                    :workflow-id  "wf-fire-test"
-                    :kill-fn      #(reset! killed? true)})]
-      ;; Wait up to 3 seconds for the kill to fire (check runs every 5s normally,
-      ;; but the threshold is 100ms so the very first check — at 5s — will exceed
-      ;; it; we wait up to 3× the check-interval-seconds window)
-      ;; Note: actual check fires at check-interval-seconds (5s). For speed in
-      ;; unit tests we manipulate the last-event timestamp directly.
-      (let [^AtomicLong ts (:last-event-ts wd)]
-        ;; Back-date the timestamp so the gap is already exceeded
-        (.set ts (- (System/currentTimeMillis) 200)))
-      (let [fired? (await-condition #(deref killed?) 12000)]
+                   (make-test-watchdog
+                    {:threshold-ms      200
+                     :check-interval-ms 50
+                     :kill-fn           #(reset! killed? true)}))]
+      ;; Back-date to make the gap already exceeded
+      (backdate! wd 400)
+      ;; Wait for the first check tick (up to 2s)
+      (let [fired? (await-condition #(deref killed?) 2000)]
         (sut/stop! wd)
-        (is fired? "kill-fn should have been called when the gap exceeded threshold-ms")
-        (is (sut/stalled? wd) "watchdog should be marked stalled after kill")))))
+        (is fired? "kill-fn should fire when gap > threshold-ms")
+        (is (sut/stalled? wd) "watchdog should be marked stalled")))))
 
-(deftest watchdog-does-not-fire-when-regularly-reset
-  (testing "kill-fn is NOT called when reset! is called frequently enough"
-    (let [killed?    (atom false)
-          threshold  200
-          wd         (sut/create-watchdog
-                      {:threshold-ms threshold
-                       :phase-id     :test
-                       :backend      :mock
-                       :event-stream nil
-                       :workflow-id  "wf-no-fire"
-                       :kill-fn      #(reset! killed? true)})]
-      ;; Keep resetting every 50ms for 2 seconds (well within check interval)
-      (dotimes [_ 10]
-        (Thread/sleep 50)
-        (sut/reset! wd))
-      (sut/stop! wd)
-      ;; The scheduler fires every 5s; we stopped it cleanly before any check.
-      ;; If no check ran, kill should not have fired.
-      (is (not (sut/stalled? wd)))
-      (is (false? @killed?)))))
+;; ---------------------------------------------------------------------------
+;; ping! actually prevents the kill from firing
+
+(deftest ping-prevents-kill-when-gap-was-backdated
+  "ping! resets the timestamp to now. Even if the timestamp was back-dated
+   to simulate a stale gap, calling ping! before the next check tick should
+   make the gap measurement fresh and suppress the kill.
+
+   This test is effective because we use a fast 50ms check-interval-ms and
+   call ping! immediately after backdating, then verify the kill never fires
+   over multiple check cycles."
+  (let [killed? (atom false)
+        wd      (sut/create-watchdog
+                 (make-test-watchdog
+                  {:threshold-ms      200
+                   :check-interval-ms 50
+                   :kill-fn           #(reset! killed? true)}))]
+    ;; Simulate a gap that would exceed threshold...
+    (backdate! wd 400)
+    ;; ...but immediately reset the timestamp via ping!
+    (sut/ping! wd)
+    ;; Let multiple check ticks run (300ms = ~6 ticks at 50ms interval)
+    (Thread/sleep 300)
+    (sut/stop! wd)
+    (is (not @killed?)
+        "kill-fn must NOT fire if ping! kept the timestamp current")
+    (is (not (sut/stalled? wd))
+        "watchdog must NOT be marked stalled when ping! suppressed the kill")))
 
 ;; ---------------------------------------------------------------------------
 ;; Interface namespace re-export sanity
@@ -231,8 +253,20 @@
     (require 'ai.miniforge.agent.interface.watchdog)
     (let [iface (find-ns 'ai.miniforge.agent.interface.watchdog)]
       (is (some? (ns-resolve iface 'create-watchdog)))
-      (is (some? (ns-resolve iface 'reset!)))
+      (is (some? (ns-resolve iface 'ping!)))
       (is (some? (ns-resolve iface 'stop!)))
       (is (some? (ns-resolve iface 'stalled?)))
       (is (some? (ns-resolve iface 'resolve-gap-threshold)))
-      (is (some? (ns-resolve iface 'default-gap-threshold-ms))))))
+      (is (some? (ns-resolve iface 'default-gap-threshold-ms)))
+      (is (some? (ns-resolve iface 'default-check-interval-ms))))))
+
+(deftest interface-watchdog-vars-point-to-same-fns
+  (testing "re-exported vars are identical to source vars (not copies)"
+    (require 'ai.miniforge.agent.interface.watchdog)
+    (let [iface (find-ns 'ai.miniforge.agent.interface.watchdog)]
+      (is (= (var-get (ns-resolve iface 'ping!))
+             sut/ping!))
+      (is (= (var-get (ns-resolve iface 'stop!))
+             sut/stop!))
+      (is (= (var-get (ns-resolve iface 'stalled?))
+             sut/stalled?)))))

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -28,11 +28,11 @@
 ;; Helpers
 
 (defn- make-test-watchdog
-  "Merge caller opts over safe defaults. Uses a fast check interval so
-   fire-on-threshold tests complete quickly without sleep gymnastics."
+  "Merge caller opts over safe defaults. Uses fast check-interval-ms so
+   fire-on-threshold tests complete quickly."
   [opts]
   (merge {:threshold-ms      200
-          :check-interval-ms 50        ;; fast checks for test speed
+          :check-interval-ms 50         ;; fast checks for test speed
           :phase-id          :test-phase
           :backend           :mock
           :event-stream      nil
@@ -101,10 +101,19 @@
         (is (contains? wd :stalled-atom))
         (is (contains? wd :scheduler))
         (is (contains? wd :threshold-ms))
+        (is (contains? wd :check-interval-ms))
         (is (contains? wd :phase-id))
         (is (contains? wd :backend))
         (is (instance? AtomicLong (:last-event-ts wd)))
         (is (instance? clojure.lang.Atom (:stalled-atom wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest create-watchdog-stores-check-interval-ms
+  (testing ":check-interval-ms is stored in the returned watchdog map"
+    (let [wd (sut/create-watchdog (make-test-watchdog {:check-interval-ms 123}))]
+      (try
+        (is (= 123 (:check-interval-ms wd)))
         (finally
           (sut/stop! wd))))))
 
@@ -123,17 +132,6 @@
                                    :kill-fn (fn [])})]
       (try
         (is (= sut/default-gap-threshold-ms (:threshold-ms wd)))
-        (finally
-          (sut/stop! wd))))))
-
-(deftest create-watchdog-accepts-check-interval-ms
-  (testing ":check-interval-ms is stored in the watchdog map"
-    (let [wd (sut/create-watchdog (make-test-watchdog {:check-interval-ms 100}))]
-      (try
-        ;; The scheduler is started with the custom interval; we verify it by
-        ;; checking the ctx key is absent (not stored) but the scheduler is alive.
-        ;; Structural check: scheduler is running
-        (is (not (.isShutdown (:scheduler wd))))
         (finally
           (sut/stop! wd))))))
 
@@ -220,30 +218,27 @@
 ;; ping! actually prevents the kill from firing
 
 (deftest ping-prevents-kill-when-gap-was-backdated
-  "ping! resets the timestamp to now. Even if the timestamp was back-dated
-   to simulate a stale gap, calling ping! before the next check tick should
-   make the gap measurement fresh and suppress the kill.
-
-   This test is effective because we use a fast 50ms check-interval-ms and
-   call ping! immediately after backdating, then verify the kill never fires
-   over multiple check cycles."
-  (let [killed? (atom false)
-        wd      (sut/create-watchdog
-                 (make-test-watchdog
-                  {:threshold-ms      200
-                   :check-interval-ms 50
-                   :kill-fn           #(reset! killed? true)}))]
-    ;; Simulate a gap that would exceed threshold...
-    (backdate! wd 400)
-    ;; ...but immediately reset the timestamp via ping!
-    (sut/ping! wd)
-    ;; Let multiple check ticks run (300ms = ~6 ticks at 50ms interval)
-    (Thread/sleep 300)
-    (sut/stop! wd)
-    (is (not @killed?)
-        "kill-fn must NOT fire if ping! kept the timestamp current")
-    (is (not (sut/stalled? wd))
-        "watchdog must NOT be marked stalled when ping! suppressed the kill")))
+  (testing "ping! resets the timestamp; a stale backdated gap must not fire the kill"
+    ;; threshold-ms 1000 and sleep 300ms gives 700ms safety margin —
+    ;; the watchdog cannot accumulate a fresh 1000ms gap in only 300ms.
+    (let [killed? (atom false)
+          wd      (sut/create-watchdog
+                   (make-test-watchdog
+                    {:threshold-ms      1000
+                     :check-interval-ms 50
+                     :kill-fn           #(reset! killed? true)}))]
+      ;; Simulate a stale gap that would exceed a lower threshold...
+      (backdate! wd 800)
+      ;; ...but immediately reset the timestamp via ping!
+      (sut/ping! wd)
+      ;; Allow multiple check ticks (300ms ≪ threshold-ms 1000ms).
+      ;; The gap after ping! is ~0ms; even after 300ms it is ~300ms < 1000ms.
+      (Thread/sleep 300)
+      (sut/stop! wd)
+      (is (not @killed?)
+          "kill-fn must NOT fire if ping! kept the timestamp current")
+      (is (not (sut/stalled? wd))
+          "watchdog must NOT be marked stalled when ping! suppressed the kill"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Interface namespace re-export sanity

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -499,7 +499,9 @@
           redirect-to (assoc :phase/redirect-to redirect-to)
           (:tokens result) (assoc :phase/tokens (:tokens result))
           (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))
-          (:meta result) (assoc :phase/meta (:meta result))))))
+          (:meta result) (assoc :phase/meta (:meta result))
+          (:phase/termination-reason result)
+          (assoc :phase/termination-reason (:phase/termination-reason result))))))
 
 (defn workspace-persisted
   "Build a :workspace/persisted event recording that a phase's worktree was
@@ -1318,6 +1320,34 @@
                        (str "Meta-loop cycle failed: " (ex-message error)))
       (assoc :meta-loop/error (ex-message error)
              :meta-loop/error-class (.getName (class error)))))
+
+;------------------------------------------------------------------------------ Layer 6.5
+;; Agent stream-stall events (GROUP 1+4)
+
+(defn agent-stream-stalled
+  "Build an :agent/stream-stalled event indicating the agent output stream
+   has gone silent beyond the configured gap threshold.
+
+   Consumed by the self-healing supervisor to decide whether to kill the
+   hung backend process and retry on the next eligible backend.
+
+   Arguments:
+   - stream:          event-stream atom
+   - workflow-id:     owning workflow UUID
+   - phase-id:        keyword identifying the current phase (e.g. :implement)
+   - gap-duration-ms: measured silence gap in milliseconds
+   - backend:         keyword identifying the backend (:codex, :claude, etc.)
+
+   Valid `:phase/termination-reason` enum values for `phase-completed`:
+     :agent-stalled, :curator-rejected, :tool-error, :normal"
+  [stream workflow-id phase-id gap-duration-ms backend]
+  (-> (create-envelope stream :agent/stream-stalled workflow-id
+                       (str "Agent stream stalled in " (name phase-id)
+                            " after " gap-duration-ms "ms"
+                            " (backend: " (name backend) ")"))
+      (assoc :phase/id phase-id
+             :stream/gap-duration-ms gap-duration-ms
+             :agent/backend backend)))
 
 ;------------------------------------------------------------------------------ Layer 7
 ;; Observer / knowledge failure events

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1345,7 +1345,7 @@
                        (str "Agent stream stalled in " (name phase-id)
                             " after " gap-duration-ms "ms"
                             " (backend: " (name backend) ")"))
-      (assoc :phase/id phase-id
+      (assoc :workflow/phase phase-id
              :stream/gap-duration-ms gap-duration-ms
              :agent/backend backend)))
 

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -353,6 +353,12 @@
    {:constructor "phase-heartbeat"
     :event-type  :workflow/phase-heartbeat
     :json-string "workflow/phase-heartbeat"
+    :browser?    false}
+
+   ;; GROUP 1+4 agent stream-stall events
+   {:constructor "agent-stream-stalled"
+    :event-type  :agent/stream-stalled
+    :json-string "agent/stream-stalled"
     :browser?    false}])
 
 ;------------------------------------------------------------------------------ Layer 0

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -183,6 +183,9 @@
 (def knowledge-synthesis-failed events/knowledge-synthesis-failed)
 (def knowledge-promotion-failed events/knowledge-promotion-failed)
 
+;; Agent stream-stall events (GROUP 1+4)
+(def agent-stream-stalled events/agent-stream-stalled)
+
 ;------------------------------------------------------------------------------ Layer 4
 ;; Event-stream reader — replay events from the file-sink layout
 

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -124,3 +124,8 @@
 (def observer-signal-failed core/observer-signal-failed)
 (def knowledge-synthesis-failed core/knowledge-synthesis-failed)
 (def knowledge-promotion-failed core/knowledge-promotion-failed)
+
+;------------------------------------------------------------------------------ Layer 3.5
+;; Agent stream-stall event constructors (GROUP 1+4)
+
+(def agent-stream-stalled core/agent-stream-stalled)

--- a/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
@@ -1,0 +1,153 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.stall-events-test
+  "Tests for GROUP 1+4 foundation: agent-stream-stalled constructor and
+   phase-completed :phase/termination-reason extension."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.event-stream.interface :as events-iface]
+   [ai.miniforge.event-stream.interface.events :as events]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn no-op-stream
+  "Create a stream with no sinks — event constructors only build maps."
+  []
+  (core/create-event-stream {:sinks []}))
+
+;------------------------------------------------------------------------------ agent-stream-stalled
+
+(deftest agent-stream-stalled-type-test
+  (testing "event type is :agent/stream-stalled"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
+      (is (= :agent/stream-stalled (:event/type event))))))
+
+(deftest agent-stream-stalled-fields-test
+  (testing "carries phase-id, gap-duration-ms, and backend"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
+      (is (= :implement (:phase/id event)))
+      (is (= 95000 (:stream/gap-duration-ms event)))
+      (is (= :codex (:agent/backend event)))))
+
+  (testing "workflow-id is propagated"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :verify 120000 :claude)]
+      (is (= wf-id (:workflow/id event)))))
+
+  (testing "message includes phase-id and gap-duration"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :plan 88000 :claude)]
+      (is (string? (:message event)))
+      (is (re-find #"plan" (:message event)))
+      (is (re-find #"88000" (:message event)))))
+
+  (testing "envelope fields are present"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-stream-stalled stream wf-id :implement 90001 :codex)]
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= core/event-version (:event/version event)))
+      (is (number? (:event/sequence-number event))))))
+
+(deftest agent-stream-stalled-works-with-any-backend-test
+  (testing "backend keyword is preserved as-is"
+    (doseq [backend [:codex :claude :openai :local]]
+      (let [stream (no-op-stream)
+            event  (core/agent-stream-stalled stream (random-uuid) :implement 90000 backend)]
+        (is (= backend (:agent/backend event)))))))
+
+;------------------------------------------------------------------------------ phase-completed :phase/termination-reason
+
+(deftest phase-completed-termination-reason-test
+  (testing "termination-reason :normal is passed through"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :implement
+                                       {:outcome :success
+                                        :phase/termination-reason :normal})]
+      (is (= :normal (:phase/termination-reason event)))))
+
+  (testing "termination-reason :agent-stalled is passed through"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :implement
+                                       {:outcome :failure
+                                        :phase/termination-reason :agent-stalled})]
+      (is (= :agent-stalled (:phase/termination-reason event)))))
+
+  (testing "termination-reason :curator-rejected is passed through"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :verify
+                                       {:outcome :failure
+                                        :phase/termination-reason :curator-rejected})]
+      (is (= :curator-rejected (:phase/termination-reason event)))))
+
+  (testing "termination-reason :tool-error is passed through"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :implement
+                                       {:outcome :failure
+                                        :phase/termination-reason :tool-error})]
+      (is (= :tool-error (:phase/termination-reason event)))))
+
+  (testing "absence of termination-reason leaves key absent"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :plan {:outcome :success})]
+      (is (not (contains? event :phase/termination-reason)))))
+
+  (testing "termination-reason does not displace existing result fields"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/phase-completed stream wf-id :implement
+                                       {:outcome :success
+                                        :duration-ms 4200
+                                        :phase/termination-reason :normal})]
+      (is (= :success (:phase/outcome event)))
+      (is (= 4200 (:phase/duration-ms event)))
+      (is (= :normal (:phase/termination-reason event))))))
+
+;------------------------------------------------------------------------------ Re-export verification
+
+(deftest interface-events-re-export-test
+  (testing "agent-stream-stalled is exported through interface.events"
+    (is (fn? events/agent-stream-stalled)))
+
+  (testing "agent-stream-stalled is exported through interface"
+    (is (fn? events-iface/agent-stream-stalled)))
+
+  (testing "re-exported function produces the same result as core"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          direct (core/agent-stream-stalled stream wf-id :implement 90000 :codex)
+          via-if (events/agent-stream-stalled stream wf-id :implement 90000 :codex)]
+      ;; Type, phase, gap, and backend must match; ids and timestamps differ
+      (is (= (:event/type direct) (:event/type via-if)))
+      (is (= (:phase/id direct) (:phase/id via-if)))
+      (is (= (:stream/gap-duration-ms direct) (:stream/gap-duration-ms via-if)))
+      (is (= (:agent/backend direct) (:agent/backend via-if))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
@@ -42,11 +42,11 @@
       (is (= :agent/stream-stalled (:event/type event))))))
 
 (deftest agent-stream-stalled-fields-test
-  (testing "carries phase-id, gap-duration-ms, and backend"
+  (testing "carries workflow-phase, gap-duration-ms, and backend"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
           event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
-      (is (= :implement (:phase/id event)))
+      (is (= :implement (:workflow/phase event)))
       (is (= 95000 (:stream/gap-duration-ms event)))
       (is (= :codex (:agent/backend event)))))
 
@@ -148,6 +148,6 @@
           via-if (events/agent-stream-stalled stream wf-id :implement 90000 :codex)]
       ;; Type, phase, gap, and backend must match; ids and timestamps differ
       (is (= (:event/type direct) (:event/type via-if)))
-      (is (= (:phase/id direct) (:phase/id via-if)))
+      (is (= (:workflow/phase direct) (:workflow/phase via-if)))
       (is (= (:stream/gap-duration-ms direct) (:stream/gap-duration-ms via-if)))
       (is (= (:agent/backend direct) (:agent/backend via-if))))))

--- a/docs/pull-requests/2026-05-19-group-1-core-per-phase-event-gap-watchdog-timer-in-agent-component.md
+++ b/docs/pull-requests/2026-05-19-group-1-core-per-phase-event-gap-watchdog-timer-in-agent-component.md
@@ -1,0 +1,27 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 1 core: Per-phase event-gap watchdog timer in agent component.
+
+**PR:** [#918](https://github.com/miniforge-ai/miniforge/pull/918)
+**Branch:** `mf/group-1-core-per-phase-event-gap-watchdo-82e6c2cd`
+
+## Summary
+
+GROUP 1 core: Per-phase event-gap watchdog timer in agent component.
+
+## Files Changed
+
+- `components/agent/src/ai/miniforge/agent/stream_watchdog.clj` (modify)
+- `components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -47,8 +47,8 @@
                  :agent/stream-gap-threshold-ms 90000
                  ;; Per-backend overrides for the gap threshold. Keys are backend
                  ;; keywords; values are millisecond integers. Empty by default.
-                 ;; Example: {:codex 120000} gives Codex 2 extra minutes before
-                 ;; stall detection fires.
+                 ;; Example: {:codex 210000} gives Codex 2 extra minutes
+                 ;; (210s total) before stall detection fires.
                  :agent/per-backend-gap-thresholds {}}
   :governance {:readiness {}
                :risk {}

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -39,7 +39,17 @@
                  :backend-health-threshold 0.90
                  :backend-switch-cooldown-ms 1800000
                  :allowed-failover-backends [:claude :codex]
-                 :max-cost-per-workflow nil}
+                 :max-cost-per-workflow nil
+                 ;; Agent output-stream gap threshold. If no output line is received
+                 ;; from the backend process for this many milliseconds, a
+                 ;; :agent/stream-stalled event is emitted and self-healing may
+                 ;; terminate and retry the phase on a fallback backend.
+                 :agent/stream-gap-threshold-ms 90000
+                 ;; Per-backend overrides for the gap threshold. Keys are backend
+                 ;; keywords; values are millisecond integers. Empty by default.
+                 ;; Example: {:codex 120000} gives Codex 2 extra minutes before
+                 ;; stall detection fires.
+                 :agent/per-backend-gap-thresholds {}}
   :governance {:readiness {}
                :risk {}
                :tiers {}


### PR DESCRIPTION
## Summary

GROUP 1 core — lands the per-phase event-gap watchdog timer in the `agent` component. Adds `ai.miniforge.agent.stream-watchdog` (Layer 0 config helpers; Layer 1 lifecycle: `create-watchdog`, `ping!`, `stop!`, `stalled?`) and an `agent/interface/watchdog` re-export shim alongside the agent interface update. The watchdog runs on a daemon `ScheduledExecutorService`, never blocks the event hot path, and on gap-exceeded:

1. Calls the supplied `:kill-fn` to terminate the agent subprocess.
2. Emits `:agent/stream-stalled` via `event-stream.interface/agent-stream-stalled`.
3. Sets `:stalled?`, shuts down the scheduler one-shot.

This PR is stacked on #917 (the foundation that introduces the `agent-stream-stalled` constructor and the `:agent/stream-gap-threshold-ms` config keys).

## Files Changed

- `components/agent/src/ai/miniforge/agent/stream_watchdog.clj` (create)
- `components/agent/src/ai/miniforge/agent/interface/watchdog.clj` (create)
- `components/agent/src/ai/miniforge/agent/interface.clj` (modify)
- `components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj` (create)
- Carries forward the PR #917 base (event-stream constructor, registry, default-user-config keys, stall-events test)

## Test Plan

- [x] `bb pre-commit` — clean (lint, format, smoke 14ns / 289 tests / 1017 assertions, GraalVM compatibility)
- [x] `ai.miniforge.agent.stream-watchdog-test` + `ai.miniforge.event-stream.stall-events-test` — 24 tests, 68 assertions, 0 failures (covers default threshold, per-backend overrides, watchdog lifecycle, ping resets the gap, gap-exceeded fires kill-fn, idempotent stop, interface re-exports)

## Review

Copilot review pass (4 inline threads) addressed in 924767b5:

- `emit-stall-event!` now calls the `event-stream.interface/agent-stream-stalled` constructor introduced in PR #917 (correct signature; envelope handling stays consistent with the rest of the event-stream component).
- `build-check-task` now threads the measured gap into the stall event so `:stream/gap-duration-ms` is populated as documented.
- All `log/warn` / `log/error` calls reshaped to the in-repo `(log/level logger :category :event-key {data})` convention (matches `implementer.clj`, `reviewer.clj`, `event-stream/core.clj`).
- One thread (config key namespacing under `:self-healing`) declined with explanation — the `:agent/…` keys are intentional and resolve at the merged-config level in the GROUP 1 wire-up PR.

## Authorship

- Generated by **Heimdall** (Miniforge phase-software-factory agent) on 2026-05-19 in its `verify` phase. Commit message and PR template are the verify-step artifacts.
- Copilot review pass + body backfill by Claude Code on behalf of @ChristopherLester. Commit `924767b5` carries the review-pass fixes; original Heimdall verify commit is `0ca64260`.

<details>
<summary>Original Heimdall PR template</summary>

**PR:** [#918](https://github.com/miniforge-ai/miniforge/pull/918)
**Branch:** `mf/group-1-core-per-phase-event-gap-watchdo-82e6c2cd`

Test Results and Review Decision sections were left as `_No * available._` placeholders by the Heimdall template; backfilled above.

</details>