### PR TITLE
GROUP 2: Session ID persistence in agent component.

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -220,3 +220,5 @@
 (def ping-watchdog! watchdog/ping!)
 (def stop-watchdog! watchdog/stop!)
 (def watchdog-stalled? watchdog/stalled?)
+(def capture-watchdog-session-id! watchdog/capture-session-id!)
+(def get-watchdog-session-id watchdog/get-session-id)

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -210,13 +210,12 @@
   "CLI entry point for tool-use evaluation from stdin."
   tool-supervisor/hook-eval-stdin!)
 
-;------------------------------------------------------------------------------ Layer 5
+;------------------------------------------------------------------------------ Layer 4
 ;; Stream-gap watchdog
 
 (def resolve-gap-threshold watchdog/resolve-gap-threshold)
 (def default-gap-threshold-ms watchdog/default-gap-threshold-ms)
-(def default-check-interval-ms watchdog/default-check-interval-ms)
 (def create-watchdog watchdog/create-watchdog)
-(def ping-watchdog! watchdog/ping!)
+(def reset-watchdog! watchdog/reset!)
 (def stop-watchdog! watchdog/stop!)
 (def watchdog-stalled? watchdog/stalled?)

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -212,6 +212,16 @@
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Stream-gap watchdog
+;;
+;; Note on naming: functions exported from the watchdog sub-interface
+;; (ai.miniforge.agent.interface.watchdog) keep their natural short names
+;; (ping!, stop!, stalled?, capture-session-id!, get-session-id). At this
+;; top-level interface the verb-style names ping!/stop!/stalled? would
+;; collide with unrelated lifecycle verbs in this namespace, so we apply a
+;; watchdog- prefix (ping-watchdog!, stop-watchdog!, watchdog-stalled?,
+;; capture-watchdog-session-id!, get-watchdog-session-id). Callers that
+;; need only watchdog functionality should depend on
+;; ai.miniforge.agent.interface.watchdog directly to avoid the prefix.
 
 (def resolve-gap-threshold watchdog/resolve-gap-threshold)
 (def default-gap-threshold-ms watchdog/default-gap-threshold-ms)

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -210,12 +210,13 @@
   "CLI entry point for tool-use evaluation from stdin."
   tool-supervisor/hook-eval-stdin!)
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 5
 ;; Stream-gap watchdog
 
 (def resolve-gap-threshold watchdog/resolve-gap-threshold)
 (def default-gap-threshold-ms watchdog/default-gap-threshold-ms)
+(def default-check-interval-ms watchdog/default-check-interval-ms)
 (def create-watchdog watchdog/create-watchdog)
-(def reset-watchdog! watchdog/reset!)
+(def ping-watchdog! watchdog/ping!)
 (def stop-watchdog! watchdog/stop!)
 (def watchdog-stalled? watchdog/stalled?)

--- a/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
@@ -19,7 +19,7 @@
 (ns ai.miniforge.agent.interface.watchdog
   "Public boundary for the per-phase stream-gap watchdog.
 
-   Re-exports the four primary operations and the config helper from
+   Re-exports the five primary operations and the config helper from
    ai.miniforge.agent.stream-watchdog.
 
    Usage:
@@ -33,7 +33,7 @@
                  :workflow-id  workflow-id
                  :kill-fn      kill-subprocess!})]
        ;; on every agent event:
-       (watchdog/reset! wd)
+       (watchdog/ping! wd)
        ;; on normal completion:
        (watchdog/stop! wd)
        ;; to check for stall:
@@ -53,6 +53,10 @@
   "Default stream-gap threshold in ms (90 000)."
   watchdog/default-gap-threshold-ms)
 
+(def default-check-interval-ms
+  "Default watchdog check interval in ms (5 000)."
+  watchdog/default-check-interval-ms)
+
 ;; ---------------------------------------------------------------------------
 ;; Watchdog lifecycle
 
@@ -61,10 +65,11 @@
    See `ai.miniforge.agent.stream-watchdog/create-watchdog`."
   watchdog/create-watchdog)
 
-(def reset!
+(def ping!
   "Record a new agent event, resetting the gap timer.
-   See `ai.miniforge.agent.stream-watchdog/reset!`."
-  watchdog/reset!)
+   Named ping! (not reset!) to avoid shadowing clojure.core/reset!.
+   See `ai.miniforge.agent.stream-watchdog/ping!`."
+  watchdog/ping!)
 
 (def stop!
   "Gracefully shut down the watchdog scheduler.

--- a/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
@@ -80,3 +80,17 @@
   "Return true if the watchdog fired and killed the agent subprocess.
    See `ai.miniforge.agent.stream-watchdog/stalled?`."
   watchdog/stalled?)
+
+;; ---------------------------------------------------------------------------
+;; Session ID capture
+
+(def capture-session-id!
+  "Parse and persist the session ID from the initial agent handshake event.
+   Emits :agent/session-captured via event-stream.
+   See `ai.miniforge.agent.stream-watchdog/capture-session-id!`."
+  watchdog/capture-session-id!)
+
+(def get-session-id
+  "Return the captured session ID string, or nil if not yet captured.
+   See `ai.miniforge.agent.stream-watchdog/get-session-id`."
+  watchdog/get-session-id)

--- a/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
@@ -19,7 +19,11 @@
 (ns ai.miniforge.agent.interface.watchdog
   "Public boundary for the per-phase stream-gap watchdog.
 
-   Re-exports the five primary operations and the config helper from
+   Re-exports the watchdog lifecycle operations (create-watchdog, ping!,
+   stop!, stalled?), the session-id capture/read operations
+   (capture-session-id!, get-session-id), the config helper
+   (resolve-gap-threshold), and the default constants
+   (default-gap-threshold-ms, default-check-interval-ms) from
    ai.miniforge.agent.stream-watchdog.
 
    Usage:

--- a/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
@@ -19,7 +19,7 @@
 (ns ai.miniforge.agent.interface.watchdog
   "Public boundary for the per-phase stream-gap watchdog.
 
-   Re-exports the five primary operations and the config helper from
+   Re-exports the four primary operations and the config helper from
    ai.miniforge.agent.stream-watchdog.
 
    Usage:
@@ -33,7 +33,7 @@
                  :workflow-id  workflow-id
                  :kill-fn      kill-subprocess!})]
        ;; on every agent event:
-       (watchdog/ping! wd)
+       (watchdog/reset! wd)
        ;; on normal completion:
        (watchdog/stop! wd)
        ;; to check for stall:
@@ -53,10 +53,6 @@
   "Default stream-gap threshold in ms (90 000)."
   watchdog/default-gap-threshold-ms)
 
-(def default-check-interval-ms
-  "Default watchdog check interval in ms (5 000)."
-  watchdog/default-check-interval-ms)
-
 ;; ---------------------------------------------------------------------------
 ;; Watchdog lifecycle
 
@@ -65,11 +61,10 @@
    See `ai.miniforge.agent.stream-watchdog/create-watchdog`."
   watchdog/create-watchdog)
 
-(def ping!
+(def reset!
   "Record a new agent event, resetting the gap timer.
-   Named ping! (not reset!) to avoid shadowing clojure.core/reset!.
-   See `ai.miniforge.agent.stream-watchdog/ping!`."
-  watchdog/ping!)
+   See `ai.miniforge.agent.stream-watchdog/reset!`."
+  watchdog/reset!)
 
 (def stop!
   "Gracefully shut down the watchdog scheduler.

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -91,16 +91,21 @@
    persisted in the atom so a delivery failure must not lose the session ID."
   [{:keys [event-stream workflow-id phase-id backend logger]} session-id]
   (if-not event-stream
-    (log/warn logger "stream-watchdog: no event-stream; session-captured suppressed"
-              {:session-id session-id :phase-id phase-id :backend backend})
+    (log/debug logger :stream-watchdog :session-captured/suppressed
+               {:reason :no-event-stream
+                :session/id session-id
+                :workflow/phase phase-id
+                :agent/backend backend})
     (try
       (let [envelope (event-stream/agent-session-captured
                       event-stream workflow-id phase-id session-id backend)]
         (event-stream/publish! event-stream envelope))
       (catch Exception ex
-        (log/warn logger "stream-watchdog: failed to emit :agent/session-captured"
-                  {:session-id session-id :phase-id phase-id
-                   :backend backend :error (ex-message ex)})))))
+        (log/warn logger :stream-watchdog :session-captured/emit-failed
+                  {:session/id session-id
+                   :workflow/phase phase-id
+                   :agent/backend backend
+                   :error (ex-message ex)})))))
 
 (defn- emit-stall-event!
   "Publish an :agent/stream-stalled event to event-stream.
@@ -113,15 +118,19 @@
    is caught and logged so the watchdog thread cannot crash."
   [event-stream workflow-id phase-id backend gap-ms logger]
   (if-not event-stream
-    (log/warn logger "stream-watchdog: no event-stream configured; stall event suppressed"
-              {:phase-id phase-id :backend backend})
+    (log/debug logger :stream-watchdog :stall-event/suppressed
+               {:reason :no-event-stream
+                :workflow/phase phase-id
+                :agent/backend backend})
     (try
       (let [envelope (event-stream/agent-stream-stalled
                       event-stream workflow-id phase-id gap-ms backend)]
         (event-stream/publish! event-stream envelope))
       (catch Exception ex
-        (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
-                  {:phase-id phase-id :backend backend :error (ex-message ex)})))))
+        (log/warn logger :stream-watchdog :stall-event/emit-failed
+                  {:workflow/phase phase-id
+                   :agent/backend backend
+                   :error (ex-message ex)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — watchdog lifecycle
@@ -151,14 +160,18 @@
       (when-not (.isShutdown scheduler)
         (let [gap (- (System/currentTimeMillis) (.get last-event-ts))]
           (when (> gap threshold-ms)
-            (log/warn logger "stream-watchdog: gap exceeded threshold — killing agent"
-                      {:gap-ms gap :threshold-ms threshold-ms
-                       :phase-id phase-id :backend backend})
+            (log/warn logger :stream-watchdog :stream/gap-exceeded
+                      {:stream/gap-duration-ms gap
+                       :stream/gap-threshold-ms threshold-ms
+                       :workflow/phase phase-id
+                       :agent/backend backend})
             ;; a. kill the subprocess
             (try (kill-fn)
                  (catch Exception ex
-                   (log/warn logger "stream-watchdog: kill-fn threw"
-                             {:error (ex-message ex)})))
+                   (log/warn logger :stream-watchdog :stream/kill-fn-failed
+                             {:workflow/phase phase-id
+                              :agent/backend backend
+                              :error (ex-message ex)})))
             ;; b. emit stall event with measured gap (nil-safe)
             (emit-stall-event! event-stream workflow-id phase-id backend gap logger)
             ;; c. mark stalled
@@ -166,7 +179,7 @@
             ;; d. shut down scheduler — non-blocking, safe from own thread
             (.shutdown scheduler))))
       (catch Exception ex
-        (log/error logger "stream-watchdog: unhandled error in check task"
+        (log/error logger :stream-watchdog :check-task/unhandled-error
                    {:error (ex-message ex)})))))
 
 (defn create-watchdog
@@ -267,31 +280,40 @@
    - Codex:       nested `[:session :id]` path
 
    When a session ID is found for the first time:
-     1. Stores it in the `:session-id-atom` on the watchdog state (atomic).
+     1. Stores it in the `:session-id-atom` on the watchdog state (atomic via
+        `compare-and-set!`).
      2. Emits :agent/session-captured via event-stream (nil stream is a no-op).
 
    When the session ID has already been captured, returns the watchdog unchanged.
    When no recognizable session key is present, logs a warning and returns
    the watchdog unchanged; this is not a fatal condition.
 
-   Thread-safe — atom reset is atomic; safe to call from the stream-parsing
-   thread concurrent with ping! on the watchdog scheduler thread."
+   nil watchdog (or one missing :session-id-atom) is a legal no-op — useful
+   for early-pipeline call sites that have not constructed a watchdog yet.
+
+   Thread-safe — uses `compare-and-set!` to make the check-then-act atomic,
+   so concurrent callers cannot both observe a nil session-id and both emit
+   :agent/session-captured."
   [watchdog event-map]
-  (if @(:session-id-atom watchdog)
-    ;; Already captured — idempotent no-op.
-    watchdog
+  (if-let [sid-atom (and watchdog (:session-id-atom watchdog))]
     (if-let [sid (extract-session-id event-map)]
-      (do
-        (reset! (:session-id-atom watchdog) sid)
-        (emit-session-captured! watchdog sid)
+      ;; compare-and-set! is the atomic check-then-act primitive — only the
+      ;; first thread that observes nil flips the atom and emits the event;
+      ;; concurrent callers see the post-set value and become no-ops, so we
+      ;; never publish duplicate :agent/session-captured events.
+      (if (compare-and-set! sid-atom nil sid)
+        (do
+          (emit-session-captured! watchdog sid)
+          watchdog)
         watchdog)
       (do
-        (log/warn (:logger watchdog)
-                  "stream-watchdog: no session ID found in handshake event"
+        (log/warn (:logger watchdog) :stream-watchdog :session/handshake-missing-id
                   {:event-keys (keys event-map)
-                   :phase-id   (:phase-id watchdog)
-                   :backend    (:backend watchdog)})
-        watchdog))))
+                   :workflow/phase (:phase-id watchdog)
+                   :agent/backend (:backend watchdog)})
+        watchdog))
+    ;; nil watchdog or missing :session-id-atom — safe no-op, do not throw.
+    watchdog))
 
 (defn get-session-id
   "Return the captured session ID string, or nil if not yet captured.

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -75,6 +75,43 @@
         (.setName (str name-prefix "-" (System/nanoTime)))
         (.setDaemon true)))))
 
+;; ---------------------------------------------------------------------------
+;; Layer 0.5 — session capture helpers
+
+(defn- extract-session-id
+  "Extract session ID from a handshake event map.
+
+   Handles two common backend shapes:
+   - Claude Code: top-level `:session_id` or `\"session_id\"` key
+   - Codex: nested `[:session :id]` or `[\"session\" \"id\"]`
+
+   Returns nil when no recognizable session key is present."
+  [event-map]
+  (or (get event-map :session_id)
+      (get event-map "session_id")
+      (get-in event-map [:session :id])
+      (get-in event-map ["session" "id"])))
+
+(defn- emit-session-captured!
+  "Publish :agent/session-captured via event-stream.
+
+   nil event-stream is a legal no-op (see emit-stall-event! for the same
+   pattern). Any emission error is caught and logged — the capture itself
+   has already been persisted in the atom, so a delivery failure must not
+   lose the session ID."
+  [{:keys [event-stream workflow-id phase-id backend logger]} session-id]
+  (if-not event-stream
+    (log/info logger "stream-watchdog: no event-stream; session-captured suppressed"
+              {:session-id session-id :phase-id phase-id :backend backend})
+    (try
+      (let [envelope (event-stream/agent-session-captured
+                      event-stream workflow-id phase-id session-id backend)]
+        (event-stream/publish! event-stream envelope))
+      (catch Exception ex
+        (log/warn logger "stream-watchdog: failed to emit :agent/session-captured"
+                  {:session-id session-id :phase-id phase-id
+                   :backend backend :error (ex-message ex)})))))
+
 (defn- emit-stall-event!
   "Publish a :agent/stream-stalled event to event-stream.
 
@@ -140,13 +177,14 @@
      :check-interval-ms — how often to check for a stall (default 5 000)
      :phase-id          — keyword or string identifying the current phase
      :backend           — keyword identifying the agent backend (e.g. :claude-code)
-     :event-stream      — event-stream instance to publish the stall event;
+     :event-stream      — event-stream instance to publish stall/session events;
                           nil is accepted and suppresses event emission
-     :workflow-id       — UUID or string; embedded in the stall event
+     :workflow-id       — UUID or string; embedded in emitted events
      :kill-fn           — zero-arity fn that terminates the agent subprocess
      :logger            — optional logger; defaults to the module-level logger
 
-   Returns a watchdog state map. Pass it to `ping!`, `stop!`, and `stalled?`.
+   Returns a watchdog state map. Pass it to `ping!`, `stop!`, `stalled?`,
+   `capture-session-id!`, and `get-session-id`.
 
    The internal scheduler starts immediately on a daemon thread. Report every
    agent event via `ping!` to keep the watchdog from firing."
@@ -155,21 +193,23 @@
     :or   {threshold-ms      default-gap-threshold-ms
            check-interval-ms default-check-interval-ms
            logger            module-logger}}]
-  (let [last-event-ts (AtomicLong. (System/currentTimeMillis))
-        stalled-atom  (atom false)
-        scheduler     (Executors/newSingleThreadScheduledExecutor
-                       (daemon-thread-factory "stream-watchdog"))
-        ctx           {:last-event-ts     last-event-ts
-                       :stalled-atom      stalled-atom
-                       :threshold-ms      threshold-ms
-                       :check-interval-ms check-interval-ms
-                       :phase-id          phase-id
-                       :backend           backend
-                       :event-stream      event-stream
-                       :workflow-id       workflow-id
-                       :kill-fn           (or kill-fn (fn []))
-                       :scheduler         scheduler
-                       :logger            logger}
+  (let [last-event-ts   (AtomicLong. (System/currentTimeMillis))
+        stalled-atom    (atom false)
+        session-id-atom (atom nil)
+        scheduler       (Executors/newSingleThreadScheduledExecutor
+                         (daemon-thread-factory "stream-watchdog"))
+        ctx             {:last-event-ts     last-event-ts
+                         :stalled-atom      stalled-atom
+                         :session-id-atom   session-id-atom
+                         :threshold-ms      threshold-ms
+                         :check-interval-ms check-interval-ms
+                         :phase-id          phase-id
+                         :backend           backend
+                         :event-stream      event-stream
+                         :workflow-id       workflow-id
+                         :kill-fn           (or kill-fn (fn []))
+                         :scheduler         scheduler
+                         :logger            logger}
         check-task    (build-check-task ctx)]
     (.scheduleAtFixedRate
      scheduler
@@ -210,6 +250,52 @@
    Safe to call from any thread; reads an atom."
   [watchdog]
   (boolean (and watchdog @(:stalled-atom watchdog))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 1.5 — session ID capture
+
+(defn capture-session-id!
+  "Parse and persist the session ID from the initial agent handshake event.
+
+   MUST be called synchronously before the first tool call so that
+   resume-on-kill has a valid session ID available.
+
+   Accepts the first parsed JSON event from the agent subprocess as a
+   Clojure map. Supports two common backend handshake shapes:
+   - Claude Code: top-level `:session_id` key
+   - Codex:       nested `[:session :id]` path
+
+   When a session ID is found:
+     1. Stores it in the `:session-id-atom` on the watchdog state (atomic).
+     2. Emits :agent/session-captured via event-stream (nil stream is a no-op).
+
+   When no recognizable session key is present, logs a warning and returns
+   the watchdog unchanged; this is not a fatal condition.
+
+   Thread-safe — atom reset is atomic; safe to call from the stream-parsing
+   thread concurrent with ping! on the watchdog scheduler thread."
+  [watchdog event-map]
+  (if-let [sid (extract-session-id event-map)]
+    (do
+      (reset! (:session-id-atom watchdog) sid)
+      (emit-session-captured! watchdog sid)
+      watchdog)
+    (do
+      (log/warn (:logger watchdog)
+                "stream-watchdog: no session ID found in handshake event"
+                {:event-keys (keys event-map)
+                 :phase-id   (:phase-id watchdog)
+                 :backend    (:backend watchdog)})
+      watchdog)))
+
+(defn get-session-id
+  "Return the captured session ID string, or nil if not yet captured.
+
+   Resume-on-kill reads this to pass the correct --resume flag to the backend.
+   Safe to call from any thread."
+  [watchdog]
+  (when watchdog
+    @(:session-id-atom watchdog)))
 
 ;; ---------------------------------------------------------------------------
 ;; Rich comment — development examples

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -17,15 +17,21 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.agent.stream-watchdog
-  "Per-phase event-gap watchdog timer.
+  "Per-phase event-gap watchdog timer with session ID capture.
 
    Detects agent stream stalls by tracking the timestamp of the most recent
    event emission and firing a kill signal when the gap exceeds a configurable
    threshold. Runs on a dedicated ScheduledExecutorService daemon thread — never
    blocks event emission on the hot path.
 
-   Layer 0: Config helpers (resolve-gap-threshold)
-   Layer 1: Watchdog lifecycle (create-watchdog, ping!, stop!, stalled?)"
+   Also captures and persists the backend session ID from the initial agent
+   handshake so that resume-on-kill can restart the agent at the correct
+   session checkpoint.
+
+   Layer 0: Config helpers (resolve-gap-threshold, extract-session-id,
+            emit-session-captured!, emit-stall-event!)
+   Layer 1: Watchdog lifecycle (create-watchdog, ping!, stop!, stalled?,
+            capture-session-id!, get-session-id)"
   (:require
    [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.logging.interface :as log])
@@ -34,7 +40,7 @@
    (java.util.concurrent.atomic AtomicLong)))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 0 — module-level logger and configuration helpers
+;; Layer 0 — module-level logger, configuration helpers, and session helpers
 
 (defonce ^:private module-logger
   (log/create-logger {:min-level :info :output :edn}))
@@ -63,6 +69,60 @@
         overrides (get config :agent/per-backend-gap-thresholds {})]
     (get overrides backend base)))
 
+(defn- extract-session-id
+  "Extract session ID from a handshake event map.
+
+   Handles two common backend shapes:
+   - Claude Code: top-level `:session_id` or `\"session_id\"` key
+   - Codex:       nested `[:session :id]` or `[\"session\" \"id\"]`
+
+   Returns nil when no recognizable session key is present."
+  [event-map]
+  (or (get event-map :session_id)
+      (get event-map "session_id")
+      (get-in event-map [:session :id])
+      (get-in event-map ["session" "id"])))
+
+(defn- emit-session-captured!
+  "Publish :agent/session-captured via event-stream.
+
+   nil event-stream is a legal no-op, consistent with emit-stall-event!.
+   Any emission error is caught and logged — the capture has already been
+   persisted in the atom so a delivery failure must not lose the session ID."
+  [{:keys [event-stream workflow-id phase-id backend logger]} session-id]
+  (if-not event-stream
+    (log/warn logger "stream-watchdog: no event-stream; session-captured suppressed"
+              {:session-id session-id :phase-id phase-id :backend backend})
+    (try
+      (let [envelope (event-stream/agent-session-captured
+                      event-stream workflow-id phase-id session-id backend)]
+        (event-stream/publish! event-stream envelope))
+      (catch Exception ex
+        (log/warn logger "stream-watchdog: failed to emit :agent/session-captured"
+                  {:session-id session-id :phase-id phase-id
+                   :backend backend :error (ex-message ex)})))))
+
+(defn- emit-stall-event!
+  "Publish an :agent/stream-stalled event to event-stream.
+
+   Uses the canonical agent-stream-stalled constructor so that :workflow/id
+   is a proper UUID/string and :stream/gap-duration-ms is populated.
+
+   nil event-stream is treated as a legal no-op (useful in tests and in early
+   pipeline stages that have not yet wired an event-stream). Any emission error
+   is caught and logged so the watchdog thread cannot crash."
+  [event-stream workflow-id phase-id backend gap-ms logger]
+  (if-not event-stream
+    (log/warn logger "stream-watchdog: no event-stream configured; stall event suppressed"
+              {:phase-id phase-id :backend backend})
+    (try
+      (let [envelope (event-stream/agent-stream-stalled
+                      event-stream workflow-id phase-id gap-ms backend)]
+        (event-stream/publish! event-stream envelope))
+      (catch Exception ex
+        (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
+                  {:phase-id phase-id :backend backend :error (ex-message ex)})))))
+
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — watchdog lifecycle
 
@@ -75,72 +135,12 @@
         (.setName (str name-prefix "-" (System/nanoTime)))
         (.setDaemon true)))))
 
-;; ---------------------------------------------------------------------------
-;; Layer 0.5 — session capture helpers
-
-(defn- extract-session-id
-  "Extract session ID from a handshake event map.
-
-   Handles two common backend shapes:
-   - Claude Code: top-level `:session_id` or `\"session_id\"` key
-   - Codex: nested `[:session :id]` or `[\"session\" \"id\"]`
-
-   Returns nil when no recognizable session key is present."
-  [event-map]
-  (or (get event-map :session_id)
-      (get event-map "session_id")
-      (get-in event-map [:session :id])
-      (get-in event-map ["session" "id"])))
-
-(defn- emit-session-captured!
-  "Publish :agent/session-captured via event-stream.
-
-   nil event-stream is a legal no-op (see emit-stall-event! for the same
-   pattern). Any emission error is caught and logged — the capture itself
-   has already been persisted in the atom, so a delivery failure must not
-   lose the session ID."
-  [{:keys [event-stream workflow-id phase-id backend logger]} session-id]
-  (if-not event-stream
-    (log/info logger "stream-watchdog: no event-stream; session-captured suppressed"
-              {:session-id session-id :phase-id phase-id :backend backend})
-    (try
-      (let [envelope (event-stream/agent-session-captured
-                      event-stream workflow-id phase-id session-id backend)]
-        (event-stream/publish! event-stream envelope))
-      (catch Exception ex
-        (log/warn logger "stream-watchdog: failed to emit :agent/session-captured"
-                  {:session-id session-id :phase-id phase-id
-                   :backend backend :error (ex-message ex)})))))
-
-(defn- emit-stall-event!
-  "Publish a :agent/stream-stalled event to event-stream.
-
-   nil event-stream is treated as a legal no-op (useful in tests and in early
-   pipeline stages that have not yet wired an event-stream). Any emission error
-   is caught and logged so the watchdog thread cannot crash."
-  [event-stream workflow-id phase-id backend logger]
-  (if-not event-stream
-    (log/warn logger "stream-watchdog: no event-stream configured; stall event suppressed"
-              {:phase-id phase-id :backend backend})
-    (try
-      (let [envelope (event-stream/create-envelope
-                      event-stream
-                      :agent/stream-stalled
-                      {:phase/id          phase-id
-                       :agent/backend     backend
-                       :event/workflow-id workflow-id}
-                      {})]
-        (event-stream/publish! event-stream envelope))
-      (catch Exception ex
-        (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
-                  {:phase-id phase-id :backend backend :error (ex-message ex)})))))
-
 (defn- build-check-task
   "Build the Runnable that the scheduler fires every check interval.
 
    When (now − last-event-timestamp) exceeds threshold-ms the task:
      a. Calls kill-fn (kills the agent subprocess).
-     b. Emits :agent/stream-stalled via event-stream.
+     b. Emits :agent/stream-stalled via event-stream with the measured gap.
      c. Sets the stalled? atom to true.
      d. Shuts down the scheduler (one-shot; non-blocking from own thread)."
   [{:keys [^AtomicLong last-event-ts stalled-atom
@@ -159,8 +159,8 @@
                  (catch Exception ex
                    (log/warn logger "stream-watchdog: kill-fn threw"
                              {:error (ex-message ex)})))
-            ;; b. emit stall event (nil-safe)
-            (emit-stall-event! event-stream workflow-id phase-id backend logger)
+            ;; b. emit stall event with measured gap (nil-safe)
+            (emit-stall-event! event-stream workflow-id phase-id backend gap logger)
             ;; c. mark stalled
             (clojure.core/reset! stalled-atom true)
             ;; d. shut down scheduler — non-blocking, safe from own thread
@@ -210,7 +210,7 @@
                          :kill-fn           (or kill-fn (fn []))
                          :scheduler         scheduler
                          :logger            logger}
-        check-task    (build-check-task ctx)]
+        check-task      (build-check-task ctx)]
     (.scheduleAtFixedRate
      scheduler
      check-task
@@ -251,42 +251,47 @@
   [watchdog]
   (boolean (and watchdog @(:stalled-atom watchdog))))
 
-;; ---------------------------------------------------------------------------
-;; Layer 1.5 — session ID capture
-
 (defn capture-session-id!
   "Parse and persist the session ID from the initial agent handshake event.
 
    MUST be called synchronously before the first tool call so that
    resume-on-kill has a valid session ID available.
 
+   Idempotent — once a session ID has been captured further calls are
+   no-ops. This prevents a second :agent/session-captured event if the
+   consumer mistakenly passes multiple early events.
+
    Accepts the first parsed JSON event from the agent subprocess as a
    Clojure map. Supports two common backend handshake shapes:
    - Claude Code: top-level `:session_id` key
    - Codex:       nested `[:session :id]` path
 
-   When a session ID is found:
+   When a session ID is found for the first time:
      1. Stores it in the `:session-id-atom` on the watchdog state (atomic).
      2. Emits :agent/session-captured via event-stream (nil stream is a no-op).
 
+   When the session ID has already been captured, returns the watchdog unchanged.
    When no recognizable session key is present, logs a warning and returns
    the watchdog unchanged; this is not a fatal condition.
 
    Thread-safe — atom reset is atomic; safe to call from the stream-parsing
    thread concurrent with ping! on the watchdog scheduler thread."
   [watchdog event-map]
-  (if-let [sid (extract-session-id event-map)]
-    (do
-      (reset! (:session-id-atom watchdog) sid)
-      (emit-session-captured! watchdog sid)
-      watchdog)
-    (do
-      (log/warn (:logger watchdog)
-                "stream-watchdog: no session ID found in handshake event"
-                {:event-keys (keys event-map)
-                 :phase-id   (:phase-id watchdog)
-                 :backend    (:backend watchdog)})
-      watchdog)))
+  (if @(:session-id-atom watchdog)
+    ;; Already captured — idempotent no-op.
+    watchdog
+    (if-let [sid (extract-session-id event-map)]
+      (do
+        (reset! (:session-id-atom watchdog) sid)
+        (emit-session-captured! watchdog sid)
+        watchdog)
+      (do
+        (log/warn (:logger watchdog)
+                  "stream-watchdog: no session ID found in handshake event"
+                  {:event-keys (keys event-map)
+                   :phase-id   (:phase-id watchdog)
+                   :backend    (:backend watchdog)})
+        watchdog))))
 
 (defn get-session-id
   "Return the captured session ID string, or nil if not yet captured.
@@ -315,7 +320,13 @@
   ;; Simulate an event ping
   (ping! wd)
 
-  ;; Check status
+  ;; Capture session ID from the first handshake event (Claude Code shape)
+  (capture-session-id! wd {:session_id "cc-abc123" :type "system" :subtype "init"})
+
+  ;; Read back the captured ID
+  (get-session-id wd)
+
+  ;; Check stall status
   (stalled? wd)
 
   ;; Graceful shutdown on normal completion

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -25,7 +25,7 @@
    blocks event emission on the hot path.
 
    Layer 0: Config helpers (resolve-gap-threshold)
-   Layer 1: Watchdog lifecycle (create-watchdog, reset!, stop!, stalled?)"
+   Layer 1: Watchdog lifecycle (create-watchdog, ping!, stop!, stalled?)"
   (:require
    [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.logging.interface :as log])
@@ -34,22 +34,25 @@
    (java.util.concurrent.atomic AtomicLong)))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 0 — configuration helpers
+;; Layer 0 — module-level logger and configuration helpers
+
+(defonce ^:private module-logger
+  (log/create-logger {:min-level :info :output :edn}))
 
 (def ^:const default-gap-threshold-ms
   "Default stream-gap threshold in milliseconds (90 seconds)."
   90000)
 
-(def ^:const check-interval-seconds
-  "How often the scheduled watcher fires, in seconds."
-  5)
+(def ^:const default-check-interval-ms
+  "Default watchdog check interval in milliseconds (5 seconds)."
+  5000)
 
 (defn resolve-gap-threshold
   "Resolve the stream-gap threshold in ms for a given backend.
 
    Precedence (highest wins):
-     1. backend-specific entry in :agent/per-backend-gap-thresholds
-     2. global :agent/stream-gap-threshold-ms in config
+     1. Backend-specific entry in :agent/per-backend-gap-thresholds
+     2. Global :agent/stream-gap-threshold-ms in config
      3. `default-gap-threshold-ms` (90 000 ms)
 
    Example config:
@@ -74,15 +77,15 @@
 
 (defn- emit-stall-event!
   "Publish a :agent/stream-stalled event to the event-stream.
-   Best-effort: log and swallow any emission failure so the watchdog
+   Best-effort — logs and swallows any emission failure so the watchdog
    thread itself does not crash."
   [event-stream workflow-id phase-id backend logger]
   (try
     (let [envelope (event-stream/create-envelope
                     event-stream
                     :agent/stream-stalled
-                    {:phase/id       phase-id
-                     :agent/backend  backend
+                    {:phase/id          phase-id
+                     :agent/backend     backend
                      :event/workflow-id workflow-id}
                     {})]
       (event-stream/publish! event-stream envelope))
@@ -91,14 +94,13 @@
                 {:phase-id phase-id :backend backend :error (ex-message ex)}))))
 
 (defn- build-check-task
-  "Build the Runnable that the scheduler fires every `check-interval-seconds`.
+  "Build the Runnable that the scheduler fires every check interval.
 
-   When the gap between now and the last recorded event timestamp exceeds
-   threshold-ms the task:
+   When (now − last-event-timestamp) exceeds threshold-ms the task:
      a. Calls kill-fn (kills the agent subprocess).
      b. Emits :agent/stream-stalled via event-stream.
      c. Sets the stalled? atom to true.
-     d. Shuts down the scheduler (one-shot; idempotent via isShutdown guard)."
+     d. Shuts down the scheduler (one-shot; non-blocking from own thread)."
   [{:keys [^AtomicLong last-event-ts stalled-atom
            threshold-ms phase-id backend event-stream workflow-id kill-fn
            ^ScheduledExecutorService scheduler logger]}]
@@ -118,9 +120,9 @@
             ;; b. emit stall event
             (emit-stall-event! event-stream workflow-id phase-id backend logger)
             ;; c. mark stalled
-            (reset! stalled-atom true)
-            ;; d. shut down scheduler (one-shot)
-            (future (.shutdown scheduler)))))
+            (clojure.core/reset! stalled-atom true)
+            ;; d. shut down scheduler — safe and non-blocking from own thread
+            (.shutdown scheduler))))
       (catch Exception ex
         (log/error logger "stream-watchdog: unhandled error in check task"
                    {:error (ex-message ex)})))))
@@ -129,21 +131,25 @@
   "Create and start a stream-gap watchdog.
 
    Options map:
-     :threshold-ms  — gap in ms before the kill fires (required)
-     :phase-id      — keyword or string identifying the current phase
-     :backend       — keyword identifying the agent backend (e.g. :claude-code)
-     :event-stream  — event-stream instance to publish the stall event
-     :workflow-id   — UUID or string; embedded in the stall event
-     :kill-fn       — zero-arity fn that terminates the agent subprocess
+     :threshold-ms      — gap in ms before the kill fires (default 90 000)
+     :check-interval-ms — how often to check for a stall (default 5 000)
+     :phase-id          — keyword or string identifying the current phase
+     :backend           — keyword identifying the agent backend (e.g. :claude-code)
+     :event-stream      — event-stream instance to publish the stall event
+     :workflow-id       — UUID or string; embedded in the stall event
+     :kill-fn           — zero-arity fn that terminates the agent subprocess
+     :logger            — optional logger; defaults to the module-level logger
 
-   Returns a watchdog state map. Pass it to `reset!`, `stop!`, and `stalled?`.
+   Returns a watchdog state map. Pass it to `ping!`, `stop!`, and `stalled?`.
 
-   The internal scheduler starts immediately on a daemon thread. Events must be
-   reported via `reset!` on every emission to keep the watchdog from firing."
-  [{:keys [threshold-ms phase-id backend event-stream workflow-id kill-fn]
-    :or   {threshold-ms default-gap-threshold-ms}}]
-  (let [logger       (log/create-logger {:min-level :info :output :edn})
-        last-event-ts (AtomicLong. (System/currentTimeMillis))
+   The internal scheduler starts immediately on a daemon thread. Report every
+   agent event via `ping!` to keep the watchdog from firing."
+  [{:keys [threshold-ms check-interval-ms phase-id backend
+           event-stream workflow-id kill-fn logger]
+    :or   {threshold-ms      default-gap-threshold-ms
+           check-interval-ms default-check-interval-ms
+           logger            module-logger}}]
+  (let [last-event-ts (AtomicLong. (System/currentTimeMillis))
         stalled-atom  (atom false)
         scheduler     (Executors/newSingleThreadScheduledExecutor
                        (daemon-thread-factory "stream-watchdog"))
@@ -161,16 +167,18 @@
     (.scheduleAtFixedRate
      scheduler
      check-task
-     check-interval-seconds
-     check-interval-seconds
-     TimeUnit/SECONDS)
+     check-interval-ms
+     check-interval-ms
+     TimeUnit/MILLISECONDS)
     ctx))
 
-(defn reset!
+(defn ping!
   "Record that an agent event just occurred, resetting the gap timer.
 
    Call this on every event emitted by the agent (tool-call, chunk, status, etc.).
-   Thread-safe via AtomicLong.set — never blocks."
+   Thread-safe via AtomicLong.set — never blocks.
+
+   Named `ping!` (not `reset!`) to avoid shadowing `clojure.core/reset!`."
   [watchdog]
   (when-let [^AtomicLong ts (:last-event-ts watchdog)]
     (.set ts (System/currentTimeMillis)))
@@ -200,21 +208,22 @@
 ;; Rich comment — development examples
 
 (comment
-  ;; Minimal watchdog with a 5-second threshold (fires in ~5s without resets)
+  ;; Minimal watchdog with a 200ms threshold and 50ms check interval (for REPL)
   (def wd
     (create-watchdog
-     {:threshold-ms 5000
-      :phase-id     :implement
-      :backend      :claude-code
-      :event-stream nil
-      :workflow-id  "wf-test-001"
-      :kill-fn      #(println "KILL SIGNAL")}))
+     {:threshold-ms      200
+      :check-interval-ms 50
+      :phase-id          :implement
+      :backend           :claude-code
+      :event-stream      nil
+      :workflow-id       "wf-test-001"
+      :kill-fn           #(println "KILL SIGNAL")}))
 
-  ;; Simulate an event
-  (reset! wd)
+  ;; Simulate an event ping
+  (ping! wd)
 
   ;; Check status
   (stalled? wd)
 
-  ;; Graceful shutdown
+  ;; Graceful shutdown on normal completion
   (stop! wd))

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -76,22 +76,27 @@
         (.setDaemon true)))))
 
 (defn- emit-stall-event!
-  "Publish a :agent/stream-stalled event to the event-stream.
-   Best-effort — logs and swallows any emission failure so the watchdog
-   thread itself does not crash."
+  "Publish a :agent/stream-stalled event to event-stream.
+
+   nil event-stream is treated as a legal no-op (useful in tests and in early
+   pipeline stages that have not yet wired an event-stream). Any emission error
+   is caught and logged so the watchdog thread cannot crash."
   [event-stream workflow-id phase-id backend logger]
-  (try
-    (let [envelope (event-stream/create-envelope
-                    event-stream
-                    :agent/stream-stalled
-                    {:phase/id          phase-id
-                     :agent/backend     backend
-                     :event/workflow-id workflow-id}
-                    {})]
-      (event-stream/publish! event-stream envelope))
-    (catch Exception ex
-      (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
-                {:phase-id phase-id :backend backend :error (ex-message ex)}))))
+  (if-not event-stream
+    (log/warn logger "stream-watchdog: no event-stream configured; stall event suppressed"
+              {:phase-id phase-id :backend backend})
+    (try
+      (let [envelope (event-stream/create-envelope
+                      event-stream
+                      :agent/stream-stalled
+                      {:phase/id          phase-id
+                       :agent/backend     backend
+                       :event/workflow-id workflow-id}
+                      {})]
+        (event-stream/publish! event-stream envelope))
+      (catch Exception ex
+        (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
+                  {:phase-id phase-id :backend backend :error (ex-message ex)})))))
 
 (defn- build-check-task
   "Build the Runnable that the scheduler fires every check interval.
@@ -117,11 +122,11 @@
                  (catch Exception ex
                    (log/warn logger "stream-watchdog: kill-fn threw"
                              {:error (ex-message ex)})))
-            ;; b. emit stall event
+            ;; b. emit stall event (nil-safe)
             (emit-stall-event! event-stream workflow-id phase-id backend logger)
             ;; c. mark stalled
             (clojure.core/reset! stalled-atom true)
-            ;; d. shut down scheduler — safe and non-blocking from own thread
+            ;; d. shut down scheduler — non-blocking, safe from own thread
             (.shutdown scheduler))))
       (catch Exception ex
         (log/error logger "stream-watchdog: unhandled error in check task"
@@ -135,7 +140,8 @@
      :check-interval-ms — how often to check for a stall (default 5 000)
      :phase-id          — keyword or string identifying the current phase
      :backend           — keyword identifying the agent backend (e.g. :claude-code)
-     :event-stream      — event-stream instance to publish the stall event
+     :event-stream      — event-stream instance to publish the stall event;
+                          nil is accepted and suppresses event emission
      :workflow-id       — UUID or string; embedded in the stall event
      :kill-fn           — zero-arity fn that terminates the agent subprocess
      :logger            — optional logger; defaults to the module-level logger
@@ -153,16 +159,17 @@
         stalled-atom  (atom false)
         scheduler     (Executors/newSingleThreadScheduledExecutor
                        (daemon-thread-factory "stream-watchdog"))
-        ctx           {:last-event-ts last-event-ts
-                       :stalled-atom  stalled-atom
-                       :threshold-ms  threshold-ms
-                       :phase-id      phase-id
-                       :backend       backend
-                       :event-stream  event-stream
-                       :workflow-id   workflow-id
-                       :kill-fn       (or kill-fn (fn []))
-                       :scheduler     scheduler
-                       :logger        logger}
+        ctx           {:last-event-ts     last-event-ts
+                       :stalled-atom      stalled-atom
+                       :threshold-ms      threshold-ms
+                       :check-interval-ms check-interval-ms
+                       :phase-id          phase-id
+                       :backend           backend
+                       :event-stream      event-stream
+                       :workflow-id       workflow-id
+                       :kill-fn           (or kill-fn (fn []))
+                       :scheduler         scheduler
+                       :logger            logger}
         check-task    (build-check-task ctx)]
     (.scheduleAtFixedRate
      scheduler
@@ -208,11 +215,11 @@
 ;; Rich comment — development examples
 
 (comment
-  ;; Minimal watchdog with a 200ms threshold and 50ms check interval (for REPL)
+  ;; Minimal watchdog with fast settings for REPL experimentation
   (def wd
     (create-watchdog
-     {:threshold-ms      200
-      :check-interval-ms 50
+     {:threshold-ms      1000
+      :check-interval-ms 100
       :phase-id          :implement
       :backend           :claude-code
       :event-stream      nil

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -25,7 +25,7 @@
    blocks event emission on the hot path.
 
    Layer 0: Config helpers (resolve-gap-threshold)
-   Layer 1: Watchdog lifecycle (create-watchdog, ping!, stop!, stalled?)"
+   Layer 1: Watchdog lifecycle (create-watchdog, reset!, stop!, stalled?)"
   (:require
    [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.logging.interface :as log])
@@ -34,25 +34,22 @@
    (java.util.concurrent.atomic AtomicLong)))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 0 — module-level logger and configuration helpers
-
-(defonce ^:private module-logger
-  (log/create-logger {:min-level :info :output :edn}))
+;; Layer 0 — configuration helpers
 
 (def ^:const default-gap-threshold-ms
   "Default stream-gap threshold in milliseconds (90 seconds)."
   90000)
 
-(def ^:const default-check-interval-ms
-  "Default watchdog check interval in milliseconds (5 seconds)."
-  5000)
+(def ^:const check-interval-seconds
+  "How often the scheduled watcher fires, in seconds."
+  5)
 
 (defn resolve-gap-threshold
   "Resolve the stream-gap threshold in ms for a given backend.
 
    Precedence (highest wins):
-     1. Backend-specific entry in :agent/per-backend-gap-thresholds
-     2. Global :agent/stream-gap-threshold-ms in config
+     1. backend-specific entry in :agent/per-backend-gap-thresholds
+     2. global :agent/stream-gap-threshold-ms in config
      3. `default-gap-threshold-ms` (90 000 ms)
 
    Example config:
@@ -76,40 +73,32 @@
         (.setDaemon true)))))
 
 (defn- emit-stall-event!
-  "Publish a :agent/stream-stalled event to event-stream.
-
-   nil event-stream is treated as a legal no-op (useful in tests and in early
-   pipeline stages that have not yet wired an event-stream). Any emission error
-   is caught and logged so the watchdog thread cannot crash.
-
-   Uses the `agent-stream-stalled` constructor from `event-stream.interface`
-   (added in PR #917 / GROUP 1+4 foundation) so the envelope, sequence
-   numbering, and `:workflow/phase` correlation key stay consistent with the
-   rest of the event-stream component."
-  [event-stream workflow-id phase-id gap-duration-ms backend logger]
-  (if-not event-stream
-    (log/debug logger :stream-watchdog :stall-event/suppressed
-               {:reason :no-event-stream
-                :workflow/phase phase-id
-                :agent/backend backend})
-    (try
-      (let [envelope (event-stream/agent-stream-stalled
-                      event-stream workflow-id phase-id gap-duration-ms backend)]
-        (event-stream/publish! event-stream envelope))
-      (catch Exception ex
-        (log/warn logger :stream-watchdog :stall-event/emit-failed
-                  {:workflow/phase phase-id
-                   :agent/backend backend
-                   :error (ex-message ex)})))))
+  "Publish a :agent/stream-stalled event to the event-stream.
+   Best-effort: log and swallow any emission failure so the watchdog
+   thread itself does not crash."
+  [event-stream workflow-id phase-id backend logger]
+  (try
+    (let [envelope (event-stream/create-envelope
+                    event-stream
+                    :agent/stream-stalled
+                    {:phase/id       phase-id
+                     :agent/backend  backend
+                     :event/workflow-id workflow-id}
+                    {})]
+      (event-stream/publish! event-stream envelope))
+    (catch Exception ex
+      (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
+                {:phase-id phase-id :backend backend :error (ex-message ex)}))))
 
 (defn- build-check-task
-  "Build the Runnable that the scheduler fires every check interval.
+  "Build the Runnable that the scheduler fires every `check-interval-seconds`.
 
-   When (now − last-event-timestamp) exceeds threshold-ms the task:
+   When the gap between now and the last recorded event timestamp exceeds
+   threshold-ms the task:
      a. Calls kill-fn (kills the agent subprocess).
      b. Emits :agent/stream-stalled via event-stream.
      c. Sets the stalled? atom to true.
-     d. Shuts down the scheduler (one-shot; non-blocking from own thread)."
+     d. Shuts down the scheduler (one-shot; idempotent via isShutdown guard)."
   [{:keys [^AtomicLong last-event-ts stalled-atom
            threshold-ms phase-id backend event-stream workflow-id kill-fn
            ^ScheduledExecutorService scheduler logger]}]
@@ -118,82 +107,70 @@
       (when-not (.isShutdown scheduler)
         (let [gap (- (System/currentTimeMillis) (.get last-event-ts))]
           (when (> gap threshold-ms)
-            (log/warn logger :stream-watchdog :stream/gap-exceeded
-                      {:stream/gap-duration-ms gap
-                       :stream/gap-threshold-ms threshold-ms
-                       :workflow/phase phase-id
-                       :agent/backend backend})
+            (log/warn logger "stream-watchdog: gap exceeded threshold — killing agent"
+                      {:gap-ms gap :threshold-ms threshold-ms
+                       :phase-id phase-id :backend backend})
             ;; a. kill the subprocess
             (try (kill-fn)
                  (catch Exception ex
-                   (log/warn logger :stream-watchdog :stream/kill-fn-failed
-                             {:workflow/phase phase-id
-                              :agent/backend backend
-                              :error (ex-message ex)})))
-            ;; b. emit stall event (nil-safe)
-            (emit-stall-event! event-stream workflow-id phase-id gap backend logger)
+                   (log/warn logger "stream-watchdog: kill-fn threw"
+                             {:error (ex-message ex)})))
+            ;; b. emit stall event
+            (emit-stall-event! event-stream workflow-id phase-id backend logger)
             ;; c. mark stalled
-            (clojure.core/reset! stalled-atom true)
-            ;; d. shut down scheduler — non-blocking, safe from own thread
-            (.shutdown scheduler))))
+            (reset! stalled-atom true)
+            ;; d. shut down scheduler (one-shot)
+            (future (.shutdown scheduler)))))
       (catch Exception ex
-        (log/error logger :stream-watchdog :check-task/unhandled-error
+        (log/error logger "stream-watchdog: unhandled error in check task"
                    {:error (ex-message ex)})))))
 
 (defn create-watchdog
   "Create and start a stream-gap watchdog.
 
    Options map:
-     :threshold-ms      — gap in ms before the kill fires (default 90 000)
-     :check-interval-ms — how often to check for a stall (default 5 000)
-     :phase-id          — keyword or string identifying the current phase
-     :backend           — keyword identifying the agent backend (e.g. :claude-code)
-     :event-stream      — event-stream instance to publish the stall event;
-                          nil is accepted and suppresses event emission
-     :workflow-id       — UUID or string; embedded in the stall event
-     :kill-fn           — zero-arity fn that terminates the agent subprocess
-     :logger            — optional logger; defaults to the module-level logger
+     :threshold-ms  — gap in ms before the kill fires (required)
+     :phase-id      — keyword or string identifying the current phase
+     :backend       — keyword identifying the agent backend (e.g. :claude-code)
+     :event-stream  — event-stream instance to publish the stall event
+     :workflow-id   — UUID or string; embedded in the stall event
+     :kill-fn       — zero-arity fn that terminates the agent subprocess
 
-   Returns a watchdog state map. Pass it to `ping!`, `stop!`, and `stalled?`.
+   Returns a watchdog state map. Pass it to `reset!`, `stop!`, and `stalled?`.
 
-   The internal scheduler starts immediately on a daemon thread. Report every
-   agent event via `ping!` to keep the watchdog from firing."
-  [{:keys [threshold-ms check-interval-ms phase-id backend
-           event-stream workflow-id kill-fn logger]
-    :or   {threshold-ms      default-gap-threshold-ms
-           check-interval-ms default-check-interval-ms
-           logger            module-logger}}]
-  (let [last-event-ts (AtomicLong. (System/currentTimeMillis))
+   The internal scheduler starts immediately on a daemon thread. Events must be
+   reported via `reset!` on every emission to keep the watchdog from firing."
+  [{:keys [threshold-ms phase-id backend event-stream workflow-id kill-fn]
+    :or   {threshold-ms default-gap-threshold-ms}}]
+  (let [logger       (log/create-logger {:min-level :info :output :edn})
+        last-event-ts (AtomicLong. (System/currentTimeMillis))
         stalled-atom  (atom false)
         scheduler     (Executors/newSingleThreadScheduledExecutor
                        (daemon-thread-factory "stream-watchdog"))
-        ctx           {:last-event-ts     last-event-ts
-                       :stalled-atom      stalled-atom
-                       :threshold-ms      threshold-ms
-                       :check-interval-ms check-interval-ms
-                       :phase-id          phase-id
-                       :backend           backend
-                       :event-stream      event-stream
-                       :workflow-id       workflow-id
-                       :kill-fn           (or kill-fn (fn []))
-                       :scheduler         scheduler
-                       :logger            logger}
+        ctx           {:last-event-ts last-event-ts
+                       :stalled-atom  stalled-atom
+                       :threshold-ms  threshold-ms
+                       :phase-id      phase-id
+                       :backend       backend
+                       :event-stream  event-stream
+                       :workflow-id   workflow-id
+                       :kill-fn       (or kill-fn (fn []))
+                       :scheduler     scheduler
+                       :logger        logger}
         check-task    (build-check-task ctx)]
     (.scheduleAtFixedRate
      scheduler
      check-task
-     check-interval-ms
-     check-interval-ms
-     TimeUnit/MILLISECONDS)
+     check-interval-seconds
+     check-interval-seconds
+     TimeUnit/SECONDS)
     ctx))
 
-(defn ping!
+(defn reset!
   "Record that an agent event just occurred, resetting the gap timer.
 
    Call this on every event emitted by the agent (tool-call, chunk, status, etc.).
-   Thread-safe via AtomicLong.set — never blocks.
-
-   Named `ping!` (not `reset!`) to avoid shadowing `clojure.core/reset!`."
+   Thread-safe via AtomicLong.set — never blocks."
   [watchdog]
   (when-let [^AtomicLong ts (:last-event-ts watchdog)]
     (.set ts (System/currentTimeMillis)))
@@ -223,22 +200,21 @@
 ;; Rich comment — development examples
 
 (comment
-  ;; Minimal watchdog with fast settings for REPL experimentation
+  ;; Minimal watchdog with a 5-second threshold (fires in ~5s without resets)
   (def wd
     (create-watchdog
-     {:threshold-ms      1000
-      :check-interval-ms 100
-      :phase-id          :implement
-      :backend           :claude-code
-      :event-stream      nil
-      :workflow-id       "wf-test-001"
-      :kill-fn           #(println "KILL SIGNAL")}))
+     {:threshold-ms 5000
+      :phase-id     :implement
+      :backend      :claude-code
+      :event-stream nil
+      :workflow-id  "wf-test-001"
+      :kill-fn      #(println "KILL SIGNAL")}))
 
-  ;; Simulate an event ping
-  (ping! wd)
+  ;; Simulate an event
+  (reset! wd)
 
   ;; Check status
   (stalled? wd)
 
-  ;; Graceful shutdown on normal completion
+  ;; Graceful shutdown
   (stop! wd))

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -30,14 +30,17 @@
 
 (defn- make-test-watchdog
   "Merge caller opts over safe defaults. Uses fast check-interval-ms so
-   fire-on-threshold tests complete quickly."
+   fire-on-threshold tests complete quickly.
+
+   `:workflow-id` defaults to a random UUID (matches production usage and
+   the `:workflow/id uuid?` constraint in the event-stream schemas)."
   [opts]
   (merge {:threshold-ms      200
           :check-interval-ms 50         ;; fast checks for test speed
           :phase-id          :test-phase
           :backend           :mock
           :event-stream      nil
-          :workflow-id       "wf-test"
+          :workflow-id       (random-uuid)
           :kill-fn           (fn [])}
          opts))
 
@@ -129,7 +132,7 @@
 (deftest create-watchdog-uses-default-threshold-when-omitted
   (testing "omitting :threshold-ms falls back to default-gap-threshold-ms"
     (let [wd (sut/create-watchdog {:phase-id :x :backend :y
-                                   :event-stream nil :workflow-id "w"
+                                   :event-stream nil :workflow-id (random-uuid)
                                    :kill-fn (fn [])})]
       (try
         (is (= sut/default-gap-threshold-ms (:threshold-ms wd)))
@@ -366,7 +369,7 @@
                         {:event-stream mock-stream
                          :phase-id     :implement
                          :backend      :claude-code
-                         :workflow-id  "wf-session-test"}))]
+                         :workflow-id  (random-uuid)}))]
       (try
         (sut/capture-session-id! wd {:session_id "cc-emit-test-session"})
         ;; Atom store is synchronous; event emission is also synchronous.
@@ -377,7 +380,7 @@
         (let [evt (first @published)]
           (is (= :agent/session-captured (:event/type evt)))
           (is (= "cc-emit-test-session" (:agent/session-id evt)))
-          (is (= :implement (:phase/id evt)))
+          (is (= :implement (:workflow/phase evt)))
           (is (= :claude-code (:agent/backend evt))))
         (finally
           (sut/stop! wd))))))
@@ -392,7 +395,7 @@
                         {:event-stream mock-stream
                          :phase-id     :implement
                          :backend      :claude-code
-                         :workflow-id  "wf-idempotent-test"}))]
+                         :workflow-id  (random-uuid)}))]
       (try
         (sut/capture-session-id! wd {:session_id "once-only-session"})
         (sut/capture-session-id! wd {:session_id "second-call-ignored"})

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -20,7 +20,8 @@
   "Tests for the per-phase stream-gap watchdog timer."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.agent.stream-watchdog :as sut])
+   [ai.miniforge.agent.stream-watchdog :as sut]
+   [ai.miniforge.event-stream.interface :as event-stream-iface])
   (:import
    (java.util.concurrent.atomic AtomicLong)))
 
@@ -208,10 +209,12 @@
                      :kill-fn           #(reset! killed? true)}))]
       ;; Back-date to make the gap already exceeded
       (backdate! wd 400)
-      ;; Wait for the first check tick (up to 2s)
-      (let [fired? (await-condition #(deref killed?) 2000)]
+      ;; Gate on BOTH kill-fn having fired AND stalled? being true so the
+      ;; assertion can never outrun the scheduler thread (which sets
+      ;; stalled-atom after calling kill-fn).
+      (let [fired? (await-condition #(and @killed? (sut/stalled? wd)) 2000)]
         (sut/stop! wd)
-        (is fired? "kill-fn should fire when gap > threshold-ms")
+        (is fired? "kill-fn fired and watchdog marked stalled")
         (is (sut/stalled? wd) "watchdog should be marked stalled")))))
 
 ;; ---------------------------------------------------------------------------
@@ -335,18 +338,29 @@
           (sut/stop! wd))))))
 
 ;; ---------------------------------------------------------------------------
+;; capture-session-id! — idempotency
+
+(deftest capture-session-id-is-idempotent
+  (testing "second call with different session ID is a no-op; first ID is preserved"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (sut/capture-session-id! wd {:session_id "first-session-id"})
+        (sut/capture-session-id! wd {:session_id "second-session-id"})
+        (is (= "first-session-id" (sut/get-session-id wd))
+            "second call must not overwrite the first captured session ID")
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
 ;; capture-session-id! — emits :agent/session-captured event
 
 (deftest capture-session-id-emits-event
   (testing "capture-session-id! publishes :agent/session-captured to event-stream"
     (let [published   (atom [])
-          mock-stream (atom {:seq 0 :events [] :sinks []
-                             :quiesced-workflows #{} :in-flight 0
-                             :snowflake-generator nil
-                             :subscribers {}})
-          ;; Intercept publish! by swapping a fake sink
-          _           (swap! mock-stream assoc :sinks
-                             [(fn [evt] (swap! published conj evt))])
+          ;; Use the real create-event-stream so the mock matches the
+          ;; authoritative schema (sequence-numbers, subscribers, etc.).
+          mock-stream (event-stream-iface/create-event-stream
+                       {:sinks [(fn [evt] (swap! published conj evt))]})
           wd          (sut/create-watchdog
                        (make-test-watchdog
                         {:event-stream mock-stream
@@ -355,9 +369,35 @@
                          :workflow-id  "wf-session-test"}))]
       (try
         (sut/capture-session-id! wd {:session_id "cc-emit-test-session"})
-        ;; Allow a moment for synchronous publish
+        ;; Atom store is synchronous; event emission is also synchronous.
         (is (= "cc-emit-test-session" (sut/get-session-id wd))
             "session ID must be stored in atom")
+        (is (= 1 (count @published))
+            "exactly one :agent/session-captured event should be published")
+        (let [evt (first @published)]
+          (is (= :agent/session-captured (:event/type evt)))
+          (is (= "cc-emit-test-session" (:agent/session-id evt)))
+          (is (= :implement (:phase/id evt)))
+          (is (= :claude-code (:agent/backend evt))))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest capture-session-id-emits-event-only-once-when-idempotent
+  (testing "idempotent second call does not emit a second event"
+    (let [published   (atom [])
+          mock-stream (event-stream-iface/create-event-stream
+                       {:sinks [(fn [evt] (swap! published conj evt))]})
+          wd          (sut/create-watchdog
+                       (make-test-watchdog
+                        {:event-stream mock-stream
+                         :phase-id     :implement
+                         :backend      :claude-code
+                         :workflow-id  "wf-idempotent-test"}))]
+      (try
+        (sut/capture-session-id! wd {:session_id "once-only-session"})
+        (sut/capture-session-id! wd {:session_id "second-call-ignored"})
+        (is (= 1 (count @published))
+            "only one event should be published even when called twice")
         (finally
           (sut/stop! wd))))))
 

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -19,7 +19,7 @@
 (ns ai.miniforge.agent.stream-watchdog-test
   "Tests for the per-phase stream-gap watchdog timer."
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.agent.stream-watchdog :as sut])
   (:import
    (java.util.concurrent.atomic AtomicLong)))
@@ -28,16 +28,14 @@
 ;; Helpers
 
 (defn- make-test-watchdog
-  "Merge caller opts over safe defaults. Uses fast check-interval-ms so
-   fire-on-threshold tests complete quickly."
+  "Create a watchdog with an artificially short threshold for testing."
   [opts]
-  (merge {:threshold-ms      200
-          :check-interval-ms 50         ;; fast checks for test speed
-          :phase-id          :test-phase
-          :backend           :mock
-          :event-stream      nil
-          :workflow-id       "wf-test"
-          :kill-fn           (fn [])}
+  (merge {:threshold-ms 200
+          :phase-id     :test-phase
+          :backend      :mock
+          :event-stream nil
+          :workflow-id  "wf-test"
+          :kill-fn      (fn [])}
          opts))
 
 (defn- await-condition
@@ -50,15 +48,7 @@
         true
         (if (> (System/currentTimeMillis) deadline)
           false
-          (do (Thread/sleep 10) (recur)))))))
-
-(defn- backdate!
-  "Back-date a watchdog's AtomicLong by `offset-ms` so the gap is already
-   exceeded on the next check tick."
-  [watchdog offset-ms]
-  (let [^AtomicLong ts (:last-event-ts watchdog)]
-    (.set ts (- (System/currentTimeMillis) offset-ms)))
-  watchdog)
+          (do (Thread/sleep 50) (recur)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; resolve-gap-threshold
@@ -76,18 +66,18 @@
             :claude-code)))))
 
 (deftest resolve-gap-threshold-returns-backend-specific-override
-  (testing "per-backend entry wins over global threshold"
-    (let [config {:agent/stream-gap-threshold-ms     60000
+  (testing "per-backend entry overrides global threshold"
+    (let [config {:agent/stream-gap-threshold-ms      60000
                   :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
       (is (= 120000 (sut/resolve-gap-threshold config :claude-code)))))
 
-  (testing "falls back to global for an unlisted backend"
-    (let [config {:agent/stream-gap-threshold-ms     60000
+  (testing "falls back to global threshold for an unlisted backend"
+    (let [config {:agent/stream-gap-threshold-ms      60000
                   :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
       (is (= 60000 (sut/resolve-gap-threshold config :other-backend))))))
 
 (deftest resolve-gap-threshold-default-constant-is-90s
-  (testing "default constant is 90 000 ms"
+  (testing "default constant value is 90 000 ms"
     (is (= 90000 sut/default-gap-threshold-ms))))
 
 ;; ---------------------------------------------------------------------------
@@ -101,19 +91,10 @@
         (is (contains? wd :stalled-atom))
         (is (contains? wd :scheduler))
         (is (contains? wd :threshold-ms))
-        (is (contains? wd :check-interval-ms))
         (is (contains? wd :phase-id))
         (is (contains? wd :backend))
         (is (instance? AtomicLong (:last-event-ts wd)))
         (is (instance? clojure.lang.Atom (:stalled-atom wd)))
-        (finally
-          (sut/stop! wd))))))
-
-(deftest create-watchdog-stores-check-interval-ms
-  (testing ":check-interval-ms is stored in the returned watchdog map"
-    (let [wd (sut/create-watchdog (make-test-watchdog {:check-interval-ms 123}))]
-      (try
-        (is (= 123 (:check-interval-ms wd)))
         (finally
           (sut/stop! wd))))))
 
@@ -136,26 +117,26 @@
           (sut/stop! wd))))))
 
 ;; ---------------------------------------------------------------------------
-;; ping!
+;; reset!
 
-(deftest ping-updates-timestamp
-  (testing "ping! advances the AtomicLong to current time"
+(deftest reset-updates-timestamp
+  (testing "reset! updates the AtomicLong to current time"
     (let [wd (sut/create-watchdog (make-test-watchdog {}))]
       (try
         (let [^AtomicLong ts (:last-event-ts wd)
               before          (.get ts)]
           (Thread/sleep 5)
-          (sut/ping! wd)
+          (sut/reset! wd)
           (let [after (.get ts)]
             (is (>= after before))))
         (finally
           (sut/stop! wd))))))
 
-(deftest ping-returns-the-watchdog-map
-  (testing "ping! returns the watchdog map (fluent chaining)"
+(deftest reset-returns-the-watchdog-map
+  (testing "reset! returns the watchdog map (fluent chaining)"
     (let [wd (sut/create-watchdog (make-test-watchdog {}))]
       (try
-        (is (= wd (sut/ping! wd)))
+        (is (= wd (sut/reset! wd)))
         (finally
           (sut/stop! wd))))))
 
@@ -199,46 +180,48 @@
 ;; End-to-end: kill fires when threshold exceeded
 
 (deftest watchdog-fires-kill-when-gap-exceeded
-  (testing "kill-fn is called when the backdated gap exceeds threshold-ms"
+  (testing "kill-fn is called after the threshold is exceeded"
     (let [killed? (atom false)
           wd      (sut/create-watchdog
-                   (make-test-watchdog
-                    {:threshold-ms      200
-                     :check-interval-ms 50
-                     :kill-fn           #(reset! killed? true)}))]
-      ;; Back-date to make the gap already exceeded
-      (backdate! wd 400)
-      ;; Wait for the first check tick (up to 2s)
-      (let [fired? (await-condition #(deref killed?) 2000)]
+                   {:threshold-ms 100          ;; 100 ms threshold
+                    :phase-id     :test
+                    :backend      :mock
+                    :event-stream nil
+                    :workflow-id  "wf-fire-test"
+                    :kill-fn      #(reset! killed? true)})]
+      ;; Wait up to 3 seconds for the kill to fire (check runs every 5s normally,
+      ;; but the threshold is 100ms so the very first check — at 5s — will exceed
+      ;; it; we wait up to 3× the check-interval-seconds window)
+      ;; Note: actual check fires at check-interval-seconds (5s). For speed in
+      ;; unit tests we manipulate the last-event timestamp directly.
+      (let [^AtomicLong ts (:last-event-ts wd)]
+        ;; Back-date the timestamp so the gap is already exceeded
+        (.set ts (- (System/currentTimeMillis) 200)))
+      (let [fired? (await-condition #(deref killed?) 12000)]
         (sut/stop! wd)
-        (is fired? "kill-fn should fire when gap > threshold-ms")
-        (is (sut/stalled? wd) "watchdog should be marked stalled")))))
+        (is fired? "kill-fn should have been called when the gap exceeded threshold-ms")
+        (is (sut/stalled? wd) "watchdog should be marked stalled after kill")))))
 
-;; ---------------------------------------------------------------------------
-;; ping! actually prevents the kill from firing
-
-(deftest ping-prevents-kill-when-gap-was-backdated
-  (testing "ping! resets the timestamp; a stale backdated gap must not fire the kill"
-    ;; threshold-ms 1000 and sleep 300ms gives 700ms safety margin —
-    ;; the watchdog cannot accumulate a fresh 1000ms gap in only 300ms.
-    (let [killed? (atom false)
-          wd      (sut/create-watchdog
-                   (make-test-watchdog
-                    {:threshold-ms      1000
-                     :check-interval-ms 50
-                     :kill-fn           #(reset! killed? true)}))]
-      ;; Simulate a stale gap that would exceed a lower threshold...
-      (backdate! wd 800)
-      ;; ...but immediately reset the timestamp via ping!
-      (sut/ping! wd)
-      ;; Allow multiple check ticks (300ms ≪ threshold-ms 1000ms).
-      ;; The gap after ping! is ~0ms; even after 300ms it is ~300ms < 1000ms.
-      (Thread/sleep 300)
+(deftest watchdog-does-not-fire-when-regularly-reset
+  (testing "kill-fn is NOT called when reset! is called frequently enough"
+    (let [killed?    (atom false)
+          threshold  200
+          wd         (sut/create-watchdog
+                      {:threshold-ms threshold
+                       :phase-id     :test
+                       :backend      :mock
+                       :event-stream nil
+                       :workflow-id  "wf-no-fire"
+                       :kill-fn      #(reset! killed? true)})]
+      ;; Keep resetting every 50ms for 2 seconds (well within check interval)
+      (dotimes [_ 10]
+        (Thread/sleep 50)
+        (sut/reset! wd))
       (sut/stop! wd)
-      (is (not @killed?)
-          "kill-fn must NOT fire if ping! kept the timestamp current")
-      (is (not (sut/stalled? wd))
-          "watchdog must NOT be marked stalled when ping! suppressed the kill"))))
+      ;; The scheduler fires every 5s; we stopped it cleanly before any check.
+      ;; If no check ran, kill should not have fired.
+      (is (not (sut/stalled? wd)))
+      (is (false? @killed?)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Interface namespace re-export sanity
@@ -248,20 +231,8 @@
     (require 'ai.miniforge.agent.interface.watchdog)
     (let [iface (find-ns 'ai.miniforge.agent.interface.watchdog)]
       (is (some? (ns-resolve iface 'create-watchdog)))
-      (is (some? (ns-resolve iface 'ping!)))
+      (is (some? (ns-resolve iface 'reset!)))
       (is (some? (ns-resolve iface 'stop!)))
       (is (some? (ns-resolve iface 'stalled?)))
       (is (some? (ns-resolve iface 'resolve-gap-threshold)))
-      (is (some? (ns-resolve iface 'default-gap-threshold-ms)))
-      (is (some? (ns-resolve iface 'default-check-interval-ms))))))
-
-(deftest interface-watchdog-vars-point-to-same-fns
-  (testing "re-exported vars are identical to source vars (not copies)"
-    (require 'ai.miniforge.agent.interface.watchdog)
-    (let [iface (find-ns 'ai.miniforge.agent.interface.watchdog)]
-      (is (= (var-get (ns-resolve iface 'ping!))
-             sut/ping!))
-      (is (= (var-get (ns-resolve iface 'stop!))
-             sut/stop!))
-      (is (= (var-get (ns-resolve iface 'stalled?))
-             sut/stalled?)))))
+      (is (some? (ns-resolve iface 'default-gap-threshold-ms))))))

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -19,7 +19,7 @@
 (ns ai.miniforge.agent.stream-watchdog-test
   "Tests for the per-phase stream-gap watchdog timer."
   (:require
-   [clojure.test :refer [deftest is testing use-fixtures]]
+   [clojure.test :refer [deftest is testing]]
    [ai.miniforge.agent.stream-watchdog :as sut])
   (:import
    (java.util.concurrent.atomic AtomicLong)))
@@ -28,14 +28,16 @@
 ;; Helpers
 
 (defn- make-test-watchdog
-  "Create a watchdog with an artificially short threshold for testing."
+  "Merge caller opts over safe defaults. Uses a fast check interval so
+   fire-on-threshold tests complete quickly without sleep gymnastics."
   [opts]
-  (merge {:threshold-ms 200
-          :phase-id     :test-phase
-          :backend      :mock
-          :event-stream nil
-          :workflow-id  "wf-test"
-          :kill-fn      (fn [])}
+  (merge {:threshold-ms      200
+          :check-interval-ms 50        ;; fast checks for test speed
+          :phase-id          :test-phase
+          :backend           :mock
+          :event-stream      nil
+          :workflow-id       "wf-test"
+          :kill-fn           (fn [])}
          opts))
 
 (defn- await-condition
@@ -48,7 +50,15 @@
         true
         (if (> (System/currentTimeMillis) deadline)
           false
-          (do (Thread/sleep 50) (recur)))))))
+          (do (Thread/sleep 10) (recur)))))))
+
+(defn- backdate!
+  "Back-date a watchdog's AtomicLong by `offset-ms` so the gap is already
+   exceeded on the next check tick."
+  [watchdog offset-ms]
+  (let [^AtomicLong ts (:last-event-ts watchdog)]
+    (.set ts (- (System/currentTimeMillis) offset-ms)))
+  watchdog)
 
 ;; ---------------------------------------------------------------------------
 ;; resolve-gap-threshold
@@ -66,18 +76,18 @@
             :claude-code)))))
 
 (deftest resolve-gap-threshold-returns-backend-specific-override
-  (testing "per-backend entry overrides global threshold"
-    (let [config {:agent/stream-gap-threshold-ms      60000
+  (testing "per-backend entry wins over global threshold"
+    (let [config {:agent/stream-gap-threshold-ms     60000
                   :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
       (is (= 120000 (sut/resolve-gap-threshold config :claude-code)))))
 
-  (testing "falls back to global threshold for an unlisted backend"
-    (let [config {:agent/stream-gap-threshold-ms      60000
+  (testing "falls back to global for an unlisted backend"
+    (let [config {:agent/stream-gap-threshold-ms     60000
                   :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
       (is (= 60000 (sut/resolve-gap-threshold config :other-backend))))))
 
 (deftest resolve-gap-threshold-default-constant-is-90s
-  (testing "default constant value is 90 000 ms"
+  (testing "default constant is 90 000 ms"
     (is (= 90000 sut/default-gap-threshold-ms))))
 
 ;; ---------------------------------------------------------------------------
@@ -116,27 +126,38 @@
         (finally
           (sut/stop! wd))))))
 
-;; ---------------------------------------------------------------------------
-;; reset!
+(deftest create-watchdog-accepts-check-interval-ms
+  (testing ":check-interval-ms is stored in the watchdog map"
+    (let [wd (sut/create-watchdog (make-test-watchdog {:check-interval-ms 100}))]
+      (try
+        ;; The scheduler is started with the custom interval; we verify it by
+        ;; checking the ctx key is absent (not stored) but the scheduler is alive.
+        ;; Structural check: scheduler is running
+        (is (not (.isShutdown (:scheduler wd))))
+        (finally
+          (sut/stop! wd))))))
 
-(deftest reset-updates-timestamp
-  (testing "reset! updates the AtomicLong to current time"
+;; ---------------------------------------------------------------------------
+;; ping!
+
+(deftest ping-updates-timestamp
+  (testing "ping! advances the AtomicLong to current time"
     (let [wd (sut/create-watchdog (make-test-watchdog {}))]
       (try
         (let [^AtomicLong ts (:last-event-ts wd)
               before          (.get ts)]
           (Thread/sleep 5)
-          (sut/reset! wd)
+          (sut/ping! wd)
           (let [after (.get ts)]
             (is (>= after before))))
         (finally
           (sut/stop! wd))))))
 
-(deftest reset-returns-the-watchdog-map
-  (testing "reset! returns the watchdog map (fluent chaining)"
+(deftest ping-returns-the-watchdog-map
+  (testing "ping! returns the watchdog map (fluent chaining)"
     (let [wd (sut/create-watchdog (make-test-watchdog {}))]
       (try
-        (is (= wd (sut/reset! wd)))
+        (is (= wd (sut/ping! wd)))
         (finally
           (sut/stop! wd))))))
 
@@ -180,48 +201,49 @@
 ;; End-to-end: kill fires when threshold exceeded
 
 (deftest watchdog-fires-kill-when-gap-exceeded
-  (testing "kill-fn is called after the threshold is exceeded"
+  (testing "kill-fn is called when the backdated gap exceeds threshold-ms"
     (let [killed? (atom false)
           wd      (sut/create-watchdog
-                   {:threshold-ms 100          ;; 100 ms threshold
-                    :phase-id     :test
-                    :backend      :mock
-                    :event-stream nil
-                    :workflow-id  "wf-fire-test"
-                    :kill-fn      #(reset! killed? true)})]
-      ;; Wait up to 3 seconds for the kill to fire (check runs every 5s normally,
-      ;; but the threshold is 100ms so the very first check — at 5s — will exceed
-      ;; it; we wait up to 3× the check-interval-seconds window)
-      ;; Note: actual check fires at check-interval-seconds (5s). For speed in
-      ;; unit tests we manipulate the last-event timestamp directly.
-      (let [^AtomicLong ts (:last-event-ts wd)]
-        ;; Back-date the timestamp so the gap is already exceeded
-        (.set ts (- (System/currentTimeMillis) 200)))
-      (let [fired? (await-condition #(deref killed?) 12000)]
+                   (make-test-watchdog
+                    {:threshold-ms      200
+                     :check-interval-ms 50
+                     :kill-fn           #(reset! killed? true)}))]
+      ;; Back-date to make the gap already exceeded
+      (backdate! wd 400)
+      ;; Wait for the first check tick (up to 2s)
+      (let [fired? (await-condition #(deref killed?) 2000)]
         (sut/stop! wd)
-        (is fired? "kill-fn should have been called when the gap exceeded threshold-ms")
-        (is (sut/stalled? wd) "watchdog should be marked stalled after kill")))))
+        (is fired? "kill-fn should fire when gap > threshold-ms")
+        (is (sut/stalled? wd) "watchdog should be marked stalled")))))
 
-(deftest watchdog-does-not-fire-when-regularly-reset
-  (testing "kill-fn is NOT called when reset! is called frequently enough"
-    (let [killed?    (atom false)
-          threshold  200
-          wd         (sut/create-watchdog
-                      {:threshold-ms threshold
-                       :phase-id     :test
-                       :backend      :mock
-                       :event-stream nil
-                       :workflow-id  "wf-no-fire"
-                       :kill-fn      #(reset! killed? true)})]
-      ;; Keep resetting every 50ms for 2 seconds (well within check interval)
-      (dotimes [_ 10]
-        (Thread/sleep 50)
-        (sut/reset! wd))
-      (sut/stop! wd)
-      ;; The scheduler fires every 5s; we stopped it cleanly before any check.
-      ;; If no check ran, kill should not have fired.
-      (is (not (sut/stalled? wd)))
-      (is (false? @killed?)))))
+;; ---------------------------------------------------------------------------
+;; ping! actually prevents the kill from firing
+
+(deftest ping-prevents-kill-when-gap-was-backdated
+  "ping! resets the timestamp to now. Even if the timestamp was back-dated
+   to simulate a stale gap, calling ping! before the next check tick should
+   make the gap measurement fresh and suppress the kill.
+
+   This test is effective because we use a fast 50ms check-interval-ms and
+   call ping! immediately after backdating, then verify the kill never fires
+   over multiple check cycles."
+  (let [killed? (atom false)
+        wd      (sut/create-watchdog
+                 (make-test-watchdog
+                  {:threshold-ms      200
+                   :check-interval-ms 50
+                   :kill-fn           #(reset! killed? true)}))]
+    ;; Simulate a gap that would exceed threshold...
+    (backdate! wd 400)
+    ;; ...but immediately reset the timestamp via ping!
+    (sut/ping! wd)
+    ;; Let multiple check ticks run (300ms = ~6 ticks at 50ms interval)
+    (Thread/sleep 300)
+    (sut/stop! wd)
+    (is (not @killed?)
+        "kill-fn must NOT fire if ping! kept the timestamp current")
+    (is (not (sut/stalled? wd))
+        "watchdog must NOT be marked stalled when ping! suppressed the kill")))
 
 ;; ---------------------------------------------------------------------------
 ;; Interface namespace re-export sanity
@@ -231,8 +253,20 @@
     (require 'ai.miniforge.agent.interface.watchdog)
     (let [iface (find-ns 'ai.miniforge.agent.interface.watchdog)]
       (is (some? (ns-resolve iface 'create-watchdog)))
-      (is (some? (ns-resolve iface 'reset!)))
+      (is (some? (ns-resolve iface 'ping!)))
       (is (some? (ns-resolve iface 'stop!)))
       (is (some? (ns-resolve iface 'stalled?)))
       (is (some? (ns-resolve iface 'resolve-gap-threshold)))
-      (is (some? (ns-resolve iface 'default-gap-threshold-ms))))))
+      (is (some? (ns-resolve iface 'default-gap-threshold-ms)))
+      (is (some? (ns-resolve iface 'default-check-interval-ms))))))
+
+(deftest interface-watchdog-vars-point-to-same-fns
+  (testing "re-exported vars are identical to source vars (not copies)"
+    (require 'ai.miniforge.agent.interface.watchdog)
+    (let [iface (find-ns 'ai.miniforge.agent.interface.watchdog)]
+      (is (= (var-get (ns-resolve iface 'ping!))
+             sut/ping!))
+      (is (= (var-get (ns-resolve iface 'stop!))
+             sut/stop!))
+      (is (= (var-get (ns-resolve iface 'stalled?))
+             sut/stalled?)))))

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -28,11 +28,11 @@
 ;; Helpers
 
 (defn- make-test-watchdog
-  "Merge caller opts over safe defaults. Uses a fast check interval so
-   fire-on-threshold tests complete quickly without sleep gymnastics."
+  "Merge caller opts over safe defaults. Uses fast check-interval-ms so
+   fire-on-threshold tests complete quickly."
   [opts]
   (merge {:threshold-ms      200
-          :check-interval-ms 50        ;; fast checks for test speed
+          :check-interval-ms 50         ;; fast checks for test speed
           :phase-id          :test-phase
           :backend           :mock
           :event-stream      nil
@@ -101,10 +101,19 @@
         (is (contains? wd :stalled-atom))
         (is (contains? wd :scheduler))
         (is (contains? wd :threshold-ms))
+        (is (contains? wd :check-interval-ms))
         (is (contains? wd :phase-id))
         (is (contains? wd :backend))
         (is (instance? AtomicLong (:last-event-ts wd)))
         (is (instance? clojure.lang.Atom (:stalled-atom wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest create-watchdog-stores-check-interval-ms
+  (testing ":check-interval-ms is stored in the returned watchdog map"
+    (let [wd (sut/create-watchdog (make-test-watchdog {:check-interval-ms 123}))]
+      (try
+        (is (= 123 (:check-interval-ms wd)))
         (finally
           (sut/stop! wd))))))
 
@@ -123,17 +132,6 @@
                                    :kill-fn (fn [])})]
       (try
         (is (= sut/default-gap-threshold-ms (:threshold-ms wd)))
-        (finally
-          (sut/stop! wd))))))
-
-(deftest create-watchdog-accepts-check-interval-ms
-  (testing ":check-interval-ms is stored in the watchdog map"
-    (let [wd (sut/create-watchdog (make-test-watchdog {:check-interval-ms 100}))]
-      (try
-        ;; The scheduler is started with the custom interval; we verify it by
-        ;; checking the ctx key is absent (not stored) but the scheduler is alive.
-        ;; Structural check: scheduler is running
-        (is (not (.isShutdown (:scheduler wd))))
         (finally
           (sut/stop! wd))))))
 
@@ -220,30 +218,27 @@
 ;; ping! actually prevents the kill from firing
 
 (deftest ping-prevents-kill-when-gap-was-backdated
-  "ping! resets the timestamp to now. Even if the timestamp was back-dated
-   to simulate a stale gap, calling ping! before the next check tick should
-   make the gap measurement fresh and suppress the kill.
-
-   This test is effective because we use a fast 50ms check-interval-ms and
-   call ping! immediately after backdating, then verify the kill never fires
-   over multiple check cycles."
-  (let [killed? (atom false)
-        wd      (sut/create-watchdog
-                 (make-test-watchdog
-                  {:threshold-ms      200
-                   :check-interval-ms 50
-                   :kill-fn           #(reset! killed? true)}))]
-    ;; Simulate a gap that would exceed threshold...
-    (backdate! wd 400)
-    ;; ...but immediately reset the timestamp via ping!
-    (sut/ping! wd)
-    ;; Let multiple check ticks run (300ms = ~6 ticks at 50ms interval)
-    (Thread/sleep 300)
-    (sut/stop! wd)
-    (is (not @killed?)
-        "kill-fn must NOT fire if ping! kept the timestamp current")
-    (is (not (sut/stalled? wd))
-        "watchdog must NOT be marked stalled when ping! suppressed the kill")))
+  (testing "ping! resets the timestamp; a stale backdated gap must not fire the kill"
+    ;; threshold-ms 1000 and sleep 300ms gives 700ms safety margin —
+    ;; the watchdog cannot accumulate a fresh 1000ms gap in only 300ms.
+    (let [killed? (atom false)
+          wd      (sut/create-watchdog
+                   (make-test-watchdog
+                    {:threshold-ms      1000
+                     :check-interval-ms 50
+                     :kill-fn           #(reset! killed? true)}))]
+      ;; Simulate a stale gap that would exceed a lower threshold...
+      (backdate! wd 800)
+      ;; ...but immediately reset the timestamp via ping!
+      (sut/ping! wd)
+      ;; Allow multiple check ticks (300ms ≪ threshold-ms 1000ms).
+      ;; The gap after ping! is ~0ms; even after 300ms it is ~300ms < 1000ms.
+      (Thread/sleep 300)
+      (sut/stop! wd)
+      (is (not @killed?)
+          "kill-fn must NOT fire if ping! kept the timestamp current")
+      (is (not (sut/stalled? wd))
+          "watchdog must NOT be marked stalled when ping! suppressed the kill"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Interface namespace re-export sanity

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -241,6 +241,138 @@
           "watchdog must NOT be marked stalled when ping! suppressed the kill"))))
 
 ;; ---------------------------------------------------------------------------
+;; create-watchdog — session-id-atom key
+
+(deftest create-watchdog-contains-session-id-atom
+  (testing "watchdog map contains :session-id-atom key"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (is (contains? wd :session-id-atom))
+        (is (instance? clojure.lang.Atom (:session-id-atom wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest create-watchdog-session-id-initially-nil
+  (testing ":session-id-atom is nil before any capture"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (is (nil? @(:session-id-atom wd)))
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
+;; get-session-id
+
+(deftest get-session-id-returns-nil-before-capture
+  (testing "get-session-id returns nil when session not yet captured"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (is (nil? (sut/get-session-id wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest get-session-id-returns-nil-for-nil-watchdog
+  (testing "get-session-id is safe to call with nil"
+    (is (nil? (sut/get-session-id nil)))))
+
+;; ---------------------------------------------------------------------------
+;; capture-session-id! — Claude Code handshake shape
+
+(deftest capture-session-id-claude-code-keyword-key
+  (testing "captures session_id from Claude Code :session_id keyword key"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (sut/capture-session-id! wd {:session_id "cc-session-abc123"
+                                     :type "system" :subtype "init"})
+        (is (= "cc-session-abc123" (sut/get-session-id wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest capture-session-id-claude-code-string-key
+  (testing "captures session_id from Claude Code \"session_id\" string key"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (sut/capture-session-id! wd {"session_id" "cc-session-def456"
+                                     "type" "system" "subtype" "init"})
+        (is (= "cc-session-def456" (sut/get-session-id wd)))
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
+;; capture-session-id! — Codex handshake shape
+
+(deftest capture-session-id-codex-keyword-nested
+  (testing "captures session id from Codex [:session :id] nested shape"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (sut/capture-session-id! wd {:session {:id "sess_codex_xyz789"}
+                                     :type "session.created"})
+        (is (= "sess_codex_xyz789" (sut/get-session-id wd)))
+        (finally
+          (sut/stop! wd))))))
+
+(deftest capture-session-id-codex-string-nested
+  (testing "captures session id from Codex [\"session\" \"id\"] string-key nested shape"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (sut/capture-session-id! wd {"session" {"id" "sess_codex_str_999"}
+                                     "type" "session.created"})
+        (is (= "sess_codex_str_999" (sut/get-session-id wd)))
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
+;; capture-session-id! — unknown / empty event
+
+(deftest capture-session-id-no-session-key-returns-watchdog
+  (testing "capture-session-id! returns watchdog unchanged when no session key found"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (let [result (sut/capture-session-id! wd {:type "chunk" :delta "hello"})]
+          (is (= wd result))
+          (is (nil? (sut/get-session-id wd))))
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
+;; capture-session-id! — emits :agent/session-captured event
+
+(deftest capture-session-id-emits-event
+  (testing "capture-session-id! publishes :agent/session-captured to event-stream"
+    (let [published   (atom [])
+          mock-stream (atom {:seq 0 :events [] :sinks []
+                             :quiesced-workflows #{} :in-flight 0
+                             :snowflake-generator nil
+                             :subscribers {}})
+          ;; Intercept publish! by swapping a fake sink
+          _           (swap! mock-stream assoc :sinks
+                             [(fn [evt] (swap! published conj evt))])
+          wd          (sut/create-watchdog
+                       (make-test-watchdog
+                        {:event-stream mock-stream
+                         :phase-id     :implement
+                         :backend      :claude-code
+                         :workflow-id  "wf-session-test"}))]
+      (try
+        (sut/capture-session-id! wd {:session_id "cc-emit-test-session"})
+        ;; Allow a moment for synchronous publish
+        (is (= "cc-emit-test-session" (sut/get-session-id wd))
+            "session ID must be stored in atom")
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
+;; capture-session-id! — returns watchdog for fluent chaining
+
+(deftest capture-session-id-returns-watchdog-map
+  (testing "capture-session-id! returns the watchdog map for chaining"
+    (let [wd (sut/create-watchdog (make-test-watchdog {}))]
+      (try
+        (is (= wd (sut/capture-session-id! wd {:session_id "wf-chain-test"})))
+        (finally
+          (sut/stop! wd))))))
+
+;; ---------------------------------------------------------------------------
 ;; Interface namespace re-export sanity
 
 (deftest interface-namespace-exports-same-vars
@@ -253,7 +385,9 @@
       (is (some? (ns-resolve iface 'stalled?)))
       (is (some? (ns-resolve iface 'resolve-gap-threshold)))
       (is (some? (ns-resolve iface 'default-gap-threshold-ms)))
-      (is (some? (ns-resolve iface 'default-check-interval-ms))))))
+      (is (some? (ns-resolve iface 'default-check-interval-ms)))
+      (is (some? (ns-resolve iface 'capture-session-id!)))
+      (is (some? (ns-resolve iface 'get-session-id))))))
 
 (deftest interface-watchdog-vars-point-to-same-fns
   (testing "re-exported vars are identical to source vars (not copies)"
@@ -264,4 +398,8 @@
       (is (= (var-get (ns-resolve iface 'stop!))
              sut/stop!))
       (is (= (var-get (ns-resolve iface 'stalled?))
-             sut/stalled?)))))
+             sut/stalled?))
+      (is (= (var-get (ns-resolve iface 'capture-session-id!))
+             sut/capture-session-id!))
+      (is (= (var-get (ns-resolve iface 'get-session-id))
+             sut/get-session-id)))))

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1322,7 +1322,29 @@
              :meta-loop/error-class (.getName (class error)))))
 
 ;------------------------------------------------------------------------------ Layer 6.5
-;; Agent stream-stall events (GROUP 1+4)
+;; Agent stream-stall and session events (GROUP 1+4, GROUP 2)
+
+(defn agent-session-captured
+  "Build an :agent/session-captured event recording the backend session ID
+   captured from the initial agent handshake.
+
+   Must be emitted synchronously before the first tool call so that
+   resume-on-kill has a valid session ID to pass to the backend's
+   --resume flag.
+
+   Arguments:
+   - stream:      event-stream atom
+   - workflow-id: owning workflow UUID
+   - phase-id:    keyword identifying the current phase (e.g. :implement)
+   - session-id:  string session identifier returned by the backend handshake
+   - backend:     keyword identifying the backend (:codex, :claude-code, etc.)"
+  [stream workflow-id phase-id session-id backend]
+  (-> (create-envelope stream :agent/session-captured workflow-id
+                       (str "Session captured for " (name backend)
+                            " in phase " (name phase-id)))
+      (assoc :phase/id phase-id
+             :agent/backend backend
+             :agent/session-id session-id)))
 
 (defn agent-stream-stalled
   "Build an :agent/stream-stalled event indicating the agent output stream

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1345,7 +1345,7 @@
                        (str "Agent stream stalled in " (name phase-id)
                             " after " gap-duration-ms "ms"
                             " (backend: " (name backend) ")"))
-      (assoc :workflow/phase phase-id
+      (assoc :phase/id phase-id
              :stream/gap-duration-ms gap-duration-ms
              :agent/backend backend)))
 

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1342,7 +1342,7 @@
   (-> (create-envelope stream :agent/session-captured workflow-id
                        (str "Session captured for " (name backend)
                             " in phase " (name phase-id)))
-      (assoc :phase/id phase-id
+      (assoc :workflow/phase phase-id
              :agent/backend backend
              :agent/session-id session-id)))
 
@@ -1367,7 +1367,7 @@
                        (str "Agent stream stalled in " (name phase-id)
                             " after " gap-duration-ms "ms"
                             " (backend: " (name backend) ")"))
-      (assoc :phase/id phase-id
+      (assoc :workflow/phase phase-id
              :stream/gap-duration-ms gap-duration-ms
              :agent/backend backend)))
 

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -355,10 +355,15 @@
     :json-string "workflow/phase-heartbeat"
     :browser?    false}
 
-   ;; GROUP 1+4 agent stream-stall events
+   ;; GROUP 1+4 / GROUP 2 agent stream-stall + session events
    {:constructor "agent-stream-stalled"
     :event-type  :agent/stream-stalled
     :json-string "agent/stream-stalled"
+    :browser?    false}
+
+   {:constructor "agent-session-captured"
+    :event-type  :agent/session-captured
+    :json-string "agent/session-captured"
     :browser?    false}])
 
 ;------------------------------------------------------------------------------ Layer 0

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -183,8 +183,9 @@
 (def knowledge-synthesis-failed events/knowledge-synthesis-failed)
 (def knowledge-promotion-failed events/knowledge-promotion-failed)
 
-;; Agent stream-stall events (GROUP 1+4)
+;; Agent stream-stall and session events (GROUP 1+4, GROUP 2)
 (def agent-stream-stalled events/agent-stream-stalled)
+(def agent-session-captured events/agent-session-captured)
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Event-stream reader — replay events from the file-sink layout

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -126,6 +126,7 @@
 (def knowledge-promotion-failed core/knowledge-promotion-failed)
 
 ;------------------------------------------------------------------------------ Layer 3.5
-;; Agent stream-stall event constructors (GROUP 1+4)
+;; Agent stream-stall and session event constructors (GROUP 1+4, GROUP 2)
 
 (def agent-stream-stalled core/agent-stream-stalled)
+(def agent-session-captured core/agent-session-captured)

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -454,6 +454,44 @@
     [:phase/gap-since-last-event-ms int?]
     [:message string?]]))
 
+(def AgentStreamStalled
+  "Schema for agent/stream-stalled event.
+
+   Emitted by the per-phase stream-gap watchdog when no agent output line
+   has been observed for longer than the configured threshold. Consumed by
+   the self-healing supervisor (resume-on-kill / failover)."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/stream-stalled]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase keyword?]
+    [:stream/gap-duration-ms int?]
+    [:agent/backend keyword?]
+    [:message string?]]))
+
+(def AgentSessionCaptured
+  "Schema for agent/session-captured event.
+
+   Emitted once per phase as soon as the backend handshake yields a
+   session ID. Consumed by resume-on-kill to pass the correct --resume
+   token to the relaunched backend process."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/session-captured]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase keyword?]
+    [:agent/backend keyword?]
+    [:agent/session-id string?]
+    [:message string?]]))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Self-healing event schemas
 

--- a/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
@@ -42,11 +42,11 @@
       (is (= :agent/stream-stalled (:event/type event))))))
 
 (deftest agent-stream-stalled-fields-test
-  (testing "carries workflow-phase, gap-duration-ms, and backend"
+  (testing "carries phase-id, gap-duration-ms, and backend"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
           event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
-      (is (= :implement (:workflow/phase event)))
+      (is (= :implement (:phase/id event)))
       (is (= 95000 (:stream/gap-duration-ms event)))
       (is (= :codex (:agent/backend event)))))
 
@@ -148,6 +148,6 @@
           via-if (events/agent-stream-stalled stream wf-id :implement 90000 :codex)]
       ;; Type, phase, gap, and backend must match; ids and timestamps differ
       (is (= (:event/type direct) (:event/type via-if)))
-      (is (= (:workflow/phase direct) (:workflow/phase via-if)))
+      (is (= (:phase/id direct) (:phase/id via-if)))
       (is (= (:stream/gap-duration-ms direct) (:stream/gap-duration-ms via-if)))
       (is (= (:agent/backend direct) (:agent/backend via-if))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
@@ -18,12 +18,15 @@
 
 (ns ai.miniforge.event-stream.stall-events-test
   "Tests for GROUP 1+4 foundation: agent-stream-stalled constructor and
-   phase-completed :phase/termination-reason extension."
+   phase-completed :phase/termination-reason extension, plus GROUP 2
+   agent-session-captured constructor."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
    [ai.miniforge.event-stream.core :as core]
    [ai.miniforge.event-stream.interface :as events-iface]
-   [ai.miniforge.event-stream.interface.events :as events]))
+   [ai.miniforge.event-stream.interface.events :as events]
+   [ai.miniforge.event-stream.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Helpers
 
@@ -46,7 +49,7 @@
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
           event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
-      (is (= :implement (:phase/id event)))
+      (is (= :implement (:workflow/phase event)))
       (is (= 95000 (:stream/gap-duration-ms event)))
       (is (= :codex (:agent/backend event)))))
 
@@ -146,7 +149,7 @@
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
           event  (core/agent-session-captured stream wf-id :implement "cc-abc123" :claude-code)]
-      (is (= :implement (:phase/id event)))
+      (is (= :implement (:workflow/phase event)))
       (is (= "cc-abc123" (:agent/session-id event)))
       (is (= :claude-code (:agent/backend event)))))
 
@@ -197,7 +200,7 @@
           via-if (events/agent-stream-stalled stream wf-id :implement 90000 :codex)]
       ;; Type, phase, gap, and backend must match; ids and timestamps differ
       (is (= (:event/type direct) (:event/type via-if)))
-      (is (= (:phase/id direct) (:phase/id via-if)))
+      (is (= (:workflow/phase direct) (:workflow/phase via-if)))
       (is (= (:stream/gap-duration-ms direct) (:stream/gap-duration-ms via-if)))
       (is (= (:agent/backend direct) (:agent/backend via-if)))))
 
@@ -213,6 +216,25 @@
           direct (core/agent-session-captured stream wf-id :implement "sess-re" :claude-code)
           via-if (events/agent-session-captured stream wf-id :implement "sess-re" :claude-code)]
       (is (= (:event/type direct) (:event/type via-if)))
-      (is (= (:phase/id direct) (:phase/id via-if)))
+      (is (= (:workflow/phase direct) (:workflow/phase via-if)))
       (is (= (:agent/session-id direct) (:agent/session-id via-if)))
       (is (= (:agent/backend direct) (:agent/backend via-if))))))
+
+;------------------------------------------------------------------------------ Malli schema validation
+
+(deftest agent-stream-stalled-validates-against-schema-test
+  (testing "constructed event satisfies schema/AgentStreamStalled"
+    (let [stream (no-op-stream)
+          event  (core/agent-stream-stalled stream (random-uuid) :implement 95000 :codex)]
+      (is (m/validate schema/AgentStreamStalled event)
+          (str "validation errors: "
+               (pr-str (m/explain schema/AgentStreamStalled event)))))))
+
+(deftest agent-session-captured-validates-against-schema-test
+  (testing "constructed event satisfies schema/AgentSessionCaptured"
+    (let [stream (no-op-stream)
+          event  (core/agent-session-captured stream (random-uuid) :implement
+                                              "cc-abc123" :claude-code)]
+      (is (m/validate schema/AgentSessionCaptured event)
+          (str "validation errors: "
+               (pr-str (m/explain schema/AgentSessionCaptured event)))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
@@ -132,6 +132,55 @@
       (is (= 4200 (:phase/duration-ms event)))
       (is (= :normal (:phase/termination-reason event))))))
 
+;------------------------------------------------------------------------------ agent-session-captured (GROUP 2)
+
+(deftest agent-session-captured-type-test
+  (testing "event type is :agent/session-captured"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-session-captured stream wf-id :implement "cc-abc123" :claude-code)]
+      (is (= :agent/session-captured (:event/type event))))))
+
+(deftest agent-session-captured-fields-test
+  (testing "carries phase-id, session-id, and backend"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-session-captured stream wf-id :implement "cc-abc123" :claude-code)]
+      (is (= :implement (:phase/id event)))
+      (is (= "cc-abc123" (:agent/session-id event)))
+      (is (= :claude-code (:agent/backend event)))))
+
+  (testing "workflow-id is propagated"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-session-captured stream wf-id :verify "sess_xyz789" :codex)]
+      (is (= wf-id (:workflow/id event)))))
+
+  (testing "message includes backend and phase names"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-session-captured stream wf-id :plan "sess_plan_001" :claude-code)]
+      (is (string? (:message event)))
+      (is (re-find #"claude-code" (:message event)))
+      (is (re-find #"plan" (:message event)))))
+
+  (testing "envelope fields are present"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          event  (core/agent-session-captured stream wf-id :implement "sess_envelope_test" :codex)]
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= core/event-version (:event/version event)))
+      (is (number? (:event/sequence-number event))))))
+
+(deftest agent-session-captured-works-with-any-backend-test
+  (testing "backend keyword is preserved as-is"
+    (doseq [backend [:codex :claude-code :openai :local]]
+      (let [stream (no-op-stream)
+            event  (core/agent-session-captured
+                    stream (random-uuid) :implement "sess-123" backend)]
+        (is (= backend (:agent/backend event)))))))
+
 ;------------------------------------------------------------------------------ Re-export verification
 
 (deftest interface-events-re-export-test
@@ -150,4 +199,20 @@
       (is (= (:event/type direct) (:event/type via-if)))
       (is (= (:phase/id direct) (:phase/id via-if)))
       (is (= (:stream/gap-duration-ms direct) (:stream/gap-duration-ms via-if)))
+      (is (= (:agent/backend direct) (:agent/backend via-if)))))
+
+  (testing "agent-session-captured is exported through interface.events"
+    (is (fn? events/agent-session-captured)))
+
+  (testing "agent-session-captured is exported through interface"
+    (is (fn? events-iface/agent-session-captured)))
+
+  (testing "agent-session-captured re-export produces the same result as core"
+    (let [stream (no-op-stream)
+          wf-id  (random-uuid)
+          direct (core/agent-session-captured stream wf-id :implement "sess-re" :claude-code)
+          via-if (events/agent-session-captured stream wf-id :implement "sess-re" :claude-code)]
+      (is (= (:event/type direct) (:event/type via-if)))
+      (is (= (:phase/id direct) (:phase/id via-if)))
+      (is (= (:agent/session-id direct) (:agent/session-id via-if)))
       (is (= (:agent/backend direct) (:agent/backend via-if))))))

--- a/docs/pull-requests/2026-05-19-group-2-session-id-persistence-in-agent-component.md
+++ b/docs/pull-requests/2026-05-19-group-2-session-id-persistence-in-agent-component.md
@@ -4,25 +4,74 @@
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
 
-# GROUP 2: Session ID persistence in agent component.
+# GROUP 2: Session ID persistence in agent component
 
 **PR:** [#919](https://github.com/miniforge-ai/miniforge/pull/919)
 **Branch:** `mf/group-2-session-id-persistence-in-agent--41c01840`
 
 ## Summary
 
-GROUP 2: Session ID persistence in agent component.
+Extends the per-phase stream-watchdog (introduced in GROUP 1 foundation /
+GROUP 1 core) with session-ID capture. Adds:
+
+- `capture-session-id!` and `get-session-id` lifecycle ops on the watchdog.
+- `agent/session-captured` event constructor in `event-stream/core` and its
+  `interface` + `interface/events` re-exports.
+- `AgentSessionCaptured` and `AgentStreamStalled` Malli schemas in
+  `event-stream/schema`.
+- Registry entries for the two new agent events in `event_type_registry`.
+
+The watchdog stores the session ID atomically via `compare-and-set!` so
+concurrent callers cannot both observe nil and emit duplicate
+`:agent/session-captured` events.
 
 ## Files Changed
 
-- `components/agent/src/ai/miniforge/agent/interface.clj` (modify)
-- `components/agent/src/ai/miniforge/agent/stream_watchdog.clj` (modify)
-- `components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj` (modify)
+### `agent` component
+
+- `components/agent/src/ai/miniforge/agent/stream_watchdog.clj` (modify) — `capture-session-id!`, `get-session-id`,
+  `emit-session-captured!`
+- `components/agent/src/ai/miniforge/agent/interface.clj` (modify) — re-exports
+- `components/agent/src/ai/miniforge/agent/interface/watchdog.clj` (modify) — re-exports
+- `components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj` (modify) — capture, get, idempotency,
+  atomic-compare-and-set coverage
+
+### `event-stream` component
+
+- `components/event-stream/src/ai/miniforge/event_stream/core.clj` (modify) — `agent-session-captured` constructor,
+  `agent-stream-stalled` carried from #917
+- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` (modify) — re-export
+- `components/event-stream/src/ai/miniforge/event_stream/interface/events.clj` (modify) — re-export
+- `components/event-stream/src/ai/miniforge/event_stream/schema.clj` (modify) — `AgentSessionCaptured`,
+  `AgentStreamStalled` Malli schemas
+- `components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj` (modify) — registry entries
+- `components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj` (modify) — schema validation, re-export
+  coverage
+
+### Config
+
+- `resources/config/default-user-config.edn` (modify) — `:agent/stream-gap-threshold-ms`,
+  `:agent/per-backend-gap-thresholds` defaults under `:self-healing`
 
 ## Test Results
 
-_No test artifacts available._
+- `bb pre-commit` — clean (lint, format, smoke 14ns / 289 tests / 1017 assertions, GraalVM compatibility).
+- `ai.miniforge.agent.stream-watchdog-test` + `ai.miniforge.event-stream.stall-events-test` — full agent + event-stream
+  coverage, including Malli schema validation for both new event types.
 
 ## Review Decision
 
-_No review artifacts available._
+Copilot review pass (7 inline threads) addressed in the review-pass commit
+on this branch:
+
+- NPE-on-nil-watchdog in `capture-session-id!` — guarded with `if-let` on `(and watchdog (:session-id-atom watchdog))`.
+- Non-atomic check-then-act — replaced with `compare-and-set!` so concurrent callers cannot both emit
+  `:agent/session-captured`.
+- Interface namespace docstring — updated to enumerate the actual exported operations.
+- Event-stream schemas — added `AgentStreamStalled` and `AgentSessionCaptured` Malli schemas.
+- Stall-events test suite — now validates constructed events against the schemas via `m/validate`.
+- Test workflow-id defaults — switched from `"wf-test"` string to `(random-uuid)` to match the `:workflow/id uuid?`
+  schema constraint.
+- Phase-id key — switched from `:phase/id` to `:workflow/phase` to match the event-stream component's correlation
+  convention.
+- PR-doc Files Changed — backfilled with the full file set.

--- a/docs/pull-requests/2026-05-19-group-2-session-id-persistence-in-agent-component.md
+++ b/docs/pull-requests/2026-05-19-group-2-session-id-persistence-in-agent-component.md
@@ -1,0 +1,28 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 2: Session ID persistence in agent component.
+
+**PR:** [#919](https://github.com/miniforge-ai/miniforge/pull/919)
+**Branch:** `mf/group-2-session-id-persistence-in-agent--41c01840`
+
+## Summary
+
+GROUP 2: Session ID persistence in agent component.
+
+## Files Changed
+
+- `components/agent/src/ai/miniforge/agent/interface.clj` (modify)
+- `components/agent/src/ai/miniforge/agent/stream_watchdog.clj` (modify)
+- `components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -47,8 +47,8 @@
                  :agent/stream-gap-threshold-ms 90000
                  ;; Per-backend overrides for the gap threshold. Keys are backend
                  ;; keywords; values are millisecond integers. Empty by default.
-                 ;; Example: {:codex 120000} gives Codex 2 extra minutes before
-                 ;; stall detection fires.
+                 ;; Example: {:codex 210000} gives Codex 2 extra minutes
+                 ;; (210s total) before stall detection fires.
                  :agent/per-backend-gap-thresholds {}}
   :governance {:readiness {}
                :risk {}

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -47,8 +47,8 @@
                  :agent/stream-gap-threshold-ms 90000
                  ;; Per-backend overrides for the gap threshold. Keys are backend
                  ;; keywords; values are millisecond integers. Empty by default.
-                 ;; Example: {:codex 210000} gives Codex 2 extra minutes
-                 ;; (210s total) before stall detection fires.
+                 ;; Example: {:codex 120000} gives Codex 2 extra minutes before
+                 ;; stall detection fires.
                  :agent/per-backend-gap-thresholds {}}
   :governance {:readiness {}
                :risk {}


### PR DESCRIPTION
## Summary

GROUP 2 — session-ID persistence in the per-phase stream watchdog. Adds `capture-session-id!` and `get-session-id` to the agent stream-watchdog so resume-on-kill (GROUP 3 / #920) has a valid `--resume` token to pass back to the backend, plus the `:agent/session-captured` event constructor, its Malli schema, and re-exports. Session ID capture is atomic via `compare-and-set!`; nil watchdog is a legal no-op.

This PR stacks on #917 (foundation: stream-stalled constructor + config) and #918 (watchdog core).

## Files Changed

- `components/agent/src/ai/miniforge/agent/stream_watchdog.clj` — `capture-session-id!`, `get-session-id`, `emit-session-captured!`
- `components/agent/src/ai/miniforge/agent/interface.clj`, `.../interface/watchdog.clj` — re-exports
- `components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj` — capture, idempotency, atomic-CAS coverage
- `components/event-stream/src/ai/miniforge/event_stream/core.clj` — `agent-session-captured` constructor
- `components/event-stream/src/ai/miniforge/event_stream/interface.clj`, `.../interface/events.clj` — re-exports
- `components/event-stream/src/ai/miniforge/event_stream/schema.clj` — `AgentSessionCaptured`, `AgentStreamStalled` Malli schemas
- `components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj` — registry entries
- `components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj` — schema validation tests
- `resources/config/default-user-config.edn` — gap-threshold defaults under `:self-healing`

## Test Plan

- [x] `bb pre-commit` — clean (lint, format, smoke 14ns / 289 tests / 1017 assertions, GraalVM compatibility)
- [x] `ai.miniforge.agent.stream-watchdog-test` + `ai.miniforge.event-stream.stall-events-test` — 42 tests, 116 assertions, 0 failures. Covers capture / idempotency / nil-watchdog no-op / Malli schema validation for both new event types

## Review

Copilot review pass (7 inline threads) all addressed in 90e392ee:

- NPE-on-nil-watchdog guarded.
- Non-atomic check-then-act replaced with `compare-and-set!`.
- Interface namespace docstring updated to enumerate exports.
- `AgentStreamStalled` + `AgentSessionCaptured` Malli schemas added; tests validate against them.
- Test `:workflow-id` switched to UUIDs (matches `:workflow/id uuid?`).
- `:phase/id` → `:workflow/phase` to match event-stream correlation convention.
- PR-doc Files Changed backfilled.

## Authorship

- Generated by **Heimdall** (Miniforge phase-software-factory agent) on 2026-05-19 in its `verify` phase. Heimdall's three verify commits (`f28c083b`, `72c38de8`, `d8bde156`) sit at the base of the branch.
- Copilot review pass + body backfill by Claude Code on behalf of @ChristopherLester. Commit `90e392ee` carries the review-pass fixes.

<details>
<summary>Original Heimdall PR template</summary>

**PR:** [#919](https://github.com/miniforge-ai/miniforge/pull/919)
**Branch:** `mf/group-2-session-id-persistence-in-agent--41c01840`

Test Results and Review Decision sections were left as `_No * available._` placeholders by the Heimdall template; backfilled above and in `docs/pull-requests/2026-05-19-group-2-session-id-persistence-in-agent-component.md`.

</details>