### PR TITLE
GROUP 3: Resume-on-kill logic + self-healing integration.

### DIFF
--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -91,16 +91,21 @@
    persisted in the atom so a delivery failure must not lose the session ID."
   [{:keys [event-stream workflow-id phase-id backend logger]} session-id]
   (if-not event-stream
-    (log/warn logger "stream-watchdog: no event-stream; session-captured suppressed"
-              {:session-id session-id :phase-id phase-id :backend backend})
+    (log/debug logger :stream-watchdog :session-captured/suppressed
+               {:reason :no-event-stream
+                :session/id session-id
+                :workflow/phase phase-id
+                :agent/backend backend})
     (try
       (let [envelope (event-stream/agent-session-captured
                       event-stream workflow-id phase-id session-id backend)]
         (event-stream/publish! event-stream envelope))
       (catch Exception ex
-        (log/warn logger "stream-watchdog: failed to emit :agent/session-captured"
-                  {:session-id session-id :phase-id phase-id
-                   :backend backend :error (ex-message ex)})))))
+        (log/warn logger :stream-watchdog :session-captured/emit-failed
+                  {:session/id session-id
+                   :workflow/phase phase-id
+                   :agent/backend backend
+                   :error (ex-message ex)})))))
 
 (defn- emit-stall-event!
   "Publish an :agent/stream-stalled event to event-stream.
@@ -113,15 +118,19 @@
    is caught and logged so the watchdog thread cannot crash."
   [event-stream workflow-id phase-id backend gap-ms logger]
   (if-not event-stream
-    (log/warn logger "stream-watchdog: no event-stream configured; stall event suppressed"
-              {:phase-id phase-id :backend backend})
+    (log/debug logger :stream-watchdog :stall-event/suppressed
+               {:reason :no-event-stream
+                :workflow/phase phase-id
+                :agent/backend backend})
     (try
       (let [envelope (event-stream/agent-stream-stalled
                       event-stream workflow-id phase-id gap-ms backend)]
         (event-stream/publish! event-stream envelope))
       (catch Exception ex
-        (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
-                  {:phase-id phase-id :backend backend :error (ex-message ex)})))))
+        (log/warn logger :stream-watchdog :stall-event/emit-failed
+                  {:workflow/phase phase-id
+                   :agent/backend backend
+                   :error (ex-message ex)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — watchdog lifecycle
@@ -159,8 +168,10 @@
             ;; a. kill the subprocess
             (try (kill-fn)
                  (catch Exception ex
-                   (log/warn logger "stream-watchdog: kill-fn threw"
-                             {:error (ex-message ex)})))
+                   (log/warn logger :stream-watchdog :stream/kill-fn-failed
+                             {:workflow/phase phase-id
+                              :agent/backend backend
+                              :error (ex-message ex)})))
             ;; b. emit stall event with measured gap (nil-safe)
             (emit-stall-event! event-stream workflow-id phase-id backend gap logger)
             ;; c. mark stalled
@@ -279,25 +290,23 @@
    nil watchdog (or one missing :session-id-atom) is a legal no-op — useful
    for early-pipeline call sites that have not constructed a watchdog yet.
 
-   Thread-safe — uses `compare-and-set!` to make the check-then-act atomic,
-   so concurrent callers cannot both observe a nil session-id and both emit
-   :agent/session-captured."
+   Thread-safe — uses compare-and-set! so concurrent callers cannot both
+   observe a nil session-id and both emit :agent/session-captured."
   [watchdog event-map]
-  (if @(:session-id-atom watchdog)
-    ;; Already captured — idempotent no-op.
-    watchdog
+  (if-let [sid-atom (and watchdog (:session-id-atom watchdog))]
     (if-let [sid (extract-session-id event-map)]
-      (do
-        (reset! (:session-id-atom watchdog) sid)
-        (emit-session-captured! watchdog sid)
+      (if (compare-and-set! sid-atom nil sid)
+        (do
+          (emit-session-captured! watchdog sid)
+          watchdog)
         watchdog)
       (do
-        (log/warn (:logger watchdog)
-                  "stream-watchdog: no session ID found in handshake event"
+        (log/warn (:logger watchdog) :stream-watchdog :session/handshake-missing-id
                   {:event-keys (keys event-map)
-                   :phase-id   (:phase-id watchdog)
-                   :backend    (:backend watchdog)})
-        watchdog))))
+                   :workflow/phase (:phase-id watchdog)
+                   :agent/backend (:backend watchdog)})
+        watchdog))
+    watchdog))
 
 (defn get-session-id
   "Return the captured session ID string, or nil if not yet captured.

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -91,21 +91,16 @@
    persisted in the atom so a delivery failure must not lose the session ID."
   [{:keys [event-stream workflow-id phase-id backend logger]} session-id]
   (if-not event-stream
-    (log/debug logger :stream-watchdog :session-captured/suppressed
-               {:reason :no-event-stream
-                :session/id session-id
-                :workflow/phase phase-id
-                :agent/backend backend})
+    (log/warn logger "stream-watchdog: no event-stream; session-captured suppressed"
+              {:session-id session-id :phase-id phase-id :backend backend})
     (try
       (let [envelope (event-stream/agent-session-captured
                       event-stream workflow-id phase-id session-id backend)]
         (event-stream/publish! event-stream envelope))
       (catch Exception ex
-        (log/warn logger :stream-watchdog :session-captured/emit-failed
-                  {:session/id session-id
-                   :workflow/phase phase-id
-                   :agent/backend backend
-                   :error (ex-message ex)})))))
+        (log/warn logger "stream-watchdog: failed to emit :agent/session-captured"
+                  {:session-id session-id :phase-id phase-id
+                   :backend backend :error (ex-message ex)})))))
 
 (defn- emit-stall-event!
   "Publish an :agent/stream-stalled event to event-stream.
@@ -118,19 +113,15 @@
    is caught and logged so the watchdog thread cannot crash."
   [event-stream workflow-id phase-id backend gap-ms logger]
   (if-not event-stream
-    (log/debug logger :stream-watchdog :stall-event/suppressed
-               {:reason :no-event-stream
-                :workflow/phase phase-id
-                :agent/backend backend})
+    (log/warn logger "stream-watchdog: no event-stream configured; stall event suppressed"
+              {:phase-id phase-id :backend backend})
     (try
       (let [envelope (event-stream/agent-stream-stalled
                       event-stream workflow-id phase-id gap-ms backend)]
         (event-stream/publish! event-stream envelope))
       (catch Exception ex
-        (log/warn logger :stream-watchdog :stall-event/emit-failed
-                  {:workflow/phase phase-id
-                   :agent/backend backend
-                   :error (ex-message ex)})))))
+        (log/warn logger "stream-watchdog: failed to emit :agent/stream-stalled"
+                  {:phase-id phase-id :backend backend :error (ex-message ex)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — watchdog lifecycle
@@ -168,10 +159,8 @@
             ;; a. kill the subprocess
             (try (kill-fn)
                  (catch Exception ex
-                   (log/warn logger :stream-watchdog :stream/kill-fn-failed
-                             {:workflow/phase phase-id
-                              :agent/backend backend
-                              :error (ex-message ex)})))
+                   (log/warn logger "stream-watchdog: kill-fn threw"
+                             {:error (ex-message ex)})))
             ;; b. emit stall event with measured gap (nil-safe)
             (emit-stall-event! event-stream workflow-id phase-id backend gap logger)
             ;; c. mark stalled
@@ -280,8 +269,7 @@
    - Codex:       nested `[:session :id]` path
 
    When a session ID is found for the first time:
-     1. Stores it in the `:session-id-atom` on the watchdog state (atomic via
-        `compare-and-set!`).
+     1. Stores it in the `:session-id-atom` on the watchdog state (atomic).
      2. Emits :agent/session-captured via event-stream (nil stream is a no-op).
 
    When the session ID has already been captured, returns the watchdog unchanged.
@@ -295,25 +283,21 @@
    so concurrent callers cannot both observe a nil session-id and both emit
    :agent/session-captured."
   [watchdog event-map]
-  (if-let [sid-atom (and watchdog (:session-id-atom watchdog))]
+  (if @(:session-id-atom watchdog)
+    ;; Already captured — idempotent no-op.
+    watchdog
     (if-let [sid (extract-session-id event-map)]
-      ;; compare-and-set! is the atomic check-then-act primitive — only the
-      ;; first thread that observes nil flips the atom and emits the event;
-      ;; concurrent callers see the post-set value and become no-ops, so we
-      ;; never publish duplicate :agent/session-captured events.
-      (if (compare-and-set! sid-atom nil sid)
-        (do
-          (emit-session-captured! watchdog sid)
-          watchdog)
+      (do
+        (reset! (:session-id-atom watchdog) sid)
+        (emit-session-captured! watchdog sid)
         watchdog)
       (do
-        (log/warn (:logger watchdog) :stream-watchdog :session/handshake-missing-id
+        (log/warn (:logger watchdog)
+                  "stream-watchdog: no session ID found in handshake event"
                   {:event-keys (keys event-map)
-                   :workflow/phase (:phase-id watchdog)
-                   :agent/backend (:backend watchdog)})
-        watchdog))
-    ;; nil watchdog or missing :session-id-atom — safe no-op, do not throw.
-    watchdog))
+                   :phase-id   (:phase-id watchdog)
+                   :backend    (:backend watchdog)})
+        watchdog))))
 
 (defn get-session-id
   "Return the captured session ID string, or nil if not yet captured.

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -380,7 +380,7 @@
         (let [evt (first @published)]
           (is (= :agent/session-captured (:event/type evt)))
           (is (= "cc-emit-test-session" (:agent/session-id evt)))
-          (is (= :implement (:workflow/phase evt)))
+          (is (= :implement (:phase/id evt)))
           (is (= :claude-code (:agent/backend evt))))
         (finally
           (sut/stop! wd))))))
@@ -395,7 +395,7 @@
                         {:event-stream mock-stream
                          :phase-id     :implement
                          :backend      :claude-code
-                         :workflow-id  (random-uuid)}))]
+                         :workflow-id  "wf-idempotent-test"}))]
       (try
         (sut/capture-session-id! wd {:session_id "once-only-session"})
         (sut/capture-session-id! wd {:session_id "second-call-ignored"})

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -380,7 +380,7 @@
         (let [evt (first @published)]
           (is (= :agent/session-captured (:event/type evt)))
           (is (= "cc-emit-test-session" (:agent/session-id evt)))
-          (is (= :implement (:phase/id evt)))
+          (is (= :implement (:workflow/phase evt)))
           (is (= :claude-code (:agent/backend evt))))
         (finally
           (sut/stop! wd))))))
@@ -395,7 +395,7 @@
                         {:event-stream mock-stream
                          :phase-id     :implement
                          :backend      :claude-code
-                         :workflow-id  "wf-idempotent-test"}))]
+                         :workflow-id  (random-uuid)}))]
       (try
         (sut/capture-session-id! wd {:session_id "once-only-session"})
         (sut/capture-session-id! wd {:session_id "second-call-ignored"})

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -455,11 +455,7 @@
     [:message string?]]))
 
 (def AgentStreamStalled
-  "Schema for agent/stream-stalled event.
-
-   Emitted by the per-phase stream-gap watchdog when no agent output line
-   has been observed for longer than the configured threshold. Consumed by
-   the self-healing supervisor (resume-on-kill / failover)."
+  "Schema for agent/stream-stalled event."
   (with-identity
    [:map
       [:event/type [:= :agent/stream-stalled]]
@@ -474,11 +470,7 @@
     [:message string?]]))
 
 (def AgentSessionCaptured
-  "Schema for agent/session-captured event.
-
-   Emitted once per phase as soon as the backend handshake yields a
-   session ID. Consumed by resume-on-kill to pass the correct --resume
-   token to the relaunched backend process."
+  "Schema for agent/session-captured event."
   (with-identity
    [:map
       [:event/type [:= :agent/session-captured]]

--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -271,10 +271,14 @@
      threshold       - Success rate threshold (default 0.90)
      cooldown-ms     - Cooldown period in milliseconds (default 1800000)
      allowed-set     - Optional set of keyword backends to restrict selection.
-                       When nil, all backends in the stored fallback-order are
-                       considered.  When provided, only those backends present
-                       in allowed-set (and also in fallback-order) are eligible,
-                       preserving the global priority ordering.
+                       When `nil` (not supplied), all backends in the stored
+                       fallback-order are considered. When a non-nil empty set
+                       is supplied, the caller has explicitly restricted to
+                       *no* allowed backends — returns nil immediately rather
+                       than silently expanding to the full fallback-order.
+                       When non-empty, only backends in the intersection of
+                       allowed-set and fallback-order are eligible, preserving
+                       the global priority ordering.
 
    Returns: Keyword backend name or nil if none available"
   ([current-backend]
@@ -282,23 +286,29 @@
   ([current-backend threshold cooldown-ms]
    (select-best-backend current-backend threshold cooldown-ms nil))
   ([current-backend threshold cooldown-ms allowed-set]
-   (let [health        (load-health)
-         fallback-order (:fallback-order health)
-         current-key   (keyword current-backend)
-         ;; When an allowed-set is provided, filter the global fallback-order so
-         ;; we preserve priority ordering while restricting the candidate pool.
-         candidates    (if (seq allowed-set)
-                         (filter allowed-set fallback-order)
-                         fallback-order)]
-     (first
-      (filter
-       (fn [backend]
-         (and (not= backend current-key)
-              (not (in-cooldown? backend cooldown-ms))
-              (if-let [rate (get-backend-success-rate backend)]
-                (>= rate threshold)
-                true))) ;; No data = eligible
-       candidates)))))
+   ;; An explicitly empty allowed-set means "no failover targets are
+   ;; permitted" — treating it as nil (and silently expanding to the full
+   ;; fallback-order) would defeat the purpose of the restriction.
+   (if (and (some? allowed-set) (empty? allowed-set))
+     nil
+     (let [health         (load-health)
+           fallback-order (:fallback-order health)
+           current-key    (keyword current-backend)
+           ;; When an allowed-set is provided and non-empty, filter the
+           ;; global fallback-order so we preserve priority ordering while
+           ;; restricting the candidate pool.
+           candidates     (if (seq allowed-set)
+                            (filter allowed-set fallback-order)
+                            fallback-order)]
+       (first
+        (filter
+         (fn [backend]
+           (and (not= backend current-key)
+                (not (in-cooldown? backend cooldown-ms))
+                (if-let [rate (get-backend-success-rate backend)]
+                  (>= rate threshold)
+                  true))) ;; No data = eligible
+         candidates))))))
 
 (defn trigger-backend-switch!
   "Trigger a backend switch and record cooldown.

--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -268,20 +268,28 @@
 
    Arguments:
      current-backend - Keyword current backend
-     threshold - Success rate threshold (default 0.90)
-     cooldown-ms - Cooldown period in milliseconds (default 1800000)
+     threshold       - Success rate threshold (default 0.90)
+     cooldown-ms     - Cooldown period in milliseconds (default 1800000)
+     allowed-set     - Optional set of keyword backends to restrict selection.
+                       When nil, all backends in the stored fallback-order are
+                       considered.  When provided, only those backends present
+                       in allowed-set (and also in fallback-order) are eligible,
+                       preserving the global priority ordering.
 
    Returns: Keyword backend name or nil if none available"
   ([current-backend]
-   (select-best-backend current-backend 0.90 1800000))
+   (select-best-backend current-backend 0.90 1800000 nil))
   ([current-backend threshold cooldown-ms]
-   (let [health (load-health)
+   (select-best-backend current-backend threshold cooldown-ms nil))
+  ([current-backend threshold cooldown-ms allowed-set]
+   (let [health        (load-health)
          fallback-order (:fallback-order health)
-         current-key (keyword current-backend)]
-     ;; Find first backend in fallback order that is:
-     ;; 1. Not the current backend
-     ;; 2. Not in cooldown
-     ;; 3. Either has no data or has good success rate
+         current-key   (keyword current-backend)
+         ;; When an allowed-set is provided, filter the global fallback-order so
+         ;; we preserve priority ordering while restricting the candidate pool.
+         candidates    (if (seq allowed-set)
+                         (filter allowed-set fallback-order)
+                         fallback-order)]
      (first
       (filter
        (fn [backend]
@@ -290,7 +298,7 @@
               (if-let [rate (get-backend-success-rate backend)]
                 (>= rate threshold)
                 true))) ;; No data = eligible
-       fallback-order)))))
+       candidates)))))
 
 (defn trigger-backend-switch!
   "Trigger a backend switch and record cooldown.

--- a/components/self-healing/src/ai/miniforge/self_healing/interface.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/interface.clj
@@ -121,11 +121,26 @@
 
 (def evaluate-stall-recovery
   "Decide whether to resume, failover, or abort after a watchdog kill.
+
+   Takes a context map with :phase-id, :backend, :session-id, :hang-count (atom),
+   :config (self-healing config section), and :allowed-failover-backends.
+
+   Returns one of:
+     {:action :resume,   :session-id sid, :backend current-backend-kw}
+     {:action :failover, :new-backend kw}
+     {:action :abort,    :reason \"no healthy backends\"}
+
    See ai.miniforge.self-healing.stream-recovery/evaluate-stall-recovery."
   stream-recovery/evaluate-stall-recovery)
 
 (def execute-resume!
   "Restart an agent subprocess using the backend-specific resume flag.
+
+   Arguments: backend, session-id, optional extra-args.
+
+   Returns a process map {:process, :backend, :session-id, :command} on success,
+   or an anomaly map {:anomaly/category, :anomaly/message, :cmd} on IOException.
+
    See ai.miniforge.self-healing.stream-recovery/execute-resume!"
   stream-recovery/execute-resume!)
 

--- a/components/self-healing/src/ai/miniforge/self_healing/interface.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/interface.clj
@@ -18,12 +18,14 @@
 
 (ns ai.miniforge.self-healing.interface
   "Public interface for self-healing system.
-   Exports functions from workaround-registry, workaround-detector, backend-health, and integration."
+   Exports functions from workaround-registry, workaround-detector, backend-health,
+   integration, and stream-recovery."
   (:require
    [ai.miniforge.self-healing.workaround-registry :as registry]
    [ai.miniforge.self-healing.workaround-detector :as detector]
    [ai.miniforge.self-healing.backend-health :as health]
-   [ai.miniforge.self-healing.integration :as integration]))
+   [ai.miniforge.self-healing.integration :as integration]
+   [ai.miniforge.self-healing.stream-recovery :as stream-recovery]))
 
 ;;------------------------------------------------------------------------------ Workaround Registry
 
@@ -114,6 +116,18 @@
 (def reset-backend-health!
   "Reset all backend health data to defaults, clearing stale metrics."
   health/reset-backend-health!)
+
+;;------------------------------------------------------------------------------ Stream Recovery
+
+(def evaluate-stall-recovery
+  "Decide whether to resume, failover, or abort after a watchdog kill.
+   See ai.miniforge.self-healing.stream-recovery/evaluate-stall-recovery."
+  stream-recovery/evaluate-stall-recovery)
+
+(def execute-resume!
+  "Restart an agent subprocess using the backend-specific resume flag.
+   See ai.miniforge.self-healing.stream-recovery/execute-resume!"
+  stream-recovery/execute-resume!)
 
 ;;------------------------------------------------------------------------------ Integration
 

--- a/components/self-healing/src/ai/miniforge/self_healing/interface.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/interface.clj
@@ -125,10 +125,15 @@
    Takes a context map with :phase-id, :backend, :session-id, :hang-count (atom),
    :config (self-healing config section), and :allowed-failover-backends.
 
-   Returns one of:
-     {:action :resume,   :session-id sid, :backend current-backend-kw}
-     {:action :failover, :new-backend kw}
-     {:action :abort,    :reason \"no healthy backends\"}
+   Decision rules:
+     hang-count = 1, backend healthy   → {:action :resume,   :session-id sid, :backend kw}
+     hang-count = 1, backend unhealthy → {:action :failover, :new-backend kw}
+     hang-count >= 2                   → {:action :failover, :new-backend kw}
+     no candidate                      → {:action :abort,    :reason \"no healthy backends\"}
+
+   Side effects on :failover path:
+     - record-backend-call! marks current backend unhealthy
+     - trigger-backend-switch! records cooldown and updates default-backend
 
    See ai.miniforge.self-healing.stream-recovery/evaluate-stall-recovery."
   stream-recovery/evaluate-stall-recovery)
@@ -137,6 +142,9 @@
   "Restart an agent subprocess using the backend-specific resume flag.
 
    Arguments: backend, session-id, optional extra-args.
+
+   Constructs: <backend-binary> <resume-flag> <session-id> [extra-args...]
+   and launches it with inherited stdio.
 
    Returns a process map {:process, :backend, :session-id, :command} on success,
    or an anomaly map {:anomaly/category, :anomaly/message, :cmd} on IOException.

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -1,0 +1,255 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.self-healing.stream-recovery
+  "Resume-on-kill logic: decide resume vs failover vs abort after a watchdog kill.
+
+   After a stall watchdog terminates a hung agent subprocess, the caller must
+   decide what to do next.  This namespace provides two functions:
+
+   - `evaluate-stall-recovery` — pure decision: resume / failover / abort
+   - `execute-resume!`         — side-effecting: relaunch subprocess with resume flag
+
+   Decision rules
+   --------------
+   hang-count = 1  → :resume   (same backend, same session — first stall may be transient)
+   hang-count >= 2 → :failover (backend is flaky; record failure, select healthiest alternative)
+   no candidate    → :abort    (all failover backends are in cooldown or unhealthy)"
+  (:require
+   [ai.miniforge.self-healing.backend-health :as backend-health]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Backend-specific resume CLI flags
+
+(def ^:private backend-resume-flags
+  "Map of backend keyword → CLI flag used to resume a prior session."
+  {:anthropic   "--resume"
+   :claude-code "--resume"
+   :openai      "--resume"
+   :codex       "--resume"
+   :ollama      "--continue"
+   :google      "--resume"})
+
+(defn resume-flag-for
+  "Return the backend-specific CLI resume flag.
+
+   Arguments:
+     backend - Keyword backend name
+
+   Returns: String CLI flag (defaults to \"--resume\")"
+  [backend]
+  (get backend-resume-flags (keyword backend) "--resume"))
+
+(defn build-resume-command
+  "Build the full CLI command vector to resume an agent session.
+
+   Arguments:
+     backend    - Keyword backend name (:anthropic, :openai, etc.)
+     session-id - String session identifier to resume
+     extra-args - Optional seq of additional CLI arguments
+
+   Returns: Vector of strings, e.g. [\"anthropic\" \"--resume\" \"<sid>\"]"
+  ([backend session-id]
+   (build-resume-command backend session-id []))
+  ([backend session-id extra-args]
+   (let [backend-kw (keyword backend)
+         flag       (resume-flag-for backend-kw)
+         binary     (name backend-kw)]
+     (into [binary flag (str session-id)] extra-args))))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Process management (isolated for testability)
+
+(defn- start-process!
+  "Launch a subprocess from a command vector.
+
+   Arguments:
+     cmd - Seq of strings forming the command
+
+   Returns: java.lang.Process"
+  [cmd]
+  (-> (ProcessBuilder. ^java.util.List (vec cmd))
+      (doto (.redirectErrorStream true)
+            (.inheritIO))
+      (.start)))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Failover candidate selection
+
+(defn- pick-failover-candidate
+  "Select the best backend from allowed-failover-backends, respecting health data.
+
+   Iterates the global fallback-order (from persistent health) and returns the
+   first backend that:
+     1. Is not the current backend
+     2. Is present in allowed-failover-backends
+     3. Is not in cooldown
+     4. Has no data (treated as healthy) or success-rate >= threshold
+
+   Arguments:
+     current-backend          - Keyword current backend to exclude
+     allowed-failover-backends - Seq of keyword backends eligible for failover
+     threshold                - Double success-rate minimum (e.g. 0.90)
+     cooldown-ms              - Long cooldown period in ms
+
+   Returns: Keyword backend or nil if none qualifies"
+  [current-backend allowed-failover-backends threshold cooldown-ms]
+  (let [backend-kw  (keyword current-backend)
+        allowed-set (set (map keyword allowed-failover-backends))
+        health      (backend-health/load-health)
+        order       (:fallback-order health)]
+    (first
+     (filter
+      (fn [b]
+        (and (not= b backend-kw)
+             (contains? allowed-set b)
+             (not (backend-health/in-cooldown? b cooldown-ms))
+             (if-let [rate (backend-health/get-backend-success-rate b)]
+               (>= rate threshold)
+               true)))  ; no data → eligible
+      order))))
+
+;;------------------------------------------------------------------------------ Layer 3
+;; Core decision function
+
+(defn evaluate-stall-recovery
+  "Decide whether to resume, failover, or abort after a watchdog kill.
+
+   Decision logic:
+     hang-count = 1  → {:action :resume, ...}
+       Same backend, same session.  Single stall may be transient.
+
+     hang-count >= 2 → {:action :failover, :new-backend kw}
+       Backend is persistently flaky.
+       Side effects: records backend failure via record-backend-call!,
+                     calls trigger-backend-switch! on the chosen candidate.
+
+     no candidate    → {:action :abort, :reason \"no healthy backends\"}
+       All allowed failover backends are in cooldown or unhealthy.
+
+   Arguments:
+     ctx - Map with:
+       :phase-id                  - Any; ID of the stalled phase (for logging)
+       :backend                   - Keyword or string; current backend
+       :session-id                - String session ID to resume
+       :hang-count                - clojure.lang.IAtom<Long>; deref'd to read count
+       :config                    - Map; self-healing config section, may contain
+                                    :backend-switch-cooldown-ms and
+                                    :backend-health-threshold
+       :allowed-failover-backends - Seq of keywords; eligible failover targets
+
+   Returns: One of:
+     {:action :resume,   :session-id sid,  :backend current-backend-kw}
+     {:action :failover, :new-backend kw}
+     {:action :abort,    :reason \"no healthy backends\"}"
+  [{:keys [backend session-id hang-count config allowed-failover-backends]
+    :as _ctx}]
+  (let [count       @hang-count
+        backend-kw  (keyword backend)
+        cooldown-ms (get config :backend-switch-cooldown-ms 1800000)
+        threshold   (get config :backend-health-threshold 0.90)]
+    (cond
+      ;; First stall — attempt transparent resume
+      (= count 1)
+      {:action     :resume
+       :session-id session-id
+       :backend    backend-kw}
+
+      ;; Second or subsequent stall — failover
+      (>= count 2)
+      (do
+        ;; Record backend as unhealthy
+        (backend-health/record-backend-call! backend-kw false)
+        (let [candidate (pick-failover-candidate
+                         backend-kw
+                         allowed-failover-backends
+                         threshold
+                         cooldown-ms)]
+          (if candidate
+            (do
+              (backend-health/trigger-backend-switch! backend-kw candidate cooldown-ms)
+              {:action      :failover
+               :new-backend candidate})
+            {:action :abort
+             :reason "no healthy backends"})))
+
+      ;; Degenerate: hang-count <= 0 (should not occur) — treat as resume
+      :else
+      {:action     :resume
+       :session-id session-id
+       :backend    backend-kw})))
+
+;;------------------------------------------------------------------------------ Layer 4
+;; Public subprocess restart
+
+(defn execute-resume!
+  "Restart an agent subprocess using the backend-specific resume flag.
+
+   Constructs a command of the form:
+     <backend-binary> <resume-flag> <session-id> [extra-args...]
+
+   and launches it with inherited stdio.
+
+   Arguments:
+     backend    - Keyword backend name (:anthropic, :openai, :ollama, etc.)
+     session-id - String session ID to resume
+     extra-args - Optional seq of additional CLI arguments
+
+   Returns: Map with:
+     {:process    java.lang.Process
+      :backend    backend-kw
+      :session-id session-id-str
+      :command    [...]}"
+  ([backend session-id]
+   (execute-resume! backend session-id []))
+  ([backend session-id extra-args]
+   (let [cmd (build-resume-command backend session-id extra-args)]
+     {:process    (start-process! cmd)
+      :backend    (keyword backend)
+      :session-id (str session-id)
+      :command    cmd})))
+
+;;------------------------------------------------------------------------------ Rich comment
+
+(comment
+  ;; Simulating a first-stall resume decision
+  (let [hang (atom 1)]
+    (evaluate-stall-recovery
+     {:phase-id                  :implement
+      :backend                   :anthropic
+      :session-id                "sess-abc123"
+      :hang-count                hang
+      :config                    {:backend-switch-cooldown-ms 1800000
+                                  :backend-health-threshold   0.90}
+      :allowed-failover-backends [:openai :codex]}))
+  ;; => {:action :resume, :session-id "sess-abc123", :backend :anthropic}
+
+  ;; Simulating a second-stall failover decision
+  (let [hang (atom 2)]
+    (evaluate-stall-recovery
+     {:phase-id                  :implement
+      :backend                   :anthropic
+      :session-id                "sess-abc123"
+      :hang-count                hang
+      :config                    {}
+      :allowed-failover-backends [:openai :codex]}))
+  ;; => {:action :failover, :new-backend :openai}   (or :codex if openai is in cooldown)
+
+  ;; Build resume command without launching a process
+  (build-resume-command :anthropic "sess-xyz" ["--timeout" "120"]))
+  ;; => ["anthropic" "--resume" "sess-xyz" "--timeout" "120"]

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -20,25 +20,25 @@
   "Resume-on-kill logic: decide resume vs failover vs abort after a watchdog kill.
 
    After a stall watchdog terminates a hung agent subprocess, the caller must
-   decide what to do next. This namespace provides two functions:
+   decide what to do next.  This namespace provides two functions:
 
    - `evaluate-stall-recovery` — decides :resume / :failover / :abort.
      The :failover and health-gated paths have side effects: they call
      record-backend-call! and trigger-backend-switch! on the backend-health store.
    - `execute-resume!` — side-effecting: relaunches subprocess with resume flag.
-     Returns the process map on success or an anomaly map on IOException.
+     Returns a process map on success or an anomaly map on java.io.IOException.
 
    Decision rules
    --------------
    hang-count = 1, backend healthy   → :resume   (transparent retry)
    hang-count = 1, backend unhealthy → :failover (skip wasted retry)
-   hang-count >= 2                   → :failover (backend is flaky)
+   hang-count >= 2                   → :failover (backend is persistently flaky)
    no candidate                      → :abort    (all failovers exhausted)
 
    NOTE on observability: Decision events are currently emitted to stderr via
    println rather than through ai.miniforge.logging, because that component is
    not a declared dependency of self-healing (adding it would introduce
-   cross-component coupling not yet approved). Follow-up: wire into the
+   cross-component coupling not yet approved).  Follow-up: wire into the
    logging infrastructure once the dependency is reviewed."
   (:require
    [ai.miniforge.self-healing.backend-health :as backend-health]))
@@ -105,7 +105,8 @@
 ;; Process management (isolated for testability)
 
 (defn- start-process!
-  "Launch a subprocess from a command vector. Propagates java.io.IOException.
+  "Launch a subprocess from a command vector.
+   Propagates java.io.IOException — caller is responsible for catching.
 
    Arguments:
      cmd - Seq of strings forming the command
@@ -161,8 +162,15 @@
 
    Decision logic:
      hang-count = 1, backend healthy   → {:action :resume, ...}
+       Backend has no known bad health: attempt transparent resume.
+
      hang-count = 1, backend unhealthy → {:action :failover, ...}
+       Skip the wasted retry: backend is already below threshold.
+       Same side effects as hang-count >= 2.
+
      hang-count >= 2                   → {:action :failover, :new-backend kw}
+       Backend persistently flaky; records failure and switches.
+
      no candidate found                → {:action :abort, :reason \"no healthy backends\"}
 
    Arguments:
@@ -266,7 +274,7 @@
       :command    vector            — the exact command vector launched}
 
    On java.io.IOException (binary not found, not executable, etc.) returns
-   an anomaly map instead of throwing, per the exceptions-as-data convention:
+   an anomaly map per the exceptions-as-data convention:
      {:anomaly/category :anomaly.category/fault
       :anomaly/message  \"<error message>\"
       :cmd              [...]}"

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -22,19 +22,22 @@
    After a stall watchdog terminates a hung agent subprocess, the caller must
    decide what to do next.  This namespace provides two functions:
 
-   - `evaluate-stall-recovery` — pure decision: resume / failover / abort
-   - `execute-resume!`         — side-effecting: relaunch subprocess with resume flag
+   - `evaluate-stall-recovery` — decides :resume / :failover / :abort.
+     NOTE: the :failover and health-gated paths have side effects — they call
+     record-backend-call! and trigger-backend-switch! on the backend-health store.
+   - `execute-resume!` — side-effecting: relaunch subprocess with resume flag.
 
    Decision rules
    --------------
-   hang-count = 1  → :resume   (same backend, same session — first stall may be transient)
-   hang-count >= 2 → :failover (backend is flaky; record failure, select healthiest alternative)
-   no candidate    → :abort    (all failover backends are in cooldown or unhealthy)"
+   hang-count = 1, backend healthy   → :resume   (transparent retry)
+   hang-count = 1, backend unhealthy → :failover (skip wasted retry)
+   hang-count >= 2                   → :failover (backend is flaky)
+   no candidate                      → :abort    (all failovers exhausted)"
   (:require
    [ai.miniforge.self-healing.backend-health :as backend-health]))
 
 ;;------------------------------------------------------------------------------ Layer 0
-;; Backend-specific resume CLI flags
+;; Backend-specific CLI metadata
 
 (def ^:private backend-resume-flags
   "Map of backend keyword → CLI flag used to resume a prior session."
@@ -44,6 +47,15 @@
    :codex       "--resume"
    :ollama      "--continue"
    :google      "--resume"})
+
+(def ^:private backend-binaries
+  "Map of backend keyword → actual CLI binary name."
+  {:anthropic   "claude"
+   :claude-code "claude"
+   :openai      "openai"
+   :codex       "codex"
+   :ollama      "ollama"
+   :google      "gemini"})
 
 (defn resume-flag-for
   "Return the backend-specific CLI resume flag.
@@ -55,6 +67,16 @@
   [backend]
   (get backend-resume-flags (keyword backend) "--resume"))
 
+(defn- binary-for
+  "Return the CLI binary name for a backend.
+
+   Arguments:
+     backend - Keyword backend name
+
+   Returns: String binary name (defaults to (name backend))"
+  [backend]
+  (get backend-binaries (keyword backend) (name backend)))
+
 (defn build-resume-command
   "Build the full CLI command vector to resume an agent session.
 
@@ -63,13 +85,13 @@
      session-id - String session identifier to resume
      extra-args - Optional seq of additional CLI arguments
 
-   Returns: Vector of strings, e.g. [\"anthropic\" \"--resume\" \"<sid>\"]"
+   Returns: Vector of strings, e.g. [\"claude\" \"--resume\" \"<sid>\"]"
   ([backend session-id]
    (build-resume-command backend session-id []))
   ([backend session-id extra-args]
    (let [backend-kw (keyword backend)
          flag       (resume-flag-for backend-kw)
-         binary     (name backend-kw)]
+         binary     (binary-for backend-kw)]
      (into [binary flag (str session-id)] extra-args))))
 
 ;;------------------------------------------------------------------------------ Layer 1
@@ -81,48 +103,49 @@
    Arguments:
      cmd - Seq of strings forming the command
 
-   Returns: java.lang.Process"
+   Returns: java.lang.Process, or throws ex-info on java.io.IOException."
   [cmd]
-  (-> (ProcessBuilder. ^java.util.List (vec cmd))
-      (doto (.redirectErrorStream true)
-            (.inheritIO))
-      (.start)))
+  (try
+    (-> (ProcessBuilder. ^java.util.List (vec cmd))
+        (.inheritIO)
+        (.start))
+    (catch java.io.IOException e
+      (throw (ex-info "Failed to start agent subprocess"
+                      {:cmd     cmd
+                       :cause   (ex-message e)}
+                      e)))))
 
 ;;------------------------------------------------------------------------------ Layer 2
-;; Failover candidate selection
+;; Shared failover helper
 
-(defn- pick-failover-candidate
-  "Select the best backend from allowed-failover-backends, respecting health data.
-
-   Iterates the global fallback-order (from persistent health) and returns the
-   first backend that:
-     1. Is not the current backend
-     2. Is present in allowed-failover-backends
-     3. Is not in cooldown
-     4. Has no data (treated as healthy) or success-rate >= threshold
+(defn- perform-failover
+  "Record the current backend as unhealthy, select a candidate from
+   allowed-failover-backends, trigger a switch, and return the decision.
 
    Arguments:
-     current-backend          - Keyword current backend to exclude
-     allowed-failover-backends - Seq of keyword backends eligible for failover
-     threshold                - Double success-rate minimum (e.g. 0.90)
-     cooldown-ms              - Long cooldown period in ms
+     backend-kw                - Keyword current backend
+     allowed-failover-backends - Seq of keyword failover candidates
+     threshold                 - Double success-rate minimum
+     cooldown-ms               - Long cooldown in ms
 
-   Returns: Keyword backend or nil if none qualifies"
-  [current-backend allowed-failover-backends threshold cooldown-ms]
-  (let [backend-kw  (keyword current-backend)
-        allowed-set (set (map keyword allowed-failover-backends))
-        health      (backend-health/load-health)
-        order       (:fallback-order health)]
-    (first
-     (filter
-      (fn [b]
-        (and (not= b backend-kw)
-             (contains? allowed-set b)
-             (not (backend-health/in-cooldown? b cooldown-ms))
-             (if-let [rate (backend-health/get-backend-success-rate b)]
-               (>= rate threshold)
-               true)))  ; no data → eligible
-      order))))
+   Returns: {:action :failover, :new-backend kw} or {:action :abort, ...}"
+  [backend-kw allowed-failover-backends threshold cooldown-ms]
+  (backend-health/record-backend-call! backend-kw false)
+  (let [allowed-set (set (map keyword allowed-failover-backends))
+        candidate   (backend-health/select-best-backend
+                     backend-kw threshold cooldown-ms allowed-set)]
+    (if candidate
+      (do
+        (backend-health/trigger-backend-switch! backend-kw candidate cooldown-ms)
+        {:action      :failover
+         :new-backend candidate})
+      (do
+        (binding [*out* *err*]
+          (println (pr-str {:event   :stream-recovery/abort
+                            :backend backend-kw
+                            :reason  "no healthy backends in allowed-failover-backends"})))
+        {:action :abort
+         :reason "no healthy backends"}))))
 
 ;;------------------------------------------------------------------------------ Layer 3
 ;; Core decision function
@@ -130,21 +153,26 @@
 (defn evaluate-stall-recovery
   "Decide whether to resume, failover, or abort after a watchdog kill.
 
+   Side effects on :failover path:
+     - record-backend-call! marks current backend unhealthy
+     - trigger-backend-switch! records cooldown and updates default-backend
+
    Decision logic:
-     hang-count = 1  → {:action :resume, ...}
-       Same backend, same session.  Single stall may be transient.
+     hang-count = 1, backend healthy   → {:action :resume, ...}
+       Backend has no known bad health: attempt transparent resume.
 
-     hang-count >= 2 → {:action :failover, :new-backend kw}
-       Backend is persistently flaky.
-       Side effects: records backend failure via record-backend-call!,
-                     calls trigger-backend-switch! on the chosen candidate.
+     hang-count = 1, backend unhealthy → {:action :failover, ...}
+       Skip the wasted retry: backend is already below threshold.
+       Same side effects as hang-count >= 2.
 
-     no candidate    → {:action :abort, :reason \"no healthy backends\"}
-       All allowed failover backends are in cooldown or unhealthy.
+     hang-count >= 2                   → {:action :failover, :new-backend kw}
+       Backend persistently flaky; records failure and switches.
+
+     no candidate found                → {:action :abort, :reason \"no healthy backends\"}
 
    Arguments:
      ctx - Map with:
-       :phase-id                  - Any; ID of the stalled phase (for logging)
+       :phase-id                  - Any; ID of the stalled phase (used in log events)
        :backend                   - Keyword or string; current backend
        :session-id                - String session ID to resume
        :hang-count                - clojure.lang.IAtom<Long>; deref'd to read count
@@ -157,42 +185,60 @@
      {:action :resume,   :session-id sid,  :backend current-backend-kw}
      {:action :failover, :new-backend kw}
      {:action :abort,    :reason \"no healthy backends\"}"
-  [{:keys [backend session-id hang-count config allowed-failover-backends]
-    :as _ctx}]
+  [{:keys [phase-id backend session-id hang-count config allowed-failover-backends]}]
   (let [count       @hang-count
         backend-kw  (keyword backend)
         cooldown-ms (get config :backend-switch-cooldown-ms 1800000)
         threshold   (get config :backend-health-threshold 0.90)]
     (cond
-      ;; First stall — attempt transparent resume
+      ;; First stall — check backend health before committing to a resume attempt
       (= count 1)
-      {:action     :resume
-       :session-id session-id
-       :backend    backend-kw}
+      (let [rate (backend-health/get-backend-success-rate backend-kw)]
+        (if (and rate (< rate threshold))
+          ;; Backend already known-unhealthy; skip the wasted retry
+          (do
+            (binding [*out* *err*]
+              (println (pr-str {:event      :stream-recovery/early-failover
+                                :phase-id   phase-id
+                                :backend    backend-kw
+                                :hang-count count
+                                :rate       rate
+                                :threshold  threshold})))
+            (perform-failover backend-kw allowed-failover-backends threshold cooldown-ms))
+          ;; Backend healthy or no data yet — attempt transparent resume
+          (do
+            (binding [*out* *err*]
+              (println (pr-str {:event      :stream-recovery/resume
+                                :phase-id   phase-id
+                                :backend    backend-kw
+                                :hang-count count})))
+            {:action     :resume
+             :session-id session-id
+             :backend    backend-kw})))
 
-      ;; Second or subsequent stall — failover
+      ;; Second or subsequent stall — backend is persistently flaky
       (>= count 2)
       (do
-        ;; Record backend as unhealthy
-        (backend-health/record-backend-call! backend-kw false)
-        (let [candidate (pick-failover-candidate
-                         backend-kw
-                         allowed-failover-backends
-                         threshold
-                         cooldown-ms)]
-          (if candidate
-            (do
-              (backend-health/trigger-backend-switch! backend-kw candidate cooldown-ms)
-              {:action      :failover
-               :new-backend candidate})
-            {:action :abort
-             :reason "no healthy backends"})))
+        (binding [*out* *err*]
+          (println (pr-str {:event      :stream-recovery/failover
+                            :phase-id   phase-id
+                            :backend    backend-kw
+                            :hang-count count})))
+        (perform-failover backend-kw allowed-failover-backends threshold cooldown-ms))
 
-      ;; Degenerate: hang-count <= 0 (should not occur) — treat as resume
+      ;; Degenerate: hang-count <= 0 (should not occur in normal operation)
       :else
-      {:action     :resume
-       :session-id session-id
-       :backend    backend-kw})))
+      (do
+        (binding [*out* *err*]
+          (println (pr-str {:event      :stream-recovery/degenerate-hang-count
+                            :phase-id   phase-id
+                            :backend    backend-kw
+                            :hang-count count
+                            :anomaly?   true})))
+        {:action     :resume
+         :session-id session-id
+         :backend    backend-kw
+         :anomaly?   true}))))
 
 ;;------------------------------------------------------------------------------ Layer 4
 ;; Public subprocess restart
@@ -214,7 +260,10 @@
      {:process    java.lang.Process
       :backend    backend-kw
       :session-id session-id-str
-      :command    [...]}"
+      :command    [...]}
+
+   Throws: ex-info with :cmd and :cause keys if the binary is not found
+   or not executable."
   ([backend session-id]
    (execute-resume! backend session-id []))
   ([backend session-id extra-args]
@@ -227,7 +276,7 @@
 ;;------------------------------------------------------------------------------ Rich comment
 
 (comment
-  ;; Simulating a first-stall resume decision
+  ;; First stall: resume (backend healthy)
   (let [hang (atom 1)]
     (evaluate-stall-recovery
      {:phase-id                  :implement
@@ -239,7 +288,7 @@
       :allowed-failover-backends [:openai :codex]}))
   ;; => {:action :resume, :session-id "sess-abc123", :backend :anthropic}
 
-  ;; Simulating a second-stall failover decision
+  ;; Second stall: failover
   (let [hang (atom 2)]
     (evaluate-stall-recovery
      {:phase-id                  :implement
@@ -248,8 +297,8 @@
       :hang-count                hang
       :config                    {}
       :allowed-failover-backends [:openai :codex]}))
-  ;; => {:action :failover, :new-backend :openai}   (or :codex if openai is in cooldown)
+  ;; => {:action :failover, :new-backend :openai}
 
-  ;; Build resume command without launching a process
+  ;; Build command without launching a process
   (build-resume-command :anthropic "sess-xyz" ["--timeout" "120"]))
-  ;; => ["anthropic" "--resume" "sess-xyz" "--timeout" "120"]
+  ;; => ["claude" "--resume" "sess-xyz" "--timeout" "120"]

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -41,6 +41,7 @@
    cross-component coupling not yet approved).  Follow-up: wire into the
    logging infrastructure once the dependency is reviewed."
   (:require
+   [clojure.string :as str]
    [ai.miniforge.self-healing.backend-health :as backend-health]))
 
 ;;------------------------------------------------------------------------------ Layer 0
@@ -78,10 +79,19 @@
   "Return the CLI binary name for a backend.
 
    Arguments:
-     backend - Keyword backend name
+     backend - Keyword (or anything `clojure.lang.Named`) backend identifier.
+               Must be non-nil; nil/non-Named values throw `ex-info` rather
+               than producing a downstream NPE inside execute-resume!'s
+               ProcessBuilder.
 
    Returns: String binary name (defaults to (name backend))"
   [backend]
+  (when (nil? backend)
+    (throw (ex-info "binary-for: backend must not be nil"
+                    {:backend backend})))
+  (when-not (instance? clojure.lang.Named backend)
+    (throw (ex-info "binary-for: backend must be a keyword or symbol"
+                    {:backend backend :type (type backend)})))
   (get backend-binaries (keyword backend) (name backend)))
 
 (defn build-resume-command
@@ -198,16 +208,19 @@
   (when (nil? backend)
     (throw (ex-info ":backend is required and must not be nil"
                     {:ctx ctx})))
-  (let [count       @hang-count
-        backend-kw  (keyword backend)
-        cooldown-ms (get config :backend-switch-cooldown-ms 1800000)
-        threshold   (get config :backend-health-threshold 0.90)]
+  (let [count            @hang-count
+        backend-kw       (keyword backend)
+        cooldown-ms      (get config :backend-switch-cooldown-ms 1800000)
+        threshold        (get config :backend-health-threshold 0.90)
+        resumable?       (and (string? session-id)
+                              (not (str/blank? session-id)))]
     (cond
       ;; First stall — check backend health before committing to a resume attempt
       (= count 1)
       (let [rate (backend-health/get-backend-success-rate backend-kw)]
-        (if (and rate (< rate threshold))
+        (cond
           ;; Backend already known-unhealthy; skip the wasted retry
+          (and rate (< rate threshold))
           (do
             (binding [*out* *err*]
               (println (pr-str {:event      :stream-recovery/early-failover
@@ -217,7 +230,22 @@
                                 :rate       rate
                                 :threshold  threshold})))
             (perform-failover backend-kw allowed-failover-backends threshold cooldown-ms))
-          ;; Backend healthy or no data yet — attempt transparent resume
+
+          ;; No captured session — resume is impossible; treat first stall as
+          ;; a backend failure and failover instead of feeding nil/blank to
+          ;; execute-resume! (which would coerce nil to the string "nil" and
+          ;; fail the relaunch).
+          (not resumable?)
+          (do
+            (binding [*out* *err*]
+              (println (pr-str {:event      :stream-recovery/failover-no-session
+                                :phase-id   phase-id
+                                :backend    backend-kw
+                                :hang-count count})))
+            (perform-failover backend-kw allowed-failover-backends threshold cooldown-ms))
+
+          ;; Backend healthy and we have a session — attempt transparent resume
+          :else
           (do
             (binding [*out* *err*]
               (println (pr-str {:event      :stream-recovery/resume
@@ -247,10 +275,14 @@
                             :backend    backend-kw
                             :hang-count count
                             :anomaly?   true})))
-        {:action     :resume
-         :session-id session-id
-         :backend    backend-kw
-         :anomaly?   true}))))
+        (if resumable?
+          {:action     :resume
+           :session-id session-id
+           :backend    backend-kw
+           :anomaly?   true}
+          {:action   :abort
+           :reason   "degenerate hang-count and no resumable session"
+           :anomaly? true})))))
 
 ;;------------------------------------------------------------------------------ Layer 4
 ;; Public subprocess restart

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -20,19 +20,26 @@
   "Resume-on-kill logic: decide resume vs failover vs abort after a watchdog kill.
 
    After a stall watchdog terminates a hung agent subprocess, the caller must
-   decide what to do next.  This namespace provides two functions:
+   decide what to do next. This namespace provides two functions:
 
    - `evaluate-stall-recovery` — decides :resume / :failover / :abort.
-     NOTE: the :failover and health-gated paths have side effects — they call
+     The :failover and health-gated paths have side effects: they call
      record-backend-call! and trigger-backend-switch! on the backend-health store.
-   - `execute-resume!` — side-effecting: relaunch subprocess with resume flag.
+   - `execute-resume!` — side-effecting: relaunches subprocess with resume flag.
+     Returns the process map on success or an anomaly map on IOException.
 
    Decision rules
    --------------
    hang-count = 1, backend healthy   → :resume   (transparent retry)
    hang-count = 1, backend unhealthy → :failover (skip wasted retry)
    hang-count >= 2                   → :failover (backend is flaky)
-   no candidate                      → :abort    (all failovers exhausted)"
+   no candidate                      → :abort    (all failovers exhausted)
+
+   NOTE on observability: Decision events are currently emitted to stderr via
+   println rather than through ai.miniforge.logging, because that component is
+   not a declared dependency of self-healing (adding it would introduce
+   cross-component coupling not yet approved). Follow-up: wire into the
+   logging infrastructure once the dependency is reviewed."
   (:require
    [ai.miniforge.self-healing.backend-health :as backend-health]))
 
@@ -98,22 +105,16 @@
 ;; Process management (isolated for testability)
 
 (defn- start-process!
-  "Launch a subprocess from a command vector.
+  "Launch a subprocess from a command vector. Propagates java.io.IOException.
 
    Arguments:
      cmd - Seq of strings forming the command
 
-   Returns: java.lang.Process, or throws ex-info on java.io.IOException."
+   Returns: java.lang.Process"
   [cmd]
-  (try
-    (-> (ProcessBuilder. ^java.util.List (vec cmd))
-        (.inheritIO)
-        (.start))
-    (catch java.io.IOException e
-      (throw (ex-info "Failed to start agent subprocess"
-                      {:cmd   cmd
-                       :cause (ex-message e)}
-                      e)))))
+  (-> (ProcessBuilder. ^java.util.List (vec cmd))
+      (.inheritIO)
+      (.start)))
 
 ;;------------------------------------------------------------------------------ Layer 2
 ;; Shared failover helper
@@ -160,23 +161,16 @@
 
    Decision logic:
      hang-count = 1, backend healthy   → {:action :resume, ...}
-       Backend has no known bad health: attempt transparent resume.
-
      hang-count = 1, backend unhealthy → {:action :failover, ...}
-       Skip the wasted retry: backend is already below threshold.
-       Same side effects as hang-count >= 2.
-
      hang-count >= 2                   → {:action :failover, :new-backend kw}
-       Backend persistently flaky; records failure and switches.
-
      no candidate found                → {:action :abort, :reason \"no healthy backends\"}
 
    Arguments:
      ctx - Map with:
        :phase-id                  - Any; ID of the stalled phase (used in log events)
-       :backend                   - Keyword or string; current backend
+       :backend                   - Keyword or string; current backend (required, non-nil)
        :session-id                - String session ID to resume
-       :hang-count                - clojure.lang.IAtom<Long>; deref'd to read count
+       :hang-count                - IAtom<Long>; deref'd to read count (required atom)
        :config                    - Map; self-healing config section, may contain
                                     :backend-switch-cooldown-ms and
                                     :backend-health-threshold
@@ -186,7 +180,16 @@
      {:action :resume,   :session-id sid,  :backend current-backend-kw}
      {:action :failover, :new-backend kw}
      {:action :abort,    :reason \"no healthy backends\"}"
-  [{:keys [phase-id backend session-id hang-count config allowed-failover-backends]}]
+  [{:keys [phase-id backend session-id hang-count config allowed-failover-backends]
+    :as ctx}]
+  ;; Guard against programmer errors: fail loudly on the watchdog hot-path
+  ;; rather than producing an opaque NPE.
+  (when-not (instance? clojure.lang.IAtom hang-count)
+    (throw (ex-info ":hang-count must be an IAtom (e.g. (atom 1))"
+                    {:ctx ctx :type (type hang-count)})))
+  (when (nil? backend)
+    (throw (ex-info ":backend is required and must not be nil"
+                    {:ctx ctx})))
   (let [count       @hang-count
         backend-kw  (keyword backend)
         cooldown-ms (get config :backend-switch-cooldown-ms 1800000)
@@ -249,7 +252,6 @@
 
    Constructs a command of the form:
      <backend-binary> <resume-flag> <session-id> [extra-args...]
-
    and launches it with inherited stdio.
 
    Arguments:
@@ -258,21 +260,29 @@
      extra-args - Optional seq of additional CLI arguments
 
    Returns: Map with:
-     {:process    java.lang.Process
-      :backend    backend-kw
-      :session-id session-id-str
-      :command    [...]}
+     {:process    java.lang.Process — the launched agent process
+      :backend    keyword           — normalised backend
+      :session-id string            — normalised session id
+      :command    vector            — the exact command vector launched}
 
-   Throws: ex-info with :cmd and :cause keys if the binary is not found
-   or not executable."
+   On java.io.IOException (binary not found, not executable, etc.) returns
+   an anomaly map instead of throwing, per the exceptions-as-data convention:
+     {:anomaly/category :anomaly.category/fault
+      :anomaly/message  \"<error message>\"
+      :cmd              [...]}"
   ([backend session-id]
    (execute-resume! backend session-id []))
   ([backend session-id extra-args]
    (let [cmd (build-resume-command backend session-id extra-args)]
-     {:process    (start-process! cmd)
-      :backend    (keyword backend)
-      :session-id (str session-id)
-      :command    cmd})))
+     (try
+       {:process    (start-process! cmd)
+        :backend    (keyword backend)
+        :session-id (str session-id)
+        :command    cmd}
+       (catch java.io.IOException e
+         {:anomaly/category :anomaly.category/fault
+          :anomaly/message  (ex-message e)
+          :cmd              cmd})))))
 
 ;;------------------------------------------------------------------------------ Rich comment
 

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -111,8 +111,8 @@
         (.start))
     (catch java.io.IOException e
       (throw (ex-info "Failed to start agent subprocess"
-                      {:cmd     cmd
-                       :cause   (ex-message e)}
+                      {:cmd   cmd
+                       :cause (ex-message e)}
                       e)))))
 
 ;;------------------------------------------------------------------------------ Layer 2
@@ -120,7 +120,8 @@
 
 (defn- perform-failover
   "Record the current backend as unhealthy, select a candidate from
-   allowed-failover-backends, trigger a switch, and return the decision.
+   allowed-failover-backends via backend-health/select-best-backend,
+   trigger a switch, and return the decision map.
 
    Arguments:
      backend-kw                - Keyword current backend

--- a/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
@@ -1,0 +1,280 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.self-healing.stream-recovery-test
+  "Tests for resume-on-kill / stall-recovery logic."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.self-healing.stream-recovery :as sut]
+   [ai.miniforge.self-healing.backend-health :as health]))
+
+;;------------------------------------------------------------------------------ helpers
+
+(def ^:private base-config
+  {:backend-switch-cooldown-ms 1800000
+   :backend-health-threshold   0.90})
+
+(defn- make-ctx
+  "Build a minimal recovery context map."
+  [backend session-id hang-count-val allowed-failover]
+  {:phase-id                  :implement
+   :backend                   backend
+   :session-id                session-id
+   :hang-count                (atom hang-count-val)
+   :config                    base-config
+   :allowed-failover-backends allowed-failover})
+
+;;------------------------------------------------------------------------------ resume-flag-for
+
+(deftest resume-flag-for-known-backends
+  (testing "well-known backends return their documented flag"
+    (is (= "--resume"   (sut/resume-flag-for :anthropic)))
+    (is (= "--resume"   (sut/resume-flag-for :openai)))
+    (is (= "--resume"   (sut/resume-flag-for :codex)))
+    (is (= "--continue" (sut/resume-flag-for :ollama)))
+    (is (= "--resume"   (sut/resume-flag-for :google)))))
+
+(deftest resume-flag-for-unknown-backend
+  (testing "unknown backend defaults to --resume"
+    (is (= "--resume" (sut/resume-flag-for :unknown-backend-xyz)))))
+
+;;------------------------------------------------------------------------------ build-resume-command
+
+(deftest build-resume-command-basic
+  (testing "produces [binary flag session-id]"
+    (is (= ["anthropic" "--resume" "sess-abc"]
+           (sut/build-resume-command :anthropic "sess-abc")))))
+
+(deftest build-resume-command-with-extra-args
+  (testing "appends extra args after session-id"
+    (is (= ["openai" "--resume" "s123" "--timeout" "90"]
+           (sut/build-resume-command :openai "s123" ["--timeout" "90"])))))
+
+(deftest build-resume-command-ollama-uses-continue
+  (testing "ollama uses --continue flag"
+    (is (= ["ollama" "--continue" "s999"]
+           (sut/build-resume-command :ollama "s999")))))
+
+(deftest build-resume-command-string-backend
+  (testing "string backend coerced to keyword correctly"
+    (is (= ["codex" "--resume" "sid"]
+           (sut/build-resume-command "codex" "sid")))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – :resume path
+
+(deftest evaluate-stall-recovery-first-hang-returns-resume
+  (testing "hang-count = 1 → :resume action with same session and backend"
+    (let [ctx    (make-ctx :anthropic "sess-111" 1 [:openai :codex])
+          result (sut/evaluate-stall-recovery ctx)]
+      (is (= :resume      (:action result)))
+      (is (= "sess-111"   (:session-id result)))
+      (is (= :anthropic   (:backend result))))))
+
+(deftest evaluate-stall-recovery-zero-hang-count-returns-resume
+  (testing "hang-count = 0 (degenerate) → :resume action (safe fallback)"
+    (let [ctx    (make-ctx :openai "sess-000" 0 [:anthropic])
+          result (sut/evaluate-stall-recovery ctx)]
+      (is (= :resume (:action result)))
+      (is (= :openai (:backend result))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – :failover path
+
+(deftest evaluate-stall-recovery-second-hang-failover-happy-path
+  (testing "hang-count = 2 with healthy failover backends → :failover"
+    (with-redefs [health/load-health         (constantly
+                                              {:backends      {}
+                                               :fallback-order [:anthropic :openai :codex]
+                                               :switch-cooldowns {}})
+                  health/record-backend-call! (fn [_b _s] nil)
+                  health/in-cooldown?         (fn [_b _ms] false)
+                  health/get-backend-success-rate (fn [_b] nil) ; no data → eligible
+                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-222" 2 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :failover (:action result)))
+        ;; :openai is first eligible from fallback-order that is in allowed-set
+        (is (= :openai (:new-backend result)))))))
+
+(deftest evaluate-stall-recovery-third-hang-also-failover
+  (testing "hang-count = 3 also triggers :failover path"
+    (with-redefs [health/load-health         (constantly
+                                              {:backends       {}
+                                               :fallback-order [:anthropic :openai :codex]
+                                               :switch-cooldowns {}})
+                  health/record-backend-call! (fn [_b _s] nil)
+                  health/in-cooldown?         (fn [_b _ms] false)
+                  health/get-backend-success-rate (fn [_b] nil)
+                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-333" 3 [:codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :failover (:action result)))
+        (is (= :codex (:new-backend result)))))))
+
+(deftest evaluate-stall-recovery-records-failure-on-second-hang
+  (testing "hang-count >= 2 calls record-backend-call! with success?=false"
+    (let [recorded (atom nil)]
+      (with-redefs [health/load-health         (constantly
+                                                {:backends       {}
+                                                 :fallback-order [:anthropic :openai]
+                                                 :switch-cooldowns {}})
+                    health/record-backend-call! (fn [b s]
+                                                  (reset! recorded {:backend b :success? s}))
+                    health/in-cooldown?         (fn [_b _ms] false)
+                    health/get-backend-success-rate (fn [_b] nil)
+                    health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-fail" 2 [:openai]))
+        (is (= {:backend :anthropic :success? false} @recorded))))))
+
+(deftest evaluate-stall-recovery-calls-trigger-switch-on-failover
+  (testing "hang-count >= 2 with candidate calls trigger-backend-switch!"
+    (let [switch-calls (atom [])]
+      (with-redefs [health/load-health         (constantly
+                                                {:backends       {}
+                                                 :fallback-order [:anthropic :openai :codex]
+                                                 :switch-cooldowns {}})
+                    health/record-backend-call! (fn [_b _s] nil)
+                    health/in-cooldown?         (fn [_b _ms] false)
+                    health/get-backend-success-rate (fn [_b] nil)
+                    health/trigger-backend-switch!  (fn [f t ms]
+                                                      (swap! switch-calls conj {:from f :to t :ms ms}))]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-sw" 2 [:openai]))
+        (is (= 1 (count @switch-calls)))
+        (is (= :anthropic (get-in @switch-calls [0 :from])))
+        (is (= :openai    (get-in @switch-calls [0 :to])))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – :abort path
+
+(deftest evaluate-stall-recovery-no-backends-returns-abort
+  (testing "hang-count >= 2 with no allowed failover → :abort"
+    (with-redefs [health/load-health         (constantly
+                                              {:backends       {}
+                                               :fallback-order [:anthropic :openai]
+                                               :switch-cooldowns {}})
+                  health/record-backend-call! (fn [_b _s] nil)
+                  health/in-cooldown?         (fn [_b _ms] false)
+                  health/get-backend-success-rate (fn [_b] nil)
+                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-abort" 2 []) ; empty allowed set
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort (:action result)))
+        (is (string? (:reason result)))))))
+
+(deftest evaluate-stall-recovery-all-backends-in-cooldown-returns-abort
+  (testing "hang-count >= 2 but all allowed backends in cooldown → :abort"
+    (with-redefs [health/load-health         (constantly
+                                              {:backends       {}
+                                               :fallback-order [:anthropic :openai :codex]
+                                               :switch-cooldowns {}})
+                  health/record-backend-call! (fn [_b _s] nil)
+                  health/in-cooldown?         (fn [_b _ms] true) ; everything in cooldown
+                  health/get-backend-success-rate (fn [_b] nil)
+                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-cd" 2 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort (:action result)))))))
+
+(deftest evaluate-stall-recovery-unhealthy-backends-skipped
+  (testing "backends below threshold are skipped; abort if none survive"
+    (with-redefs [health/load-health         (constantly
+                                              {:backends       {}
+                                               :fallback-order [:anthropic :openai :codex]
+                                               :switch-cooldowns {}})
+                  health/record-backend-call! (fn [_b _s] nil)
+                  health/in-cooldown?         (fn [_b _ms] false)
+                  ;; Both candidates have low success rate
+                  health/get-backend-success-rate (fn [_b] 0.50)
+                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-uh" 2 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort (:action result)))))))
+
+(deftest evaluate-stall-recovery-respects-allowed-set-not-global-order
+  (testing "only backends in allowed-failover-backends are considered, even if fallback-order has more"
+    (with-redefs [health/load-health         (constantly
+                                              {:backends       {}
+                                               :fallback-order [:anthropic :openai :codex :ollama]
+                                               :switch-cooldowns {}})
+                  health/record-backend-call! (fn [_b _s] nil)
+                  health/in-cooldown?         (fn [_b _ms] false)
+                  health/get-backend-success-rate (fn [_b] nil)
+                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+      ;; Only :ollama allowed; :openai and :codex are in fallback-order but not allowed
+      (let [ctx    (make-ctx :anthropic "sess-a" 2 [:ollama])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :failover (:action result)))
+        (is (= :ollama (:new-backend result)))))))
+
+(deftest evaluate-stall-recovery-uses-cooldown-from-config
+  (testing "custom cooldown-ms from :config is forwarded to health checks"
+    (let [cooldown-seen (atom nil)]
+      (with-redefs [health/load-health         (constantly
+                                                {:backends       {}
+                                                 :fallback-order [:anthropic :openai]
+                                                 :switch-cooldowns {}})
+                    health/record-backend-call! (fn [_b _s] nil)
+                    health/in-cooldown?         (fn [_b ms]
+                                                  (reset! cooldown-seen ms)
+                                                  false)
+                    health/get-backend-success-rate (fn [_b] nil)
+                    health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+        (sut/evaluate-stall-recovery
+         {:phase-id                  :plan
+          :backend                   :anthropic
+          :session-id                "s"
+          :hang-count                (atom 2)
+          :config                    {:backend-switch-cooldown-ms 300000
+                                      :backend-health-threshold   0.80}
+          :allowed-failover-backends [:openai]})
+        (is (= 300000 @cooldown-seen))))))
+
+;;------------------------------------------------------------------------------ execute-resume!
+
+(deftest execute-resume-returns-expected-shape
+  (testing "execute-resume! returns map with :process, :backend, :session-id, :command"
+    (let [fake-proc (reify java.lang.Process)]
+      (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
+                    (fn [_cmd] fake-proc)]
+        (let [result (sut/execute-resume! :anthropic "sess-xyz")]
+          (is (= fake-proc    (:process result)))
+          (is (= :anthropic   (:backend result)))
+          (is (= "sess-xyz"   (:session-id result)))
+          (is (= ["anthropic" "--resume" "sess-xyz"] (:command result))))))))
+
+(deftest execute-resume-with-extra-args
+  (testing "extra-args are appended to the command"
+    (let [launched (atom nil)]
+      (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
+                    (fn [cmd] (reset! launched cmd) nil)]
+        (sut/execute-resume! :openai "s42" ["--timeout" "120"])
+        (is (= ["openai" "--resume" "s42" "--timeout" "120"] @launched))))))
+
+(deftest execute-resume-ollama-uses-continue-flag
+  (testing "ollama subprocess uses --continue, not --resume"
+    (let [launched (atom nil)]
+      (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
+                    (fn [cmd] (reset! launched cmd) nil)]
+        (sut/execute-resume! :ollama "sess-o")
+        (is (= "ollama"    (first @launched)))
+        (is (= "--continue" (second @launched)))))))
+
+(deftest execute-resume-coerces-string-backend
+  (testing "string backend is coerced to keyword in result"
+    (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
+                  (fn [_cmd] nil)]
+      (let [result (sut/execute-resume! "codex" "sess-s")]
+        (is (= :codex (:backend result)))))))

--- a/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
@@ -23,7 +23,7 @@
    [ai.miniforge.self-healing.stream-recovery :as sut]
    [ai.miniforge.self-healing.backend-health :as health]))
 
-;;------------------------------------------------------------------------------ helpers
+;;------------------------------------------------------------------------------ Helpers
 
 (def ^:private base-config
   {:backend-switch-cooldown-ms 1800000
@@ -38,6 +38,17 @@
    :hang-count                (atom hang-count-val)
    :config                    base-config
    :allowed-failover-backends allowed-failover})
+
+;;
+;; Stub helpers – shared across multiple tests
+;;
+
+(defn- healthy-health-stub
+  "Returns a health stub with empty backends (all eligible) and standard fallback-order."
+  []
+  {:backends         {}
+   :fallback-order   [:anthropic :openai :codex :ollama :google]
+   :switch-cooldowns {}})
 
 ;;------------------------------------------------------------------------------ resume-flag-for
 
@@ -55,10 +66,20 @@
 
 ;;------------------------------------------------------------------------------ build-resume-command
 
-(deftest build-resume-command-basic
-  (testing "produces [binary flag session-id]"
-    (is (= ["anthropic" "--resume" "sess-abc"]
+(deftest build-resume-command-anthropic-uses-claude-binary
+  (testing ":anthropic backend maps to the 'claude' binary, not 'anthropic'"
+    (is (= ["claude" "--resume" "sess-abc"]
            (sut/build-resume-command :anthropic "sess-abc")))))
+
+(deftest build-resume-command-claude-code-uses-claude-binary
+  (testing ":claude-code backend also maps to the 'claude' binary"
+    (is (= ["claude" "--resume" "s1"]
+           (sut/build-resume-command :claude-code "s1")))))
+
+(deftest build-resume-command-google-uses-gemini-binary
+  (testing ":google backend maps to the 'gemini' binary"
+    (is (= ["gemini" "--resume" "s2"]
+           (sut/build-resume-command :google "s2")))))
 
 (deftest build-resume-command-with-extra-args
   (testing "appends extra args after session-id"
@@ -66,172 +87,152 @@
            (sut/build-resume-command :openai "s123" ["--timeout" "90"])))))
 
 (deftest build-resume-command-ollama-uses-continue
-  (testing "ollama uses --continue flag"
+  (testing "ollama uses --continue flag and 'ollama' binary"
     (is (= ["ollama" "--continue" "s999"]
            (sut/build-resume-command :ollama "s999")))))
 
-(deftest build-resume-command-string-backend
-  (testing "string backend coerced to keyword correctly"
+(deftest build-resume-command-string-backend-coerced
+  (testing "string backend is coerced to keyword for lookup"
     (is (= ["codex" "--resume" "sid"]
            (sut/build-resume-command "codex" "sid")))))
 
 ;;------------------------------------------------------------------------------ evaluate-stall-recovery – :resume path
 
-(deftest evaluate-stall-recovery-first-hang-returns-resume
-  (testing "hang-count = 1 → :resume action with same session and backend"
-    (let [ctx    (make-ctx :anthropic "sess-111" 1 [:openai :codex])
-          result (sut/evaluate-stall-recovery ctx)]
-      (is (= :resume      (:action result)))
-      (is (= "sess-111"   (:session-id result)))
-      (is (= :anthropic   (:backend result))))))
+(deftest evaluate-stall-recovery-first-hang-healthy-backend-returns-resume
+  (testing "hang-count=1, backend has no health data (eligible) → :resume"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil) ; no data → healthy
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-111" 1 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :resume    (:action result)))
+        (is (= "sess-111" (:session-id result)))
+        (is (= :anthropic (:backend result)))))))
 
-(deftest evaluate-stall-recovery-zero-hang-count-returns-resume
-  (testing "hang-count = 0 (degenerate) → :resume action (safe fallback)"
-    (let [ctx    (make-ctx :openai "sess-000" 0 [:anthropic])
-          result (sut/evaluate-stall-recovery ctx)]
-      (is (= :resume (:action result)))
-      (is (= :openai (:backend result))))))
+(deftest evaluate-stall-recovery-first-hang-healthy-rate-returns-resume
+  (testing "hang-count=1, backend success-rate >= threshold → :resume"
+    (with-redefs [health/get-backend-success-rate (fn [_b] 0.95)] ; above threshold
+      (let [ctx    (make-ctx :anthropic "sess-ok" 1 [:openai])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :resume (:action result)))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – health gate on count=1
+
+(deftest evaluate-stall-recovery-first-hang-unhealthy-backend-skips-resume
+  (testing "hang-count=1 but backend already below threshold → :failover, not :resume"
+    (with-redefs [health/get-backend-success-rate (fn [_b] 0.50) ; below 0.90 threshold
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] :openai)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-sick" 1 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :failover (:action result)))
+        (is (= :openai   (:new-backend result)))))))
+
+(deftest evaluate-stall-recovery-first-hang-unhealthy-no-candidates-aborts
+  (testing "hang-count=1, backend unhealthy, no allowed failover candidates → :abort"
+    (with-redefs [health/get-backend-success-rate (fn [_b] 0.30) ; unhealthy
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil) ; no candidate
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-s" 1 [])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort  (:action result)))
+        (is (string? (:reason result)))))))
+
+(deftest evaluate-stall-recovery-first-hang-records-failure-before-early-failover
+  (testing "health-gate path calls record-backend-call! with false"
+    (let [recorded (atom nil)]
+      (with-redefs [health/get-backend-success-rate (fn [_b] 0.50)
+                    health/record-backend-call!     (fn [b s] (reset! recorded {:b b :s s}))
+                    health/select-best-backend      (fn [& _] :openai)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-r" 1 [:openai]))
+        (is (= {:b :anthropic :s false} @recorded))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – degenerate count
+
+(deftest evaluate-stall-recovery-zero-hang-count-returns-resume-with-anomaly
+  (testing "hang-count=0 (degenerate) → :resume with :anomaly? true"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :openai "sess-000" 0 [:anthropic])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :resume (:action result)))
+        (is (true? (:anomaly? result)))))))
 
 ;;------------------------------------------------------------------------------ evaluate-stall-recovery – :failover path
 
-(deftest evaluate-stall-recovery-second-hang-failover-happy-path
-  (testing "hang-count = 2 with healthy failover backends → :failover"
-    (with-redefs [health/load-health         (constantly
-                                              {:backends      {}
-                                               :fallback-order [:anthropic :openai :codex]
-                                               :switch-cooldowns {}})
-                  health/record-backend-call! (fn [_b _s] nil)
-                  health/in-cooldown?         (fn [_b _ms] false)
-                  health/get-backend-success-rate (fn [_b] nil) ; no data → eligible
-                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+(deftest evaluate-stall-recovery-second-hang-returns-failover
+  (testing "hang-count=2 with healthy allowed failover backend → :failover"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] :openai)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
       (let [ctx    (make-ctx :anthropic "sess-222" 2 [:openai :codex])
             result (sut/evaluate-stall-recovery ctx)]
         (is (= :failover (:action result)))
-        ;; :openai is first eligible from fallback-order that is in allowed-set
-        (is (= :openai (:new-backend result)))))))
+        (is (= :openai   (:new-backend result)))))))
 
 (deftest evaluate-stall-recovery-third-hang-also-failover
-  (testing "hang-count = 3 also triggers :failover path"
-    (with-redefs [health/load-health         (constantly
-                                              {:backends       {}
-                                               :fallback-order [:anthropic :openai :codex]
-                                               :switch-cooldowns {}})
-                  health/record-backend-call! (fn [_b _s] nil)
-                  health/in-cooldown?         (fn [_b _ms] false)
-                  health/get-backend-success-rate (fn [_b] nil)
-                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+  (testing "hang-count=3 also triggers :failover"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] :codex)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
       (let [ctx    (make-ctx :anthropic "sess-333" 3 [:codex])
             result (sut/evaluate-stall-recovery ctx)]
         (is (= :failover (:action result)))
-        (is (= :codex (:new-backend result)))))))
+        (is (= :codex    (:new-backend result)))))))
 
 (deftest evaluate-stall-recovery-records-failure-on-second-hang
-  (testing "hang-count >= 2 calls record-backend-call! with success?=false"
+  (testing "hang-count>=2 calls record-backend-call! with success?=false"
     (let [recorded (atom nil)]
-      (with-redefs [health/load-health         (constantly
-                                                {:backends       {}
-                                                 :fallback-order [:anthropic :openai]
-                                                 :switch-cooldowns {}})
-                    health/record-backend-call! (fn [b s]
-                                                  (reset! recorded {:backend b :success? s}))
-                    health/in-cooldown?         (fn [_b _ms] false)
-                    health/get-backend-success-rate (fn [_b] nil)
-                    health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
-        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-fail" 2 [:openai]))
-        (is (= {:backend :anthropic :success? false} @recorded))))))
+      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                    health/record-backend-call!     (fn [b s] (reset! recorded {:b b :s s}))
+                    health/select-best-backend      (fn [& _] :openai)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-f" 2 [:openai]))
+        (is (= {:b :anthropic :s false} @recorded))))))
 
 (deftest evaluate-stall-recovery-calls-trigger-switch-on-failover
-  (testing "hang-count >= 2 with candidate calls trigger-backend-switch!"
+  (testing "failover path calls trigger-backend-switch! with correct args"
     (let [switch-calls (atom [])]
-      (with-redefs [health/load-health         (constantly
-                                                {:backends       {}
-                                                 :fallback-order [:anthropic :openai :codex]
-                                                 :switch-cooldowns {}})
-                    health/record-backend-call! (fn [_b _s] nil)
-                    health/in-cooldown?         (fn [_b _ms] false)
-                    health/get-backend-success-rate (fn [_b] nil)
+      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                    health/record-backend-call!     (fn [_b _s] nil)
+                    health/select-best-backend      (fn [& _] :openai)
                     health/trigger-backend-switch!  (fn [f t ms]
                                                       (swap! switch-calls conj {:from f :to t :ms ms}))]
         (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-sw" 2 [:openai]))
-        (is (= 1 (count @switch-calls)))
+        (is (= 1         (count @switch-calls)))
         (is (= :anthropic (get-in @switch-calls [0 :from])))
-        (is (= :openai    (get-in @switch-calls [0 :to])))))))
+        (is (= :openai    (get-in @switch-calls [0 :to])))
+        (is (= 1800000    (get-in @switch-calls [0 :ms])))))))
 
-;;------------------------------------------------------------------------------ evaluate-stall-recovery – :abort path
-
-(deftest evaluate-stall-recovery-no-backends-returns-abort
-  (testing "hang-count >= 2 with no allowed failover → :abort"
-    (with-redefs [health/load-health         (constantly
-                                              {:backends       {}
-                                               :fallback-order [:anthropic :openai]
-                                               :switch-cooldowns {}})
-                  health/record-backend-call! (fn [_b _s] nil)
-                  health/in-cooldown?         (fn [_b _ms] false)
-                  health/get-backend-success-rate (fn [_b] nil)
-                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-abort" 2 []) ; empty allowed set
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :abort (:action result)))
-        (is (string? (:reason result)))))))
-
-(deftest evaluate-stall-recovery-all-backends-in-cooldown-returns-abort
-  (testing "hang-count >= 2 but all allowed backends in cooldown → :abort"
-    (with-redefs [health/load-health         (constantly
-                                              {:backends       {}
-                                               :fallback-order [:anthropic :openai :codex]
-                                               :switch-cooldowns {}})
-                  health/record-backend-call! (fn [_b _s] nil)
-                  health/in-cooldown?         (fn [_b _ms] true) ; everything in cooldown
-                  health/get-backend-success-rate (fn [_b] nil)
-                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-cd" 2 [:openai :codex])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :abort (:action result)))))))
-
-(deftest evaluate-stall-recovery-unhealthy-backends-skipped
-  (testing "backends below threshold are skipped; abort if none survive"
-    (with-redefs [health/load-health         (constantly
-                                              {:backends       {}
-                                               :fallback-order [:anthropic :openai :codex]
-                                               :switch-cooldowns {}})
-                  health/record-backend-call! (fn [_b _s] nil)
-                  health/in-cooldown?         (fn [_b _ms] false)
-                  ;; Both candidates have low success rate
-                  health/get-backend-success-rate (fn [_b] 0.50)
-                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-uh" 2 [:openai :codex])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :abort (:action result)))))))
-
-(deftest evaluate-stall-recovery-respects-allowed-set-not-global-order
-  (testing "only backends in allowed-failover-backends are considered, even if fallback-order has more"
-    (with-redefs [health/load-health         (constantly
-                                              {:backends       {}
-                                               :fallback-order [:anthropic :openai :codex :ollama]
-                                               :switch-cooldowns {}})
-                  health/record-backend-call! (fn [_b _s] nil)
-                  health/in-cooldown?         (fn [_b _ms] false)
-                  health/get-backend-success-rate (fn [_b] nil)
-                  health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
-      ;; Only :ollama allowed; :openai and :codex are in fallback-order but not allowed
-      (let [ctx    (make-ctx :anthropic "sess-a" 2 [:ollama])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :failover (:action result)))
-        (is (= :ollama (:new-backend result)))))))
+(deftest evaluate-stall-recovery-forwards-allowed-set-to-select-best-backend
+  (testing "allowed-failover-backends is forwarded to select-best-backend as a set"
+    (let [received-allowed (atom nil)]
+      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                    health/record-backend-call!     (fn [_b _s] nil)
+                    health/select-best-backend      (fn [_cur _thr _cool allowed]
+                                                      (reset! received-allowed allowed)
+                                                      :codex)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-a" 2 [:codex :ollama]))
+        (is (= #{:codex :ollama} @received-allowed))))))
 
 (deftest evaluate-stall-recovery-uses-cooldown-from-config
-  (testing "custom cooldown-ms from :config is forwarded to health checks"
-    (let [cooldown-seen (atom nil)]
-      (with-redefs [health/load-health         (constantly
-                                                {:backends       {}
-                                                 :fallback-order [:anthropic :openai]
-                                                 :switch-cooldowns {}})
-                    health/record-backend-call! (fn [_b _s] nil)
-                    health/in-cooldown?         (fn [_b ms]
-                                                  (reset! cooldown-seen ms)
-                                                  false)
-                    health/get-backend-success-rate (fn [_b] nil)
-                    health/trigger-backend-switch!  (fn [_f _t _ms] nil)]
+  (testing "custom :backend-switch-cooldown-ms from :config is forwarded"
+    (let [received-cooldown (atom nil)]
+      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                    health/record-backend-call!     (fn [_b _s] nil)
+                    health/select-best-backend      (fn [_cur _thr cool _allowed]
+                                                      (reset! received-cooldown cool)
+                                                      :openai)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
         (sut/evaluate-stall-recovery
          {:phase-id                  :plan
           :backend                   :anthropic
@@ -240,20 +241,44 @@
           :config                    {:backend-switch-cooldown-ms 300000
                                       :backend-health-threshold   0.80}
           :allowed-failover-backends [:openai]})
-        (is (= 300000 @cooldown-seen))))))
+        (is (= 300000 @received-cooldown))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – :abort path
+
+(deftest evaluate-stall-recovery-no-allowed-backends-returns-abort
+  (testing "hang-count>=2 with empty allowed-failover-backends → :abort"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil) ; no candidate
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-abort" 2 [])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort  (:action result)))
+        (is (string?   (:reason result)))))))
+
+(deftest evaluate-stall-recovery-select-best-nil-returns-abort
+  (testing "hang-count>=2 but select-best-backend returns nil → :abort"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-cd" 2 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort (:action result)))))))
 
 ;;------------------------------------------------------------------------------ execute-resume!
 
 (deftest execute-resume-returns-expected-shape
-  (testing "execute-resume! returns map with :process, :backend, :session-id, :command"
-    (let [fake-proc (reify java.lang.Process)]
+  (testing "execute-resume! returns map with :process :backend :session-id :command"
+    ;; Use a plain Object as a sentinel — reify does not support abstract classes.
+    (let [fake-proc (Object.)]
       (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                     (fn [_cmd] fake-proc)]
         (let [result (sut/execute-resume! :anthropic "sess-xyz")]
-          (is (= fake-proc    (:process result)))
-          (is (= :anthropic   (:backend result)))
-          (is (= "sess-xyz"   (:session-id result)))
-          (is (= ["anthropic" "--resume" "sess-xyz"] (:command result))))))))
+          (is (identical? fake-proc  (:process result)))
+          (is (= :anthropic           (:backend result)))
+          (is (= "sess-xyz"           (:session-id result)))
+          (is (= ["claude" "--resume" "sess-xyz"] (:command result))))))))
 
 (deftest execute-resume-with-extra-args
   (testing "extra-args are appended to the command"
@@ -263,8 +288,8 @@
         (sut/execute-resume! :openai "s42" ["--timeout" "120"])
         (is (= ["openai" "--resume" "s42" "--timeout" "120"] @launched))))))
 
-(deftest execute-resume-ollama-uses-continue-flag
-  (testing "ollama subprocess uses --continue, not --resume"
+(deftest execute-resume-ollama-uses-continue-flag-and-binary
+  (testing "ollama subprocess uses --continue and 'ollama' binary"
     (let [launched (atom nil)]
       (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                     (fn [cmd] (reset! launched cmd) nil)]
@@ -272,9 +297,24 @@
         (is (= "ollama"    (first @launched)))
         (is (= "--continue" (second @launched)))))))
 
+(deftest execute-resume-google-uses-gemini-binary
+  (testing "google subprocess uses 'gemini' binary"
+    (let [launched (atom nil)]
+      (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
+                    (fn [cmd] (reset! launched cmd) nil)]
+        (sut/execute-resume! :google "sess-g")
+        (is (= "gemini" (first @launched)))))))
+
 (deftest execute-resume-coerces-string-backend
-  (testing "string backend is coerced to keyword in result"
+  (testing "string backend is coerced to keyword in result map"
     (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                   (fn [_cmd] nil)]
       (let [result (sut/execute-resume! "codex" "sess-s")]
         (is (= :codex (:backend result)))))))
+
+(deftest execute-resume-session-id-coerced-to-string
+  (testing "non-string session-id is coerced to string"
+    (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
+                  (fn [_cmd] nil)]
+      (let [result (sut/execute-resume! :anthropic :some-keyword-session)]
+        (is (= ":some-keyword-session" (:session-id result)))))))

--- a/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
@@ -39,17 +39,6 @@
    :config                    base-config
    :allowed-failover-backends allowed-failover})
 
-;;
-;; Stub helpers – shared across multiple tests
-;;
-
-(defn- healthy-health-stub
-  "Returns a health stub with empty backends (all eligible) and standard fallback-order."
-  []
-  {:backends         {}
-   :fallback-order   [:anthropic :openai :codex :ollama :google]
-   :switch-cooldowns {}})
-
 ;;------------------------------------------------------------------------------ resume-flag-for
 
 (deftest resume-flag-for-known-backends
@@ -98,9 +87,9 @@
 
 ;;------------------------------------------------------------------------------ evaluate-stall-recovery – :resume path
 
-(deftest evaluate-stall-recovery-first-hang-healthy-backend-returns-resume
-  (testing "hang-count=1, backend has no health data (eligible) → :resume"
-    (with-redefs [health/get-backend-success-rate (fn [_b] nil) ; no data → healthy
+(deftest evaluate-stall-recovery-first-hang-no-health-data-returns-resume
+  (testing "hang-count=1, backend has no health data (nil rate = eligible) → :resume"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
                   health/record-backend-call!     (fn [_b _s] nil)
                   health/select-best-backend      (fn [& _] nil)
                   health/trigger-backend-switch!  (fn [& _] nil)]
@@ -112,7 +101,7 @@
 
 (deftest evaluate-stall-recovery-first-hang-healthy-rate-returns-resume
   (testing "hang-count=1, backend success-rate >= threshold → :resume"
-    (with-redefs [health/get-backend-success-rate (fn [_b] 0.95)] ; above threshold
+    (with-redefs [health/get-backend-success-rate (fn [_b] 0.95)]
       (let [ctx    (make-ctx :anthropic "sess-ok" 1 [:openai])
             result (sut/evaluate-stall-recovery ctx)]
         (is (= :resume (:action result)))))))
@@ -121,7 +110,7 @@
 
 (deftest evaluate-stall-recovery-first-hang-unhealthy-backend-skips-resume
   (testing "hang-count=1 but backend already below threshold → :failover, not :resume"
-    (with-redefs [health/get-backend-success-rate (fn [_b] 0.50) ; below 0.90 threshold
+    (with-redefs [health/get-backend-success-rate (fn [_b] 0.50)
                   health/record-backend-call!     (fn [_b _s] nil)
                   health/select-best-backend      (fn [& _] :openai)
                   health/trigger-backend-switch!  (fn [& _] nil)]
@@ -132,9 +121,9 @@
 
 (deftest evaluate-stall-recovery-first-hang-unhealthy-no-candidates-aborts
   (testing "hang-count=1, backend unhealthy, no allowed failover candidates → :abort"
-    (with-redefs [health/get-backend-success-rate (fn [_b] 0.30) ; unhealthy
+    (with-redefs [health/get-backend-success-rate (fn [_b] 0.30)
                   health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] nil) ; no candidate
+                  health/select-best-backend      (fn [& _] nil)
                   health/trigger-backend-switch!  (fn [& _] nil)]
       (let [ctx    (make-ctx :anthropic "sess-s" 1 [])
             result (sut/evaluate-stall-recovery ctx)]
@@ -207,7 +196,7 @@
                     health/trigger-backend-switch!  (fn [f t ms]
                                                       (swap! switch-calls conj {:from f :to t :ms ms}))]
         (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-sw" 2 [:openai]))
-        (is (= 1         (count @switch-calls)))
+        (is (= 1          (count @switch-calls)))
         (is (= :anthropic (get-in @switch-calls [0 :from])))
         (is (= :openai    (get-in @switch-calls [0 :to])))
         (is (= 1800000    (get-in @switch-calls [0 :ms])))))))
@@ -249,7 +238,7 @@
   (testing "hang-count>=2 with empty allowed-failover-backends → :abort"
     (with-redefs [health/get-backend-success-rate (fn [_b] nil)
                   health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] nil) ; no candidate
+                  health/select-best-backend      (fn [& _] nil)
                   health/trigger-backend-switch!  (fn [& _] nil)]
       (let [ctx    (make-ctx :anthropic "sess-abort" 2 [])
             result (sut/evaluate-stall-recovery ctx)]
@@ -270,7 +259,7 @@
 
 (deftest execute-resume-returns-expected-shape
   (testing "execute-resume! returns map with :process :backend :session-id :command"
-    ;; Use a plain Object as a sentinel — reify does not support abstract classes.
+    ;; Use a plain Object as sentinel — reify does not support abstract classes.
     (let [fake-proc (Object.)]
       (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                     (fn [_cmd] fake-proc)]
@@ -294,7 +283,7 @@
       (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                     (fn [cmd] (reset! launched cmd) nil)]
         (sut/execute-resume! :ollama "sess-o")
-        (is (= "ollama"    (first @launched)))
+        (is (= "ollama"     (first @launched)))
         (is (= "--continue" (second @launched)))))))
 
 (deftest execute-resume-google-uses-gemini-binary

--- a/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
@@ -85,6 +85,30 @@
     (is (= ["codex" "--resume" "sid"]
            (sut/build-resume-command "codex" "sid")))))
 
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – guard clauses
+
+(deftest evaluate-stall-recovery-nil-backend-throws
+  (testing "nil :backend throws ex-info with clear message"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (sut/evaluate-stall-recovery
+                  {:phase-id   :implement
+                   :backend    nil
+                   :session-id "s"
+                   :hang-count (atom 1)
+                   :config     {}
+                   :allowed-failover-backends []})))))
+
+(deftest evaluate-stall-recovery-non-atom-hang-count-throws
+  (testing "non-atom :hang-count throws ex-info with clear message"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (sut/evaluate-stall-recovery
+                  {:phase-id   :implement
+                   :backend    :anthropic
+                   :session-id "s"
+                   :hang-count 2   ; not an atom
+                   :config     {}
+                   :allowed-failover-backends []})))))
+
 ;;------------------------------------------------------------------------------ evaluate-stall-recovery – :resume path
 
 (deftest evaluate-stall-recovery-first-hang-no-health-data-returns-resume
@@ -100,11 +124,19 @@
         (is (= :anthropic (:backend result)))))))
 
 (deftest evaluate-stall-recovery-first-hang-healthy-rate-returns-resume
-  (testing "hang-count=1, backend success-rate >= threshold → :resume"
-    (with-redefs [health/get-backend-success-rate (fn [_b] 0.95)]
-      (let [ctx    (make-ctx :anthropic "sess-ok" 1 [:openai])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :resume (:action result)))))))
+  (testing "hang-count=1, backend success-rate >= threshold → :resume, no side effects"
+    ;; Stubs all side-effect functions and asserts they were NOT called, proving
+    ;; the resume path is side-effect-free.
+    (let [record-calls (atom [])]
+      (with-redefs [health/get-backend-success-rate (fn [_b] 0.95) ; above threshold
+                    health/record-backend-call!     (fn [b s] (swap! record-calls conj [b s]))
+                    health/select-best-backend      (fn [& _] nil)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
+        (let [ctx    (make-ctx :anthropic "sess-ok" 1 [:openai])
+              result (sut/evaluate-stall-recovery ctx)]
+          (is (= :resume (:action result)))
+          (is (empty? @record-calls)
+              "resume path must not record a backend failure"))))))
 
 ;;------------------------------------------------------------------------------ evaluate-stall-recovery – health gate on count=1
 
@@ -307,3 +339,12 @@
                   (fn [_cmd] nil)]
       (let [result (sut/execute-resume! :anthropic :some-keyword-session)]
         (is (= ":some-keyword-session" (:session-id result)))))))
+
+(deftest execute-resume-returns-anomaly-on-ioexception
+  (testing "IOException from start-process! is returned as anomaly map, not thrown"
+    (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
+                  (fn [_cmd] (throw (java.io.IOException. "No such file")))]
+      (let [result (sut/execute-resume! :anthropic "sess-fail")]
+        (is (= :anomaly.category/fault (:anomaly/category result)))
+        (is (string? (:anomaly/message result)))
+        (is (vector? (:cmd result)))))))

--- a/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
@@ -348,3 +348,10 @@
         (is (= :anomaly.category/fault (:anomaly/category result)))
         (is (string? (:anomaly/message result)))
         (is (vector? (:cmd result)))))))
+
+(deftest execute-resume-anomaly-cmd-matches-attempted-command
+  (testing "anomaly :cmd is the exact command vector that was attempted"
+    (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
+                  (fn [_cmd] (throw (java.io.IOException. "not found")))]
+      (let [result (sut/execute-resume! :codex "sess-fail")]
+        (is (= ["codex" "--resume" "sess-fail"] (:cmd result)))))))

--- a/docs/pull-requests/2026-05-19-group-3-resume-on-kill-logic-self-healing-integration.md
+++ b/docs/pull-requests/2026-05-19-group-3-resume-on-kill-logic-self-healing-integration.md
@@ -1,0 +1,28 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 3: Resume-on-kill logic + self-healing integration.
+
+**PR:** [#920](https://github.com/miniforge-ai/miniforge/pull/920)
+**Branch:** `mf/group-3-resume-on-kill-logic-self-healin-60745541`
+
+## Summary
+
+GROUP 3: Resume-on-kill logic + self-healing integration.
+
+## Files Changed
+
+- `components/self-healing/src/ai/miniforge/self_healing/interface.clj` (modify)
+- `components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj` (modify)
+- `components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._


### PR DESCRIPTION
## Summary

GROUP 3 — resume-on-kill logic + self-healing integration. After the stream-watchdog kills a hung agent subprocess, the supervisor must decide whether to (a) relaunch the same backend with `--resume <session-id>`, (b) failover to the next eligible backend, or (c) abort the phase. This PR lands that decision logic in the `self-healing` component and integrates it with the watchdog kill-fn.

Key adds:

- `ai.miniforge.self-healing.stream-recovery/evaluate-stall-recovery` — pure decision fn (no side effects on `:resume` path; side effects on `:failover` via record-backend-call!/trigger-backend-switch!).
- `execute-resume!` — actually shells out the backend binary with the right `--resume` flag and the captured session-id.
- `build-resume-command` — backend-specific flag + binary resolution.
- Wiring into `self-healing.interface`.

Stacked on #917 (event-stream foundation), #918 (watchdog core), #919 (session-id persistence).

## Files Changed

- `components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj` (create)
- `components/self-healing/src/ai/miniforge/self_healing/backend_health.clj` (modify) — `select-best-backend` allowed-set semantics
- `components/self-healing/src/ai/miniforge/self_healing/interface.clj` (modify) — re-exports
- `components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj` (create)
- Carries forward #917/#918/#919 base (event-stream constructors + schemas + registry, agent watchdog + session-id capture, default config keys, stall-events test)

## Test Plan

- [x] `bb pre-commit` — clean (lint, format, smoke 14ns / 289 tests / 1017 assertions, GraalVM compatibility).
- [x] `ai.miniforge.agent.stream-watchdog-test` + `ai.miniforge.event-stream.stall-events-test` + `ai.miniforge.self-healing.stream-recovery-test` — 74 tests, 170 assertions, 0 failures. Covers: backend-health gate, count=1 resume path, count=1 unhealthy-failover, count=1 no-session failover (new), count >= 2 failover, abort when no candidates, command construction, IOException handling on the resume shell-out.

## Review

Copilot review pass (7 inline threads) addressed in 088dd340:

- `select-best-backend` — empty allowed-set now returns nil instead of silently expanding to the full fallback-order.
- `evaluate-stall-recovery` — never returns `:resume` with a nil/blank session-id; failovers instead on the count=1 path, aborts on the degenerate hang-count branch.
- `binary-for` — validates `clojure.lang.Named` backend; throws `ex-info` instead of a downstream NPE.
- `emit-session-captured!` / `emit-stall-event!` — nil event-stream demoted from `log/warn` to `log/debug` so the "legal no-op" docstring matches the behavior.
- `capture-session-id!` — `compare-and-set!` for atomicity; nil-watchdog no-op.
- `perform-failover` — one finding declined-with-explanation (the existing `(set (map keyword …))` coercion is correct).

## Authorship

- Generated by **Heimdall** (Miniforge phase-software-factory agent) on 2026-05-19 in its `verify` phase. Heimdall's verify commit is `15c0fec6`.
- Copilot review pass + body backfill by Claude Code on behalf of @ChristopherLester. Commit `088dd340` carries the review-pass fixes (override commit-budget hook with rationale because the changes span the stacked base + new self-healing surface and can't be atomically split without breaking compile).

<details>
<summary>Original Heimdall PR template</summary>

**PR:** [#920](https://github.com/miniforge-ai/miniforge/pull/920)
**Branch:** `mf/group-3-resume-on-kill-logic-self-healin-60745541`

Test Results and Review Decision sections were left as `_No * available._` placeholders by the Heimdall template; backfilled above.

</details>