### PR TITLE
GROUP 4: Wire richer terminal events into phase-software-factory.

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -33,6 +33,7 @@
    [ai.miniforge.repo-index.interface :as repo-index]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
+   [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -565,33 +566,43 @@
        (:knowledge-store ctx) :implementer
        (get-in ctx [:execution/input :title]) iterations))
     ;; Handle retrying, failure, completed, or already-implemented outcomes
-    (cond-> updated-ctx
-      (contains? #{:completed :already-implemented} phase-status)
-      (update-in [:execution :phases-completed] (fnil conj []) :implement)
+    (let [final-ctx
+          (cond-> updated-ctx
+            (contains? #{:completed :already-implemented} phase-status)
+            (update-in [:execution :phases-completed] (fnil conj []) :implement)
 
-      ;; On success: store lightweight result — code is in the environment, not here
-      (= :completed phase-status)
-      (-> (assoc-in [:phase :result] (phase/success env-id summary))
-          (assoc-in [:phase :artifact]
-                    (cond-> (lightweight-curated-artifact curated-artifact)
-                      degraded-handoff?
-                      (assoc :code/degraded-handoff? true
-                             :code/raw-agent-status raw-agent-status
-                             :code/raw-error (:raw-error result)))))
-      (phase/retrying? (:phase updated-ctx))
-      (-> (update-in [:phase :iterations] (fnil inc 1))
-          (assoc-in [:phase :last-error]
-                    (extract-error-message result (messages/t :implement/agent-error))))
+            ;; On success: store lightweight result — code is in the environment, not here
+            (= :completed phase-status)
+            (-> (assoc-in [:phase :result] (phase/success env-id summary))
+                (assoc-in [:phase :artifact]
+                          (cond-> (lightweight-curated-artifact curated-artifact)
+                            degraded-handoff?
+                            (assoc :code/degraded-handoff? true
+                                   :code/raw-agent-status raw-agent-status
+                                   :code/raw-error (:raw-error result)))))
+            (phase/retrying? (:phase updated-ctx))
+            (-> (update-in [:phase :iterations] (fnil inc 1))
+                (assoc-in [:phase :last-error]
+                          (extract-error-message result (messages/t :implement/agent-error))))
 
-      (= :failed phase-status)
-      (assoc-in [:phase :error]
-                (if invalid-already-implemented?
-                  (build-unverified-already-implemented-error ctx result iterations)
-                  (build-phase-error result agent-status rate-limited? iterations)))
+            (= :failed phase-status)
+            (assoc-in [:phase :error]
+                      (if invalid-already-implemented?
+                        (build-unverified-already-implemented-error ctx result iterations)
+                        (build-phase-error result agent-status rate-limited? iterations)))
 
-      (and (= :already-implemented agent-status)
-           (not invalid-already-implemented?))
-      (assoc-in [:phase :skipped-reason] :already-implemented))))
+            (and (= :already-implemented agent-status)
+                 (not invalid-already-implemented?))
+            (assoc-in [:phase :skipped-reason] :already-implemented))]
+      ;; Emit phase-completed telemetry with termination reason
+      (phase/emit-phase-completed! final-ctx :implement
+        (merge {:outcome     (if (contains? #{:completed :already-implemented} phase-status)
+                               :success
+                               :failure)
+                :duration-ms duration-ms
+                :tokens      (get metrics :tokens 0)}
+               (phase-terminal/derive-termination-reason result {:rate-limited? rate-limited?})))
+      final-ctx)))
 
 (defn error-implement
   "Handle implementation phase errors. Attempts repair via inner loop

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj
@@ -1,0 +1,79 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-software-factory.phase-terminal
+  "Termination-reason derivation for phase-completed events.
+
+   Inspects the phase result map and optional watchdog / hint state to produce
+   the :phase/termination-reason keyword merged into the
+   :workflow/phase-completed event payload.
+
+   Layer 0 — pure function, no side effects, no external dependencies.")
+
+(defn derive-termination-reason
+  "Derive the :phase/termination-reason for a phase-completed event.
+
+   Checks in priority order:
+     1. Watchdog stall    → :agent-stalled  (+ :stall/gap-duration-ms when present)
+     2. Curator rejection → :curator-rejected
+     3. Tool / infra error → :tool-error
+     4. Default           → :normal
+
+   Arguments:
+     result         — phase result map (from [:phase :result] in context).
+     watchdog-state — optional map of hints derived from the watchdog or
+                      phase-local detection; may contain:
+                        :stalled?              truthy when supervisor detected a hang
+                        :stall/gap-duration-ms gap in ms since the last agent event
+                        :rate-limited?         truthy to force :tool-error classification
+
+   Returns a map suitable for merging into a phase-completed event payload:
+
+     {:phase/termination-reason :normal}
+     {:phase/termination-reason :agent-stalled
+      :stall/gap-duration-ms    <ms>}
+     {:phase/termination-reason :curator-rejected}
+     {:phase/termination-reason :tool-error}"
+  ([result]
+   (derive-termination-reason result nil))
+  ([result watchdog-state]
+   (let [error-code    (get-in result [:error :data :code])
+         error-type    (get-in result [:error :data :type])
+         gap-ms        (get watchdog-state :stall/gap-duration-ms)
+         stalled?      (or (boolean (:stalled? watchdog-state))
+                           (and (number? gap-ms) (pos? gap-ms)))
+         rate-limited? (boolean (:rate-limited? watchdog-state))]
+     (cond
+       ;; Watchdog stall takes precedence — explicit signal from the supervisor
+       stalled?
+       (cond-> {:phase/termination-reason :agent-stalled}
+         gap-ms (assoc :stall/gap-duration-ms gap-ms))
+
+       ;; Curator or release executor found nothing to commit/ship
+       (or (= :curator/no-files-written error-code)
+           (= :release/zero-files error-type)
+           (= :release/zero-files error-code))
+       {:phase/termination-reason :curator-rejected}
+
+       ;; Infrastructure / tool failure (rate-limit hint or explicit :tool-error code)
+       (or rate-limited? (= :tool-error error-code))
+       {:phase/termination-reason :tool-error}
+
+       ;; Default — phase ran to completion (success or ordinary failure)
+       :else
+       {:phase/termination-reason :normal}))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -22,10 +22,10 @@
    Creates implementation plans from specifications.
    Agent: :planner
    Default gates: [:plan-complete]"
-  (:require            [ai.miniforge.phase.interface :as phase]
+  (:require [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.phase-software-factory.phase-config :as phase-config]
-            
             [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
+            [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.response.interface :as response]))
 
@@ -143,9 +143,16 @@
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
     ;; Handle :already-satisfied — signal pipeline to skip to :done
-    (if (= :already-satisfied (:status result))
-      (assoc-in updated-ctx [:phase :status] :already-satisfied)
-      updated-ctx)))
+    (let [final-ctx (if (= :already-satisfied (:status result))
+                      (assoc-in updated-ctx [:phase :status] :already-satisfied)
+                      updated-ctx)]
+      ;; Emit phase-completed telemetry with termination reason
+      (phase/emit-phase-completed! final-ctx :plan
+        (merge {:outcome     :success
+                :duration-ms duration-ms
+                :tokens      (get metrics :tokens 0)}
+               (phase-terminal/derive-termination-reason result nil)))
+      final-ctx)))
 
 (defn error-plan
   "Handle planning phase errors. Retry within budget, then fail in

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -32,8 +32,8 @@
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.phase-software-factory.messages :as messages]
-
             [ai.miniforge.phase-software-factory.phase-config :as phase-config]
+            [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
             [ai.miniforge.release-executor.interface :as release-executor]
             [ai.miniforge.response.interface :as response]))
 
@@ -444,9 +444,11 @@
                 (assoc-in [:phase :last-error]
                           (get-in result [:error :message] (messages/t :release/phase-failed)))))
       (phase/emit-phase-completed! :release
-        {:outcome     (if (= :completed phase-status) :success :failure)
-         :duration-ms duration-ms
-         :tokens      (:tokens metrics 0)}))))
+        (merge {:outcome     (if (= :completed phase-status) :success :failure)
+                :duration-ms duration-ms
+                :tokens      (:tokens metrics 0)}
+               ;; :release/zero-files is treated as curator-rejected (nothing to ship)
+               (phase-terminal/derive-termination-reason result nil))))))
 
 (defn error-release
   "Handle release phase errors."

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]
    [ai.miniforge.phase-software-factory.phase-handoff :as phase-handoff]
    [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
+   [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.response.interface :as response]
@@ -346,9 +347,10 @@
        (:knowledge-store ctx) :reviewer
        (get-in ctx [:execution/input :title]) feedback))
     (phase/emit-phase-completed! next-ctx :review
-      {:outcome     (if (= :completed phase-status) :success :failure)
-       :duration-ms duration-ms
-       :tokens      (:tokens metrics 0)})
+      (merge {:outcome     (if (= :completed phase-status) :success :failure)
+              :duration-ms duration-ms
+              :tokens      (:tokens metrics 0)}
+             (phase-terminal/derive-termination-reason result nil)))
     next-ctx))
 
 (defn error-review

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -23,10 +23,10 @@
    No tester agent: the implementer wrote both source and test files;
    this phase validates them by running the test suite.
    Default gates: [:tests-pass :coverage]"
-  (:require            [ai.miniforge.phase.interface :as phase]
+  (:require [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.phase-software-factory.phase-config :as phase-config]
-            
             [ai.miniforge.phase-software-factory.messages :as messages]
+            [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
             [babashka.process :as process]
             [babashka.fs :as fs]
             [clojure.string :as str]))
@@ -391,9 +391,14 @@
                            :rate-limited? rate-limited?
                            :gate-failed?  gate-failed?})))
         (phase/emit-phase-completed! :verify
-          {:outcome     (if (= :completed phase-status) :success :failure)
-           :duration-ms duration-ms
-           :tokens      (get metrics :tokens 0)}))))
+          (merge {:outcome     (if (= :completed phase-status) :success :failure)
+                  :duration-ms duration-ms
+                  :tokens      (get metrics :tokens 0)}
+                 ;; :stalled? true when the test process timed out (hung BB/cargo)
+                 ;; :rate-limited? true when provider quota blocked the phase
+                 (phase-terminal/derive-termination-reason result
+                   {:stalled?      timeout?
+                    :rate-limited? rate-limited?}))))))
 
 (defn error-verify
   "Handle verification phase errors. Retries within budget; on

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj
@@ -1,0 +1,167 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-software-factory.phase-terminal-test
+  "Unit tests for derive-termination-reason in phase-terminal.
+
+   All inputs are plain data maps — no live state, no event streams.
+   Tests cover every branch of the priority-ordered cond."
+  (:require [clojure.test :refer [deftest testing is]]
+            [ai.miniforge.phase-software-factory.phase-terminal :as sut]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+
+(defn reason [result & [watchdog]]
+  (:phase/termination-reason
+   (if watchdog
+     (sut/derive-termination-reason result watchdog)
+     (sut/derive-termination-reason result))))
+
+;; ---------------------------------------------------------------------------
+;; Happy path — normal termination
+
+(deftest normal-success
+  (testing "success result with no watchdog yields :normal"
+    (let [result {:status :success :output {} :metrics {:tokens 100}}]
+      (is (= :normal (reason result)))))
+
+  (testing "nil result yields :normal"
+    (is (= :normal (reason nil))))
+
+  (testing "empty result yields :normal"
+    (is (= :normal (reason {}))))
+
+  (testing "arity-1 call (no watchdog arg) yields :normal"
+    (is (= :normal
+           (:phase/termination-reason
+            (sut/derive-termination-reason {:status :success}))))))
+
+;; ---------------------------------------------------------------------------
+;; Watchdog stall → :agent-stalled
+
+(deftest watchdog-stall-by-flag
+  (testing ":stalled? true produces :agent-stalled"
+    (let [result {:status :error :error {:message "silent"}}]
+      (is (= :agent-stalled (reason result {:stalled? true})))))
+
+  (testing ":stalled? false with no gap-ms is not a stall"
+    (let [result {:status :error}]
+      (is (= :normal (reason result {:stalled? false})))))
+
+  (testing "nil watchdog state is not a stall"
+    (is (= :normal (reason {} nil)))))
+
+(deftest watchdog-stall-by-gap-ms
+  (testing "positive :stall/gap-duration-ms produces :agent-stalled"
+    (let [result {:status :error}
+          ws     {:stall/gap-duration-ms 45000}]
+      (is (= :agent-stalled (reason result ws)))))
+
+  (testing "gap-ms is included in the returned map"
+    (let [result {:status :error}
+          ws     {:stall/gap-duration-ms 30000}
+          out    (sut/derive-termination-reason result ws)]
+      (is (= :agent-stalled (:phase/termination-reason out)))
+      (is (= 30000 (:stall/gap-duration-ms out)))))
+
+  (testing "zero gap-ms is NOT a stall"
+    (let [result {:status :error}]
+      (is (= :normal (reason result {:stall/gap-duration-ms 0})))))
+
+  (testing "stall from :stalled? true carries gap-ms when both present"
+    (let [out (sut/derive-termination-reason
+               {:status :error}
+               {:stalled? true :stall/gap-duration-ms 12000})]
+      (is (= :agent-stalled (:phase/termination-reason out)))
+      (is (= 12000 (:stall/gap-duration-ms out))))))
+
+;; ---------------------------------------------------------------------------
+;; Curator rejection → :curator-rejected
+
+(deftest curator-rejected-no-files-written
+  (testing ":curator/no-files-written error code maps to :curator-rejected"
+    (let [result {:status  :error
+                  :error   {:data {:code :curator/no-files-written}
+                             :message "Curator: no files written"}}]
+      (is (= :curator-rejected (reason result)))))
+
+  (testing ":curator/no-files-written beats :rate-limited? hint (stall wins over curator)"
+    ;; stall takes priority over curator-rejected
+    (let [result {:status :error
+                  :error  {:data {:code :curator/no-files-written}}}]
+      (is (= :agent-stalled
+             (reason result {:stalled? true}))))))
+
+(deftest curator-rejected-release-zero-files
+  (testing ":release/zero-files :data :type maps to :curator-rejected"
+    (let [result {:status :error
+                  :error  {:data {:type :release/zero-files}}}]
+      (is (= :curator-rejected (reason result)))))
+
+  (testing ":release/zero-files :data :code also maps to :curator-rejected"
+    (let [result {:status :error
+                  :error  {:data {:code :release/zero-files}}}]
+      (is (= :curator-rejected (reason result))))))
+
+;; ---------------------------------------------------------------------------
+;; Tool / infra error → :tool-error
+
+(deftest tool-error-from-code
+  (testing ":tool-error error code maps to :tool-error"
+    (let [result {:status :error
+                  :error  {:data {:code :tool-error}
+                            :message "MCP tool invocation failed"}}]
+      (is (= :tool-error (reason result))))))
+
+(deftest tool-error-from-rate-limit-hint
+  (testing ":rate-limited? true hint produces :tool-error"
+    (let [result {:status :error :error {:message "429 Too Many Requests"}}]
+      (is (= :tool-error (reason result {:rate-limited? true})))))
+
+  (testing ":rate-limited? falsy value is not a tool-error on its own"
+    (let [result {:status :error}]
+      (is (= :normal (reason result {:rate-limited? nil})))))
+
+  (testing ":rate-limited? from re-find match (truthy but not true) is handled"
+    ;; re-find returns a MatchResult (truthy), not literal true
+    (let [match   (re-find #"429" "429 error")
+          result  {:status :error}]
+      (is (= :tool-error (reason result {:rate-limited? match}))))))
+
+;; ---------------------------------------------------------------------------
+;; Priority ordering
+
+(deftest priority-ordering
+  (testing "stall takes precedence over curator-rejected"
+    (let [result {:status :error
+                  :error  {:data {:code :curator/no-files-written}}}]
+      (is (= :agent-stalled
+             (reason result {:stalled? true})))))
+
+  (testing "stall takes precedence over tool-error"
+    (let [result {:status :error
+                  :error  {:data {:code :tool-error}}}]
+      (is (= :agent-stalled
+             (reason result {:stalled? true :stall/gap-duration-ms 5000})))))
+
+  (testing "curator-rejected takes precedence over rate-limit hint"
+    (let [result {:status :error
+                  :error  {:data {:code :curator/no-files-written}}}]
+      (is (= :curator-rejected
+             (reason result {:rate-limited? true}))))))

--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -272,13 +272,13 @@
      cooldown-ms     - Cooldown period in milliseconds (default 1800000)
      allowed-set     - Optional set of keyword backends to restrict selection.
                        When `nil` (not supplied), all backends in the stored
-                       fallback-order are considered. When a non-nil empty set
-                       is supplied, the caller has explicitly restricted to
-                       *no* allowed backends — returns nil immediately rather
-                       than silently expanding to the full fallback-order.
-                       When non-empty, only backends in the intersection of
-                       allowed-set and fallback-order are eligible, preserving
-                       the global priority ordering.
+                       fallback-order are considered. When a non-nil empty
+                       set is supplied, the caller has explicitly restricted
+                       to *no* allowed backends — returns nil immediately
+                       rather than silently expanding to the full
+                       fallback-order. When non-empty, only backends in the
+                       intersection of allowed-set and fallback-order are
+                       eligible, preserving the global priority ordering.
 
    Returns: Keyword backend name or nil if none available"
   ([current-backend]
@@ -286,17 +286,11 @@
   ([current-backend threshold cooldown-ms]
    (select-best-backend current-backend threshold cooldown-ms nil))
   ([current-backend threshold cooldown-ms allowed-set]
-   ;; An explicitly empty allowed-set means "no failover targets are
-   ;; permitted" — treating it as nil (and silently expanding to the full
-   ;; fallback-order) would defeat the purpose of the restriction.
    (if (and (some? allowed-set) (empty? allowed-set))
      nil
      (let [health         (load-health)
            fallback-order (:fallback-order health)
            current-key    (keyword current-backend)
-           ;; When an allowed-set is provided and non-empty, filter the
-           ;; global fallback-order so we preserve priority ordering while
-           ;; restricting the candidate pool.
            candidates     (if (seq allowed-set)
                             (filter allowed-set fallback-order)
                             fallback-order)]

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -208,18 +208,17 @@
   (when (nil? backend)
     (throw (ex-info ":backend is required and must not be nil"
                     {:ctx ctx})))
-  (let [count            @hang-count
-        backend-kw       (keyword backend)
-        cooldown-ms      (get config :backend-switch-cooldown-ms 1800000)
-        threshold        (get config :backend-health-threshold 0.90)
-        resumable?       (and (string? session-id)
-                              (not (str/blank? session-id)))]
+  (let [count       @hang-count
+        backend-kw  (keyword backend)
+        cooldown-ms (get config :backend-switch-cooldown-ms 1800000)
+        threshold   (get config :backend-health-threshold 0.90)
+        resumable?  (and (string? session-id)
+                         (not (str/blank? session-id)))]
     (cond
       ;; First stall — check backend health before committing to a resume attempt
       (= count 1)
       (let [rate (backend-health/get-backend-success-rate backend-kw)]
         (cond
-          ;; Backend already known-unhealthy; skip the wasted retry
           (and rate (< rate threshold))
           (do
             (binding [*out* *err*]
@@ -231,10 +230,7 @@
                                 :threshold  threshold})))
             (perform-failover backend-kw allowed-failover-backends threshold cooldown-ms))
 
-          ;; No captured session — resume is impossible; treat first stall as
-          ;; a backend failure and failover instead of feeding nil/blank to
-          ;; execute-resume! (which would coerce nil to the string "nil" and
-          ;; fail the relaunch).
+          ;; No captured session — resume is impossible; failover.
           (not resumable?)
           (do
             (binding [*out* *err*]
@@ -244,7 +240,6 @@
                                 :hang-count count})))
             (perform-failover backend-kw allowed-failover-backends threshold cooldown-ms))
 
-          ;; Backend healthy and we have a session — attempt transparent resume
           :else
           (do
             (binding [*out* *err*]

--- a/docs/pull-requests/2026-05-19-group-4-wire-richer-terminal-events-into-phase-software-factory.md
+++ b/docs/pull-requests/2026-05-19-group-4-wire-richer-terminal-events-into-phase-software-factory.md
@@ -1,0 +1,32 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 4: Wire richer terminal events into phase-software-factory.
+
+**PR:** [#921](https://github.com/miniforge-ai/miniforge/pull/921)
+**Branch:** `mf/group-4-wire-richer-terminal-events-into-292fc25f`
+
+## Summary
+
+GROUP 4: Wire richer terminal events into phase-software-factory.
+
+## Files Changed
+
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj` (create)
+- `components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj` (create)
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj` (modify)
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj` (modify)
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj` (modify)
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj` (modify)
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._

--- a/docs/pull-requests/2026-05-19-group-4-wire-richer-terminal-events-into-phase-software-factory.md
+++ b/docs/pull-requests/2026-05-19-group-4-wire-richer-terminal-events-into-phase-software-factory.md
@@ -4,29 +4,89 @@
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
 
-# GROUP 4: Wire richer terminal events into phase-software-factory.
+# GROUP 4: Wire richer terminal events into phase-software-factory
 
 **PR:** [#921](https://github.com/miniforge-ai/miniforge/pull/921)
 **Branch:** `mf/group-4-wire-richer-terminal-events-into-292fc25f`
 
 ## Summary
 
-GROUP 4: Wire richer terminal events into phase-software-factory.
+Top of the stream-stall / self-healing stack. Lands the
+`phase-terminal` namespace that derives the
+`:phase/termination-reason` keyword for `:workflow/phase-completed`
+events, and wires every phase (`plan`, `implement`, `verify`, `review`,
+`release`) of the `phase-software-factory` component to attach a
+termination reason to their phase-completed envelope.
+
+Termination-reason priority order:
+
+1. Watchdog stall → `:agent-stalled` (+ `:stall/gap-duration-ms` when known)
+2. Curator / release rejection → `:curator-rejected`
+3. Rate-limit / tool error → `:tool-error`
+4. Default → `:normal`
+
+Stacked on #917 / #918 / #919 / #920.
 
 ## Files Changed
 
+### Phase-software-factory (new termination wiring)
+
 - `components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj` (create)
 - `components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj` (create)
-- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj` (modify)
 - `components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj` (modify)
-- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj` (modify)
-- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj` (modify)
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj` (modify)
 - `components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj` (modify)
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj` (modify)
+- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj` (modify)
+
+### Event-stream (carried from #917 / #919)
+
+- `components/event-stream/src/ai/miniforge/event_stream/core.clj` (modify)
+- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` (modify)
+- `components/event-stream/src/ai/miniforge/event_stream/interface/events.clj` (modify)
+- `components/event-stream/src/ai/miniforge/event_stream/schema.clj` (modify) — `AgentStreamStalled`,
+  `AgentSessionCaptured`
+- `components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj` (modify)
+- `components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj` (modify)
+
+### Agent (carried from #918 / #919)
+
+- `components/agent/src/ai/miniforge/agent/stream_watchdog.clj` (modify)
+- `components/agent/src/ai/miniforge/agent/interface.clj` (modify)
+- `components/agent/src/ai/miniforge/agent/interface/watchdog.clj` (modify)
+- `components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj` (modify)
+
+### Self-healing (carried from #920)
+
+- `components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj` (create)
+- `components/self-healing/src/ai/miniforge/self_healing/backend_health.clj` (modify)
+- `components/self-healing/src/ai/miniforge/self_healing/interface.clj` (modify)
+- `components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj` (create)
+
+### Config
+
+- `resources/config/default-user-config.edn` (modify) — stream-gap thresholds under `:self-healing`
 
 ## Test Results
 
-_No test artifacts available._
+- `bb pre-commit` — clean (lint, format, smoke 14ns / 289 tests / 1017 assertions, GraalVM compatibility).
+- `phase-terminal-test` + `stream-watchdog-test` + `stall-events-test` + `stream-recovery-test` — full stack pass,
+  including Malli schema validation.
 
 ## Review Decision
 
-_No review artifacts available._
+Copilot review pass (3 inline threads) addressed in the review-pass
+commit on this branch:
+
+- `select-best-backend` empty allowed-set → returns nil instead of expanding to full fallback-order (carry-forward from
+  #920).
+- Default-config comment math: `{:codex 120000}` is +30 s; example bumped to `{:codex 210000}` for the actual +2 min
+  (carry-forward from #917).
+- PR-doc Files Changed backfilled with the full stack.
+
+Plus carry-forward of all base-stack fixes from #917/#918/#919/#920
+(`:workflow/phase` correlation key, AgentStreamStalled +
+AgentSessionCaptured Malli schemas, watchdog log shape,
+`capture-session-id!` atomicity, `binary-for` validation,
+`evaluate-stall-recovery` no-resume-with-nil-session-id,
+event_type_registry entries, interface docstring, test UUIDs).


### PR DESCRIPTION
## Summary

GROUP 4 — wire richer terminal events into the `phase-software-factory` component. Top of the stream-stall / self-healing PR stack (stacked on #917 / #918 / #919 / #920).

Lands the `phase-terminal` namespace that derives the `:phase/termination-reason` keyword for `:workflow/phase-completed` events, and wires every phase (`plan`, `implement`, `verify`, `review`, `release`) to attach a termination reason to their phase-completed envelope.

Termination-reason priority order:

1. Watchdog stall → `:agent-stalled` (+ `:stall/gap-duration-ms` when known)
2. Curator / release rejection → `:curator-rejected`
3. Rate-limit / tool error → `:tool-error`
4. Default → `:normal`

## Files Changed

### Phase-software-factory (new termination wiring)

- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj` (create)
- `components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj` (create)
- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/{plan,implement,verify,review,release}.clj` (modify)

### Carried from upstream stack

- `event-stream` (#917 / #919): constructors, schemas, registry, tests
- `agent` (#918 / #919): stream-watchdog + session-id capture + interface re-exports
- `self-healing` (#920): stream-recovery + backend-health
- `resources/config/default-user-config.edn` (#917)

## Test Plan

- [x] `bb pre-commit` — clean (lint, format, smoke 14ns / 289 tests / 1017 assertions, GraalVM compatibility)
- [x] `phase-terminal-test` + `stream-watchdog-test` + `stall-events-test` + `stream-recovery-test` — 82 tests, 194 assertions, 0 failures (full stack pass with Malli schema validation)

## Review

Copilot review pass (3 inline threads) addressed in 9c7aa109:

- `select-best-backend` empty allowed-set → returns nil instead of expanding (same as #920 base).
- Default-config comment math fixed (same as #917 base).
- PR-doc Files Changed backfilled with the full stack.

Plus carry-forward of all base-stack review fixes from #917/#918/#919/#920:

- `:workflow/phase` correlation key on agent events.
- `AgentStreamStalled` + `AgentSessionCaptured` Malli schemas, with validation tests.
- Watchdog log/warn/error reshape to in-repo `(logger :cat :evt {data})` convention.
- `capture-session-id!` nil-safe + `compare-and-set!` atomic.
- `binary-for` validates `clojure.lang.Named` backend.
- `evaluate-stall-recovery` no longer returns `:resume` with a nil/blank session-id.
- `event_type_registry` entries for the two agent events.
- Interface namespace docstring enumerates exports.
- Test fixtures use `(random-uuid)` for `:workflow-id`.

## Authorship

- Generated by **Heimdall** (Miniforge phase-software-factory agent) on 2026-05-19 in its `verify` phase. Heimdall's verify commit is `c5f9f7b3`.
- Copilot review pass + body backfill by Claude Code on behalf of @ChristopherLester. Commit `9c7aa109` carries the review-pass fixes (override commit-budget hook with rationale because this is the top of a 5-PR stack and the carry-forwards cross multiple components — can't be atomically split without breaking compile).

<details>
<summary>Original Heimdall PR template</summary>

**PR:** [#921](https://github.com/miniforge-ai/miniforge/pull/921)
**Branch:** `mf/group-4-wire-richer-terminal-events-into-292fc25f`

Test Results and Review Decision sections were left as `_No * available._` placeholders by the Heimdall template; backfilled above and in `docs/pull-requests/2026-05-19-group-4-wire-richer-terminal-events-into-phase-software-factory.md`.

</details>