### PR TITLE
feat(progress-detector): fuzzy repair-loop stagnation signal (M1)

### DIFF
--- a/components/progress-detector/resources/config/progress-detector/messages/en-US.edn
+++ b/components/progress-detector/resources/config/progress-detector/messages/en-US.edn
@@ -29,6 +29,9 @@
   :repair-loop/stagnation
   "Review fingerprint repeated — {count} actionable items unchanged across repair iterations"
 
+  :repair-loop/fuzzy-stagnation
+  "Review (file × severity) set repeated — {count} file/severity pairs persisted across iterations even though descriptions drifted; implementer is stuck in the same area"
+
   ;; Supervisor (supervisor.clj)
   :supervisor/terminate-reason
   "Terminating run: {summary}"

--- a/components/progress-detector/src/ai/miniforge/progress_detector/detectors/repair_loop.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/detectors/repair_loop.clj
@@ -49,11 +49,20 @@
 (def ^:private detector-version
   "Version stamp on emitted anomalies. Bump when fingerprint
    composition or termination semantics change."
-  "stage-2.0")
+  "stage-2.1")
 
 (def ^:private detector-kind :detector/repair-loop)
 
 (def ^:private anomaly-category :anomalies.review/stagnation)
+
+(def ^:private fuzzy-anomaly-category
+  "Emitted alongside the strict anomaly when consecutive reviews share
+   the same (file × severity) set but drift on line/description text.
+   The strict signal terminates; the fuzzy signal is for meta-agents
+   that want to intervene before termination by analyzing the recurring
+   bug class and synthesizing an instruction addendum. See spec
+   work/meta-agent-repair-loop-intervention.spec.edn for context."
+  :anomalies.review/fuzzy-stagnation)
 
 (def ^:private stagnation-match-count
   "Number of consecutive identical fingerprints required to declare
@@ -151,6 +160,46 @@
        (seq current)
        (= prior current)))
 
+(defn review-fingerprint-fuzzy
+  "Coarser sibling of `review-fingerprint`. Reduces a review to the
+   set of `[severity file]` pairs across actionable issues + failed
+   gates — drops line numbers and description text.
+
+   Rationale: the strict fingerprint catches verbatim repeats, but LLM
+   reviewers rephrase the same complaint between iterations (different
+   word choice, line numbers shift after edits, suggestions reorder),
+   so strict equality misses real temporal loops where the implementer
+   keeps making the same class of mistake in the same files. The
+   fuzzy fingerprint matches on `(file × severity)` set equality —
+   coarse enough to absorb LLM-text drift, specific enough that a real
+   implementer move (deleting a flagged file, dropping a severity)
+   changes it.
+
+   The fuzzy fingerprint is meant for meta-agent consumption: when it
+   repeats, an intervention agent should analyze WHY the same set of
+   problems persists. The strict signal still drives termination."
+  [review]
+  (let [llm-pairs   (->> (get review :review/issues [])
+                          (filter (comp actionable-severities :severity))
+                          (map (fn [{:keys [severity file]}]
+                                 [severity (or file "")])))
+        gate-pairs  (->> (get review :review/gate-results [])
+                          (remove :passed?)
+                          (map (fn [{:keys [gate-id]}]
+                                 [:blocking (str ":gate/" (name (or gate-id :unknown)))])))]
+    (->> (concat llm-pairs gate-pairs)
+         set)))
+
+(defn fuzzy-stagnated?
+  "True when a review's fuzzy fingerprint matches the prior review's
+   fuzzy fingerprint AND is non-empty. Same nil/empty semantics as
+   `stagnated?` — first review never short-circuits, empty fingerprint
+   never counts (no flagged files = no recurring problem)."
+  [prior current]
+  (and (some? prior)
+       (seq current)
+       (= prior current)))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Anomaly construction
 
@@ -178,23 +227,58 @@
                      :anomaly/evidence  evidence}]
     (anomaly/anomaly :fault summary data)))
 
+(defn- build-fuzzy-anomaly
+  "Construct a canonical anomaly map for a fuzzy-stagnation event.
+
+   Severity is :warning (not :error) — the fuzzy match is a softer
+   signal than strict equality and is intended to drive meta-agent
+   intervention rather than direct termination. Carries the
+   (file × severity) pair set as :fingerprint so the meta-agent can
+   inspect which files keep getting flagged."
+  [fuzzy-fingerprint event]
+  (let [match-count (count fuzzy-fingerprint)
+        summary     (msg/t :repair-loop/fuzzy-stagnation {:count match-count})
+        evidence    {:summary     summary
+                     :event-ids   (filterv some? [(:seq event)])
+                     :fingerprint (pr-str fuzzy-fingerprint)
+                     :threshold   {:n      stagnation-match-count
+                                   :window stagnation-window-size}
+                     :redacted?   true}
+        data        {:detector/kind     detector-kind
+                     :detector/version  detector-version
+                     :anomaly/class     :semantic
+                     :anomaly/severity  :warning
+                     :anomaly/category  fuzzy-anomaly-category
+                     :anomaly/evidence  evidence}]
+    (anomaly/anomaly :fault summary data)))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Detector record
 
 (defrecord RepairLoopDetector []
   proto/Detector
   (init [_ _config]
-    {:anomalies         []
-     :prior-fingerprint nil})
+    {:anomalies               []
+     :prior-fingerprint       nil
+     :prior-fuzzy-fingerprint nil})
 
   (observe [_ state event]
     (if-let [review (:review/artifact event)]
-      (let [fp           (review-fingerprint review)
-            now-stagnated? (stagnated? (:prior-fingerprint state) fp)
-            anomaly-map  (when now-stagnated? (build-anomaly fp event))]
+      (let [fp                (review-fingerprint review)
+            fuzzy-fp          (review-fingerprint-fuzzy review)
+            now-stagnated?    (stagnated? (:prior-fingerprint state) fp)
+            ;; Suppress the fuzzy anomaly when strict already fired —
+            ;; both signals point at the same problem, no need to double-emit.
+            now-fuzzy?        (and (not now-stagnated?)
+                                   (fuzzy-stagnated? (:prior-fuzzy-fingerprint state)
+                                                     fuzzy-fp))
+            strict-anomaly    (when now-stagnated? (build-anomaly fp event))
+            fuzzy-anomaly     (when now-fuzzy? (build-fuzzy-anomaly fuzzy-fp event))]
         (cond-> state
-          true        (assoc :prior-fingerprint fp)
-          anomaly-map (update :anomalies conj anomaly-map)))
+          true           (assoc :prior-fingerprint fp
+                                :prior-fuzzy-fingerprint fuzzy-fp)
+          strict-anomaly (update :anomalies conj strict-anomaly)
+          fuzzy-anomaly  (update :anomalies conj fuzzy-anomaly)))
       state)))
 
 (defn make-repair-loop-detector

--- a/components/progress-detector/src/ai/miniforge/progress_detector/detectors/repair_loop.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/detectors/repair_loop.clj
@@ -230,7 +230,7 @@
 (defn- build-fuzzy-anomaly
   "Construct a canonical anomaly map for a fuzzy-stagnation event.
 
-   Severity is :warning (not :error) — the fuzzy match is a softer
+   Severity is :warn (not :error) — the fuzzy match is a softer
    signal than strict equality and is intended to drive meta-agent
    intervention rather than direct termination. Carries the
    (file × severity) pair set as :fingerprint so the meta-agent can
@@ -240,14 +240,14 @@
         summary     (msg/t :repair-loop/fuzzy-stagnation {:count match-count})
         evidence    {:summary     summary
                      :event-ids   (filterv some? [(:seq event)])
-                     :fingerprint (pr-str fuzzy-fingerprint)
+                     :fingerprint (pr-str (vec (sort fuzzy-fingerprint)))
                      :threshold   {:n      stagnation-match-count
                                    :window stagnation-window-size}
                      :redacted?   true}
         data        {:detector/kind     detector-kind
                      :detector/version  detector-version
-                     :anomaly/class     :semantic
-                     :anomaly/severity  :warning
+                     :anomaly/class     :heuristic
+                     :anomaly/severity  :warn
                      :anomaly/category  fuzzy-anomaly-category
                      :anomaly/evidence  evidence}]
     (anomaly/anomaly :fault summary data)))

--- a/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
@@ -411,6 +411,19 @@
   "True when the current review fingerprint has made no actionable progress."
   repair-loop/stagnated?)
 
+(def review-fingerprint-fuzzy
+  "Coarser fingerprint: set of (severity, file) pairs across actionable
+   issues. Drops line numbers and description text. Catches temporal
+   loops where the implementer keeps making the same class of mistake
+   in the same files but the LLM reviewer rephrases the complaint."
+  repair-loop/review-fingerprint-fuzzy)
+
+(def fuzzy-stagnated?
+  "True when the current fuzzy fingerprint matches the prior and is
+   non-empty. Intended to drive meta-agent intervention rather than
+   direct termination."
+  repair-loop/fuzzy-stagnated?)
+
 ;------------------------------------------------------------------------------ Rich Comment
 
 (comment

--- a/components/progress-detector/test/ai/miniforge/progress_detector/detectors/repair_loop_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/detectors/repair_loop_test.clj
@@ -331,9 +331,15 @@
       (is (= :anomalies.review/fuzzy-stagnation
              (get-in (first anoms) [:anomaly/data :anomaly/category]))
           "the emitted anomaly must be the fuzzy category")
-      (is (= :warning
+      (is (= :heuristic
+             (get-in (first anoms) [:anomaly/data :anomaly/class]))
+          "fuzzy is a heuristic detector signal")
+      (is (= :warn
              (get-in (first anoms) [:anomaly/data :anomaly/severity]))
-          "fuzzy fires at :warning severity (meta-agent intervention signal, not terminator)"))))
+          "fuzzy fires at :warn severity (meta-agent intervention signal, not terminator)")
+      (is (= "[[:blocking \"src/foo.clj\"]]"
+             (get-in (first anoms) [:anomaly/data :anomaly/evidence :fingerprint]))
+          "fingerprint evidence is serialized in deterministic order"))))
 
 (deftest detector-emits-only-strict-when-both-would-match-test
   (testing "verbatim repeat fires strict ONLY — no double-emission to confuse downstream consumers"

--- a/components/progress-detector/test/ai/miniforge/progress_detector/detectors/repair_loop_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/detectors/repair_loop_test.clj
@@ -237,3 +237,124 @@
       (is (vector? (:event-ids ev)))
       (is (string? (:fingerprint ev)))
       (is (true? (:redacted? ev))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Fuzzy stagnation — the real-world loop catcher
+;;
+;; The 2026-05-19 dogfood (workflow 55eb2c77) burned 3 hours in a
+;; review→implement loop where every iteration's strict fingerprint
+;; was different (the LLM rephrased issue descriptions and line numbers
+;; shifted after edits) but the SAME files kept getting flagged at
+;; :blocking severity. The strict signal correctly stayed quiet; the
+;; fuzzy signal exists to catch exactly this case.
+
+(def ^:private blocking-issue-a-rephrased
+  {:severity :blocking :file "src/foo.clj" :line 14
+   :description "Null pointer dereference on input arg"})
+
+(def ^:private blocking-issue-a-moved-line
+  {:severity :blocking :file "src/foo.clj" :line 42
+   :description "Null pointer access"})
+
+(deftest review-fingerprint-fuzzy-returns-file-severity-set-test
+  (testing "fuzzy fingerprint reduces to a set of [severity file] pairs"
+    (let [fp (sut/review-fingerprint-fuzzy
+              {:review/issues [blocking-issue-a warning-issue]})]
+      (is (set? fp))
+      (is (= #{[:blocking "src/foo.clj"]
+               [:warning  "src/foo.clj"]}
+             fp)))))
+
+(deftest review-fingerprint-fuzzy-deduplicates-same-pair-test
+  (testing "two issues at the same severity in the same file collapse to one pair"
+    ;; Mock-shape bugs from the 55eb2c77 loop produced multiple
+    ;; :blocking-severity issues in the same test file each iteration —
+    ;; the fuzzy fingerprint must collapse them so the SIGNAL is
+    ;; \"this file keeps producing blocking issues\" not
+    ;; \"there are exactly N issues this round.\"
+    (let [fp (sut/review-fingerprint-fuzzy
+              {:review/issues [blocking-issue-a blocking-issue-a-rephrased
+                               blocking-issue-a-moved-line]})]
+      (is (= #{[:blocking "src/foo.clj"]} fp)))))
+
+(deftest review-fingerprint-fuzzy-excludes-nits-test
+  (testing "nits are still excluded from the fuzzy fingerprint"
+    (is (= #{} (sut/review-fingerprint-fuzzy
+                {:review/issues [nit-issue]})))))
+
+(deftest review-fingerprint-fuzzy-includes-failed-gates-test
+  (testing "failed gate-results contribute virtual [:blocking :gate/X] pairs"
+    (let [fp (sut/review-fingerprint-fuzzy
+              {:review/issues       []
+               :review/gate-results [{:gate-id :format :passed? false
+                                      :errors [{:message "fmt"}]}]})]
+      (is (= #{[:blocking ":gate/format"]} fp)))))
+
+(deftest fuzzy-stagnated?-true-when-pair-sets-match-test
+  (testing "fuzzy stagnation fires when (file × severity) sets repeat"
+    ;; Same pair set, different lines, different descriptions — the
+    ;; strict detector would NOT fire here, the fuzzy detector MUST.
+    (let [prior   #{[:blocking "src/foo.clj"]}
+          current #{[:blocking "src/foo.clj"]}]
+      (is (true? (sut/fuzzy-stagnated? prior current))))))
+
+(deftest fuzzy-stagnated?-false-on-first-iteration-test
+  (is (false? (boolean (sut/fuzzy-stagnated? nil #{[:blocking "src/foo.clj"]})))))
+
+(deftest fuzzy-stagnated?-false-on-empty-current-test
+  (is (false? (boolean (sut/fuzzy-stagnated? #{[:blocking "src/foo.clj"]} #{})))))
+
+(deftest fuzzy-stagnated?-false-when-pair-sets-differ-test
+  (testing "swapping in a different file or severity counts as progress"
+    (is (false? (boolean (sut/fuzzy-stagnated?
+                          #{[:blocking "src/foo.clj"]}
+                          #{[:blocking "src/bar.clj"]}))))
+    (is (false? (boolean (sut/fuzzy-stagnated?
+                          #{[:blocking "src/foo.clj"]}
+                          #{[:warning  "src/foo.clj"]}))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Detector wiring — fuzzy anomaly emission
+
+(deftest detector-emits-fuzzy-anomaly-when-strict-misses-test
+  (testing "two reviews with same (file × severity) but drifting descriptions fire a fuzzy anomaly, NOT a strict one"
+    ;; This is the regression pin for the 55eb2c77 loop pattern.
+    (let [det    (sut/make-repair-loop-detector)
+          review-1 {:review/issues [blocking-issue-a]}
+          review-2 {:review/issues [blocking-issue-a-moved-line]}
+          state  (-> (proto/init det {})
+                     (#(proto/observe det % (review-event review-1 1)))
+                     (#(proto/observe det % (review-event review-2 2))))
+          anoms  (:anomalies state)]
+      (is (= 1 (count anoms))
+          "exactly one anomaly — strict-stagnation must NOT fire on drift")
+      (is (= :anomalies.review/fuzzy-stagnation
+             (get-in (first anoms) [:anomaly/data :anomaly/category]))
+          "the emitted anomaly must be the fuzzy category")
+      (is (= :warning
+             (get-in (first anoms) [:anomaly/data :anomaly/severity]))
+          "fuzzy fires at :warning severity (meta-agent intervention signal, not terminator)"))))
+
+(deftest detector-emits-only-strict-when-both-would-match-test
+  (testing "verbatim repeat fires strict ONLY — no double-emission to confuse downstream consumers"
+    (let [det    (sut/make-repair-loop-detector)
+          review {:review/issues [blocking-issue-a]}
+          state  (-> (proto/init det {})
+                     (#(proto/observe det % (review-event review 1)))
+                     (#(proto/observe det % (review-event review 2))))
+          anoms  (:anomalies state)]
+      (is (= 1 (count anoms)))
+      (is (= :anomalies.review/stagnation
+             (get-in (first anoms) [:anomaly/data :anomaly/category]))
+          "strict wins; fuzzy is suppressed to avoid double-signalling"))))
+
+(deftest detector-progress-clears-both-signals-test
+  (testing "implementer changing the set of flagged files clears both strict and fuzzy"
+    (let [det    (sut/make-repair-loop-detector)
+          review-1 {:review/issues [blocking-issue-a]}
+          review-2 {:review/issues [blocking-issue-b]}  ; different file
+          state  (-> (proto/init det {})
+                     (#(proto/observe det % (review-event review-1 1)))
+                     (#(proto/observe det % (review-event review-2 2))))]
+      (is (zero? (count-anomalies state))
+          "real progress (file set changed) must not fire either signal"))))

--- a/work/meta-agent-repair-loop-intervention.spec.edn
+++ b/work/meta-agent-repair-loop-intervention.spec.edn
@@ -1,0 +1,132 @@
+;; =============================================================================
+;; Spec: Meta-agent intervention on repair-loop temporal stagnation
+;; =============================================================================
+;;
+;; Observed failure mode (dogfood run 2026-05-19, workflow 55eb2c77):
+;;   Implement → verify → review (rejected) → implement → verify → review
+;;   (rejected) → … for 3+ hours. Each iteration's review fingerprint differed
+;;   slightly (different file:line tuples for the same class of bug — mock-shape
+;;   mistakes around java.lang.Process / hang-count atom deref), so the strict
+;;   equality stagnation detector in progress-detector/detectors/repair_loop.clj
+;;   never fired. Per-phase iteration budgets were respected (review default 2),
+;;   but across 7 DAG tasks the workflow burned ~$5+ and 3+ hours of wall clock
+;;   making zero net progress.
+;;
+;; The system has machinery for hangs (PR #915 bounded verify with descendant
+;; kill + handback). It does NOT have machinery for "doing the same thing
+;; wrong over and over." A meta-agent should:
+;;   1. Notice the pattern (same files keep getting flagged, fuzzy-stagnation)
+;;   2. Pause the loop
+;;   3. Analyze the recurring bug class (LLM call over the recent reviews)
+;;   4. Synthesize an instruction addendum for the implementer
+;;   5. Resume implementer with the addendum injected into the task description
+;;
+;; Without (3-5), terminating on fuzzy-stagnation is strictly better than
+;; today (no progress is no progress) but the workflow still fails. WITH the
+;; intervention, the workflow self-heals.
+
+{:spec/title "Meta-agent intervention on repair-loop temporal stagnation"
+
+ :spec/description
+ "Detect repair-loop temporal stagnation via a fuzzy file×severity signal
+  (today's strict-equality detector misses real loops because LLM-generated
+  issue descriptions drift between iterations). When fuzzy-stagnation fires
+  after N=2 consecutive non-progressing reviews, route through a meta-agent
+  that analyzes the recurring failure pattern and synthesizes an instruction
+  addendum injected into the next implementer invocation.
+
+  GROUP 1 — Fuzzy stagnation signal (M1)
+  Extend `components/progress-detector/src/.../detectors/repair_loop.clj`
+  with a second fingerprint mode: `(file × severity)` set equality, returned
+  from a new `review-fingerprint-fuzzy` fn. Existing strict-equality path
+  stays — fuzzy is a parallel signal at lower severity. The detector emits a
+  new anomaly category `:anomalies.review/fuzzy-stagnation` (:class
+  :semantic, :severity :warning) when two consecutive reviews share the same
+  `(file × severity)` set. Strict stagnation still terminates; fuzzy
+  stagnation is observable but doesn't terminate on its own — its job is to
+  signal the meta-agent.
+
+  GROUP 2 — `:intervene` decision type (M2)
+  Extend `components/agent/src/.../meta_protocol.clj` MetaAgent return
+  schema with a third status: `:status :intervene` plus
+  `:intervention/addendum` (string — appended to next implement task
+  description) and `:intervention/scope` (`:next-implement | :next-N-phases
+  | :workflow`). Add `intervene?` predicate alongside `halt?` / `warning?` /
+  `healthy?`. Existing meta-agents stay compatible (return :halt or
+  :healthy as before).
+
+  GROUP 3 — RepairLoopMetaAgent (M3)
+  New meta-agent implementation at
+  `components/agent/src/.../meta/repair_loop_meta_agent.clj`. Consumes the
+  fuzzy-stagnation anomaly stream. When fired, invokes an LLM (Sonnet, same
+  shape as reviewer) with the last N=2 review artifacts + the relevant file
+  diff and asks for a structured response:
+    {:diagnosis            string  ; what class of mistake repeats?
+     :instruction-addendum string  ; what to tell the implementer
+     :confidence           :high | :medium | :low}
+  Returns `:status :intervene :intervention/addendum diagnosis+addendum`
+  when confidence >= :medium; otherwise `:status :warning` (don't intervene
+  on weak signals — they're worse than the loop continuing one more
+  iteration).
+
+  GROUP 4 — Workflow-runner hook (M4)
+  In `components/workflow/src/.../execution.clj`, before `execute-phase-step`
+  routes to implement, check the meta-decision channel for an
+  `:intervene` whose scope covers this phase. If present, append the
+  addendum to the implement task's `:task/description` (or `:task/intent` —
+  whichever the implementer prompt threads), emit a
+  `:meta/intervention-applied` event with the addendum text and source
+  meta-agent id, then proceed. Clear the intervention after consumption
+  (scope `:next-implement` is one-shot; `:next-N-phases` decrements).
+
+  GROUP 5 — Integration test (M5)
+  End-to-end pin: mock reviewer to return 3 consecutive reviews with same
+  `(file × severity)` set but drifting descriptions → fuzzy stagnation
+  fires → RepairLoopMetaAgent (mocked LLM returning fixed addendum) emits
+  `:intervene` → next implement invocation receives the addendum appended
+  to its task. Assert the addendum reaches the agent's input map and an
+  `:meta/intervention-applied` event is recorded."
+
+ :spec/scope
+ {:in-scope ["progress-detector/repair_loop.clj — add fuzzy fingerprint"
+             "agent/meta_protocol.clj — add :intervene + intervene?"
+             "agent/meta/repair_loop_meta_agent.clj — new file"
+             "workflow/execution.clj — intervention hook before implement"
+             "Integration test through all four"
+             "messages/en-US.edn — :meta/intervention-applied label"]
+  :out-of-scope ["Workflow-wide token + wall-clock budget (separate spec)"
+                 "Pause/resume UX in TUI (separate work)"
+                 "Cross-workflow intervention memory (later)"]}
+
+ :spec/acceptance-criteria
+ ["Fuzzy stagnation detector emits :anomalies.review/fuzzy-stagnation when (file × severity) set repeats for 2 consecutive reviews"
+  "Strict equality stagnation path unchanged — existing tests stay green"
+  "MetaAgent protocol accepts :status :intervene with :intervention/addendum and :intervention/scope"
+  "intervene? predicate added alongside halt?/warning?/healthy?"
+  "RepairLoopMetaAgent invokes LLM only when fuzzy-stagnation anomaly is present (no per-tick cost)"
+  "RepairLoopMetaAgent returns :status :warning instead of :intervene when LLM confidence is :low"
+  "Workflow runner appends :intervention/addendum to :task/description before next implement"
+  "Workflow runner emits :meta/intervention-applied event with addendum + source meta-agent id"
+  "Intervention is single-shot for scope :next-implement (cleared after one use)"
+  "End-to-end test: 3 fingerprint-drifting reviews → fuzzy stagnation → mocked-LLM intervention → addendum reaches implementer agent input"]
+
+ :spec/risks
+ ["LLM analysis adds cost per intervention (~2k tokens) — bounded by firing only on fuzzy-stagnation, not per phase"
+  "Bad addendum could push implementer further off course — confidence threshold (>= :medium) is the guard"
+  "Strict-stagnation path may now NEVER fire if fuzzy fires first and terminates → acceptable, both signals point at same problem"
+  "Workflow runner hook is on the critical path — must be defensive about missing/malformed :intervene shapes"
+  "Per-workflow intervention budget may be needed to prevent meta-agent thrashing if the loop is unfixable"]
+
+ :spec/non-goals
+ ["This spec does NOT add workflow-wide token / wall-clock budgets — that is a separate spec (see project_workflow_budget.md follow-up)."
+  "This spec does NOT modify reviewer prompt or behavior — the reviewer is already exhaustive per single-pass; the problem is implementer not absorbing feedback, not reviewer incompleteness."
+  "This spec does NOT introduce pause/resume UX — intervention is synchronous within the phase transition."]
+
+ :spec/test-command "bb test:precommit"
+ :spec/test-timeout-ms 600000
+
+ :spec/related
+ [{:type :pr  :id 915 :reason "Per-process hang detection — sibling work, complements this temporal-loop detection"}
+  {:type :file :id "components/progress-detector/src/ai/miniforge/progress_detector/detectors/repair_loop.clj" :reason "Extension point for fuzzy fingerprint"}
+  {:type :file :id "components/agent/src/ai/miniforge/agent/meta_protocol.clj" :reason ":intervene decision added here"}
+  {:type :file :id "components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj" :reason "compute-stagnated? consumes the strict signal; fuzzy joins as a parallel input"}]}

--- a/work/meta-agent-repair-loop-intervention.spec.edn
+++ b/work/meta-agent-repair-loop-intervention.spec.edn
@@ -41,7 +41,7 @@
   from a new `review-fingerprint-fuzzy` fn. Existing strict-equality path
   stays — fuzzy is a parallel signal at lower severity. The detector emits a
   new anomaly category `:anomalies.review/fuzzy-stagnation` (:class
-  :semantic, :severity :warning) when two consecutive reviews share the same
+  :heuristic, :severity :warn) when two consecutive reviews share the same
   `(file × severity)` set. Strict stagnation still terminates; fuzzy
   stagnation is observable but doesn't terminate on its own — its job is to
   signal the meta-agent.
@@ -113,7 +113,7 @@
  :spec/risks
  ["LLM analysis adds cost per intervention (~2k tokens) — bounded by firing only on fuzzy-stagnation, not per phase"
   "Bad addendum could push implementer further off course — confidence threshold (>= :medium) is the guard"
-  "Strict-stagnation path may now NEVER fire if fuzzy fires first and terminates → acceptable, both signals point at same problem"
+  "Fuzzy stagnation may mask strict stagnation in reporting if both signals point at the same recurring problem"
   "Workflow runner hook is on the critical path — must be defensive about missing/malformed :intervene shapes"
   "Per-workflow intervention budget may be needed to prevent meta-agent thrashing if the loop is unfixable"]
 


### PR DESCRIPTION
## Summary

- New `review-fingerprint-fuzzy` — reduces a review to `#{[severity file]}` pairs, dropping line numbers and description text.
- New `fuzzy-stagnated?` predicate over fuzzy fingerprints.
- Detector emits `:anomalies.review/fuzzy-stagnation` at `:warning` severity when consecutive reviews share the same `(file × severity)` set but drift on line/description. Strict-equality `:anomalies.review/stagnation` path unchanged. Fuzzy is suppressed when strict already fires — single signal per iteration.
- Spec at `work/meta-agent-repair-loop-intervention.spec.edn` describing the full M1-M5 series.

## Why

The 2026-05-19 dogfood (workflow `55eb2c77`, in this PR's commit message) burned 3+ hours in a review→implement loop. The strict-equality stagnation detector stayed quiet — correctly — because each iteration's fingerprint was *technically* different: the LLM reviewer rephrased issue descriptions, line numbers shifted after each implementer edit. But the SAME test file kept producing the SAME class of blocking issue (mock-shape bugs around `java.lang.Process` / `hang-count` atom deref) for three iterations.

Fuzzy fingerprint matches the *area* not the *text*. Coarse enough to absorb LLM rephrasing; specific enough that real progress (file dropped from the flagged set, severity downgraded) clears it.

## What this is NOT

This PR ships the **signal only**. Nothing terminates on the fuzzy anomaly yet — that's the job of subsequent PRs in the M2-M5 series specified in `work/meta-agent-repair-loop-intervention.spec.edn`:

- **M2**: `:intervene` decision type added to MetaAgent protocol
- **M3**: `RepairLoopMetaAgent` that LLM-analyzes the recurring pattern and synthesizes an instruction addendum
- **M4**: Workflow-runner hook that injects the addendum into the next implement invocation
- **M5**: End-to-end integration pin

Shipping the signal first means M2-M4 can land independently and dogfood cycles in between produce useful observability data (which workflows fire fuzzy stagnation, what file sets recur) without changing termination semantics.

## Test plan

- [x] `clojure -M:poly test project:miniforge-core brick:progress-detector` — 29 tests / 47 assertions in `repair_loop_test`, 0 failures
- [x] Strict-equality path stays green (verbatim-repeat test still emits `:anomalies.review/stagnation` exactly once)
- [x] Fuzzy + strict both fire on same input → only strict emitted (no double-signal)
- [x] Real progress (different file flagged) clears both signals
- [x] `bb lint:clj` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)