### PR TITLE
refactor(self-healing): name three magic numbers in backend_health.clj

### DIFF
--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -24,30 +24,33 @@
    [clojure.java.io :as io]))
 
 ;;------------------------------------------------------------------------------ Layer 0
-;; Tuning constants
+;; Tuning constants + file paths
 
-(def default-success-rate-threshold
-  "Minimum rolling success rate before a backend is considered degraded
-   and a failover is triggered. 0.90 = at most 1 failure per 10 calls
-   tolerated; below that the backend is skipped in favor of a healthier
-   one. Picked to absorb transient single failures without flapping."
+(def ^:private default-success-rate-threshold
+  "Minimum cumulative success rate (`:successful-calls / :total-calls`)
+   before a backend is considered degraded and a failover is triggered.
+   0.90 = at most 1 failure per 10 cumulative calls tolerated; below
+   that the backend is skipped in favor of a healthier one. Picked to
+   absorb transient single failures without flapping. (Note: the rate
+   is cumulative since last decay, not a sliding window — `maybe-decay-health`
+   resets the counters wholesale after 24h of stale data.)"
   0.90)
 
-(def default-switch-cooldown-ms
+(def ^:private default-switch-cooldown-ms
   "Minimum interval between automatic backend switches (30 min). After
    a switch fires, the FROM backend is parked for this long even if its
    success rate recovers — prevents two flaky backends from oscillating
    between healthy and degraded."
   (* 30 60 1000))
 
-(def default-failure-recency-window-ms
+(def ^:private default-failure-recency-window-ms
   "Window during which a recent failure is considered fresh enough to
-   trigger a switch decision (5 min). Older failures sit in the rolling
-   counter for accounting but do not by themselves cause a switch —
-   stale failure data shouldn't trigger live failover."
+   trigger a switch decision (5 min). The stored `:last-failure`
+   timestamp is compared against this window; older failures stay in
+   the cumulative counter for accounting but do not by themselves
+   cause a switch — stale failure data shouldn't trigger live failover."
   (* 5 60 1000))
 
-;;------------------------------------------------------------------------------ Layer 0
 ;; File paths and utilities
 
 (defn backend-health-path

--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -24,6 +24,30 @@
    [clojure.java.io :as io]))
 
 ;;------------------------------------------------------------------------------ Layer 0
+;; Tuning constants
+
+(def default-success-rate-threshold
+  "Minimum rolling success rate before a backend is considered degraded
+   and a failover is triggered. 0.90 = at most 1 failure per 10 calls
+   tolerated; below that the backend is skipped in favor of a healthier
+   one. Picked to absorb transient single failures without flapping."
+  0.90)
+
+(def default-switch-cooldown-ms
+  "Minimum interval between automatic backend switches (30 min). After
+   a switch fires, the FROM backend is parked for this long even if its
+   success rate recovers — prevents two flaky backends from oscillating
+   between healthy and degraded."
+  (* 30 60 1000))
+
+(def default-failure-recency-window-ms
+  "Window during which a recent failure is considered fresh enough to
+   trigger a switch decision (5 min). Older failures sit in the rolling
+   counter for accounting but do not by themselves cause a switch —
+   stale failure data shouldn't trigger live failover."
+  (* 5 60 1000))
+
+;;------------------------------------------------------------------------------ Layer 0
 ;; File paths and utilities
 
 (defn backend-health-path
@@ -208,11 +232,11 @@
 
    Arguments:
      backend - Keyword backend name
-     recency-ms - Recency window in milliseconds (default 300000 = 5 min)
+     recency-ms - Recency window in milliseconds (default `default-failure-recency-window-ms`)
 
    Returns: Boolean true if last failure is recent (or nil if no failure recorded)"
   ([backend]
-   (recent-failure? backend 300000))
+   (recent-failure? backend default-failure-recency-window-ms))
   ([backend recency-ms]
    (let [health (load-health)
          backend-key (keyword backend)
@@ -230,11 +254,11 @@
 
    Arguments:
      backend - Keyword backend name
-     threshold - Double threshold (default 0.90)
+     threshold - Double threshold (default `default-success-rate-threshold`)
 
    Returns: Boolean true if should switch"
   ([backend]
-   (should-switch-backend? backend 0.90))
+   (should-switch-backend? backend default-success-rate-threshold))
   ([backend threshold]
    (if-let [success-rate (get-backend-success-rate backend)]
      (and (recent-failure? backend)
@@ -246,11 +270,11 @@
 
    Arguments:
      backend - Keyword backend name
-     cooldown-ms - Cooldown period in milliseconds (default 1800000 = 30 min)
+     cooldown-ms - Cooldown period in milliseconds (default `default-switch-cooldown-ms`)
 
    Returns: Boolean true if in cooldown"
   ([backend]
-   (in-cooldown? backend 1800000))
+   (in-cooldown? backend default-switch-cooldown-ms))
   ([backend cooldown-ms]
    (let [health (load-health)
          backend-key (keyword backend)
@@ -268,8 +292,8 @@
 
    Arguments:
      current-backend - Keyword current backend
-     threshold       - Success rate threshold (default 0.90)
-     cooldown-ms     - Cooldown period in milliseconds (default 1800000)
+     threshold       - Success rate threshold (default `default-success-rate-threshold`)
+     cooldown-ms     - Cooldown period in milliseconds (default `default-switch-cooldown-ms`)
      allowed-set     - Optional set of keyword backends to restrict selection.
                        When `nil` (not supplied), all backends in the stored
                        fallback-order are considered. When a non-nil empty
@@ -282,7 +306,10 @@
 
    Returns: Keyword backend name or nil if none available"
   ([current-backend]
-   (select-best-backend current-backend 0.90 1800000 nil))
+   (select-best-backend current-backend
+                        default-success-rate-threshold
+                        default-switch-cooldown-ms
+                        nil))
   ([current-backend threshold cooldown-ms]
    (select-best-backend current-backend threshold cooldown-ms nil))
   ([current-backend threshold cooldown-ms allowed-set]
@@ -310,11 +337,11 @@
    Arguments:
      from-backend - Keyword current backend
      to-backend - Keyword new backend
-     cooldown-ms - Cooldown period in milliseconds (default 1800000)
+     cooldown-ms - Cooldown period in milliseconds (default `default-switch-cooldown-ms`)
 
    Returns: Map with :from, :to, :cooldown-until"
   ([from-backend to-backend]
-   (trigger-backend-switch! from-backend to-backend 1800000))
+   (trigger-backend-switch! from-backend to-backend default-switch-cooldown-ms))
   ([from-backend to-backend cooldown-ms]
    (let [health (load-health)
          now (java.time.Instant/now)
@@ -338,12 +365,14 @@
 
    Arguments:
      current-backend - Keyword current backend
-     threshold - Success rate threshold (default 0.90)
-     cooldown-ms - Cooldown period in milliseconds (default 1800000)
+     threshold - Success rate threshold (default `default-success-rate-threshold`)
+     cooldown-ms - Cooldown period in milliseconds (default `default-switch-cooldown-ms`)
 
    Returns: Map with :should-switch?, :from, :to, or nil if no switch"
   ([current-backend]
-   (check-and-switch-if-needed current-backend 0.90 1800000))
+   (check-and-switch-if-needed current-backend
+                                default-success-rate-threshold
+                                default-switch-cooldown-ms))
   ([current-backend threshold cooldown-ms]
    (when (and (should-switch-backend? current-backend threshold)
               (not (in-cooldown? current-backend cooldown-ms)))


### PR DESCRIPTION
## Summary

Pure refactor. Three magic numbers in `components/self-healing/src/ai/miniforge/self_healing/backend_health.clj` are now named constants with intent docstrings:

| Magic | Name | What it means |
| --- | --- | --- |
| `0.90` | `default-success-rate-threshold` | Below this rolling success rate the backend is skipped in favor of a healthier one. |
| `1800000` | `default-switch-cooldown-ms` (`(* 30 60 1000)`) | Minimum interval between automatic backend switches; prevents flap. |
| `300000` | `default-failure-recency-window-ms` (`(* 5 60 1000)`) | Window during which a failure is fresh enough to trigger a switch decision. |

All 6 call sites updated; docstrings now reference the def name instead of the bare number.

## Why now

Companion to **#923** (`.standards` submodule bump + pack recompile), which adds the new `foundations/named-constants.mdc` rule (dewey 006). This PR pays down the violation the rule is most directly inspired by — `(select-best-backend backend 0.90 1800000)` was the example I cited in the rule docs. Lands the rule's principle in the file the autonomous review missed.

## Test plan

- [x] `bb test:poly project:miniforge brick:self-healing` — 26 tests / 61 assertions, 0 failures
- [x] No behavior change (pure rename + doc update); existing test coverage suffices per pure-restructuring exception in the new `workflows/tests-with-code.mdc` rule
- [x] No-direct-tests gap on `backend_health.clj` itself is noted as a follow-up; tests-with-code requires coverage on *changed behavior*, not on the surface area touched by a rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)