### PR TITLE
fix: move :done phase registration into phase core component

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -47,12 +47,6 @@
 ;; Register defaults on load
 (phase/register-phase-defaults! :release default-config)
 
-;; Also register :done as a terminal phase
-(phase/register-phase-defaults! :done
-                                   {:agent nil
-                                    :gates []
-                                    :budget {:tokens 0 :iterations 1 :time-seconds 1}})
-
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
 
@@ -491,24 +485,9 @@
      :leave leave-release
      :error error-release}))
 
-(defmethod phase/get-phase-interceptor-method :done
-  [config]
-  (let [merged (phase/merge-with-defaults config)]
-    {:name ::done
-     :config merged
-     :enter (fn [ctx]
-              (-> ctx
-                  (assoc-in [:phase :name] :done)
-                  (assoc-in [:phase :status] :completed)
-                  (assoc-in [:execution :status] :completed)))
-     :leave identity
-     :error (fn [ctx _ex] ctx)}))
-
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (phase/get-phase-interceptor {:phase :release})
-  (phase/get-phase-interceptor {:phase :done})
   (phase/phase-defaults :release)
-  (phase/phase-defaults :done)
   (phase/list-phases)
   :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/done.clj
+++ b/components/phase/src/ai/miniforge/phase/done.clj
@@ -1,0 +1,72 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.done
+  "Terminal `:done` phase interceptor.
+
+   `:done` is an FSM/phase-core concept — every workflow EDN may declare
+   `{:phase :done}` as its terminal step, and the workflow FSM in
+   `ai.miniforge.workflow.fsm` treats `:done` as the canonical
+   already-done sentinel (see `done-index` in `build-phase-state`).
+
+   Lives in the `phase` core component so any workflow runtime that
+   loads the phase registry gets `:done` for free, without depending on
+   `phase-software-factory`."
+  (:require [ai.miniforge.phase.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  "Terminal phase has no agent, no gates, and a minimal budget."
+  {:agent nil
+   :gates []
+   :budget {:tokens 0 :iterations 1 :time-seconds 1}})
+
+;; Register defaults on load
+(registry/register-phase-defaults! :done default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Interceptor
+
+(defn- enter-done
+  "Mark both the phase and the enclosing execution as completed."
+  [ctx]
+  (-> ctx
+      (assoc-in [:phase :name] :done)
+      (assoc-in [:phase :status] :completed)
+      (assoc-in [:execution :status] :completed)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry method
+
+(defmethod registry/get-phase-interceptor :done
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name ::done
+     :config merged
+     :enter enter-done
+     :leave identity
+     :error (fn [ctx _ex] ctx)}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (registry/get-phase-interceptor {:phase :done})
+  (registry/phase-defaults :done)
+  (registry/list-phases)
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -33,6 +33,11 @@
       :error   (fn [ctx ex] -> ctx) ; Error handling/repair}"
   (:require
    [ai.miniforge.phase.agent-behavior :as agent-behavior]
+   ;; Load core terminal phase so `{:phase :done}` works in every runtime
+   ;; that depends on the phase registry. The require is for side effects
+   ;; (defmethod + register-phase-defaults!) — no symbols are referenced
+   ;; from this namespace.
+   [ai.miniforge.phase.done]
    [ai.miniforge.phase.file-context :as file-context]
    [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.phase.phase-result :as phase-result]

--- a/components/phase/test/ai/miniforge/phase/done_test.clj
+++ b/components/phase/test/ai/miniforge/phase/done_test.clj
@@ -1,0 +1,67 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.done-test
+  "Regression tests for the core `:done` terminal phase.
+
+   Originally lived in phase-software-factory/release.clj, which meant
+   any runtime that did not depend on that component (e.g. the career
+   bb runtime running `:career-growth-framework-ingest`) could not
+   resolve `{:phase :done}` and would crash with
+   `Unknown phase type: :done`. The registration now lives in
+   `ai.miniforge.phase.done` so it travels with the phase registry."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.phase.interface :as phase]))
+
+(deftest done-resolves-via-registry-test
+  (testing "get-phase-interceptor returns an interceptor map for :done"
+    (let [interceptor (phase/get-phase-interceptor {:phase :done})]
+      (is (map? interceptor))
+      (is (keyword? (:name interceptor)))
+      (is (fn? (:enter interceptor)))
+      (is (fn? (:leave interceptor)))
+      (is (fn? (:error interceptor))))))
+
+(deftest done-enter-marks-context-completed-test
+  (testing ":done :enter marks both phase and execution status :completed"
+    (let [interceptor (phase/get-phase-interceptor {:phase :done})
+          ctx-out ((:enter interceptor) {})]
+      (is (= :done (get-in ctx-out [:phase :name])))
+      (is (= :completed (get-in ctx-out [:phase :status])))
+      (is (= :completed (get-in ctx-out [:execution :status]))))))
+
+(deftest done-leave-and-error-are-noops-test
+  (testing ":done :leave and :error pass the context through unchanged"
+    (let [interceptor (phase/get-phase-interceptor {:phase :done})
+          ctx {:some :value}]
+      (is (= ctx ((:leave interceptor) ctx)))
+      (is (= ctx ((:error interceptor) ctx (ex-info "boom" {})))))))
+
+(deftest done-defaults-registered-test
+  (testing "phase-defaults returns the registered :done defaults"
+    (let [defaults (phase/phase-defaults :done)]
+      (is (some? defaults))
+      (is (nil? (:agent defaults)))
+      (is (= [] (:gates defaults)))
+      (is (= {:tokens 0 :iterations 1 :time-seconds 1}
+             (:budget defaults))))))
+
+(deftest done-listed-in-phases-test
+  (testing "list-phases includes :done"
+    (is (contains? (phase/list-phases) :done))))


### PR DESCRIPTION
## Summary
- Move the terminal `:done` phase out of `phase-software-factory/release.clj` and into a dedicated `ai.miniforge.phase.done` ns under the `phase` core component.
- Wire it into `phase/interface.clj` so any runtime that depends on the phase registry gets `:done` for free, even without `phase-software-factory` on the classpath.

## Root cause
The career bb runtime running the `:career-growth-framework-ingest` workflow crashed with:

```
Unknown phase type: :done. Available: (:career-growth-score-ground ...)
```

`workflow/fsm.clj` (`build-phase-state`, `done-index` lookup) treats `:done` as the canonical already-done sentinel, and workflow EDNs across the workspace (`career-growth-framework-ingest-v1.0.0.edn`, `canonical-sdlc-v2.0.0.edn`, `quick-deploy-v1.0.0.edn`, `compliance-execute-v1.0.0.edn`, ...) declare `{:phase :done}` as the terminal step.

But the `register-phase-defaults! :done` call and the `defmethod get-phase-interceptor-method :done` lived inside `phase-software-factory/release.clj`. Runtimes that do not load `phase-software-factory` (career bb runtime, growth-pipeline harness, etc.) saw `:done` as unknown — yet the workflow EDN demanded it.

`:done` is an FSM/phase-core concept, not a phase-software-factory concept. It belongs alongside the registry it terminates.

## Files changed
- `components/phase/src/ai/miniforge/phase/done.clj` — new. Apache 2.0 header (miniforge convention), Layer 0 defaults, Layer 1 `enter-done` (marks `[:phase :status]` and `[:execution :status]` `:completed`), Layer 2 defmethod on `registry/get-phase-interceptor`.
- `components/phase/src/ai/miniforge/phase/interface.clj` — `:require [ai.miniforge.phase.done]` for side effects so the registration travels with the interface ns.
- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj` — removed the orphan `register-phase-defaults! :done` block (lines 50-55) and `defmethod ... :done` block (lines 446-457); pruned the `:done` references from the `leave-this-here` rich comment.
- `components/phase/test/ai/miniforge/phase/done_test.clj` — new regression coverage.

## Test plan
- [x] Verified single source of registration after the move: `grep -rn "register-phase-defaults! :done|get-phase-interceptor-method :done|get-phase-interceptor :done" miniforge` returns the two lines in `done.clj`.
- [x] `clojure -M:dev:test ... ai.miniforge.phase.done-test` — 5 tests, 15 assertions, 0 failures.
- [x] `clojure -M:dev:test ... ai.miniforge.phase.interface-test` — 11 tests, 25 assertions, 0 failures (no regressions).
- [x] `clojure -M:dev:test ... ai.miniforge.phase-software-factory.release-test` — 18 tests, 43 assertions, 0 failures.
- [x] thesium-workflows side: `bb pre-commit` clean, `bb test` (1312 tests, 3844 assertions, 0 failures), `bb test:graalvm` (4 tests, 217 assertions, 0 failures).
- [ ] After merge: bump miniforge submodule in `thesium-workflows`; rerun `bb growth-ingest` against `growth-run-20260519-200732`; confirm `:done` resolves.

Surfaced via dogfood failure on `growth-run-20260519-200732` against `components/adapter-thesium-career/resources/workflows/career-growth-framework-ingest-v1.0.0.edn` in the `thesium-career` worktree.

DO NOT MERGE — leaving open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)