### PR TITLE
feat(agent): M2 — `:intervene` decision type in MetaAgent protocol

### DIFF
--- a/components/agent/src/ai/miniforge/agent/meta_protocol.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_protocol.clj
@@ -29,7 +29,8 @@
    - Decisions are observable and logged
    - Lightweight coordinator routes information, doesn't control"
   (:require [ai.miniforge.anomaly.interface :as anomaly]
-            [ai.miniforge.response.interface :as response]))
+            [ai.miniforge.response.interface :as response]
+            [clojure.string :as str]))
 
 (defprotocol MetaAgent
   "Protocol for meta-agents that monitor workflow execution.
@@ -51,16 +52,27 @@
         :workflow/files-written [...]}
 
      Returns:
-     {:status :healthy|:warning|:halt
+     {:status :healthy|:warning|:halt|:intervene
       :agent/id keyword (e.g., :progress-monitor)
       :message string (human-readable explanation)
       :data {} (diagnostic data)
-      :checked-at inst}
+      :checked-at inst
+      ;; Only when :status is :intervene:
+      :intervention/addendum string  ; text appended to next agent invocation
+      :intervention/scope    keyword ; :next-implement | :next-N-phases | :workflow
+      :intervention/n        int     ; for :next-N-phases scope}
 
      Status meanings:
-     - :healthy - Workflow is progressing normally
-     - :warning - Issue detected but not critical yet
-     - :halt - Workflow must stop immediately")
+     - :healthy   - Workflow is progressing normally
+     - :warning   - Issue detected but not critical yet
+     - :halt      - Workflow must stop immediately
+     - :intervene - Workflow may continue but must apply the supplied
+                    instruction addendum to the next agent invocation
+                    in scope. This is the soft-fix path: an alternative
+                    to :halt when the meta-agent has a specific fix in
+                    mind (e.g. \"implementer keeps using reify on
+                    abstract class — tell it to use proxy instead\").
+                    See work/meta-agent-repair-loop-intervention.spec.edn.")
 
   (get-meta-config [this]
     "Get meta-agent configuration.
@@ -90,6 +102,42 @@
   [health-check]
   (= :warning (:status health-check)))
 
+(def ^:private intervention-scopes
+  "Valid scopes for an :intervene decision. The runner consults the
+   scope to decide how many agent invocations the addendum applies to:
+     - :next-implement → exactly the next implement call, one-shot
+     - :next-N-phases  → next N phase invocations, regardless of phase id
+     - :workflow       → every remaining agent call in this workflow run"
+  #{:next-implement :next-N-phases :workflow})
+
+(defn intervene?
+  "Check if health status indicates the workflow should continue with
+   an injected instruction addendum applied to the next in-scope agent
+   invocation."
+  [health-check]
+  (= :intervene (:status health-check)))
+
+(defn valid-intervention?
+  "True when a health-check carrying `:status :intervene` has the
+   companion intervention keys populated to a usable shape:
+
+   - `:intervention/addendum` is a non-blank string.
+   - `:intervention/scope` is one of `intervention-scopes`.
+   - For `:next-N-phases` scope, `:intervention/n` is a positive int.
+
+   Workflow runners MUST validate before applying — an :intervene
+   decision with a missing or malformed addendum is treated as a
+   :warning, not an unhandled exception."
+  [health-check]
+  (let [{:intervention/keys [addendum scope n]} health-check]
+    (and (intervene? health-check)
+         (string? addendum)
+         (not (str/blank? addendum))
+         (contains? intervention-scopes scope)
+         (if (= :next-N-phases scope)
+           (and (integer? n) (pos? n))
+           true))))
+
 (defn create-health-check
   "Helper to create a health check result.
 
@@ -105,6 +153,39 @@
                           (cond-> {:agent/id agent-id
                                    :message message}
                             data (assoc :data data)))))
+
+(defn create-intervention
+  "Helper to create an `:intervene` health-check result.
+
+   Returns a health-check map with `:status :intervene` plus the
+   companion `:intervention/*` keys. Use this in preference to
+   hand-building the map — keeps the shape canonical and the validation
+   contract (`valid-intervention?`) in sync.
+
+   Required:
+   - `agent-id` — the meta-agent's `:agent/id` keyword.
+   - `message`  — short human-readable why (shown in observability).
+   - `addendum` — non-blank string appended to the next in-scope
+                  agent invocation's task description.
+
+   Optional (defaults):
+   - `:scope`   — `:next-implement` (default) | `:next-N-phases` | `:workflow`.
+   - `:n`       — required when `scope` is `:next-N-phases`; ignored
+                  otherwise.
+   - `:data`    — additional diagnostic data the meta-agent wants to
+                  surface alongside the intervention (e.g. the
+                  fingerprint history that triggered it)."
+  [agent-id message addendum
+   & {:keys [scope n data]
+      :or   {scope :next-implement}}]
+  (let [base (response/status-check :intervene
+                                    (cond-> {:agent/id agent-id
+                                             :message message}
+                                      data (assoc :data data)))]
+    (cond-> (assoc base
+                   :intervention/addendum addendum
+                   :intervention/scope    scope)
+      (= :next-N-phases scope) (assoc :intervention/n n))))
 
 (defrecord MetaAgentConfig
   [id                    ; Keyword ID (:progress-monitor, :test-quality, etc.)

--- a/components/agent/src/ai/miniforge/agent/meta_protocol.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_protocol.clj
@@ -178,6 +178,17 @@
   [agent-id message addendum
    & {:keys [scope n data]
       :or   {scope :next-implement}}]
+  ;; Fail loud when :next-N-phases is requested without a positive :n.
+  ;; The previous shape silently assoc'd :intervention/n nil, producing
+  ;; an intervention that immediately failed valid-intervention? at
+  ;; the runner — confusing because it looked syntactically fine but
+  ;; was semantically malformed. Surface the misconfiguration here.
+  (when (and (= :next-N-phases scope)
+             (not (and (integer? n) (pos? n))))
+    (throw (ex-info "create-intervention: :next-N-phases scope requires positive integer :n"
+                    {:scope     scope
+                     :n         n
+                     :hint      "either pass :n <pos-int>, or pick a scope that doesn't need it (:next-implement or :workflow)"})))
   (let [base (response/status-check :intervene
                                     (cond-> {:agent/id agent-id
                                              :message message}

--- a/components/agent/test/ai/miniforge/agent/meta_protocol_test.clj
+++ b/components/agent/test/ai/miniforge/agent/meta_protocol_test.clj
@@ -130,6 +130,28 @@
       (is (not (contains? one-shot :intervention/n))
           ":n is omitted when the scope doesn't need it — keeps the map shape minimal"))))
 
+(deftest create-intervention-throws-when-next-N-phases-without-n-test
+  (testing ":next-N-phases scope without :n throws ex-info at construction — fail loud, not silently"
+    ;; The old shape silently assoc'd :intervention/n nil, producing a
+    ;; map that LOOKED ok but failed valid-intervention? at the runner.
+    ;; Surfacing the misconfiguration at create-intervention time
+    ;; matches the rest of the protocol's fail-fast posture.
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #":next-N-phases"
+                          (sut/create-intervention :rl "msg" "fix"
+                                                   :scope :next-N-phases)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #":next-N-phases"
+                          (sut/create-intervention :rl "msg" "fix"
+                                                   :scope :next-N-phases
+                                                   :n nil)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #":next-N-phases"
+                          (sut/create-intervention :rl "msg" "fix"
+                                                   :scope :next-N-phases
+                                                   :n 0))
+        "0 is not a positive integer — must reject")))
+
 (deftest create-intervention-carries-data-test
   (testing "diagnostic data flows through via :data, not flattened into top-level"
     (let [fingerprints [#{[:blocking "src/foo.clj"]}

--- a/components/agent/test/ai/miniforge/agent/meta_protocol_test.clj
+++ b/components/agent/test/ai/miniforge/agent/meta_protocol_test.clj
@@ -1,0 +1,162 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.meta-protocol-test
+  "Tests for the meta-agent protocol surface — specifically the
+   `:intervene` decision type added in M2 of the meta-agent
+   intervention spec (see
+   `work/meta-agent-repair-loop-intervention.spec.edn`)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.agent.meta-protocol :as sut]))
+
+;------------------------------------------------------------------------------ intervene? predicate
+
+(deftest intervene?-true-for-intervene-status-test
+  (is (true? (sut/intervene? {:status :intervene}))))
+
+(deftest intervene?-false-for-other-statuses-test
+  (testing "intervene? does not collide with the existing healthy/warning/halt"
+    (is (false? (sut/intervene? {:status :healthy})))
+    (is (false? (sut/intervene? {:status :warning})))
+    (is (false? (sut/intervene? {:status :halt})))
+    (is (false? (sut/intervene? {})) "no status → not intervene")))
+
+;------------------------------------------------------------------------------ valid-intervention?
+
+(deftest valid-intervention?-true-for-canonical-shape-test
+  (testing ":intervene + non-blank addendum + valid scope → valid"
+    (is (true? (sut/valid-intervention?
+                {:status :intervene
+                 :intervention/addendum "tell implementer to use proxy not reify"
+                 :intervention/scope :next-implement})))))
+
+(deftest valid-intervention?-false-without-addendum-test
+  (testing "missing :intervention/addendum → invalid; runner treats as :warning"
+    (is (false? (sut/valid-intervention?
+                 {:status :intervene
+                  :intervention/scope :next-implement})))))
+
+(deftest valid-intervention?-false-with-blank-addendum-test
+  (testing "blank addendum is treated as missing — agent didn't actually decide what to inject"
+    (is (false? (sut/valid-intervention?
+                 {:status :intervene
+                  :intervention/addendum "   \n   "
+                  :intervention/scope :next-implement})))))
+
+(deftest valid-intervention?-false-with-unknown-scope-test
+  (testing "scope must be one of {:next-implement :next-N-phases :workflow}"
+    (is (false? (sut/valid-intervention?
+                 {:status :intervene
+                  :intervention/addendum "fix"
+                  :intervention/scope :next-everything})))))
+
+(deftest valid-intervention?-requires-n-when-scope-is-next-N-phases-test
+  (testing ":next-N-phases scope requires positive integer :intervention/n"
+    (is (false? (sut/valid-intervention?
+                 {:status :intervene
+                  :intervention/addendum "fix"
+                  :intervention/scope :next-N-phases}))
+        ":next-N-phases without :intervention/n is malformed")
+    (is (false? (sut/valid-intervention?
+                 {:status :intervene
+                  :intervention/addendum "fix"
+                  :intervention/scope :next-N-phases
+                  :intervention/n 0}))
+        ":n must be positive — 0 makes no sense")
+    (is (true? (sut/valid-intervention?
+                {:status :intervene
+                 :intervention/addendum "fix"
+                 :intervention/scope :next-N-phases
+                 :intervention/n 3})))))
+
+(deftest valid-intervention?-other-scopes-ignore-n-test
+  (testing ":next-implement and :workflow scopes don't require :intervention/n"
+    (is (true? (sut/valid-intervention?
+                {:status :intervene
+                 :intervention/addendum "fix"
+                 :intervention/scope :next-implement})))
+    (is (true? (sut/valid-intervention?
+                {:status :intervene
+                 :intervention/addendum "fix"
+                 :intervention/scope :workflow})))))
+
+(deftest valid-intervention?-false-for-non-intervene-status-test
+  (testing "valid-intervention? gates on :intervene status — :warning + addendum-keys is NOT a valid intervention"
+    (is (false? (sut/valid-intervention?
+                 {:status :warning
+                  :intervention/addendum "fix"
+                  :intervention/scope :next-implement})))))
+
+;------------------------------------------------------------------------------ create-intervention constructor
+
+(deftest create-intervention-default-scope-test
+  (testing "default scope is :next-implement — one-shot is the sane default"
+    (let [hc (sut/create-intervention :repair-loop-meta
+                                      "fuzzy stagnation detected"
+                                      "tell implementer to use proxy not reify")]
+      (is (sut/intervene? hc))
+      (is (sut/valid-intervention? hc))
+      (is (= :next-implement (:intervention/scope hc)))
+      (is (= :repair-loop-meta (:agent/id hc))))))
+
+(deftest create-intervention-with-explicit-scope-test
+  (testing "explicit :scope flows through to :intervention/scope"
+    (let [hc (sut/create-intervention :repair-loop-meta "msg" "addendum"
+                                      :scope :workflow)]
+      (is (= :workflow (:intervention/scope hc))))))
+
+(deftest create-intervention-attaches-n-only-when-scope-needs-it-test
+  (testing ":n is included for :next-N-phases; absent for others"
+    (let [bounded (sut/create-intervention :rl "m" "a" :scope :next-N-phases :n 2)
+          one-shot (sut/create-intervention :rl "m" "a" :scope :next-implement :n 5)]
+      (is (= 2 (:intervention/n bounded)))
+      (is (sut/valid-intervention? bounded))
+      (is (not (contains? one-shot :intervention/n))
+          ":n is omitted when the scope doesn't need it — keeps the map shape minimal"))))
+
+(deftest create-intervention-carries-data-test
+  (testing "diagnostic data flows through via :data, not flattened into top-level"
+    (let [fingerprints [#{[:blocking "src/foo.clj"]}
+                       #{[:blocking "src/foo.clj"]}]
+          hc (sut/create-intervention :rl "msg" "fix"
+                                      :data {:review/fingerprint-history fingerprints})]
+      (is (= fingerprints
+             (get-in hc [:data :review/fingerprint-history]))))))
+
+;------------------------------------------------------------------------------ Status-predicate cohabitation
+
+(deftest decision-statuses-are-mutually-exclusive-test
+  (testing "exactly one of healthy?/warning?/halt?/intervene? is true for any well-formed decision"
+    (let [hc-h (sut/create-health-check :a :healthy "x")
+          hc-w (sut/create-health-check :a :warning "x")
+          hc-x (sut/create-health-check :a :halt "x")
+          hc-i (sut/create-intervention :a "x" "addendum")]
+      (is (and (sut/healthy?   hc-h) (not (sut/warning? hc-h))
+               (not (sut/halt? hc-h)) (not (sut/intervene? hc-h))))
+      (is (and (sut/warning?   hc-w) (not (sut/healthy? hc-w))
+               (not (sut/halt? hc-w)) (not (sut/intervene? hc-w))))
+      (is (and (sut/halt?      hc-x) (not (sut/healthy? hc-x))
+               (not (sut/warning? hc-x)) (not (sut/intervene? hc-x))))
+      (is (and (sut/intervene? hc-i) (not (sut/healthy? hc-i))
+               (not (sut/warning? hc-i)) (not (sut/halt? hc-i)))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.agent.meta-protocol-test)
+  :leave-this-here)


### PR DESCRIPTION
## Summary

- Adds `:intervene` as a fourth `MetaAgent/check-health` return status, alongside `:healthy`, `:warning`, `:halt`.
- New `intervene?` predicate + `valid-intervention?` shape check.
- New `create-intervention` constructor — mirrors `create-health-check`; default scope is `:next-implement` (one-shot).
- 14 tests / 28 assertions covering all branches.

## Why

The 2026-05-19 dogfood spent 3 hours in a review→implement loop because the implementer kept producing semantically-equivalent variants of the same mock-shape bug. The strict-equality stagnation detector correctly stayed quiet; even the fuzzy signal shipped in PR #922 (M1) only *terminates*, not *fixes*. The user's stated goal was for the meta-agent to "notice that pattern, intervene, and then fix it by adjusting the instructions being given to the implementer agent."

M2 adds the contract that lets a meta-agent express that intent. The shape:

```clojure
{:status :intervene
 :agent/id :repair-loop-meta
 :message  "fuzzy stagnation in src/foo.clj across 2 reviews"
 :intervention/addendum
 "Your previous implementation used `reify` on `java.lang.Process` — that's
  an abstract class, not an interface. Use `proxy` instead, or wrap the
  atom in a thin record that exposes only the kill-fn shape you need."
 :intervention/scope :next-implement}
```

## Failure mode this addresses

`:halt` was the only escape valve the protocol gave a meta-agent — kill the workflow. That's the right call when the system is wedged, but wrong when the meta-agent has a *specific* fix in mind. Without `:intervene` the only options were halt-and-burn or stay-quiet-and-burn.

## Files Changed

- `components/agent/src/.../meta_protocol.clj` (modify) — status enum extended; `intervene?`, `valid-intervention?`, `create-intervention` added; existing `ProgressMonitorMetaAgent` (the only impl today) untouched and still loads.
- `components/agent/test/.../meta_protocol_test.clj` (create) — 14-test suite.

## Test plan

- [x] `clojure -M:dev:test … meta-protocol-test` — 14 / 28, 0 failures
- [x] `ai.miniforge.agent.meta.progress-monitor` still loads (existing meta-agent)
- [x] Mutual exclusion test: `(healthy? hc) (warning? hc) (halt? hc) (intervene? hc)` — exactly one true for any well-formed decision
- [x] `valid-intervention?` returns `false` for the failure modes that would otherwise let malformed interventions reach the runner: missing addendum, blank addendum, unknown scope, `:next-N-phases` without `:n`, `:next-N-phases` with `:n` ≤ 0, `:warning` status carrying intervention keys

## Followups (other PRs in this spec)

- **M3**: `RepairLoopMetaAgent` — LLM-driven meta-agent that consumes `:anomalies.review/fuzzy-stagnation` (M1, PR #922), analyzes the recurring pattern over the last N=2 reviews + file diff, and returns either `:intervene` with an addendum (confidence ≥ medium) or `:warning` (confidence low).
- **M4**: workflow-runner hook — append the addendum to the implement task's description before the next agent invocation, emit `:meta/intervention-applied`, consume per scope.
- **M5**: end-to-end integration pin through M1 → M3 → M4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)