### PR TITLE
fix: add automation correlator to bb CLI path

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -592,6 +592,7 @@
                  "components/event-stream/src"
                  "components/event-stream/resources"
                  "components/supervisory-state/src"
+                 "components/automation-edge-correlator/src"
                  "components/workflow-resume/src"
                  "components/workflow-resume/resources"
                  "components/dag-primitives/src"


### PR DESCRIPTION
## Summary
- add the automation-edge-correlator component source path to the Babashka miniforge CLI task
- unblocks dogfood runs after the workflow runner started requiring the correlator interface

## Test
- bb miniforge --help
- clj-kondo --lint bb.edn
- bb dogfood:check work/in-progress/event-log-tool-visibility.spec.edn