### PR TITLE
GROUP 1 — Wire paired tool-call event emission into streaming...

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -592,6 +592,7 @@
                  "components/event-stream/src"
                  "components/event-stream/resources"
                  "components/supervisory-state/src"
+                 "components/automation-edge-correlator/src"
                  "components/workflow-resume/src"
                  "components/workflow-resume/resources"
                  "components/dag-primitives/src"

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -37,7 +37,10 @@
       (messages/t :stream/tool-use-line {:names (str/join ", " names)}))))
 
 (defn- maybe-digest
-  "Apply digest-content to `content` only when content is non-nil."
+  "Apply digest-content to `content` only when content is non-nil.
+   digest-content handles the 1KB threshold internally (preview is always
+   capped; SHA-256 is always computed). We guard only against nil so the
+   event constructors receive a clean, fully-formed digest map or nothing."
   [content]
   (when (some? content)
     (digest/digest-content content)))
@@ -118,9 +121,13 @@
               stream-atom
               (events/agent-tool-call-started
                 stream-atom workflow-id agent-id
-                {:tool/name        tool-name
-                 :tool/call-id     tool-call-id
-                 :tool/args-digest (maybe-digest tool-args-preview)}))))
+                ;; cond-> keeps nil keys out of the map explicitly,
+                ;; independent of constructor nil-stripping behaviour.
+                (cond-> {:tool/name    tool-name
+                         :tool/call-id tool-call-id}
+                  tool-args-preview
+                  (assoc :tool/args-digest
+                         (digest/digest-content tool-args-preview)))))))
 
         ;; Tool-result closes the latency span opened by tool-use.
         ;; Emit :tool/call-completed with duration and digested result.
@@ -138,10 +145,12 @@
               stream-atom
               (events/tool-call-completed
                 stream-atom workflow-id
-                {:tool/call-id       correlated-id
-                 :tool/result-digest result-digest
-                 :tool/duration-ms   duration-ms
-                 :tool/success?      (not (true? tool-result-is-error))}))))
+                ;; cond-> excludes optional keys explicitly when nil,
+                ;; decoupled from constructor nil-filtering behaviour.
+                (cond-> {:tool/call-id  correlated-id
+                         :tool/success? (not (true? tool-result-is-error))}
+                  result-digest (assoc :tool/result-digest result-digest)
+                  duration-ms   (assoc :tool/duration-ms duration-ms))))))
 
         heartbeat
         nil

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -23,7 +23,9 @@
    [ai.miniforge.event-stream.digest :as digest]
    [ai.miniforge.event-stream.interface.events :as events]
    [ai.miniforge.event-stream.interface.stream :as stream]
-   [ai.miniforge.event-stream.messages :as messages]))
+   [ai.miniforge.event-stream.messages :as messages])
+  (:import
+   [java.util.concurrent TimeUnit]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Convenience callbacks
@@ -157,11 +159,16 @@
                                   (swap! tool-start-times dissoc correlated-id)
                                   t))
                 duration-ms   (when start-ns
-                                ;; Convert monotonic nanos → ms. nanoTime
-                                ;; never decreases on the same JVM, so the
-                                ;; delta is always non-negative; no clamp
-                                ;; needed.
-                                (quot (- (System/nanoTime) start-ns) 1000000))
+                                ;; Convert monotonic nanos → ms via TimeUnit
+                                ;; rather than a bare 1000000 divisor — the
+                                ;; named conversion documents the intent and
+                                ;; matches the named-constants rule
+                                ;; (.standards/foundations/named-constants.mdc).
+                                ;; nanoTime never decreases on the same JVM,
+                                ;; so the delta is always non-negative; no
+                                ;; clamp needed.
+                                (.toMillis TimeUnit/NANOSECONDS
+                                           (- (System/nanoTime) start-ns)))
                 result-digest (maybe-digest tool-result-content)]
             (stream/publish!
               stream-atom

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -20,6 +20,7 @@
   "Streaming callback helpers for the event-stream public API."
   (:require
    [clojure.string :as str]
+   [ai.miniforge.event-stream.digest :as digest]
    [ai.miniforge.event-stream.interface.events :as events]
    [ai.miniforge.event-stream.interface.stream :as stream]
    [ai.miniforge.event-stream.messages :as messages]))
@@ -35,6 +36,12 @@
     (when (seq names)
       (messages/t :stream/tool-use-line {:names (str/join ", " names)}))))
 
+(defn- maybe-digest
+  "Apply digest-content to `content` only when content is non-nil."
+  [content]
+  (when (some? content)
+    (digest/digest-content content)))
+
 (defn create-streaming-callback
   "Callback invoked by the LLM client for each parsed stream event.
 
@@ -45,36 +52,59 @@
      :tool-name   — single tool name when available (Claude / codex)
      :tool-names  — vector of tool names (Claude multi-tool blocks)
      :tool-call-id — provider-supplied id when available
-     :tool-args-preview — bounded args digest when the parser can safely
-                          expose it
+     :tool-args-preview — bounded args preview when the parser can safely
+                          expose it; will be digested via digest-content
      :tool-result — boolean, true when the LLM streamed a tool-result
-                    block (outcome of a prior tool-use). Treated as a
-                    pure liveness signal here — supervisors/detectors
-                    consume it via the stream accumulator, not via this
-                    streaming callback. Suppressed so it doesn't publish
-                    an empty :agent/chunk.
+                    block (outcome of a prior tool-use)
+     :tool-result-call-id — provider id correlating this result to its
+                            originating tool-use; may be nil
+     :tool-result-content — raw result payload (string or map) when the
+                            parser surfaces it; may be nil
+     :tool-result-is-error — boolean, true when the result is an error
      :heartbeat   — keepalive, ignored for diagnostic emission
 
-   For tool-use events emits BOTH:
-     :agent/tool-call  — structured, carries :tool/name / :tool/names /
-                          :tool/call-id / :tool/args-preview
-     :agent/status     — legacy generic 'Agent calling tool' status-type
-                          :tool-calling, preserved so existing consumers
-                          (dashboard, TUI, tests) keep working during the
-                          migration."
+   For tool-use events emits BOTH (in order):
+     :agent/tool-call          — legacy event; carries :tool/name /
+                                 :tool/names / :tool/call-id /
+                                 :tool/args-preview.  Preserved for
+                                 backward compatibility with existing
+                                 consumers (dashboard, TUI, tests).
+     :agent/tool-call-started  — new paired start event; carries
+                                 :tool/name / :tool/call-id /
+                                 :tool/args-digest (digest-content of
+                                 tool-args-preview when present).
+
+   NOTE: The bare :agent/status :tool-calling emission has been removed.
+         :agent/tool-call-started replaces it with richer structured data.
+
+   For tool-result events emits:
+     :tool/call-completed — closing event for the latency span opened by
+                            :agent/tool-call-started.  Carries
+                            :tool/call-id / :tool/result-digest /
+                            :tool/duration-ms / :tool/success?."
   [stream-atom workflow-id agent-id & [opts]]
-  (let [{:keys [print? quiet?]} opts]
+  (let [{:keys [print? quiet?]} opts
+        ;; Local start-time registry keyed by tool-call-id.
+        ;; Populated on tool-use; consumed and cleared on tool-result.
+        tool-start-times (atom {})]
     (fn [{:keys [delta done? tool-use tool-result heartbeat
-                 tool-name tool-names tool-call-id tool-args-preview]}]
+                 tool-name tool-names tool-call-id tool-args-preview
+                 tool-result-call-id tool-result-content tool-result-is-error]}]
       (cond
         tool-use
         (do
+          ;; Record wall-clock start for subsequent duration computation.
+          (when tool-call-id
+            (swap! tool-start-times assoc tool-call-id (System/currentTimeMillis)))
+
           (when-let [line (and print? (not quiet?)
                                (tool-use-line {:tool-name tool-name
                                                :tool-names tool-names}))]
             (print line)
             (flush))
+
           (when stream-atom
+            ;; ── Legacy event — keeps existing consumers working ──────────
             (stream/publish!
               stream-atom
               (events/agent-tool-call stream-atom workflow-id agent-id
@@ -82,17 +112,36 @@
                                        :tool-names tool-names
                                        :tool-call-id tool-call-id
                                        :tool-args-preview tool-args-preview}))
+
+            ;; ── New paired started event — replaces :agent/status :tool-calling
             (stream/publish!
               stream-atom
-              (events/agent-status stream-atom workflow-id agent-id
-                                   :tool-calling
-                                   (messages/t :stream/agent-calling-tool)))))
+              (events/agent-tool-call-started
+                stream-atom workflow-id agent-id
+                {:tool/name        tool-name
+                 :tool/call-id     tool-call-id
+                 :tool/args-digest (maybe-digest tool-args-preview)}))))
 
-        ;; Tool-result chunks are liveness signals (no delta payload).
-        ;; Suppressed here — without this branch the :else clause would
-        ;; publish an empty :agent/chunk for every tool round-trip.
+        ;; Tool-result closes the latency span opened by tool-use.
+        ;; Emit :tool/call-completed with duration and digested result.
         tool-result
-        nil
+        (when stream-atom
+          (let [correlated-id (or tool-result-call-id tool-call-id)
+                start-ms      (when correlated-id
+                                (let [t (get @tool-start-times correlated-id)]
+                                  (swap! tool-start-times dissoc correlated-id)
+                                  t))
+                duration-ms   (when start-ms
+                                (- (System/currentTimeMillis) start-ms))
+                result-digest (maybe-digest tool-result-content)]
+            (stream/publish!
+              stream-atom
+              (events/tool-call-completed
+                stream-atom workflow-id
+                {:tool/call-id       correlated-id
+                 :tool/result-digest result-digest
+                 :tool/duration-ms   duration-ms
+                 :tool/success?      (not (true? tool-result-is-error))}))))
 
         heartbeat
         nil

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -94,6 +94,11 @@
         ;; lifetime of this callback instance.  Callbacks are short-lived
         ;; per agent turn, so the practical leak bound is O(concurrent
         ;; outstanding tool calls) — negligible in normal operation.
+        ;; Monotonic — `nanoTime` is immune to wall-clock adjustments
+        ;; (NTP step, manual sysclock changes) that can make a paired
+        ;; `currentTimeMillis` delta negative or implausibly large.
+        ;; Durations published downstream stay non-negative without a
+        ;; clamp/abs guard at the read site.
         tool-start-times (atom {})]
     (fn [{:keys [delta done? tool-use tool-result heartbeat
                  tool-name tool-names tool-call-id tool-args-preview
@@ -101,9 +106,9 @@
       (cond
         tool-use
         (do
-          ;; Record wall-clock start for subsequent duration computation.
+          ;; Record monotonic start for subsequent duration computation.
           (when tool-call-id
-            (swap! tool-start-times assoc tool-call-id (System/currentTimeMillis)))
+            (swap! tool-start-times assoc tool-call-id (System/nanoTime)))
 
           (when-let [line (and print? (not quiet?)
                                (tool-use-line {:tool-name tool-name
@@ -130,10 +135,15 @@
                 ;; independent of constructor nil-stripping behaviour.
                 ;; :tool/names mirrors the legacy :agent/tool-call field so
                 ;; consumers can handle multi-tool provider blocks correctly.
+                ;; `some?` mirrors `maybe-digest`'s contract — guard on
+                ;; nil only, not truthiness, so an empty-string preview
+                ;; (e.g. a tool invoked with no args) still produces a
+                ;; consistent digest map rather than silently dropping
+                ;; the field.
                 (cond-> {:tool/name    tool-name
                          :tool/call-id tool-call-id}
                   (seq tool-names) (assoc :tool/names (vec tool-names))
-                  tool-args-preview
+                  (some? tool-args-preview)
                   (assoc :tool/args-digest
                          (digest/digest-content tool-args-preview)))))))
 
@@ -142,12 +152,16 @@
         tool-result
         (when stream-atom
           (let [correlated-id (or tool-result-call-id tool-call-id)
-                start-ms      (when correlated-id
+                start-ns      (when correlated-id
                                 (let [t (get @tool-start-times correlated-id)]
                                   (swap! tool-start-times dissoc correlated-id)
                                   t))
-                duration-ms   (when start-ms
-                                (- (System/currentTimeMillis) start-ms))
+                duration-ms   (when start-ns
+                                ;; Convert monotonic nanos → ms. nanoTime
+                                ;; never decreases on the same JVM, so the
+                                ;; delta is always non-negative; no clamp
+                                ;; needed.
+                                (quot (- (System/nanoTime) start-ns) 1000000))
                 result-digest (maybe-digest tool-result-content)]
             (stream/publish!
               stream-atom

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -89,6 +89,11 @@
   (let [{:keys [print? quiet?]} opts
         ;; Local start-time registry keyed by tool-call-id.
         ;; Populated on tool-use; consumed and cleared on tool-result.
+        ;; Accepted trade-off: entries for tool-calls whose result never
+        ;; arrives (timeout, cancellation, stream cut) accumulate for the
+        ;; lifetime of this callback instance.  Callbacks are short-lived
+        ;; per agent turn, so the practical leak bound is O(concurrent
+        ;; outstanding tool calls) — negligible in normal operation.
         tool-start-times (atom {})]
     (fn [{:keys [delta done? tool-use tool-result heartbeat
                  tool-name tool-names tool-call-id tool-args-preview
@@ -123,8 +128,11 @@
                 stream-atom workflow-id agent-id
                 ;; cond-> keeps nil keys out of the map explicitly,
                 ;; independent of constructor nil-stripping behaviour.
+                ;; :tool/names mirrors the legacy :agent/tool-call field so
+                ;; consumers can handle multi-tool provider blocks correctly.
                 (cond-> {:tool/name    tool-name
                          :tool/call-id tool-call-id}
+                  (seq tool-names) (assoc :tool/names (vec tool-names))
                   tool-args-preview
                   (assoc :tool/args-digest
                          (digest/digest-content tool-args-preview)))))))
@@ -157,7 +165,7 @@
 
         :else
         (do
-          (when (and print? (not quiet?) delta (not (empty? delta)))
+          (when (and print? (not quiet?) (seq delta))
             (print delta)
             (flush))
           (when stream-atom

--- a/components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj
@@ -71,7 +71,14 @@
                                  :tool-call-id "tc-002"}])
           status-tool-calling? (fn [ev]
                                  (and (= :agent/status (:event/type ev))
-                                      (= :tool-calling (:agent/status ev))))]
+                                      ;; :agent/status events carry the
+                                      ;; status keyword under :status/type
+                                      ;; (see event-stream.core/agent-status
+                                      ;; — `:status/type status-type`), NOT
+                                      ;; :agent/status. The old predicate
+                                      ;; pass-by-default'd because no event
+                                      ;; ever has :agent/status as a field.
+                                      (= :tool-calling (:status/type ev))))]
       (is (not (some status-tool-calling? events))
           "bare :agent/status :tool-calling must not be emitted"))))
 

--- a/components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj
@@ -44,7 +44,7 @@
                     opts     {}}}]
   (let [stream (make-stream)
         collected (atom [])
-        _ (es/subscribe! stream (fn [ev] (swap! collected conj ev)))
+        _ (es/subscribe! stream ::test-collector (fn [ev] (swap! collected conj ev)))
         cb (es/create-streaming-callback stream workflow agent opts)]
     (doseq [ev events]
       (cb ev))

--- a/components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj
@@ -1,0 +1,206 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.callbacks-test
+  "Tests for create-streaming-callback paired tool-call event emission.
+
+   Verifies:
+     • tool-use path emits :agent/tool-call-started + legacy :agent/tool-call
+     • tool-use path does NOT emit :agent/status :tool-calling
+     • tool-result path emits :tool/call-completed
+     • duration-ms is computed when call-id correlates the pair
+     • digest-content is applied to args-preview and result-content
+     • nil args/results do not produce a digest key"
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.event-stream.interface :as es]))
+
+;------------------------------------------------------------------------------ helpers
+
+(defn- make-stream []
+  (es/create-event-stream))
+
+(defn- invoke!
+  "Drive `cb` with `event-map` and return the published events."
+  [cb event-map]
+  (cb event-map)
+  ;; give publish a tick (it is synchronous, so this is just defensive)
+  nil)
+
+(defn- run-callback
+  "Creates a stream, attaches a subscriber, fires `events` through the
+   callback, and returns the collected published events (in order)."
+  [events & {:keys [call-id agent workflow opts]
+             :or   {agent    :implementer
+                    workflow (random-uuid)
+                    opts     {}}}]
+  (let [stream (make-stream)
+        collected (atom [])
+        _ (es/subscribe! stream (fn [ev] (swap! collected conj ev)))
+        cb (es/create-streaming-callback stream workflow agent opts)]
+    (doseq [ev events]
+      (cb ev))
+    @collected))
+
+;------------------------------------------------------------------------------ tool-use tests
+
+(deftest tool-use-emits-legacy-and-started-events
+  (testing "A tool-use event publishes both :agent/tool-call and :agent/tool-call-started"
+    (let [events (run-callback [{:tool-use true
+                                 :tool-name "Read"
+                                 :tool-call-id "tc-001"
+                                 :tool-args-preview "{:file_path \"/foo.clj\"}"}])
+          types (mapv :event/type events)]
+      (is (some #{:agent/tool-call} types)
+          "legacy :agent/tool-call must be present")
+      (is (some #{:agent/tool-call-started} types)
+          ":agent/tool-call-started must be present"))))
+
+(deftest tool-use-does-not-emit-agent-status-tool-calling
+  (testing ":agent/status :tool-calling is NOT emitted — replaced by :agent/tool-call-started"
+    (let [events (run-callback [{:tool-use true
+                                 :tool-name "Grep"
+                                 :tool-call-id "tc-002"}])
+          status-tool-calling? (fn [ev]
+                                 (and (= :agent/status (:event/type ev))
+                                      (= :tool-calling (:agent/status ev))))]
+      (is (not (some status-tool-calling? events))
+          "bare :agent/status :tool-calling must not be emitted"))))
+
+(deftest tool-call-started-carries-tool-name-and-call-id
+  (testing ":agent/tool-call-started carries :tool/name and :tool/call-id"
+    (let [events (run-callback [{:tool-use true
+                                 :tool-name "Write"
+                                 :tool-call-id "tc-003"
+                                 :tool-args-preview "{:file_path \"/bar.clj\"}"}])
+          started (first (filter #(= :agent/tool-call-started (:event/type %)) events))]
+      (is (= "Write" (:tool/name started)))
+      (is (= "tc-003" (:tool/call-id started))))))
+
+(deftest tool-call-started-has-args-digest-when-preview-present
+  (testing ":agent/tool-call-started includes :tool/args-digest when args-preview provided"
+    (let [preview "{:file_path \"/src/core.clj\"}"
+          events (run-callback [{:tool-use true
+                                 :tool-name "Read"
+                                 :tool-call-id "tc-004"
+                                 :tool-args-preview preview}])
+          started (first (filter #(= :agent/tool-call-started (:event/type %)) events))]
+      (is (contains? started :tool/args-digest)
+          ":tool/args-digest key must be present when args-preview given")
+      (is (contains? (:tool/args-digest started) :digest/sha256)
+          "digest must contain :digest/sha256")
+      (is (contains? (:tool/args-digest started) :digest/preview)
+          "digest must contain :digest/preview")
+      (is (contains? (:tool/args-digest started) :digest/original-size)
+          "digest must contain :digest/original-size"))))
+
+(deftest tool-call-started-no-digest-when-no-preview
+  (testing ":agent/tool-call-started does not add :tool/args-digest when args-preview is nil"
+    (let [events (run-callback [{:tool-use true
+                                 :tool-name "Glob"
+                                 :tool-call-id "tc-005"}])
+          started (first (filter #(= :agent/tool-call-started (:event/type %)) events))]
+      (is (not (contains? started :tool/args-digest))
+          ":tool/args-digest must not appear when no args-preview"))))
+
+;------------------------------------------------------------------------------ tool-result tests
+
+(deftest tool-result-emits-call-completed
+  (testing "A tool-result event publishes :tool/call-completed"
+    (let [events (run-callback [{:tool-result true
+                                 :tool-call-id "tc-006"
+                                 :tool-result-content "file contents here"
+                                 :tool-result-is-error false}])
+          types (mapv :event/type events)]
+      (is (some #{:tool/call-completed} types)
+          ":tool/call-completed must be published on tool-result"))))
+
+(deftest tool-result-carries-success-flag
+  (testing ":tool/call-completed carries :tool/success? true on non-error results"
+    (let [events (run-callback [{:tool-result true
+                                 :tool-call-id "tc-007"
+                                 :tool-result-is-error false}])
+          completed (first (filter #(= :tool/call-completed (:event/type %)) events))]
+      (is (true? (:tool/success? completed)))))
+
+  (testing ":tool/call-completed carries :tool/success? false on error results"
+    (let [events (run-callback [{:tool-result true
+                                 :tool-call-id "tc-008"
+                                 :tool-result-is-error true}])
+          completed (first (filter #(= :tool/call-completed (:event/type %)) events))]
+      (is (false? (:tool/success? completed))))))
+
+(deftest tool-result-has-result-digest-when-content-present
+  (testing ":tool/call-completed includes :tool/result-digest when result-content provided"
+    (let [events (run-callback [{:tool-result true
+                                 :tool-call-id "tc-009"
+                                 :tool-result-content "some tool output"}])
+          completed (first (filter #(= :tool/call-completed (:event/type %)) events))]
+      (is (contains? completed :tool/result-digest)
+          ":tool/result-digest must be present when result-content given")
+      (is (contains? (:tool/result-digest completed) :digest/sha256)))))
+
+(deftest tool-result-no-digest-when-no-content
+  (testing ":tool/call-completed omits :tool/result-digest when result-content is nil"
+    (let [events (run-callback [{:tool-result true
+                                 :tool-call-id "tc-010"}])
+          completed (first (filter #(= :tool/call-completed (:event/type %)) events))]
+      (is (not (contains? completed :tool/result-digest))))))
+
+;------------------------------------------------------------------------------ duration tests
+
+(deftest duration-ms-computed-when-call-id-correlates-pair
+  (testing ":tool/duration-ms is present and non-negative when tool-use and tool-result share call-id"
+    (let [events (run-callback [{:tool-use true
+                                 :tool-name "Read"
+                                 :tool-call-id "tc-dur-1"}
+                                {:tool-result true
+                                 :tool-result-call-id "tc-dur-1"}])
+          completed (first (filter #(= :tool/call-completed (:event/type %)) events))]
+      (is (contains? completed :tool/duration-ms)
+          ":tool/duration-ms must be present when call-ids correlate")
+      (is (nat-int? (:tool/duration-ms completed))
+          ":tool/duration-ms must be a non-negative integer"))))
+
+(deftest duration-ms-nil-when-no-prior-tool-use
+  (testing ":tool/duration-ms is absent when there is no tracked tool-use start"
+    (let [events (run-callback [{:tool-result true}])
+          completed (first (filter #(= :tool/call-completed (:event/type %)) events))]
+      (is (not (contains? completed :tool/duration-ms))
+          ":tool/duration-ms must be absent when no tracked start"))))
+
+;------------------------------------------------------------------------------ passthrough tests
+
+(deftest non-tool-events-still-emit-agent-chunk
+  (testing "Plain delta events still produce :agent/chunk events"
+    (let [events (run-callback [{:delta "hello " :done? false}
+                                {:delta "world" :done? true}])
+          types (mapv :event/type events)]
+      (is (= [:agent/chunk :agent/chunk] types)))))
+
+(deftest heartbeat-produces-no-events
+  (testing "Heartbeat events are silently ignored"
+    (let [events (run-callback [{:heartbeat true}])]
+      (is (empty? events)))))
+
+(deftest nil-stream-atom-does-not-throw
+  (testing "Passing nil as stream-atom is safe — no publishes attempted"
+    (let [cb (es/create-streaming-callback nil (random-uuid) :implementer {})]
+      (is (nil? (cb {:tool-use true :tool-name "Read" :tool-call-id "x"})))
+      (is (nil? (cb {:tool-result true :tool-call-id "x"})))
+      (is (nil? (cb {:delta "text" :done? false}))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj
@@ -35,17 +35,10 @@
 (defn- make-stream []
   (es/create-event-stream))
 
-(defn- invoke!
-  "Drive `cb` with `event-map` and return the published events."
-  [cb event-map]
-  (cb event-map)
-  ;; give publish a tick (it is synchronous, so this is just defensive)
-  nil)
-
 (defn- run-callback
   "Creates a stream, attaches a subscriber, fires `events` through the
    callback, and returns the collected published events (in order)."
-  [events & {:keys [call-id agent workflow opts]
+  [events & {:keys [agent workflow opts]
              :or   {agent    :implementer
                     workflow (random-uuid)
                     opts     {}}}]

--- a/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
@@ -320,7 +320,10 @@
                               :content ""}))]
       (is (= "\n[tool] context_read\n" output))
       (is (= 1 (count (es/get-events stream {:event-type :agent/tool-call}))))
-      (is (= 1 (count (es/get-events stream {:event-type :agent/status})))))))
+      ;; :agent/status :tool-calling removed — :agent/tool-call-started replaces it
+      (is (= 0 (count (es/get-events stream {:event-type :agent/status}))))
+      (is (= 1 (count (es/get-events stream {:event-type :agent/tool-call-started})))))))
+
 
 ;; --------------------------------------------------------------------------- New N3 event constructors
 

--- a/docs/pull-requests/2026-05-19-group-1-wire-paired-tool-call-event-emission-into-streaming.md
+++ b/docs/pull-requests/2026-05-19-group-1-wire-paired-tool-call-event-emission-into-streaming.md
@@ -1,0 +1,29 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 1 — Wire paired tool-call event emission into streaming...
+
+**PR:** [#931](https://github.com/miniforge-ai/miniforge/pull/931)
+**Branch:** `mf/group-1-wire-paired-tool-call-event-emis-927f03c4`
+
+## Summary
+
+GROUP 1 — Wire paired tool-call event emission into streaming callback.
+
+## Files Changed
+
+- `components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj` (modify)
+- `components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj` (modify)
+- `components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj` (modify)
+- `components/event-stream/test/ai/miniforge/event_stream/interface_test.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._

--- a/docs/pull-requests/2026-05-19-group-1-wire-paired-tool-call-event-emission-into-streaming.md
+++ b/docs/pull-requests/2026-05-19-group-1-wire-paired-tool-call-event-emission-into-streaming.md
@@ -4,7 +4,7 @@
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
 
-# GROUP 1 — Wire paired tool-call event emission into streaming...
+# GROUP 1 — Wire paired tool-call event emission into streaming
 
 **PR:** [#931](https://github.com/miniforge-ai/miniforge/pull/931)
 **Branch:** `mf/group-1-wire-paired-tool-call-event-emis-927f03c4`
@@ -15,7 +15,6 @@ GROUP 1 — Wire paired tool-call event emission into streaming callback.
 
 ## Files Changed
 
-- `components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj` (modify)
 - `components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj` (modify)
 - `components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj` (modify)
 - `components/event-stream/test/ai/miniforge/event_stream/interface_test.clj` (modify)


### PR DESCRIPTION
## Summary

GROUP 1 — Wire paired tool-call event emission into streaming callback.

## Changes

- `components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj` (modify)
- `components/event-stream/test/ai/miniforge/event_stream/callbacks_test.clj` (modify)
- `components/event-stream/test/ai/miniforge/event_stream/interface_test.clj` (modify)

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (4 files)