### PR TITLE
feat: emit paired tool callback events

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -567,23 +567,25 @@
 
 (defn agent-tool-call-started
   "Build an :agent/tool-call-started event marking the moment an agent
-   begins executing a single named tool call.
+   begins executing a named tool call or tool-use block.
 
    Arguments:
    - stream:      event stream
    - workflow-id: owning workflow UUID
    - agent-id:    keyword identifying the agent (e.g. :implementer)
    - opts:        {:tool/name     string  — tool being called when known
+                   :tool/names    vector  — tool names for provider blocks
                    :tool/args-digest map   — bounded digest of tool args
                    :tool/call-id  string  — provider-supplied call id}"
   [stream workflow-id agent-id
-   {:keys [:tool/name :tool/args-digest :tool/call-id]}]
+   {:keys [:tool/name :tool/names :tool/args-digest :tool/call-id]}]
   (cond-> (create-envelope stream :agent/tool-call-started workflow-id
                            (messages/t :tool-call/started
                                        {:tool-name-suffix
                                         (if name (str ": " name) "")}))
     true            (assoc :agent/id agent-id)
     name            (assoc :tool/name name)
+    (seq names)     (assoc :tool/names (vec names))
     args-digest     (assoc :tool/args-digest args-digest)
     call-id         (assoc :tool/call-id call-id)))
 

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -20,6 +20,7 @@
   "Streaming callback helpers for the event-stream public API."
   (:require
    [clojure.string :as str]
+   [ai.miniforge.event-stream.digest :as digest]
    [ai.miniforge.event-stream.interface.events :as events]
    [ai.miniforge.event-stream.interface.stream :as stream]
    [ai.miniforge.event-stream.messages :as messages]))
@@ -35,6 +36,15 @@
     (when (seq names)
       (messages/t :stream/tool-use-line {:names (str/join ", " names)}))))
 
+(defn- maybe-digest
+  "Apply digest-content to `content` only when content is non-nil.
+   digest-content handles the 1KB threshold internally (preview is always
+   capped; SHA-256 is always computed). We guard only against nil so the
+   event constructors receive a clean, fully-formed digest map or nothing."
+  [content]
+  (when (some? content)
+    (digest/digest-content content)))
+
 (defn create-streaming-callback
   "Callback invoked by the LLM client for each parsed stream event.
 
@@ -45,36 +55,64 @@
      :tool-name   — single tool name when available (Claude / codex)
      :tool-names  — vector of tool names (Claude multi-tool blocks)
      :tool-call-id — provider-supplied id when available
-     :tool-args-preview — bounded args digest when the parser can safely
-                          expose it
+     :tool-args-preview — bounded args preview when the parser can safely
+                          expose it; will be digested via digest-content
      :tool-result — boolean, true when the LLM streamed a tool-result
-                    block (outcome of a prior tool-use). Treated as a
-                    pure liveness signal here — supervisors/detectors
-                    consume it via the stream accumulator, not via this
-                    streaming callback. Suppressed so it doesn't publish
-                    an empty :agent/chunk.
+                    block (outcome of a prior tool-use)
+     :tool-result-call-id — provider id correlating this result to its
+                            originating tool-use; may be nil
+     :tool-result-content — raw result payload (string or map) when the
+                            parser surfaces it; may be nil
+     :tool-result-is-error — boolean, true when the result is an error
      :heartbeat   — keepalive, ignored for diagnostic emission
 
-   For tool-use events emits BOTH:
-     :agent/tool-call  — structured, carries :tool/name / :tool/names /
-                          :tool/call-id / :tool/args-preview
-     :agent/status     — legacy generic 'Agent calling tool' status-type
-                          :tool-calling, preserved so existing consumers
-                          (dashboard, TUI, tests) keep working during the
-                          migration."
+   For tool-use events emits BOTH (in order):
+     :agent/tool-call          — legacy event; carries :tool/name /
+                                 :tool/names / :tool/call-id /
+                                 :tool/args-preview.  Preserved for
+                                 backward compatibility with existing
+                                 consumers (dashboard, TUI, tests).
+     :agent/tool-call-started  — new paired start event; carries
+                                 :tool/name / :tool/call-id /
+                                 :tool/args-digest (digest-content of
+                                 tool-args-preview when present).
+
+   NOTE: The bare :agent/status :tool-calling emission has been removed.
+         :agent/tool-call-started replaces it with richer structured data.
+
+   For tool-result events emits:
+     :tool/call-completed — closing event for the latency span opened by
+                            :agent/tool-call-started.  Carries
+                            :tool/call-id / :tool/result-digest /
+                            :tool/duration-ms / :tool/success?."
   [stream-atom workflow-id agent-id & [opts]]
-  (let [{:keys [print? quiet?]} opts]
+  (let [{:keys [print? quiet?]} opts
+        ;; Local start-time registry keyed by tool-call-id.
+        ;; Populated on tool-use; consumed and cleared on tool-result.
+        ;; Accepted trade-off: entries for tool-calls whose result never
+        ;; arrives (timeout, cancellation, stream cut) accumulate for the
+        ;; lifetime of this callback instance.  Callbacks are short-lived
+        ;; per agent turn, so the practical leak bound is O(concurrent
+        ;; outstanding tool calls) — negligible in normal operation.
+        tool-start-times (atom {})]
     (fn [{:keys [delta done? tool-use tool-result heartbeat
-                 tool-name tool-names tool-call-id tool-args-preview]}]
+                 tool-name tool-names tool-call-id tool-args-preview
+                 tool-result-call-id tool-result-content tool-result-is-error]}]
       (cond
         tool-use
         (do
+          ;; Record wall-clock start for subsequent duration computation.
+          (when tool-call-id
+            (swap! tool-start-times assoc tool-call-id (System/currentTimeMillis)))
+
           (when-let [line (and print? (not quiet?)
                                (tool-use-line {:tool-name tool-name
                                                :tool-names tool-names}))]
             (print line)
             (flush))
+
           (when stream-atom
+            ;; ── Legacy event — keeps existing consumers working ──────────
             (stream/publish!
               stream-atom
               (events/agent-tool-call stream-atom workflow-id agent-id
@@ -82,24 +120,52 @@
                                        :tool-names tool-names
                                        :tool-call-id tool-call-id
                                        :tool-args-preview tool-args-preview}))
+
+            ;; ── New paired started event — replaces :agent/status :tool-calling
             (stream/publish!
               stream-atom
-              (events/agent-status stream-atom workflow-id agent-id
-                                   :tool-calling
-                                   (messages/t :stream/agent-calling-tool)))))
+              (events/agent-tool-call-started
+                stream-atom workflow-id agent-id
+                ;; cond-> keeps nil keys out of the map explicitly,
+                ;; independent of constructor nil-stripping behaviour.
+                ;; :tool/names mirrors the legacy :agent/tool-call field so
+                ;; consumers can handle multi-tool provider blocks correctly.
+                (cond-> {:tool/name    tool-name
+                         :tool/call-id tool-call-id}
+                  (seq tool-names) (assoc :tool/names (vec tool-names))
+                  tool-args-preview
+                  (assoc :tool/args-digest
+                         (digest/digest-content tool-args-preview)))))))
 
-        ;; Tool-result chunks are liveness signals (no delta payload).
-        ;; Suppressed here — without this branch the :else clause would
-        ;; publish an empty :agent/chunk for every tool round-trip.
+        ;; Tool-result closes the latency span opened by tool-use.
+        ;; Emit :tool/call-completed with duration and digested result.
         tool-result
-        nil
+        (when stream-atom
+          (let [correlated-id (or tool-result-call-id tool-call-id)
+                start-ms      (when correlated-id
+                                (let [t (get @tool-start-times correlated-id)]
+                                  (swap! tool-start-times dissoc correlated-id)
+                                  t))
+                duration-ms   (when start-ms
+                                (- (System/currentTimeMillis) start-ms))
+                result-digest (maybe-digest tool-result-content)]
+            (stream/publish!
+              stream-atom
+              (events/tool-call-completed
+                stream-atom workflow-id
+                ;; cond-> excludes optional keys explicitly when nil,
+                ;; decoupled from constructor nil-filtering behaviour.
+                (cond-> {:tool/call-id  correlated-id
+                         :tool/success? (not (true? tool-result-is-error))}
+                  result-digest (assoc :tool/result-digest result-digest)
+                  duration-ms   (assoc :tool/duration-ms duration-ms))))))
 
         heartbeat
         nil
 
         :else
         (do
-          (when (and print? (not quiet?) delta (not (empty? delta)))
+          (when (and print? (not quiet?) (seq delta))
             (print delta)
             (flush))
           (when stream-atom

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -408,6 +408,7 @@
     [:event/sequence-number int?]
     [:workflow/id uuid?]
     [:tool/name {:optional true} string?]
+    [:tool/names {:optional true} [:vector string?]]
     [:tool/args-digest {:optional true} DigestSummary]
     [:tool/call-id {:optional true} string?]
     [:agent/id keyword?]

--- a/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
@@ -320,7 +320,28 @@
                               :content ""}))]
       (is (= "\n[tool] context_read\n" output))
       (is (= 1 (count (es/get-events stream {:event-type :agent/tool-call}))))
-      (is (= 1 (count (es/get-events stream {:event-type :agent/status})))))))
+      ;; :agent/status :tool-calling removed — :agent/tool-call-started replaces it
+      (is (= 0 (count (es/get-events stream {:event-type :agent/status}))))
+      (is (= 1 (count (es/get-events stream {:event-type :agent/tool-call-started}))))))
+
+  (testing "tool-result callback publishes a completed event with correlated duration"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          callback (es/create-streaming-callback stream wf-id :planner)]
+      (callback {:tool-use true
+                 :tool-name "context_read"
+                 :tool-call-id "call-1"
+                 :tool-args-preview "{:path \"deps.edn\"}"})
+      (callback {:tool-result true
+                 :tool-result-call-id "call-1"
+                 :tool-result-content "ok"
+                 :tool-result-is-error false})
+      (let [completed (first (es/get-events stream {:event-type :tool/call-completed}))]
+        (is (= "call-1" (:tool/call-id completed)))
+        (is (true? (:tool/success? completed)))
+        (is (nat-int? (:tool/duration-ms completed)))
+        (is (contains? completed :tool/result-digest))))))
+
 
 ;; --------------------------------------------------------------------------- New N3 event constructors
 

--- a/components/event-stream/test/ai/miniforge/event_stream/new_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/new_events_test.clj
@@ -84,6 +84,14 @@
       (is (not (contains? ev :tool/call-id)))
       (is (not (contains? ev :tool/args-digest))))))
 
+(deftest agent-tool-call-started-carries-batched-tool-names
+  (testing "multi-tool provider blocks retain the vector of tool names"
+    (let [ev (es/agent-tool-call-started
+              (stream) (random-uuid) :implementer
+              {:tool/names ["Read" "Write"]})]
+      (is (= ["Read" "Write"] (:tool/names ev)))
+      (is (m/validate schema/AgentToolCallStarted ev)))))
+
 (deftest agent-tool-call-started-envelope-fields
   (testing "envelope fields are present and typed correctly"
     (let [ev (es/agent-tool-call-started


### PR DESCRIPTION
## Summary
- emit :agent/tool-call-started alongside the legacy :agent/tool-call callback event
- emit :tool/call-completed for tool-result chunks with success, digest, and correlated duration fields
- stop emitting legacy :agent/status :tool-calling from streaming callbacks

## Size
- commit-budget: 107 / 200 lines

## Test
- clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.event-stream.interface-test)(let [r (clojure.test/run-tests 'ai.miniforge.event-stream.interface-test)](System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
- clj-kondo --lint components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
- git commit hook pre-commit smoke