### PR TITLE
feat: add phase heartbeat scheduler

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/heartbeat.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/heartbeat.clj
@@ -1,0 +1,100 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.heartbeat
+  "Phase heartbeat scheduler."
+  (:require
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.logging.interface :as log])
+  (:import
+   [java.util.concurrent Executors ScheduledExecutorService ThreadFactory TimeUnit]))
+
+(def ^:const default-interval-ms
+  "Default interval between heartbeat events: 30 seconds."
+  30000)
+
+(defn- daemon-thread-factory [phase-id]
+  (reify ThreadFactory
+    (newThread [_ runnable]
+      (doto (Thread. runnable (str "miniforge-phase-heartbeat-" (name phase-id)))
+        (.setDaemon true)))))
+
+(defn- resolve-interval-ms [opts]
+  (let [interval-ms (or (:interval-ms opts) default-interval-ms)]
+    (when-not (pos-int? interval-ms)
+      (throw (ex-info "Heartbeat interval must be a positive integer"
+                      {:interval-ms interval-ms})))
+    interval-ms))
+
+(defn- make-heartbeat-task
+  "Return one scheduled heartbeat emission task."
+  [event-stream workflow-id phase-id active-since seq-num last-tick]
+  (fn []
+    (try
+      (let [now    (System/currentTimeMillis)
+            gap-ms (- now @last-tick)
+            seq-n  (swap! seq-num inc)
+            event  (-> (core/phase-heartbeat
+                         event-stream workflow-id phase-id
+                         {:phase/active-since            active-since
+                          :phase/events-emitted          seq-n
+                          :phase/gap-since-last-event-ms gap-ms
+                          :phase/last-event-at           (java.util.Date. ^long @last-tick)})
+                       (assoc :heartbeat/phase-id              phase-id
+                              :heartbeat/seq-in-phase           seq-n
+                              :heartbeat/gap-since-last-event-ms gap-ms))]
+        (when-not (:rejected? (core/publish! event-stream event))
+          (reset! last-tick now)))
+      (catch Exception e
+        (log/warn (some-> event-stream deref :logger)
+                  :event-stream
+                  :heartbeat/emission-error
+                  {:message "Phase heartbeat emission failed"
+                   :data {:phase-id phase-id
+                          :error (ex-message e)}})))))
+
+(defn start-heartbeat!
+  "Start :workflow/phase-heartbeat emission for phase-id.
+   opts: {:interval-ms long}. Returns an opaque stop handle."
+  ([event-stream workflow-id phase-id]
+   (start-heartbeat! event-stream workflow-id phase-id {}))
+  ([event-stream workflow-id phase-id opts]
+   (let [interval-ms (resolve-interval-ms opts)
+         seq-num     (atom 0)
+         start-ms    (System/currentTimeMillis)
+         active-since (java.util.Date. ^long start-ms)
+         last-tick   (atom start-ms)
+         executor    (Executors/newSingleThreadScheduledExecutor
+                       (daemon-thread-factory phase-id))
+         task        (make-heartbeat-task event-stream workflow-id phase-id
+                                          active-since seq-num last-tick)]
+     (.scheduleAtFixedRate ^ScheduledExecutorService executor
+                           task
+                           interval-ms
+                           interval-ms
+                           TimeUnit/MILLISECONDS)
+     {:heartbeat/executor    executor
+      :heartbeat/phase-id    phase-id
+      :heartbeat/last-tick   last-tick
+      :heartbeat/seq-num     seq-num})))
+
+(defn stop-heartbeat!
+  "Stop a heartbeat scheduler returned by start-heartbeat!. Nil-safe."
+  [handle]
+  (when-let [^ScheduledExecutorService executor (:heartbeat/executor handle)]
+    (.shutdown executor)))

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -29,6 +29,7 @@
    [ai.miniforge.event-stream.interface.listeners :as listeners]
    [ai.miniforge.event-stream.interface.stream :as stream]
    [ai.miniforge.event-stream.digest :as digest]
+   [ai.miniforge.event-stream.heartbeat :as heartbeat]
    [ai.miniforge.event-stream.reader :as reader]
    [ai.miniforge.event-stream.sinks :as sinks]))
 
@@ -60,6 +61,10 @@
 ;; BD-2a shutdown-ordering primitives.
 (def quiesce! stream/quiesce!)
 (def drain! stream/drain!)
+
+;; Phase heartbeat scheduler — start/stop liveness signalling for long-running phases.
+(def start-heartbeat! heartbeat/start-heartbeat!)
+(def stop-heartbeat!  heartbeat/stop-heartbeat!)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Event constructors

--- a/components/event-stream/test/ai/miniforge/event_stream/heartbeat_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/heartbeat_test.clj
@@ -1,0 +1,98 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.heartbeat-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.event-stream.heartbeat :as heartbeat])
+  (:import
+   [java.util.concurrent ScheduledExecutorService TimeUnit]))
+
+(defn- collecting-stream []
+  (let [events (atom [])]
+    {:events events
+     :stream (core/create-event-stream
+               {:sinks [(fn [event] (swap! events conj event))]})}))
+
+(defn- wait-for-events [events n]
+  (let [deadline (+ (System/currentTimeMillis) 500)]
+    (loop []
+      (if (or (>= (count @events) n)
+              (>= (System/currentTimeMillis) deadline))
+        @events
+        (do (Thread/sleep 10)
+            (recur))))))
+
+(deftest start-heartbeat!-returns-handle
+  (let [{:keys [stream]} (collecting-stream)
+        handle (heartbeat/start-heartbeat! stream (random-uuid) :plan
+                                           {:interval-ms 5000})]
+    (try
+      (is (instance? ScheduledExecutorService (:heartbeat/executor handle)))
+      (is (= :plan (:heartbeat/phase-id handle)))
+      (is (instance? clojure.lang.Atom (:heartbeat/last-tick handle)))
+      (is (instance? clojure.lang.Atom (:heartbeat/seq-num handle)))
+      (finally
+        (heartbeat/stop-heartbeat! handle)))))
+
+(deftest heartbeat-emits-phase-liveness-events
+  (testing "heartbeat events carry workflow, phase, gap, and monotonic sequence"
+    (let [{:keys [stream events]} (collecting-stream)
+          workflow-id (random-uuid)
+          handle (heartbeat/start-heartbeat! stream workflow-id :implement
+                                             {:interval-ms 25})]
+      (try
+        (let [published (wait-for-events events 2)
+              seqs (mapv :heartbeat/seq-in-phase published)]
+          (is (<= 2 (count published)))
+          (is (every? #(= :workflow/phase-heartbeat (:event/type %)) published))
+          (is (every? #(= workflow-id (:workflow/id %)) published))
+          (is (every? #(= :implement (:heartbeat/phase-id %)) published))
+          (is (every? #(inst? (:phase/active-since %)) published))
+          (is (= seqs (mapv :phase/events-emitted published)))
+          (is (every? #(nat-int? (:heartbeat/gap-since-last-event-ms %)) published))
+          (is (= (range 1 (inc (count seqs))) seqs)))
+        (finally
+          (heartbeat/stop-heartbeat! handle))))))
+
+(deftest stop-heartbeat!-halts-emissions
+  (let [{:keys [stream events]} (collecting-stream)
+        handle (heartbeat/start-heartbeat! stream (random-uuid) :test
+                                           {:interval-ms 25})]
+    (wait-for-events events 1)
+    (heartbeat/stop-heartbeat! handle)
+    (is (.awaitTermination ^ScheduledExecutorService (:heartbeat/executor handle)
+                           200 TimeUnit/MILLISECONDS))
+    (let [count-at-stop (count @events)]
+      (Thread/sleep 75)
+      (is (= count-at-stop (count @events))))))
+
+(deftest stop-heartbeat!-is-safe
+  (is (nil? (heartbeat/stop-heartbeat! nil)))
+  (let [{:keys [stream]} (collecting-stream)
+        handle (heartbeat/start-heartbeat! stream (random-uuid) :plan)]
+    (heartbeat/stop-heartbeat! handle)
+    (is (nil? (heartbeat/stop-heartbeat! handle)))))
+
+(deftest start-heartbeat!-rejects-invalid-interval
+  (let [{:keys [stream]} (collecting-stream)]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"positive integer"
+                          (heartbeat/start-heartbeat! stream (random-uuid) :plan
+                                                      {:interval-ms 0})))))


### PR DESCRIPTION
## Summary
- add an event-stream heartbeat scheduler that emits :workflow/phase-heartbeat events
- expose start-heartbeat! and stop-heartbeat! from the event-stream interface
- cover handle shape, liveness fields, stop behavior, and nil-safe stop

## Size
- commit-budget: 128 / 200 lines

## Test
- clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.event-stream.heartbeat-test)(let [r (clojure.test/run-tests 'ai.miniforge.event-stream.heartbeat-test)](System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
- clj-kondo --lint components/event-stream/src/ai/miniforge/event_stream/heartbeat.clj components/event-stream/src/ai/miniforge/event_stream/interface.clj components/event-stream/test/ai/miniforge/event_stream/heartbeat_test.clj
- git commit hook pre-commit smoke