### PR TITLE
feat: wire phase heartbeat lifecycle

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -6,6 +6,8 @@
   :warn/publish-completed    "Warning: Failed to publish workflow-completed event: {error}"
   :warn/publish-phase-started   "Warning: Failed to publish phase-started event: {error}"
   :warn/publish-phase-completed "Warning: Failed to publish phase-completed event: {error}"
+  :warn/heartbeat-start      "Warning: Failed to start phase heartbeat: {error}"
+  :warn/heartbeat-stop       "Warning: Failed to stop phase heartbeat: {error}"
   :warn/health-check         "Warning: Self-healing health check failed: {error}"
 
   ;; Workflow status messages

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -293,21 +293,37 @@
 (defn- wrap-phase-callbacks
   "Wrap caller callbacks with event publishing."
   [event-stream opts]
-  (letfn [(phase-name [interceptor]
-            (get interceptor :phase
-                 (get-in interceptor [:config :phase])))
-          (on-phase-start [ctx interceptor]
-            (when-let [phase-name' (phase-name interceptor)]
-              (events/publish-phase-started! event-stream ctx phase-name'))
-            (when-let [callback (:on-phase-start opts)]
-              (callback ctx interceptor)))
-          (on-phase-complete [ctx interceptor result]
-            (when-let [phase-name' (phase-name interceptor)]
-              (events/publish-phase-completed! event-stream ctx phase-name' result))
-            (when-let [callback (:on-phase-complete opts)]
-              (callback ctx interceptor result)))]
-    {:on-phase-start on-phase-start
-     :on-phase-complete on-phase-complete}))
+  (let [heartbeat-handles (atom {})
+        heartbeat-opts (cond-> {}
+                         (:phase-heartbeat-interval-ms opts)
+                         (assoc :interval-ms (:phase-heartbeat-interval-ms opts)))
+        stop-heartbeat! (fn [phase-name']
+                          (when-let [handle (get @heartbeat-handles phase-name')]
+                            (events/stop-phase-heartbeat! handle)
+                            (swap! heartbeat-handles dissoc phase-name')))
+        stop-all-heartbeats! (fn []
+                               (doseq [phase-name' (keys @heartbeat-handles)]
+                                 (stop-heartbeat! phase-name')))]
+    (letfn [(phase-name [interceptor]
+              (get interceptor :phase
+                   (get-in interceptor [:config :phase])))
+            (on-phase-start [ctx interceptor]
+              (when-let [phase-name' (phase-name interceptor)]
+                (events/publish-phase-started! event-stream ctx phase-name')
+                (when-let [handle (events/start-phase-heartbeat! event-stream ctx phase-name'
+                                                                  heartbeat-opts)]
+                  (swap! heartbeat-handles assoc phase-name' handle)))
+              (when-let [callback (:on-phase-start opts)]
+                (callback ctx interceptor)))
+            (on-phase-complete [ctx interceptor result]
+              (when-let [phase-name' (phase-name interceptor)]
+                (stop-heartbeat! phase-name')
+                (events/publish-phase-completed! event-stream ctx phase-name' result))
+              (when-let [callback (:on-phase-complete opts)]
+                (callback ctx interceptor result)))]
+      {:on-phase-start on-phase-start
+       :on-phase-complete on-phase-complete
+       :stop-phase-heartbeats! stop-all-heartbeats!})))
 
 (defn- governed-capsule-missing-anomaly
   "Return an `:invalid-input` anomaly when `:governed` mode is requested
@@ -487,8 +503,10 @@
          (when-not skip-lifecycle?
            (events/publish-workflow-completed! event-stream output-ctx))
          output-ctx)
-       (finally
-         (cleanup/post-workflow-cleanup! opts @output-ctx-vol workflow
+      (finally
+        (when-let [stop-heartbeats! (:stop-phase-heartbeats! callbacks)]
+          (stop-heartbeats!))
+        (cleanup/post-workflow-cleanup! opts @output-ctx-vol workflow
                                         @exception-vol acquired-env))))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -323,6 +323,28 @@
         (println (messages/t :warn/publish-phase-completed {:error (ex-message e)}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
+;; Phase heartbeat lifecycle
+
+(defn start-phase-heartbeat!
+  ([event-stream context phase-name]
+   (start-phase-heartbeat! event-stream context phase-name {}))
+  ([event-stream context phase-name opts]
+   (when (durable-event-stream? event-stream)
+     (try
+       (es/start-heartbeat! event-stream (:execution/id context) phase-name opts)
+       (catch Exception e
+         (println (messages/t :warn/heartbeat-start {:error (ex-message e)}))
+         nil)))))
+
+(defn stop-phase-heartbeat!
+  "Stop a phase heartbeat handle. Nil-safe."
+  [handle]
+  (try
+    (es/stop-heartbeat! handle)
+    (catch Exception e
+      (println (messages/t :warn/heartbeat-stop {:error (ex-message e)})))))
+
+;------------------------------------------------------------------------------ Layer 2
 ;; Health check at phase boundary
 
 (defn check-backend-health-at-boundary!

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -137,6 +137,11 @@
   (testing "nil event-stream does not throw"
     (is (nil? (events/publish-phase-started! nil (test-context) :plan)))))
 
+(deftest start-phase-heartbeat-websocket-stream-is-noop-test
+  (testing "heartbeats require a durable stream because the scheduler derefs it"
+    (is (nil? (events/start-phase-heartbeat! {:websocket :fake} (test-context) :plan
+                                             {:interval-ms 10})))))
+
 ;------------------------------------------------------------------------------ publish-phase-completed!
 
 (deftest publish-phase-completed-includes-transition-request-test

--- a/components/workflow/test/ai/miniforge/workflow/runner_pipeline_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_pipeline_test.clj
@@ -26,6 +26,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.workflow.runner :as runner]
+   [ai.miniforge.workflow.runner-events :as events]
    [ai.miniforge.workflow.runner-cleanup :as cleanup]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -76,7 +77,31 @@
   (testing "wraps both on-phase-start and on-phase-complete"
     (let [callbacks (wrap-phase-callbacks nil {})]
       (is (fn? (:on-phase-start callbacks)))
-      (is (fn? (:on-phase-complete callbacks))))))
+      (is (fn? (:on-phase-complete callbacks)))
+      (is (fn? (:stop-phase-heartbeats! callbacks))))))
+
+(deftest wrap-phase-callbacks-stops-heartbeat-on-complete-test
+  (let [stopped (atom [])
+        callbacks (wrap-phase-callbacks nil {})
+        ctx {:execution/id (random-uuid)}
+        interceptor {:phase :implement}]
+    (with-redefs [events/publish-phase-started! (constantly nil)
+                  events/publish-phase-completed! (constantly nil)
+                  events/start-phase-heartbeat! (fn [& _] :handle)
+                  events/stop-phase-heartbeat! #(swap! stopped conj %)]
+      ((:on-phase-start callbacks) ctx interceptor)
+      ((:on-phase-complete callbacks) ctx interceptor {:status :success}))
+    (is (= [:handle] @stopped))))
+
+(deftest wrap-phase-callbacks-stop-all-cleans-active-heartbeats-test
+  (let [stopped (atom [])
+        callbacks (wrap-phase-callbacks nil {})]
+    (with-redefs [events/publish-phase-started! (constantly nil)
+                  events/start-phase-heartbeat! (fn [& _] :handle)
+                  events/stop-phase-heartbeat! #(swap! stopped conj %)]
+      ((:on-phase-start callbacks) {:execution/id (random-uuid)} {:phase :verify})
+      ((:stop-phase-heartbeats! callbacks)))
+    (is (= [:handle] @stopped))))
 
 (deftest post-workflow-cleanup-survives-nil-test
   (testing "cleanup handles all-nil args without throwing"


### PR DESCRIPTION
## Summary
- start phase heartbeat schedulers from workflow phase-start callbacks
- stop phase heartbeat handles on phase completion and in run-pipeline cleanup
- add workflow message keys and callback tests for stop-on-complete and stop-all cleanup

## Size
- commit-budget: 94 / 200 lines

## Test
- clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.workflow.runner-pipeline-test)(let [r (clojure.test/run-tests 'ai.miniforge.workflow.runner-pipeline-test)](System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
- clj-kondo --lint components/workflow/src/ai/miniforge/workflow/runner.clj components/workflow/src/ai/miniforge/workflow/runner_events.clj components/workflow/test/ai/miniforge/workflow/runner_pipeline_test.clj components/workflow/resources/config/workflow/messages/en-US.edn
- git commit hook pre-commit smoke