### PR TITLE
GROUP 3a: Event timeline renderer in the event-stream component.

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -31,7 +31,8 @@
    [ai.miniforge.event-stream.digest :as digest]
    [ai.miniforge.event-stream.heartbeat :as heartbeat]
    [ai.miniforge.event-stream.reader :as reader]
-   [ai.miniforge.event-stream.sinks :as sinks]))
+   [ai.miniforge.event-stream.sinks :as sinks]
+   [ai.miniforge.event-stream.timeline :as timeline]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Stream lifecycle and control state
@@ -198,3 +199,8 @@
 (def strip-transit-prefix reader/strip-transit-prefix)
 (def read-workflow-events reader/read-workflow-events)
 (def read-workflow-events-by-id reader/read-workflow-events-by-id)
+
+;------------------------------------------------------------------------------ Layer 5
+;; Event timeline renderer
+
+(def render-timeline timeline/render-timeline)

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -161,15 +161,31 @@
     (format "%s  %s  %s  %s" ts phase tool args-sum)))
 
 (defn- render-tool-call-completed
-  "`:tool/call-completed` — show tool name + duration + success/error."
-  [event]
+  "`:tool/call-completed` — show tool name + duration + success/error.
+
+   Per `schema/ToolCallCompleted` the event does NOT carry `:tool/name`;
+   the name lives on the paired `:agent/tool-call-started` event,
+   correlated via `:tool/call-id`. `tool-names-by-call-id` is the
+   correlation map built by `render-timeline` as it walks the stream.
+   Fallbacks (in order): correlated name → `:tool/call-id` →
+   `<unknown>`.
+
+   Status is sourced from `:tool/success?` (per the schema), with
+   `:tool/error` presence as the secondary signal for legacy events
+   that omitted the boolean."
+  [event tool-names-by-call-id]
   (let [ts       (format-hms (event-timestamp event))
         phase    (event-phase event)
-        tool     (or (:tool/name event) "<unknown>")
+        call-id  (:tool/call-id event)
+        tool     (or (get tool-names-by-call-id call-id)
+                     call-id
+                     "<unknown>")
         dur-ms   (:tool/duration-ms event)
-        status   (if (get event :tool/error)
-                   "error"
-                   "success")
+        status   (cond
+                   (false? (:tool/success? event)) "error"
+                   (true?  (:tool/success? event)) "success"
+                   (some? (:tool/error event))     "error"
+                   :else                           "success")
         dur-str  (if dur-ms
                    (str "  " (format-duration-ms dur-ms) "  " status)
                    (str "  " status))]
@@ -219,15 +235,20 @@
     (format "%s  %s  %s  %s" ts phase (str ev-type) (truncate msg args-preview-length))))
 
 (defn- render-event
-  "Dispatch to the appropriate per-event-type renderer."
-  [event]
+  "Dispatch to the appropriate per-event-type renderer.
+
+   `tool-names-by-call-id` is the correlation map render-timeline
+   builds as it walks the event stream — only consulted by the
+   completed-event renderer, but threaded through every dispatch so
+   the signature stays uniform."
+  [event tool-names-by-call-id]
   (let [et (event-type event)]
     (cond
       (contains? terminal-event-types et)   (render-terminal event)
       (contains? stall-event-types et)      (render-stall event)
       (contains? phase-lifecycle-types et)  (render-phase-lifecycle event)
       (= et :agent/tool-call-started)       (render-tool-call-started event)
-      (= et :tool/call-completed)           (render-tool-call-completed event)
+      (= et :tool/call-completed)           (render-tool-call-completed event tool-names-by-call-id)
       :else                                 (render-generic event))))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -245,6 +266,21 @@
 ;------------------------------------------------------------------------------ Layer 3
 ;; Public API
 
+(defn- index-tool-names
+  "Build a `{tool-call-id → tool-name}` lookup map from the event stream.
+
+   `:tool/call-completed` events don't carry the tool name (per the
+   `ToolCallCompleted` schema) — the name lives on the paired
+   `:agent/tool-call-started` event. Pre-walk the stream once so the
+   completed-event renderer can look the name up without re-scanning."
+  [events]
+  (->> events
+       (filter #(and (= :agent/tool-call-started (event-type %))
+                     (:tool/call-id %)
+                     (:tool/name %)))
+       (reduce (fn [m e] (assoc m (:tool/call-id e) (:tool/name e)))
+               {})))
+
 (defn render-timeline
   "Transform a seq of parsed event maps into a human-readable timeline string.
 
@@ -261,20 +297,30 @@
      (render-timeline events)        — default 60s gap threshold
      (render-timeline events opts)   — opts: {:gap-threshold-ms long}
 
-   Returns a string. Pure function — no IO."
+   Returns a string (empty string for empty / nil input — consistent
+   return type so callers don't have to nil-check before
+   `println`/`spit`). Pure function — no IO."
   ([events]
    (render-timeline events {}))
   ([events opts]
-   (when (seq events)
+   (if (empty? events)
+     ""
      (let [gap-threshold (get opts :gap-threshold-ms default-gap-threshold-ms)
+           name-by-id    (index-tool-names events)
            lines         (reduce
                           (fn [{:keys [prev-ts lines]} event]
-                            (let [cur-ts (ts->epoch-ms (event-timestamp event))
-                                  gap-line (when (and prev-ts cur-ts
-                                                      (> (- cur-ts prev-ts) gap-threshold))
-                                             (render-gap-line prev-ts cur-ts (- cur-ts prev-ts)))
-                                  event-line (render-event event)]
-                              {:prev-ts (or cur-ts prev-ts)
+                            (let [cur-ts     (ts->epoch-ms (event-timestamp event))
+                                  gap-line   (when (and prev-ts cur-ts
+                                                        (> (- cur-ts prev-ts) gap-threshold))
+                                               (render-gap-line prev-ts cur-ts (- cur-ts prev-ts)))
+                                  event-line (render-event event name-by-id)]
+                              ;; Update `:prev-ts` to `cur-ts` (allowing
+                              ;; nil) rather than clinging to the last
+                              ;; non-nil value — otherwise an event with
+                              ;; no timestamp injected between two
+                              ;; timestamped events fires a phantom gap
+                              ;; line spanning across it.
+                              {:prev-ts cur-ts
                                :lines   (cond-> lines
                                           gap-line   (conj gap-line)
                                           event-line (conj event-line))}))
@@ -290,7 +336,7 @@
     (println (render-timeline events)))
 
   (render-timeline [] {})
-  ;; => nil
+  ;; => ""
 
   (render-timeline
    [{:event/type      :agent/tool-call-started

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -1,0 +1,302 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.timeline
+  "Pure namespace: transforms a seq of parsed event maps into a
+   human-readable timeline string.
+
+   Input: event maps as returned by `reader/read-workflow-events`.
+   Output: a multi-line string. No IO, no side effects.
+
+   Column layout per event line:
+     HH:mm:ss  <phase>  <tool-name>  <args-summary>
+
+   Gap detection: consecutive events whose timestamp gap exceeds
+   `gap-threshold-ms` (default 60 000 ms) produce an inserted gap line:
+     HH:mm:ss→HH:mm:ss — Xm Ys event-stream gap (stalled)
+
+   Terminal events (:workflow/completed, :workflow/failed) produce:
+     HH:mm:ss  <phase>  TERMINATED  <reason>"
+  (:import
+   [java.text SimpleDateFormat]
+   [java.util Date TimeZone]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants
+
+(def ^:const default-gap-threshold-ms
+  "Default gap threshold in milliseconds (60 seconds)."
+  60000)
+
+(def ^:const args-preview-length
+  "Maximum character length for the args-summary column."
+  60)
+
+(def ^:private terminal-event-types
+  "Event types that denote workflow termination."
+  #{:workflow/completed :workflow/failed})
+
+(def ^:private stall-event-types
+  "Event types that denote stream stalls."
+  #{:agent/stream-stalled})
+
+(def ^:private phase-lifecycle-types
+  "Event types for phase start/stop lifecycle."
+  #{:workflow/phase-started :workflow/phase-completed})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Time formatting helpers
+
+(defn- make-hms-formatter
+  "Create a thread-local HH:mm:ss formatter in UTC."
+  ^SimpleDateFormat []
+  (doto (SimpleDateFormat. "HH:mm:ss")
+    (.setTimeZone (TimeZone/getTimeZone "UTC"))))
+
+(def ^:private ^ThreadLocal hms-formatter-local
+  "Thread-local SimpleDateFormat to avoid allocation on hot paths."
+  (proxy [ThreadLocal] []
+    (initialValue [] (make-hms-formatter))))
+
+(defn- format-hms
+  "Format `ts` (a Date, long epoch-ms, or ISO-8601 string) as HH:mm:ss.
+   Returns \"??:??:??\" when `ts` is nil or unparseable."
+  [ts]
+  (try
+    (let [^SimpleDateFormat fmt (.get hms-formatter-local)
+          ^Date d (cond
+                    (nil? ts)    nil
+                    (instance? Date ts) ts
+                    (number? ts) (Date. (long ts))
+                    (string? ts) (-> (java.time.Instant/parse ts)
+                                     (.toEpochMilli)
+                                     (Date.))
+                    :else        nil)]
+      (if d
+        (.format fmt d)
+        "??:??:??"))
+    (catch Exception _
+      "??:??:??")))
+
+(defn- ts->epoch-ms
+  "Coerce `ts` to epoch-ms long. Returns nil on failure."
+  [ts]
+  (try
+    (cond
+      (nil? ts)            nil
+      (instance? Date ts)  (.getTime ^Date ts)
+      (number? ts)         (long ts)
+      (string? ts)         (-> (java.time.Instant/parse ts)
+                               (.toEpochMilli))
+      :else                nil)
+    (catch Exception _
+      nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Field extraction helpers
+
+(defn- event-timestamp [event]
+  (:event/timestamp event))
+
+(defn- event-phase [event]
+  (or (:workflow/phase event) "-"))
+
+(defn- event-type [event]
+  (:event/type event))
+
+(defn- truncate
+  "Truncate string `s` to at most `n` characters, appending \"…\" if cut."
+  [s n]
+  (when (string? s)
+    (if (<= (count s) n)
+      s
+      (str (subs s 0 (dec n)) "…"))))
+
+(defn- args-summary
+  "Extract the args preview from an event, truncated to `args-preview-length` chars.
+   Prefers `:tool/args-digest :digest/preview`, falls back to `:message`."
+  [event]
+  (let [preview (get-in event [:tool/args-digest :digest/preview])
+        raw     (or preview (:message event) "")]
+    (truncate (str raw) args-preview-length)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Duration helpers
+
+(defn- format-duration-ms
+  "Format `ms` as a human-readable \"Xm Ys\" string (omits minutes if 0)."
+  [ms]
+  (let [total-s (long (/ ms 1000))
+        m       (long (/ total-s 60))
+        s       (long (rem total-s 60))]
+    (if (pos? m)
+      (format "%dm %ds" m s)
+      (format "%ds" s))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Per-event-type render dispatch
+
+(defn- render-tool-call-started
+  "`:agent/tool-call-started` — show tool name + args digest preview."
+  [event]
+  (let [ts       (format-hms (event-timestamp event))
+        phase    (event-phase event)
+        tool     (or (:tool/name event) "<unknown>")
+        args-sum (args-summary event)]
+    (format "%s  %s  %s  %s" ts phase tool args-sum)))
+
+(defn- render-tool-call-completed
+  "`:tool/call-completed` — show tool name + duration + success/error."
+  [event]
+  (let [ts       (format-hms (event-timestamp event))
+        phase    (event-phase event)
+        tool     (or (:tool/name event) "<unknown>")
+        dur-ms   (:tool/duration-ms event)
+        status   (if (get event :tool/error)
+                   "error"
+                   "success")
+        dur-str  (if dur-ms
+                   (str "  " (format-duration-ms dur-ms) "  " status)
+                   (str "  " status))]
+    (format "%s  %s  %s%s" ts phase tool dur-str)))
+
+(defn- render-phase-lifecycle
+  "`:workflow/phase-started` / `:workflow/phase-completed` — phase lifecycle."
+  [event]
+  (let [ts       (format-hms (event-timestamp event))
+        phase    (event-phase event)
+        ev-type  (event-type event)
+        suffix   (case ev-type
+                   :workflow/phase-started   "started"
+                   :workflow/phase-completed "completed"
+                   (name ev-type))
+        msg      (or (:message event) "")]
+    (if (seq msg)
+      (format "%s  %s  [phase %s]  %s" ts phase suffix msg)
+      (format "%s  %s  [phase %s]" ts phase suffix))))
+
+(defn- render-terminal
+  "`:workflow/completed` / `:workflow/failed` — terminal status with TERMINATED marker."
+  [event]
+  (let [ts     (format-hms (event-timestamp event))
+        phase  (event-phase event)
+        reason (or (:message event)
+                   (when-let [r (:workflow/result event)]
+                     (str r))
+                   "")]
+    (format "%s  %s  TERMINATED  %s" ts phase reason)))
+
+(defn- render-stall
+  "`:agent/stream-stalled` — stall marker."
+  [event]
+  (let [ts  (format-hms (event-timestamp event))
+        phase (event-phase event)
+        msg (or (:message event) "stream stalled")]
+    (format "%s  %s  [stall]  %s" ts phase msg)))
+
+(defn- render-generic
+  "Catch-all for event types without a specific renderer."
+  [event]
+  (let [ts       (format-hms (event-timestamp event))
+        phase    (event-phase event)
+        ev-type  (or (event-type event) "<unknown>")
+        msg      (or (:message event) "")]
+    (format "%s  %s  %s  %s" ts phase (str ev-type) (truncate msg args-preview-length))))
+
+(defn- render-event
+  "Dispatch to the appropriate per-event-type renderer."
+  [event]
+  (let [et (event-type event)]
+    (cond
+      (contains? terminal-event-types et)   (render-terminal event)
+      (contains? stall-event-types et)      (render-stall event)
+      (contains? phase-lifecycle-types et)  (render-phase-lifecycle event)
+      (= et :agent/tool-call-started)       (render-tool-call-started event)
+      (= et :tool/call-completed)           (render-tool-call-completed event)
+      :else                                 (render-generic event))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Gap line rendering
+
+(defn- render-gap-line
+  "Format a gap line between two events with timestamps `ts-a` and `ts-b`
+   and a computed gap of `gap-ms` milliseconds."
+  [ts-a ts-b gap-ms]
+  (format "%s→%s — %s event-stream gap (stalled)"
+          (format-hms ts-a)
+          (format-hms ts-b)
+          (format-duration-ms gap-ms)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Public API
+
+(defn render-timeline
+  "Transform a seq of parsed event maps into a human-readable timeline string.
+
+   Each event renders as one line:
+     HH:mm:ss  <phase>  <detail>
+
+   Gap lines are inserted between consecutive events whose timestamp gap
+   exceeds `gap-threshold-ms` (default 60 000 ms):
+     HH:mm:ss→HH:mm:ss — Xm Ys event-stream gap (stalled)
+
+   Terminal events render with TERMINATED marker.
+
+   Arity:
+     (render-timeline events)        — default 60s gap threshold
+     (render-timeline events opts)   — opts: {:gap-threshold-ms long}
+
+   Returns a string. Pure function — no IO."
+  ([events]
+   (render-timeline events {}))
+  ([events opts]
+   (when (seq events)
+     (let [gap-threshold (get opts :gap-threshold-ms default-gap-threshold-ms)
+           lines         (reduce
+                          (fn [{:keys [prev-ts lines]} event]
+                            (let [cur-ts (ts->epoch-ms (event-timestamp event))
+                                  gap-line (when (and prev-ts cur-ts
+                                                      (> (- cur-ts prev-ts) gap-threshold))
+                                             (render-gap-line prev-ts cur-ts (- cur-ts prev-ts)))
+                                  event-line (render-event event)]
+                              {:prev-ts (or cur-ts prev-ts)
+                               :lines   (cond-> lines
+                                          gap-line   (conj gap-line)
+                                          event-line (conj event-line))}))
+                          {:prev-ts nil :lines []}
+                          events)]
+       (clojure.string/join "\n" (:lines lines))))))
+
+;------------------------------------------------------------------------------ Rich comment
+(comment
+  ;; Example usage:
+  (require '[ai.miniforge.event-stream.reader :as reader])
+  (let [events (reader/read-workflow-events "/tmp/my-workflow")]
+    (println (render-timeline events)))
+
+  (render-timeline [] {})
+  ;; => nil
+
+  (render-timeline
+   [{:event/type      :agent/tool-call-started
+     :event/timestamp (java.util.Date.)
+     :workflow/phase  :implement
+     :tool/name       "Write"
+     :tool/args-digest {:digest/preview "Writing src/foo.clj"}}])
+  ;; => "HH:mm:ss  implement  Write  Writing src/foo.clj"
+  )

--- a/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
@@ -1,0 +1,225 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.timeline-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.event-stream.timeline :as sut]))
+
+;------------------------------------------------------------------------------ helpers
+
+(defn- epoch->date
+  "Coerce epoch-ms long to a java.util.Date."
+  [ms]
+  (java.util.Date. (long ms)))
+
+(def ^:private base-ms
+  "A fixed epoch-ms (2025-01-01T00:00:00Z) for deterministic timestamps."
+  1735689600000)
+
+(defn- mk-event
+  "Build a minimal event map with optional extra keys merged in."
+  [event-type ts-offset-ms & {:as extra}]
+  (merge {:event/type      event-type
+          :event/timestamp (epoch->date (+ base-ms ts-offset-ms))
+          :workflow/phase  :implement}
+         extra))
+
+;------------------------------------------------------------------------------ tests
+
+(deftest empty-events-returns-empty-string
+  (testing "empty seq returns nil (no output)"
+    (is (nil? (sut/render-timeline [])))
+    (is (nil? (sut/render-timeline nil)))
+    (is (nil? (sut/render-timeline [] {})))))
+
+(deftest tool-call-started-renders-correctly
+  (testing "agent/tool-call-started shows tool name and args digest preview"
+    (let [event  (mk-event :agent/tool-call-started 0
+                            :tool/name "Write"
+                            :tool/args-digest {:digest/preview "Writing src/foo.clj"})
+          result (sut/render-timeline [event])]
+      (is (string? result))
+      (is (str/includes? result "Write"))
+      (is (str/includes? result "Writing src/foo.clj"))
+      (is (str/includes? result "implement")))))
+
+(deftest tool-call-completed-renders-correctly
+  (testing "tool/call-completed shows tool name, duration, and success status"
+    (let [event  (mk-event :tool/call-completed 1000
+                            :tool/name "Write"
+                            :tool/duration-ms 423)
+          result (sut/render-timeline [event])]
+      (is (str/includes? result "Write"))
+      (is (str/includes? result "success"))
+      (is (str/includes? result "0s"))))
+
+  (testing "tool/call-completed shows error status when :tool/error is present"
+    (let [event  (mk-event :tool/call-completed 2000
+                            :tool/name "Read"
+                            :tool/duration-ms 100
+                            :tool/error "file not found")
+          result (sut/render-timeline [event])]
+      (is (str/includes? result "error")))))
+
+(deftest tool-call-pair-renders-both-lines
+  (testing "started + completed pair produces two lines"
+    (let [events [(mk-event :agent/tool-call-started 0
+                            :tool/name "Bash"
+                            :tool/args-digest {:digest/preview "ls -la"})
+                  (mk-event :tool/call-completed 500
+                            :tool/name "Bash"
+                            :tool/duration-ms 500)]
+          result (sut/render-timeline events)
+          lines  (str/split-lines result)]
+      (is (= 2 (count lines)))
+      (is (str/includes? (first lines) "Bash"))
+      (is (str/includes? (second lines) "success")))))
+
+(deftest gap-detection-inserts-stall-line
+  (testing "gap above threshold inserts a gap line between events"
+    ;; Put events 90 seconds apart (above default 60s threshold)
+    (let [events [(mk-event :agent/tool-call-started 0
+                            :tool/name "Read")
+                  (mk-event :agent/tool-call-started 90000
+                            :tool/name "Write")]
+          result (sut/render-timeline events)
+          lines  (str/split-lines result)]
+      (is (= 3 (count lines)))
+      (is (str/includes? (second lines) "event-stream gap (stalled)"))))
+
+  (testing "gap below threshold does not insert a gap line"
+    ;; 30 seconds — under default 60s
+    (let [events [(mk-event :agent/tool-call-started 0
+                            :tool/name "Read")
+                  (mk-event :agent/tool-call-started 30000
+                            :tool/name "Write")]
+          result (sut/render-timeline events)
+          lines  (str/split-lines result)]
+      (is (= 2 (count lines)))))
+
+  (testing "custom gap threshold is respected"
+    ;; 15 seconds gap, threshold set to 10s — should trigger
+    (let [events [(mk-event :agent/tool-call-started 0
+                            :tool/name "Read")
+                  (mk-event :agent/tool-call-started 15000
+                            :tool/name "Write")]
+          result (sut/render-timeline events {:gap-threshold-ms 10000})
+          lines  (str/split-lines result)]
+      (is (= 3 (count lines)))
+      (is (str/includes? (second lines) "event-stream gap (stalled)")))))
+
+(deftest terminal-event-renders-terminated-marker
+  (testing "workflow/completed renders TERMINATED marker"
+    (let [event  (mk-event :workflow/completed 5000
+                            :message "all phases passed")
+          result (sut/render-timeline [event])]
+      (is (str/includes? result "TERMINATED"))
+      (is (str/includes? result "all phases passed"))))
+
+  (testing "workflow/failed renders TERMINATED marker"
+    (let [event  (mk-event :workflow/failed 5000
+                            :message "phase implement failed")
+          result (sut/render-timeline [event])]
+      (is (str/includes? result "TERMINATED"))
+      (is (str/includes? result "phase implement failed")))))
+
+(deftest phase-lifecycle-events-render
+  (testing "workflow/phase-started renders phase started label"
+    (let [event  (mk-event :workflow/phase-started 0
+                            :workflow/phase :plan
+                            :message "starting plan phase")
+          result (sut/render-timeline [event])]
+      (is (str/includes? result "phase started"))
+      (is (str/includes? result "starting plan phase"))))
+
+  (testing "workflow/phase-completed renders phase completed label"
+    (let [event  (mk-event :workflow/phase-completed 1000
+                            :workflow/phase :plan)
+          result (sut/render-timeline [event])]
+      (is (str/includes? result "phase completed")))))
+
+(deftest stream-stall-event-renders
+  (testing "agent/stream-stalled renders stall marker"
+    (let [event  (mk-event :agent/stream-stalled 3000
+                            :message "no output for 120s")
+          result (sut/render-timeline [event])]
+      (is (str/includes? result "[stall]"))
+      (is (str/includes? result "no output for 120s")))))
+
+(deftest generic-event-renders-fallback
+  (testing "unknown event type renders event-type + message"
+    (let [event  (mk-event :some/unknown-event 1000
+                            :message "something happened")
+          result (sut/render-timeline [event])]
+      (is (str/includes? result ":some/unknown-event"))
+      (is (str/includes? result "something happened")))))
+
+(deftest events-without-timestamps-handled-gracefully
+  (testing "events with nil timestamp render with ?? placeholders but do not throw"
+    (let [event  {:event/type     :agent/tool-call-started
+                  :workflow/phase :implement
+                  :tool/name      "Read"}
+          result (sut/render-timeline [event])]
+      (is (string? result))
+      (is (str/includes? result "??:??:??"))))
+
+  (testing "gap detection is skipped when timestamps are absent"
+    (let [events [{:event/type     :agent/tool-call-started
+                   :tool/name      "Read"}
+                  {:event/type     :agent/tool-call-started
+                   :tool/name      "Write"}]
+          result (sut/render-timeline events)
+          lines  (str/split-lines result)]
+      ;; No gap line expected — timestamps are nil so gap cannot be computed
+      (is (= 2 (count lines))))))
+
+(deftest args-summary-truncated-at-60-chars
+  (testing "args preview longer than 60 chars is truncated"
+    (let [long-preview (apply str (repeat 80 "x"))
+          event        (mk-event :agent/tool-call-started 0
+                                 :tool/name "Write"
+                                 :tool/args-digest {:digest/preview long-preview})
+          result       (sut/render-timeline [event])]
+      ;; Must not contain the full 80-char string
+      (is (not (str/includes? result long-preview)))
+      ;; Must contain truncation indicator
+      (is (str/includes? result "…")))))
+
+(deftest message-fallback-when-no-args-digest
+  (testing "falls back to :message when :tool/args-digest is absent"
+    (let [event  (mk-event :agent/tool-call-started 0
+                            :tool/name "Bash"
+                            :message "running tests")
+          result (sut/render-timeline [event])]
+      (is (str/includes? result "running tests")))))
+
+(deftest render-timeline-returns-string
+  (testing "render-timeline with multiple events returns a single string"
+    (let [events [(mk-event :workflow/phase-started 0 :workflow/phase :plan)
+                  (mk-event :agent/tool-call-started 1000
+                            :tool/name "Write"
+                            :tool/args-digest {:digest/preview "foo"})
+                  (mk-event :tool/call-completed 2000
+                            :tool/name "Write"
+                            :tool/duration-ms 1000)
+                  (mk-event :workflow/completed 3000 :message "done")]
+          result (sut/render-timeline events)]
+      (is (string? result))
+      (is (= 4 (count (str/split-lines result)))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
@@ -44,10 +44,10 @@
 ;------------------------------------------------------------------------------ tests
 
 (deftest empty-events-returns-empty-string
-  (testing "empty seq returns nil (no output)"
-    (is (nil? (sut/render-timeline [])))
-    (is (nil? (sut/render-timeline nil)))
-    (is (nil? (sut/render-timeline [] {})))))
+  (testing "empty / nil input yields empty string — consistent return type so callers don't have to nil-check"
+    (is (= "" (sut/render-timeline [])))
+    (is (= "" (sut/render-timeline nil)))
+    (is (= "" (sut/render-timeline [] {})))))
 
 (deftest tool-call-started-renders-correctly
   (testing "agent/tool-call-started shows tool name and args digest preview"
@@ -60,36 +60,71 @@
       (is (str/includes? result "Writing src/foo.clj"))
       (is (str/includes? result "implement")))))
 
-(deftest tool-call-completed-renders-correctly
-  (testing "tool/call-completed shows tool name, duration, and success status"
-    (let [event  (mk-event :tool/call-completed 1000
+(deftest tool-call-completed-uses-tool-success-flag-not-error-presence
+  (testing "tool/call-completed shows success status from :tool/success? per ToolCallCompleted schema"
+    ;; ToolCallCompleted in schema.clj does NOT carry :tool/name; the
+    ;; name is correlated via :tool/call-id back to the started event
+    ;; (see render-timeline/index-tool-names). Status comes from
+    ;; :tool/success? (boolean), with :tool/error presence as a
+    ;; secondary signal — fixtures here match the real emitted shape.
+    (let [events [(mk-event :agent/tool-call-started 0
                             :tool/name "Write"
-                            :tool/duration-ms 423)
-          result (sut/render-timeline [event])]
-      (is (str/includes? result "Write"))
+                            :tool/call-id "tc-1"
+                            :tool/args-digest {:digest/preview "Writing src/foo.clj"})
+                  (mk-event :tool/call-completed 1000
+                            :tool/call-id   "tc-1"
+                            :tool/duration-ms 423
+                            :tool/success?  true)]
+          result (sut/render-timeline events)]
+      (is (str/includes? result "Write")
+          "tool name resolved via :tool/call-id correlation, not from a non-existent :tool/name on the completed event")
       (is (str/includes? result "success"))
       (is (str/includes? result "0s"))))
 
-  (testing "tool/call-completed shows error status when :tool/error is present"
-    (let [event  (mk-event :tool/call-completed 2000
+  (testing "tool/call-completed shows error status when :tool/success? is false"
+    (let [events [(mk-event :agent/tool-call-started 0
                             :tool/name "Read"
+                            :tool/call-id "tc-2")
+                  (mk-event :tool/call-completed 2000
+                            :tool/call-id   "tc-2"
                             :tool/duration-ms 100
-                            :tool/error "file not found")
+                            :tool/success?  false
+                            :tool/error     {:type :not-found :path "/missing.clj"})]
+          result (sut/render-timeline events)]
+      (is (str/includes? result "error")
+          "status is sourced from :tool/success? false, not from :tool/error string presence")
+      (is (str/includes? result "Read")
+          "tool name still resolves via correlation in the error path"))))
+
+(deftest tool-call-completed-falls-back-to-call-id-when-no-started-event
+  (testing "if the started event is missing, the completed event renders with :tool/call-id as the tool label"
+    ;; Defensive: prevents <unknown> from showing up when there's a
+    ;; correlatable id but no preceding started event (e.g. truncated
+    ;; event log, replay starting mid-call).
+    (let [event  (mk-event :tool/call-completed 0
+                            :tool/call-id  "tc-orphan"
+                            :tool/success? true)
           result (sut/render-timeline [event])]
-      (is (str/includes? result "error")))))
+      (is (str/includes? result "tc-orphan")
+          "call-id substitutes for tool name when correlation is impossible")
+      (is (not (str/includes? result "<unknown>"))))))
 
 (deftest tool-call-pair-renders-both-lines
-  (testing "started + completed pair produces two lines"
+  (testing "started + completed pair produces two lines, name correlated via :tool/call-id"
     (let [events [(mk-event :agent/tool-call-started 0
                             :tool/name "Bash"
+                            :tool/call-id "tc-3"
                             :tool/args-digest {:digest/preview "ls -la"})
                   (mk-event :tool/call-completed 500
-                            :tool/name "Bash"
-                            :tool/duration-ms 500)]
+                            :tool/call-id   "tc-3"
+                            :tool/duration-ms 500
+                            :tool/success?  true)]
           result (sut/render-timeline events)
           lines  (str/split-lines result)]
       (is (= 2 (count lines)))
       (is (str/includes? (first lines) "Bash"))
+      (is (str/includes? (second lines) "Bash")
+          "completed line carries the same tool name as started, via correlation")
       (is (str/includes? (second lines) "success")))))
 
 (deftest gap-detection-inserts-stall-line

--- a/docs/pull-requests/2026-05-20-group-3a-event-timeline-renderer-in-the-event-stream-component.md
+++ b/docs/pull-requests/2026-05-20-group-3a-event-timeline-renderer-in-the-event-stream-component.md
@@ -1,0 +1,28 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 3a: Event timeline renderer in the event-stream component.
+
+**PR:** [#940](https://github.com/miniforge-ai/miniforge/pull/940)
+**Branch:** `mf/group-3a-event-timeline-renderer-in-the--9af3d247`
+
+## Summary
+
+GROUP 3a: Event timeline renderer in the event-stream component.
+
+## Files Changed
+
+- `components/event-stream/src/ai/miniforge/event_stream/timeline.clj` (create)
+- `components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj` (create)
+- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._


### PR DESCRIPTION
## Summary

GROUP 3a: Event timeline renderer in the event-stream component.

## Changes

- `components/event-stream/src/ai/miniforge/event_stream/timeline.clj` (create)
- `components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj` (create)
- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` (modify)

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (3 files)