### PR TITLE
fix(cli/events + timeline): localize user-facing strings — standards gap from #940 + #941

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -822,4 +822,18 @@
   :backends/status-needs-key                "Needs {api-key-var}"
   :backends/status-unknown                  "Unknown backend type"
   :backends/unknown-issue                   "Unknown issue with backend: {backend}"
-  :backends/validate-unknown                "Unknown backend: {backend}\nRun '{command}' to see available backends."}}
+  :backends/validate-unknown                "Unknown backend: {backend}\nRun '{command}' to see available backends."
+
+  ;; events show <workflow-id> — operator-facing CLI surface
+  :events/dir-not-found
+  "Events directory not found: {base-dir}\nRun at least one workflow first to create it."
+  :events/no-events
+  "No events found for workflow: {workflow-id}\nChecked layouts: archived/, live/, and flat under {base-dir}"
+  :events/no-renderable-events
+  "(no renderable events for workflow {workflow-id})"
+  :events/usage
+  "Usage: miniforge events show <workflow-id>\n  --gap-threshold <seconds>   Gap detection threshold (default: 60)\n  --raw                       Dump parsed events as EDN (debug)"
+  :events/workflow-id-required
+  "Workflow id is required."
+  :events/read-failed
+  "Unable to read workflow events: {error}"}}

--- a/bases/cli/src/ai/miniforge/cli/main/commands/events.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/events.clj
@@ -38,6 +38,7 @@
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -78,13 +79,12 @@
     (cond
       (str/blank? workflow-id)
       {:status :error
-       :message "Workflow id is required."
+       :message (messages/t :events/workflow-id-required)
        :exit-code 1}
 
       (not (fs/exists? base-dir))
       {:status    :error
-       :message   (str "Events directory not found: " base-dir
-                       "\nRun at least one workflow first to create it.")
+       :message   (messages/t :events/dir-not-found {:base-dir (str base-dir)})
        :exit-code 1}
 
       :else
@@ -93,8 +93,9 @@
         (cond
           (nil? events)
           {:status    :error
-           :message   (str "No events found for workflow: " wf-id-str
-                           "\nChecked layouts: archived/, live/, and flat under " base-dir)
+           :message   (messages/t :events/no-events
+                                  {:workflow-id wf-id-str
+                                   :base-dir    (str base-dir)})
            :exit-code 1}
 
           raw
@@ -105,11 +106,11 @@
           (let [rendered (es/render-timeline events {:gap-threshold-ms (gap-threshold-ms gap-threshold)})]
             {:status :ok
              :output (if (str/blank? rendered)
-                       (str "(no renderable events for workflow " wf-id-str ")")
+                       (messages/t :events/no-renderable-events {:workflow-id wf-id-str})
                        rendered)}))))
     (catch Exception e
       {:status :error
-       :message (str "Unable to read workflow events: " (.getMessage e))
+       :message (messages/t :events/read-failed {:error (.getMessage e)})
        :exit-code 1})))
 
 ;------------------------------------------------------------------------------ Layer 3
@@ -128,10 +129,7 @@
   (let [{:keys [workflow-id gap-threshold raw]} opts]
     (if (str/blank? workflow-id)
       (do
-        (display/print-error
-         (str "Usage: miniforge events show <workflow-id>\n"
-              "  --gap-threshold <seconds>   Gap detection threshold (default: 60)\n"
-              "  --raw                       Dump parsed events as EDN (debug)"))
+        (display/print-error (messages/t :events/usage))
         (shared/exit! 1))
       (let [events-dir (app-config/events-dir)
             result     (events-show events-dir workflow-id

--- a/components/event-stream/resources/config/event-stream/messages/en-US.edn
+++ b/components/event-stream/resources/config/event-stream/messages/en-US.edn
@@ -16,6 +16,27 @@
   ;; tool-heavy phases don't look dead. Format: "\n[tool] <names>\n".
   :stream/tool-use-line       "\n[tool] {names}\n"
 
+  ;; ── Timeline renderer (event-stream.timeline) ─────────────────
+  ;; Every label/format string the user sees in `miniforge events
+  ;; show` flows through these keys (per
+  ;; .standards/foundations/localization.mdc — user-facing CLI
+  ;; output is user-locale, not system-locale).
+  :timeline/unknown-time        "??:??:??"
+  :timeline/no-phase            "-"
+  :timeline/truncation-suffix   "…"
+  :timeline/unknown-tool        "<unknown>"
+  :timeline/status-success      "success"
+  :timeline/status-error        "error"
+  :timeline/terminated-marker   "TERMINATED"
+  :timeline/stall-marker        "[stall]"
+  :timeline/stall-default-msg   "stream stalled"
+  :timeline/phase-marker        "[phase {suffix}]"
+  :timeline/phase-suffix-started   "started"
+  :timeline/phase-suffix-completed "completed"
+  :timeline/duration-mins-secs  "{mins}m {secs}s"
+  :timeline/duration-secs       "{secs}s"
+  :timeline/gap-line            "{ts-a}→{ts-b} — {gap} event-stream gap (stalled)"
+
   ;; Status payload published when the agent calls one or more tools.
   :stream/agent-calling-tool  "Agent calling tool"
 

--- a/components/event-stream/resources/config/event-stream/messages/en-US.edn
+++ b/components/event-stream/resources/config/event-stream/messages/en-US.edn
@@ -25,6 +25,10 @@
   :timeline/no-phase            "-"
   :timeline/truncation-suffix   "…"
   :timeline/unknown-tool        "<unknown>"
+  ;; Separate key for the catch-all render path so translators don't
+  ;; have to reason about a tool-shaped label appearing in an
+  ;; event-type-shaped slot. Same visible English; distinct context.
+  :timeline/unknown-event-type  "<unknown>"
   :timeline/status-success      "success"
   :timeline/status-error        "error"
   :timeline/terminated-marker   "TERMINATED"

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -245,7 +245,7 @@
   [event]
   (let [ts       (format-hms (event-timestamp event))
         phase    (event-phase event)
-        ev-type  (or (event-type event) (messages/t :timeline/unknown-tool))
+        ev-type  (or (event-type event) (messages/t :timeline/unknown-event-type))
         msg      (or (:message event) "")]
     (format "%s  %s  %s  %s" ts phase (str ev-type) (truncate msg args-preview-length))))
 

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -131,7 +131,11 @@
   (when (string? s)
     (if (<= (count s) n)
       s
-      (str (subs s 0 (dec n)) (messages/t :timeline/truncation-suffix)))))
+      (let [suffix        (str (messages/t :timeline/truncation-suffix))
+            suffix-length (min (count suffix) (max 0 n))
+            prefix-length (max 0 (- n suffix-length))]
+        (str (subs s 0 prefix-length)
+             (subs suffix 0 suffix-length))))))
 
 (defn- args-summary
   "Extract the args preview from an event, truncated to `args-preview-length` chars.

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -27,11 +27,15 @@
      HH:mm:ss  <phase>  <tool-name>  <args-summary>
 
    Gap detection: consecutive events whose timestamp gap exceeds
-   `gap-threshold-ms` (default 60 000 ms) produce an inserted gap line:
-     HH:mm:ss→HH:mm:ss — Xm Ys event-stream gap (stalled)
+   `gap-threshold-ms` (default 60 000 ms) produce an inserted gap line.
 
-   Terminal events (:workflow/completed, :workflow/failed) produce:
-     HH:mm:ss  <phase>  TERMINATED  <reason>"
+   Every user-facing label/marker (status words, missing-value
+   sentinels, format templates) flows through `messages/t` per
+   .standards/foundations/localization.mdc — the catalog lives at
+   `resources/config/event-stream/messages/en-US.edn` under the
+   `:timeline/*` namespace."
+  (:require
+   [ai.miniforge.event-stream.messages :as messages])
   (:import
    [java.text SimpleDateFormat]
    [java.util Date TimeZone]))
@@ -75,7 +79,8 @@
 
 (defn- format-hms
   "Format `ts` (a Date, long epoch-ms, or ISO-8601 string) as HH:mm:ss.
-   Returns \"??:??:??\" when `ts` is nil or unparseable."
+   Returns the localized `:timeline/unknown-time` sentinel when `ts` is
+   nil or unparseable."
   [ts]
   (try
     (let [^SimpleDateFormat fmt (.get hms-formatter-local)
@@ -89,9 +94,9 @@
                     :else        nil)]
       (if d
         (.format fmt d)
-        "??:??:??"))
+        (messages/t :timeline/unknown-time)))
     (catch Exception _
-      "??:??:??")))
+      (messages/t :timeline/unknown-time))))
 
 (defn- ts->epoch-ms
   "Coerce `ts` to epoch-ms long. Returns nil on failure."
@@ -114,18 +119,19 @@
   (:event/timestamp event))
 
 (defn- event-phase [event]
-  (or (:workflow/phase event) "-"))
+  (or (:workflow/phase event) (messages/t :timeline/no-phase)))
 
 (defn- event-type [event]
   (:event/type event))
 
 (defn- truncate
-  "Truncate string `s` to at most `n` characters, appending \"…\" if cut."
+  "Truncate string `s` to at most `n` characters, appending the
+   localized `:timeline/truncation-suffix` if cut."
   [s n]
   (when (string? s)
     (if (<= (count s) n)
       s
-      (str (subs s 0 (dec n)) "…"))))
+      (str (subs s 0 (dec n)) (messages/t :timeline/truncation-suffix)))))
 
 (defn- args-summary
   "Extract the args preview from an event, truncated to `args-preview-length` chars.
@@ -139,14 +145,15 @@
 ;; Duration helpers
 
 (defn- format-duration-ms
-  "Format `ms` as a human-readable \"Xm Ys\" string (omits minutes if 0)."
+  "Format `ms` as a human-readable duration string. Both shapes
+   (mins+secs, secs-only) flow through the user catalog."
   [ms]
   (let [total-s (long (/ ms 1000))
         m       (long (/ total-s 60))
         s       (long (rem total-s 60))]
     (if (pos? m)
-      (format "%dm %ds" m s)
-      (format "%ds" s))))
+      (messages/t :timeline/duration-mins-secs {:mins m :secs s})
+      (messages/t :timeline/duration-secs      {:secs s}))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Per-event-type render dispatch
@@ -156,7 +163,7 @@
   [event]
   (let [ts       (format-hms (event-timestamp event))
         phase    (event-phase event)
-        tool     (or (:tool/name event) "<unknown>")
+        tool     (or (:tool/name event) (messages/t :timeline/unknown-tool))
         args-sum (args-summary event)]
     (format "%s  %s  %s  %s" ts phase tool args-sum)))
 
@@ -168,7 +175,7 @@
    correlated via `:tool/call-id`. `tool-names-by-call-id` is the
    correlation map built by `render-timeline` as it walks the stream.
    Fallbacks (in order): correlated name → `:tool/call-id` →
-   `<unknown>`.
+   localized `:timeline/unknown-tool` sentinel.
 
    Status is sourced from `:tool/success?` (per the schema), with
    `:tool/error` presence as the secondary signal for legacy events
@@ -179,13 +186,13 @@
         call-id  (:tool/call-id event)
         tool     (or (get tool-names-by-call-id call-id)
                      call-id
-                     "<unknown>")
+                     (messages/t :timeline/unknown-tool))
         dur-ms   (:tool/duration-ms event)
         status   (cond
-                   (false? (:tool/success? event)) "error"
-                   (true?  (:tool/success? event)) "success"
-                   (some? (:tool/error event))     "error"
-                   :else                           "success")
+                   (false? (:tool/success? event)) (messages/t :timeline/status-error)
+                   (true?  (:tool/success? event)) (messages/t :timeline/status-success)
+                   (some? (:tool/error event))     (messages/t :timeline/status-error)
+                   :else                           (messages/t :timeline/status-success))
         dur-str  (if dur-ms
                    (str "  " (format-duration-ms dur-ms) "  " status)
                    (str "  " status))]
@@ -198,39 +205,43 @@
         phase    (event-phase event)
         ev-type  (event-type event)
         suffix   (case ev-type
-                   :workflow/phase-started   "started"
-                   :workflow/phase-completed "completed"
+                   :workflow/phase-started   (messages/t :timeline/phase-suffix-started)
+                   :workflow/phase-completed (messages/t :timeline/phase-suffix-completed)
                    (name ev-type))
+        marker   (messages/t :timeline/phase-marker {:suffix suffix})
         msg      (or (:message event) "")]
     (if (seq msg)
-      (format "%s  %s  [phase %s]  %s" ts phase suffix msg)
-      (format "%s  %s  [phase %s]" ts phase suffix))))
+      (format "%s  %s  %s  %s" ts phase marker msg)
+      (format "%s  %s  %s" ts phase marker))))
 
 (defn- render-terminal
-  "`:workflow/completed` / `:workflow/failed` — terminal status with TERMINATED marker."
+  "`:workflow/completed` / `:workflow/failed` — terminal status with the
+   localized terminated marker."
   [event]
   (let [ts     (format-hms (event-timestamp event))
         phase  (event-phase event)
+        marker (messages/t :timeline/terminated-marker)
         reason (or (:message event)
                    (when-let [r (:workflow/result event)]
                      (str r))
                    "")]
-    (format "%s  %s  TERMINATED  %s" ts phase reason)))
+    (format "%s  %s  %s  %s" ts phase marker reason)))
 
 (defn- render-stall
   "`:agent/stream-stalled` — stall marker."
   [event]
-  (let [ts  (format-hms (event-timestamp event))
-        phase (event-phase event)
-        msg (or (:message event) "stream stalled")]
-    (format "%s  %s  [stall]  %s" ts phase msg)))
+  (let [ts     (format-hms (event-timestamp event))
+        phase  (event-phase event)
+        marker (messages/t :timeline/stall-marker)
+        msg    (or (:message event) (messages/t :timeline/stall-default-msg))]
+    (format "%s  %s  %s  %s" ts phase marker msg)))
 
 (defn- render-generic
   "Catch-all for event types without a specific renderer."
   [event]
   (let [ts       (format-hms (event-timestamp event))
         phase    (event-phase event)
-        ev-type  (or (event-type event) "<unknown>")
+        ev-type  (or (event-type event) (messages/t :timeline/unknown-tool))
         msg      (or (:message event) "")]
     (format "%s  %s  %s  %s" ts phase (str ev-type) (truncate msg args-preview-length))))
 
@@ -258,10 +269,10 @@
   "Format a gap line between two events with timestamps `ts-a` and `ts-b`
    and a computed gap of `gap-ms` milliseconds."
   [ts-a ts-b gap-ms]
-  (format "%s→%s — %s event-stream gap (stalled)"
-          (format-hms ts-a)
-          (format-hms ts-b)
-          (format-duration-ms gap-ms)))
+  (messages/t :timeline/gap-line
+              {:ts-a (format-hms ts-a)
+               :ts-b (format-hms ts-b)
+               :gap  (format-duration-ms gap-ms)}))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Public API


### PR DESCRIPTION
## Summary

Backfill for the localization gap (.standards/foundations/localization.mdc — 050) that #940 and #941 both shipped: every emitted user-facing string was a raw literal. This PR routes both surfaces (the event-stream timeline renderer and the events-show CLI command) through their respective message catalogs.

## Scope

| Surface | Catalog | Keys |
|---|---|---|
| `event-stream/timeline.clj` (from #940) | `event-stream/messages/en-US.edn` | 15 `:timeline/*` keys: marker text, status labels, missing-value sentinels, duration formats, gap line |
| `cli/main/commands/events.clj` (from #941) | `cli/messages/en-US.edn` | 6 `:events/*` keys: error messages, usage banner, missing-arg, read-failure |

No behavior change in either surface. Visible strings byte-for-byte identical; the source is now the catalog.

## Why this is a real gap, not a nit

`miniforge events show <workflow-id>` is operator-facing CLI output. The user reads:
- Error messages directly
- The timeline rendering (status, markers, durations, stall lines)

Per the 050 rule, both surfaces are **user locale**, not system locale. Without catalog wiring, a future ja-JP overlay can't translate the column without rewriting the source files.

## Why it didn't ship in #940/#941

The reviewer agent missed it. **Separate investigation needed** into the rule-application path — if `localization.mdc` is in the compiled standards pack with `alwaysApply: true`, every PR touching emit-site code should surface raw-string warnings. The shepherd spec (`work/autonomous-pr-shepherd.spec.edn`) is the longer-term fix to keep this kind of gap from re-landing; this PR is the short-term backfill.

## Files Changed

- `components/event-stream/resources/config/event-stream/messages/en-US.edn` — 15 new `:timeline/*` keys
- `components/event-stream/src/ai/miniforge/event_stream/timeline.clj` — emit sites rewired through `messages/t`
- `bases/cli/resources/config/cli/messages/en-US.edn` — 6 new `:events/*` keys
- `bases/cli/src/ai/miniforge/cli/main/commands/events.clj` — emit sites rewired through `cli.messages/t`

## Test plan

- [x] `timeline-test` — 14 / 42, 0 failures
- [x] `events-test` — 14 / 29, 0 failures
- [x] Visible strings unchanged (catalog values match the prior literals byte-for-byte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)