### PR TITLE
feat(event-stream): N15-5 — declare three routing trigger event types

### DIFF
--- a/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/integration_test.clj
+++ b/components/automation-edge-correlator/test/ai/miniforge/automation_edge_correlator/integration_test.clj
@@ -282,3 +282,29 @@
               "Handler workflow already started — edge stays pending
                regardless of age."))
         (finally (iface/stop! handle))))))
+
+(deftest new-trigger-event-types-emit-observed-edges
+  (testing "N15-5 trigger constructors flow through the correlator and open
+            edges with the right :edge/trigger-kind."
+    (let [stream (in-memory-stream)
+          t-atom (atom (at-ms 1000))
+          handle (start-with-clock stream t-atom)]
+      (try
+        (es/publish! stream (es/pr-monitor-review-comments-arrived
+                             stream "miniforge-ai/miniforge" 999 3))
+        (es/publish! stream (es/pr-monitor-ci-failed
+                             stream "miniforge-ai/miniforge" 999 "tests" :failure))
+        (es/publish! stream (es/standards-review-posted
+                             stream "miniforge-ai/miniforge" 999 :advisory))
+        (is (await-upsert-count stream 3 500))
+        (let [edges (->> (upserts stream)
+                         (map :supervisory/entity)
+                         (sort-by :edge/trigger-kind))]
+          (is (= [:ci-failed :review-comments-arrived :standards-review-arrived]
+                 (mapv :edge/trigger-kind edges))
+              "Each new trigger event type MUST classify to its matching RoutingTriggerKind and surface as an :observed upsert. Three events in, three edges out.")
+          (is (every? #(= :observed %) (map :edge/status edges))
+              "All three open as :observed — handler signals come later.")
+          (is (every? #(seq (:edge/affected-pr-ids %)) edges)
+              "Each constructor carries :pr/repo + :pr/number; the correlator's §3.4 payload-derivation lifts a single [repo number] tuple onto :edge/affected-pr-ids."))
+        (finally (iface/stop! handle))))))

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1397,6 +1397,70 @@
                        (str "Knowledge promotion failed: " (ex-message error)))
       (assoc :knowledge/error (ex-message error))))
 
+;------------------------------------------------------------------------------ Layer 9
+;; Routing trigger events (N5-delta-4 §4.2)
+;;
+;; The automation-edge-correlator classifies these via
+;; `triggers/classify-trigger` and opens `:observed` AutomationEdge entries.
+;; `:workflow/id` is intentionally nil on these envelopes — routing
+;; triggers are PR-scoped, not workflow-scoped; the handler workflow's
+;; `:workflow/started` (with `:routing/trigger-event-id` per N15-4) is
+;; what brings the workflow id into scope on the correlator side.
+
+(defn pr-monitor-review-comments-arrived
+  "Emit when the GitHub webhook (or polling fallback) reports new review
+   comments on a PR Miniforge owns (N5-delta-4 §4.2.1).
+
+   `:comments/agent-session-id`, when supplied, names the agent owning
+   the PR per the PR↔agent index (AA-2). Omit when no session is
+   known — the correlator's affected-agent-session-ids vector goes
+   empty and surfaces a warn log on the consumer side."
+  ([stream repo number comments-count]
+   (pr-monitor-review-comments-arrived stream repo number comments-count nil))
+  ([stream repo number comments-count agent-session-id]
+   (cond-> (-> (create-envelope stream :pr-monitor/review-comments-arrived nil
+                                (str "Review comments on " repo "#" number
+                                     " (" comments-count ")"))
+               (assoc :pr/repo repo
+                      :pr/number number
+                      :comments/count comments-count))
+     agent-session-id (assoc :comments/agent-session-id agent-session-id))))
+
+(defn pr-monitor-ci-failed
+  "Emit when a CI status transitions to a non-success terminal state on a
+   PR Miniforge owns (N5-delta-4 §4.2.2).
+
+   `conclusion` is an open keyword — known values: `:failure`,
+   `:timed-out`, `:cancelled`. Producers MAY emit additional keywords;
+   downstream consumers MUST tolerate them for forward compatibility."
+  [stream repo number check-name conclusion]
+  (-> (create-envelope stream :pr-monitor/ci-failed nil
+                       (str "CI " (name conclusion) " on "
+                            repo "#" number " — " check-name))
+      (assoc :pr/repo repo
+             :pr/number number
+             :ci/check-name check-name
+             :ci/conclusion conclusion)))
+
+(defn standards-review-posted
+  "Emit when a standards-review comment lands on a PR (N5-delta-4 §4.2.3).
+
+   `severity` is an open keyword — known values: `:advisory`, `:blocking`.
+   `affected-workflow-run-id`, when supplied, names the workflow the
+   reviewer's comment scopes; the correlator maps this through a
+   workflow→agent index when one is available (§3.4)."
+  ([stream repo number severity]
+   (standards-review-posted stream repo number severity nil))
+  ([stream repo number severity affected-workflow-run-id]
+   (cond-> (-> (create-envelope stream :standards-review/posted nil
+                                (str "Standards review " (name severity)
+                                     " on " repo "#" number))
+               (assoc :pr/repo repo
+                      :pr/number number
+                      :review/severity severity))
+     affected-workflow-run-id (assoc :affected/workflow-run-id
+                                     affected-workflow-run-id))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Create event stream

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -133,6 +133,11 @@
 (def pr-created events/pr-created)
 (def pr-scored events/pr-scored)
 
+;; Routing trigger events (N5-delta-4 §4.2)
+(def pr-monitor-review-comments-arrived events/pr-monitor-review-comments-arrived)
+(def pr-monitor-ci-failed events/pr-monitor-ci-failed)
+(def standards-review-posted events/standards-review-posted)
+
 ;; Zettelkasten lifecycle (miniforge-fleet Phase E.3)
 (def zettel-promoted events/zettel-promoted)
 

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -95,6 +95,11 @@
 (def pr-created core/pr-created)
 (def pr-scored core/pr-scored)
 
+;; Routing trigger event constructors (N5-delta-4 §4.2)
+(def pr-monitor-review-comments-arrived core/pr-monitor-review-comments-arrived)
+(def pr-monitor-ci-failed core/pr-monitor-ci-failed)
+(def standards-review-posted core/standards-review-posted)
+
 ;; Zettelkasten lifecycle event constructors (miniforge-fleet
 ;; Phase E.3 outbox path).
 

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -793,10 +793,18 @@
 (def PrMonitorReviewCommentsArrived
   "Schema for `:pr-monitor/review-comments-arrived` event (N5-delta-4 §4.2.1).
 
-   Emitted by `components/pr-monitor` (sub-modules in `pr-lifecycle`) when
-   the GitHub webhook (or polling fallback) reports new review comments on
-   a PR Miniforge owns. `:comments/agent-session-id`, when present, names
-   the agent owning the PR per the PR↔agent index (AA-2)."
+   Emitted by the PR-watcher sub-modules in `components/pr-lifecycle`
+   (the `pr-monitor` namespace cluster — there is no separate
+   `components/pr-monitor` brick) when the GitHub webhook (or polling
+   fallback) reports new review comments on a PR Miniforge owns.
+   `:comments/agent-session-id`, when present, names the agent owning
+   the PR per the PR↔agent index (AA-2).
+
+   `:workflow/id` is `:optional`/`:maybe` and effectively nil on every
+   real emission — `core/create-envelope` always stamps the key for
+   envelope-shape uniformity, but routing-trigger events are PR-scoped
+   not workflow-scoped, so the value carries no information. Schema
+   models that shape rather than dropping the key entirely."
   (with-identity
    [:map
     [:event/type [:= :pr-monitor/review-comments-arrived]]
@@ -804,6 +812,7 @@
     [:event/timestamp inst?]
     [:event/version string?]
     [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
     [:pr/repo string?]
     [:pr/number int?]
     [:comments/count int?]
@@ -813,10 +822,13 @@
 (def PrMonitorCiFailed
   "Schema for `:pr-monitor/ci-failed` event (N5-delta-4 §4.2.2).
 
-   Emitted by `components/pr-monitor` (sub-modules in `pr-lifecycle`) when
-   a CI status transitions to a non-success terminal state. `:ci/conclusion`
-   is an open keyword — known values: `:failure`, `:timed-out`, `:cancelled`.
-   Consumers MUST tolerate additional values for forward compatibility."
+   Emitted by the PR-watcher sub-modules in `components/pr-lifecycle`
+   (the `pr-monitor` namespace cluster) when a CI status transitions to
+   a non-success terminal state. `:ci/conclusion` is an open keyword —
+   known values: `:failure`, `:timed-out`, `:cancelled`. Consumers MUST
+   tolerate additional values for forward compatibility.
+
+   `:workflow/id` — see PrMonitorReviewCommentsArrived docstring."
   (with-identity
    [:map
     [:event/type [:= :pr-monitor/ci-failed]]
@@ -824,6 +836,7 @@
     [:event/timestamp inst?]
     [:event/version string?]
     [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
     [:pr/repo string?]
     [:pr/number int?]
     [:ci/check-name string?]
@@ -833,9 +846,13 @@
 (def StandardsReviewPosted
   "Schema for `:standards-review/posted` event (N5-delta-4 §4.2.3).
 
-   Emitted by `components/standards-reviewer` when a standards-review
-   comment lands on a PR. `:review/severity` is an open keyword — known
-   values: `:advisory`, `:blocking`."
+   Emitted by `components/standards-reviewer` (deferred; the component
+   does not yet exist — the constructor lives in event-stream so any
+   future producer can emit a well-formed event the correlator picks
+   up). `:review/severity` is an open keyword — known values:
+   `:advisory`, `:blocking`.
+
+   `:workflow/id` — see PrMonitorReviewCommentsArrived docstring."
   (with-identity
    [:map
     [:event/type [:= :standards-review/posted]]
@@ -843,6 +860,7 @@
     [:event/timestamp inst?]
     [:event/version string?]
     [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
     [:pr/repo string?]
     [:pr/number int?]
     [:affected/workflow-run-id {:optional true} [:maybe uuid?]]

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -771,6 +771,84 @@
     [:intervention/updated-at {:optional true} inst?]
     [:message string?]]))
 
+;; Routing trigger event schemas (N5-delta-4 §4.2)
+;;
+;; Three new first-class trigger event types the automation-edge-correlator
+;; classifies into RoutingTriggerKind values. Producer mapping per N5-δ4
+;; §4.2:
+;;
+;;   :pr-monitor/review-comments-arrived  ← components/pr-lifecycle (PR webhook)
+;;   :pr-monitor/ci-failed                ← components/pr-lifecycle (CI watcher)
+;;   :standards-review/posted             ← components/standards-reviewer
+;;                                          (deferred; emission site lands when
+;;                                          the component exists)
+;;
+;; Schemas are added here so producers anywhere in the workspace can emit
+;; well-formed events the correlator picks up via
+;; `triggers/classify-trigger`. The correlator's heuristic-fallback path
+;; (§3.5 case 2) covers absence at the producer side; the explicit-id path
+;; (§3.5 case 1) needs N15-4's `:routing/trigger-event-id` on the handler
+;; workflow's `:workflow/started`.
+
+(def PrMonitorReviewCommentsArrived
+  "Schema for `:pr-monitor/review-comments-arrived` event (N5-delta-4 §4.2.1).
+
+   Emitted by `components/pr-monitor` (sub-modules in `pr-lifecycle`) when
+   the GitHub webhook (or polling fallback) reports new review comments on
+   a PR Miniforge owns. `:comments/agent-session-id`, when present, names
+   the agent owning the PR per the PR↔agent index (AA-2)."
+  (with-identity
+   [:map
+    [:event/type [:= :pr-monitor/review-comments-arrived]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:pr/repo string?]
+    [:pr/number int?]
+    [:comments/count int?]
+    [:comments/agent-session-id {:optional true} [:maybe uuid?]]
+    [:message string?]]))
+
+(def PrMonitorCiFailed
+  "Schema for `:pr-monitor/ci-failed` event (N5-delta-4 §4.2.2).
+
+   Emitted by `components/pr-monitor` (sub-modules in `pr-lifecycle`) when
+   a CI status transitions to a non-success terminal state. `:ci/conclusion`
+   is an open keyword — known values: `:failure`, `:timed-out`, `:cancelled`.
+   Consumers MUST tolerate additional values for forward compatibility."
+  (with-identity
+   [:map
+    [:event/type [:= :pr-monitor/ci-failed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:pr/repo string?]
+    [:pr/number int?]
+    [:ci/check-name string?]
+    [:ci/conclusion keyword?]
+    [:message string?]]))
+
+(def StandardsReviewPosted
+  "Schema for `:standards-review/posted` event (N5-delta-4 §4.2.3).
+
+   Emitted by `components/standards-reviewer` when a standards-review
+   comment lands on a PR. `:review/severity` is an open keyword — known
+   values: `:advisory`, `:blocking`."
+  (with-identity
+   [:map
+    [:event/type [:= :standards-review/posted]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:pr/repo string?]
+    [:pr/number int?]
+    [:affected/workflow-run-id {:optional true} [:maybe uuid?]]
+    [:review/severity keyword?]
+    [:message string?]]))
+
 ;; Automation-edge correlator emission (N5-delta-4 §4.1)
 ;;
 ;; The correlator is the sole producer of this event per N5-delta-1 §3.4

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -529,7 +529,7 @@
 ;; Routing trigger events (N5-delta-4 §4.2)
 
 (deftest pr-monitor-review-comments-arrived-test
-  (testing "3-arg form: no agent-session-id field"
+  (testing "without :comments/agent-session-id (shorter overload)"
     (let [stream (no-op-stream)
           event  (core/pr-monitor-review-comments-arrived
                    stream "miniforge-ai/miniforge" 999 3)]
@@ -539,7 +539,7 @@
       (is (= 3 (:comments/count event)))
       (is (not (contains? event :comments/agent-session-id)))))
 
-  (testing "4-arg form: agent-session-id threads onto the envelope"
+  (testing "with :comments/agent-session-id threaded onto the envelope"
     (let [stream     (no-op-stream)
           session-id (random-uuid)
           event      (core/pr-monitor-review-comments-arrived
@@ -558,7 +558,7 @@
       (is (= :failure (:ci/conclusion event))))))
 
 (deftest standards-review-posted-test
-  (testing "3-arg form: no affected-workflow-run-id"
+  (testing "without :affected/workflow-run-id (shorter overload)"
     (let [stream (no-op-stream)
           event  (core/standards-review-posted
                    stream "miniforge-ai/miniforge" 999 :advisory)]
@@ -568,7 +568,7 @@
       (is (= :advisory (:review/severity event)))
       (is (not (contains? event :affected/workflow-run-id)))))
 
-  (testing "4-arg form: affected-workflow-run-id threads onto the envelope"
+  (testing "with :affected/workflow-run-id threaded onto the envelope"
     (let [stream  (no-op-stream)
           wf-id   (random-uuid)
           event   (core/standards-review-posted

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -524,3 +524,54 @@
                          {:dependency-id "anthropic"
                           :status "healthy"})
              (:message event))))))
+
+;------------------------------------------------------------------------------ Layer 9
+;; Routing trigger events (N5-delta-4 §4.2)
+
+(deftest pr-monitor-review-comments-arrived-test
+  (testing "3-arg form: no agent-session-id field"
+    (let [stream (no-op-stream)
+          event  (core/pr-monitor-review-comments-arrived
+                   stream "miniforge-ai/miniforge" 999 3)]
+      (is (= :pr-monitor/review-comments-arrived (:event/type event)))
+      (is (= "miniforge-ai/miniforge" (:pr/repo event)))
+      (is (= 999 (:pr/number event)))
+      (is (= 3 (:comments/count event)))
+      (is (not (contains? event :comments/agent-session-id)))))
+
+  (testing "4-arg form: agent-session-id threads onto the envelope"
+    (let [stream     (no-op-stream)
+          session-id (random-uuid)
+          event      (core/pr-monitor-review-comments-arrived
+                       stream "miniforge-ai/miniforge" 999 3 session-id)]
+      (is (= session-id (:comments/agent-session-id event))))))
+
+(deftest pr-monitor-ci-failed-test
+  (testing "carries pr/repo, pr/number, ci/check-name, ci/conclusion"
+    (let [stream (no-op-stream)
+          event  (core/pr-monitor-ci-failed stream "miniforge-ai/miniforge"
+                                            999 "tests" :failure)]
+      (is (= :pr-monitor/ci-failed (:event/type event)))
+      (is (= "miniforge-ai/miniforge" (:pr/repo event)))
+      (is (= 999 (:pr/number event)))
+      (is (= "tests" (:ci/check-name event)))
+      (is (= :failure (:ci/conclusion event))))))
+
+(deftest standards-review-posted-test
+  (testing "3-arg form: no affected-workflow-run-id"
+    (let [stream (no-op-stream)
+          event  (core/standards-review-posted
+                   stream "miniforge-ai/miniforge" 999 :advisory)]
+      (is (= :standards-review/posted (:event/type event)))
+      (is (= "miniforge-ai/miniforge" (:pr/repo event)))
+      (is (= 999 (:pr/number event)))
+      (is (= :advisory (:review/severity event)))
+      (is (not (contains? event :affected/workflow-run-id)))))
+
+  (testing "4-arg form: affected-workflow-run-id threads onto the envelope"
+    (let [stream  (no-op-stream)
+          wf-id   (random-uuid)
+          event   (core/standards-review-posted
+                    stream "miniforge-ai/miniforge" 999 :blocking wf-id)]
+      (is (= wf-id (:affected/workflow-run-id event)))
+      (is (= :blocking (:review/severity event))))))


### PR DESCRIPTION
## Summary

Schemas + constructors for the three new trigger event types the
automation-edge-correlator already classifies via `triggers/classify-trigger`
(N15-1). Producers anywhere in the workspace can now emit well-formed events
that flow end-to-end through the correlator into
`:supervisory/automation-edge-upserted` upserts.

## Event types (N5-delta-4 §4.2)

- `:pr-monitor/review-comments-arrived` — webhook reports new review comments
  on a PR Miniforge owns. Carries `:pr/repo`, `:pr/number`, `:comments/count`,
  optional `:comments/agent-session-id`.
- `:pr-monitor/ci-failed` — CI status transitioned to a non-success terminal
  state. Carries `:pr/repo`, `:pr/number`, `:ci/check-name`, `:ci/conclusion`
  (open keyword; known: `:failure`, `:timed-out`, `:cancelled`).
- `:standards-review/posted` — standards-review comment landed on a PR.
  Carries `:pr/repo`, `:pr/number`, `:review/severity` (open keyword;
  known: `:advisory`, `:blocking`), optional `:affected/workflow-run-id`.

## Producer-side wiring NOT included (deferred)

Emission sites for the three event types are deliberately NOT wired into
existing components in this slice. The user-facing producers either don't
exist as components yet (`standards-reviewer`, `comment-response-agent`)
or emit a different internal event shape keyed on (dag-id, run-id, task-id)
rather than the canonical (pr-repo, pr-number) the correlator wants (the
`ci_monitor` sub-module in `pr-lifecycle`). Wiring the canonical emission
alongside the existing internal one requires plumbing repo identity through
the monitor's state — bigger than this "basics" slice. The constructors are
in place so wiring is a one-liner once the producer side is ready.

The correlator's heuristic-fallback path (§3.5 case 2) already absorbs the
absence — emitted handler workflows correlate via `:workflow/spec` matching
within the 60 s correlation window, with a warn log on each fallback.

## Tests

- `event-stream.core-test`: three new constructor tests (5 sub-tests total)
  pin each constructor's required + optional fields.
- `automation-edge-correlator.integration-test`:
  `new-trigger-event-types-emit-observed-edges` exercises the full
  producer → correlator → upsert path for all three new event types in
  one test, using the new event-stream constructors.

## Interface re-exports

- `event-stream.interface.events` (Polylith brick interface): adds the
  three constructors.
- `event-stream.interface` (top-level facade): adds the three
  constructors via the standard `(def x events/x)` delegation.

## Verification

- [x] Brick suite (automation-edge-correlator): 50 / 117 green.
- [x] `event-stream.core-test`: 34 / 143 green.
- [x] `clj-kondo`: 0 errors / 0 warnings on every touched file.
- [x] `bb poly:check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)