### PR TITLE
fix: surface phase-enter throws in workflow/failed event (G10 residual)

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -36,33 +36,48 @@
 
 ;------------------------------------------------------------------------------ Layer 0: Atomic operations
 
+(defn- enter-error-record
+  "Build the canonical entry recorded against `:execution/errors` for a
+   phase-enter exception. Used uniformly whether or not the interceptor
+   defines its own `:error` handler, so the `workflow/failed` event
+   always carries the underlying exception message + ex-data."
+  [phase-name ex anom]
+  {:type :phase-error
+   :phase phase-name
+   :message (ex-message ex)
+   :data (ex-data ex)
+   :anomaly anom})
+
 (defn execute-enter
   "Execute the :enter function of an interceptor.
 
-   Returns updated context."
+   Returns updated context. When the enter function throws, the
+   exception's message + ex-data are appended to `:execution/errors`
+   so the eventual `workflow/failed` event surfaces the failure. This
+   accumulator is populated even when the interceptor defines its own
+   `:error` handler (the handler still runs to set `[:phase :error]`,
+   but the workflow-level error list is the authoritative source for
+   downstream consumers such as the CLI and bridge surfaces)."
   [interceptor ctx]
   (let [phase-name (get-in interceptor [:config :phase])]
     (if-let [enter-fn (:enter interceptor)]
       (try
         (enter-fn ctx)
         (catch Exception ex
-          (if-let [error-fn (:error interceptor)]
-            (error-fn ctx ex)
-            (let [anom (response/from-exception ex)]
-              (-> ctx
-                  (context/transition-to-failed)
-                  (update :execution/errors conj
-                          {:type :phase-error
-                           :phase phase-name
-                           :message (ex-message ex)
-                           :data (ex-data ex)
-                           :anomaly anom})
-                  (update :execution/response-chain
-                          response/add-failure phase-name
-                          (assoc anom :anomaly/category :anomalies.phase/enter-failed
-                                      :anomaly/phase phase-name)
-                          {:error (ex-message ex)
-                           :data (ex-data ex)}))))))
+          (let [anom (response/from-exception ex)
+                error-record (enter-error-record phase-name ex anom)
+                ctx-with-error (-> ctx
+                                   (update :execution/errors conj error-record)
+                                   (update :execution/response-chain
+                                           response/add-failure phase-name
+                                           (assoc anom
+                                                  :anomaly/category :anomalies.phase/enter-failed
+                                                  :anomaly/phase phase-name)
+                                           {:error (ex-message ex)
+                                            :data (ex-data ex)}))]
+            (if-let [error-fn (:error interceptor)]
+              (error-fn ctx-with-error ex)
+              (context/transition-to-failed ctx-with-error)))))
       ctx)))
 
 (defn execute-leave

--- a/components/workflow/test/ai/miniforge/workflow/execute_enter_error_propagation_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/execute_enter_error_propagation_test.clj
@@ -64,12 +64,22 @@
   {:execution/errors []
    :execution/response-chain (response/create :test-workflow)})
 
+(defn- chain-failure-entry-for
+  "Locate the entry in `:execution/response-chain` whose operation
+   matches `phase-name`. Returns nil when no matching entry exists,
+   so tests can `(is (some? ...))` against it."
+  [result phase-name]
+  (->> (get-in result [:execution/response-chain :response-chain])
+       (filter #(= phase-name (:operation %)))
+       first))
+
 (deftest enter-throw-with-error-handler-populates-execution-errors-test
   (testing "phase-enter throw appends to :execution/errors even when an :error handler is set"
     (let [interceptor (interceptor-with-error-handler)
           result (exec/execute-enter interceptor (empty-execution-context))
           errors (:execution/errors result)
-          first-error (first errors)]
+          first-error (first errors)
+          chain-entry (chain-failure-entry-for result test-phase-name)]
       (is (= 1 (count errors))
           "exactly one error record should be appended for a single throw")
       (is (= :phase-error (:type first-error))
@@ -81,14 +91,40 @@
       (is (= test-error-data (:data first-error))
           "error record should carry the thrown exception's ex-data")
       (is (= :failed (get-in result [:phase :status]))
-          ":error handler should still run and mark the phase failed"))))
+          ":error handler should still run and mark the phase failed")
+      ;; Lock in the response-chain side of the contract: downstream
+      ;; consumers (e.g. workflow-runner's failed-event publisher) read
+      ;; `:execution/response-chain` to enumerate per-phase outcomes;
+      ;; an empty chain here would re-introduce the silent-failure mode
+      ;; G10 was about.
+      (is (some? chain-entry)
+          "response-chain should carry an entry naming the failing phase")
+      (is (false? (:succeeded? chain-entry))
+          "the response-chain entry for a phase-enter throw must be marked failed")
+      (is (some? (:anomaly chain-entry))
+          "the response-chain entry should carry the anomaly keyword")
+      (is (= test-error-message (get-in chain-entry [:response :error]))
+          "the chain entry's :response should carry the thrown exception's message under :error")
+      (is (= test-error-data (get-in chain-entry [:response :data]))
+          "the chain entry's :response should carry the thrown exception's ex-data under :data"))))
 
 (deftest enter-throw-without-error-handler-populates-execution-errors-test
   (testing "phase-enter throw appends to :execution/errors when no :error handler is set"
     (let [interceptor (interceptor-without-error-handler)
           result (exec/execute-enter interceptor (empty-execution-context))
           errors (:execution/errors result)
-          first-error (first errors)]
+          first-error (first errors)
+          chain-entry (chain-failure-entry-for result test-phase-name)]
       (is (= 1 (count errors)))
       (is (= test-error-message (:message first-error)))
-      (is (= test-error-data (:data first-error))))))
+      (is (= test-error-data (:data first-error)))
+      ;; Lock in the full fallback contract: the no-handler branch
+      ;; must mark execution failed AND record the failing phase in
+      ;; the response-chain. Without these, the workflow could
+      ;; advance past a failed enter and lose the failure trace.
+      (is (= :failed (:execution/status result))
+          "no-handler enter throw must mark :execution/status :failed")
+      (is (some? chain-entry)
+          "response-chain should carry an entry naming the failing phase")
+      (is (false? (:succeeded? chain-entry))
+          "the response-chain entry must be marked failed"))))

--- a/components/workflow/test/ai/miniforge/workflow/execute_enter_error_propagation_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/execute_enter_error_propagation_test.clj
@@ -1,0 +1,94 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.execute-enter-error-propagation-test
+  "Phase-enter exceptions must populate `:execution/errors` so the
+   downstream `workflow/failed` event surfaces the underlying message
+   and ex-data. Regression coverage for the G10 residual where a
+   throwing `validate-required-inputs!` produced an empty
+   `{:errors []}` payload and the bridge reported `\"Workflow failed:
+   no error message\"`."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.response.interface :as response]
+   [ai.miniforge.workflow.execution :as exec]))
+
+(def ^:private test-phase-name :phase-under-test)
+(def ^:private test-error-message "preflight check rejected input")
+(def ^:private test-error-data {:input-key :career/growth-framework-payload})
+
+(defn- throwing-enter-fn
+  []
+  (fn [_ctx]
+    (throw (ex-info test-error-message test-error-data))))
+
+(defn- interceptor-with-error-handler
+  "Build an interceptor that mimics the career-side `fail-phase`
+   convention: its `:error` handler only writes into the per-phase
+   `:phase` map. Before the G10 fix the workflow-level
+   `:execution/errors` accumulator stayed empty for this shape."
+  []
+  {:name :test
+   :config {:phase test-phase-name}
+   :enter (throwing-enter-fn)
+   :error (fn [ctx ex]
+            (-> ctx
+                (assoc-in [:phase :status] :failed)
+                (assoc-in [:phase :error]
+                          {:message (ex-message ex)
+                           :data (ex-data ex)})))})
+
+(defn- interceptor-without-error-handler
+  []
+  {:name :test
+   :config {:phase test-phase-name}
+   :enter (throwing-enter-fn)})
+
+(defn- empty-execution-context
+  []
+  {:execution/errors []
+   :execution/response-chain (response/create :test-workflow)})
+
+(deftest enter-throw-with-error-handler-populates-execution-errors-test
+  (testing "phase-enter throw appends to :execution/errors even when an :error handler is set"
+    (let [interceptor (interceptor-with-error-handler)
+          result (exec/execute-enter interceptor (empty-execution-context))
+          errors (:execution/errors result)
+          first-error (first errors)]
+      (is (= 1 (count errors))
+          "exactly one error record should be appended for a single throw")
+      (is (= :phase-error (:type first-error))
+          "error record should carry the canonical :phase-error type")
+      (is (= test-phase-name (:phase first-error))
+          "error record should name the failing phase")
+      (is (= test-error-message (:message first-error))
+          "error record should carry the thrown exception's message")
+      (is (= test-error-data (:data first-error))
+          "error record should carry the thrown exception's ex-data")
+      (is (= :failed (get-in result [:phase :status]))
+          ":error handler should still run and mark the phase failed"))))
+
+(deftest enter-throw-without-error-handler-populates-execution-errors-test
+  (testing "phase-enter throw appends to :execution/errors when no :error handler is set"
+    (let [interceptor (interceptor-without-error-handler)
+          result (exec/execute-enter interceptor (empty-execution-context))
+          errors (:execution/errors result)
+          first-error (first errors)]
+      (is (= 1 (count errors)))
+      (is (= test-error-message (:message first-error)))
+      (is (= test-error-data (:data first-error))))))


### PR DESCRIPTION
## Summary
- Phase `:enter` exceptions caught by an interceptor's `:error` handler were only being recorded in `[:phase :error]`, never appended to `:execution/errors`.
- The downstream `workflow/failed` event reads from `:execution/errors` and was emitting an empty `{:errors []}` payload, so the thesium-career bridge surfaced `"Workflow failed: no error message"` instead of the underlying validator text (G10 residual).
- `execute-enter` now appends the canonical `:phase-error` record to `:execution/errors` before delegating to the interceptor's `:error` handler. Symmetric with `execute-leave`, which already populates the accumulator unconditionally.

## Root cause
`components/workflow/src/ai/miniforge/workflow/execution.clj` — `execute-enter` had two mutually-exclusive branches in its `(catch Exception ex …)`:
- if an `:error` handler was set: call it, return its ctx (no `:execution/errors` update);
- otherwise: populate `:execution/errors` + `:execution/response-chain` and transition to failed.

The first branch is the one career hits (the `:error` handler is `fail-phase` from `phase-thesium-career/workflow_runtime.clj`, which only writes per-phase state). That's the silent failure mode.

## Fix
Lift the `:execution/errors` + `:execution/response-chain` updates out of the no-handler branch so they always run; the `:error` handler still runs to set the per-phase status, but the workflow-level accumulator is no longer silent.

## Cross-repo chain
Paired with miniforge-ai/thesium-workflows#187, which bumps the miniforge submodule pointer in thesium-workflows and adds career-side regression tests:
- a phase-thesium-career test that drives `:career-growth-framework-check-inputs` through real `execute-enter` and asserts the localized validator text lands in `:execution/errors`;
- a career-workflow-cli bridge test that asserts the CLI's `throw-if-workflow-failed!` surfaces the localized message instead of "no error message".

## Test plan
- [x] New unit test `components/workflow/test/ai/miniforge/workflow/execute_enter_error_propagation_test.clj` covers both shapes: phase-enter throw with an `:error` handler set, and without.
- [x] `clojure -M:poly test brick:workflow` — all workflow brick tests pass (1 preexisting failure in `runner-environment-test/build-env-record-captures-base-sha-test` is unrelated to this change; confirmed by running the test suite on the clean tree before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)