### PR TITLE
feat: --help support on workflow-runner subcommands

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -727,7 +727,6 @@
   "Execute a chain (multi-workflow) by ID."
   :workflow-runner.help/chain-list-summary
   "List available chain definitions."
-  :workflow-runner.help/flag-help-desc "show this help message and exit"
 
   ;; control-plane CLI commands
   :cp/dashboard-not-running    "Dashboard not running."

--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -701,6 +701,34 @@
   :workflow-runner/list-chains-failed "Failed to list chains: {error}"
   :workflow-runner/chain-step-completed "chain {chain-id} completed"
 
+  ;; workflow-runner subcommand --help support (per-subcommand usage)
+  :workflow-runner.help/subcommand-heading "{subcommand}"
+  :workflow-runner.help/usage-prefix       "Usage: {line}"
+  :workflow-runner.help/options-heading    "Options:"
+  :workflow-runner.help/group-heading      "{group}"
+  :workflow-runner.help/group-usage-prefix "Usage: {line}"
+  :workflow-runner.help/group-subcommands-heading "Subcommands:"
+  :workflow-runner.help/group-subcommand-row "  {name}  {summary}"
+  :workflow-runner.help/workflow-summary
+  "Workflow lifecycle commands (run, list, execute, status, cancel)."
+  :workflow-runner.help/chain-summary
+  "Chain execution commands (run, list)."
+  :workflow-runner.help/workflow-run-summary
+  "Execute a registered workflow by ID."
+  :workflow-runner.help/workflow-list-summary
+  "List available workflows discoverable on the classpath."
+  :workflow-runner.help/workflow-execute-summary
+  "Execute a workflow from a spec file path (alias for `run <spec>`)."
+  :workflow-runner.help/workflow-status-summary
+  "Show the status of a workflow by ID."
+  :workflow-runner.help/workflow-cancel-summary
+  "Cancel a running workflow by ID."
+  :workflow-runner.help/chain-run-summary
+  "Execute a chain (multi-workflow) by ID."
+  :workflow-runner.help/chain-list-summary
+  "List available chain definitions."
+  :workflow-runner.help/flag-help-desc "show this help message and exit"
+
   ;; control-plane CLI commands
   :cp/dashboard-not-running    "Dashboard not running."
   :cp/dashboard-start-hint     "Start it with: miniforge web"

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -46,6 +46,8 @@
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-runner :as workflow-runner]
+   [ai.miniforge.cli.workflow-runner.help :as wr-help]
+   [ai.miniforge.cli.workflow-runner.help.registry :as wr-help-registry]
    [ai.miniforge.cli.config :as config]
    [ai.miniforge.cli.observability :as observability]
    [ai.miniforge.cli.main.display :as display]
@@ -547,48 +549,54 @@
     :fn tui-cmd
     :spec {:debug {:coerce :boolean :alias :d :default false}}}
 
-   ;; Workflow commands
+   ;; Workflow parent — `mf workflow --help` / `mf workflow` lists the
+   ;; group's subcommands with their one-line summaries.
+   {:cmds ["workflow"]
+    :fn (wr-help/group-handler wr-help-registry/workflow-group-help)}
+
+   ;; Workflow commands (each subcommand carries a `--help` / `-h`
+   ;; flag wired through `wr-help/handler-with-help`; the spec from
+   ;; `wr-help-registry/subcommands` is the single source of truth for
+   ;; the auto-generated flag table).
    {:cmds ["workflow" "run"]
-    :fn workflow-run-cmd
+    :fn (wr-help/handler-with-help :workflow-run workflow-run-cmd)
     :args->opts [:workflow-id]
-    :spec {:version {:coerce :string :alias :v :default "latest"}
-           :input {:alias :i}
-           :input-json {}
-           :output {:coerce :keyword :alias :o :default :pretty}
-           :quiet {:coerce :boolean :alias :q}
-           :dashboard-url {:coerce :string :alias :d}}}
+    :spec (wr-help-registry/spec-for :workflow-run)}
 
    {:cmds ["workflow" "list"]
-    :fn workflow-list-cmd}
+    :fn (wr-help/handler-with-help :workflow-list workflow-list-cmd)
+    :spec (wr-help-registry/spec-for :workflow-list)}
 
    ;; Workflow subcommands — spec-driven execution and lifecycle (N5)
    {:cmds ["workflow" "execute"]
-    :fn workflow-execute-cmd
+    :fn (wr-help/handler-with-help :workflow-execute workflow-execute-cmd)
     :args->opts [:spec]
-    :spec {:worktree       {:alias :w}
-           :backend        {:coerce :keyword :alias :b}
-           :execution-mode {:coerce :keyword :alias :m}
-           :quiet          {:coerce :boolean :alias :q}}}
+    :spec (wr-help-registry/spec-for :workflow-execute)}
 
    {:cmds ["workflow" "status"]
-    :fn workflow-status-cmd
-    :args->opts [:id]}
+    :fn (wr-help/handler-with-help :workflow-status workflow-status-cmd)
+    :args->opts [:id]
+    :spec (wr-help-registry/spec-for :workflow-status)}
 
    {:cmds ["workflow" "cancel"]
-    :fn workflow-cancel-cmd
-    :args->opts [:id]}
+    :fn (wr-help/handler-with-help :workflow-cancel workflow-cancel-cmd)
+    :args->opts [:id]
+    :spec (wr-help-registry/spec-for :workflow-cancel)}
+
+   ;; Chain parent — `mf chain --help` / `mf chain` lists the group's
+   ;; subcommands with their one-line summaries.
+   {:cmds ["chain"]
+    :fn (wr-help/group-handler wr-help-registry/chain-group-help)}
 
    ;; Chain commands
    {:cmds ["chain" "run"]
-    :fn chain-run-cmd
+    :fn (wr-help/handler-with-help :chain-run chain-run-cmd)
     :args->opts [:chain-id]
-    :spec {:version {:coerce :string :alias :v :default "latest"}
-           :spec {:alias :s}
-           :input-json {}
-           :quiet {:coerce :boolean :alias :q}}}
+    :spec (wr-help-registry/spec-for :chain-run)}
 
    {:cmds ["chain" "list"]
-    :fn chain-list-cmd}
+    :fn (wr-help/handler-with-help :chain-list chain-list-cmd)
+    :spec (wr-help-registry/spec-for :chain-list)}
 
    ;; Config subcommands
    {:cmds ["config"] :fn help-cmd}

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help.clj
@@ -1,0 +1,154 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.workflow-runner.help
+  "Per-subcommand `--help` rendering for the workflow-runner-facing CLI
+   subcommands (`workflow run/list/execute/status/cancel` and
+   `chain run/list`).
+
+   Stratification:
+   Layer 0 — pure predicates and the babashka.cli `:spec` filter that
+             strips the help-flag entry so it doesn't appear in its own
+             usage block.
+   Layer 1 — `usage-text` / `group-usage-text` compose localized
+             usage strings from a registry entry.
+   Layer 2 — `print-usage!` / `print-group-usage!` are the
+             side-effecting handlers and the `handler-with-help` /
+             `group-handler` factories the dispatch table wires in."
+  (:require
+   [babashka.cli :as cli]
+   [clojure.string :as str]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.workflow-runner.help.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def help-flag-keys
+  "Keys reserved for the help flag itself. Stripped from the usage
+   table so `--help` doesn't appear inside its own description block."
+  #{:help})
+
+(defn help-requested?
+  "Truthy when the parsed `opts` map carries the `--help` / `-h` flag."
+  [opts]
+  (boolean (:help opts)))
+
+(defn- without-help-flag
+  "Drop the help flag from a babashka.cli `:spec` map so it doesn't
+   appear inside the flag table its presence triggered."
+  [spec]
+  (into {} (remove (fn [[k _]] (contains? help-flag-keys k))) spec))
+
+(defn- usage-line
+  "First-line usage banner for a subcommand."
+  [subcommand positional]
+  (let [binary (app-config/binary-name)
+        positionals (when (seq positional)
+                      (->> positional
+                           (map (fn [k] (str "<" (name k) ">")))
+                           (str/join " ")))]
+    (->> [binary subcommand positionals "[options]"]
+         (remove str/blank?)
+         (str/join " "))))
+
+(defn- flag-table
+  "Auto-generate the flag table from a babashka.cli `:spec`. Returns
+   nil when the (filtered) spec has no entries."
+  [spec]
+  (let [filtered (without-help-flag spec)]
+    (when (seq filtered)
+      (cli/format-opts {:spec filtered}))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn usage-text
+  "Render the full localized usage block for a registry entry."
+  [{:keys [subcommand summary-key spec positional]}]
+  (let [usage   (messages/t :workflow-runner.help/usage-prefix
+                            {:line (usage-line subcommand positional)})
+        summary (messages/t summary-key)
+        table   (flag-table spec)]
+    (->> [(messages/t :workflow-runner.help/subcommand-heading
+                      {:subcommand subcommand})
+          summary
+          ""
+          usage
+          (when table
+            (messages/t :workflow-runner.help/options-heading))
+          table]
+         (remove nil?)
+         (str/join "\n"))))
+
+(defn group-usage-text
+  "Render the localized parent-level usage block for a subcommand group."
+  [{:keys [group summary-key subcommands]}]
+  (let [usage    (messages/t :workflow-runner.help/group-usage-prefix
+                             {:line (str (app-config/binary-name)
+                                         " "
+                                         group
+                                         " <subcommand> [options]")})
+        summary  (messages/t summary-key)
+        row-text (fn [entry]
+                   (messages/t :workflow-runner.help/group-subcommand-row
+                               {:name    (:name entry)
+                                :summary (messages/t (:summary-key entry))}))
+        rows     (map row-text subcommands)]
+    (->> [(messages/t :workflow-runner.help/group-heading {:group group})
+          summary
+          ""
+          usage
+          ""
+          (messages/t :workflow-runner.help/group-subcommands-heading)
+          (str/join "\n" rows)]
+         (str/join "\n"))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn print-usage!
+  "Print the localized usage block for `entry` to stdout."
+  [entry]
+  (println (usage-text entry)))
+
+(defn print-group-usage!
+  "Print the localized parent-level usage block for `group-entry`."
+  [group-entry]
+  (println (group-usage-text group-entry)))
+
+(defn handler-with-help
+  "Wrap a dispatch handler `cmd-fn` so that `--help` / `-h` short-circuits
+   to a localized usage block. `subcommand-key` is one of the keys in
+   `registry/subcommands` (e.g. `:workflow-run`)."
+  [subcommand-key cmd-fn]
+  (let [entry (registry/entry-for subcommand-key)]
+    (when-not entry
+      (throw (ex-info "Unknown workflow-runner help subcommand-key"
+                      {:subcommand-key subcommand-key
+                       :known-keys (keys registry/subcommands)})))
+    (fn dispatch-handler [m]
+      (let [opts (if (contains? m :opts) (:opts m) m)]
+        (if (help-requested? opts)
+          (print-usage! entry)
+          (cmd-fn m))))))
+
+(defn group-handler
+  "Return a dispatch handler that prints the group-level usage block
+   for `group-entry` (e.g. `registry/workflow-group-help`)."
+  [group-entry]
+  (fn group-help-handler [_m]
+    (print-group-usage! group-entry)))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
@@ -1,0 +1,160 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.workflow-runner.help.registry
+  "Pure data registry of every workflow-runner CLI subcommand
+   (`workflow run/list/execute/status/cancel` and `chain run/list`).
+
+   The registry is the single source of truth for:
+   - the babashka.cli `:spec` (flag definitions) wired into the
+     `main.clj` dispatch table,
+   - the per-subcommand `--help` usage block rendered by
+     `ai.miniforge.cli.workflow-runner.help/usage-text`, and
+   - the parent-level (`workflow --help` / `chain --help`) listing.
+
+   Stratification:
+   Layer 0 — flag-spec data + the `with-help-flag` helper.
+   Layer 1 — the `subcommands` map + per-group ordering.
+   Layer 2 — group-listing inputs derived from Layer 1."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^:private help-flag-spec
+  "The `--help`/`-h` boolean flag added to every workflow-runner
+   subcommand spec. Single definition keeps the alias consistent."
+  {:coerce :boolean :alias :h})
+
+(defn with-help-flag
+  "Return `spec` with the `--help`/`-h` boolean flag merged in. Idempotent."
+  [spec]
+  (assoc spec :help help-flag-spec))
+
+(def workflow-run-flag-spec
+  (with-help-flag
+    {:version       {:coerce :string  :alias :v :default "latest"}
+     :input         {:alias :i}
+     :input-json    {}
+     :output        {:coerce :keyword :alias :o :default :pretty}
+     :quiet         {:coerce :boolean :alias :q}
+     :dashboard-url {:coerce :string  :alias :d}}))
+
+(def workflow-list-flag-spec
+  (with-help-flag {}))
+
+(def workflow-execute-flag-spec
+  (with-help-flag
+    {:worktree       {:alias :w}
+     :backend        {:coerce :keyword :alias :b}
+     :execution-mode {:coerce :keyword :alias :m}
+     :quiet          {:coerce :boolean :alias :q}}))
+
+(def workflow-status-flag-spec
+  (with-help-flag {}))
+
+(def workflow-cancel-flag-spec
+  (with-help-flag {}))
+
+(def chain-run-flag-spec
+  (with-help-flag
+    {:version    {:coerce :string :alias :v :default "latest"}
+     :spec       {:alias :s}
+     :input-json {}
+     :quiet      {:coerce :boolean :alias :q}}))
+
+(def chain-list-flag-spec
+  (with-help-flag {}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def subcommands
+  "Keyword-addressable registry of every workflow-runner subcommand.
+   Each value is the input shape consumed by the help renderer."
+  {:workflow-run     {:subcommand  "workflow run"
+                      :summary-key :workflow-runner.help/workflow-run-summary
+                      :spec        workflow-run-flag-spec
+                      :positional  [:workflow-id]}
+   :workflow-list    {:subcommand  "workflow list"
+                      :summary-key :workflow-runner.help/workflow-list-summary
+                      :spec        workflow-list-flag-spec
+                      :positional  []}
+   :workflow-execute {:subcommand  "workflow execute"
+                      :summary-key :workflow-runner.help/workflow-execute-summary
+                      :spec        workflow-execute-flag-spec
+                      :positional  [:spec]}
+   :workflow-status  {:subcommand  "workflow status"
+                      :summary-key :workflow-runner.help/workflow-status-summary
+                      :spec        workflow-status-flag-spec
+                      :positional  [:id]}
+   :workflow-cancel  {:subcommand  "workflow cancel"
+                      :summary-key :workflow-runner.help/workflow-cancel-summary
+                      :spec        workflow-cancel-flag-spec
+                      :positional  [:id]}
+   :chain-run        {:subcommand  "chain run"
+                      :summary-key :workflow-runner.help/chain-run-summary
+                      :spec        chain-run-flag-spec
+                      :positional  [:chain-id]}
+   :chain-list       {:subcommand  "chain list"
+                      :summary-key :workflow-runner.help/chain-list-summary
+                      :spec        chain-list-flag-spec
+                      :positional  []}})
+
+(def workflow-subcommand-keys
+  "Display order for `mf workflow --help`."
+  [:workflow-run :workflow-list :workflow-execute :workflow-status
+   :workflow-cancel])
+
+(def chain-subcommand-keys
+  "Display order for `mf chain --help`."
+  [:chain-run :chain-list])
+
+(defn spec-for
+  "Look up the babashka.cli `:spec` for a subcommand by key."
+  [subcommand-key]
+  (:spec (get subcommands subcommand-key)))
+
+(defn entry-for
+  "Look up the full registry entry for `subcommand-key`. Returns nil
+   when unknown — callers may treat that as a programming error."
+  [subcommand-key]
+  (get subcommands subcommand-key))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- subcommand-leaf [entry]
+  (-> (:subcommand entry) (str/split #"\s+") last))
+
+(defn- group-subcommand-rows [entry-keys]
+  (map (fn [entry-key]
+         (let [entry (get subcommands entry-key)]
+           {:name        (subcommand-leaf entry)
+            :summary-key (:summary-key entry)}))
+       entry-keys))
+
+(def workflow-group-help
+  "Input shape for the `workflow` parent's `--help` listing."
+  {:group       "workflow"
+   :summary-key :workflow-runner.help/workflow-summary
+   :subcommands (group-subcommand-rows workflow-subcommand-keys)})
+
+(def chain-group-help
+  "Input shape for the `chain` parent's `--help` listing."
+  {:group       "chain"
+   :summary-key :workflow-runner.help/chain-summary
+   :subcommands (group-subcommand-rows chain-subcommand-keys)})

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/help/registry_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/help/registry_test.clj
@@ -1,0 +1,54 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.workflow-runner.help.registry-test
+  "Shape tests for the pure-data subcommand registry."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.workflow-runner.help.registry :as sut]))
+
+(deftest registry-covers-every-workflow-runner-subcommand-test
+  (testing "subcommands map contains every workflow / chain subcommand by key"
+    (is (= #{:workflow-run :workflow-list :workflow-execute :workflow-status
+             :workflow-cancel :chain-run :chain-list}
+           (set (keys sut/subcommands))))))
+
+(deftest every-subcommand-spec-carries-the-help-flag-test
+  (testing "every registered subcommand spec includes the --help / -h flag"
+    (doseq [[subcommand-key entry] sut/subcommands]
+      (let [help-spec (get-in entry [:spec :help])]
+        (is (= :boolean (:coerce help-spec))
+            (str "subcommand " subcommand-key " must coerce --help as boolean"))
+        (is (= :h (:alias help-spec))
+            (str "subcommand " subcommand-key " must alias --help to -h"))))))
+
+(deftest spec-for-returns-the-registered-flag-spec-test
+  (testing "spec-for round-trips through the registry"
+    (is (= (get-in sut/subcommands [:workflow-run :spec])
+           (sut/spec-for :workflow-run))))
+  (testing "spec-for returns nil for unknown keys (callers treat as error)"
+    (is (nil? (sut/spec-for :no-such-subcommand)))))
+
+(deftest group-listings-cover-every-child-test
+  (testing "workflow group lists every workflow-* subcommand"
+    (is (= #{:workflow-run :workflow-list :workflow-execute :workflow-status
+             :workflow-cancel}
+           (set sut/workflow-subcommand-keys))))
+  (testing "chain group lists every chain-* subcommand"
+    (is (= #{:chain-run :chain-list}
+           (set sut/chain-subcommand-keys)))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/help_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/help_test.clj
@@ -1,0 +1,128 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.workflow-runner.help-test
+  "Tests for `--help` / `-h` rendering on workflow-runner CLI subcommands."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.string :as str]
+   [ai.miniforge.cli.workflow-runner.help :as sut]
+   [ai.miniforge.cli.workflow-runner.help.registry :as registry]))
+
+(defn- record-call-fn
+  "Factory returning [fn calls-atom]; the fn appends every dispatch
+   map it sees to the atom. Lets handler-with-help tests assert
+   delegation without coupling to the real subcommand handlers."
+  []
+  (let [calls (atom [])]
+    [(fn [m]
+       (swap! calls conj m)
+       :cmd-fn-called)
+     calls]))
+
+;------------------------------------------------------------------------------ Layer 0 — predicate
+
+(deftest help-requested?-recognizes-true-and-false-test
+  (testing "truthy when :help is true"
+    (is (true? (sut/help-requested? {:help true}))))
+  (testing "false when :help is missing or false"
+    (is (false? (sut/help-requested? {})))
+    (is (false? (sut/help-requested? {:help false})))))
+
+;------------------------------------------------------------------------------ Layer 1 — rendering
+
+(deftest usage-text-renders-subcommand-and-flags-test
+  (testing "every subcommand renders a usage block containing its name "
+    (testing "and at least one of its declared flags"
+      (doseq [[subcommand-key entry] registry/subcommands]
+        (let [output (sut/usage-text entry)
+              non-help-flags (remove #{:help} (keys (:spec entry)))]
+          (is (str/includes? output (:subcommand entry))
+              (str "expected " subcommand-key " usage to mention its name"))
+          (is (str/includes? output "Usage:")
+              (str "expected " subcommand-key " usage to include 'Usage:' line"))
+          (when (seq non-help-flags)
+            (let [flag-name (name (first non-help-flags))]
+              (is (str/includes? output flag-name)
+                  (str "expected " subcommand-key " usage to mention --"
+                       flag-name)))))))))
+
+(deftest usage-text-omits-help-flag-from-flag-table-test
+  (testing "the --help flag itself is not listed inside its own usage table"
+    (let [entry  (registry/entry-for :workflow-run)
+          output (sut/usage-text entry)]
+      (is (not (str/includes? output "--help"))))))
+
+(deftest group-usage-text-lists-every-child-subcommand-test
+  (testing "workflow group usage lists every workflow subcommand by leaf name"
+    (let [output (sut/group-usage-text registry/workflow-group-help)]
+      (is (str/includes? output "workflow"))
+      (doseq [leaf ["run" "list" "execute" "status" "cancel"]]
+        (is (str/includes? output leaf)
+            (str "expected workflow group usage to list '" leaf "'")))))
+  (testing "chain group usage lists every chain subcommand by leaf name"
+    (let [output (sut/group-usage-text registry/chain-group-help)]
+      (is (str/includes? output "chain"))
+      (doseq [leaf ["run" "list"]]
+        (is (str/includes? output leaf)
+            (str "expected chain group usage to list '" leaf "'"))))))
+
+;------------------------------------------------------------------------------ Layer 2 — handler-with-help delegation
+
+(deftest handler-with-help-short-circuits-on-help-flag-test
+  (testing "--help triggers the usage block and does not call the wrapped cmd-fn"
+    (let [[cmd-fn calls] (record-call-fn)
+          wrapped        (sut/handler-with-help :workflow-run cmd-fn)
+          output         (with-out-str (wrapped {:opts {:help true}}))]
+      (is (str/includes? output "workflow run"))
+      (is (empty? @calls)
+          "cmd-fn must not be invoked when --help is set"))))
+
+(deftest handler-with-help-delegates-when-help-absent-test
+  (testing "without --help, the wrapped cmd-fn receives the original dispatch map"
+    (let [[cmd-fn calls] (record-call-fn)
+          wrapped        (sut/handler-with-help :workflow-run cmd-fn)
+          dispatch-map   {:opts {:workflow-id "demo"}}]
+      (wrapped dispatch-map)
+      (is (= [dispatch-map] @calls)
+          "cmd-fn should be called once with the original dispatch map"))))
+
+(deftest handler-with-help-rejects-unknown-subcommand-key-test
+  (testing "wiring an unknown subcommand-key fails fast at construction time"
+    (is (thrown? Exception
+                 (sut/handler-with-help :no-such-subcommand
+                                        (fn [_m] :should-not-run))))))
+
+;------------------------------------------------------------------------------ Layer 2 — group-handler
+
+(deftest group-handler-prints-group-usage-test
+  (testing "workflow group handler prints every workflow subcommand leaf"
+    (let [handler (sut/group-handler registry/workflow-group-help)
+          output  (with-out-str (handler {}))]
+      (doseq [leaf ["run" "list" "execute" "status" "cancel"]]
+        (is (str/includes? output leaf)
+            (str "expected output to list '" leaf "'"))))))
+
+;------------------------------------------------------------------------------ Layer 2 — per-subcommand sweep
+
+(deftest print-usage!-includes-subcommand-name-for-every-registered-entry-test
+  (testing "every entry in the registry renders a usable --help block"
+    (doseq [[subcommand-key entry] registry/subcommands]
+      (let [output (with-out-str (sut/print-usage! entry))]
+        (is (str/includes? output (:subcommand entry))
+            (str subcommand-key " --help output should contain its name"))))))

--- a/resources/precommit-smoke-tests.edn
+++ b/resources/precommit-smoke-tests.edn
@@ -39,6 +39,8 @@
   "ai.miniforge.mcp-context-server.context-cache-test"
   "ai.miniforge.cli.main.commands.resume-test"
   "ai.miniforge.cli.workflow-runner.display-output-test"
+  "ai.miniforge.cli.workflow-runner.help.registry-test"
+  "ai.miniforge.cli.workflow-runner.help-test"
   "ai.miniforge.agent.reviewer-test"
   ;; Safe to include now that PR #897 landed the namespace-level
   ;; acquire-environment! mock — runner-test tests no longer commit


### PR DESCRIPTION
## Summary
- `mf workflow <sub> --help` and `mf chain <sub> --help` now print a localized usage block (subcommand name, one-line description, auto-generated flag table from the babashka.cli `:spec`) instead of erroring or returning the wrong thing.
- `mf workflow --help` / `mf chain --help` (no subcommand) list every child subcommand with its one-line summary.
- Single source of truth: babashka.cli `:spec` is shared between dispatch and the `--help` renderer, alongside localized summary keys in a pure-data registry.

## Pattern
Mirrors babashka.cli's own `format-opts` for the flag table + the i18n idiom from `bases/etl/src/ai/miniforge/etl/main.clj`'s `help-cmd`. The trick — keep the spec as single source of truth for both dispatch and `--help` output — is the load-bearing improvement over earlier CLIs that duplicated help copy in `:help/command-lines` static vectors.

## Subcommands covered
| Group | Subcommand |
|---|---|
| `workflow` | `run`, `list`, `execute`, `status`, `cancel` |
| `chain` | `run`, `list` |
| parent-level | `workflow` and `chain` group listings |

## Test plan
- [x] `bb test:precommit` — 302 tests / 1087 assertions / 0 failures (+2 namespaces)
- [x] `bb test:graalvm` — 6 tests / 510 assertions / 0 failures
- [x] `clj-kondo` — 0 errors / 0 warnings
- [x] Manual smoke: `mf workflow run --help`, `mf workflow list -h`, `mf chain --help` all render expected usage blocks

## Follow-up
A `thesium-workflows` submodule bump will pull the help wiring into downstream consumers; that's filed for the user to open after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)