### PR TITLE
Add observer alert rule evaluator

### DIFF
--- a/components/observer/src/ai/miniforge/observer/alerts.clj
+++ b/components/observer/src/ai/miniforge/observer/alerts.clj
@@ -1,0 +1,154 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.observer.alerts
+  (:require [clojure.string :as str]))
+
+(def AlertRule
+  [:multi {:dispatch :alert/type}
+   [:phase-gap [:map [:alert/id keyword?] [:alert/type [:= :phase-gap]]
+                [:alert/threshold [:map [:threshold-ms pos-int?]]]
+                [:alert/severity {:optional true} [:enum :info :warning :critical]]
+                [:alert/message-template {:optional true} string?]]]
+   [:tool-call-timeout [:map [:alert/id keyword?] [:alert/type [:= :tool-call-timeout]]
+                        [:alert/threshold [:map [:threshold-ms pos-int?]]]
+                        [:alert/severity {:optional true} [:enum :info :warning :critical]]
+                        [:alert/message-template {:optional true} string?]]]
+   [:tool-error-rate [:map [:alert/id keyword?] [:alert/type [:= :tool-error-rate]]
+                      [:alert/threshold [:map [:threshold-pct [:and number? [:fn #(<= 0.0 % 1.0)]]]]]
+                      [:alert/severity {:optional true} [:enum :info :warning :critical]]
+                      [:alert/message-template {:optional true} string?]]]])
+
+(def AlertMap [:map [:alert/rule-id keyword?]
+               [:alert/type [:enum :phase-gap :tool-call-timeout :tool-error-rate]]
+               [:alert/severity [:enum :info :warning :critical]]
+               [:alert/message string?] [:alert/data map?] [:alert/timestamp inst?]])
+
+(def AlertFired [:map [:event/type [:= :observer/alert-fired]]
+                 [:event/workflow-id some?] [:event/timestamp inst?]
+                 [:alert/rule-id keyword?]
+                 [:alert/type [:enum :phase-gap :tool-call-timeout :tool-error-rate]]
+                 [:alert/severity [:enum :info :warning :critical]]
+                 [:alert/message string?] [:alert/data map?] [:alert/timestamp inst?]])
+
+(def ^:private window-size 100)
+
+(defn create-alert-state []
+  (atom {:outstanding-calls {} :tool-outcomes []}))
+
+(defn- event-ms [event]
+  (try
+    (let [ts (:event/timestamp event)]
+      (cond
+        (instance? java.util.Date ts) (.getTime ^java.util.Date ts)
+        (number? ts) (long ts)
+        (string? ts) (.toEpochMilli (java.time.Instant/parse ts))
+        :else (System/currentTimeMillis)))
+    (catch Exception _ (System/currentTimeMillis))))
+
+(defn- update-state! [state event]
+  (case (:event/type event)
+    :agent/tool-call-started
+    (when-let [call-id (:tool/call-id event)]
+      (swap! state assoc-in [:outstanding-calls call-id] {:started-at (event-ms event)}))
+
+    :tool/call-completed
+    (let [call-id (:tool/call-id event)]
+      (swap! state
+             (fn [s]
+               (cond-> (update s :outstanding-calls dissoc call-id)
+                 (contains? event :tool/success?)
+                 (update :tool-outcomes
+                         (fn [xs]
+                           (let [xs' (conj (vec xs) (:tool/success? event))]
+                             (if (> (count xs') window-size)
+                               (subvec xs' (- (count xs') window-size))
+                               xs'))))))))
+    nil))
+
+(defn- template [s data]
+  (str/replace s #"\{\{([\w][\w/-]*)\}\}" #(str (get data (keyword (second %)) ""))))
+
+(defn- message [rule data]
+  (if-let [s (:alert/message-template rule)]
+    (template s data)
+    (case (:alert/type rule)
+      :phase-gap (str "Phase gap of " (:gap-ms data) "ms exceeds threshold")
+      :tool-call-timeout (str "Tool call " (:call-id data) " timed out")
+      :tool-error-rate (format "Tool error rate %.1f%% exceeds threshold"
+                               (* 100.0 (double (:error-rate data)))))))
+
+(defn- alert [rule data]
+  {:alert/rule-id (:alert/id rule)
+   :alert/type (:alert/type rule)
+   :alert/severity (get rule :alert/severity :warning)
+   :alert/message (message rule data)
+   :alert/data data
+   :alert/timestamp (java.util.Date.)})
+
+(defn- phase-gap [rule event]
+  (when (= :workflow/phase-heartbeat (:event/type event))
+    (let [gap (:phase/gap-since-last-event-ms event)
+          threshold (get-in rule [:alert/threshold :threshold-ms])]
+      (when (and gap threshold (> gap threshold))
+        (alert rule {:gap-ms gap :threshold-ms threshold})))))
+
+(defn- timeouts [rule event state]
+  (when (= :workflow/phase-heartbeat (:event/type event))
+    (let [threshold (get-in rule [:alert/threshold :threshold-ms])
+          now (event-ms event)]
+      (->> (:outstanding-calls @state)
+           (keep (fn [[call-id {:keys [started-at alerted?]}]]
+                   (let [elapsed (- now started-at)]
+                     (when (and threshold (not alerted?) (> elapsed threshold))
+                       (swap! state assoc-in [:outstanding-calls call-id :alerted?] true)
+                       (alert rule {:call-id call-id :elapsed-ms elapsed
+                                    :threshold-ms threshold})))))
+           vec))))
+
+(defn- error-rate [rule event state]
+  (when (= :workflow/phase-heartbeat (:event/type event))
+    (let [xs (:tool-outcomes @state)
+          threshold (get-in rule [:alert/threshold :threshold-pct])]
+      (when (and (seq xs) threshold)
+        (let [failures (count (remove true? xs))
+              rate (double (/ failures (count xs)))]
+          (when (> rate threshold)
+            (alert rule {:error-rate rate
+                         :failure-count failures
+                         :total-count (count xs)
+                         :threshold-pct threshold})))))))
+
+(defn evaluate-rules [rules event state]
+  (update-state! state event)
+  (into []
+        (mapcat (fn [rule]
+                  (let [x (case (:alert/type rule)
+                            :phase-gap (phase-gap rule event)
+                            :tool-call-timeout (timeouts rule event state)
+                            :tool-error-rate (error-rate rule event state)
+                            nil)]
+                    (cond (nil? x) [] (sequential? x) x :else [x]))))
+        rules))
+
+(defn alert-fired [_stream workflow-id alert-map]
+  (merge {:event/type :observer/alert-fired
+          :event/workflow-id workflow-id
+          :event/timestamp (java.util.Date.)}
+         (select-keys alert-map [:alert/rule-id :alert/type :alert/severity
+                                 :alert/message :alert/data :alert/timestamp])))

--- a/components/observer/src/ai/miniforge/observer/interface.clj
+++ b/components/observer/src/ai/miniforge/observer/interface.clj
@@ -47,8 +47,9 @@
      ;; Create telemetry artifact
      (observer/create-telemetry-artifact obs artifact-store)"
   (:require
-   [ai.miniforge.observer.protocol :as proto]
-   [ai.miniforge.observer.core :as core]))
+   [ai.miniforge.observer.alerts :as alerts]
+   [ai.miniforge.observer.core :as core]
+   [ai.miniforge.observer.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Observer creation
@@ -288,3 +289,15 @@
         :data {:count 100 :avg 5000 ...}
         :summary \"Analyzed 100 workflows...\"})"
   proto/analysis-result)
+
+(def create-alert-state
+  "Create alert evaluator state: outstanding tool calls and known tool outcomes."
+  alerts/create-alert-state)
+
+(def evaluate-rules
+  "Evaluate alert rule maps against an event; returns fired alert maps."
+  alerts/evaluate-rules)
+
+(def alert-fired
+  "Build an :observer/alert-fired event from workflow id and fired alert map."
+  alerts/alert-fired)

--- a/components/observer/test/ai/miniforge/observer/alerts_test.clj
+++ b/components/observer/test/ai/miniforge/observer/alerts_test.clj
@@ -1,0 +1,102 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.observer.alerts-test
+  (:require
+   [ai.miniforge.observer.alerts :as alerts]
+   [ai.miniforge.observer.interface :as observer]
+   [clojure.test :refer [deftest is]]))
+
+(defn- heartbeat [gap]
+  (cond-> {:event/type :workflow/phase-heartbeat}
+    gap (assoc :phase/gap-since-last-event-ms gap)))
+
+(defn- start [id]
+  {:event/type :agent/tool-call-started :tool/call-id id
+   :event/timestamp #inst "2026-05-21T00:00:00Z"})
+
+(defn- done [id ok?]
+  (cond-> {:event/type :tool/call-completed :tool/call-id id}
+    (some? ok?) (assoc :tool/success? ok?)))
+
+(defn- phase-rule [ms]
+  {:alert/id :phase-gap :alert/type :phase-gap :alert/threshold {:threshold-ms ms}})
+
+(defn- timeout-rule [ms]
+  {:alert/id :timeout :alert/type :tool-call-timeout
+   :alert/threshold {:threshold-ms ms} :alert/severity :critical})
+
+(defn- error-rule [pct]
+  {:alert/id :error-rate :alert/type :tool-error-rate :alert/threshold {:threshold-pct pct}})
+
+(deftest state-and-phase-gap
+  (let [state (alerts/create-alert-state)]
+    (is (= {:outstanding-calls {} :tool-outcomes []} @state))
+    (is (empty? (alerts/evaluate-rules [(phase-rule 10)] (heartbeat 10) state)))
+    (let [fired (alerts/evaluate-rules [(phase-rule 10)] (heartbeat 11) state)]
+      (is (= [:phase-gap] (mapv :alert/type fired)))
+      (is (= :warning (:alert/severity (first fired))))
+      (is (inst? (:alert/timestamp (first fired)))))))
+
+(deftest tool-timeout-tracks-start-and-completion
+  (let [state (alerts/create-alert-state)
+        rules [(timeout-rule 100000)]]
+    (alerts/evaluate-rules rules (start "c1") state)
+    (is (contains? (:outstanding-calls @state) "c1"))
+    (alerts/evaluate-rules rules (done "c1" true) state)
+    (is (not (contains? (:outstanding-calls @state) "c1")))
+    (is (= [true] (:tool-outcomes @state)))))
+
+(deftest tool-timeout-fires-on-heartbeat
+  (let [state (alerts/create-alert-state)]
+    (alerts/evaluate-rules [(timeout-rule 1)] (start "old") state)
+    (let [tick (assoc (heartbeat nil) :event/timestamp #inst "2026-05-21T00:00:02Z")
+          fired (alerts/evaluate-rules [(timeout-rule 1)] tick state)]
+      (is (= [:tool-call-timeout] (mapv :alert/type fired)))
+      (is (= :critical (:alert/severity (first fired))))
+      (is (empty? (alerts/evaluate-rules [(timeout-rule 1)] tick state))))))
+
+(deftest error-rate-fires-only-on-heartbeat
+  (let [state (alerts/create-alert-state)
+        rules [(error-rule 0.5)]]
+    (doseq [[id ok?] [["a" false] ["b" false] ["c" true]]]
+      (alerts/evaluate-rules rules (done id ok?) state))
+    (alerts/evaluate-rules rules (done "unknown" nil) state)
+    (is (= 3 (count (:tool-outcomes @state))))
+    (is (empty? (alerts/evaluate-rules rules {:event/type :agent/chunk} state)))
+    (let [fired (alerts/evaluate-rules rules (heartbeat nil) state)]
+      (is (= [:tool-error-rate] (mapv :alert/type fired)))
+      (is (= 2 (get-in (first fired) [:alert/data :failure-count]))))))
+
+(deftest alert-envelope-preserves-alert-timestamp
+  (let [state (observer/create-alert-state)
+        alert (first (observer/evaluate-rules [(phase-rule 1)] (heartbeat 2) state))
+        event (observer/alert-fired nil "wf-1" alert)]
+    (is (= :observer/alert-fired (:event/type event)))
+    (is (= "wf-1" (:event/workflow-id event)))
+    (is (= (:alert/timestamp alert) (:alert/timestamp event)))))
+
+(deftest templates-and-empty-rules
+  (let [state (alerts/create-alert-state)
+        rule {:alert/id :template
+              :alert/type :phase-gap
+              :alert/threshold {:threshold-ms 1}
+              :alert/message-template "gap={{gap-ms}} missing={{nope}}"}]
+    (is (empty? (alerts/evaluate-rules [] (heartbeat 100) state)))
+    (is (= "gap=2 missing="
+           (:alert/message (first (alerts/evaluate-rules [rule] (heartbeat 2) state)))))))


### PR DESCRIPTION
## Summary
- add compact observer alert evaluator for phase gaps, tool-call timeouts, and tool error rate
- expose evaluator helpers through observer interface
- cover heartbeat-only error-rate evaluation and alert event timestamp propagation

## Tests
- clojure -M:dev:test -e "(require 'ai.miniforge.observer.alerts-test)(let [r (clojure.test/run-tests 'ai.miniforge.observer.alerts-test)](System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
- pre-commit hook passed: commit-budget 194/200, poly check, lint, smoke, GraalVM/Babashka compatibility