### PR TITLE
Wire observer alert subscriber

### DIFF
--- a/components/observer/deps.edn
+++ b/components/observer/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         ai.miniforge/workflow {:local/root "../workflow"}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/artifact {:local/root "../artifact"}
         ai.miniforge/knowledge {:local/root "../knowledge"}}
  

--- a/components/observer/src/ai/miniforge/observer/alert_subscriber.clj
+++ b/components/observer/src/ai/miniforge/observer/alert_subscriber.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.observer.alert-subscriber
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.observer.alerts :as alerts]))
+
+(def ^:private watched-types
+  #{:workflow/phase-heartbeat :agent/tool-call-started :tool/call-completed})
+
+(defn rules-from-config [config]
+  (vec (get-in config [:observability :alerts] [])))
+
+(defn- alert-event [workflow-id alert]
+  (assoc (alerts/alert-fired nil workflow-id alert) :workflow/id workflow-id))
+
+(defn- watched-workflow-event? [workflow-id event]
+  (and (contains? watched-types (:event/type event))
+       (= workflow-id (:workflow/id event))))
+
+(defn start-alert-subscriber!
+  ([event-stream workflow-id rules]
+   (start-alert-subscriber! event-stream workflow-id rules {}))
+  ([event-stream workflow-id rules {:keys [subscriber-id alert-state]}]
+   (if (empty? rules)
+     {:noop? true}
+     (let [id (or subscriber-id (keyword "observer.alerts" (str workflow-id)))
+           state (or alert-state (alerts/create-alert-state))]
+       (es/subscribe!
+        event-stream
+        id
+        (fn [event]
+          (doseq [alert (alerts/evaluate-rules rules event state)]
+            (es/publish! event-stream (alert-event workflow-id alert))))
+        (partial watched-workflow-event? workflow-id))
+       {:subscriber-id id :alert-state state}))))
+
+(defn stop-alert-subscriber! [event-stream handle]
+  (when-let [id (:subscriber-id handle)]
+    (es/unsubscribe! event-stream id))
+  nil)

--- a/components/observer/src/ai/miniforge/observer/interface.clj
+++ b/components/observer/src/ai/miniforge/observer/interface.clj
@@ -47,6 +47,7 @@
      ;; Create telemetry artifact
      (observer/create-telemetry-artifact obs artifact-store)"
   (:require
+   [ai.miniforge.observer.alert-subscriber :as alert-subscriber]
    [ai.miniforge.observer.alerts :as alerts]
    [ai.miniforge.observer.core :as core]
    [ai.miniforge.observer.protocol :as proto]))
@@ -301,3 +302,15 @@
 (def alert-fired
   "Build an :observer/alert-fired event from workflow id and fired alert map."
   alerts/alert-fired)
+
+(def start-alert-subscriber!
+  "Subscribe to workflow heartbeat/tool events and publish fired alert events."
+  alert-subscriber/start-alert-subscriber!)
+
+(def stop-alert-subscriber!
+  "Stop a handle returned by start-alert-subscriber!; nil/no-op safe."
+  alert-subscriber/stop-alert-subscriber!)
+
+(def rules-from-config
+  "Return alert rule maps from [:observability :alerts] config."
+  alert-subscriber/rules-from-config)

--- a/components/observer/test/ai/miniforge/observer/alert_subscriber_test.clj
+++ b/components/observer/test/ai/miniforge/observer/alert_subscriber_test.clj
@@ -1,0 +1,65 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.observer.alert-subscriber-test
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.observer.alert-subscriber :as sut]
+   [clojure.test :refer [deftest is]]))
+
+(defn- heartbeat [wf-id gap]
+  {:event/type :workflow/phase-heartbeat
+   :workflow/id wf-id
+   :phase/gap-since-last-event-ms gap
+   :event/timestamp #inst "2026-05-21T00:00:01Z"})
+
+(def phase-rule
+  {:alert/id :phase-gap
+   :alert/type :phase-gap
+   :alert/threshold {:threshold-ms 10}})
+
+(deftest subscriber-publishes-alert-event
+  (let [stream (es/create-event-stream)
+        wf-id (random-uuid)
+        handle (sut/start-alert-subscriber! stream wf-id [phase-rule])]
+    (es/publish! stream (heartbeat (random-uuid) 99))
+    (es/publish! stream (heartbeat wf-id 11))
+    (let [events (es/get-events stream)
+          alerts (filter #(= :observer/alert-fired (:event/type %)) events)]
+      (is (= 3 (count events)))
+      (is (= 1 (count alerts)))
+      (is (= wf-id (:event/workflow-id (first alerts))))
+      (is (= wf-id (:workflow/id (first alerts))))
+      (is (= :phase-gap (:alert/type (first alerts)))))
+    (sut/stop-alert-subscriber! stream handle)
+    (es/publish! stream (heartbeat wf-id 12))
+    (is (= 1 (count (filter #(= :observer/alert-fired (:event/type %))
+                            (es/get-events stream)))))))
+
+(deftest no-op-when-rules-empty
+  (let [stream (es/create-event-stream)
+        handle (sut/start-alert-subscriber! stream "wf" [])]
+    (is (:noop? handle))
+    (es/publish! stream (heartbeat (random-uuid) 99))
+    (is (= 1 (count (es/get-events stream))))
+    (is (nil? (sut/stop-alert-subscriber! stream nil)))))
+
+(deftest rules-from-config-reads-observability-alerts
+  (is (= [phase-rule]
+         (sut/rules-from-config {:observability {:alerts [phase-rule]}})))
+  (is (= [] (sut/rules-from-config {}))))


### PR DESCRIPTION
## Summary
- add observer alert subscriber lifecycle around event-stream subscriptions
- publish fired observer alert events back into the event stream
- add config rule extraction and tests for stop/no-op behavior

## Tests
- clojure -M:dev:test -e "(require 'ai.miniforge.observer.alert-subscriber-test)(let [r (clojure.test/run-tests 'ai.miniforge.observer.alert-subscriber-test)](System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
- pre-commit hook passed: commit-budget 80/200, poly check, lint, smoke, GraalVM/Babashka compatibility