### PR TITLE
Add dogfood runner output specs

### DIFF
--- a/work/in-progress/dogfood-final-result-summary.spec.edn
+++ b/work/in-progress/dogfood-final-result-summary.spec.edn
@@ -1,0 +1,26 @@
+{:spec/title "Dogfood: summarize final workflow result output"
+
+ :spec/description
+ "Dogfood runs currently print the entire workflow result map under `Full result:` by default. The event-log-visibility rerun completed successfully but still dumped thousands of lines of event, artifact, and exploration content to the terminal. Replace the default full EDN dump with a compact operator summary and a pointer to the full persisted result for debugging."
+
+ :spec/intent {:type :fix
+               :scope ["bases/cli/src"
+                       "components/workflow/src"
+                       "components/event-stream/src"]}
+
+ :spec/constraints
+ ["Do not change persisted event/result payload shapes"
+  "Do not remove access to the full result; gate it behind a debug flag or print a file/checkpoint path"
+  "Default success and failure output should remain human-readable in a terminal"
+  "Summary must include workflow status, phase statuses/durations, failed task ids when present, PRs created/merged when present, and a pointer to full logs/result"
+  "Keep existing machine-readable/debug output paths available"]
+
+ :spec/acceptance-criteria
+ ["Successful workflow completion no longer prints a multi-thousand-line `Full result:` EDN map by default"
+  "Failed workflow completion prints a compact failure summary with failed task ids and short error text"
+  "Default output includes a path or id that lets an operator inspect the full persisted result"
+  "A debug flag or equivalent opt-in still prints or retrieves the full result"
+  "Tests cover success and failure terminal rendering paths"
+  "Dogfood rerun output ends with the compact summary instead of a full result dump"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/in-progress/dogfood-plan-artifact-warning.spec.edn
+++ b/work/in-progress/dogfood-plan-artifact-warning.spec.edn
@@ -1,0 +1,27 @@
+{:spec/title "Dogfood: suppress false plan artifact missing warning"
+
+ :spec/description
+ "Successful dogfood runs can still print `ERROR: artifact file not found ... artifact.edn -- MCP tool was likely not called by the LLM` after the planner writes `.miniforge/plan.edn` and the runtime accepts it. The warning is misleading: the expected worktree-promoted plan artifact exists, the plan phase succeeds, and the workflow can complete. Fix the artifact retrieval/reporting path so missing optional MCP artifact files do not render as terminal errors when a valid phase artifact was found."
+
+ :spec/intent {:type :fix
+               :scope ["components/agent/src"
+                       "components/workflow/src"
+                       "bases/cli/src"
+                       "components/phase-software-factory/src"]}
+
+ :spec/constraints
+ ["Do not reintroduce a submit_artifact MCP requirement"
+  "The worktree-promoted `.miniforge/plan.edn` path remains the planner submission source of truth"
+  "Keep a hard failure when neither the MCP artifact nor the expected on-disk phase artifact exists"
+  "Do not suppress genuine parse/validation errors for malformed plan files"
+  "Default terminal output must not include a false `ERROR:` line on successful already-satisfied or plan-file runs"]
+
+ :spec/acceptance-criteria
+ ["A planner run that writes a valid `.miniforge/plan.edn` completes without printing `artifact.edn` missing as an ERROR"
+  "A planner run that writes no plan file and provides no valid fallback still fails with a clear missing-artifact diagnostic"
+  "Malformed `.miniforge/plan.edn` still fails with parse/validation context"
+  "Regression test covers the successful plan-file path without a submitted MCP artifact"
+  "Regression test covers the real missing-artifact failure path"
+  "Dogfood rerun of an already-satisfied spec produces no false artifact warning"]
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
Adds two in-progress dogfood specs for runner output defects observed during the event-log visibility rerun:

- suppress the false missing artifact.edn ERROR when .miniforge/plan.edn is accepted
- replace default Full result EDN dumps with a compact terminal summary and a pointer to full persisted output

Local checks passed via the commit hook, including poly check, clj-kondo, pre-commit smoke, and GraalVM compatibility.