### PR TITLE
Fix dogfood spec intent types

### DIFF
--- a/work/in-progress/dogfood-final-result-summary.spec.edn
+++ b/work/in-progress/dogfood-final-result-summary.spec.edn
@@ -3,7 +3,7 @@
  :spec/description
  "Dogfood runs currently print the entire workflow result map under `Full result:` by default. The event-log-visibility rerun completed successfully but still dumped thousands of lines of event, artifact, and exploration content to the terminal. Replace the default full EDN dump with a compact operator summary and a pointer to the full persisted result for debugging."
 
- :spec/intent {:type :fix
+ :spec/intent {:type :bugfix
                :scope ["bases/cli/src"
                        "components/workflow/src"
                        "components/event-stream/src"]}

--- a/work/in-progress/dogfood-plan-artifact-warning.spec.edn
+++ b/work/in-progress/dogfood-plan-artifact-warning.spec.edn
@@ -3,7 +3,7 @@
  :spec/description
  "Successful dogfood runs can still print `ERROR: artifact file not found ... artifact.edn -- MCP tool was likely not called by the LLM` after the planner writes `.miniforge/plan.edn` and the runtime accepts it. The warning is misleading: the expected worktree-promoted plan artifact exists, the plan phase succeeds, and the workflow can complete. Fix the artifact retrieval/reporting path so missing optional MCP artifact files do not render as terminal errors when a valid phase artifact was found."
 
- :spec/intent {:type :fix
+ :spec/intent {:type :bugfix
                :scope ["components/agent/src"
                        "components/workflow/src"
                        "bases/cli/src"


### PR DESCRIPTION
The dogfood specs added in PR 951 used :fix, but the workflow spec schema accepts :bugfix for fixes. This changes both specs to :bugfix so they can run.

Local commit hook passed: poly check, clj-kondo, pre-commit smoke, and GraalVM compatibility.