### PR TITLE
feat(plan+release): inject phase-filtered standards addendum into planner and releaser prompts

### DIFF
--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -394,5 +394,29 @@ These are documented real failures that cost real tokens:
    not `[{:plan/id ...}]`.
 4. **Invalid EDN** — file must parse. Check your syntax before Write.
 
+## Standards enforcement (CRITICAL)
+
+When this prompt is delivered to the LLM, the runtime may append one or
+both of these sections produced by `phase/format-behavior-addendum` and
+`phase/format-knowledge-addendum`:
+
+- `## Policy Rules — Required Behaviors` — numbered, one entry per rule
+  in the compiled policy pack that targets the plan phase and ships a
+  `:rule/agent-behavior` string.
+- `## Reference Material` — per-rule `:rule/knowledge-content` blocks
+  for rules whose enforcement needs reference detail.
+
+Neither section is exhaustive. Rules without `:rule/agent-behavior` /
+`:rule/knowledge-content`, and rules whose context filter excludes
+this task, are not appended.
+
+**Each entry in those sections is a constraint the plan you write MUST
+honor.** Examples of patterns the appended rules currently flag (when
+their rule fires): specification-standards (work-spec authoring shape),
+simple-made-easy (decomposition), localization rules that bear on
+user-facing strings the plan introduces. Cite the rule by dewey code
+or slug in the relevant plan task's notes when a rule shapes a
+decomposition choice.
+
 Remember: A good plan enables parallel execution where possible while
 respecting necessary dependencies. Optimize for clarity and testability."}

--- a/components/agent/resources/prompts/releaser.edn
+++ b/components/agent/resources/prompts/releaser.edn
@@ -138,5 +138,33 @@ If existing files are provided in your context, use them directly.
 **Do NOT use Read, mcp__context__context_read, or any tool to re-read files
 whose content is already provided.**
 
+## Standards enforcement (CRITICAL)
+
+When this prompt is delivered to the LLM, the runtime may append one or
+both of these sections produced by `phase/format-behavior-addendum` and
+`phase/format-knowledge-addendum`:
+
+- `## Policy Rules — Required Behaviors` — numbered, one entry per rule
+  in the compiled policy pack that targets the release phase and ships
+  a `:rule/agent-behavior` string.
+- `## Reference Material` — per-rule `:rule/knowledge-content` blocks
+  for rules whose enforcement needs reference detail.
+
+Neither section is exhaustive. Rules without `:rule/agent-behavior` /
+`:rule/knowledge-content`, and rules whose context filter excludes
+this task, are not appended.
+
+**Each entry in those sections is a constraint your release artifact
+MUST satisfy.** Examples of patterns that may appear:
+
+- Localization (050): user-visible strings — including the PR title and
+  PR description sections you generate here — must route through
+  `messages/t`-style keys, not be hardcoded English literals if the
+  rule targets release. Apply per the rule's `:rule/applies-to`.
+- Conventional commit / branch naming rules, if present.
+
+Cite the rule by its dewey code or slug in your reasoning when a rule
+shapes a choice (branch name, title format, etc.).
+
 Remember: Your release metadata will be used for git commits and GitHub PRs.
 Write messages that help reviewers understand the changes at a glance."}

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -427,8 +427,13 @@
                                  :prompt/progress-monitor))
 
 (defn- invoke-planner-session
-  "Session body for the planner: build mcp-opts with model hint, call LLM."
-  [session llm-client user-prompt config context on-chunk existing-files]
+  "Session body for the planner: build mcp-opts with model hint, call LLM.
+
+   `effective-system` is the base planner prompt with the phase-filtered
+   policy addendum appended by the caller (mirrors reviewer / releaser /
+   implementer wiring so the planner sees the same compiled standards
+   pack)."
+  [session llm-client user-prompt effective-system config context on-chunk existing-files]
   (when (seq existing-files)
     (artifact-session/write-context-cache-for-session!
      session
@@ -455,9 +460,9 @@
                    (:workdir session) (assoc :workdir (:workdir session)))]
     (if on-chunk
       (llm/chat-stream llm-client user-prompt on-chunk
-                       (merge {:system @planner-system-prompt} mcp-opts))
+                       (merge {:system effective-system} mcp-opts))
       (llm/chat llm-client user-prompt
-                (merge {:system @planner-system-prompt} mcp-opts)))))
+                (merge {:system effective-system} mcp-opts)))))
 
 (defn- normalize-planner-result
   [response worktree-artifacts artifact]
@@ -490,8 +495,12 @@
   "Run one short follow-up turn that only submits the final plan.
    Turn cap and progress-monitor thresholds come from
    resources/prompts/planner.edn (:prompt/submission-retry-max-turns,
-   :prompt/submission-retry-monitor)."
-  [session llm-client retry-prompt config context on-chunk]
+   :prompt/submission-retry-monitor).
+
+   `effective-system` is the same base-plus-addendum string used by the
+   main session, so the retry turn enforces the same compiled policy
+   pack the planner saw on the first call."
+  [session llm-client retry-prompt effective-system config context on-chunk]
   (let [prompt-data    @planner-prompt-data
         budget-usd     (budget/resolve-cost-budget-usd :planner config context)
         retry-max-turns (get prompt-data :prompt/submission-retry-max-turns)
@@ -504,17 +513,17 @@
                          (:workdir session) (assoc :workdir (:workdir session)))]
     (if on-chunk
       (llm/chat-stream llm-client retry-prompt on-chunk
-                       (merge {:system @planner-system-prompt} mcp-opts))
+                       (merge {:system effective-system} mcp-opts))
       (llm/chat llm-client retry-prompt
-                (merge {:system @planner-system-prompt} mcp-opts)))))
+                (merge {:system effective-system} mcp-opts)))))
 
 (defn- recover-submitted-plan
   "Retry planner submission once when analysis exists but the final submission
    did not land. Returns {:llm-response ... :submitted-plan ... :parsed-plan ...}."
-  [llm-client spec-text config context on-chunk prior-content]
+  [llm-client spec-text effective-system config context on-chunk prior-content]
   (let [retry-prompt   (submission-retry-prompt spec-text prior-content)
         run-retry      #(invoke-planner-submission-retry-session
-                          % llm-client retry-prompt config context on-chunk)
+                          % llm-client retry-prompt effective-system config context on-chunk)
         {:keys [llm-result artifact worktree-artifacts]}
         (artifact-session/with-session context run-retry)
         normalized     (normalize-planner-result llm-result worktree-artifacts artifact)
@@ -609,13 +618,16 @@
               on-chunk (:on-chunk context)
               spec-text (spec->text input)
               existing-files (:task/existing-files input)
-              user-prompt    (build-user-prompt spec-text existing-files)]
+              user-prompt    (build-user-prompt spec-text existing-files)
+              effective-system (str @planner-system-prompt
+                                    (get input :task/behavior-addendum ""))]
           ;; Past this point `llm-client` is non-nil — the
           ;; require-llm-client-or-anomaly boundary above already
           ;; escalated when the backend was missing.
           (let [{:keys [llm-result artifact worktree-artifacts context-misses]}
                   (artifact-session/with-session context
-                    #(invoke-planner-session % llm-client user-prompt config context
+                    #(invoke-planner-session % llm-client user-prompt
+                                             effective-system config context
                                              on-chunk existing-files))
                   llm-response llm-result
                   normalized (normalize-planner-result llm-response worktree-artifacts artifact)
@@ -630,6 +642,7 @@
                                            {:data {:reason :missing-plan-submission
                                                    :content-length (count response-content)}})
                                  (recover-submitted-plan llm-client spec-text
+                                                         effective-system
                                                          config context on-chunk
                                                          response-content))
                   final-llm-response   (or (:llm-response retry-result) llm-response)

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -199,15 +199,20 @@
 ;; Public API
 
 (defn- invoke-releaser-session
-  "Session body for the releaser: build mcp-opts, call LLM."
-  [session llm-client user-prompt config context on-chunk]
+  "Session body for the releaser: build mcp-opts, call LLM.
+
+   `effective-system` is the base releaser prompt with the
+   phase-filtered policy addendum appended by the caller (mirrors
+   reviewer/implementer wiring so the releaser sees the same compiled
+   standards pack)."
+  [session llm-client user-prompt effective-system config context on-chunk]
   (let [budget-usd (budget/resolve-cost-budget-usd :releaser config context)
         mcp-opts (artifact-session/session->mcp-opts session budget-usd 15)]
     (if on-chunk
       (llm/chat-stream llm-client user-prompt on-chunk
-                       (merge {:system @releaser-system-prompt} mcp-opts))
+                       (merge {:system effective-system} mcp-opts))
       (llm/chat llm-client user-prompt
-                (merge {:system @releaser-system-prompt} mcp-opts)))))
+                (merge {:system effective-system} mcp-opts)))))
 
 (defn create-releaser
   "Create a Releaser agent with optional configuration overrides.
@@ -239,12 +244,15 @@
                           :releaser
                           (get opts :llm-backend (:llm-backend context)))
               on-chunk (:on-chunk context)
-              user-prompt (input->text input context)]
+              user-prompt (input->text input context)
+              effective-system (str @releaser-system-prompt
+                                    (get input :task/behavior-addendum ""))]
           (if llm-client
             ;; Use the real LLM with artifact session for MCP tool support
             (let [{:keys [llm-result artifact worktree-artifacts]}
                   (artifact-session/with-session context
-                    #(invoke-releaser-session % llm-client user-prompt config context on-chunk))
+                    #(invoke-releaser-session % llm-client user-prompt
+                                              effective-system config context on-chunk))
                   llm-response llm-result
                   normalized (result-boundary/normalize-llm-result
                               {:role :release

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -243,6 +243,89 @@
           (is (str/includes? (second @prompts) "Do NOT explore further"))
           (is (str/includes? (second @prompts) "Write `.miniforge/plan.edn`"))))))))
 
+(deftest planner-system-prompt-includes-behavior-addendum-test
+  ;; Pins the wiring that lets the planner agent see the phase-filtered
+  ;; standards rules `phase/load-and-filter-behaviors :plan` produces.
+  ;; Without this, rules targeting :plan (specification-standards,
+  ;; simple-made-easy, …) stay invisible to the planner the same way
+  ;; the reviewer was blind to them before #945.
+  (testing ":task/behavior-addendum on the input is appended to the LLM :system opt"
+    (let [captured (atom nil)
+          fake-llm-client {:type :fake}
+          fake-plan {:plan/id (random-uuid)
+                     :plan/name "addendum-test"
+                     :plan/tasks []}
+          addendum "\n\n## Policy Rules — Required Behaviors\n\n1. Plan rule body."
+          agent (planner/create-planner {:llm-backend fake-llm-client})]
+      (with-redefs [model/resolve-llm-client-for-role
+                    (fn [_role provided] provided)
+                    artifact-session/with-session
+                    (fn [_context body-fn]
+                      (let [llm-result (body-fn {:dir "/tmp/fake-session"
+                                                 :workdir "/tmp/fake-workdir"
+                                                 :mcp-config-path "/tmp/fake-session/mcp-config.json"
+                                                 :mcp-allowed-tools []
+                                                 :supervision {}
+                                                 :pre-session-snapshot {}})]
+                        {:llm-result llm-result
+                         :artifact fake-plan
+                         :worktree-artifacts {}
+                         :context-misses nil
+                         :pre-session-snapshot {}
+                         :session-mode :host}))
+                    llm/chat (fn [_client _prompt opts]
+                               (reset! captured opts)
+                               {:status :success :content ""})
+                    llm/success? #(= :success (:status %))
+                    llm/get-content :content]
+        (core/invoke agent {:llm-backend fake-llm-client}
+                     {:description "Plan this"
+                      :task/behavior-addendum addendum})
+        (is (some? @captured) "LLM client should have been called")
+        (let [system-prompt (:system @captured)]
+          (is (string? system-prompt))
+          (is (str/includes? system-prompt "Policy Rules")
+              "appended addendum must surface in the LLM :system opt — the whole point of the wiring")
+          (is (str/includes? system-prompt "Plan rule body.")
+              "rule body text must reach the LLM verbatim"))))))
+
+(deftest planner-system-prompt-empty-when-no-addendum-test
+  (testing "absent :task/behavior-addendum is treated as empty — no nil concat"
+    (let [captured (atom nil)
+          fake-llm-client {:type :fake}
+          fake-plan {:plan/id (random-uuid)
+                     :plan/name "no-addendum"
+                     :plan/tasks []}
+          agent (planner/create-planner {:llm-backend fake-llm-client})]
+      (with-redefs [model/resolve-llm-client-for-role
+                    (fn [_role provided] provided)
+                    artifact-session/with-session
+                    (fn [_context body-fn]
+                      (let [llm-result (body-fn {:dir "/tmp/fake-session"
+                                                 :workdir "/tmp/fake-workdir"
+                                                 :mcp-config-path "/tmp/fake-session/mcp-config.json"
+                                                 :mcp-allowed-tools []
+                                                 :supervision {}
+                                                 :pre-session-snapshot {}})]
+                        {:llm-result llm-result
+                         :artifact fake-plan
+                         :worktree-artifacts {}
+                         :context-misses nil
+                         :pre-session-snapshot {}
+                         :session-mode :host}))
+                    llm/chat (fn [_client _prompt opts]
+                               (reset! captured opts)
+                               {:status :success :content ""})
+                    llm/success? #(= :success (:status %))
+                    llm/get-content :content]
+        (core/invoke agent {:llm-backend fake-llm-client}
+                     {:description "Plan this"})
+        (is (some? @captured))
+        (let [system-prompt (:system @captured)]
+          (is (string? system-prompt)
+              ":system must always be a string (default \"\" when no addendum)")
+          (is (pos? (count system-prompt))))))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests
 

--- a/components/agent/test/ai/miniforge/agent/releaser_test.clj
+++ b/components/agent/test/ai/miniforge/agent/releaser_test.clj
@@ -115,6 +115,87 @@
           (is (= "feature/already-ready"
                  (get-in result [:output :release/branch-name]))))))))
 
+(deftest releaser-system-prompt-includes-behavior-addendum-test
+  ;; Pins the wiring that lets the releaser agent see the standards
+  ;; rules `phase/load-and-filter-behaviors` produces for the :release
+  ;; phase. Without this, conventional-commit / branch-naming /
+  ;; localization rules that target the release phase stay invisible
+  ;; to the releaser, the same way the reviewer was blind to them
+  ;; before #945.
+  (testing ":task/behavior-addendum on the input is appended to the LLM :system opt"
+    (let [captured (atom nil)
+          fake-llm-client {:type :fake}
+          parsed-release {:release/id (random-uuid)
+                          :release/branch-name "feature/x"
+                          :release/commit-message "feat: x"
+                          :release/pr-title "feat: x"
+                          :release/pr-description "## Summary\nx"}
+          addendum "\n\n## Policy Rules — Required Behaviors\n\n1. Test release rule body."
+          agent (releaser/create-releaser {:llm-backend fake-llm-client})]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role provided] provided)
+                    artifact-session/with-session
+                    (fn [_context body-fn]
+                      (let [session {:mcp-config-path nil
+                                     :mcp-allowed-tools []
+                                     :supervision nil}
+                            llm-result (body-fn session)]
+                        {:llm-result llm-result
+                         :artifact nil
+                         :worktree-artifacts {}
+                         :session-mode :host}))
+                    llm/chat (fn [_client _prompt opts]
+                               (reset! captured opts)
+                               {:success? true
+                                :content (pr-str parsed-release)
+                                :tokens 1})
+                    llm/success? :success?
+                    llm/get-content :content]
+        (core/invoke agent {:llm-backend fake-llm-client}
+                     (assoc code-artifact-input
+                            :task/behavior-addendum addendum))
+        (is (some? @captured) "LLM client should have been called")
+        (let [system-prompt (:system @captured)]
+          (is (string? system-prompt))
+          (is (clojure.string/includes? system-prompt "Policy Rules")
+              "appended addendum must surface in the LLM :system opt — the whole point of the wiring")
+          (is (clojure.string/includes? system-prompt "Test release rule body.")
+              "rule body text must reach the LLM verbatim"))))))
+
+(deftest releaser-system-prompt-empty-when-no-addendum-test
+  (testing "absent :task/behavior-addendum is treated as empty — no nil concat"
+    (let [captured (atom nil)
+          fake-llm-client {:type :fake}
+          parsed-release {:release/id (random-uuid)
+                          :release/branch-name "feature/x"
+                          :release/commit-message "feat: x"
+                          :release/pr-title "feat: x"
+                          :release/pr-description "## Summary\nx"}
+          agent (releaser/create-releaser {:llm-backend fake-llm-client})]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role provided] provided)
+                    artifact-session/with-session
+                    (fn [_context body-fn]
+                      (let [session {:mcp-config-path nil
+                                     :mcp-allowed-tools []
+                                     :supervision nil}
+                            llm-result (body-fn session)]
+                        {:llm-result llm-result
+                         :artifact nil
+                         :worktree-artifacts {}
+                         :session-mode :host}))
+                    llm/chat (fn [_client _prompt opts]
+                               (reset! captured opts)
+                               {:success? true
+                                :content (pr-str parsed-release)
+                                :tokens 1})
+                    llm/success? :success?
+                    llm/get-content :content]
+        (core/invoke agent {:llm-backend fake-llm-client} code-artifact-input)
+        (is (some? @captured))
+        (let [system-prompt (:system @captured)]
+          (is (string? system-prompt)
+              ":system must always be a string (default \"\" when no addendum)")
+          (is (pos? (count system-prompt))))))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests
 

--- a/components/agent/test/ai/miniforge/agent/releaser_test.clj
+++ b/components/agent/test/ai/miniforge/agent/releaser_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.agent.releaser-test
   "Tests for the Releaser agent."
   (:require
+   [clojure.string :as str]
    [clojure.test :as test :refer [deftest testing is]]
    [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.core :as core]
@@ -156,9 +157,9 @@
         (is (some? @captured) "LLM client should have been called")
         (let [system-prompt (:system @captured)]
           (is (string? system-prompt))
-          (is (clojure.string/includes? system-prompt "Policy Rules")
+          (is (str/includes? system-prompt "Policy Rules")
               "appended addendum must surface in the LLM :system opt — the whole point of the wiring")
-          (is (clojure.string/includes? system-prompt "Test release rule body.")
+          (is (str/includes? system-prompt "Test release rule body.")
               "rule body text must reach the LLM verbatim"))))))
 
 (deftest releaser-system-prompt-empty-when-no-addendum-test

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -59,11 +59,21 @@
 
 (defn build-planner-task
   "Build the task map to pass to the planner agent.
+
+   The planner now receives a `:task/behavior-addendum` produced by
+   `phase/load-and-filter-behaviors` for rules that target `:plan`
+   (specification-standards, work-spec-authoring, simple-made-easy,
+   etc.) — same mechanism implement and review use. Closes the gap
+   where the planner generated plans without consulting the
+   compiled standards pack.
+
    Returns {:task task-map :rules-manifest manifest-or-nil}."
   [input explore-result knowledge-store]
   (let [existing-files (:exploration/files explore-result)
         {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
                                        knowledge-store :planner (get input :tags []))
+        behavior-addendum (phase/load-and-filter-behaviors
+                            :plan {:task {:task/intent (:intent input)}})
         task (cond-> {:task/id (random-uuid)
                       :task/type :plan
                       :task/description (:description input)
@@ -73,7 +83,9 @@
                (seq existing-files)
                (assoc :task/existing-files existing-files)
                formatted
-               (assoc :task/knowledge-context formatted))]
+               (assoc :task/knowledge-context formatted)
+               behavior-addendum
+               (assoc :task/behavior-addendum behavior-addendum))]
     {:task task
      :rules-manifest manifest}))
 

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -268,9 +268,19 @@
    log calls (phase-started / fail / phase-completed) are emitted
    even when the workflow ctx lacks :execution/logger — observed in
    the 2026-05-03 dogfood, where release failed in 0ms with zero
-   visible log lines because the executor's logger was nil."
+   visible log lines because the executor's logger was nil.
+
+   Also computes the phase-filtered policy-pack behavior addendum via
+   `phase/load-and-filter-behaviors :release` and threads it as
+   `:task/behavior-addendum` so `release-executor/invoke-releaser` can
+   forward it into the agent input. Mirrors the wiring review (#945)
+   and plan use; closes the gap where the releaser ran without the
+   compiled standards pack."
   [ctx config logger]
-  (let [on-chunk (phase/create-streaming-callback ctx :release)]
+  (let [on-chunk (phase/create-streaming-callback ctx :release)
+        input (get-in ctx [:execution/input])
+        behavior-addendum (phase/load-and-filter-behaviors
+                            :release {:task {:task/intent (:intent input)}})]
     (cond-> {:worktree-path (or (get-in ctx [:execution/worktree-path])
                                 (get-in ctx [:worktree-path])
                                 (get-in config [:worktree-path])
@@ -287,7 +297,8 @@
                              (get config :create-pr? true))
              ;; Resolve and inject GitHub token for capsule gh CLI auth
              :github-token (resolve-github-token ctx)}
-      on-chunk (assoc :on-chunk on-chunk))))
+      on-chunk (assoc :on-chunk on-chunk)
+      behavior-addendum (assoc :task/behavior-addendum behavior-addendum))))
 
 (defn enter-release
   "Execute release phase.

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/plan_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/plan_test.clj
@@ -1,0 +1,62 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-software-factory.plan-test
+  "Tests for the plan phase — specifically the policy-pack wiring that
+   was added so the planner agent sees the same compiled standards
+   pack the rest of the phases do."
+  (:require
+   [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
+   [ai.miniforge.phase-software-factory.plan :as plan]
+   [ai.miniforge.phase.interface :as phase]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest build-planner-task-threads-behavior-addendum-test
+  (testing "build-planner-task computes and attaches :task/behavior-addendum"
+    (let [stub-addendum "\n\n## Policy Rules — Required Behaviors\n\n1. Plan rule body."]
+      (with-redefs [phase/load-and-filter-behaviors
+                    (fn [phase-kw _ctx]
+                      (when (= :plan phase-kw) stub-addendum))
+                    kb-helpers/inject-with-manifest
+                    (fn [_store _role _tags]
+                      {:formatted nil :manifest nil})]
+        (let [{:keys [task]} (plan/build-planner-task
+                              {:description "Add feature"
+                               :title "Feature"
+                               :intent "testing"
+                               :constraints nil}
+                              {:exploration/files []}
+                              nil)]
+          (is (= stub-addendum (:task/behavior-addendum task))
+              "planner task must carry the phase-filtered addendum so create-planner can append it to the system prompt"))))))
+
+(deftest build-planner-task-omits-behavior-addendum-when-filter-returns-nil-test
+  (testing "no :task/behavior-addendum key when phase/load-and-filter-behaviors yields nil"
+    (with-redefs [phase/load-and-filter-behaviors (fn [_phase _ctx] nil)
+                  kb-helpers/inject-with-manifest
+                  (fn [_store _role _tags]
+                    {:formatted nil :manifest nil})]
+      (let [{:keys [task]} (plan/build-planner-task
+                            {:description "Add feature"
+                             :title "Feature"
+                             :intent "testing"
+                             :constraints nil}
+                            {:exploration/files []}
+                            nil)]
+        (is (not (contains? task :task/behavior-addendum))
+            "no addendum key when filter yields nothing — avoids nil-valued task entries")))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -288,6 +288,59 @@
   [entries-atom]
   (into #{} (keep :log/event) @entries-atom))
 
+(deftest release-threads-behavior-addendum-onto-executor-context-test
+  (testing "build-executor-context computes :task/behavior-addendum and threads it to the release executor"
+    ;; Pins the wiring that lets the releaser agent see the
+    ;; phase-filtered policy pack. Mirrors PR #945 (reviewer):
+    ;; release.clj must call phase/load-and-filter-behaviors :release
+    ;; and forward the resulting addendum via the executor context so
+    ;; release-executor/invoke-releaser can put it on the agent input.
+    (with-test-worktree
+      (fn [worktree]
+        (let [captured-context (atom nil)
+              stub-addendum "\n\n## Policy Rules — Required Behaviors\n\n1. Release rule body."]
+          (with-redefs [phase/load-and-filter-behaviors
+                        (fn [phase-kw _ctx]
+                          (when (= :release phase-kw) stub-addendum))
+                        release-executor/execute-release-phase
+                        (fn [_ws ec _opts]
+                          (reset! captured-context ec)
+                          {:success? true
+                           :artifacts [{:artifact/id (random-uuid)
+                                        :artifact/type :release
+                                        :artifact/content {}}]
+                           :metrics {:files-written 0}})]
+            (let [ctx (create-base-context worktree)
+                  ctx-with-config (assoc ctx :phase-config {:phase :release})
+                  interceptor (phase/get-phase-interceptor {:phase :release})]
+              ((:enter interceptor) ctx-with-config)
+              (is (some? @captured-context)
+                  "executor must be invoked")
+              (is (= stub-addendum (:task/behavior-addendum @captured-context))
+                  ":task/behavior-addendum from phase/load-and-filter-behaviors must reach the executor context"))))))))
+
+(deftest release-omits-behavior-addendum-when-filter-returns-nil-test
+  (testing "no addendum key on executor context when phase/load-and-filter-behaviors returns nil"
+    (with-test-worktree
+      (fn [worktree]
+        (let [captured-context (atom nil)]
+          (with-redefs [phase/load-and-filter-behaviors (fn [_phase _ctx] nil)
+                        release-executor/execute-release-phase
+                        (fn [_ws ec _opts]
+                          (reset! captured-context ec)
+                          {:success? true
+                           :artifacts [{:artifact/id (random-uuid)
+                                        :artifact/type :release
+                                        :artifact/content {}}]
+                           :metrics {:files-written 0}})]
+            (let [ctx (create-base-context worktree)
+                  ctx-with-config (assoc ctx :phase-config {:phase :release})
+                  interceptor (phase/get-phase-interceptor {:phase :release})]
+              ((:enter interceptor) ctx-with-config)
+              (is (some? @captured-context))
+              (is (not (contains? @captured-context :task/behavior-addendum))
+                  "no addendum key when filter yields nothing — avoids nil-valued context entries"))))))))
+
 (deftest release-passes-non-nil-logger-to-executor-when-ctx-logger-absent-test
   (testing "build-executor-context falls back to the phase-local logger when :execution/logger is absent"
     ;; Pre-fix the release-executor ran with logger=nil whenever the

--- a/components/release-executor/src/ai/miniforge/release_executor/metadata.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/metadata.clj
@@ -186,14 +186,24 @@
 
 (defn invoke-releaser
   "Invoke the releaser agent to generate release metadata.
-   Falls back to nil if agent fails (caller should use fallback)."
+   Falls back to nil if agent fails (caller should use fallback).
+
+   Reads `:task/behavior-addendum` from `context` (placed there by the
+   release phase via `phase/load-and-filter-behaviors :release`) and
+   threads it into the agent input so `releaser.clj` can append it to
+   the system prompt. Mirrors the wiring used by review and implement
+   so the releaser sees the same compiled policy pack the rest of the
+   phases do."
   [releaser code-artifacts task-description context logger]
   (let [llm-backend (:llm-backend context)
         first-artifact (first code-artifacts)
-        input {:code-artifact first-artifact
-               :task-description (or task-description
-                                     (:code/summary first-artifact)
-                                     (default-task-description))}]
+        behavior-addendum (:task/behavior-addendum context)
+        input (cond-> {:code-artifact first-artifact
+                       :task-description (or task-description
+                                             (:code/summary first-artifact)
+                                             (default-task-description))}
+                behavior-addendum
+                (assoc :task/behavior-addendum behavior-addendum))]
     (if (and releaser llm-backend)
       (try
         (let [result ((:invoke-fn releaser)

--- a/components/release-executor/test/ai/miniforge/release_executor/metadata_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/metadata_test.clj
@@ -136,3 +136,44 @@
           result (metadata/extract-test-artifacts artifacts)]
       (is (= 1 (count result)))
       (is (= :passed (:test/results (first result)))))))
+
+(deftest invoke-releaser-threads-behavior-addendum-from-context
+  ;; Pins the wiring that lets the release phase forward the
+  ;; phase-filtered policy pack to the releaser agent. The release
+  ;; phase puts `:task/behavior-addendum` on the executor context
+  ;; (via `phase/load-and-filter-behaviors :release` in
+  ;; `build-executor-context`); `invoke-releaser` must lift that
+  ;; value off the context and assoc it onto the agent input so
+  ;; `releaser.clj` can append it to the system prompt.
+  (testing ":task/behavior-addendum on context flows into agent input"
+    (let [captured-input (atom nil)
+          fake-releaser {:invoke-fn (fn [_ctx input]
+                                      (reset! captured-input input)
+                                      {:status :success
+                                       :output {:release/branch-name "x"}})}
+          addendum "\n\n## Policy Rules\n1. test"
+          context {:llm-backend ::fake
+                   :task/behavior-addendum addendum}
+          code-artifacts [{:code/files [{:path "a.clj" :action :create}]
+                           :code/summary "x"}]]
+      (metadata/invoke-releaser fake-releaser code-artifacts
+                                "describe" context nil)
+      (is (some? @captured-input) "agent should be invoked")
+      (is (= addendum (:task/behavior-addendum @captured-input))
+          "addendum from context must be threaded onto agent input"))))
+
+(deftest invoke-releaser-omits-behavior-addendum-when-absent
+  (testing "no :task/behavior-addendum key when context lacks it"
+    (let [captured-input (atom nil)
+          fake-releaser {:invoke-fn (fn [_ctx input]
+                                      (reset! captured-input input)
+                                      {:status :success
+                                       :output {:release/branch-name "x"}})}
+          context {:llm-backend ::fake}
+          code-artifacts [{:code/files [{:path "a.clj" :action :create}]
+                           :code/summary "x"}]]
+      (metadata/invoke-releaser fake-releaser code-artifacts
+                                "describe" context nil)
+      (is (some? @captured-input))
+      (is (not (contains? @captured-input :task/behavior-addendum))
+          "absent context addendum must not produce a nil-valued input key"))))


### PR DESCRIPTION
## Summary

- Wires `phase/load-and-filter-behaviors` into `plan.clj` and `release.clj` so the planner and releaser agents see the same compiled policy pack the implementer and reviewer do.
- Mirrors PR #945 (reviewer) shape: phase computes the addendum → threads it into the agent input → agent appends to `@system-prompt`.
- Updates `releaser.edn` to describe the appended `## Policy Rules` / `## Reference Material` sections so the LLM treats them as constraints, not flavour text.

## Why

Pre-#945 the reviewer was blind to the compiled standards pack and let policy violations through; #945 fixed reviewer. The planner and releaser were the next two phases stuck in that same blind state — plan was generating plans without consulting the catalog, and the releaser was generating PR titles / branch names / descriptions without seeing rules that target the release phase (e.g. localization on PR-body strings, conventional-commit shape). This closes both gaps so *every transition applies policy appropriate for the transition it's in* — the architectural point that motivated #945.

## Files Changed

- `components/phase-software-factory/src/.../plan.clj` (modify) — `build-planner-task` computes and attaches `:task/behavior-addendum` for `:plan`.
- `components/phase-software-factory/src/.../release.clj` (modify) — `build-executor-context` computes `:task/behavior-addendum` for `:release` and forwards via executor context.
- `components/release-executor/src/.../metadata.clj` (modify) — `invoke-releaser` lifts the addendum off context and assoc's it onto the agent input.
- `components/agent/src/.../releaser.clj` (modify) — appends `(get input :task/behavior-addendum "")` to `@releaser-system-prompt`.
- `components/agent/resources/prompts/releaser.edn` (modify) — Standards-enforcement section documenting the appended sections.
- New `plan_test.clj` (create) — pins addendum threading + omission.
- `release_test.clj` (modify) — adds addendum-threading + omission pins.
- `metadata_test.clj` (modify) — adds invoke-releaser threading + omission pins.
- `releaser_test.clj` (modify) — adds system-prompt-includes-addendum + empty-addendum pins.

## Test plan

- [x] `clojure -M:test … plan-test` — 2/2 passes
- [x] `clojure -M:test … releaser-test` (new pins) — 7 assertions
- [x] `clojure -M:test … metadata-test` (new pins) — 4 assertions
- [x] Pre-commit smoke (16 namespaces, 1120 assertions, 0 failures)
- [ ] Dogfood validation: rerun the spec from the 2026-05-20 cycle and confirm the planner/releaser prompts now carry `## Policy Rules` text (B in the A→B→C plan).

Budget rationale (encoded with the commit): single-purpose mirror of #945 wired across plan and release in lock-step; splitting would just produce two PRs that share docstrings and the same intent. Most lines are mandatory test pins (#716) for both phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)