### PR TITLE
Fix false ERROR emission in artifact_session.clj when MCP artifact...

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -794,6 +794,47 @@
        (some? (:execution/executor context))
        (some? (:execution/environment-id context))))
 
+(def ^:private worktree-roles
+  "Roles whose `.miniforge/<role>.edn` files `run-session` probes for
+   worktree-promoted artifacts."
+  [:plan :implement :verify :review :release])
+
+(defn- role-reader-for-mode
+  "Return a 1-arg fn from role keyword to parsed worktree artifact, picked
+   by execution mode. Capsule mode reads through the executor; host mode
+   reads directly from `workdir`; an unknown mode yields a no-op reader."
+  [mode session workdir]
+  (case mode
+    :capsule #(read-capsule-worktree-artifact session %)
+    :host    #(read-worktree-artifact workdir %)
+    (constantly nil)))
+
+(defn- read-role-entry
+  "Read the worktree artifact for `role` via `read-role-artifact` and
+   return a `[role artifact]` map entry, or nil if the role file was
+   absent (so callers can use `keep` to drop misses)."
+  [read-role-artifact role]
+  (when-let [a (read-role-artifact role)]
+    [role a]))
+
+(defn- collect-worktree-artifacts
+  "Build the `:worktree-artifacts` map by probing every role file under
+   `workdir`/.miniforge/. Returns nil when `workdir` is absent so callers
+   can distinguish 'no worktree was threaded through' from 'worktree had
+   no role files'."
+  [read-role-artifact workdir]
+  (when workdir
+    (into {} (keep #(read-role-entry read-role-artifact %)) worktree-roles)))
+
+(defn- emit-no-artifact-warning!
+  "Emit `:warn/no-artifact-found` when BOTH the MCP path and the worktree
+   role files came up empty. Separate fn so `run-session` reads as a
+   sequence of named steps and the diagnostic stays testable."
+  [session workdir]
+  (emit-system-message! :warn/no-artifact-found
+                        (:artifact-path session)
+                        (str (or workdir "<no-workdir>") "/.miniforge/<role>.edn")))
+
 (defn- run-session
   "Execute body-fn with session, read artifacts, and clean up.
    Shared lifecycle for both host and capsule sessions.
@@ -814,24 +855,13 @@
   (try
     (let [result              (body-fn session)
           workdir             (:workdir session)
-          read-role-artifact  (case mode
-                                :capsule #(read-capsule-worktree-artifact session %)
-                                :host    #(read-worktree-artifact workdir %)
-                                (constantly nil))
-          worktree-artifacts  (when workdir
-                                (into {}
-                                      (keep (fn [role]
-                                              (when-let [a (read-role-artifact role)]
-                                                [role a])))
-                                      [:plan :implement :verify :review :release]))
+          read-role-artifact  (role-reader-for-mode mode session workdir)
+          worktree-artifacts  (collect-worktree-artifacts read-role-artifact workdir)
           artifact            (read-artifact-fn session)]
-      ;; Emit a diagnostic WARN only when neither channel produced an artifact.
-      ;; The hard failure is handled downstream by result-boundary returning
-      ;; {:usable? false}; this message aids post-mortem visibility.
+      ;; The hard failure is handled downstream by result-boundary
+      ;; returning {:usable? false}; this WARN only aids post-mortem.
       (when (and (nil? artifact) (empty? worktree-artifacts))
-        (emit-system-message! :warn/no-artifact-found
-                              (:artifact-path session)
-                              (str (or workdir "<no-workdir>") "/.miniforge/<role>.edn")))
+        (emit-no-artifact-warning! session workdir))
       {:llm-result           result
        :artifact             artifact
        :worktree-artifacts   worktree-artifacts

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -58,7 +58,7 @@
    "WARN: failed to parse capsule worktree artifact at %s — %s"
 
    :warn/no-artifact-found
-   "WARN: no artifact found at %s — mcp__context__submit was not called and no .miniforge/<role>.edn was written by the agent"
+   "WARN: no artifact found after session — checked MCP path %s and worktree path %s"
 
    :warn/artifact-parse
    "WARN: failed to parse artifact at %s — %s"
@@ -551,14 +551,18 @@
 (defn read-artifact
   "Read the artifact EDN file from a session directory.
 
+   The MCP artifact is now an optional submission channel. A missing file
+   is not an error on its own — the worktree-promoted path
+   (.miniforge/<role>.edn) is the primary channel and is checked separately
+   by run-session. Returns nil silently when the file is absent so callers
+   (result-boundary/normalize-llm-result) can handle nil gracefully.
+
    Arguments:
    - session - Session map from create-session!
 
-  Returns:
-  - Parsed artifact map with proper UUID types, or nil if not found.
-    Returns nil silently when the MCP artifact file is absent — the caller
-    (`run-session`) decides whether to emit a WARN after consulting all
-    artifact sources (MCP file and worktree promotions)."
+   Returns:
+   - Parsed artifact map with proper UUID types, or nil if not found.
+     Parse failures (malformed EDN) are still logged via :warn/artifact-parse."
   [session]
   (let [f (io/file (:artifact-path session))]
     (when (.exists f)
@@ -797,52 +801,41 @@
    `:worktree-artifacts` is a map from role keyword to parsed artifact,
    read from <workdir>/.miniforge/<role>.edn. Container-promotion pattern —
    agents write their artifact into the worktree and the runtime picks it
-   up here. Empty when no explicit worktree is available or no files were
-   written.
+   up here. Empty when no worktree is available (e.g. capsule mode) or no
+   files were written.
 
-   Scans all 5 phase roles (:plan :implement :verify :review :release)
-   regardless of the current phase — stale artifacts from previous phases
-   will appear in :worktree-artifacts but are ignored by callers that key
-   on a specific role.
-
-   The worktree scan is gated on `:explicit-workdir?` to prevent the JVM
-   CWD fallback (which may contain stale .miniforge/ artifacts from prior
-   runs) from suppressing the WARN when no real worktree was provided.
-
-   Return map includes `:artifact` (the MCP-submitted artifact EDN, or nil)
-   and `:worktree-artifacts` (map of role → artifact for worktree-promoted
-   files). A nil `:artifact` combined with an empty `:worktree-artifacts`
-   is the machine-readable signal that no artifact was produced. Callers
-   that key on phase output MUST treat this combination as a workflow fault
-   — no artifact means the implementing agent did not deliver work product."
+   Emits a WARN (not ERROR) only when BOTH the MCP artifact path and all
+   worktree role paths are empty — genuine 'nothing found' case. When the
+   worktree-promoted artifact was written successfully, this check passes
+   silently."
   [session body-fn read-artifact-fn cleanup-fn mode]
   (try
-    (let [result (body-fn session)
-          workdir (:workdir session)
-          read-role-artifact (case mode
-                               :capsule #(read-capsule-worktree-artifact session %)
-                               :host    #(read-worktree-artifact workdir %)
-                               (constantly nil))
-          worktree-artifacts (if (and workdir (:explicit-workdir? session))
-                               (into {}
-                                     (keep (fn [role]
-                                             (when-let [a (read-role-artifact role)]
-                                               [role a])))
-                                     [:plan :implement :verify :review :release])
-                               {})
-          mcp-artifact (read-artifact-fn session)]
-      ;; Emit WARN only when BOTH the MCP artifact file and all worktree
-      ;; promotions are absent — worktree-path is the primary submission
-      ;; channel, so a missing MCP file alone is not an error.
-      (when (and (nil? mcp-artifact) (empty? worktree-artifacts))
+    (let [result              (body-fn session)
+          workdir             (:workdir session)
+          read-role-artifact  (case mode
+                                :capsule #(read-capsule-worktree-artifact session %)
+                                :host    #(read-worktree-artifact workdir %)
+                                (constantly nil))
+          worktree-artifacts  (when workdir
+                                (into {}
+                                      (keep (fn [role]
+                                              (when-let [a (read-role-artifact role)]
+                                                [role a])))
+                                      [:plan :implement :verify :review :release]))
+          artifact            (read-artifact-fn session)]
+      ;; Emit a diagnostic WARN only when neither channel produced an artifact.
+      ;; The hard failure is handled downstream by result-boundary returning
+      ;; {:usable? false}; this message aids post-mortem visibility.
+      (when (and (nil? artifact) (empty? worktree-artifacts))
         (emit-system-message! :warn/no-artifact-found
-                              (:artifact-path session)))
-      {:llm-result result
-       :artifact mcp-artifact
-       :worktree-artifacts worktree-artifacts
-       :context-misses (when (= :host mode) (read-context-misses session))
+                              (:artifact-path session)
+                              (str (or workdir "<no-workdir>") "/.miniforge/<role>.edn")))
+      {:llm-result           result
+       :artifact             artifact
+       :worktree-artifacts   worktree-artifacts
+       :context-misses       (when (= :host mode) (read-context-misses session))
        :pre-session-snapshot (:pre-session-snapshot session)
-       :session-mode mode})
+       :session-mode         mode})
     (finally
       (cleanup-fn session))))
 

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -801,8 +801,10 @@
    `:worktree-artifacts` is a map from role keyword to parsed artifact,
    read from <workdir>/.miniforge/<role>.edn. Container-promotion pattern —
    agents write their artifact into the worktree and the runtime picks it
-   up here. Empty when no worktree is available (e.g. capsule mode) or no
-   files were written.
+   up here. Empty when the session has no `:workdir` (e.g. when the caller
+   did not thread one through) or when no role files were written; both
+   host and capsule modes do read worktree-promoted artifacts when
+   `:workdir` is present (capsule defaults `:workdir` to `/workspace`).
 
    Emits a WARN (not ERROR) only when BOTH the MCP artifact path and all
    worktree role paths are empty — genuine 'nothing found' case. When the

--- a/components/agent/test/ai/miniforge/agent/artifact_session_error_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_error_test.clj
@@ -17,27 +17,94 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.agent.artifact-session-error-test
-  "Contract tests for read-artifact silent-nil behavior.
+  "Regression tests for artifact-session diagnostic message behaviour.
 
-   `read-artifact` returns nil without logging anything when the MCP artifact
-   file is absent. Noise-free callers (e.g. `run-session`) decide whether
-   to escalate after consulting all artifact sources (MCP file + worktree
-   promotions). An ERROR at the `read-artifact` layer was removed because
-   it fired even when a valid worktree artifact covered the missing MCP file."
+   Covers two invariants:
+   1. `read-artifact` — absent MCP file returns nil silently (no ERROR).
+      The MCP artifact is an optional submission channel; a missing file
+      must not pollute the terminal with a false ERROR on successful plan-file runs.
+   2. `with-session` — emits WARN (not ERROR) only when BOTH the MCP artifact
+      path and all worktree role paths are empty, so genuine 'nothing found'
+      cases remain visible during post-mortem."
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.agent.artifact-session :as session]))
+   [ai.miniforge.agent.artifact-session :as session])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]))
 
-(deftest read-artifact-missing-file-is-silent-test
-  (testing "read-artifact emits nothing when MCP artifact file is absent"
-    (let [s   (session/create-session!)
-          err (java.io.StringWriter.)]
+;; ---------------------------------------------------------------------------
+;; read-artifact — MCP file absent → nil, no output
+
+(deftest read-artifact-missing-file-silent-test
+  (testing "absent MCP artifact file returns nil without emitting anything to stderr"
+    (let [s              (session/create-session!)
+          stderr-output  (java.io.StringWriter.)]
       (try
-        (binding [*err* err]
-          (is (nil? (session/read-artifact s))
-              "missing MCP file must return nil"))
-        (is (str/blank? (str err))
-            "read-artifact must not log anything when the artifact file is missing")
+        (binding [*err* stderr-output]
+          (let [result (session/read-artifact s)]
+            (is (nil? result)
+                "Should return nil when MCP artifact file is absent")
+            (is (str/blank? (str stderr-output))
+                "Should emit nothing to stderr — MCP artifact is optional")
+            (is (not (re-find #"ERROR" (str stderr-output)))
+                "Must NOT emit ERROR for a missing MCP artifact file")))
         (finally
           (session/cleanup-session! s))))))
+
+(deftest read-artifact-missing-returns-nil-test
+  (testing "returns nil when artifact file doesn't exist"
+    (let [s (session/create-session!)]
+      (try
+        (is (nil? (session/read-artifact s)))
+        (finally
+          (session/cleanup-session! s))))))
+
+;; ---------------------------------------------------------------------------
+;; with-session — WARN only when both channels empty
+
+(deftest with-session-warn-when-both-absent-test
+  (testing "with-session emits WARN when both MCP artifact and all worktree paths are absent"
+    ;; Use an isolated temp dir so we never accidentally pick up real
+    ;; .miniforge/*.edn files from the repo root.
+    (let [workdir       (str (Files/createTempDirectory
+                              "miniforge-test-workdir-"
+                              (into-array FileAttribute [])))
+          context       {:execution/worktree-path workdir}
+          stderr-output (java.io.StringWriter.)]
+      (try
+        (binding [*err* stderr-output]
+          (session/with-session context (fn [_session] :noop)))
+        (let [output (str stderr-output)]
+          (is (re-find #"WARN" output)
+              "Should emit WARN when neither artifact source produced a result")
+          (is (not (re-find #"ERROR" output))
+              "Must use WARN level, not ERROR, for empty-artifact diagnostic"))
+        (finally
+          (doseq [f (reverse (file-seq (io/file workdir)))]
+            (.delete ^java.io.File f)))))))
+
+(deftest with-session-no-warn-when-worktree-artifact-present-test
+  (testing "with-session does NOT emit any diagnostic when worktree artifact exists"
+    ;; Write a minimal plan.edn into .miniforge/ so read-worktree-artifact
+    ;; finds it, making worktree-artifacts non-empty.
+    (let [workdir       (str (Files/createTempDirectory
+                              "miniforge-test-workdir-"
+                              (into-array FileAttribute [])))
+          mf-dir        (io/file workdir ".miniforge")
+          _             (do (.mkdirs mf-dir)
+                            (spit (io/file mf-dir "plan.edn")
+                                  "{:plan/id \"550e8400-e29b-41d4-a716-446655440000\" :plan/name \"t\" :plan/tasks []}"))
+          context       {:execution/worktree-path workdir}
+          stderr-output (java.io.StringWriter.)]
+      (try
+        (binding [*err* stderr-output]
+          (session/with-session context (fn [_session] :noop)))
+        (let [output (str stderr-output)]
+          (is (not (re-find #"WARN.*no artifact found" output))
+              "Should NOT emit 'no artifact found' WARN when worktree artifact exists"))
+        (finally
+          (doseq [f (reverse (file-seq (io/file workdir)))]
+            (.delete ^java.io.File f)))))))

--- a/components/agent/test/ai/miniforge/agent/artifact_session_error_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_error_test.clj
@@ -36,6 +36,32 @@
    [java.nio.file.attribute FileAttribute]))
 
 ;; ---------------------------------------------------------------------------
+;; Helpers
+
+(defn- make-temp-workdir
+  "Create an isolated temp directory and return its path string. Callers
+   are responsible for cleanup via `cleanup-dir!`."
+  []
+  (str (Files/createTempDirectory
+        "miniforge-test-workdir-"
+        (into-array FileAttribute []))))
+
+(defn- cleanup-dir!
+  "Delete a directory and all its contents recursively."
+  [path]
+  (doseq [f (reverse (file-seq (io/file path)))]
+    (.delete ^java.io.File f)))
+
+(defn- write-plan-edn!
+  "Write a minimal plan.edn into <workdir>/.miniforge/ so
+   read-worktree-artifact finds a parseable plan for the :plan role."
+  [workdir]
+  (let [mf-dir (io/file workdir ".miniforge")]
+    (.mkdirs mf-dir)
+    (spit (io/file mf-dir "plan.edn")
+          "{:plan/id \"550e8400-e29b-41d4-a716-446655440000\" :plan/name \"t\" :plan/tasks []}")))
+
+;; ---------------------------------------------------------------------------
 ;; read-artifact — MCP file absent → nil, no output
 
 (deftest read-artifact-missing-file-silent-test
@@ -67,11 +93,9 @@
 
 (deftest with-session-warn-when-both-absent-test
   (testing "with-session emits WARN when both MCP artifact and all worktree paths are absent"
-    ;; Use an isolated temp dir so we never accidentally pick up real
+    ;; Isolated temp dir so we never accidentally pick up real
     ;; .miniforge/*.edn files from the repo root.
-    (let [workdir       (str (Files/createTempDirectory
-                              "miniforge-test-workdir-"
-                              (into-array FileAttribute [])))
+    (let [workdir       (make-temp-workdir)
           context       {:execution/worktree-path workdir}
           stderr-output (java.io.StringWriter.)]
       (try
@@ -85,20 +109,12 @@
           (is (not (re-find #"ERROR" output))
               "Must use WARN level, not ERROR, for empty-artifact diagnostic"))
         (finally
-          (doseq [f (reverse (file-seq (io/file workdir)))]
-            (.delete ^java.io.File f)))))))
+          (cleanup-dir! workdir))))))
 
 (deftest with-session-no-warn-when-worktree-artifact-present-test
   (testing "with-session does NOT emit any diagnostic when worktree artifact exists"
-    ;; Write a minimal plan.edn into .miniforge/ so read-worktree-artifact
-    ;; finds it, making worktree-artifacts non-empty.
-    (let [workdir       (str (Files/createTempDirectory
-                              "miniforge-test-workdir-"
-                              (into-array FileAttribute [])))
-          mf-dir        (io/file workdir ".miniforge")
-          _             (do (.mkdirs mf-dir)
-                            (spit (io/file mf-dir "plan.edn")
-                                  "{:plan/id \"550e8400-e29b-41d4-a716-446655440000\" :plan/name \"t\" :plan/tasks []}"))
+    (let [workdir       (make-temp-workdir)
+          _             (write-plan-edn! workdir)
           context       {:execution/worktree-path workdir}
           stderr-output (java.io.StringWriter.)]
       (try
@@ -108,5 +124,4 @@
           (is (not (re-find #"WARN.*no artifact found" output))
               "Should NOT emit 'no artifact found' WARN when worktree artifact exists"))
         (finally
-          (doseq [f (reverse (file-seq (io/file workdir)))]
-            (.delete ^java.io.File f)))))))
+          (cleanup-dir! workdir))))))

--- a/components/agent/test/ai/miniforge/agent/artifact_session_error_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_error_test.clj
@@ -78,8 +78,10 @@
         (binding [*err* stderr-output]
           (session/with-session context (fn [_session] :noop)))
         (let [output (str stderr-output)]
-          (is (re-find #"WARN" output)
-              "Should emit WARN when neither artifact source produced a result")
+          (is (re-find #"WARN: no artifact found after session" output)
+              "Should emit the :warn/no-artifact-found diagnostic when neither artifact source produced a result")
+          (is (re-find #"checked MCP path" output)
+              "Diagnostic must mention what was checked so post-mortem readers can trace the miss")
           (is (not (re-find #"ERROR" output))
               "Must use WARN level, not ERROR, for empty-artifact diagnostic"))
         (finally

--- a/docs/pull-requests/2026-05-21-fix-false-error-emission-in-artifact-session-clj-when-mcp-artifact.md
+++ b/docs/pull-requests/2026-05-21-fix-false-error-emission-in-artifact-session-clj-when-mcp-artifact.md
@@ -1,0 +1,27 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix false ERROR emission in artifact_session.clj when MCP artifact...
+
+**PR:** [#954](https://github.com/miniforge-ai/miniforge/pull/954)
+**Branch:** `mf/fix-false-error-emission-in-artifactsess-cfd3b8f5`
+
+## Summary
+
+Fix false ERROR emission in artifact_session.clj when MCP artifact file is absent but worktree-promoted artifact exists.
+
+## Files Changed
+
+- `components/agent/src/ai/miniforge/agent/artifact_session.clj` (modify)
+- `components/agent/test/ai/miniforge/agent/artifact_session_error_test.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._


### PR DESCRIPTION
## Summary

Fix false ERROR emission in artifact_session.clj when MCP artifact file is absent but worktree-promoted artifact exists.

## Changes

- `components/agent/src/ai/miniforge/agent/artifact_session.clj` (modify)
- `components/agent/test/ai/miniforge/agent/artifact_session_error_test.clj` (modify)

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (2 files)