### PR TITLE
Cover capsule artifact warning paths

### DIFF
--- a/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
@@ -20,11 +20,38 @@
   "Tests for capsule-aware artifact sessions (N11 §6.3-6.4).
    Verifies with-session dispatches correctly between host and capsule modes."
   (:require
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
    [ai.miniforge.agent.artifact-session :as session]
    [ai.miniforge.dag-executor.executor :as executor]
    [ai.miniforge.dag-executor.result :as result]))
+
+;------------------------------------------------------------------------------ helpers
+
+(defn- delete-dir!
+  "Recursively delete a directory tree."
+  [path]
+  (doseq [^java.io.File f (reverse (file-seq (io/file path)))]
+    (.delete f)))
+
+(defn- local-cat-exec!
+  "Stub exec! that reads 'cat <path>' from the local filesystem.
+   All other commands (mkdir, rm, git status, etc.) succeed with empty output.
+   Used for tests that need a real workdir on disk without a live executor."
+  [_executor _env-id cmd _opts]
+  (if (str/starts-with? cmd "cat ")
+    (let [path (subs cmd 4)
+          f    (io/file path)]
+      {:ok?  true
+       :data {:exit-code (if (.exists f) 0 1)
+              :stdout    (if (.exists f) (slurp f) "")
+              :stderr    ""}})
+    {:ok? true :data {:exit-code 0 :stdout "" :stderr ""}}))
+
+;; run-session is private; accessed via ns-resolve for white-box testing.
+(def ^:private run-session*
+  @(ns-resolve 'ai.miniforge.agent.artifact-session 'run-session))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Mock executor infrastructure
@@ -187,6 +214,79 @@
           artifact (session/read-capsule-worktree-artifact s :implement)]
       (is (= :already-implemented (:status artifact)))
       (is (= "already there" (:summary artifact))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; :explicit-workdir? flag and WARN suppression (artifact-warning-suppression PR)
+
+(deftest create-capsule-session-sets-explicit-workdir-test
+  (testing "create-capsule-session! always sets :explicit-workdir? true"
+    ;; The 4-arity form accepts an inject execute-fn, so the test never
+    ;; touches requiring-resolve or a live Docker executor.
+    (let [dir (str (System/getProperty "java.io.tmpdir") "/caps-test-" (random-uuid))]
+      (.mkdirs (io/file dir))
+      (try
+        (let [s (session/create-capsule-session! ::stub "env-1" dir local-cat-exec!)]
+          (is (true? (:explicit-workdir? s))
+              ":explicit-workdir? must be true so run-session scans worktree artifacts")
+          (is (= dir (:workdir s)))
+          (is (true? (:capsule? s))))
+        (finally
+          (delete-dir! dir))))))
+
+(deftest capsule-worktree-artifact-suppresses-warn-test
+  (testing "no WARN when .miniforge/plan.edn exists in capsule workdir (no MCP artifact)"
+    (let [dir       (str (System/getProperty "java.io.tmpdir") "/caps-warn-" (random-uuid))
+          plan-file (io/file dir ".miniforge" "plan.edn")]
+      (.mkdirs (.getParentFile plan-file))
+      ;; Write a minimal parseable plan artifact to the capsule workdir
+      (spit plan-file "{:plan/summary \"stub\" :plan/tasks []}")
+      (try
+        (let [session {:workdir           dir
+                       :explicit-workdir? true
+                       :capsule?          true
+                       ;; artifact-path does NOT exist → read-capsule-artifact returns nil
+                       :artifact-path     (str dir "/.miniforge-session/artifact.edn")
+                       :exec!             local-cat-exec!
+                       :executor          ::stub
+                       :environment-id    "env-1"}
+              err    (java.io.StringWriter.)
+              result (binding [*err* err]
+                       (run-session* session
+                                     (constantly :ok)
+                                     session/read-capsule-artifact
+                                     (constantly nil)   ; cleanup noop
+                                     :capsule))]
+          (is (not (str/includes? (str err) "WARN: no artifact found"))
+              "WARN must be suppressed when worktree artifact covers the missing MCP file")
+          (is (contains? (:worktree-artifacts result) :plan)
+              "worktree-artifacts must include :plan from .miniforge/plan.edn"))
+        (finally
+          (delete-dir! dir))))))
+
+(deftest capsule-warn-fires-when-both-sources-absent-test
+  (testing "WARN fires when both MCP artifact and all worktree artifacts are absent"
+    (let [dir     (str (System/getProperty "java.io.tmpdir") "/caps-nowarn-" (random-uuid))]
+      (.mkdirs (io/file dir))
+      (try
+        (let [session {:workdir           dir
+                       :explicit-workdir? true
+                       :capsule?          true
+                       :artifact-path     (str dir "/.miniforge-session/artifact.edn")
+                       :exec!             local-cat-exec!
+                       :executor          ::stub
+                       :environment-id    "env-2"}
+              err    (java.io.StringWriter.)]
+          (binding [*err* err]
+            (run-session* session
+                          (constantly :ok)
+                          session/read-capsule-artifact
+                          (constantly nil)
+                          :capsule))
+          ;; Both sources absent → WARN must have been written
+          (is (str/includes? (str err) "WARN: no artifact found")
+              "WARN must fire when both MCP and worktree artifacts are absent"))
+        (finally
+          (delete-dir! dir))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
@@ -18,7 +18,12 @@
 
 (ns ai.miniforge.workflow.runner-environment-test
   "Tests for runner-environment — specifically the M1 base-sha
-   capture path that future label-action watchers consume."
+   capture path that future label-action watchers consume.
+
+   This file appears in the artifact-warning-suppression PR because
+   `build-env-record` was touched in surrounding context (`:base-sha`
+   capture pre-dates this PR). These are additive regression tests only;
+   no behavior changes were made to runner-environment.clj itself."
   (:require [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]
@@ -26,17 +31,31 @@
             [ai.miniforge.dag-executor.result :as result]
             [ai.miniforge.workflow.runner-environment :as env]))
 
+(defn- sh!
+  "Run a shell command and throw ex-info when exit != 0."
+  [& args]
+  (let [r (apply shell/sh args)]
+    (when-not (zero? (:exit r))
+      (throw (ex-info (str "shell command failed: " (pr-str args))
+                      {:cmd args :exit (:exit r) :err (:err r) :out (:out r)})))
+    r))
+
 (defn- with-temp-git-repo
-  "Initialise a temp git repo with one commit and pass its path to f."
+  "Initialise a temp git repo with one commit and pass its path to f.
+   Every shell call is checked for a zero exit code — a silent failure
+   would leave an unborn branch and cause `git rev-parse HEAD` to return
+   the literal string 'HEAD' instead of a SHA, producing a misleading
+   test failure downstream."
   [f]
   (let [dir (str (System/getProperty "java.io.tmpdir") "/m1-base-sha-"
                  (random-uuid))]
     (.mkdirs (io/file dir))
     (try
-      (shell/sh "git" "init" "-q" :dir dir)
-      (shell/sh "git" "-C" dir "config" "user.email" "test@local")
-      (shell/sh "git" "-C" dir "config" "user.name" "Test")
-      (shell/sh "git" "-C" dir "commit" "--allow-empty" "-m" "seed")
+      (sh! "git" "init" "-q" "-b" "main" :dir dir)
+      (sh! "git" "-C" dir "config" "user.email" "test@local")
+      (sh! "git" "-C" dir "config" "user.name" "Test")
+      (sh! "git" "-C" dir "config" "commit.gpgsign" "false")
+      (sh! "git" "-C" dir "commit" "--allow-empty" "-m" "seed")
       (f dir)
       (finally
         (doseq [^java.io.File fp (reverse (file-seq (io/file dir)))]
@@ -50,7 +69,7 @@
   (testing "[:environment-metadata :base-sha] is populated from worktree HEAD"
     (with-temp-git-repo
       (fn [dir]
-        (let [expected-sha (-> (shell/sh "git" "-C" dir "rev-parse" "HEAD")
+        (let [expected-sha (-> (sh! "git" "-C" dir "rev-parse" "HEAD")
                                :out
                                str/trim)
               fns {:create-registry (constantly {})
@@ -70,7 +89,7 @@
           (is (some? record))
           (is (= dir (:worktree-path record)))
           (is (= expected-sha (get-in record [:environment-metadata :base-sha]))
-              "base-sha must match the worktree's HEAD at acquire time")
+              "build-env-record sets :base-sha to resolved worktree HEAD SHA")
           (is (= "main" (get-in record [:environment-metadata :base-branch]))
               "pre-existing metadata fields must survive the merge"))))))
 


### PR DESCRIPTION
Second split from the dogfood run for work/in-progress/dogfood-plan-artifact-warning.spec.edn.

Changes:
- add capsule-session tests for explicit workdir behavior
- verify capsule worktree artifacts suppress the no-artifact WARN
- verify capsule sessions still WARN when both MCP and worktree sources are absent
- harden runner-environment temp git fixture by creating main explicitly, checking git command exits, and disabling commit signing in the throwaway repo

Commit budget: 116/200 counted by hook.

Local checks passed via commit hook: poly check, clj-kondo, pre-commit smoke, and GraalVM compatibility. Focused capsule and runner-environment tests also passed.