### PR TITLE
Suppress no-workdir artifact warning

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -827,9 +827,10 @@
     (into {} (keep #(read-role-entry read-role-artifact %)) worktree-roles)))
 
 (defn- emit-no-artifact-warning!
-  "Emit `:warn/no-artifact-found` when BOTH the MCP path and the worktree
-   role files came up empty. Separate fn so `run-session` reads as a
-   sequence of named steps and the diagnostic stays testable."
+  "Emit `:warn/no-artifact-found` after an explicit worktree scan confirms
+   both the MCP path and the worktree role files came up empty. Separate fn
+   so `run-session` reads as a sequence of named steps and the diagnostic
+   stays testable."
   [session workdir]
   (emit-system-message! :warn/no-artifact-found
                         (:artifact-path session)
@@ -842,25 +843,39 @@
    `:worktree-artifacts` is a map from role keyword to parsed artifact,
    read from <workdir>/.miniforge/<role>.edn. Container-promotion pattern —
    agents write their artifact into the worktree and the runtime picks it
-   up here. Empty when the session has no `:workdir` (e.g. when the caller
-   did not thread one through) or when no role files were written; both
-   host and capsule modes do read worktree-promoted artifacts when
-   `:workdir` is present (capsule defaults `:workdir` to `/workspace`).
+   up here. Empty when no explicit worktree is available or no files were
+   written.
 
-   Emits a WARN (not ERROR) only when BOTH the MCP artifact path and all
-   worktree role paths are empty — genuine 'nothing found' case. When the
-   worktree-promoted artifact was written successfully, this check passes
-   silently."
+   Scans all 5 phase roles (:plan :implement :verify :review :release)
+   regardless of the current phase - stale artifacts from previous phases
+   will appear in :worktree-artifacts but are ignored by callers that key
+   on a specific role.
+
+   The worktree scan and WARN are gated on `:explicit-workdir?` to prevent
+   the JVM CWD fallback (which may contain stale .miniforge/ artifacts from
+   prior runs) from suppressing or emitting diagnostics when no real
+   worktree was provided.
+
+   Return map includes `:artifact` (the MCP-submitted artifact EDN, or nil)
+   and `:worktree-artifacts` (map of role -> artifact for worktree-promoted
+   files). A nil `:artifact` combined with an empty `:worktree-artifacts`
+   is the machine-readable signal that no artifact was produced. Callers
+   that key on phase output MUST treat this combination as a workflow fault
+   - no artifact means the implementing agent did not deliver work product."
   [session body-fn read-artifact-fn cleanup-fn mode]
   (try
     (let [result              (body-fn session)
           workdir             (:workdir session)
           read-role-artifact  (role-reader-for-mode mode session workdir)
-          worktree-artifacts  (collect-worktree-artifacts read-role-artifact workdir)
+          worktree-artifacts  (if (:explicit-workdir? session)
+                                (collect-worktree-artifacts read-role-artifact workdir)
+                                {})
           artifact            (read-artifact-fn session)]
       ;; The hard failure is handled downstream by result-boundary
       ;; returning {:usable? false}; this WARN only aids post-mortem.
-      (when (and (nil? artifact) (empty? worktree-artifacts))
+      (when (and (:explicit-workdir? session)
+                 (nil? artifact)
+                 (empty? worktree-artifacts))
         (emit-no-artifact-warning! session workdir))
       {:llm-result           result
        :artifact             artifact

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -485,18 +485,37 @@
 ;; is the public, production-path entry that selects host vs. capsule mode.
 
 (deftest with-session-warn-when-both-sources-absent-test
-  (testing "emits WARN to stderr when neither MCP artifact nor worktree artifacts are written"
-    ;; Both submission channels are empty — this is the one case that should
-    ;; surface a WARN so operators know the agent did not submit an artifact.
+  (testing "suppresses WARN when no explicit workdir was provided"
+    ;; Without an explicit workdir, the worktree-artifact scan is intentionally
+    ;; skipped. Its empty result should not be diagnosed as a failed artifact
+    ;; submission.
     (let [err    (java.io.StringWriter.)
           result (binding [*err* err]
                    (session/with-session {} (constantly :no-submit)))]
       (is (= :no-submit (:llm-result result)))
       (is (nil? (:artifact result)))
-      (is (str/includes? (str err) "WARN")
-          "run-session must emit WARN when neither MCP file nor worktree artifacts exist")
+      (is (not (str/includes? (str err) "WARN"))
+          "run-session must not warn when the worktree scan was not engaged")
       (is (not (str/includes? (str err) "ERROR"))
           "ERROR must never be emitted from the artifact-session layer")))
+
+  (testing "emits WARN when explicit workdir has neither MCP nor worktree artifact"
+    ;; Both submission channels are empty after an explicit worktree scan -
+    ;; this is the one case that should surface a WARN.
+    (let [wt     (make-worktree-with-plan nil)
+          err    (java.io.StringWriter.)
+          ctx    {:execution/worktree-path wt}
+          result (binding [*err* err]
+                   (session/with-session ctx (constantly :no-submit)))]
+      (try
+        (is (= :no-submit (:llm-result result)))
+        (is (nil? (:artifact result)))
+        (is (empty? (:worktree-artifacts result)))
+        (is (str/includes? (str err) "WARN")
+            "run-session must warn when explicit workdir scan finds no artifact")
+        (finally
+          (doseq [^java.io.File f (reverse (file-seq (io/file wt)))]
+            (io/delete-file f true))))))
 
   (testing "suppresses WARN when worktree artifact exists but MCP file is absent"
     ;; Container-promotion path: agent wrote .miniforge/plan.edn into the


### PR DESCRIPTION
## Summary
- require an explicit workdir before emitting the no-artifact warning
- keep the real warning path covered for explicit workdirs with no artifacts

## Validation
- clojure -M:poly test project:miniforge brick:agent
- git diff --check
- commit hook: commit-budget 25/200, poly check, clj-kondo, pre-commit smoke, GraalVM compatibility

Dogfood rerun note: the previous false ERROR is gone; rerun found this narrower WARN-only false positive when the worktree scan is intentionally skipped.