### PR TITLE
Fix the artifact retrieval/reporting path in artifact_session.clj so...

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -64,7 +64,10 @@
    "WARN: failed to parse artifact at %s — %s"
 
    :warn/context-misses-parse
-   "WARN: failed to parse context misses at %s — %s"})
+   "WARN: failed to parse context misses at %s — %s"
+
+   :info/mcp-artifact-skipped
+   "INFO: MCP artifact not submitted — worktree-promotion succeeded (workdir: %s)"})
 
 (defn validate-session
   "Validate a session map against the Session schema.
@@ -826,6 +829,24 @@
   (when workdir
     (into {} (keep #(read-role-entry read-role-artifact %)) worktree-roles)))
 
+(defn- any-worktree-files-exist?
+  "Check if any .miniforge/<role>.edn file exists under workdir without parsing.
+
+   Used in host-mode sessions to distinguish 'truly no files' from 'files existed
+   but all failed to parse'. A parse failure emits :warn/worktree-artifact-parse and
+   returns nil from read-role-artifact, which causes collect-worktree-artifacts to
+   yield an empty map indistinguishable from the no-files case. This function
+   inspects the filesystem directly so run-session can suppress the redundant
+   :warn/no-artifact-found message when files were present but malformed.
+
+   Not used in capsule mode — the executor would require an additional exec call
+   per role to check existence, which is deferred to a future iteration."
+  [workdir]
+  (boolean
+   (when workdir
+     (some #(.exists (worktree-artifact-file workdir %))
+           worktree-roles))))
+
 (defn- emit-no-artifact-warning!
   "Emit `:warn/no-artifact-found` after an explicit worktree scan confirms
    both the MCP path and the worktree role files came up empty. Separate fn
@@ -870,12 +891,35 @@
           worktree-artifacts  (if (:explicit-workdir? session)
                                 (collect-worktree-artifacts read-role-artifact workdir)
                                 {})
-          artifact            (read-artifact-fn session)]
-      ;; The hard failure is handled downstream by result-boundary
-      ;; returning {:usable? false}; this WARN only aids post-mortem.
+          artifact            (read-artifact-fn session)
+          ;; Track whether any .miniforge/<role>.edn files existed on disk,
+          ;; independent of parse success. A file that exists but contains
+          ;; malformed EDN returns nil from read-role-artifact (and emits
+          ;; :warn/worktree-artifact-parse) — that nil is dropped by
+          ;; collect-worktree-artifacts, making worktree-artifacts appear
+          ;; empty even though the agent DID write a file. Without this flag,
+          ;; :warn/no-artifact-found fires on top of the parse WARN.
+          ;; Host-mode only: capsule mode defers existence probing to a future
+          ;; iteration to avoid extra executor round-trips per role.
+          any-file-existed?   (and (:explicit-workdir? session)
+                                   (= mode :host)
+                                   (any-worktree-files-exist? workdir))]
+      ;; Diagnostic INFO: MCP submission channel was skipped but the
+      ;; worktree-promotion channel succeeded. Suppresses alarm for the normal
+      ;; Write-based submission pattern while still being visible for diagnostics.
       (when (and (:explicit-workdir? session)
                  (nil? artifact)
-                 (empty? worktree-artifacts))
+                 (seq worktree-artifacts))
+        (emit-system-message! :info/mcp-artifact-skipped
+                              (or workdir "<no-workdir>")))
+      ;; Hard-failure WARN: neither submission channel produced an artifact AND
+      ;; no worktree role files were present on disk. Parse-failed files are
+      ;; deliberately excluded — :warn/worktree-artifact-parse already covers
+      ;; that failure mode and firing both warnings would be misleading.
+      (when (and (:explicit-workdir? session)
+                 (nil? artifact)
+                 (empty? worktree-artifacts)
+                 (not any-file-existed?))
         (emit-no-artifact-warning! session workdir))
       {:llm-result           result
        :artifact             artifact

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -562,6 +562,46 @@
       (is (not (str/includes? (str err) "WARN"))
           "no WARN when MCP artifact is present and worktree is absent"))))
 
+(deftest with-session-no-artifact-warn-suppressed-when-parse-failed-test
+  (testing "no-artifact WARN is suppressed when worktree file exists but fails to parse"
+    ;; If the agent wrote plan.edn but it contains malformed EDN, the parse
+    ;; warning (:warn/worktree-artifact-parse) is the correct diagnostic.
+    ;; :warn/no-artifact-found must NOT also fire — the file DID exist.
+    (let [wt  (make-worktree-with-plan "{{{invalid edn not parseable")
+          err (java.io.StringWriter.)
+          ctx {:execution/worktree-path wt}]
+      (try
+        (binding [*err* err]
+          (session/with-session ctx (constantly :bad-edn)))
+        (let [stderr (str err)]
+          (is (str/includes? stderr "failed to parse worktree artifact")
+              "parse WARN must still fire to alert on the malformed file")
+          (is (not (str/includes? stderr "no artifact found after session"))
+              "no-artifact WARN must be suppressed when the file existed — parse WARN covers it"))
+        (finally
+          (doseq [^java.io.File f (reverse (file-seq (io/file wt)))]
+            (.delete f)))))))
+
+(deftest with-session-emits-mcp-skipped-info-when-worktree-only-test
+  (testing "INFO message emitted when worktree artifact found but MCP not submitted"
+    ;; Normal Write-based submission: agent wrote .miniforge/plan.edn, skipped
+    ;; MCP submit_artifact. Should surface a diagnostic INFO (not a WARN) so
+    ;; operators can confirm the worktree-promotion path was used.
+    (let [wt  (make-worktree-with-plan (pr-str (plan-artifact)))
+          err (java.io.StringWriter.)
+          ctx {:execution/worktree-path wt}]
+      (try
+        (binding [*err* err]
+          (session/with-session ctx (constantly :worktree-only)))
+        (let [stderr (str err)]
+          (is (str/includes? stderr "MCP artifact not submitted")
+              "INFO must note that MCP was skipped and worktree-promotion succeeded")
+          (is (not (str/includes? stderr "WARN"))
+              "INFO message must not be prefixed WARN — it is not a failure"))
+        (finally
+          (doseq [^java.io.File f (reverse (file-seq (io/file wt)))]
+            (.delete f)))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.agent.artifact-session-test)

--- a/docs/pull-requests/2026-05-21-fix-the-artifact-retrieval-reporting-path-in-artifact-session-clj-so.md
+++ b/docs/pull-requests/2026-05-21-fix-the-artifact-retrieval-reporting-path-in-artifact-session-clj-so.md
@@ -1,0 +1,27 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix the artifact retrieval/reporting path in artifact_session.clj so...
+
+**PR:** [#960](https://github.com/miniforge-ai/miniforge/pull/960)
+**Branch:** `mf/fix-the-artifact-retrievalreporting-path-4464ed9c`
+
+## Summary
+
+Fix the artifact retrieval/reporting path in artifact_session.clj so that the no-artifact-found warning does not fire when a valid worktree-promoted artifact exists.
+
+## Files Changed
+
+- `components/agent/src/ai/miniforge/agent/artifact_session.clj` (modify)
+- `components/agent/test/ai/miniforge/agent/artifact_session_test.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._


### PR DESCRIPTION
## Summary

Fix the artifact retrieval/reporting path in artifact_session.clj so that the no-artifact-found warning does not fire when a valid worktree-promoted artifact exists.

## Changes

- `components/agent/src/ai/miniforge/agent/artifact_session.clj` (modify)
- `components/agent/test/ai/miniforge/agent/artifact_session_test.clj` (modify)

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (2 files)