### PR TITLE
Add dogfood follow-up specs

### DIFF
--- a/work/dogfood-handoff-redirect-loop.spec.edn
+++ b/work/dogfood-handoff-redirect-loop.spec.edn
@@ -1,0 +1,35 @@
+{:spec/title "Dogfood: stop degraded handoff redirect loops"
+
+ :spec/description
+ "A dogfood run of `dogfood-plan-artifact-warning.spec.edn` on 2026-05-21 passed plan, implement, verify, review, release, and done for multiple DAG tasks, but the outer workflow failed with `:anomalies.workflow/max-redirects-exceeded` after five redirects. Reviewer output showed the implementation handoff was treated as degraded because the artifact was recovered after an implementer-side failure, then rejected for out-of-scope writes. The workflow should converge to a clear failed state with actionable diagnostics instead of cycling through redirects after task-level phases have already completed."
+
+ :spec/intent {:type :bugfix
+               :scope ["components/workflow/src"
+                       "components/agent/src"
+                       "components/phase/src"
+                       "components/dag-executor/src"]}
+
+ :spec/constraints
+ ["Do not accept out-of-scope artifacts silently"
+  "Do not treat a recovered artifact as clean success without preserving the degraded handoff signal"
+  "Keep task-level phase checkpoints and persisted bundles available for debugging"
+  "Keep redirect/repair behavior for genuinely repairable review failures"
+  "Do not increase the default redirect limit to hide the loop"]
+
+ :spec/acceptance-criteria
+ ["A degraded implement handoff that is rejected for scope drift terminates with one clear workflow failure instead of redirecting until `max-redirects-exceeded`"
+  "The failure summary includes the rejected task id, rejected file paths, and the recovered artifact or bundle path"
+  "Completed task phases are not rerun indefinitely after the review gate has already rejected the handoff"
+  "Repair redirects still occur for review failures that provide an in-scope repair path"
+ "Tests cover rejected degraded handoff, accepted clean handoff, and repairable review redirect paths"
+ "A dogfood rerun of the same scenario exits with the direct degraded-handoff failure, not a redirect-cycle anomaly"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:dogfood-enabler :correctness :token-conservation}
+  :theme :dogfood-resilience
+  :rationale "Observed dogfood failure on 2026-05-21: task phases completed but the outer workflow redirected until `max-redirects-exceeded`. This burns tokens and hides the actionable degraded-handoff rejection."
+  :blocks []
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/tui-phase-loader-classpath.spec.edn
+++ b/work/tui-phase-loader-classpath.spec.edn
@@ -1,0 +1,35 @@
+{:spec/title "Fix miniforge-tui phase loader classpath drift"
+
+ :spec/description
+ "Dogfood verification repeatedly surfaced `ai.miniforge.phase.done-test` errors in the `miniforge-tui` project: `FileNotFoundException` for `ai/miniforge/workflow_compliance_scanner/phases`. The broader runner output could still report a green summary while raw test output contained these errors. Fix the TUI project classpath or phase loading boundary so missing optional phase namespaces do not create false failures or false-green summaries."
+
+ :spec/intent {:type :bugfix
+               :scope ["projects/miniforge-tui"
+                       "components/phase/src"
+                       "components/phase/test"
+                       "bases/tui/src"]}
+
+ :spec/constraints
+ ["Do not add broad project dependencies to miniforge-tui unless the TUI genuinely needs them"
+  "Prefer explicit optional phase loading or project deps over catching every load failure as success"
+  "Do not hide real phase implementation load errors"
+  "Keep the test runner summary consistent with raw clojure.test failures and errors"
+  "Keep the fix small enough for a sub-200-line PR"]
+
+ :spec/acceptance-criteria
+ ["`ai.miniforge.phase.done-test` passes when run under the `miniforge-tui` project classpath"
+  "Missing optional phase namespaces are reported as skipped or unavailable without failing unrelated TUI tests"
+  "Real load errors inside present phase namespaces still fail loudly"
+  "The project test summary reports failure when raw test output contains clojure.test failures or errors"
+ "Regression tests cover optional namespace absence and present-namespace load failure"
+ "Dogfood verification no longer reports the TUI classpath error as a pre-existing warning"]
+
+ :spec/priority
+ {:tier :high
+  :axes #{:correctness :dogfood-enabler}
+  :theme :polylith-compliance
+  :rationale "Dogfood verification repeatedly reports `miniforge-tui` classpath errors while some summaries still appear green. This undermines test signal quality and can mask TUI regressions."
+  :blocks []
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
## Summary
- add a dogfood spec for degraded handoff redirect loops
- add a dogfood spec for miniforge-tui phase loader classpath drift

## Validation
- git diff --cached --check
- clojure EDN parse for both specs
- bb commit-budget
- pre-commit hook passed