### PR TITLE
Replace throw/catch control flow in transit store link-artifacts with...

### DIFF
--- a/components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj
@@ -215,46 +215,74 @@
 
 (defn persist-linked-artifacts
   "Persist both linked artifacts to disk."
-  [record artifacts-dir parent-id child-id]
+  [record artifacts-dir parent-id child-id logger]
   (future
-    (when-let [parent (p/load-artifact record parent-id)]
-      (persist-artifact! artifacts-dir parent))
-    (when-let [child (p/load-artifact record child-id)]
-      (persist-artifact! artifacts-dir child))))
+    (try
+      (when-let [parent (p/load-artifact record parent-id)]
+        (persist-artifact! artifacts-dir parent))
+      (when-let [child (p/load-artifact record child-id)]
+        (persist-artifact! artifacts-dir child))
+      (catch Exception e
+        (when logger
+          (log/error logger :system :artifact/link-persist-failed
+                     {:message (.getMessage e)
+                      :data {:parent-id parent-id
+                             :child-id child-id}}))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Anomaly-returning helpers
+
+(defn- anomaly?
+  [x]
+  (and (map? x) (contains? x :anomaly/category)))
+
+(defn find-link-target
+  "Load an artifact for linking, or return a typed not-found anomaly."
+  [record artifact-id role]
+  (if-let [artifact (load-artifact-impl record artifact-id)]
+    artifact
+     {:anomaly/category :anomalies/not-found
+      :anomaly/message  (case role
+                           :parent "Parent artifact not found"
+                           :child  "Child artifact not found"
+                           "Artifact not found")
+      :artifact-id      artifact-id
+      :role             role}))
 
 (defn link-artifacts
-  "Link artifacts implementation."
+  "Link artifacts, preserving the ArtifactStore boolean facade.
+   Missing link targets are represented as anomalies internally and logged."
   [{:keys [artifacts-dir cache index logger] :as record} parent-id child-id]
-  (try
-    ;; Load both artifacts to ensure they exist
-    (when-not (p/load-artifact record parent-id)
-      (throw (ex-info "Parent artifact not found" {:parent-id parent-id})))
-    (when-not (p/load-artifact record child-id)
-      (throw (ex-info "Child artifact not found" {:child-id child-id})))
+  (let [parent-result (find-link-target record parent-id :parent)
+        child-result  (find-link-target record child-id  :child)]
+    (if (or (anomaly? parent-result) (anomaly? child-result))
+      (do
+        (doseq [result [parent-result child-result]
+                :when  (anomaly? result)]
+          (when logger
+            (log/error logger :system :artifact/link-failed
+                       {:message (:anomaly/message result)
+                        :data    {:parent-id parent-id
+                                  :child-id  child-id
+                                  :role      (:role result)}})))
+        false)
+      (do
+        ;; Update index with links
+        (let [new-index (update-index-links @index parent-id child-id)]
+          (reset! index new-index)
+          (future (save-index! artifacts-dir new-index)))
 
-    ;; Update index with links
-    (let [new-index (update-index-links @index parent-id child-id)]
-      (reset! index new-index)
-      (future (save-index! artifacts-dir new-index)))
+        ;; Update cached artifacts if present
+        (update-cache-links cache parent-id child-id)
 
-    ;; Update cached artifacts if present
-    (update-cache-links cache parent-id child-id)
+        ;; Re-persist both artifacts to disk
+        (persist-linked-artifacts record artifacts-dir parent-id child-id logger)
 
-    ;; Re-persist both artifacts to disk
-    (persist-linked-artifacts record artifacts-dir parent-id child-id)
-
-    (when logger
-      (log/debug logger :system :artifact/linked
-                 {:data {:parent-id parent-id
-                         :child-id child-id}}))
-    true
-    (catch Exception e
-      (when logger
-        (log/error logger :system :artifact/link-failed
-                   {:message (.getMessage e)
-                    :data {:parent-id parent-id
-                           :child-id child-id}}))
-      false)))
+        (when logger
+          (log/debug logger :system :artifact/linked
+                     {:data {:parent-id parent-id
+                             :child-id  child-id}}))
+        true))))
 
 (defn close-store
   "Close store implementation."

--- a/components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj
+++ b/components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.artifact.protocols.impl.transit-store-test
+  (:require [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
+            [ai.miniforge.artifact.protocols.impl.transit-store :as impl]
+            [ai.miniforge.artifact.protocols.records.transit-store :as store]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]])
+  (:import [java.nio.file Files]))
+
+(def parent
+  {:artifact/id "parent-id"
+   :artifact/type :plan
+   :artifact/version "1.0.0"
+   :artifact/parents []
+   :artifact/children []})
+
+(def child
+  {:artifact/id "child-id"
+   :artifact/type :code
+   :artifact/version "1.0.0"
+   :artifact/parents []
+   :artifact/children []})
+
+(defn- delete-dir! [file]
+  (when (.exists (io/file file))
+    (doseq [f (reverse (file-seq (io/file file)))]
+      (io/delete-file f true))))
+
+(defn- temp-store []
+  (let [dir (.toFile (Files/createTempDirectory
+                      "transit-store-test"
+                      (make-array java.nio.file.attribute.FileAttribute 0)))]
+    [(store/create-transit-store {:dir (.getPath dir)}) dir]))
+
+(defn- save! [store artifact]
+  (p/save store artifact)
+  artifact)
+
+(deftest find-link-target-test
+  (let [[artifact-store dir] (temp-store)]
+    (try
+      (is (= parent (impl/find-link-target
+                     artifact-store (:artifact/id (save! artifact-store parent)) :parent)))
+      (let [result (impl/find-link-target artifact-store "missing-parent" :parent)]
+        (is (= :anomalies/not-found (:anomaly/category result)))
+        (is (= "missing-parent" (:artifact-id result)))
+        (is (= :parent (:role result))))
+      (is (= :unknown (:role (impl/find-link-target artifact-store "missing" :unknown))))
+      (finally
+        (delete-dir! dir)))))
+
+(deftest link-artifacts-success-test
+  (let [[artifact-store dir] (temp-store)]
+    (try
+      (save! artifact-store parent)
+      (save! artifact-store child)
+      (is (true? (impl/link-artifacts artifact-store "parent-id" "child-id")))
+      (is (contains? (set (:artifact/children (p/load-artifact artifact-store "parent-id")))
+                     "child-id"))
+      (is (contains? (set (:artifact/parents (p/load-artifact artifact-store "child-id")))
+                     "parent-id"))
+      (finally
+        (delete-dir! dir)))))
+
+(deftest link-artifacts-missing-targets-test
+  (doseq [[label artifacts parent-id child-id]
+          [["missing parent" [child] "missing-parent" "child-id"]
+           ["missing child" [parent] "parent-id" "missing-child"]
+           ["missing both" [] "missing-parent" "missing-child"]]]
+    (let [[artifact-store dir] (temp-store)]
+      (try
+        (doseq [artifact artifacts]
+          (save! artifact-store artifact))
+        (is (false? (impl/link-artifacts artifact-store parent-id child-id)) label)
+        (finally
+          (delete-dir! dir))))))


### PR DESCRIPTION
## Summary

Replace throw/catch control flow in Transit artifact link lookup with anomaly-returning data while preserving the public boolean `ArtifactStore/link` facade.

## Changes

- Add `find-link-target` for artifact-or-anomaly lookup during parent/child linking.
- Refactor `link-artifacts` to log typed missing-target anomalies and return `false` instead of throwing internally.
- Log async link persistence failures instead of letting background futures fail silently.
- Add temp-backed Transit store coverage for success, missing parent, missing child, missing both, and unexpected role lookup.

## Test plan

- [x] `clj-kondo --lint components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj`
- [x] `clojure -M:dev:test -e '(require (quote ai.miniforge.artifact.protocols.impl.transit-store-test)) (let [r (clojure.test/run-tests (quote ai.miniforge.artifact.protocols.impl.transit-store-test))] (shutdown-agents) (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
- [x] pre-commit hook
- [x] `bb commit-budget`
