### PR TITLE
Fail release phase on zero-file artifacts

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -344,22 +344,25 @@
 
 (defn extract-code-blocks
   "Extract code blocks from markdown response and convert to file list.
-   Tries to detect file paths from markdown headings before each block."
+   Tries to detect file paths from markdown headings before each block.
+
+   Pathless blocks are not repo artifacts. Treating them as generated
+   filenames lets narrative snippets pass implement, verify, and review
+   without producing a releasable diff."
   [response-content]
   (let [pattern patterns/md-code-block
         matcher (re-matcher pattern response-content)]
     (loop [results [] idx 0]
       (if (.find matcher)
-        (let [lang (.group matcher 1)
-              content (.group matcher 2)
+        (let [content (.group matcher 2)
               block-start (.start matcher)
-              path (or (extract-path-from-context response-content block-start)
-                       (str "generated/file" idx
-                            (get @ext->language lang ".clj")))]
-          (recur (conj results {:path path
-                                :content (str/trim content)
-                                :action :create})
-                 (inc idx)))
+              path (extract-path-from-context response-content block-start)]
+          (if path
+            (recur (conj results {:path path
+                                  :content (str/trim content)
+                                  :action :create})
+                   (inc idx))
+            nil))
         (when (seq results) results)))))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -487,6 +490,13 @@
   (and (map? artifact)
        (contains? artifact :code/files)))
 
+(defn- metadata-only-submit?
+  "True when MCP submit produced metadata but no file payload."
+  [artifact-source structured-artifact]
+  (and (= :mcp artifact-source)
+       (map? structured-artifact)
+       (not (code-artifact? structured-artifact))))
+
 (defn- code-from-blocks
   "Build a code artifact map from extracted markdown code blocks."
   [content]
@@ -535,7 +545,8 @@
            artifact-source tokens cost-usd tools-called]}
    context logger input]
   (let [parsed (or structured-artifact parsed-content)
-        tools tools-called]
+        tools tools-called
+        metadata-only? (metadata-only-submit? artifact-source structured-artifact)]
     (when (nil? artifact-source)
       (log/warn logger :implementer :implementer/mcp-tool-not-called
                 {:data {:content-length (count (or content ""))
@@ -552,6 +563,16 @@
              input artifact-source content tools)
             (unverified-already-implemented-response input tokens))
         (build-already-implemented-response parsed tokens cost-usd))
+
+      metadata-only?
+      (do
+        (log-implementer-rejection
+         logger :metadata-only-submit
+         input artifact-source content tools)
+        (response/error (messages/t :error/parse-failed)
+                        {:tokens tokens
+                         :data {:reject/reason :metadata-only-submit
+                                :artifact-source artifact-source}}))
 
       :else
       ;; Prefer derived-artifact (code blocks extracted from text) over a
@@ -671,7 +692,7 @@
       (file-artifacts/collect-worktree-files working-dir base-refs))))
 
 (defn- collect-session-artifact
-  "Collect a file artifact when the agent did not submit one explicitly."
+  "Collect a file artifact from the promoted or written working tree."
   [context session-mode working-dir pre-session-snapshot]
   (or (collect-promoted-artifact context session-mode working-dir)
       (if (= :capsule session-mode)
@@ -696,11 +717,10 @@
           #(invoke-implementer-session % llm-client user-prompt effective-system-prompt
                                        config context on-chunk existing-files working-dir))
         response llm-result
-        file-artifact (when-not artifact
-                        (collect-session-artifact context
-                                                  session-mode
-                                                  working-dir
-                                                  pre-session-snapshot))
+        file-artifact (collect-session-artifact context
+                                                session-mode
+                                                working-dir
+                                                pre-session-snapshot)
         normalized (result-boundary/normalize-llm-result
                     {:role :implement
                      :response response

--- a/components/agent/test/ai/miniforge/agent/implementer_extended_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_extended_test.clj
@@ -20,6 +20,7 @@
   "Extended tests for implementer: response parsing, code block extraction,
    language detection, artifact repair edge cases, formatting, and prior-attempts."
   (:require
+   [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.implementer :as impl]
    [ai.miniforge.response.interface :as response]
    [clojure.string :as str]
@@ -127,13 +128,87 @@
     (is (nil? (impl/extract-code-blocks "Just plain text, no code blocks.")))
     (is (nil? (impl/extract-code-blocks "")))))
 
-(deftest extract-code-blocks-generated-path-test
-  (testing "generates fallback path when no heading found"
+(deftest extract-code-blocks-pathless-block-test
+  (testing "rejects pathless fenced code blocks"
     (let [text "Here's some code:\n\n```clojure\n(ns mystery)\n```"
           result (impl/extract-code-blocks text)]
-      (is (= 1 (count result)))
-      ;; Should have a generated path with index
-      (is (string? (:path (first result)))))))
+      (is (nil? result)))))
+
+(deftest invoke-with-llm-merges-submit-metadata-with-collected-files-test
+  (testing "summary-only MCP submit does not hide files written by the agent"
+    (let [submit-artifact {:code/summary "Updated transit store tests"
+                           :code/tests-needed? true}
+          collected-artifact {:code/files [{:path "test/transit_store_test.clj"
+                                            :content "(ns transit-store-test)"
+                                            :action :modify}]
+                              :code/summary "fallback summary"
+                              :code/language "clojure"
+                              :code/tests-needed? false}
+          response {:success true
+                    :content "Run:\n```\nclojure -M:test\n```"
+                    :tools-called ["Write" "mcp__context__submit"]
+                    :tokens 13
+                    :cost-usd 0.01}]
+      (with-redefs [artifact-session/with-session
+                    (fn [_context _session-fn]
+                      {:llm-result response
+                       :artifact submit-artifact
+                       :worktree-artifacts nil
+                       :context-misses nil
+                       :pre-session-snapshot {}
+                       :session-mode :worktree})
+                    impl/collect-session-artifact
+                    (fn [& _] collected-artifact)]
+        (let [result (#'impl/invoke-with-llm
+                      nil "" "" {} {:execution/worktree-path "/tmp/worktree"}
+                      nil nil [] {})
+              artifact (:output result)]
+          (is (response/success? result))
+          (is (= "Updated transit store tests" (:code/summary artifact)))
+          (is (true? (:code/tests-needed? artifact)))
+          (is (= [{:path "test/transit_store_test.clj"
+                   :content "(ns transit-store-test)"
+                   :action :modify}]
+                 (:code/files artifact))))))))
+
+(deftest process-llm-response-rejects-metadata-only-submit-test
+  (testing "MCP submit metadata cannot be replaced by final chat code blocks"
+    (let [result (#'impl/process-llm-response
+                  {:content "### src/incorrect.clj\n```clojure\n(ns incorrect)\n```"
+                   :structured-artifact {:code/summary "Only metadata"}
+                   :parsed-content nil
+                   :derived-artifact {:code/files [{:path "src/incorrect.clj"
+                                                    :content "(ns incorrect)"
+                                                    :action :create}]}
+                   :artifact-source :mcp
+                   :tokens 21
+                   :tools-called ["mcp__context__submit"]}
+                  {}
+                  nil
+                  {})]
+      (is (= :error (:status result)))
+      (is (= :metadata-only-submit
+             (get-in result [:error :data :reject/reason]))))))
+
+(deftest process-llm-response-rejects-incident-shaped-submit-test
+  (testing "summary-only submit plus a pathless final command block is rejected"
+    (let [result (#'impl/process-llm-response
+                  {:content "Run:\n```\nclojure -M:test -n ai.miniforge.artifact.protocols.impl.transit-store-test\n```"
+                   :structured-artifact {:code/summary "Updated tests"
+                                         :code/tests-needed? true}
+                   :parsed-content nil
+                   :derived-artifact nil
+                   :artifact-source :mcp
+                   :tokens 21
+                   :tools-called ["Write" "mcp__context__submit"]}
+                  {}
+                  nil
+                  {})]
+      (is (= :error (:status result)))
+      (is (= :metadata-only-submit
+             (get-in result [:error :data :reject/reason])))
+      (is (= :mcp
+             (get-in result [:error :data :artifact-source]))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; extract-language tests

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -452,6 +452,9 @@
         on-fail (get-in ctx [:phase-config :on-fail])
         error-map (phase/exception-error ex)]
     (cond
+      (= :release/zero-files (get (ex-data ex) :type))
+      (assoc ctx :phase (phase/fail-phase (:phase ctx) error-map))
+
       ;; Within budget - retry
       (< iterations max-iterations)
       (-> ctx

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -648,6 +648,25 @@
           result ((:leave interceptor) ctx)]
       (is (= :failed (get-in result [:phase :status]))))))
 
+(deftest error-release-treats-zero-files-as-terminal-test
+  (testing "zero-files exceptions fail instead of retrying the release phase"
+    (let [interceptor (phase/get-phase-interceptor {:phase :release})
+          exception (ex-info "Release phase received code artifact with zero files"
+                             {:type :release/zero-files
+                              :phase :release
+                              :environment-id "task-1"
+                              :worktree-path "/tmp/task-1"})
+          result ((:error interceptor)
+                  {:phase {:iterations 0
+                           :budget {:iterations 2}}
+                   :phase-config {:phase :release}
+                   :execution/metrics {:tokens 0 :duration-ms 0}}
+                  exception)]
+      (is (= :failed (get-in result [:phase :status])))
+      (is (not (phase/retrying? (:phase result))))
+      (is (= :release/zero-files
+             (get-in result [:phase :error :data :type]))))))
+
 ;------------------------------------------------------------------------------ Layer 2: Interceptor Leave Tests
 
 (deftest leave-release-records-metrics-test


### PR DESCRIPTION
## Summary
- Treat :release/zero-files exceptions as terminal release failures instead of retryable errors.
- Collect Write/Edit worktree files even when the implementer also submits MCP metadata, then merge the submit summary with the collected file artifact.
- Reject metadata-only MCP submit artifacts instead of allowing final chat/code-block parsing to invent a file payload.
- Reject pathless fenced code blocks at the implementer boundary instead of manufacturing generated/fileN.clj artifacts.

## Diagnosis
The raw implementer transcript shows the agent did write components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj, then called mcp__context__submit with only summary/test-needed metadata. That is expected: submit intentionally does not carry code_files; runtime is supposed to derive files from Write/Edit or the worktree diff.

The boundary bug was that invoke-with-llm only collected the file artifact when no MCP submit artifact existed. A summary-only submit therefore suppressed the actual Write/Edit diff. Because the structured artifact had no :code/files, process-llm-response fell through to derived chat parsing. The final assistant text contained a pathless fenced command block, so the old parser manufactured generated/file0.clj and let implement/verify/review proceed with a meaningless artifact.

By release time the task worktree had no releasable diff, so build-workflow-state threw :release/zero-files. Release then treated that enter exception as retryable; the lifecycle clears transient :phase state before re-entry, so the release-local iteration budget never stopped the loop and it spun until the global max-phases cap.

## Regression Coverage
- Result boundary: MCP submit metadata merges with collected Write/Edit file fallback and preserves submit summary/tests-needed metadata.
- Implementer extraction: pathless fenced code blocks return nil instead of generated/fileN.clj.
- Implementer invoke path: summary-only MCP submit plus collected Write/Edit files succeeds with the real file payload, not final chat parsing.
- Implementer rejection path: metadata-only submit is rejected even if final chat contains a parseable code block.
- Incident shape: summary-only submit plus a final pathless test-command fence is rejected with :metadata-only-submit.
- Release lifecycle: :release/zero-files raised during release enter is terminal, not retryable.

## Verification
- clojure -M:test:dev -e "(require 'clojure.test 'ai.miniforge.agent.implementer-extended-test) (let [r (clojure.test/run-tests 'ai.miniforge.agent.implementer-extended-test)] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))"
- clojure -M:test:dev -e "(require 'clojure.test 'ai.miniforge.agent.result-boundary-test 'ai.miniforge.phase-software-factory.release-test 'ai.miniforge.phase-software-factory.phase-terminal-test 'ai.miniforge.phase-software-factory.artifact-persistence-test) (let [r (clojure.test/run-tests 'ai.miniforge.agent.result-boundary-test 'ai.miniforge.phase-software-factory.release-test 'ai.miniforge.phase-software-factory.phase-terminal-test 'ai.miniforge.phase-software-factory.artifact-persistence-test)] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))"
- clj-kondo --lint components/agent/src/ai/miniforge/agent/implementer.clj components/agent/test/ai/miniforge/agent/implementer_extended_test.clj components/agent/test/ai/miniforge/agent/result_boundary_test.clj components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj components/phase-software-factory/test/ai/miniforge/phase_software_factory/artifact_persistence_test.clj

Note: the broader release/artifact test command printed 38 tests / 106 assertions / 0 failures / 0 errors, then lingered briefly on non-daemon test infrastructure before exiting cleanly.