### PR TITLE
Align transit link cleanup with standards

### DIFF
--- a/components/artifact/deps.edn
+++ b/components/artifact/deps.edn
@@ -1,5 +1,7 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         datalevin/datalevin {:mvn/version "0.9.16"}

--- a/components/artifact/resources/config/artifact/messages/en-US.edn
+++ b/components/artifact/resources/config/artifact/messages/en-US.edn
@@ -1,0 +1,4 @@
+{:artifact/messages
+ {:link/parent-not-found "Parent artifact not found"
+  :link/child-not-found "Child artifact not found"
+  :link/artifact-not-found "Artifact not found"}}

--- a/components/artifact/src/ai/miniforge/artifact/messages.clj
+++ b/components/artifact/src/ai/miniforge/artifact/messages.clj
@@ -1,0 +1,24 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.artifact.messages
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  (messages/create-translator "config/artifact/messages/en-US.edn"
+                              :artifact/messages))

--- a/components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj
@@ -22,6 +22,8 @@
    These functions implement the ArtifactStore protocol for the Transit-based store.
    They are used by the TransitArtifactStore record."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.artifact.messages :as messages]
    [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [cognitect.transit :as transit]
@@ -183,15 +185,27 @@
                              :source :disk}}))
         artifact)))
 
+(defn- criterion-match?
+  [metadata [k v]]
+  (= (get metadata k) v))
+
+(defn- metadata-match?
+  [criteria metadata]
+  (every? (partial criterion-match? metadata) criteria))
+
+(defn- matching-index-id
+  [criteria [id metadata]]
+  (when (metadata-match? criteria metadata)
+    id))
+
 (defn filter-by-criteria
   "Filter artifacts by criteria."
   [index criteria]
-  (keep (fn [[id metadata]]
-          (when (every? (fn [[k v]]
-                          (= (get metadata k) v))
-                        criteria)
-            id))
-        index))
+  (keep (partial matching-index-id criteria) index))
+
+(defn- load-indexed-artifact
+  [record id]
+  (p/load-artifact record id))
 
 (defn query-artifacts
   "Query artifacts implementation."
@@ -199,10 +213,10 @@
   (if (empty? criteria)
     ;; Return all artifacts
     (let [all-ids (keys @index)]
-      (keep #(p/load-artifact record %) all-ids))
+      (keep (partial load-indexed-artifact record) all-ids))
     ;; Filter by criteria using index first for efficiency
     (let [matching-ids (filter-by-criteria @index criteria)
-          artifacts (keep #(p/load-artifact record %) matching-ids)]
+          artifacts (keep (partial load-indexed-artifact record) matching-ids)]
       (vec artifacts))))
 
 (defn update-cache-links
@@ -234,20 +248,32 @@
 
 (defn- anomaly?
   [x]
-  (and (map? x) (contains? x :anomaly/category)))
+  (anomaly/anomaly? x))
+
+(defn- link-target-message
+  [role]
+  (case role
+    :parent (messages/t :link/parent-not-found)
+    :child  (messages/t :link/child-not-found)
+    (messages/t :link/artifact-not-found)))
+
+(defn- link-target-anomaly
+  [artifact-id role]
+  (anomaly/anomaly :not-found
+                   (link-target-message role)
+                   {:artifact/id artifact-id
+                    :artifact/role role}))
+
+(defn- link-target-role
+  [result]
+  (get-in result [:anomaly/data :artifact/role]))
 
 (defn find-link-target
   "Load an artifact for linking, or return a typed not-found anomaly."
   [record artifact-id role]
   (if-let [artifact (load-artifact-impl record artifact-id)]
     artifact
-     {:anomaly/category :anomalies/not-found
-      :anomaly/message  (case role
-                           :parent "Parent artifact not found"
-                           :child  "Child artifact not found"
-                           "Artifact not found")
-      :artifact-id      artifact-id
-      :role             role}))
+    (link-target-anomaly artifact-id role)))
 
 (defn link-artifacts
   "Link artifacts, preserving the ArtifactStore boolean facade.
@@ -264,7 +290,7 @@
                        {:message (:anomaly/message result)
                         :data    {:parent-id parent-id
                                   :child-id  child-id
-                                  :role      (:role result)}})))
+                                  :role      (link-target-role result)}})))
         false)
       (do
         ;; Update index with links

--- a/components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj
+++ b/components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj
@@ -17,26 +17,32 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.artifact.protocols.impl.transit-store-test
-  (:require [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
             [ai.miniforge.artifact.protocols.impl.transit-store :as impl]
             [ai.miniforge.artifact.protocols.records.transit-store :as store]
             [clojure.java.io :as io]
-            [clojure.test :refer [deftest is]])
+            [clojure.test :refer [deftest is testing]])
   (:import [java.nio.file Files]))
 
-(def parent
-  {:artifact/id "parent-id"
-   :artifact/type :plan
+(def ^:private parent-id "parent-id")
+(def ^:private child-id "child-id")
+(def ^:private missing-parent-id "missing-parent")
+(def ^:private missing-child-id "missing-child")
+
+(defn- artifact
+  [id type]
+  {:artifact/id id
+   :artifact/type type
    :artifact/version "1.0.0"
    :artifact/parents []
    :artifact/children []})
 
-(def child
-  {:artifact/id "child-id"
-   :artifact/type :code
-   :artifact/version "1.0.0"
-   :artifact/parents []
-   :artifact/children []})
+(defn- parent-artifact []
+  (artifact parent-id :plan))
+
+(defn- child-artifact []
+  (artifact child-id :code))
 
 (defn- delete-dir! [file]
   (when (.exists (io/file file))
@@ -53,41 +59,53 @@
   (p/save store artifact)
   artifact)
 
-(deftest find-link-target-test
+(deftest test-find-link-target
   (let [[artifact-store dir] (temp-store)]
     (try
-      (is (= parent (impl/find-link-target
-                     artifact-store (:artifact/id (save! artifact-store parent)) :parent)))
-      (let [result (impl/find-link-target artifact-store "missing-parent" :parent)]
-        (is (= :anomalies/not-found (:anomaly/category result)))
-        (is (= "missing-parent" (:artifact-id result)))
-        (is (= :parent (:role result))))
-      (is (= :unknown (:role (impl/find-link-target artifact-store "missing" :unknown))))
+      (testing "given existing target -> returns artifact"
+        (let [parent (parent-artifact)]
+          (is (= parent (impl/find-link-target
+                         artifact-store (:artifact/id (save! artifact-store parent)) :parent)))))
+      (testing "given missing target -> returns canonical anomaly"
+        (let [result (impl/find-link-target artifact-store missing-parent-id :parent)]
+          (is (anomaly/anomaly? result))
+          (is (= :not-found (:anomaly/type result)))
+          (is (= {:artifact/id missing-parent-id
+                  :artifact/role :parent}
+                 (:anomaly/data result)))))
+      (testing "given unknown role -> returns anomaly data instead of throwing"
+        (is (= :unknown (get-in (impl/find-link-target artifact-store "missing" :unknown)
+                                [:anomaly/data :artifact/role]))))
       (finally
         (delete-dir! dir)))))
 
-(deftest link-artifacts-success-test
+(deftest test-link-artifacts-success
   (let [[artifact-store dir] (temp-store)]
     (try
-      (save! artifact-store parent)
-      (save! artifact-store child)
-      (is (true? (impl/link-artifacts artifact-store "parent-id" "child-id")))
-      (is (contains? (set (:artifact/children (p/load-artifact artifact-store "parent-id")))
-                     "child-id"))
-      (is (contains? (set (:artifact/parents (p/load-artifact artifact-store "child-id")))
-                     "parent-id"))
+      (save! artifact-store (parent-artifact))
+      (save! artifact-store (child-artifact))
+      (testing "given existing parent and child -> links artifacts"
+        (is (true? (impl/link-artifacts artifact-store parent-id child-id)))
+        (is (contains? (set (:artifact/children (p/load-artifact artifact-store parent-id)))
+                       child-id))
+        (is (contains? (set (:artifact/parents (p/load-artifact artifact-store child-id)))
+                       parent-id)))
       (finally
         (delete-dir! dir)))))
 
-(deftest link-artifacts-missing-targets-test
+(defn- missing-target-cases []
+  [["missing parent" [(child-artifact)] missing-parent-id child-id]
+   ["missing child" [(parent-artifact)] parent-id missing-child-id]
+   ["missing both" [] missing-parent-id missing-child-id]])
+
+(deftest test-link-artifacts-missing-targets
   (doseq [[label artifacts parent-id child-id]
-          [["missing parent" [child] "missing-parent" "child-id"]
-           ["missing child" [parent] "parent-id" "missing-child"]
-           ["missing both" [] "missing-parent" "missing-child"]]]
+          (missing-target-cases)]
     (let [[artifact-store dir] (temp-store)]
       (try
         (doseq [artifact artifacts]
           (save! artifact-store artifact))
-        (is (false? (impl/link-artifacts artifact-store parent-id child-id)) label)
+        (testing (str "given " label " -> returns false")
+          (is (false? (impl/link-artifacts artifact-store parent-id child-id))))
         (finally
           (delete-dir! dir))))))


### PR DESCRIPTION
## Summary

Follow-up to #966 to apply the explicit `.standards` pass that should have run before merge.

## Changes

- Use the canonical `ai.miniforge.anomaly.interface/anomaly` shape for Transit link target misses.
- Remove the inline `keep (fn ...)` pattern from the touched Transit store file.
- Bring the new Transit link tests into testing standards: factories, private constants, behavior names, and `testing` descriptions.

## Test plan

- [x] `clj-kondo --lint components/artifact/deps.edn components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj`
- [x] `clojure -M:dev:test -e '(require (quote ai.miniforge.artifact.protocols.impl.transit-store-test)) (let [r (clojure.test/run-tests (quote ai.miniforge.artifact.protocols.impl.transit-store-test))] (shutdown-agents) (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
- [x] `bb miniforge scan . | rg 'components/artifact/(deps.edn|src/ai/miniforge/artifact/protocols/impl/transit_store.clj|test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj)'` returned no findings for these paths
- [x] `bb commit-budget`
- [x] pre-commit hook
