### PR TITLE
Fix bundle resume for checked-out task branches

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -462,15 +462,60 @@
 
    Returns result/ok with {:restored? true :branch str} on success."
   [host-repo-path {:keys [bundle-path branch]}]
-  (try
-    (let [r (run-git "-C" host-repo-path "fetch"
-                     bundle-path (str branch ":" branch))]
-      (if (zero? (:exit r))
-        (result/ok {:restored? true :branch branch :bundle-path bundle-path})
-        (result/err :archive-restore-failed
-                    (get r :err "git fetch from bundle failed"))))
-    (catch Exception e
-      (result/err :archive-restore-failed (.getMessage e)))))
+  (letfn [(failure [fallback command]
+            (result/err :archive-restore-failed
+                        (or (not-empty (:err command)) fallback)))
+          (checked-out-branch []
+            (let [restore-ref (str "refs/miniforge/resume/" branch)
+                  cleanup     (atom nil)
+                  outcome
+                  (try
+                    (let [fetch-ref (run-git "-C" host-repo-path "fetch"
+                                             bundle-path (str branch ":" restore-ref))]
+                      (if-not (zero? (:exit fetch-ref))
+                        (failure "git fetch from bundle failed" fetch-ref)
+                        (let [branch-sha  (run-git "-C" host-repo-path "rev-parse" branch)
+                              restore-sha (run-git "-C" host-repo-path "rev-parse" restore-ref)
+                              ancestor    (run-git "-C" host-repo-path "merge-base" "--is-ancestor"
+                                                   (str/trim (:out restore-sha))
+                                                   (str/trim (:out branch-sha)))]
+                          (cond
+                            (not (zero? (:exit branch-sha)))
+                            (failure "git rev-parse branch failed" branch-sha)
+
+                            (not (zero? (:exit restore-sha)))
+                            (failure "git rev-parse resume ref failed" restore-sha)
+
+                            (zero? (:exit ancestor))
+                            (result/ok {:restored? true
+                                        :branch branch
+                                        :bundle-path bundle-path
+                                        :already-checked-out? true})
+
+                            (= 1 (:exit ancestor))
+                            (result/err :archive-restore-failed
+                                        "Checked-out branch does not contain bundled checkpoint commit")
+
+                            :else
+                            (failure "git merge-base failed" ancestor)))))
+                    (finally
+                      (reset! cleanup
+                              (run-git "-C" host-repo-path "update-ref" "-d" restore-ref))))]
+              (if (and (result/ok? outcome)
+                       (not (zero? (:exit @cleanup))))
+                (failure "git cleanup of resume ref failed" @cleanup)
+                outcome)))]
+    (try
+      (let [r (run-git "-C" host-repo-path "fetch"
+                       bundle-path (str branch ":" branch))]
+        (if (zero? (:exit r))
+          (result/ok {:restored? true :branch branch :bundle-path bundle-path})
+          (if (str/includes? (get r :err "")
+                             "refusing to fetch into branch")
+            (checked-out-branch)
+            (failure "git fetch from bundle failed" r))))
+      (catch Exception e
+        (result/err :archive-restore-failed (.getMessage e))))))
 
 ;; ============================================================================
 ;; Command Execution

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -316,6 +316,124 @@
                   "/tmp/checkpoints/env-1.bundle" "task-1:task-1"]
                  @fetch-args)))))))
 
+(deftest restore-workspace-accepts-already-checked-out-branch-test
+  (testing "restore succeeds when the checked-out branch already contains the bundled commit"
+    (let [executor (worktree/create-worktree-executor {})
+          calls (atom [])]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (swap! calls conj (vec args))
+                      (let [tail (drop 2 args)]
+                        (cond
+                          (= ["fetch" "/tmp/checkpoints/env-1.bundle" "task-1:task-1"] tail)
+                          {:exit 128
+                           :out ""
+                           :err "fatal: refusing to fetch into branch 'refs/heads/task-1' checked out"}
+
+                          (= ["fetch" "/tmp/checkpoints/env-1.bundle"
+                              "task-1:refs/miniforge/resume/task-1"] tail)
+                          {:exit 0 :out "" :err ""}
+
+                          (= ["rev-parse" "task-1"] tail)
+                          {:exit 0 :out "abc123\n" :err ""}
+
+                          (= ["rev-parse" "refs/miniforge/resume/task-1"] tail)
+                          {:exit 0 :out "abc123\n" :err ""}
+
+                          (= ["merge-base" "--is-ancestor" "abc123" "abc123"] tail)
+                          {:exit 0 :out "" :err ""}
+
+                          (= ["update-ref" "-d" "refs/miniforge/resume/task-1"] tail)
+                          {:exit 0 :out "" :err ""}
+
+                          :else {:exit 1 :out "" :err (str "unexpected git call " tail)})))]
+        (let [r (proto/restore-workspace!
+                 executor "env-1"
+                 {:host-repo-path "/host/repo"
+                  :bundle-path    "/tmp/checkpoints/env-1.bundle"
+                  :branch         "task-1"})]
+          (is (result/ok? r))
+          (is (true? (get-in r [:data :already-checked-out?])))
+          (is (some #(= ["-C" "/host/repo" "update-ref" "-d"
+                         "refs/miniforge/resume/task-1"] %)
+                    @calls)))))))
+
+(deftest restore-workspace-surfaces-resume-fetch-failure-test
+  (testing "checked-out branch fallback reports resume-ref fetch failures and cleans up"
+    (let [executor (worktree/create-worktree-executor {})
+          calls (atom [])]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (swap! calls conj (vec args))
+                      (let [tail (drop 2 args)]
+                        (cond
+                          (= ["fetch" "/tmp/checkpoints/env-1.bundle" "task-1:task-1"] tail)
+                          {:exit 128
+                           :out ""
+                           :err "fatal: refusing to fetch into branch 'refs/heads/task-1' checked out"}
+
+                          (= ["fetch" "/tmp/checkpoints/env-1.bundle"
+                              "task-1:refs/miniforge/resume/task-1"] tail)
+                          {:exit 128 :out "" :err "fatal: bad bundle"}
+
+                          (= ["update-ref" "-d" "refs/miniforge/resume/task-1"] tail)
+                          {:exit 0 :out "" :err ""}
+
+                          :else {:exit 1 :out "" :err (str "unexpected git call " tail)})))]
+        (let [r (proto/restore-workspace!
+                 executor "env-1"
+                 {:host-repo-path "/host/repo"
+                  :bundle-path    "/tmp/checkpoints/env-1.bundle"
+                  :branch         "task-1"})]
+          (is (result/err? r))
+          (is (= "fatal: bad bundle" (get-in r [:error :message])))
+          (is (some #(= ["-C" "/host/repo" "update-ref" "-d"
+                         "refs/miniforge/resume/task-1"] %)
+                    @calls)))))))
+
+(deftest restore-workspace-errors-when-checked-out-branch-lacks-bundle-tip-test
+  (testing "checked-out branch fallback rejects stale branches and cleans up"
+    (let [executor (worktree/create-worktree-executor {})
+          calls (atom [])]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (swap! calls conj (vec args))
+                      (let [tail (drop 2 args)]
+                        (cond
+                          (= ["fetch" "/tmp/checkpoints/env-1.bundle" "task-1:task-1"] tail)
+                          {:exit 128
+                           :out ""
+                           :err "fatal: refusing to fetch into branch 'refs/heads/task-1' checked out"}
+
+                          (= ["fetch" "/tmp/checkpoints/env-1.bundle"
+                              "task-1:refs/miniforge/resume/task-1"] tail)
+                          {:exit 0 :out "" :err ""}
+
+                          (= ["rev-parse" "task-1"] tail)
+                          {:exit 0 :out "branch-sha\n" :err ""}
+
+                          (= ["rev-parse" "refs/miniforge/resume/task-1"] tail)
+                          {:exit 0 :out "bundle-sha\n" :err ""}
+
+                          (= ["merge-base" "--is-ancestor" "bundle-sha" "branch-sha"] tail)
+                          {:exit 1 :out "" :err ""}
+
+                          (= ["update-ref" "-d" "refs/miniforge/resume/task-1"] tail)
+                          {:exit 0 :out "" :err ""}
+
+                          :else {:exit 1 :out "" :err (str "unexpected git call " tail)})))]
+        (let [r (proto/restore-workspace!
+                 executor "env-1"
+                 {:host-repo-path "/host/repo"
+                  :bundle-path    "/tmp/checkpoints/env-1.bundle"
+                  :branch         "task-1"})]
+          (is (result/err? r))
+          (is (= "Checked-out branch does not contain bundled checkpoint commit"
+                 (get-in r [:error :message])))
+          (is (some #(= ["-C" "/host/repo" "update-ref" "-d"
+                         "refs/miniforge/resume/task-1"] %)
+                    @calls)))))))
+
 (deftest persist-workspace-base-ref-never-falls-back-to-task-branch-test
   (testing "persist-workspace! does NOT use the task branch as base-ref fallback"
     ;; Regression: the original fallback chain was


### PR DESCRIPTION
## Summary
- tolerate bundle restore when the target task branch is already checked out and already contains the checkpoint commit
- fetch to a temporary resume ref to verify ancestry before treating restore as complete
- add regression coverage for the checked-out branch case

## Verification
- clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.dag-executor.protocols.impl.worktree-test) (let [r (clojure.test/run-tests 'ai.miniforge.dag-executor.protocols.impl.worktree-test)] (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))"
- clj-kondo --lint components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
- bb review | rg 'worktree\.clj|worktree_test\.clj'  # no touched-file standards hits
- pre-commit hook: commit-budget, poly check, lint, smoke tests, Graal/Babashka compatibility