### PR TITLE
feat: autonomous + tool-restricted Cursor backend

### DIFF
--- a/bases/cli/resources/config/cli/backends.edn
+++ b/bases/cli/resources/config/cli/backends.edn
@@ -31,7 +31,7 @@
   :cursor
   {:provider "Cursor"
    :description "Cursor AI via CLI"
-   :command "cursor-cli"
+   :command "agent"
    :installation "Install from https://cursor.sh"
    :models ["cursor-default"]
    :check-type :cli

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -366,30 +366,47 @@
          vec)))
 
 (defn write-cursor-permissions!
-  "Write or merge .cursor/cli.json with a default-deny permission allowlist.
+  "Write .cursor/cli.json with a default-deny permission allowlist.
 
    `allowed-tools` is the agent-agnostic auto-approve set (`mcp-tools`);
-   `disallowed-tools` subtracts native tools the role must not call. Merges
-   into any existing permissions arrays so a project/user cli.json is
-   preserved. Returns the path to the config file."
+   `disallowed-tools` subtracts native tools the role must not call.
+
+   Authoritative over the rules miniforge manages: any prior managed entry
+   is stripped before the role-scoped set is re-added, so rewriting with a
+   narrower `disallowed-tools` correctly shrinks the allowlist. Pre-existing
+   user/project rules are preserved. Returns the path to the config file."
   [config-root allowed-tools disallowed-tools]
-  (let [root        (or config-root (System/getProperty "user.dir"))
-        dir         (io/file root ".cursor")
-        config-file (io/file dir "cli.json")
-        allow       (cursor-permission-allow allowed-tools disallowed-tools)
-        existing    (when (.exists config-file)
-                      (try (json/parse-string (slurp config-file))
-                           (catch Exception _ {})))
-        prior-allow (get-in existing ["permissions" "allow"] [])
-        prior-deny  (get-in existing ["permissions" "deny"] [])
-        config      (-> (or existing {})
-                        (assoc-in ["permissions" "allow"]
-                                  (vec (distinct (concat prior-allow allow))))
-                        (assoc-in ["permissions" "deny"]
-                                  (vec (distinct (concat prior-deny cursor-permission-deny)))))]
+  (let [root          (or config-root (System/getProperty "user.dir"))
+        dir           (io/file root ".cursor")
+        config-file   (io/file dir "cli.json")
+        allow         (cursor-permission-allow allowed-tools disallowed-tools)
+        managed-allow (set (keep mcp-tool->cursor-permission allowed-tools))
+        managed-deny  (set cursor-permission-deny)
+        existing      (when (.exists config-file)
+                        (try (json/parse-string (slurp config-file))
+                             (catch Exception _ {})))
+        user-allow    (remove managed-allow (get-in existing ["permissions" "allow"] []))
+        user-deny     (remove managed-deny (get-in existing ["permissions" "deny"] []))
+        config        (-> (or existing {})
+                          (assoc-in ["permissions" "allow"]
+                                    (vec (distinct (concat user-allow allow))))
+                          (assoc-in ["permissions" "deny"]
+                                    (vec (distinct (concat user-deny cursor-permission-deny)))))]
     (.mkdirs dir)
     (spit config-file (json/generate-string config {:pretty true}))
     (str config-file)))
+
+(defn write-cursor-permissions-for-session!
+  "Rewrite the session's .cursor/cli.json allowlist with a role's
+   `disallowed-tools` applied (e.g. a reviewer that must not Write).
+
+   No-op for capsule sessions — Cursor configs are host-only. Returns the
+   path, or nil when skipped."
+  [session disallowed-tools]
+  (when-not (:capsule? session)
+    (write-cursor-permissions! (:config-root session)
+                               (:mcp-allowed-tools session)
+                               disallowed-tools)))
 
 (defn write-claude-settings!
   "Write Claude CLI settings JSON with PreToolUse hook for supervision.

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -374,7 +374,10 @@
    Authoritative over the rules miniforge manages: any prior managed entry
    is stripped before the role-scoped set is re-added, so rewriting with a
    narrower `disallowed-tools` correctly shrinks the allowlist. Pre-existing
-   user/project rules are preserved. Returns the path to the config file."
+   user/project rules are preserved, with one caveat — a user rule that is
+   byte-identical to a managed rule (e.g. \"Write(**)\") is indistinguishable
+   from ours and is treated as managed (stripped on cleanup). Returns the
+   path to the config file."
   [config-root allowed-tools disallowed-tools]
   (let [root          (or config-root (System/getProperty "user.dir"))
         dir           (io/file root ".cursor")
@@ -476,8 +479,12 @@
    - <session-dir>/claude-settings.json — Claude CLI hooks (passed via --settings)
    - .codex/config.toml — Codex MCP server config (cleaned up after session)
    - .cursor/mcp.json — Cursor MCP server config (cleaned up after session)
+   - .cursor/cli.json — Cursor default-deny permission allowlist
+     (cleaned up after session)
 
-   Also populates :mcp-allowed-tools and :supervision on the session.
+   Also populates :mcp-allowed-tools and :supervision on the session, and
+   tracks the project-scoped files (.codex/config.toml, .cursor/mcp.json,
+   .cursor/cli.json) in :mcp-cleanup-files for teardown.
 
    Arguments:
    - session - Session map from create-session!
@@ -705,8 +712,11 @@
 (defn cleanup-cursor-permissions!
   "Remove the permission rules we injected from .cursor/cli.json, deleting
    the file if nothing else remains. Strips the full managed superset so a
-   role-specific allow subset is always cleaned, while preserving any
-   pre-existing user/project rules."
+   role-specific allow subset is always cleaned, preserving pre-existing
+   user/project rules — except a user rule byte-identical to a managed rule
+   (e.g. \"Write(**)\"), which is indistinguishable from ours and is removed.
+   Rules are compared by exact string, so a differently-scoped user rule
+   such as \"Write(src/**)\" survives."
   [path]
   (let [f (io/file path)]
     (when (.exists f)
@@ -833,11 +843,13 @@
          (cleanup-capsule-session! session#)))))
 
 (defn cleanup-session!
-  "Delete the temporary session directory and clean up injected MCP configs.
+  "Delete the temporary session directory and clean up injected configs.
 
-   Removes the [mcp_servers.artifact] block from .codex/config.toml
-   and the artifact entry from .cursor/mcp.json, preserving any other
-   config in those files.
+   Removes the [mcp_servers.artifact] block from .codex/config.toml, the
+   artifact entry from .cursor/mcp.json, and miniforge's managed rules from
+   the .cursor/cli.json permission allowlist, preserving any other config in
+   those files. (See cleanup-cursor-permissions! for the one caveat: user
+   rules byte-identical to a managed rule are treated as managed.)
 
    Arguments:
    - session - Session map from create-session!"

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -349,16 +349,30 @@
    allowed. Globs follow Cursor's documented Write(pathOrGlob) form."
   ["Write(**/.env*)" "Write(**/*.key)" "Write(**/*.pem)"])
 
+(def ^:private cursor-write-tools
+  "Native tools that Cursor collapses into the single Write(**) permission.
+   Cursor cannot express a partial write restriction, so disallowing any one
+   of these drops the whole write permission."
+  #{:Write :Edit :MultiEdit})
+
 (defn cursor-permission-allow
   "Cursor `allow` rules for a session: the auto-approved `mcp-tools`, minus
    any native tool the role disallows, translated to Cursor rule strings.
 
    Default-deny: Cursor sees only this allowlist, so shell, arbitrary file
-   reads, and other MCP servers are denied by omission — no wildcard needed."
+   reads, and other MCP servers are denied by omission — no wildcard needed.
+
+   Cursor maps Write/Edit/MultiEdit onto one Write(**) rule, so disallowing
+   ANY of them drops Write(**) entirely (a finer-grained Claude distinction
+   like 'Edit-but-not-Write' cannot be represented here)."
   [allowed-tools disallowed-tools]
-  (let [disallowed (set (map name disallowed-tools))
-        keep?      (fn [tool] (or (map? tool)
-                                  (not (contains? disallowed (name tool)))))]
+  (let [disallowed     (set (map name disallowed-tools))
+        write-blocked? (some #(contains? disallowed (name %)) cursor-write-tools)
+        keep?          (fn [tool]
+                         (cond
+                           (map? tool)               true
+                           (cursor-write-tools tool) (not write-blocked?)
+                           :else                     (not (contains? disallowed (name tool)))))]
     (->> allowed-tools
          (filter keep?)
          (keep mcp-tool->cursor-permission)
@@ -373,11 +387,10 @@
 
    Authoritative over the rules miniforge manages: any prior managed entry
    is stripped before the role-scoped set is re-added, so rewriting with a
-   narrower `disallowed-tools` correctly shrinks the allowlist. Pre-existing
-   user/project rules are preserved, with one caveat — a user rule that is
-   byte-identical to a managed rule (e.g. \"Write(**)\") is indistinguishable
-   from ours and is treated as managed (stripped on cleanup). Returns the
-   path to the config file."
+   narrower `disallowed-tools` correctly shrinks the allowlist. The exact
+   pre-session file is captured by `backup-cursor-permissions!` and restored
+   on cleanup, so user/project rules survive byte-for-byte even when they
+   overlap a managed rule. Returns the path to the config file."
   [config-root allowed-tools disallowed-tools]
   (let [root          (or config-root (System/getProperty "user.dir"))
         dir           (io/file root ".cursor")
@@ -398,6 +411,26 @@
     (.mkdirs dir)
     (spit config-file (json/generate-string config {:pretty true}))
     (str config-file)))
+
+(def ^:private cursor-permissions-backup-suffix
+  "Suffix for the pre-session .cursor/cli.json snapshot used to restore the
+   user's exact file on cleanup."
+  ".mf-bak")
+
+(defn backup-cursor-permissions!
+  "Snapshot a pre-existing .cursor/cli.json once, before miniforge mutates
+   it, so cleanup can restore it byte-for-byte.
+
+   No-op when the file is absent (cleanup then just deletes the file we
+   generate) or when a snapshot already exists (so mid-session rewrites never
+   clobber the original). Returns the backup path or nil."
+  [config-root]
+  (let [root        (or config-root (System/getProperty "user.dir"))
+        config-file (io/file root ".cursor" "cli.json")
+        backup-file (io/file root ".cursor" (str "cli.json" cursor-permissions-backup-suffix))]
+    (when (and (.exists config-file) (not (.exists backup-file)))
+      (io/copy config-file backup-file)
+      (str backup-file))))
 
 (defn write-cursor-permissions-for-session!
   "Rewrite the session's .cursor/cli.json allowlist with a role's
@@ -500,6 +533,7 @@
         settings-path (write-claude-settings! (:dir session))
         codex-path    (write-codex-mcp-config! config-root srv-cmd)
         cursor-path   (write-cursor-mcp-config! config-root srv-cmd)
+        _             (backup-cursor-permissions! config-root)
         cursor-perms  (write-cursor-permissions! config-root mcp-tools nil)
         [hook-cmd & hook-args] (resolve-miniforge-command)
         hook-eval-cmd (str/join " " (concat [hook-cmd] hook-args ["hook-eval"]))]
@@ -710,32 +744,24 @@
         (catch Exception _ nil)))))
 
 (defn cleanup-cursor-permissions!
-  "Remove the permission rules we injected from .cursor/cli.json, deleting
-   the file if nothing else remains. Strips the full managed superset so a
-   role-specific allow subset is always cleaned, preserving pre-existing
-   user/project rules — except a user rule byte-identical to a managed rule
-   (e.g. \"Write(**)\"), which is indistinguishable from ours and is removed.
-   Rules are compared by exact string, so a differently-scoped user rule
-   such as \"Write(src/**)\" survives."
+  "Restore .cursor/cli.json to its exact pre-session contents.
+
+   If `backup-cursor-permissions!` captured a snapshot (the file pre-existed),
+   move it back over our generated file; otherwise delete the file miniforge
+   created. Fully non-destructive — user/project rules are byte-preserved
+   regardless of any overlap with managed rules."
   [path]
-  (let [f (io/file path)]
-    (when (.exists f)
-      (try
-        (let [config        (json/parse-string (slurp f))
-              managed-allow (set (keep mcp-tool->cursor-permission mcp-tools))
-              managed-deny  (set cursor-permission-deny)
-              allow'        (vec (remove managed-allow (get-in config ["permissions" "allow"] [])))
-              deny'         (vec (remove managed-deny (get-in config ["permissions" "deny"] [])))
-              perms'        (cond-> {}
-                              (seq allow') (assoc "allow" allow')
-                              (seq deny')  (assoc "deny" deny'))
-              config'       (if (empty? perms')
-                              (dissoc config "permissions")
-                              (assoc config "permissions" perms'))]
-          (if (empty? config')
-            (.delete f)
-            (spit f (json/generate-string config' {:pretty true}))))
-        (catch Exception _ nil)))))
+  (try
+    (let [config-file (io/file path)
+          backup-file (io/file (str path cursor-permissions-backup-suffix))]
+      (cond
+        (.exists backup-file)
+        (do (io/copy backup-file config-file)
+            (.delete backup-file))
+
+        (.exists config-file)
+        (.delete config-file)))
+    (catch Exception _ nil)))
 
 ;------------------------------------------------------------------------------ Layer 2.5
 ;; Capsule-aware session lifecycle (N11 §6.3-6.4)
@@ -845,11 +871,10 @@
 (defn cleanup-session!
   "Delete the temporary session directory and clean up injected configs.
 
-   Removes the [mcp_servers.artifact] block from .codex/config.toml, the
-   artifact entry from .cursor/mcp.json, and miniforge's managed rules from
-   the .cursor/cli.json permission allowlist, preserving any other config in
-   those files. (See cleanup-cursor-permissions! for the one caveat: user
-   rules byte-identical to a managed rule are treated as managed.)
+   Removes the [mcp_servers.artifact] block from .codex/config.toml and the
+   artifact entry from .cursor/mcp.json (preserving any other config), and
+   restores .cursor/cli.json to its exact pre-session contents from the
+   backup snapshot (or deletes it if miniforge created it).
 
    Arguments:
    - session - Session map from create-session!"

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -324,6 +324,73 @@
     (spit config-file (json/generate-string config {:pretty true}))
     (str config-file)))
 
+(defn- mcp-tool->cursor-permission
+  "Translate one agent-agnostic `mcp-tools` entry into a Cursor permission
+   rule string (https://cursor.com/docs/cli/reference/permissions).
+
+     {:mcp/server S :mcp/tool T} -> \"Mcp(S:T)\"
+     :Write / :Edit / :MultiEdit -> \"Write(**)\"  (Cursor models all edits
+                                                    as writes; no Edit primitive)
+
+   Returns nil for entries with no Cursor analog."
+  [tool]
+  (cond
+    (map? tool)
+    (format "Mcp(%s:%s)" (name (:mcp/server tool)) (name (:mcp/tool tool)))
+
+    (#{:Write :Edit :MultiEdit} tool)
+    "Write(**)"
+
+    :else nil))
+
+(def cursor-permission-deny
+  "Hard denials applied regardless of the allowlist. Deny takes precedence
+   over allow in Cursor, so these block secret writes even when Write(**) is
+   allowed. Globs follow Cursor's documented Write(pathOrGlob) form."
+  ["Write(**/.env*)" "Write(**/*.key)" "Write(**/*.pem)"])
+
+(defn cursor-permission-allow
+  "Cursor `allow` rules for a session: the auto-approved `mcp-tools`, minus
+   any native tool the role disallows, translated to Cursor rule strings.
+
+   Default-deny: Cursor sees only this allowlist, so shell, arbitrary file
+   reads, and other MCP servers are denied by omission — no wildcard needed."
+  [allowed-tools disallowed-tools]
+  (let [disallowed (set (map name disallowed-tools))
+        keep?      (fn [tool] (or (map? tool)
+                                  (not (contains? disallowed (name tool)))))]
+    (->> allowed-tools
+         (filter keep?)
+         (keep mcp-tool->cursor-permission)
+         distinct
+         vec)))
+
+(defn write-cursor-permissions!
+  "Write or merge .cursor/cli.json with a default-deny permission allowlist.
+
+   `allowed-tools` is the agent-agnostic auto-approve set (`mcp-tools`);
+   `disallowed-tools` subtracts native tools the role must not call. Merges
+   into any existing permissions arrays so a project/user cli.json is
+   preserved. Returns the path to the config file."
+  [config-root allowed-tools disallowed-tools]
+  (let [root        (or config-root (System/getProperty "user.dir"))
+        dir         (io/file root ".cursor")
+        config-file (io/file dir "cli.json")
+        allow       (cursor-permission-allow allowed-tools disallowed-tools)
+        existing    (when (.exists config-file)
+                      (try (json/parse-string (slurp config-file))
+                           (catch Exception _ {})))
+        prior-allow (get-in existing ["permissions" "allow"] [])
+        prior-deny  (get-in existing ["permissions" "deny"] [])
+        config      (-> (or existing {})
+                        (assoc-in ["permissions" "allow"]
+                                  (vec (distinct (concat prior-allow allow))))
+                        (assoc-in ["permissions" "deny"]
+                                  (vec (distinct (concat prior-deny cursor-permission-deny)))))]
+    (.mkdirs dir)
+    (spit config-file (json/generate-string config {:pretty true}))
+    (str config-file)))
+
 (defn write-claude-settings!
   "Write Claude CLI settings JSON with PreToolUse hook for supervision.
 
@@ -409,11 +476,12 @@
         settings-path (write-claude-settings! (:dir session))
         codex-path    (write-codex-mcp-config! config-root srv-cmd)
         cursor-path   (write-cursor-mcp-config! config-root srv-cmd)
+        cursor-perms  (write-cursor-permissions! config-root mcp-tools nil)
         [hook-cmd & hook-args] (resolve-miniforge-command)
         hook-eval-cmd (str/join " " (concat [hook-cmd] hook-args ["hook-eval"]))]
     (assoc session
            :mcp-allowed-tools mcp-tools
-           :mcp-cleanup-files [codex-path cursor-path]
+           :mcp-cleanup-files [codex-path cursor-path cursor-perms]
            :supervision {:hook-eval-cmd hook-eval-cmd
                          :settings-path settings-path
                          :policy :workspace-write
@@ -617,6 +685,31 @@
             (spit f (json/generate-string config' {:pretty true}))))
         (catch Exception _ nil)))))
 
+(defn cleanup-cursor-permissions!
+  "Remove the permission rules we injected from .cursor/cli.json, deleting
+   the file if nothing else remains. Strips the full managed superset so a
+   role-specific allow subset is always cleaned, while preserving any
+   pre-existing user/project rules."
+  [path]
+  (let [f (io/file path)]
+    (when (.exists f)
+      (try
+        (let [config        (json/parse-string (slurp f))
+              managed-allow (set (keep mcp-tool->cursor-permission mcp-tools))
+              managed-deny  (set cursor-permission-deny)
+              allow'        (vec (remove managed-allow (get-in config ["permissions" "allow"] [])))
+              deny'         (vec (remove managed-deny (get-in config ["permissions" "deny"] [])))
+              perms'        (cond-> {}
+                              (seq allow') (assoc "allow" allow')
+                              (seq deny')  (assoc "deny" deny'))
+              config'       (if (empty? perms')
+                              (dissoc config "permissions")
+                              (assoc config "permissions" perms'))]
+          (if (empty? config')
+            (.delete f)
+            (spit f (json/generate-string config' {:pretty true}))))
+        (catch Exception _ nil)))))
+
 ;------------------------------------------------------------------------------ Layer 2.5
 ;; Capsule-aware session lifecycle (N11 §6.3-6.4)
 
@@ -736,7 +829,8 @@
   (doseq [path (:mcp-cleanup-files session)]
     (cond
       (str/ends-with? path "config.toml") (cleanup-codex-mcp-config! path)
-      (str/ends-with? path "mcp.json") (cleanup-cursor-mcp-config! path)))
+      (str/ends-with? path "mcp.json") (cleanup-cursor-mcp-config! path)
+      (str/ends-with? path "cli.json") (cleanup-cursor-permissions! path)))
   ;; Delete temp session directory
   (try
     (let [dir (io/file (:dir session))]

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -458,6 +458,9 @@
                                :disallowed-tools planner-disallowed-tools
                                :progress-monitor (create-planner-progress-monitor))
                    (:workdir session) (assoc :workdir (:workdir session)))]
+    ;; Carry the role disallow-list into the Cursor backend's permission
+    ;; allowlist (Claude/Codex honor :disallowed-tools per-invocation).
+    (artifact-session/write-cursor-permissions-for-session! session planner-disallowed-tools)
     (if on-chunk
       (llm/chat-stream llm-client user-prompt on-chunk
                        (merge {:system effective-system} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -75,6 +75,11 @@
   "Full prompt data map for the tester agent."
   (delay (prompts/load-prompt-data :tester)))
 
+(def ^:private tester-disallowed-tools
+  "Native tools the tester must not call: it works from the MCP context
+   cache and writes test files, so unscoped file/web exploration is off."
+  ["Read" "Grep" "Glob" "WebSearch" "WebFetch" "LS"])
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Tester functions
 
@@ -336,7 +341,10 @@
   (let [budget-usd (budget/resolve-cost-budget-usd :tester config context)
         max-turns (get @tester-prompt-data :prompt/max-turns 10)
         mcp-opts (assoc (artifact-session/session->mcp-opts session budget-usd max-turns)
-                        :disallowed-tools ["Read" "Grep" "Glob" "WebSearch" "WebFetch" "LS"])]
+                        :disallowed-tools tester-disallowed-tools)]
+    ;; Carry the role disallow-list into the Cursor backend's permission
+    ;; allowlist (Claude/Codex honor :disallowed-tools per-invocation).
+    (artifact-session/write-cursor-permissions-for-session! session tester-disallowed-tools)
     (if on-chunk
       (llm/chat-stream llm-client user-prompt on-chunk
                        (merge {:system @tester-system-prompt} mcp-opts))

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -375,6 +375,43 @@
         (finally
           (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
 
+(deftest write-cursor-permissions-narrows-on-rewrite-test
+  (testing "rewriting with a narrower disallow set shrinks the allowlist"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-narrow-" (random-uuid)))]
+      (try
+        (.mkdirs tmp)
+        ;; First write: full allow (no disallow) includes Write(**).
+        (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
+        (let [path (str (io/file tmp ".cursor" "cli.json"))]
+          (is (some #(= "Write(**)" %)
+                    (get-in (json/parse-string (slurp path)) ["permissions" "allow"])))
+          ;; Rewrite disallowing Write: managed Write(**) is stripped, MCP stays.
+          (session/write-cursor-permissions! (str tmp) session/mcp-tools ["Write" "Edit" "MultiEdit"])
+          (let [allow (get-in (json/parse-string (slurp path)) ["permissions" "allow"])]
+            (is (not (some #(= "Write(**)" %) allow)))
+            (is (some #(str/starts-with? % "Mcp(") allow))))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
+(deftest write-cursor-permissions-for-session-test
+  (testing "no-op for capsule sessions"
+    (is (nil? (session/write-cursor-permissions-for-session!
+               {:capsule? true :config-root "/tmp/should-not-write"} ["Write"]))))
+  (testing "host session writes to its config-root"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-session-" (random-uuid)))]
+      (try
+        (.mkdirs tmp)
+        (let [path (session/write-cursor-permissions-for-session!
+                    {:config-root (str tmp) :mcp-allowed-tools session/mcp-tools}
+                    ["Write" "Edit" "MultiEdit"])
+              allow (get-in (json/parse-string (slurp path)) ["permissions" "allow"])]
+          (is (str/ends-with? path "cli.json"))
+          (is (not (some #(= "Write(**)" %) allow))))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
 (deftest cleanup-cursor-permissions-test
   (testing "cleanup strips our rules but preserves pre-existing user rules"
     (let [tmp (io/file (System/getProperty "java.io.tmpdir")

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -355,10 +355,15 @@
       (is (some #(= "Write(**)" %) allow))
       (testing "Write/Edit/MultiEdit collapse to a single Write(**) rule"
         (is (= 1 (count (filter #(= "Write(**)" %) allow)))))))
-  (testing "default-deny: disallowing Write drops the only write rule"
+  (testing "default-deny: disallowing all write tools drops the write rule"
     (let [allow (session/cursor-permission-allow session/mcp-tools ["Write" "Edit" "MultiEdit"])]
       (is (not (some #(= "Write(**)" %) allow)))
-      (is (some #(str/starts-with? % "Mcp(") allow)))))
+      (is (some #(str/starts-with? % "Mcp(") allow))))
+  (testing "disallowing ANY write tool drops Write(**) (Cursor can't distinguish)"
+    (doseq [blocked [["Write"] ["Edit"] ["MultiEdit"]]]
+      (let [allow (session/cursor-permission-allow session/mcp-tools blocked)]
+        (is (not (some #(= "Write(**)" %) allow))
+            (str "Write(**) should be dropped when disallowing " blocked))))))
 
 (deftest write-cursor-permissions-test
   (testing "writes .cursor/cli.json with allow + secret-deny baseline"
@@ -412,24 +417,42 @@
         (finally
           (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
 
-(deftest cleanup-cursor-permissions-test
-  (testing "cleanup strips our rules but preserves pre-existing user rules"
+(deftest cleanup-cursor-permissions-restores-original-test
+  (testing "cleanup restores a pre-existing cli.json byte-for-byte"
     (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "cursor-perms-cleanup-" (random-uuid)))
+                       (str "cursor-perms-restore-" (random-uuid)))
           dir (io/file tmp ".cursor")
           cli (io/file dir "cli.json")
           cleanup-fn @#'session/cleanup-cursor-permissions!]
       (try
         (.mkdirs dir)
-        ;; Seed a user rule, then inject ours via the writer.
-        (spit cli (json/generate-string {"permissions" {"allow" ["Shell(git)"]}}))
+        ;; A user rule that is byte-identical to a managed rule — the case the
+        ;; old string-stripping cleanup could not preserve.
+        (let [original (json/generate-string {"permissions" {"allow" ["Shell(git)" "Write(**)"]}})]
+          (spit cli original)
+          (session/backup-cursor-permissions! (str tmp))
+          (session/write-cursor-permissions! (str tmp) session/mcp-tools ["Write" "Edit" "MultiEdit"])
+          (is (not= original (slurp cli)) "writer mutates the live file")
+          (cleanup-fn (str cli))
+          (is (= original (slurp cli)) "cleanup restores the exact original")
+          (is (not (.exists (io/file dir (str "cli.json" @#'session/cursor-permissions-backup-suffix))))
+              "backup file is removed after restore"))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
+(deftest cleanup-cursor-permissions-deletes-generated-test
+  (testing "cleanup deletes the file when miniforge created it (no prior file)"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-del-" (random-uuid)))
+          cli (io/file tmp ".cursor" "cli.json")
+          cleanup-fn @#'session/cleanup-cursor-permissions!]
+      (try
+        (.mkdirs tmp)
+        (session/backup-cursor-permissions! (str tmp)) ; no-op: nothing to back up
         (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
-        (is (str/includes? (slurp cli) "Write(**)"))
+        (is (.exists cli))
         (cleanup-fn (str cli))
-        (let [config (json/parse-string (slurp cli))]
-          (is (not (some #(= "Write(**)" %) (get-in config ["permissions" "allow"]))))
-          (is (some #(= "Shell(git)" %) (get-in config ["permissions" "allow"])))
-          (is (nil? (get-in config ["permissions" "deny"]))))
+        (is (not (.exists cli)) "generated file is deleted, leaving no stray config")
         (finally
           (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
 

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -309,9 +309,10 @@
     (let [s (-> (session/create-session!) session/write-mcp-config!)]
       (try
         (is (vector? (:mcp-cleanup-files s)))
-        (is (= 2 (count (:mcp-cleanup-files s))))
+        (is (= 3 (count (:mcp-cleanup-files s))))
         (is (some #(str/ends-with? % "config.toml") (:mcp-cleanup-files s)))
         (is (some #(str/ends-with? % "mcp.json") (:mcp-cleanup-files s)))
+        (is (some #(str/ends-with? % "cli.json") (:mcp-cleanup-files s)))
         (finally
           (session/cleanup-session! s))))))
 
@@ -345,6 +346,55 @@
         (is (str/ends-with? cursor-file "mcp.json"))
         (finally
           (session/cleanup-session! s))))))
+
+(deftest cursor-permission-allow-test
+  (testing "mcp-tools translate to Mcp(...) + Write(**) rules"
+    (let [allow (session/cursor-permission-allow session/mcp-tools nil)]
+      (is (some #(= "Mcp(context:context_read)" %) allow))
+      (is (some #(= "Mcp(context:submit)" %) allow))
+      (is (some #(= "Write(**)" %) allow))
+      (testing "Write/Edit/MultiEdit collapse to a single Write(**) rule"
+        (is (= 1 (count (filter #(= "Write(**)" %) allow)))))))
+  (testing "default-deny: disallowing Write drops the only write rule"
+    (let [allow (session/cursor-permission-allow session/mcp-tools ["Write" "Edit" "MultiEdit"])]
+      (is (not (some #(= "Write(**)" %) allow)))
+      (is (some #(str/starts-with? % "Mcp(") allow)))))
+
+(deftest write-cursor-permissions-test
+  (testing "writes .cursor/cli.json with allow + secret-deny baseline"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-" (random-uuid)))]
+      (try
+        (.mkdirs tmp)
+        (let [path   (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
+              config (json/parse-string (slurp path))]
+          (is (str/ends-with? path "cli.json"))
+          (is (contains? (set (get-in config ["permissions" "allow"])) "Write(**)"))
+          (is (= (set session/cursor-permission-deny)
+                 (set (get-in config ["permissions" "deny"])))))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
+(deftest cleanup-cursor-permissions-test
+  (testing "cleanup strips our rules but preserves pre-existing user rules"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-cleanup-" (random-uuid)))
+          dir (io/file tmp ".cursor")
+          cli (io/file dir "cli.json")
+          cleanup-fn @#'session/cleanup-cursor-permissions!]
+      (try
+        (.mkdirs dir)
+        ;; Seed a user rule, then inject ours via the writer.
+        (spit cli (json/generate-string {"permissions" {"allow" ["Shell(git)"]}}))
+        (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
+        (is (str/includes? (slurp cli) "Write(**)"))
+        (cleanup-fn (str cli))
+        (let [config (json/parse-string (slurp cli))]
+          (is (not (some #(= "Write(**)" %) (get-in config ["permissions" "allow"]))))
+          (is (some #(= "Shell(git)" %) (get-in config ["permissions" "allow"])))
+          (is (nil? (get-in config ["permissions" "deny"]))))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
 
 (deftest cleanup-codex-config-test
   (testing "cleanup removes artifact block but preserves other config"

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -490,11 +490,26 @@
     true   (conj prompt)))
 
 (defn- cursor-args
-  "Build CLI arguments for the Cursor backend."
-  [{:keys [prompt mcp-allowed-tools]}]
-  (cond-> ["-p"]
-    (seq mcp-allowed-tools) (conj "--approve-mcps")
-    true (conj prompt)))
+  "Build CLI arguments for the Cursor backend (binary `agent`).
+
+   Flags follow https://cursor.com/docs/cli/reference/parameters:
+
+     -p / --print  non-interactive run with tool access
+     --force       required for the agent to write files in print mode;
+                   this is the autonomous-execution switch (analogous to
+                   codex `approval_policy=never`)
+
+   Tool restriction is enforced out-of-band via the default-deny
+   .cursor/cli.json permissions allowlist written by the agent session
+   (see artifact-session/write-cursor-permissions!), not via CLI flags —
+   so we do not pass --approve-mcps (which would blanket-approve every MCP
+   server). Cursor exposes no system-prompt flag, so `system` is prepended
+   to the user prompt."
+  [{:keys [prompt system model]}]
+  (let [prompt (if system (str system "\n\n" prompt) prompt)]
+    (cond-> ["-p" "--force"]
+      model (into ["--model" model])
+      true  (conj prompt))))
 
 (defn- opencode-args
   "Build CLI arguments for the OpenCode backend.

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -195,15 +195,25 @@
 ;; ============================================================================
 
 (deftest cursor-args-minimal-test
-  (testing "minimal prompt produces [-p <prompt>]"
+  (testing "minimal prompt produces [-p --force <prompt>] (autonomous writes)"
     (let [args ((private-fn 'cursor-args) {:prompt "fix it"})]
-      (is (= ["-p" "fix it"] args)))))
+      (is (= ["-p" "--force" "fix it"] args)))))
 
-(deftest cursor-args-approve-mcps-test
-  (testing "mcp-allowed-tools adds --approve-mcps"
+(deftest cursor-args-no-approve-mcps-test
+  (testing "MCP scoping is via the permissions allowlist, not --approve-mcps"
     (let [args ((private-fn 'cursor-args) {:prompt "p" :mcp-allowed-tools ["t1"]})]
-      (is (some #(= "--approve-mcps" %) args))
+      (is (not (some #(= "--approve-mcps" %) args)))
       (is (= "p" (last args))))))
+
+(deftest cursor-args-model-test
+  (testing "model adds --model <model> before the prompt"
+    (let [args ((private-fn 'cursor-args) {:prompt "p" :model "gpt-5.2"})]
+      (is (= ["-p" "--force" "--model" "gpt-5.2" "p"] args)))))
+
+(deftest cursor-args-system-test
+  (testing "system is prepended to the prompt (no system-prompt flag on cursor)"
+    (let [args ((private-fn 'cursor-args) {:prompt "do it" :system "be terse"})]
+      (is (= ["-p" "--force" "be terse\n\ndo it"] args)))))
 
 ;; ============================================================================
 ;; opencode-args

--- a/specs/informative/CONFIG-SYSTEM.md
+++ b/specs/informative/CONFIG-SYSTEM.md
@@ -10,7 +10,9 @@
 
 ## Overview
 
-Miniforge now has a comprehensive, user-friendly configuration system that makes it simple to discover, configure, and switch between LLM backends. Configuration is no longer a "rite of passage" - it's discoverable, helpful, and frictionless.
+Miniforge now has a comprehensive, user-friendly configuration system that makes it simple to discover, configure, and
+switch between LLM backends. Configuration is no longer a "rite of passage" - it's discoverable, helpful, and
+frictionless.
 
 ## Features Implemented
 
@@ -86,7 +88,7 @@ Available LLM Backends:
 
 ❌ cursor (Cursor)
    Cursor AI via CLI
-   Status: cursor-cli not found on PATH
+   Status: agent not found on PATH
    Install: Install from https://cursor.sh
 ```
 
@@ -229,7 +231,7 @@ Configuration is merged from three sources (in order of precedence):
 
 - **Provider**: Cursor
 - **Type**: CLI-based (non-streaming)
-- **Requires**: `cursor-cli` installed
+- **Requires**: `agent` installed
 - **Install**: https://cursor.sh
 - **Models**: cursor-default
 
@@ -244,13 +246,13 @@ Configuration is merged from three sources (in order of precedence):
 
 ### User Config
 
-```
+```text
 ~/.miniforge/config.edn
 ```
 
 ### Component Locations
 
-```
+```text
 components/config/              # Config management component
   src/ai/miniforge/config/
     user.clj                    # User config operations
@@ -337,7 +339,8 @@ The configuration system is complete and ready for use. Possible future enhancem
 
 ## Conclusion
 
-The frictionless configuration system transforms Miniforge's UX from "configuration as a rite of passage" to "configuration as a first-class feature." Users can now:
+The frictionless configuration system transforms Miniforge's UX from "configuration as a rite of passage" to
+"configuration as a first-class feature." Users can now:
 
 - Discover all available backends instantly
 - Understand requirements and installation steps

--- a/tasks/dogfood.clj
+++ b/tasks/dogfood.clj
@@ -20,6 +20,7 @@
   (:require
    [babashka.fs :as fs]
    [babashka.process :as p]
+   [clojure.edn :as edn]
    [clojure.string :as str]))
 
 (def ^:private default-spec-path
@@ -66,24 +67,58 @@
        (zero? (:exit (p/sh {:continue true :out :discard :err :discard}
                            "git" "diff" "--cached" "--quiet")))))
 
+(def ^:private backends-edn-path
+  "Backend metadata, read as a file since the bb task classpath does not
+   include the CLI resources dir."
+  "bases/cli/resources/config/cli/backends.edn")
+
+(def ^:private user-config-path
+  (str (or (System/getenv "MINIFORGE_HOME")
+           (str (fs/home) "/.miniforge"))
+       "/config.edn"))
+
+(defn- read-edn-file [path]
+  (when (fs/exists? path)
+    (try
+      (edn/read-string (slurp (str path)))
+      (catch Exception _ nil))))
+
+(defn- configured-backend
+  "Resolve the active LLM backend the way the CLI does: user config, then
+   MINIFORGE_LLM_BACKEND, then the shipped default in backends.edn (OpenCode)."
+  [backend-config]
+  (or (get-in (read-edn-file user-config-path) [:llm :backend])
+      (some-> (System/getenv "MINIFORGE_LLM_BACKEND") keyword)
+      (get-in backend-config [:backend/defaults :current])))
+
+(defn- backend-command
+  "CLI command a backend needs on PATH, or nil if the backend is unknown."
+  [backend-config backend]
+  (get-in backend-config [:backend/specs backend :command]))
+
 (defn- prerequisite-status [args]
   (let [spec-path (resolve-spec-path args)
         github-auth (resolve-github-auth)
-        opencode-cli (command-available? "opencode")
+        backend-config (read-edn-file backends-edn-path)
+        backend (configured-backend backend-config)
+        command (backend-command backend-config backend)
+        backend-ok? (boolean (and command (command-available? command)))
         checks {:spec-exists (fs/exists? spec-path)
                 :github-auth (some? github-auth)
-                :llm-backend opencode-cli
+                :llm-backend backend-ok?
                 :git-clean (git-clean?)}]
     {:spec-path spec-path
      :github-auth github-auth
      :checks checks
-     :backend-source (if opencode-cli :opencode-cli :none)}))
+     :backend backend
+     :backend-command command
+     :backend-ok? backend-ok?}))
 
 (defn check
   "Validate dogfooding prerequisites. Usage: bb dogfood:check [spec-path]"
   [& args]
   (println "🔍 Checking dogfooding prerequisites...")
-  (let [{:keys [spec-path github-auth checks backend-source]}
+  (let [{:keys [spec-path github-auth checks backend backend-command backend-ok?]}
         (prerequisite-status args)]
     (println "  target-spec:" spec-path)
     (doseq [[check passed?] checks]
@@ -91,9 +126,11 @@
                        (if passed? "✅" "❌")
                        (name check))))
     (println (format "  %s backend-source"
-                     (case backend-source
-                       :opencode-cli "✅ opencode-cli"
-                       "❌ none")))
+                     (if backend-ok?
+                       (format "✅ %s (%s)" (name backend) backend-command)
+                       (format "❌ %s (%s missing)"
+                               (if backend (name backend) "none")
+                               (or backend-command "no command")))))
     (println (format "  %s github-auth-source"
                      (case (:source github-auth)
                        :env "✅ env:GITHUB_TOKEN"
@@ -109,7 +146,7 @@
   "Show the exact command that dogfood would execute.
    Usage: bb dogfood:dry-run [spec-path]"
   [& args]
-  (let [{:keys [spec-path github-auth checks backend-source]}
+  (let [{:keys [spec-path github-auth checks backend]}
         (prerequisite-status args)
         command (if (= :gh-auth (:source github-auth))
                   (str "env GITHUB_TOKEN=$(gh auth token) bb miniforge run "
@@ -117,7 +154,7 @@
                   (str "bb miniforge run " spec-path))]
     (println "🤖 Dogfood dry run")
     (println "  spec:" spec-path)
-    (println "  backend:" (name backend-source))
+    (println "  backend:" (if backend (name backend) "none"))
     (println "  github-auth:" (or (some-> github-auth :source name) "none"))
     (println)
     (println "Command:")

--- a/tasks/dogfood.clj
+++ b/tasks/dogfood.clj
@@ -84,11 +84,13 @@
       (catch Exception _ nil))))
 
 (defn- configured-backend
-  "Resolve the active LLM backend the way the CLI does: user config, then
-   MINIFORGE_LLM_BACKEND, then the shipped default in backends.edn (OpenCode)."
+  "Resolve the active LLM backend the way a real run does: MINIFORGE_LLM_BACKEND
+   overrides everything (matches cli.config/load-merged-config, which applies
+   the env var as an override over the file), then the user config file, then
+   the shipped default in backends.edn (OpenCode)."
   [backend-config]
-  (or (get-in (read-edn-file user-config-path) [:llm :backend])
-      (some-> (System/getenv "MINIFORGE_LLM_BACKEND") keyword)
+  (or (some-> (System/getenv "MINIFORGE_LLM_BACKEND") keyword)
+      (get-in (read-edn-file user-config-path) [:llm :backend])
       (get-in backend-config [:backend/defaults :current])))
 
 (defn- backend-command
@@ -125,7 +127,7 @@
       (println (format "  %s %s"
                        (if passed? "✅" "❌")
                        (name check))))
-    (println (format "  %s backend-source"
+    (println (format "  %s backend"
                      (if backend-ok?
                        (format "✅ %s (%s)" (name backend) backend-command)
                        (format "❌ %s (%s missing)"


### PR DESCRIPTION
## Summary

Makes the Cursor (`agent`) backend run autonomously under tool restriction
matching the posture of the other backends (Claude is highest-fidelity;
Codex and OpenCode round out the set).

- **Autonomy** — `cursor-args` runs `-p --force` (`--force` is required to
  write files in print mode — the autonomous-execution switch, analogous to
  codex `approval_policy=never`), passes `--model`, and prepends `system`
  since Cursor has no system-prompt flag. Drops blanket `--approve-mcps`.
- **Default-deny tool restriction** — `write-cursor-permissions!` emits a
  `.cursor/cli.json` permission allowlist from the agent-agnostic `mcp-tools`
  set (`Mcp(context:*)` + `Write(**)`) plus a secret-write `deny` baseline
  (deny wins). Shell, arbitrary reads, and other MCP servers are denied by
  omission. Written at session setup, tracked in `:mcp-cleanup-files`, and
  stripped non-destructively on cleanup so pre-existing user rules survive.
- **Per-role restriction** — the writer is authoritative over managed rules
  (strip-then-add), so a rewrite can narrow the allowlist;
  `write-cursor-permissions-for-session!` rewrites a host session's file with
  a role's `disallowed-tools`. Planner and tester wire it through, mirroring
  how Claude/Codex honor `:disallowed-tools` per-invocation. No-op in capsule
  mode (Cursor configs are host-only).
- **Fixes** — Cursor CLI binary is `agent`, not `cursor-cli` (backends.edn +
  docs). `dogfood:check` now resolves the *configured* backend (user config →
  `MINIFORGE_LLM_BACKEND` → shipped default) and probes that backend's CLI,
  instead of hardwiring an opencode check.

Flags verified against https://cursor.com/docs/cli/reference/parameters and
.../permissions.

## Test plan

- [x] `bb pre-commit` green (314 + 6 tests, lint/structure/format clean)
- [x] New unit tests: `cursor-args` (force/model/system, no `--approve-mcps`);
      Cursor permission translation, default-deny subtraction, authoritative
      narrowing rewrite, non-destructive cleanup, host/capsule session wrapper
- [x] `dogfood:check` backend resolution verified across claude / opencode
      default / missing-CLI / unknown-backend
- [ ] Exercise against a live `agent` run once Cursor is an active backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)