### PR TITLE
refactor: exceptions-as-data cleanup of self-healing + progress-detector + workflow

### DIFF
--- a/components/progress-detector/deps.edn
+++ b/components/progress-detector/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["src" "resources"]
  :deps {metosin/malli            {:mvn/version "0.16.4"}
         ai.miniforge/anomaly     {:local/root "../anomaly"}
-        ai.miniforge/messages    {:local/root "../messages"}}
+        ai.miniforge/messages    {:local/root "../messages"}
+        ai.miniforge/response    {:local/root "../response"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/progress-detector/src/ai/miniforge/progress_detector/config.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/config.clj
@@ -35,7 +35,8 @@
      apply-directive   - apply one overlay layer onto an accumulated config
      enabled?          - return true if resolved config enables the detector
      effective-params  - extract merged :config/params map from resolved config"
-  )
+  (:require
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Directive resolution
@@ -141,8 +142,9 @@
      ;;     :config/directives [:inherit :tune :disable :enable]}"
   [layers]
   (when (empty? layers)
-    (throw (ex-info "merge-config requires at least one layer"
-                    {:layers layers})))
+    (response/throw-anomaly! :anomalies/incorrect
+                             "merge-config requires at least one layer"
+                             {:layers layers}))
   (let [;; The first layer is the base — its :config/params seed the
         ;; accumulator. Without this seeding the base's params get
         ;; dropped on its own implicit :inherit directive (see

--- a/components/progress-detector/src/ai/miniforge/progress_detector/event_envelope.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/event_envelope.clj
@@ -50,7 +50,8 @@
   (:require
    [malli.core :as m]
    [ai.miniforge.progress-detector.messages :as msg]
-   [ai.miniforge.progress-detector.schema :as schema]))
+   [ai.miniforge.progress-detector.schema :as schema]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants
@@ -109,11 +110,12 @@
   [event obs]
   (if (m/validate schema/Observation obs)
     obs
-    (throw (ex-info (msg/t :envelope/validation-failed)
-                    {:type   ::validation-failed
-                     :event  event
-                     :obs    obs
-                     :errors (m/explain schema/Observation obs)}))))
+    (response/throw-anomaly! :anomalies/incorrect
+                             (msg/t :envelope/validation-failed)
+                             {:type   ::validation-failed
+                              :event  event
+                              :obs    obs
+                              :errors (m/explain schema/Observation obs)})))
 
 (defn make-normalizer
   "Return a per-run normalizer function. The returned fn closes over

--- a/components/progress-detector/src/ai/miniforge/progress_detector/tool_profile.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/tool_profile.clj
@@ -46,7 +46,8 @@
    should use `make-registry` and pass the result explicitly to the
    2-arity query functions to avoid global state."
   (:require
-   [ai.miniforge.progress-detector.schema :as schema]))
+   [ai.miniforge.progress-detector.schema :as schema]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Registry construction
@@ -79,12 +80,14 @@
   [registry-atom profile]
   (let [tool-id (:tool/id profile)]
     (when-not tool-id
-      (throw (ex-info "Tool profile must include :tool/id"
-                      {:profile profile})))
+      (response/throw-anomaly! :anomalies/incorrect
+                               "Tool profile must include :tool/id"
+                               {:profile profile}))
     (when-not (schema/valid-tool-profile? profile)
-      (throw (ex-info "Tool profile fails ToolProfile schema validation"
-                      {:profile profile
-                       :errors  (schema/explain-tool-profile profile)}))))
+      (response/throw-anomaly! :anomalies/incorrect
+                               "Tool profile fails ToolProfile schema validation"
+                               {:profile profile
+                                :errors  (schema/explain-tool-profile profile)})))
   (swap! registry-atom assoc (:tool/id profile) profile))
 
 (defn unregister!

--- a/components/progress-detector/test/ai/miniforge/progress_detector/anomaly/progress_detector_anomaly_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/anomaly/progress_detector_anomaly_test.clj
@@ -37,6 +37,12 @@
                    nil
                    (catch ExceptionInfo e e))]
       (is (some? thrown))
+      ;; Message text is i18n-keyed (:envelope/validation-failed); assert
+      ;; non-blank rather than a fixed substring so the test doesn't pin
+      ;; the en-US translation. Other tests in this file assert on the
+      ;; pre-existing English error strings, which are not message-catalog
+      ;; entries.
+      (is (seq (.getMessage thrown)))
       (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
 (deftest merge-config-empty-layers-throws-anomaly

--- a/components/progress-detector/test/ai/miniforge/progress_detector/anomaly/progress_detector_anomaly_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/anomaly/progress_detector_anomaly_test.clj
@@ -1,0 +1,68 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.progress-detector.anomaly.progress-detector-anomaly-test
+  "Coverage for `event-envelope/validate-observation!`,
+   `config/merge-config`, and `tool-profile/register!` boundary
+   escalation via `response/throw-anomaly!`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.progress-detector.config :as config]
+            [ai.miniforge.progress-detector.event-envelope :as envelope]
+            [ai.miniforge.progress-detector.tool-profile :as tool-profile])
+  (:import (clojure.lang ExceptionInfo)))
+
+(deftest validate-observation-schema-failure-throws-anomaly
+  (testing "private validate-observation! raises :anomalies/incorrect on bad obs"
+    ;; validate-observation! is private; reach via the var. Boundary
+    ;; escalation is what we're pinning, not the private fn's name.
+    (let [thrown (try
+                   (@#'envelope/validate-observation!
+                    {}
+                    {:not-a-real :observation})
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+
+(deftest merge-config-empty-layers-throws-anomaly
+  (testing "empty layers raises :anomalies/incorrect"
+    (let [thrown (try (config/merge-config []) nil (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"requires at least one layer" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+
+(deftest register-missing-tool-id-throws-anomaly
+  (testing "profile missing :tool/id raises :anomalies/incorrect"
+    (let [registry (atom {})
+          thrown (try (tool-profile/register! registry {})
+                      nil
+                      (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"must include :tool/id" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+
+(deftest register-invalid-schema-throws-anomaly
+  (testing "profile failing schema validation raises :anomalies/incorrect"
+    (let [registry (atom {})
+          thrown (try (tool-profile/register! registry {:tool/id :bogus
+                                                        :tool/garbage 42})
+                      nil
+                      (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"ToolProfile schema validation" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))

--- a/components/self-healing/deps.edn
+++ b/components/self-healing/deps.edn
@@ -18,9 +18,10 @@
 
 {:paths ["src" "resources"]
 
- :deps {ai.miniforge/config {:local/root "../config"}
-        org.clojure/clojure {:mvn/version "1.12.0"}
-        clj-http/clj-http {:mvn/version "3.13.0"}}
+ :deps {ai.miniforge/config   {:local/root "../config"}
+        ai.miniforge/response {:local/root "../response"}
+        org.clojure/clojure   {:mvn/version "1.12.0"}
+        clj-http/clj-http     {:mvn/version "3.13.0"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -42,6 +42,7 @@
    logging infrastructure once the dependency is reviewed."
   (:require
    [clojure.string :as str]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.self-healing.backend-health :as backend-health]))
 
 ;;------------------------------------------------------------------------------ Layer 0
@@ -87,11 +88,13 @@
    Returns: String binary name (defaults to (name backend))"
   [backend]
   (when (nil? backend)
-    (throw (ex-info "binary-for: backend must not be nil"
-                    {:backend backend})))
+    (response/throw-anomaly! :anomalies/incorrect
+                             "binary-for: backend must not be nil"
+                             {:backend backend}))
   (when-not (instance? clojure.lang.Named backend)
-    (throw (ex-info "binary-for: backend must be a keyword or symbol"
-                    {:backend backend :type (type backend)})))
+    (response/throw-anomaly! :anomalies/incorrect
+                             "binary-for: backend must be a keyword or symbol"
+                             {:backend backend :type (type backend)}))
   (get backend-binaries (keyword backend) (name backend)))
 
 (defn build-resume-command
@@ -203,11 +206,13 @@
   ;; Guard against programmer errors: fail loudly on the watchdog hot-path
   ;; rather than producing an opaque NPE.
   (when-not (instance? clojure.lang.IAtom hang-count)
-    (throw (ex-info ":hang-count must be an IAtom (e.g. (atom 1))"
-                    {:ctx ctx :type (type hang-count)})))
+    (response/throw-anomaly! :anomalies/incorrect
+                             ":hang-count must be an IAtom (e.g. (atom 1))"
+                             {:ctx ctx :type (type hang-count)}))
   (when (nil? backend)
-    (throw (ex-info ":backend is required and must not be nil"
-                    {:ctx ctx})))
+    (response/throw-anomaly! :anomalies/incorrect
+                             ":backend is required and must not be nil"
+                             {:ctx ctx}))
   (let [count       @hang-count
         backend-kw  (keyword backend)
         cooldown-ms (get config :backend-switch-cooldown-ms 1800000)

--- a/components/self-healing/test/ai/miniforge/self_healing/anomaly/stream_recovery_anomaly_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/anomaly/stream_recovery_anomaly_test.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.self-healing.anomaly.stream-recovery-anomaly-test
+  "Coverage for `stream-recovery/binary-for` and
+   `stream-recovery/evaluate-stall-recovery` boundary escalation via
+   `response/throw-anomaly!`. Caller-supplied bad input →
+   `:anomalies/incorrect`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.self-healing.stream-recovery :as recovery])
+  (:import (clojure.lang ExceptionInfo)))
+
+(deftest binary-for-nil-backend-throws-anomaly
+  (testing "nil backend raises :anomalies/incorrect"
+    (let [thrown (try (recovery/binary-for nil) nil (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"backend must not be nil" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+
+(deftest binary-for-non-named-backend-throws-anomaly
+  (testing "non-keyword non-symbol backend raises :anomalies/incorrect"
+    (let [thrown (try (recovery/binary-for "string-backend")
+                      nil
+                      (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"keyword or symbol" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+
+(deftest evaluate-stall-recovery-non-iatom-hang-count-throws-anomaly
+  (testing "non-IAtom :hang-count raises :anomalies/incorrect"
+    (let [thrown (try
+                   (recovery/evaluate-stall-recovery
+                    {:phase-id :impl
+                     :backend :anthropic
+                     :session-id "sid"
+                     :hang-count 1
+                     :config {}
+                     :allowed-failover-backends []})
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #":hang-count must be an IAtom" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+
+(deftest evaluate-stall-recovery-nil-backend-throws-anomaly
+  (testing "nil :backend raises :anomalies/incorrect"
+    (let [thrown (try
+                   (recovery/evaluate-stall-recovery
+                    {:phase-id :impl
+                     :backend nil
+                     :session-id "sid"
+                     :hang-count (atom 1)
+                     :config {}
+                     :allowed-failover-backends []})
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #":backend is required" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))

--- a/components/workflow/src/ai/miniforge/workflow/agent_factory.clj
+++ b/components/workflow/src/ai/miniforge/workflow/agent_factory.clj
@@ -22,6 +22,7 @@
   (:require
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.loop.interface :as loop]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.task.interface :as task]
    [ai.miniforge.artifact.interface :as artifact]))
 
@@ -61,12 +62,13 @@
         llm-backend (:llm-backend context)]
 
     (when (contains? handler-only-agents agent-type)
-      (throw (ex-info (str "Agent type " agent-type " requires a :phase/handler or "
-                           "phase interceptor (see phase.registry). Configure the "
-                           "phase with :phase/handler or use the interceptor pipeline "
-                           "via runner/run-pipeline.")
-                      {:agent-type agent-type
-                       :phase-id (:phase/id phase)})))
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Agent type " agent-type " requires a :phase/handler or "
+                                    "phase interceptor (see phase.registry). Configure the "
+                                    "phase with :phase/handler or use the interceptor pipeline "
+                                    "via runner/run-pipeline.")
+                               {:agent-type agent-type
+                                :phase-id (:phase/id phase)}))
 
     (case agent-type
       ;; Core agents
@@ -82,13 +84,14 @@
       :none nil
 
       ;; Unknown agent type — fail loud
-      (throw (ex-info (str "Unknown agent type: " agent-type
-                           ". Supported: :planner :implementer :tester "
-                           ":spec-analyzer :designer :none. "
-                           "Use :default only with a :phase/handler or "
-                           "phase interceptor.")
-                      {:agent-type agent-type
-                       :phase-id (:phase/id phase)})))))
+      (response/throw-anomaly! :anomalies/unsupported
+                               (str "Unknown agent type: " agent-type
+                                    ". Supported: :planner :implementer :tester "
+                                    ":spec-analyzer :designer :none. "
+                                    "Use :default only with a :phase/handler or "
+                                    "phase interceptor.")
+                               {:agent-type agent-type
+                                :phase-id (:phase/id phase)}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Gate mapping

--- a/components/workflow/src/ai/miniforge/workflow/cost_breakdown.clj
+++ b/components/workflow/src/ai/miniforge/workflow/cost_breakdown.clj
@@ -68,6 +68,7 @@
    aggregates loses the placement-of-attention signal that's the whole
    reason for collecting the data."
   (:require
+   [ai.miniforge.response.interface :as response]
    [malli.core :as m]
    [malli.error :as me]))
 
@@ -179,16 +180,18 @@
   [breakdown {:keys [phase tokens iterations duration-ms usd]
               :or   {tokens 0 iterations 0 duration-ms 0 usd 0.0}}]
   (when-not (contains? phase-keys phase)
-    (throw (ex-info (str "Unknown phase " (pr-str phase) " — must be one of "
-                         (pr-str phase-key-order))
-                    {:phase phase :known phase-key-order})))
+    (response/throw-anomaly! :anomalies/incorrect
+                             (str "Unknown phase " (pr-str phase) " — must be one of "
+                                  (pr-str phase-key-order))
+                             {:phase phase :known phase-key-order}))
   (when (and (pos? iterations)
              (not (contains? iteration-phase-keys phase)))
-    (throw (ex-info (str "Phase " (pr-str phase) " does not iterate; "
-                         ":iterations may only be set for "
-                         (pr-str (sort iteration-phase-keys)))
-                    {:phase phase :iterations iterations
-                     :allowed (sort iteration-phase-keys)})))
+    (response/throw-anomaly! :anomalies/incorrect
+                             (str "Phase " (pr-str phase) " does not iterate; "
+                                  ":iterations may only be set for "
+                                  (pr-str (sort iteration-phase-keys)))
+                             {:phase phase :iterations iterations
+                              :allowed (sort iteration-phase-keys)}))
   (-> breakdown
       (update :cost/total + tokens)
       (update-in [:cost/breakdown phase] (fnil + 0) tokens)

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/workflow_factory_cost_anomaly_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/workflow_factory_cost_anomaly_test.clj
@@ -1,0 +1,83 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.anomaly.workflow-factory-cost-anomaly-test
+  "Coverage for `agent-factory/create-agent-for-phase` and
+   `cost-breakdown/add-phase-cost` boundary escalation via
+   `response/throw-anomaly!`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.workflow.agent-factory :as factory]
+            [ai.miniforge.workflow.cost-breakdown :as cost])
+  (:import (clojure.lang ExceptionInfo)))
+
+(deftest create-agent-for-phase-handler-only-throws-anomaly
+  (testing ":reviewer / :releaser / :observer / :default require :phase/handler — raise :anomalies/incorrect"
+    (doseq [agent-type [:default :reviewer :releaser :observer]]
+      (let [thrown (try
+                     (factory/create-agent-for-phase
+                      {:phase/agent agent-type :phase/id (str (name agent-type) "-phase")}
+                      {:llm-backend :anthropic})
+                     nil
+                     (catch ExceptionInfo e e))]
+        (is (some? thrown))
+        (is (re-find #"requires a :phase/handler" (.getMessage thrown)))
+        (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
+        (is (= agent-type (:agent-type (ex-data thrown))))))))
+
+(deftest create-agent-for-phase-unknown-type-throws-anomaly
+  (testing "unknown agent type raises :anomalies/unsupported"
+    (let [thrown (try
+                   (factory/create-agent-for-phase
+                    {:phase/agent :weird-agent :phase/id "p"}
+                    {:llm-backend :anthropic})
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"Unknown agent type" (.getMessage thrown)))
+      (is (= :anomalies/unsupported (:anomaly/category (ex-data thrown))))
+      (is (= :weird-agent (:agent-type (ex-data thrown)))))))
+
+(deftest cost-add-phase-cost-unknown-phase-throws-anomaly
+  (testing "unknown phase keyword raises :anomalies/incorrect"
+    (let [thrown (try
+                   (cost/add-phase-cost {:cost/total 0 :cost/breakdown {}}
+                                        {:phase :weird-phase :tokens 100})
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (re-find #"Unknown phase" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
+      (is (= :weird-phase (:phase (ex-data thrown)))))))
+
+(deftest cost-add-phase-cost-iterations-on-non-iter-phase-throws-anomaly
+  (testing "iterations > 0 on non-iteration phase raises :anomalies/incorrect"
+    ;; Pick a known phase that isn't in the iteration set. Most planning/release
+    ;; phases qualify; using :plan as a representative since it's authored once.
+    (let [thrown (try
+                   (cost/add-phase-cost {:cost/total 0 :cost/breakdown {}}
+                                        {:phase :plan
+                                         :tokens 100
+                                         :iterations 3})
+                   nil
+                   (catch ExceptionInfo e e))]
+      ;; This test passes only if :plan is not in iteration-phase-keys. If a
+      ;; future refactor adds :plan to that set, retarget at another non-iter
+      ;; phase.
+      (when (some? thrown)
+        (is (re-find #"does not iterate" (.getMessage thrown)))
+        (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/workflow_factory_cost_anomaly_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/workflow_factory_cost_anomaly_test.clj
@@ -66,18 +66,19 @@
 
 (deftest cost-add-phase-cost-iterations-on-non-iter-phase-throws-anomaly
   (testing "iterations > 0 on non-iteration phase raises :anomalies/incorrect"
-    ;; Pick a known phase that isn't in the iteration set. Most planning/release
-    ;; phases qualify; using :plan as a representative since it's authored once.
+    ;; :task/verify is a real phase-key but is NOT in iteration-phase-keys
+    ;; (that set is #{:task/implement :task/merge-resolution}). Using a valid
+    ;; non-iter phase exercises the "does not iterate" branch rather than
+    ;; the unknown-phase branch.
     (let [thrown (try
                    (cost/add-phase-cost {:cost/total 0 :cost/breakdown {}}
-                                        {:phase :plan
+                                        {:phase :task/verify
                                          :tokens 100
                                          :iterations 3})
                    nil
                    (catch ExceptionInfo e e))]
-      ;; This test passes only if :plan is not in iteration-phase-keys. If a
-      ;; future refactor adds :plan to that set, retarget at another non-iter
-      ;; phase.
-      (when (some? thrown)
-        (is (re-find #"does not iterate" (.getMessage thrown)))
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))))))
+      (is (some? thrown))
+      (is (re-find #"does not iterate" (.getMessage thrown)))
+      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
+      (is (= :task/verify (:phase (ex-data thrown))))
+      (is (= 3 (:iterations (ex-data thrown)))))))

--- a/docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md
+++ b/docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md
@@ -10,8 +10,10 @@ Migrates 12 throw sites across three components to the canonical
 - `components/workflow/.../{agent_factory,cost_breakdown}.clj` — 4 sites
 
 Same mechanical shape as Wave 9 + connector cluster cleanups. Each site
-gains a typed `:anomaly/category` (`:incorrect`, `:unsupported`) in
-ex-data while preserving the existing `ExceptionInfo` throw contract.
+gains a typed `:anomaly/category` (`:anomalies/incorrect`,
+`:anomalies/unsupported` — the full keywords from the canonical taxonomy
+in `components/response/src/.../anomaly.clj`) in ex-data while preserving
+the existing `ExceptionInfo` throw contract.
 
 ## Motivation
 

--- a/docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md
+++ b/docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md
@@ -1,0 +1,130 @@
+# refactor: exceptions-as-data cleanup of self-healing + progress-detector + workflow
+
+## Overview
+
+Migrates 12 throw sites across three components to the canonical
+`response/throw-anomaly!` boundary path:
+
+- `components/self-healing/.../stream_recovery.clj` — 4 sites (input validation)
+- `components/progress-detector/.../{config,event_envelope,tool_profile}.clj` — 4 sites
+- `components/workflow/.../{agent_factory,cost_breakdown}.clj` — 4 sites
+
+Same mechanical shape as Wave 9 + connector cluster cleanups. Each site
+gains a typed `:anomaly/category` (`:incorrect`, `:unsupported`) in
+ex-data while preserving the existing `ExceptionInfo` throw contract.
+
+## Motivation
+
+Per the fresh ripgrep of `origin/main` (pre-PR: 13 components × 1–4
+sites each, ~46 sites remaining across the mid-tail), these three
+components were the highest-leverage bundle: each migrates cleanly to
+the standard pattern, and the workflow component already has
+`anomaly` + `response` deps declared. Inventory regeneration after
+this PR will reflect the closure.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged)
+- `ai.miniforge.response` (merged)
+
+## What This Adds / Changes
+
+`components/self-healing/deps.edn`:
+
+- Adds `ai.miniforge/response` dep.
+
+`components/self-healing/src/.../stream_recovery.clj` (4 sites):
+
+- `binary-for` nil backend → `:anomalies/incorrect`.
+- `binary-for` non-Named backend → `:anomalies/incorrect`.
+- `evaluate-stall-recovery` non-IAtom `:hang-count` → `:anomalies/incorrect`.
+- `evaluate-stall-recovery` nil `:backend` → `:anomalies/incorrect`.
+
+`components/progress-detector/deps.edn`:
+
+- Adds `ai.miniforge/response` dep.
+
+`components/progress-detector/src/.../config.clj`:
+
+- `merge-config` empty-layers guard → `:anomalies/incorrect`.
+
+`components/progress-detector/src/.../event_envelope.clj`:
+
+- `validate-observation!` schema-failure → `:anomalies/incorrect`.
+
+`components/progress-detector/src/.../tool_profile.clj`:
+
+- `register!` missing `:tool/id` → `:anomalies/incorrect`.
+- `register!` schema-failure → `:anomalies/incorrect`.
+
+`components/workflow/src/.../agent_factory.clj`:
+
+- `create-agent-for-phase` handler-only-agents guard → `:anomalies/incorrect`.
+- `create-agent-for-phase` unknown agent-type → `:anomalies/unsupported`.
+
+`components/workflow/src/.../cost_breakdown.clj`:
+
+- `add-phase-cost` unknown phase → `:anomalies/incorrect`.
+- `add-phase-cost` iterations-on-non-iter-phase → `:anomalies/incorrect`.
+
+### Tests
+
+New decomposed anomaly tests, one file per component:
+
+- `components/self-healing/test/.../anomaly/stream_recovery_anomaly_test.clj` — 4 tests
+- `components/progress-detector/test/.../anomaly/progress_detector_anomaly_test.clj` — 4 tests
+- `components/workflow/test/.../anomaly/workflow_factory_cost_anomaly_test.clj` — 4 tests
+
+Each asserts both message + `:anomaly/category`, so tests would fail
+if a future refactor reverted to plain `(throw (ex-info ...))`.
+
+## Per-site classification
+
+| File | Site | Category |
+|------|------|----------|
+| self-healing/stream_recovery.clj | binary-for nil backend | `:anomalies/incorrect` |
+| self-healing/stream_recovery.clj | binary-for non-Named backend | `:anomalies/incorrect` |
+| self-healing/stream_recovery.clj | evaluate-stall-recovery non-IAtom hang-count | `:anomalies/incorrect` |
+| self-healing/stream_recovery.clj | evaluate-stall-recovery nil backend | `:anomalies/incorrect` |
+| progress-detector/config.clj | merge-config empty layers | `:anomalies/incorrect` |
+| progress-detector/event_envelope.clj | validate-observation! schema fail | `:anomalies/incorrect` |
+| progress-detector/tool_profile.clj | register! missing :tool/id | `:anomalies/incorrect` |
+| progress-detector/tool_profile.clj | register! schema fail | `:anomalies/incorrect` |
+| workflow/agent_factory.clj | create-agent-for-phase handler-only | `:anomalies/incorrect` |
+| workflow/agent_factory.clj | create-agent-for-phase unknown type | `:anomalies/unsupported` |
+| workflow/cost_breakdown.clj | add-phase-cost unknown phase | `:anomalies/incorrect` |
+| workflow/cost_breakdown.clj | add-phase-cost iterations-on-non-iter | `:anomalies/incorrect` |
+
+## Testing Plan
+
+- New `anomaly.*` tests assert message + `:anomaly/category` + key
+  context fields.
+- Local component-test runs blocked by the well-documented
+  `cognitect/test-runner` classpath gap in component-local aliases —
+  CI validates.
+
+## Deployment Plan
+
+No migration. ExceptionInfo shape preserved with one extra
+`:anomaly/category` key in ex-data. All callers that branch on
+`(thrown? ExceptionInfo)` or specific `ex-data` keys continue to work.
+
+## Related Issues/PRs
+
+- Built on PR #777 (kill-the-deprecation precedent)
+- Companion to Wave 7/9 + connector cluster cleanup PRs
+- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
+
+## Checklist
+
+- [x] All 12 in-scope throw sites migrated
+- [x] Single API per site (`response/throw-anomaly!`)
+- [x] New decomposed test files (three — one per component)
+- [x] No new throws in anomaly-returning code paths
+- [x] External caller contracts preserved
+- [x] Apache 2 license headers on every new file
+- [x] `deps.edn` additions explicit and minimal


### PR DESCRIPTION
## Summary

Migrates 12 throw sites across three components to the canonical \`response/throw-anomaly!\` boundary path. Each site gains a typed \`:anomaly/category\` (\`:incorrect\` / \`:unsupported\`) in ex-data while preserving the existing \`ExceptionInfo\` throw contract.

- \`self-healing/stream_recovery.clj\` (4 sites — input validation)
- \`progress-detector/{config, event_envelope, tool_profile}.clj\` (4 sites)
- \`workflow/{agent_factory, cost_breakdown}.clj\` (4 sites)

Full PR doc: \`docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md\`

## Test plan

- [x] 3 new decomposed anomaly test files (one per component) / 12 tests asserting message + \`:anomaly/category\` on every escalation path
- [x] All 12 sites collapsed (verified by grep — 0 raw \`(throw (ex-info ...))\` remain in target files)
- [ ] CI to confirm full suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)