### PR TITLE
feat(implement): arm stream watchdog + classify silent agent stalls

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -230,5 +230,6 @@
 (def ping-watchdog! watchdog/ping!)
 (def stop-watchdog! watchdog/stop!)
 (def watchdog-stalled? watchdog/stalled?)
+(def watchdog-stall-gap-ms watchdog/stall-gap-ms)
 (def capture-watchdog-session-id! watchdog/capture-session-id!)
 (def get-watchdog-session-id watchdog/get-session-id)

--- a/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/watchdog.clj
@@ -85,6 +85,11 @@
    See `ai.miniforge.agent.stream-watchdog/stalled?`."
   watchdog/stalled?)
 
+(def stall-gap-ms
+  "Return the measured stream gap (ms) at the moment the watchdog fired, or nil.
+   See `ai.miniforge.agent.stream-watchdog/stall-gap-ms`."
+  watchdog/stall-gap-ms)
+
 ;; ---------------------------------------------------------------------------
 ;; Session ID capture
 

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -152,7 +152,7 @@
      b. Emits :agent/stream-stalled via event-stream with the measured gap.
      c. Sets the stalled? atom to true.
      d. Shuts down the scheduler (one-shot; non-blocking from own thread)."
-  [{:keys [^AtomicLong last-event-ts stalled-atom
+  [{:keys [^AtomicLong last-event-ts stalled-atom gap-atom
            threshold-ms phase-id backend event-stream workflow-id kill-fn
            ^ScheduledExecutorService scheduler logger]}]
   (fn []
@@ -174,7 +174,8 @@
                               :error (ex-message ex)})))
             ;; b. emit stall event with measured gap (nil-safe)
             (emit-stall-event! event-stream workflow-id phase-id backend gap logger)
-            ;; c. mark stalled
+            ;; c. mark stalled and record the measured gap for the caller
+            (clojure.core/reset! gap-atom gap)
             (clojure.core/reset! stalled-atom true)
             ;; d. shut down scheduler — non-blocking, safe from own thread
             (.shutdown scheduler))))
@@ -208,11 +209,13 @@
            logger            module-logger}}]
   (let [last-event-ts   (AtomicLong. (System/currentTimeMillis))
         stalled-atom    (atom false)
+        gap-atom        (atom nil)
         session-id-atom (atom nil)
         scheduler       (Executors/newSingleThreadScheduledExecutor
                          (daemon-thread-factory "stream-watchdog"))
         ctx             {:last-event-ts     last-event-ts
                          :stalled-atom      stalled-atom
+                         :gap-atom          gap-atom
                          :session-id-atom   session-id-atom
                          :threshold-ms      threshold-ms
                          :check-interval-ms check-interval-ms
@@ -263,6 +266,15 @@
    Safe to call from any thread; reads an atom."
   [watchdog]
   (boolean (and watchdog @(:stalled-atom watchdog))))
+
+(defn stall-gap-ms
+  "Return the measured stream gap (ms) at the moment the watchdog fired.
+
+   Returns a positive number when the watchdog stalled, nil otherwise.
+   Safe to call from any thread; reads an atom."
+  [watchdog]
+  (when watchdog
+    @(:gap-atom watchdog)))
 
 (defn capture-session-id!
   "Parse and persist the session ID from the initial agent handshake event.

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -64,6 +64,26 @@
     (.set ts (- (System/currentTimeMillis) offset-ms)))
   watchdog)
 
+;; Timing constants for the fire-on-threshold tests. Kept small so the
+;; scheduler trips within a single test tick; named so the intent is explicit.
+(def ^:private trip-threshold-ms
+  "Gap threshold low enough that the watchdog trips almost immediately."
+  50)
+
+(def ^:private fast-check-interval-ms
+  "Poll cadence — well below the threshold so a stall is caught on the first tick."
+  10)
+
+(def ^:private gap-accrual-sleep-ms
+  "How long to leave the watchdog un-pinged so a real gap accrues past the
+   threshold before we assert it fired."
+  200)
+
+(def ^:private fire-await-timeout-ms
+  "Upper bound on the spin-wait for the async watchdog fire, so the assertion
+   never outruns the scheduler thread."
+  2000)
+
 ;; ---------------------------------------------------------------------------
 ;; resolve-gap-threshold
 
@@ -225,14 +245,14 @@
     (let [killed? (atom false)
           wd      (sut/create-watchdog
                    (make-test-watchdog
-                    {:threshold-ms      50
-                     :check-interval-ms 10
+                    {:threshold-ms      trip-threshold-ms
+                     :check-interval-ms fast-check-interval-ms
                      :kill-fn           #(reset! killed? true)}))]
       (is (nil? (sut/stall-gap-ms wd))
           "no gap measured before the watchdog fires")
       ;; Do not ping; let the timer accumulate a real gap past the threshold.
-      (Thread/sleep 200)
-      (let [fired? (await-condition #(and @killed? (sut/stalled? wd)) 2000)]
+      (Thread/sleep gap-accrual-sleep-ms)
+      (let [fired? (await-condition #(and @killed? (sut/stalled? wd)) fire-await-timeout-ms)]
         (sut/stop! wd)
         (is fired? "kill-fn fired and watchdog marked stalled")
         (is (sut/stalled? wd) "watchdog should be marked stalled")

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -220,6 +220,31 @@
         (is fired? "kill-fn fired and watchdog marked stalled")
         (is (sut/stalled? wd) "watchdog should be marked stalled")))))
 
+(deftest stall-gap-ms-exposes-measured-gap
+  (testing "stall-gap-ms returns nil before a stall and a positive number after"
+    (let [killed? (atom false)
+          wd      (sut/create-watchdog
+                   (make-test-watchdog
+                    {:threshold-ms      50
+                     :check-interval-ms 10
+                     :kill-fn           #(reset! killed? true)}))]
+      (is (nil? (sut/stall-gap-ms wd))
+          "no gap measured before the watchdog fires")
+      ;; Do not ping; let the timer accumulate a real gap past the threshold.
+      (Thread/sleep 200)
+      (let [fired? (await-condition #(and @killed? (sut/stalled? wd)) 2000)]
+        (sut/stop! wd)
+        (is fired? "kill-fn fired and watchdog marked stalled")
+        (is (sut/stalled? wd) "watchdog should be marked stalled")
+        (is @killed? "kill-fn ran")
+        (let [gap (sut/stall-gap-ms wd)]
+          (is (number? gap) "stall-gap-ms returns a number after stalling")
+          (is (pos? gap) "measured gap is positive"))))))
+
+(deftest stall-gap-ms-nil-safe-for-nil-watchdog
+  (testing "stall-gap-ms tolerates a nil watchdog"
+    (is (nil? (sut/stall-gap-ms nil)))))
+
 ;; ---------------------------------------------------------------------------
 ;; ping! actually prevents the kill from firing
 

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -264,11 +264,13 @@
 (defn- resolve-backend-keyword
   "Best-effort resolution of the configured LLM backend keyword from ctx.
 
-   The backend keyword lives under the user/self-healing config's :llm map in
-   most call sites; the live llm-backend client also carries it on its config.
-   Falls back to :unknown when none is present."
+   The live llm-backend client carries the keyword on its config at
+   `[:llm-backend :config :backend]` — the canonical location elsewhere in
+   the codebase (see agent/core) — so that wins. Falls back to the various
+   user/self-healing config :llm maps, then :unknown."
   [ctx]
-  (or (get-in ctx [:execution/opts :llm-backend :config :backend])
+  (or (get-in ctx [:llm-backend :config :backend])
+      (get-in ctx [:execution/opts :llm-backend :config :backend])
       (get-in ctx [:user-config :llm :backend])
       (get-in ctx [:config :llm :backend])
       (get-in ctx [:llm :backend])
@@ -316,13 +318,18 @@
         phase-thread (Thread/currentThread)
         wd (when on-chunk
              (agent/create-watchdog
-              {:threshold-ms (agent/resolve-gap-threshold watchdog-config backend)
-               :phase-id :implement
-               :backend backend
-               :event-stream event-stream
-               :workflow-id workflow-id
-               :logger logger
-               :kill-fn #(.interrupt phase-thread)}))
+              (cond-> {:threshold-ms (agent/resolve-gap-threshold watchdog-config backend)
+                       :phase-id :implement
+                       :backend backend
+                       :event-stream event-stream
+                       :workflow-id workflow-id
+                       :logger logger
+                       :kill-fn #(.interrupt phase-thread)}
+                ;; Optional override (mainly for tests/tuning); create-watchdog
+                ;; defaults this when absent — never pass nil.
+                (get watchdog-config :agent/stream-check-interval-ms)
+                (assoc :check-interval-ms
+                       (get watchdog-config :agent/stream-check-interval-ms)))))
         agent-ctx (cond-> ctx
                     on-chunk (assoc :on-chunk
                                     (fn [chunk]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -261,6 +261,19 @@
           {:peer-messages (vec msgs)}))
       (catch Exception _e nil))))
 
+(defn- resolve-backend-keyword
+  "Best-effort resolution of the configured LLM backend keyword from ctx.
+
+   The backend keyword lives under the user/self-healing config's :llm map in
+   most call sites; the live llm-backend client also carries it on its config.
+   Falls back to :unknown when none is present."
+  [ctx]
+  (or (get-in ctx [:execution/opts :llm-backend :config :backend])
+      (get-in ctx [:user-config :llm :backend])
+      (get-in ctx [:config :llm :backend])
+      (get-in ctx [:llm :backend])
+      :unknown))
+
 (defn enter-implement
   "Execute implementation phase.
 
@@ -284,14 +297,48 @@
                           (:task/repo-index task)
                           (:task/context-pack task))))
         on-chunk (create-streaming-callback ctx)
-        agent-ctx (cond-> ctx on-chunk (assoc :on-chunk on-chunk))
         peer-advice (collect-peer-advice ctx)
         task (cond-> task
                peer-advice (assoc :task/peer-advice peer-advice))
+        ;; Arm the stream watchdog around the synchronous agent invocation.
+        ;; Only when the run is actually streaming (on-chunk present): the
+        ;; watchdog resets its timer on each chunk, so a non-streaming run has
+        ;; no ping source and must not be armed (it would false-fire). On the
+        ;; streaming happy path it is observe-only — every chunk pings it and
+        ;; it is stopped in a finally. On a silent stall it interrupts the
+        ;; phase thread, unwinding the in-flight llm-stream-reader subprocess.
+        backend (resolve-backend-keyword ctx)
+        watchdog-config (or (get-in ctx [:execution/opts :self-healing])
+                            (get-in ctx [:user-config :self-healing])
+                            {})
+        event-stream (phase/resolve-event-stream ctx)
+        workflow-id (or (:execution/id ctx) (:workflow/id ctx))
+        phase-thread (Thread/currentThread)
+        wd (when on-chunk
+             (agent/create-watchdog
+              {:threshold-ms (agent/resolve-gap-threshold watchdog-config backend)
+               :phase-id :implement
+               :backend backend
+               :event-stream event-stream
+               :workflow-id workflow-id
+               :logger logger
+               :kill-fn #(.interrupt phase-thread)}))
+        agent-ctx (cond-> ctx
+                    on-chunk (assoc :on-chunk
+                                    (fn [chunk]
+                                      (agent/ping-watchdog! wd)
+                                      (on-chunk chunk))))
         impl-result (try
                       (agent/invoke implementer-agent task agent-ctx)
                       (catch Exception e
-                        (response/failure e)))
+                        (response/failure e))
+                      (finally
+                        (agent/stop-watchdog! wd)))
+        stalled? (agent/watchdog-stalled? wd)
+        gap-ms (agent/watchdog-stall-gap-ms wd)
+        ;; Clear any leftover interrupt flag set by the kill-fn so it does not
+        ;; poison the curator run or subsequent work on this thread.
+        _ (when stalled? (Thread/interrupted))
         ;; Curator post-processes the implementer's environment writes into a
         ;; structured :code artifact. The environment is the artifact, so we
         ;; invoke the curator regardless of the implementer's self-reported
@@ -350,6 +397,13 @@
              (= :mcp (get-in impl-result [:error :data :artifact-source])))
         degraded-handoff? (and impl-errored? (not metadata-only-submit?))
         result (cond
+                 ;; Stream watchdog fired: the agent stalled silently and was
+                 ;; killed mid-stream, so the empty diff is a stall symptom, not
+                 ;; a genuine no-files verdict. Re-code the implementer error as
+                 ;; :agent-stalled so downstream curator-terminal?/empty-diff?
+                 ;; gates treat it as RETRIABLE rather than terminal.
+                 stalled?
+                 (assoc-in impl-result [:error :data :code] :agent-stalled)
                  ;; Curator found files — use its artifact, even if the
                  ;; implementer reported error. Merge implementer metrics through.
                  (phase/result-succeeded? curator-result)
@@ -388,7 +442,9 @@
                  :else
                  curator-result)]
     (-> (phase/enter-context ctx :implement :implementer gates budget start-time result)
-        (assoc-in [:phase :rules-manifest] rules-manifest))))
+        (assoc-in [:phase :rules-manifest] rules-manifest)
+        (assoc-in [:phase :watchdog-state]
+                  {:stalled? stalled? :stall/gap-duration-ms gap-ms}))))
 
 (def ^:private rate-limit-pattern
   "Lightweight rate limit / infra-transient detection for the phase level.
@@ -519,6 +575,11 @@
         ;; are a first-class concept.
         curator-empty-diff? (= :curator/no-files-written
                                (get-in result [:error :data :code]))
+        ;; Stream watchdog outcome threaded from enter-implement. A stalled run
+        ;; is retriable, not terminal — the agent hung silently, so the next
+        ;; iteration may succeed.
+        watchdog-state (get-in ctx [:phase :watchdog-state])
+        stalled? (:stalled? watchdog-state)
         iterations (or (get-in ctx [:phase :iterations]) 1)
         max-iterations (get-in ctx [:phase :budget :iterations]
                                (get-in default-config [:budget :iterations]))
@@ -528,6 +589,11 @@
         effective-status agent-status
         invalid-already-implemented? (unverified-already-implemented? ctx result)
         phase-status (cond
+                       ;; Stream watchdog stall — retriable. Route through the
+                       ;; normal status determination so the phase retries on
+                       ;; the next iteration rather than terminating.
+                       stalled? (phase/determine-phase-status
+                                  effective-status iterations max-iterations)
                        gate-failed? :failed
                        invalid-already-implemented? :failed
                        (= :already-implemented agent-status) :already-implemented
@@ -601,7 +667,8 @@
                                :failure)
                 :duration-ms duration-ms
                 :tokens      (get metrics :tokens 0)}
-               (phase-terminal/derive-termination-reason result {:rate-limited? rate-limited?})))
+               (phase-terminal/derive-termination-reason
+                 result (merge watchdog-state {:rate-limited? rate-limited?}))))
       final-ctx)))
 
 (defn error-implement

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -505,6 +505,9 @@
                       ;; non-streaming run has no chunk ping-source by design).
                       (assoc :event-stream (es/create-event-stream {:sinks []}))
                       (assoc-in [:user-config :self-healing :agent/stream-gap-threshold-ms] 1)
+                      ;; Tiny check interval so the watchdog fires near-instantly
+                      ;; instead of waiting the 5s default — keeps the suite fast.
+                      (assoc-in [:user-config :self-healing :agent/stream-check-interval-ms] 10)
                       (assoc-in [:user-config :llm :backend] :echo)
                       (assoc :phase-config {:phase :implement}))
               interceptor (phase/get-phase-interceptor {:phase :implement})

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -26,6 +26,8 @@
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.response.interface :as response]))
 
 (def phase-test-config-resource
@@ -468,6 +470,83 @@
                (get-in final-result [:phase :result :summary])))
         (is (nil? (get-in final-result [:phase :error])))
         (is (= [:implement] (get-in final-result [:execution :phases-completed])))))))
+
+;------------------------------------------------------------------------------ Layer 2b: Stream watchdog stall classification
+
+(defn- mock-curator-no-files
+  "Mock curator returning the terminal :curator/no-files-written verdict —
+   the empty-diff outcome a killed/stalled agent leaves behind."
+  [_]
+  (response/error "No files written to environment"
+                  {:data {:code :curator/no-files-written}}))
+
+(deftest enter-implement-arms-watchdog-and-classifies-stall-test
+  (testing "a silently stalled agent stream is detected, killed, and re-coded as retriable"
+    (let [;; agent/invoke blocks (no chunks emitted) until the watchdog kill
+          ;; interrupts the phase thread; then it unwinds into the failure path.
+          invoked? (atom false)
+          interrupted? (atom false)]
+      (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                    agent/invoke (fn [_ _ _]
+                                   (reset! invoked? true)
+                                   (try
+                                     ;; Block far longer than the watchdog
+                                     ;; threshold + first check interval.
+                                     (Thread/sleep 15000)
+                                     (response/success nil {:tokens 0})
+                                     (catch InterruptedException _e
+                                       (reset! interrupted? true)
+                                       (throw (ex-info "stream killed"
+                                                       {:reason :interrupted})))))
+                    agent/curate-implement-output mock-curator-no-files]
+        (let [ctx (-> (create-base-context)
+                      ;; An event-stream makes create-streaming-callback return a
+                      ;; non-nil on-chunk, which is what arms the watchdog (a
+                      ;; non-streaming run has no chunk ping-source by design).
+                      (assoc :event-stream (es/create-event-stream {:sinks []}))
+                      (assoc-in [:user-config :self-healing :agent/stream-gap-threshold-ms] 1)
+                      (assoc-in [:user-config :llm :backend] :echo)
+                      (assoc :phase-config {:phase :implement}))
+              interceptor (phase/get-phase-interceptor {:phase :implement})
+              result ((:enter interceptor) ctx)]
+          (is @invoked? "agent/invoke ran")
+          (is @interrupted? "the watchdog interrupted the blocked stream")
+          (is (true? (get-in result [:phase :watchdog-state :stalled?]))
+              "ctx carries the stall outcome for leave-implement")
+          (is (pos? (get-in result [:phase :watchdog-state :stall/gap-duration-ms]))
+              "measured gap is recorded")
+          (is (not= :curator/no-files-written
+                    (get-in result [:phase :result :error :data :code]))
+              "stalled result must NOT be the terminal no-files verdict")
+          (is (= :agent-stalled
+                 (get-in result [:phase :result :error :data :code]))
+              "stalled result is re-coded as :agent-stalled"))))))
+
+(deftest leave-implement-stall-is-retriable-and-reports-reason-test
+  (testing "a stalled watchdog state yields a non-terminal status and :agent-stalled reason"
+    (let [result {:status :error
+                  :error {:message "stream killed"
+                          :data {:code :agent-stalled}}
+                  :metrics {:tokens 0 :duration-ms 0}}
+          ctx (-> (create-base-context)
+                  (assoc :phase {:name :implement
+                                 :agent :implementer
+                                 :status :running
+                                 :iterations 1
+                                 :budget {:iterations 8}
+                                 :started-at (System/currentTimeMillis)
+                                 :result result
+                                 :watchdog-state {:stalled? true
+                                                  :stall/gap-duration-ms 120000}}))
+          final-ctx (implement/leave-implement ctx)]
+      ;; Not the terminal :failed — the phase should retry.
+      (is (not= :failed (get-in final-ctx [:phase :status]))
+          "a stalled run must not terminate as :failed")
+      ;; derive-termination-reason resolves the stall to :agent-stalled.
+      (let [reason (phase-terminal/derive-termination-reason
+                     result {:stalled? true :stall/gap-duration-ms 120000})]
+        (is (= :agent-stalled (:phase/termination-reason reason)))
+        (is (= 120000 (:stall/gap-duration-ms reason)))))))
 
 ;------------------------------------------------------------------------------ Layer 3: Capsule File Loading
 


### PR DESCRIPTION
## Summary

Fixes the root cause of the 2026-05-24 dogfood failure (`agent-stream-watchdog-and-resume` spec): a DAG sub-task's agent stream went **silently dead ~5 min mid-turn** (announced "now writing implement.clj", then zero Write tool calls) and the empty worktree surfaced as a terminal `:curator/no-files-written`. The curator was correct — the real bug is that the stream stall was never detected and the result was misclassified as terminal instead of retriable.

Implements **GROUP 1 + GROUP 4** of `work/agent-stream-watchdog-and-resume.spec.edn`:

- **GROUP 1 — arm the watchdog.** `stream-watchdog` existed but was never started around any agent run. `enter-implement` now creates it around the agent invocation **only when the run is streaming** (`on-chunk` present — a non-streaming `llm/chat` has no chunk ping-source and must not be armed, or it would false-fire), pings it on every chunk, and stops it in a `finally`. On a gap beyond `:agent/stream-gap-threshold-ms` (default 90s) it interrupts the phase thread — unwinding the blocked `llm-stream-reader` subprocess — and emits `:agent/stream-stalled` with the measured gap.
- **GROUP 4 — classify the stall.** `derive-termination-reason` already had an `:agent-stalled` branch but never received the signal; it now gets the watchdog state, so a stalled phase reports `:phase/termination-reason :agent-stalled` (with gap). A stalled + empty-diff result is re-coded `:agent-stalled` so the phase runner treats it as **retriable** instead of the terminal `:curator/no-files-written`.
- Adds a `stall-gap-ms` accessor to the watchdog.

**No-regression by construction:** the happy path and all non-streaming runs are behaviorally identical — the watchdog is observe-only and only arms on streaming runs.

Resume-on-kill + backend failover (GROUP 3) and session-id persistence wiring (GROUP 2) are a follow-up PR.

## Test plan

- [x] `bb pre-commit` green (lint/structure/format + smoke)
- [x] `stream_watchdog` test: `stall-gap-ms` exposes the measured gap on fire (+ nil-safe)
- [x] `enter-implement` test: a blocking (no-chunk) agent invocation trips a 1ms threshold → watchdog interrupts the stream, ctx carries `:watchdog-state {:stalled? true ...}`, and the result is re-coded `:agent-stalled` (NOT `:curator/no-files-written`)
- [x] `leave-implement` test: a stalled watchdog state yields a non-`:failed` (retriable) status and `:agent-stalled` termination reason
- [ ] Live validation against a real provider stall — not reproducible locally; the kill path (thread-interrupt → subprocess teardown) is exercised by the synthetic blocking-invoke test but not against a real backend hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)