### PR TITLE
fix(reviewer): advisory gate failures must not override an LLM :approved

### DIFF
--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -228,29 +228,30 @@
          (loop/fail-result :implementation-handoff :policy errors)
          (loop/pass-result :implementation-handoff :policy))))))
 
-(def ^:private blocking-gate-types
-  "Internal gate types whose failure overrides even an LLM :approved verdict —
-   the deterministic safety net the LLM cannot be trusted to replace: broken
-   syntax, policy violations (e.g. :no-secrets, degraded implementation
-   handoff), and failing tests. Advisory gates like :lint do NOT override
-   approval — a lint failure downgrades to :conditionally-approved instead.
+(def ^:private advisory-gate-types
+  "Internal gate types whose failure is advisory — it must NOT override an
+   LLM :approved verdict. Only :lint qualifies: a style/formatting failure on
+   a build that already passed verify is not a ship-blocker, and treating it
+   as one flipped verify-passed, LLM-:approved builds to :rejected, capping
+   every dogfood spec at the :review-approved gate (observed 2026-05-24,
+   workflow adhoc-807481487).
 
-   Before this, every internal-gate error counted as blocking because
-   `loop/make-error` sets no :severity and the filter defaulted to :blocking.
-   A failing lint gate then flipped a verify-passed, LLM-:approved build to
-   :rejected, capping every dogfood spec at the :review-approved gate
-   (observed 2026-05-24, workflow adhoc-807481487)."
-  #{:syntax :policy :test})
+   Every other gate type blocks by default — fail-safe. That deliberately
+   includes unresolved `:unknown` and gate-execution exceptions
+   (`create-exception-feedback` produces `:unknown` errors with no
+   `:severity`): a gate that crashed must block review, never silently
+   approve."
+  #{:lint})
 
 (defn- error-blocking?
-  "An internal-gate error blocks when it explicitly declares
-   `:severity :blocking`, or — absent an explicit severity — when it comes
-   from a blocking gate type. Advisory-gate errors (e.g. :lint) without an
-   explicit blocking severity are not blocking."
+  "An internal-gate error is non-blocking only when it explicitly declares a
+   non-:blocking severity, or — absent an explicit severity — comes from an
+   advisory gate type. Everything else blocks (fail-safe), so an unresolved
+   `:unknown` gate type or a gate crash cannot pass review open."
   [gate-type error]
   (if-let [severity (:severity error)]
     (= :blocking severity)
-    (contains? blocking-gate-types gate-type)))
+    (not (contains? advisory-gate-types gate-type))))
 
 (defn extract-blocking-issues
   "Extract blocking errors from failed gates, honoring per-error severity and

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -228,12 +228,38 @@
          (loop/fail-result :implementation-handoff :policy errors)
          (loop/pass-result :implementation-handoff :policy))))))
 
+(def ^:private blocking-gate-types
+  "Internal gate types whose failure overrides even an LLM :approved verdict —
+   the deterministic safety net the LLM cannot be trusted to replace: broken
+   syntax, policy violations (e.g. :no-secrets, degraded implementation
+   handoff), and failing tests. Advisory gates like :lint do NOT override
+   approval — a lint failure downgrades to :conditionally-approved instead.
+
+   Before this, every internal-gate error counted as blocking because
+   `loop/make-error` sets no :severity and the filter defaulted to :blocking.
+   A failing lint gate then flipped a verify-passed, LLM-:approved build to
+   :rejected, capping every dogfood spec at the :review-approved gate
+   (observed 2026-05-24, workflow adhoc-807481487)."
+  #{:syntax :policy :test})
+
+(defn- error-blocking?
+  "An internal-gate error blocks when it explicitly declares
+   `:severity :blocking`, or — absent an explicit severity — when it comes
+   from a blocking gate type. Advisory-gate errors (e.g. :lint) without an
+   explicit blocking severity are not blocking."
+  [gate-type error]
+  (if-let [severity (:severity error)]
+    (= :blocking severity)
+    (contains? blocking-gate-types gate-type)))
+
 (defn extract-blocking-issues
-  "Extract blocking errors from failed gates."
+  "Extract blocking errors from failed gates, honoring per-error severity and
+   gate type (see `error-blocking?`). Errors from advisory gates such as
+   :lint no longer force a rejection of an otherwise-approved review."
   [failed-gates]
   (->> failed-gates
-       (mapcat :errors)
-       (filter #(= :blocking (:severity % :blocking)))
+       (mapcat (fn [{:keys [gate-type errors]}]
+                 (filter #(error-blocking? gate-type %) errors)))
        vec))
 
 (defn extract-warning-messages

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -575,6 +575,49 @@
         (is (= :rejected  (get-in override-entry [:data :final-decision])))
         (is (= [:always-fails] (get-in override-entry [:data :failing-gate-ids])))))))
 
+(defn- failed-gate-feedback
+  "Failed gate feedback with a given type and errors. Errors mirror
+   loop/make-error (no :severity) unless a caller provides one."
+  [gate-type errors]
+  {:gate-id gate-type
+   :gate-type gate-type
+   :passed? false
+   :errors errors
+   :warnings []
+   :duration-ms 0})
+
+(deftest test-advisory-gate-failure-does-not-block-approval
+  ;; Regression: a failing :lint gate (errors carry no :severity, so the old
+  ;; :blocking default classified them blocking) flipped a verify-passed,
+  ;; LLM-:approved build to :rejected — capping every dogfood spec at the
+  ;; :review-approved gate (2026-05-24, workflow adhoc-807481487).
+  (testing "a :lint gate failure (no severity) is not a blocking issue"
+    (let [failed [(failed-gate-feedback :lint [{:code :lint-error
+                                                :message "trailing whitespace"}])]]
+      (is (empty? (reviewer/extract-blocking-issues failed)))
+      (is (= :conditionally-approved
+             (:decision (reviewer/make-review-decision failed {})))
+          "non-blocking failure downgrades to :conditionally-approved, not :rejected")))
+  (testing "deterministic safety-net gates still block an LLM :approved"
+    (doseq [gate-type [:syntax :policy :test]]
+      (let [failed [(failed-gate-feedback gate-type [{:code :err :message "boom"}])]]
+        (is (seq (reviewer/extract-blocking-issues failed))
+            (str gate-type " failure must remain blocking"))
+        (is (= :rejected (:decision (reviewer/make-review-decision failed {})))))))
+  (testing "explicit :severity overrides gate-type classification"
+    (is (seq (reviewer/extract-blocking-issues
+              [(failed-gate-feedback :lint [{:message "x" :severity :blocking}])]))
+        "an explicit :blocking severity blocks even on an advisory gate")
+    (is (empty? (reviewer/extract-blocking-issues
+                 [(failed-gate-feedback :policy [{:message "y" :severity :warning}])]))
+        "an explicit :warning severity does not block even on a safety-net gate"))
+  (testing "LLM :approved survives an advisory gate failure as :conditionally-approved (gate passes)"
+    (let [gate-decision (:decision (reviewer/make-review-decision
+                                    [(failed-gate-feedback :lint
+                                                           [{:message "style"}])] {}))]
+      (is (= :conditionally-approved
+             (reviewer/merge-gate-overrides :approved gate-decision {}))))))
+
 (deftest test-gate-result-feedback-resolves-real-gate-ids
   ;; Coverage gap exposed by the 2026-05-18 dogfood: gate-result->feedback
   ;; was reading `:gate/id` off the gate defrecord (where SyntaxGate /

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -598,12 +598,22 @@
       (is (= :conditionally-approved
              (:decision (reviewer/make-review-decision failed {})))
           "non-blocking failure downgrades to :conditionally-approved, not :rejected")))
-  (testing "deterministic safety-net gates still block an LLM :approved"
-    (doseq [gate-type [:syntax :policy :test]]
+  (testing "all non-advisory gates block by default (fail-safe), incl. :unknown"
+    (doseq [gate-type [:syntax :policy :test :unknown]]
       (let [failed [(failed-gate-feedback gate-type [{:code :err :message "boom"}])]]
         (is (seq (reviewer/extract-blocking-issues failed))
             (str gate-type " failure must remain blocking"))
         (is (= :rejected (:decision (reviewer/make-review-decision failed {})))))))
+  (testing "a gate-execution exception (create-exception-feedback) fails safe (blocking)"
+    ;; create-exception-feedback yields {:gate-type :unknown :errors [{:type
+    ;; :gate-exception ...}]} with no :severity — a crashed gate must block,
+    ;; never approve open.
+    (let [crashed (reviewer/create-exception-feedback
+                   {} 0 (RuntimeException. "gate blew up") 1)]
+      (is (false? (:passed? crashed)))
+      (is (seq (reviewer/extract-blocking-issues [crashed]))
+          "a crashed gate's error must be blocking")
+      (is (= :rejected (:decision (reviewer/make-review-decision [crashed] {}))))))
   (testing "explicit :severity overrides gate-type classification"
     (is (seq (reviewer/extract-blocking-issues
               [(failed-gate-feedback :lint [{:message "x" :severity :blocking}])]))


### PR DESCRIPTION
## Summary

Fixes the `:review-approved` gate rejecting genuinely-approved builds — the single blocker that capped **every** dogfood spec at review (2026-05-24 dogfood of `worktree-persistence-scratch-branch`: 6 review cycles, ~178 min, **$5.27**, never shipped despite implement+verify passing repeatedly).

**Root cause:** the reviewer runs deterministic internal gates and, via `merge-gate-overrides` ("gate rejection always wins"), lets a failing one override the LLM verdict. But `extract-blocking-issues` classified *every* internal-gate error as blocking, because `loop/make-error` sets no `:severity` and the filter defaulted to `:blocking`. So a failing **`:lint`** gate (style only) flipped a verify-passed, LLM-`:approved` build to `:rejected` → the `:review-approved` phase gate (`gate/policy.clj`) saw a non-approving decision → failed → redirected to implement → repeat. (The no-op logger injected by `create-reviewer` hid the `:reviewer/gate-overrode-llm` warning, which is why it recurred undiagnosed.)

**Fix:** `extract-blocking-issues` is now gate-type aware. An internal-gate error blocks only when it:
- explicitly declares `:severity :blocking`, or
- comes from a deterministic safety-net gate type — `:syntax`, `:policy` (covers `:no-secrets` and degraded implementation-handoff), or `:test`.

Advisory failures like `:lint` downgrade an LLM `:approved` to `:conditionally-approved`, which `check-review-approved` accepts. Real LLM `:changes-requested`/`:rejected` verdicts and explicit `:blocking` issues are unaffected — **genuine rejections (incl. secrets/syntax/failing tests) are not masked.**

## Test plan

- [x] `bb pre-commit` green
- [x] New `test-advisory-gate-failure-does-not-block-approval`: a `:lint` failure (no severity) is non-blocking → `make-review-decision` yields `:conditionally-approved`; `merge-gate-overrides` keeps an LLM `:approved` as `:conditionally-approved` (gate-passing)
- [x] Safety net preserved: `:syntax`/`:policy`/`:test` failures still block → `:rejected`; explicit `:severity` overrides gate-type either way
- [x] Existing `test-reviewer-emits-gate-overrode-llm-warn-on-disagreement` (uses a `:policy` gate) still passes — real overrides still fire
- [ ] End-to-end re-dogfood once merged, to confirm a spec can now clear review and reach release

## Follow-up (not in this PR)
`create-reviewer` injects a no-op logger, so the `:reviewer/gate-overrode-llm` diagnostic never reaches the event stream — worth wiring so future verdict flips are traceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)