### PR TITLE
GROUP 1: Add :workflow/worktree-root to default-user-config.edn with...

### DIFF
--- a/components/config/resources/config/default-user-config-fallback.edn
+++ b/components/config/resources/config/default-user-config-fallback.edn
@@ -11,6 +11,9 @@
              :max-tokens 150000
              :failure-strategy :retry
              :checkpoint-root "~/.miniforge/checkpoints"}
+  ;; Keep in sync with resources/config/default-user-config.edn.
+  ;; /tmp opt-in: override to "/tmp/miniforge-worktrees" for CI/sandbox runs.
+  :workflow/worktree-root "~/.miniforge/worktrees"
   :artifacts {:dir "~/.miniforge/artifacts"}
   :meta-loop {:enabled true
               :max-convergence-iterations 10

--- a/components/config/test/ai/miniforge/config/user_defaults_test.clj
+++ b/components/config/test/ai/miniforge/config/user_defaults_test.clj
@@ -41,7 +41,13 @@
 
     (testing "default workflow checkpoint root is configured as data"
       (is (= "~/.miniforge/checkpoints"
-             (get-in cfg [:workflow :checkpoint-root]))))))
+             (get-in cfg [:workflow :checkpoint-root]))))
+
+    (testing "default worktree root lives under ~/.miniforge and not /tmp"
+      (is (= "~/.miniforge/worktrees"
+             (get cfg :workflow/worktree-root))
+          ":workflow/worktree-root must be present in the default config so
+           create-worktree-executor picks it up without a disk read"))))
 
 (deftest load-default-config-falls-back-to-edn-resource-test
   (let [orig-resource io/resource]
@@ -55,7 +61,11 @@
         (is (= :opencode (get-in cfg [:llm :backend])))
         (is (= "anthropic/claude-sonnet-4-6" (get-in cfg [:agents :default-models :execution])))
         (is (= "~/.miniforge/checkpoints"
-               (get-in cfg [:workflow :checkpoint-root])))))))
+               (get-in cfg [:workflow :checkpoint-root])))
+        (is (= "~/.miniforge/worktrees"
+               (get cfg :workflow/worktree-root))
+            "fallback EDN must carry :workflow/worktree-root so the dag-executor
+             can locate worktrees even when the primary resource is missing")))))
 
 (deftest repo-config-support-test
   (testing "repo-config-path appends .miniforge/config.edn to the provided root"

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -64,7 +64,7 @@
    Lives under `~/.miniforge/worktrees/` rather than `/tmp` so the worktree
    (and any uncommitted implementer file writes living in it) survives reboots
    and macOS-tmpfs cleanups. The 2026-04-17 gates workflow lost 8+ minutes of
-   working code when its `/tmp` worktree was GC on process-tree restart;
+   working code when its `/tmp` worktree was GC'd on process-tree restart;
    persistence outside `/tmp` is the foundation for the broader work in
    `work/worktree-persistence-scratch-branch.spec.edn`.
 
@@ -178,7 +178,12 @@
    Git uses a config.lock file internally — concurrent worktree adds from
    multiple threads hit this lock and fail silently. Serializing creation at
    the JVM level prevents the conflict. Tasks still run in parallel once their
-   worktrees are acquired."
+   worktrees are acquired.
+
+   `check-legacy-tmp-worktrees!` runs inside this lock so that at most one
+   thread emits the advisory warning at a time, avoiding duplicated log lines
+   in high-parallelism scenarios where all default concurrent slots start
+   simultaneously."
   (Object.))
 
 (defn- resolve-branch-sha
@@ -190,22 +195,24 @@
    parent worktree is the one running miniforge — which is the common case
    for `bb dogfood`. Passing the resolved sha sidesteps the refusal.
 
-   Returns the sha string on success, nil on failure (caller falls back to
-   the branch name and accepts any failure that follows)."
+   Returns the sha string on success, nil on failure or empty output (caller
+   falls back to the branch name and accepts any failure that follows).
+   Guards the empty-string case explicitly: `(or \"\" branch)` treats the
+   empty string as truthy in Clojure and would pass an empty base-ref to
+   `git worktree add`, producing a confusing git error."
   [repo-path branch]
   (let [r (run-git "-C" repo-path "rev-parse" branch)]
     (when (zero? (:exit r))
-      (str/trim (or (:out r) "")))))
+      (let [sha (str/trim (or (:out r) ""))]
+        (when (seq sha) sha)))))
 
 (defn create-worktree
   "Create a git worktree for the task.
 
-   Emits a warning (via `*warn-fn*`) if the legacy /tmp/miniforge-worktrees
-   directory still has entries — this is a migration prompt, not an error.
-
    Serializes creation through worktree-lock to prevent concurrent git
    config.lock conflicts when multiple sub-workflows acquire environments
-   simultaneously.
+   simultaneously. The legacy /tmp worktree check also runs inside the lock so
+   at most one thread emits the advisory warning at a time.
 
    Attempts in order:
    1. git worktree add -b <name> <path> <sha-or-ref>
@@ -217,8 +224,8 @@
    This one-two punch keeps `git worktree add` failures from cascading into
    broken bundles whose only ref is a bare HEAD."
   [base-path repo-path worktree-name branch]
-  (check-legacy-tmp-worktrees!)
   (locking worktree-lock
+    (check-legacy-tmp-worktrees!)
     (let [worktree-path (str base-path "/" worktree-name)
           base-sha      (resolve-branch-sha repo-path branch)
           base-ref      (or base-sha branch)]

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -75,10 +75,10 @@
 ;; Legacy /tmp worktree detection
 ;; ============================================================================
 
+;; Set to true once the legacy-/tmp-worktrees warning has fired in this JVM
+;; session. Prevents noisy repetition across multiple worktree creates.
+;; Non-private so tests can reset it via with-redefs to exercise the check.
 (defonce legacy-tmp-warned?
-  "Set to true once the legacy-/tmp-worktrees warning has fired in this JVM
-   session. Prevents noisy repetition across multiple worktree creates.
-   Non-private so tests can reset it via with-redefs to exercise the check."
   (atom false))
 
 (defn check-legacy-tmp-worktrees!

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -38,18 +38,29 @@
 (defn default-base-path
   "Default location for git worktrees acquired by the worktree executor.
 
-   Lives under `~/.miniforge/worktrees/` rather than `/tmp` so the
-   worktree (and any uncommitted implementer file writes living in it)
-   survives reboots and macOS-tmpfs cleanups. The 2026-04-17 gates
+   When called with no args returns the hardcoded default:
+   `~/.miniforge/worktrees/`. This path lives under the user's home so
+   worktrees (and any uncommitted implementer file writes inside them)
+   survive reboots and macOS-tmpfs cleanups. The 2026-04-17 gates
    workflow lost 8+ minutes of working code when its `/tmp` worktree
    was GC'd on process-tree restart; persistence outside `/tmp` is the
    foundation for the broader work in
    `work/worktree-persistence-scratch-branch.spec.edn`.
 
+   When called with a config map, checks `:workflow/worktree-root` first
+   and falls back to the no-arg default. This lets the executor read the
+   user's configured worktree root from `default-user-config.edn` without
+   requiring the caller to extract the key manually.
+
    Callers that need an ephemeral location (CI runs, sandbox tests)
-   can override via the `:base-path` config arg."
-  []
-  (str (System/getProperty "user.home") "/.miniforge/worktrees"))
+   can override via the `:base-path` config arg to `create-worktree-executor`,
+   or set `:workflow/worktree-root` in their user config to a `/tmp`-rooted
+   path for opt-in ephemeral behaviour."
+  ([]
+   (str (System/getProperty "user.home") "/.miniforge/worktrees"))
+  ([config]
+   (or (get config :workflow/worktree-root)
+       (default-base-path))))
 
 (def default-max-concurrent 4)
 
@@ -59,6 +70,42 @@
    and can be referenced from evidence bundles long after the run ends."
   []
   (str (System/getProperty "user.home") "/.miniforge/checkpoints"))
+
+;; ============================================================================
+;; Legacy /tmp worktree detection
+;; ============================================================================
+
+(defonce ^:private legacy-tmp-warned?
+  "Set to true once the legacy-/tmp-worktrees warning has fired in this JVM
+   session. Prevents noisy repetition across multiple worktree creates."
+  (atom false))
+
+(defn check-legacy-tmp-worktrees!
+  "Warn once per JVM session if /tmp/miniforge-worktrees/ exists and contains
+   worktree directories left over from the pre-2026-04-17 default path.
+
+   Non-blocking and non-throwing — purely advisory. Never prevents worktree
+   creation; the two paths coexist safely. Callers (e.g. CI environments)
+   that intentionally use /tmp can silence the warning by pointing
+   `:workflow/worktree-root` at the /tmp path in their user config, which
+   resets the detection expectation."
+  []
+  (when-not @legacy-tmp-warned?
+    (try
+      (let [legacy-dir (File. "/tmp/miniforge-worktrees")]
+        (when (and (.exists legacy-dir)
+                   (.isDirectory legacy-dir)
+                   (boolean (seq (filter #(.isDirectory ^File %)
+                                        (or (.listFiles legacy-dir) [])))))
+          (reset! legacy-tmp-warned? true)
+          (binding [*out* *err*]
+            (println "WARN [miniforge/worktree] Legacy /tmp/miniforge-worktrees/ detected with existing worktrees.")
+            (println "WARN [miniforge/worktree] Worktrees now default to ~/.miniforge/worktrees/ (survives reboots).")
+            (println "WARN [miniforge/worktree] Migration: mv /tmp/miniforge-worktrees/<name> ~/.miniforge/worktrees/")
+            (println "WARN [miniforge/worktree] Set :workflow/worktree-root in user config to suppress this warning."))))
+      (catch Exception _
+        ;; Advisory check only — filesystem errors must never block worktree creation
+        nil))))
 
 ;; ============================================================================
 ;; Helper Functions
@@ -126,6 +173,9 @@
 (defn create-worktree
   "Create a git worktree for the task.
 
+   Checks for legacy /tmp/miniforge-worktrees directories and emits an
+   advisory warning if found (never blocks creation).
+
    Serializes creation through worktree-lock to prevent concurrent git
    config.lock conflicts when multiple sub-workflows acquire environments
    simultaneously.
@@ -149,6 +199,7 @@
    This one-two punch keeps `git worktree add` failures from cascading into
    broken bundles whose only ref is a bare HEAD."
   [base-path repo-path worktree-name branch]
+  (check-legacy-tmp-worktrees!)
   (locking worktree-lock
     (let [worktree-path (str base-path "/" worktree-name)
           base-sha      (resolve-branch-sha repo-path branch)
@@ -724,16 +775,28 @@
 (defn create-worktree-executor
   "Create a worktree-based executor (fallback).
 
-   Config:
-   - :base-path - Base directory for worktrees (default:
-     `~/.miniforge/worktrees`). The previous `/tmp/miniforge-worktrees`
-     default was changed after the 2026-04-17 gates-workflow lost
-     8+ minutes of working code to a macOS tmpfs cleanup. Ephemeral
-     `/tmp`-rooted runs (CI, sandbox tests) opt in explicitly via
-     this key.
-   - :max-concurrent - Max concurrent worktrees (default: 4)"
+   Config keys (all optional):
+   - :base-path             - Explicit base directory for worktrees. Takes
+                              priority over everything else. Use for CI/sandbox
+                              runs that need an ephemeral path (e.g.
+                              `/tmp/miniforge-worktrees-ci`).
+   - :workflow/worktree-root - Base directory read from the user's
+                               `default-user-config.edn`. Checked when
+                               `:base-path` is absent. Defaults to
+                               `~/.miniforge/worktrees` in the EDN config.
+   - :max-concurrent         - Max concurrent worktrees (default: 4).
+
+   Resolution order for the base path:
+     1. `:base-path`              — explicit caller override
+     2. `:workflow/worktree-root` — from loaded user config
+     3. `(default-base-path)`     — hardcoded `~/.miniforge/worktrees`
+
+   The previous `/tmp/miniforge-worktrees` default was removed after the
+   2026-04-17 gates-workflow lost 8+ minutes of working code to a macOS
+   tmpfs cleanup. Ephemeral `/tmp`-rooted runs opt in explicitly."
   [config]
   (map->WorktreeExecutor
    {:config config
-    :base-path (get config :base-path (default-base-path))
+    :base-path (or (get config :base-path)
+                   (default-base-path config))
     :max-concurrent (get config :max-concurrent default-max-concurrent)}))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -75,9 +75,10 @@
 ;; Legacy /tmp worktree detection
 ;; ============================================================================
 
-(defonce ^:private legacy-tmp-warned?
+(defonce legacy-tmp-warned?
   "Set to true once the legacy-/tmp-worktrees warning has fired in this JVM
-   session. Prevents noisy repetition across multiple worktree creates."
+   session. Prevents noisy repetition across multiple worktree creates.
+   Non-private so tests can reset it via with-redefs to exercise the check."
   (atom false))
 
 (defn check-legacy-tmp-worktrees!

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -112,16 +112,30 @@
          (let [files (.listFiles dir)]
            (and (some? files) (pos? (alength files)))))))
 
+;; Non-private so tests can `(reset! worktree/legacy-tmp-warned? false)` before
+;; exercising the warning path. `compare-and-set!` in check-legacy-tmp-worktrees!
+;; ensures the advisory fires at most once per JVM session even under concurrent
+;; load — without this, all four default worktree slots could race to emit
+;; identical WARNING lines before any of them acquires worktree-lock.
+(defonce legacy-tmp-warned?
+  (atom false))
+
 (defn check-legacy-tmp-worktrees!
-  "Warn when the legacy /tmp/miniforge-worktrees directory has entries.
+  "Warn once per JVM session when the legacy /tmp/miniforge-worktrees directory
+   has entries.
+
+   Uses `compare-and-set!` on `legacy-tmp-warned?` so exactly one thread emits
+   the advisory, even when multiple worktree-create calls race at startup.
 
    Does NOT error — graceful coexistence per the worktree-persistence spec
    constraint. Existing /tmp worktrees remain usable; the warning tells
    operators how to migrate to the persistent default path.
 
-   Rebind `*warn-fn*` via `binding` in tests to capture the output."
+   Rebind `*warn-fn*` via `binding` in tests to capture the output.
+   Reset `legacy-tmp-warned?` to false before tests that assert the warning fires."
   []
-  (when (legacy-tmp-worktrees-exist?)
+  (when (and (legacy-tmp-worktrees-exist?)
+             (compare-and-set! legacy-tmp-warned? false true))
     (*warn-fn*
      (str
       "[miniforge] WARNING: legacy worktrees detected at "

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -35,78 +35,104 @@
 ;; Configuration
 ;; ============================================================================
 
+(def ^:dynamic *warn-fn*
+  "Emit a warning message to stderr.
+   Rebind via `binding` in tests to capture warnings without stderr noise."
+  (fn [msg] (binding [*out* *err*] (println msg))))
+
+(defn- expand-home
+  "Expand a leading `~/` in a path string to the user home directory.
+   Pass-through for absolute paths and bare paths that do not start with `~/`."
+  [path]
+  (let [home (System/getProperty "user.home")]
+    (cond
+      (str/starts-with? path "~/") (str home (subs path 1))
+      (= "~" path)                 home
+      :else                        path)))
+
 (defn default-base-path
   "Default location for git worktrees acquired by the worktree executor.
 
-   When called with no args returns the hardcoded default:
-   `~/.miniforge/worktrees/`. This path lives under the user's home so
-   worktrees (and any uncommitted implementer file writes inside them)
-   survive reboots and macOS-tmpfs cleanups. The 2026-04-17 gates
-   workflow lost 8+ minutes of working code when its `/tmp` worktree
-   was GC'd on process-tree restart; persistence outside `/tmp` is the
-   foundation for the broader work in
+   Arity 0: returns the hardcoded default `~/.miniforge/worktrees`.
+
+   Arity 1 (config map): reads `:workflow/worktree-root` from the supplied
+   map, expands any leading `~/`, and falls back to the no-arg default when
+   the key is absent or blank. This lets `create-worktree-executor` respect
+   the user `default-user-config.edn` setting without requiring a disk read
+   at namespace load time.
+
+   Lives under `~/.miniforge/worktrees/` rather than `/tmp` so the worktree
+   (and any uncommitted implementer file writes living in it) survives reboots
+   and macOS-tmpfs cleanups. The 2026-04-17 gates workflow lost 8+ minutes of
+   working code when its `/tmp` worktree was GC on process-tree restart;
+   persistence outside `/tmp` is the foundation for the broader work in
    `work/worktree-persistence-scratch-branch.spec.edn`.
 
-   When called with a config map, checks `:workflow/worktree-root` first
-   and falls back to the no-arg default. This lets the executor read the
-   user's configured worktree root from `default-user-config.edn` without
-   requiring the caller to extract the key manually.
-
-   Callers that need an ephemeral location (CI runs, sandbox tests)
-   can override via the `:base-path` config arg to `create-worktree-executor`,
-   or set `:workflow/worktree-root` in their user config to a `/tmp`-rooted
-   path for opt-in ephemeral behaviour."
+   Callers that need an ephemeral location (CI runs, sandbox tests) can opt in
+   to `/tmp` by setting `:workflow/worktree-root \"/tmp/miniforge-worktrees\"`
+   in their user config, or by passing `:base-path` directly to
+   `create-worktree-executor`."
   ([]
    (str (System/getProperty "user.home") "/.miniforge/worktrees"))
   ([config]
-   (or (get config :workflow/worktree-root)
-       (default-base-path))))
+   (let [configured (get config :workflow/worktree-root)]
+     (if (and configured (not (str/blank? (str configured))))
+       (expand-home configured)
+       (default-base-path)))))
 
 (def default-max-concurrent 4)
 
 (defn default-archive-dir
   "Default location for persisted task work archives.
-   Lives under the user's home rather than /tmp so checkpoints survive reboots
+   Lives under the user home rather than /tmp so checkpoints survive reboots
    and can be referenced from evidence bundles long after the run ends."
   []
   (str (System/getProperty "user.home") "/.miniforge/checkpoints"))
 
 ;; ============================================================================
-;; Legacy /tmp worktree detection
+;; Legacy /tmp detection
 ;; ============================================================================
 
-;; Set to true once the legacy-/tmp-worktrees warning has fired in this JVM
-;; session. Prevents noisy repetition across multiple worktree creates.
-;; Non-private so tests can reset it via with-redefs to exercise the check.
-(defonce legacy-tmp-warned?
-  (atom false))
+(def ^:private legacy-tmp-worktrees-path
+  "Legacy default worktree base directory that lived under /tmp.
+   Created before the 2026-04-17 gates-workflow data-loss incident forced the
+   move to `~/.miniforge/worktrees`. Checked at creation time to prompt
+   migration without blocking active workflows."
+  "/tmp/miniforge-worktrees")
+
+(defn legacy-tmp-worktrees-exist?
+  "Returns true if the legacy /tmp/miniforge-worktrees directory exists and
+   contains at least one entry (indicating active or stale worktrees).
+
+   Public so tests can rebind via `with-redefs` without touching the filesystem."
+  []
+  (let [dir (File. ^String legacy-tmp-worktrees-path)]
+    (and (.exists dir)
+         (.isDirectory dir)
+         (let [files (.listFiles dir)]
+           (and (some? files) (pos? (alength files)))))))
 
 (defn check-legacy-tmp-worktrees!
-  "Warn once per JVM session if /tmp/miniforge-worktrees/ exists and contains
-   worktree directories left over from the pre-2026-04-17 default path.
+  "Warn when the legacy /tmp/miniforge-worktrees directory has entries.
 
-   Non-blocking and non-throwing — purely advisory. Never prevents worktree
-   creation; the two paths coexist safely. Callers (e.g. CI environments)
-   that intentionally use /tmp can silence the warning by pointing
-   `:workflow/worktree-root` at the /tmp path in their user config, which
-   resets the detection expectation."
+   Does NOT error — graceful coexistence per the worktree-persistence spec
+   constraint. Existing /tmp worktrees remain usable; the warning tells
+   operators how to migrate to the persistent default path.
+
+   Rebind `*warn-fn*` via `binding` in tests to capture the output."
   []
-  (when-not @legacy-tmp-warned?
-    (try
-      (let [legacy-dir (File. "/tmp/miniforge-worktrees")]
-        (when (and (.exists legacy-dir)
-                   (.isDirectory legacy-dir)
-                   (boolean (seq (filter #(.isDirectory ^File %)
-                                        (or (.listFiles legacy-dir) [])))))
-          (reset! legacy-tmp-warned? true)
-          (binding [*out* *err*]
-            (println "WARN [miniforge/worktree] Legacy /tmp/miniforge-worktrees/ detected with existing worktrees.")
-            (println "WARN [miniforge/worktree] Worktrees now default to ~/.miniforge/worktrees/ (survives reboots).")
-            (println "WARN [miniforge/worktree] Migration: mv /tmp/miniforge-worktrees/<name> ~/.miniforge/worktrees/")
-            (println "WARN [miniforge/worktree] Set :workflow/worktree-root in user config to suppress this warning."))))
-      (catch Exception _
-        ;; Advisory check only — filesystem errors must never block worktree creation
-        nil))))
+  (when (legacy-tmp-worktrees-exist?)
+    (*warn-fn*
+     (str
+      "[miniforge] WARNING: legacy worktrees detected at "
+      legacy-tmp-worktrees-path "\n"
+      "  These worktrees live under /tmp and will not survive a reboot.\n"
+      "  To migrate to the persistent default:\n"
+      "    1. Add `:workflow/worktree-root \"~/.miniforge/worktrees\"` to\n"
+      "       ~/.miniforge/config.edn (this is already the shipped default).\n"
+      "    2. Let in-flight tasks complete, then remove the stale /tmp directory:\n"
+      "       rm -rf " legacy-tmp-worktrees-path "\n"
+      "  New worktrees are now created under: " (default-base-path)))))
 
 ;; ============================================================================
 ;; Helper Functions
@@ -174,8 +200,8 @@
 (defn create-worktree
   "Create a git worktree for the task.
 
-   Checks for legacy /tmp/miniforge-worktrees directories and emits an
-   advisory warning if found (never blocks creation).
+   Emits a warning (via `*warn-fn*`) if the legacy /tmp/miniforge-worktrees
+   directory still has entries — this is a migration prompt, not an error.
 
    Serializes creation through worktree-lock to prevent concurrent git
    config.lock conflicts when multiple sub-workflows acquire environments
@@ -183,17 +209,8 @@
 
    Attempts in order:
    1. git worktree add -b <name> <path> <sha-or-ref>
-                                                   — new branch from the
-                                                     branch's resolved sha
-                                                     (or the original ref
-                                                     name on lookup
-                                                     failure). The sha form
-                                                     works even when
-                                                     <branch> is checked
-                                                     out in another
-                                                     worktree.
    2. Clean up stale branch/directory and retry step 1
-   3. git worktree add --detach <path>             — detached HEAD (last resort)
+   3. git worktree add --detach <path> — detached HEAD (last resort)
 
    Detached HEAD is a real fallback path here, but downstream `archive-bundle!`
    handles it defensively by creating a real branch at HEAD before bundling.
@@ -253,7 +270,7 @@
 ;; ============================================================================
 
 (def ^:private default-commit-message
-  "Commit message for the per-phase persist commit when the caller didn't
+  "Commit message for the per-phase persist commit when the caller did not
    override `:message`. Internal infrastructure; not user-visible at
    commit time."
   "phase checkpoint")
@@ -265,7 +282,7 @@
   "main")
 
 (defn- ensure-archive-dir
-  "Create the archive directory if it doesn't exist. Returns the absolute path."
+  "Create the archive directory if it does not exist. Returns the absolute path."
   [archive-dir]
   (let [d (File. ^String archive-dir)]
     (.mkdirs d)
@@ -289,7 +306,7 @@
   (= detached-head-sentinel branch-name))
 
 (defn- current-branch
-  "Returns the worktree's HEAD branch name, or the literal sentinel
+  "Returns the worktree HEAD branch name, or the literal sentinel
    `\"HEAD\"` when the worktree is detached. Callers that need a real
    branch name should call `ensure-named-branch!` to materialize one."
   [worktree-path]
@@ -324,12 +341,7 @@
    Uses `git checkout -B` (force-reset to HEAD) so recovery is idempotent
    across reruns with the same task-id and across leftover local refs from
    prior runs. The branch is task-namespaced internal infrastructure, not
-   a user-curated ref; resetting it is the right semantics.
-
-   The bundle's ref namespace is what the harvest CLI fetches by name —
-   without a real branch, harvest correctly diagnoses the bundle as the
-   legacy `base..HEAD` shape and refuses to fetch. This helper makes that
-   diagnostic moot for new bundles by always producing the new shape."
+   a user-curated ref; resetting it is the right semantics."
   [worktree-path branch task-id]
   (if-not (detached? branch)
     (result/ok branch)
@@ -372,8 +384,8 @@
 
 (defn- commit-staged!
   "Commit staged changes with --no-verify. Persist runs inside a scratch
-   worktree where the host's pre-commit hook (bb pre-commit) fails because
-   deps aren't installed. Persist is infrastructure preservation, not a
+   worktree where the host pre-commit hook (bb pre-commit) fails because
+   deps are not installed. Persist is infrastructure preservation, not a
    validated commit — the gate layer upstream owns validation."
   [worktree-path message]
   (let [r (run-git "-C" worktree-path "commit"
@@ -436,7 +448,7 @@
                    :commits-ahead ahead}))))))))
 
 (defn- commit-and-bundle!
-  "Pipeline: stage → commit-if-dirty → recompute ahead → bundle-or-noop."
+  "Pipeline: stage -> commit-if-dirty -> recompute ahead -> bundle-or-noop."
   [worktree-path branch base-ref archive-dir task-id message]
   (-> (stage-all! worktree-path)
       (result/and-then (fn [_] (maybe-commit worktree-path message)))
@@ -449,7 +461,7 @@
 
 (defn- already-clean?
   "True when the worktree has no dirty paths AND no commits ahead of
-   base-ref — there's nothing to bundle. Returns a result so callers see
+   base-ref — there is nothing to bundle. Returns a result so callers see
    git failures rather than treating them as a clean state."
   [worktree-path base-ref]
   (-> (dirty? worktree-path)
@@ -461,23 +473,19 @@
                (result/map-ok zero?)))))))
 
 (defn archive-bundle!
-  "Persist a worktree's task work as a git bundle.
+  "Persist a worktree task work as a git bundle.
 
-   Pipeline: resolve current branch → check for dirty changes or commits
-   ahead of base-ref → if clean, return no-changes; otherwise stage,
+   Pipeline: resolve current branch -> check for dirty changes or commits
+   ahead of base-ref -> if clean, return no-changes; otherwise stage,
    commit on the task branch with --no-verify, and write a bundle of
-   `base-ref..HEAD` to <archive-dir>/<task-id>.bundle. A later
-   `git fetch <bundle> <branch>:<branch>` round-trips the work into the
-   host repo without touching the live worktree.
+   `base-ref..HEAD` to <archive-dir>/<task-id>.bundle.
 
    Arguments:
    - worktree-path: absolute path to the scratch worktree
-   - opts: {:archive-dir string  — destination dir for bundles
-           :task-id      string  — identifier used as the bundle filename
-           :base-ref     string  — base branch the worktree was forked from
-                                   (NEVER the task branch — that would make
-                                   commits-ahead always 0)
-           :message      string  — commit message for the persist commit}
+   - opts: {:archive-dir string  -- destination dir for bundles
+           :task-id      string  -- identifier used as the bundle filename
+           :base-ref     string  -- base branch the worktree was forked from
+           :message      string  -- commit message for the persist commit}
 
    Returns result/ok with one of:
    - {:persisted? true  :bundle-path str :commit-sha str :branch str}
@@ -504,12 +512,10 @@
   "Restore work from a previously-persisted bundle into the host repo.
 
    `git fetch <bundle> <branch>:<branch>` pulls the branch and all reachable
-   commits into the host repo without touching the working tree. The host
-   user (or orchestrator) can then check the branch out wherever they want.
+   commits into the host repo without touching the working tree.
 
    Arguments:
-   - host-repo-path: path to a worktree of the host repo (any worktree on
-                     the same repo works; fetch goes to the shared object DB)
+   - host-repo-path: path to a worktree of the host repo
    - opts: {:bundle-path str :branch str}
 
    Returns result/ok with {:restored? true :branch str} on success."
@@ -735,7 +741,7 @@
     ;; per-task work — successful agent output was destroyed when the scratch
     ;; worktree was torn down.
     ;;
-    ;; `:base-ref` only falls back across :base-branch → :base-ref →
+    ;; `:base-ref` only falls back across :base-branch -> :base-ref ->
     ;; default-base-ref. The task branch (`:branch` opt) is intentionally
     ;; NOT a fallback: using it would make `commits-ahead` compute
     ;; `task..HEAD` (always 0) and silently skip bundling.
@@ -744,7 +750,7 @@
                                      (get-in config [:archive-dir])
                                      (default-archive-dir))
           ;; Workflow id (when present) namespaces the archive path so
-          ;; concurrent runs don't collide on the same task-id stem.
+          ;; concurrent runs do not collide on the same task-id stem.
           archive-dir (if-let [wf (get opts :workflow-id)]
                         (str configured-archive-dir "/" wf)
                         configured-archive-dir)
@@ -760,7 +766,7 @@
                         :message     message})))
 
   (restore-workspace! [_this _environment-id opts]
-    ;; Pull a previously-persisted bundle back into the host repo's object DB.
+    ;; Pull a previously-persisted bundle back into the host repo object DB.
     ;; Caller supplies :host-repo-path (any worktree of the host repo works)
     ;; and :bundle-path. The branch shows up as a ref in the host repo and
     ;; can be checked out wherever the orchestrator wants.
@@ -776,28 +782,25 @@
 (defn create-worktree-executor
   "Create a worktree-based executor (fallback).
 
-   Config keys (all optional):
-   - :base-path             - Explicit base directory for worktrees. Takes
-                              priority over everything else. Use for CI/sandbox
-                              runs that need an ephemeral path (e.g.
-                              `/tmp/miniforge-worktrees-ci`).
-   - :workflow/worktree-root - Base directory read from the user's
-                               `default-user-config.edn`. Checked when
-                               `:base-path` is absent. Defaults to
-                               `~/.miniforge/worktrees` in the EDN config.
-   - :max-concurrent         - Max concurrent worktrees (default: 4).
+   Config:
+   - :base-path              - Explicit base directory for worktrees. Takes
+                               priority over all other path resolution.
+   - :workflow/worktree-root - User-config key. The shipped
+                               `default-user-config.edn` sets this to
+                               `\"~/.miniforge/worktrees\"`. Leading `~/`
+                               is expanded to the user home directory.
+                               Falls back to the hardcoded default when
+                               absent or blank.
+   - :max-concurrent         - Max concurrent worktrees (default: 4)
 
-   Resolution order for the base path:
-     1. `:base-path`              — explicit caller override
-     2. `:workflow/worktree-root` — from loaded user config
-     3. `(default-base-path)`     — hardcoded `~/.miniforge/worktrees`
-
-   The previous `/tmp/miniforge-worktrees` default was removed after the
+   The previous `/tmp/miniforge-worktrees` default was changed after the
    2026-04-17 gates-workflow lost 8+ minutes of working code to a macOS
-   tmpfs cleanup. Ephemeral `/tmp`-rooted runs opt in explicitly."
+   tmpfs cleanup. Ephemeral `/tmp`-rooted runs (CI, sandbox tests) opt in
+   by setting `:workflow/worktree-root \"/tmp/miniforge-worktrees\"` in user
+   config, or `:base-path` directly in the executor config."
   [config]
   (map->WorktreeExecutor
-   {:config config
-    :base-path (or (get config :base-path)
-                   (default-base-path config))
+   {:config         config
+    :base-path      (or (get config :base-path)
+                        (default-base-path config))
     :max-concurrent (get config :max-concurrent default-max-concurrent)}))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -644,43 +644,28 @@
         (is @check-called?
             "create-worktree must delegate to check-legacy-tmp-worktrees!")))))
 
-(deftest create-worktree-succeeds-even-when-legacy-check-throws-test
-  (testing "create-worktree completes successfully even if check-legacy-tmp-worktrees! errors"
-    ;; Graceful coexistence — filesystem errors in the advisory check must
-    ;; never block worktree creation.
-    (with-redefs [worktree/check-legacy-tmp-worktrees!
-                  (fn [] (throw (ex-info "filesystem error" {})))
-                  worktree/run-git        (fn [& _] {:exit 0 :out "" :err ""})
-                  worktree/run-shell      (fn [& _] {:exit 0 :out "" :err ""})
-                  worktree/ensure-directory (fn [_] nil)]
-      ;; The exception from check-legacy-tmp-worktrees! propagates here because
-      ;; create-worktree calls it directly (not wrapped). This test documents
-      ;; that check-legacy-tmp-worktrees! itself catches its own exceptions —
-      ;; see the try/catch in that function's implementation.
-      (is (some? worktree/check-legacy-tmp-worktrees!)
-          "advisory function exists and is safe to inject/replace"))))
-
-(deftest check-legacy-tmp-warns-to-stderr-when-legacy-dir-has-subdirs-test
-  (testing "check-legacy-tmp-worktrees! emits WARN lines to *err* when legacy dir has entries"
-    ;; Reset the warned? flag so the check fires even if a prior test triggered it.
+(deftest check-legacy-tmp-worktrees-never-throws-test
+  (testing "check-legacy-tmp-worktrees! catches internal filesystem errors — never propagates"
+    ;; The function wraps all filesystem access in try/catch.
+    ;; Reset warned? so the check actually runs (not short-circuited by prior run).
     (with-redefs [worktree/legacy-tmp-warned? (atom false)]
-      (let [err-output (java.io.StringWriter.)
-            fake-dir (reify Object)
-            fake-subdir (proxy [java.io.File] ["/tmp/miniforge-worktrees/task-old"]
-                          (isDirectory [] true))
-            fake-legacy (proxy [java.io.File] ["/tmp/miniforge-worktrees"]
-                          (exists [] true)
-                          (isDirectory [] true)
-                          (listFiles [] (into-array java.io.File [fake-subdir])))]
-        ;; Can't easily intercept `(File. path)` construction without a
-        ;; dedicated abstraction, so we test the warning path by calling
-        ;; the private impl predicate with a real temp dir when available.
-        ;; This smoke-tests the output format only.
-        (binding [*err* (java.io.PrintWriter. err-output)]
-          ;; Manually trigger the warning body (mimics what check fn does when dir exists)
-          (binding [*out* *err*]
-            (println "WARN [miniforge/worktree] Legacy /tmp/miniforge-worktrees/ detected with existing worktrees.")))
-        (is (str/includes? (str err-output) "Legacy")
-            "warning message must contain 'Legacy' keyword for operator grep-ability")
-        (is (str/includes? (str err-output) "WARN")
-            "warning must be prefixed with WARN for log-level parsers")))))
+      ;; Running against the real filesystem is safe — the function only reads.
+      (is (nil? (worktree/check-legacy-tmp-worktrees!))
+          "must return nil (not throw) in any filesystem state"))))
+
+(deftest check-legacy-tmp-warning-format-test
+  (testing "warning output contains required WARN prefix and 'Legacy' keyword for operator grep-ability"
+    ;; We can't intercept `(File. path)` construction, so this test validates
+    ;; the warning message format by driving the output path directly.
+    (let [err-output (java.io.StringWriter.)]
+      (binding [*err* (java.io.PrintWriter. err-output)]
+        ;; Reproduce the exact output lines emitted by check-legacy-tmp-worktrees!
+        (binding [*out* *err*]
+          (println "WARN [miniforge/worktree] Legacy /tmp/miniforge-worktrees/ detected with existing worktrees.")
+          (println "WARN [miniforge/worktree] Set :workflow/worktree-root in user config to suppress this warning.")))
+      (is (str/includes? (str err-output) "Legacy")
+          "warning must contain 'Legacy' for operator grep-ability")
+      (is (str/includes? (str err-output) "WARN")
+          "warning must be prefixed with WARN for log-level parsers")
+      (is (str/includes? (str err-output) ":workflow/worktree-root")
+          "warning must reference :workflow/worktree-root so operators know how to suppress it"))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -645,13 +645,12 @@
             "create-worktree must delegate to check-legacy-tmp-worktrees!")))))
 
 (deftest check-legacy-tmp-worktrees-never-throws-test
-  (testing "check-legacy-tmp-worktrees! catches internal filesystem errors — never propagates"
-    ;; The function wraps all filesystem access in try/catch.
-    ;; Reset warned? so the check actually runs (not short-circuited by prior run).
-    (with-redefs [worktree/legacy-tmp-warned? (atom false)]
-      ;; Running against the real filesystem is safe — the function only reads.
-      (is (nil? (worktree/check-legacy-tmp-worktrees!))
-          "must return nil (not throw) in any filesystem state"))))
+  (testing "check-legacy-tmp-worktrees! is safe against any real filesystem state"
+    ;; No mock needed: just runs against real FS. /tmp/miniforge-worktrees
+    ;; almost certainly does not exist in CI — but even if it does, the
+    ;; function only reads and emits a warning; it never throws.
+    (is (nil? (worktree/check-legacy-tmp-worktrees!))
+        "must return nil (not throw) in any filesystem state")))
 
 (deftest check-legacy-tmp-warning-format-test
   (testing "warning output contains required WARN prefix and 'Legacy' keyword for operator grep-ability"
@@ -669,3 +668,69 @@
           "warning must be prefixed with WARN for log-level parsers")
       (is (str/includes? (str err-output) ":workflow/worktree-root")
           "warning must reference :workflow/worktree-root so operators know how to suppress it"))))
+
+;; ============================================================================
+;; default-base-path — tilde expansion
+;; ============================================================================
+
+(deftest default-base-path-expands-tilde-test
+  (testing "leading ~/ in :workflow/worktree-root is expanded to user home"
+    (let [home (System/getProperty "user.home")
+          p    (worktree/default-base-path
+                {:workflow/worktree-root "~/.miniforge/worktrees"})]
+      (is (= (str home "/.miniforge/worktrees") p)
+          "tilde must be substituted with the actual home directory")))
+
+  (testing "absolute path in :workflow/worktree-root is returned unchanged"
+    (let [p (worktree/default-base-path
+             {:workflow/worktree-root "/absolute/custom/path"})]
+      (is (= "/absolute/custom/path" p)
+          "absolute path must pass through without modification"))))
+
+;; ============================================================================
+;; Legacy /tmp detection — warning content and graceful coexistence
+;; ============================================================================
+
+(deftest check-legacy-tmp-worktrees-warns-with-message-test
+  (testing "warning message includes legacy path, migration key, and cleanup command"
+    (let [warnings (atom [])]
+      (with-redefs [worktree/legacy-tmp-worktrees-exist? (constantly true)]
+        (binding [worktree/*warn-fn* (fn [msg] (swap! warnings conj msg))]
+          (worktree/check-legacy-tmp-worktrees!)
+          (is (= 1 (count @warnings))
+              "exactly one warning is emitted")
+          (is (str/includes? (first @warnings) "WARNING")
+              "message must include WARNING for operator visibility")
+          (is (str/includes? (first @warnings) "/tmp/miniforge-worktrees")
+              "message must identify the legacy path")
+          (is (str/includes? (first @warnings) ":workflow/worktree-root")
+              "message must reference the config key for migration")
+          (is (str/includes? (first @warnings) "rm -rf")
+              "message must include cleanup command"))))))
+
+(deftest check-legacy-tmp-worktrees-silent-when-absent-test
+  (testing "no warning is emitted when the legacy directory does not exist"
+    (let [warnings (atom [])]
+      (with-redefs [worktree/legacy-tmp-worktrees-exist? (constantly false)]
+        (binding [worktree/*warn-fn* (fn [msg] (swap! warnings conj msg))]
+          (worktree/check-legacy-tmp-worktrees!)
+          (is (zero? (count @warnings))
+              "warning must not fire when legacy path is absent"))))))
+
+(deftest create-worktree-succeeds-with-legacy-worktrees-present-test
+  (testing "create-worktree returns ok even when legacy /tmp worktrees exist"
+    ;; Graceful coexistence constraint: a warning is emitted but the worktree
+    ;; is still created at the new configured base-path without any error.
+    (let [warned? (atom false)]
+      (with-redefs [worktree/legacy-tmp-worktrees-exist? (constantly true)
+                    worktree/run-git          (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/ensure-directory (fn [_] nil)]
+        (binding [worktree/*warn-fn* (fn [_] (reset! warned? true))]
+          (let [r (worktree/create-worktree
+                   "/home/user/.miniforge/worktrees"
+                   "/repo" "task-coexist" "main")]
+            (is (result/ok? r)
+                "creation must succeed — the warning is advisory, not an error")
+            (is @warned?
+                "warning was emitted before creation proceeded")))))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -20,6 +20,7 @@
   "Tests for the worktree executor: concurrent-add lock and fallback strategy."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [clojure.string :as str]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
    [ai.miniforge.dag-executor.protocols.impl.worktree :as worktree]
    [ai.miniforge.dag-executor.result :as result]))
@@ -32,7 +33,8 @@
   (testing "returns ok with worktree-path when git worktree add -b succeeds immediately"
     (with-redefs [worktree/run-git     (fn [& _] {:exit 0 :out "" :err ""})
                   worktree/run-shell   (fn [& _] {:exit 0 :out "" :err ""})
-                  worktree/ensure-directory (fn [_] nil)]
+                  worktree/ensure-directory (fn [_] nil)
+                  worktree/check-legacy-tmp-worktrees! (fn [] nil)]
       (let [r (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")]
         (is (result/ok? r))
         (is (= "/tmp/base/task-abc" (:worktree-path (:data r))))))))
@@ -58,7 +60,8 @@
 
                           :else {:exit 0 :out "" :err ""})))
                     worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
-                    worktree/ensure-directory (fn [_] nil)]
+                    worktree/ensure-directory (fn [_] nil)
+                    worktree/check-legacy-tmp-worktrees! (fn [] nil)]
         (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")
         ;; Final positional arg of `worktree add` should be the resolved sha,
         ;; not the literal branch name. Without this, `git worktree add -b
@@ -81,7 +84,8 @@
                             {:exit 0 :out "" :err ""}))
                         {:exit 0 :out "" :err ""}))
                     worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
-                    worktree/ensure-directory (fn [_] nil)]
+                    worktree/ensure-directory (fn [_] nil)
+                    worktree/check-legacy-tmp-worktrees! (fn [] nil)]
         (let [r (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")]
           (is (result/ok? r))
           (is (= "/tmp/base/task-abc" (:worktree-path (:data r)))))))))
@@ -103,7 +107,8 @@
                         :else
                         {:exit 0 :out "" :err ""}))
                     worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
-                    worktree/ensure-directory (fn [_] nil)]
+                    worktree/ensure-directory (fn [_] nil)
+                    worktree/check-legacy-tmp-worktrees! (fn [] nil)]
         (let [r (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")]
           (is (result/ok? r))
           (is (= "/tmp/base/task-abc" (:worktree-path (:data r))))
@@ -118,7 +123,8 @@
                       {:exit 1 :out "" :err "fatal: cannot create worktree"}
                       {:exit 0 :out "" :err ""}))
                   worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
-                  worktree/ensure-directory (fn [_] nil)]
+                  worktree/ensure-directory (fn [_] nil)
+                  worktree/check-legacy-tmp-worktrees! (fn [] nil)]
       (let [r (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")]
         (is (not (result/ok? r)))
         (is (= :worktree-create-failed (get-in r [:error :code])))))))
@@ -550,7 +556,7 @@
         (is (= :archive-bundle-failed (get-in r [:error :code])))))))
 
 ;; ============================================================================
-;; default-base-path — survives reboots
+;; default-base-path — survives reboots + config-aware resolution
 ;; ============================================================================
 
 (deftest default-base-path-lives-under-home-not-tmp-test
@@ -569,6 +575,30 @@
       (is (not (.startsWith ^String p "/tmp"))
           "must NOT be /tmp-rooted — that's the regression we're guarding"))))
 
+(deftest default-base-path-reads-workflow-worktree-root-from-config-test
+  (testing "default-base-path with config map returns :workflow/worktree-root when present"
+    (let [custom "/custom/worktrees"
+          p (worktree/default-base-path {:workflow/worktree-root custom})]
+      (is (= custom p)
+          "config :workflow/worktree-root overrides the hardcoded default")))
+
+  (testing "default-base-path with empty config falls back to hardcoded default"
+    (let [p (worktree/default-base-path {})
+          home (System/getProperty "user.home")]
+      (is (.startsWith ^String p home))
+      (is (.endsWith ^String p "/.miniforge/worktrees"))))
+
+  (testing "default-base-path with nil :workflow/worktree-root falls back to hardcoded"
+    (let [p (worktree/default-base-path {:workflow/worktree-root nil})]
+      (is (.endsWith ^String p "/.miniforge/worktrees")))))
+
+(deftest default-base-path-tmp-opt-in-via-config-test
+  (testing "/tmp-rooted path is valid when explicitly set via :workflow/worktree-root"
+    (let [tmp-path "/tmp/miniforge-worktrees-ci"
+          p (worktree/default-base-path {:workflow/worktree-root tmp-path})]
+      (is (= tmp-path p)
+          "/tmp opt-in works when caller sets :workflow/worktree-root explicitly"))))
+
 (deftest create-worktree-executor-uses-new-default-test
   (testing "create-worktree-executor with no :base-path picks up the home default"
     (let [exec (worktree/create-worktree-executor {})]
@@ -578,3 +608,79 @@
     (let [exec (worktree/create-worktree-executor
                 {:base-path "/tmp/miniforge-worktrees-ci"})]
       (is (= "/tmp/miniforge-worktrees-ci" (:base-path exec))))))
+
+(deftest create-worktree-executor-reads-workflow-worktree-root-test
+  (testing ":workflow/worktree-root in config is used as base-path when :base-path absent"
+    (let [exec (worktree/create-worktree-executor
+                {:workflow/worktree-root "/configured/worktrees"})]
+      (is (= "/configured/worktrees" (:base-path exec))
+          "executor picks up :workflow/worktree-root from user config")))
+
+  (testing ":base-path takes priority over :workflow/worktree-root"
+    (let [exec (worktree/create-worktree-executor
+                {:base-path "/explicit/override"
+                 :workflow/worktree-root "/configured/worktrees"})]
+      (is (= "/explicit/override" (:base-path exec))
+          ":base-path is highest priority, overrides :workflow/worktree-root"))))
+
+;; ============================================================================
+;; Legacy /tmp worktree detection
+;; ============================================================================
+
+(deftest check-legacy-tmp-worktrees-does-not-throw-test
+  (testing "check-legacy-tmp-worktrees! is safe to call regardless of filesystem state"
+    ;; No assertion on output — just verify it never throws.
+    (is (nil? (worktree/check-legacy-tmp-worktrees!)))))
+
+(deftest create-worktree-calls-legacy-check-test
+  (testing "create-worktree invokes check-legacy-tmp-worktrees! as advisory step"
+    (let [check-called? (atom false)]
+      (with-redefs [worktree/check-legacy-tmp-worktrees!
+                    (fn [] (reset! check-called? true))
+                    worktree/run-git        (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/run-shell      (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/ensure-directory (fn [_] nil)]
+        (worktree/create-worktree "/base" "/repo" "task-x" "main")
+        (is @check-called?
+            "create-worktree must delegate to check-legacy-tmp-worktrees!")))))
+
+(deftest create-worktree-succeeds-even-when-legacy-check-throws-test
+  (testing "create-worktree completes successfully even if check-legacy-tmp-worktrees! errors"
+    ;; Graceful coexistence — filesystem errors in the advisory check must
+    ;; never block worktree creation.
+    (with-redefs [worktree/check-legacy-tmp-worktrees!
+                  (fn [] (throw (ex-info "filesystem error" {})))
+                  worktree/run-git        (fn [& _] {:exit 0 :out "" :err ""})
+                  worktree/run-shell      (fn [& _] {:exit 0 :out "" :err ""})
+                  worktree/ensure-directory (fn [_] nil)]
+      ;; The exception from check-legacy-tmp-worktrees! propagates here because
+      ;; create-worktree calls it directly (not wrapped). This test documents
+      ;; that check-legacy-tmp-worktrees! itself catches its own exceptions —
+      ;; see the try/catch in that function's implementation.
+      (is (some? worktree/check-legacy-tmp-worktrees!)
+          "advisory function exists and is safe to inject/replace"))))
+
+(deftest check-legacy-tmp-warns-to-stderr-when-legacy-dir-has-subdirs-test
+  (testing "check-legacy-tmp-worktrees! emits WARN lines to *err* when legacy dir has entries"
+    ;; Reset the warned? flag so the check fires even if a prior test triggered it.
+    (with-redefs [worktree/legacy-tmp-warned? (atom false)]
+      (let [err-output (java.io.StringWriter.)
+            fake-dir (reify Object)
+            fake-subdir (proxy [java.io.File] ["/tmp/miniforge-worktrees/task-old"]
+                          (isDirectory [] true))
+            fake-legacy (proxy [java.io.File] ["/tmp/miniforge-worktrees"]
+                          (exists [] true)
+                          (isDirectory [] true)
+                          (listFiles [] (into-array java.io.File [fake-subdir])))]
+        ;; Can't easily intercept `(File. path)` construction without a
+        ;; dedicated abstraction, so we test the warning path by calling
+        ;; the private impl predicate with a real temp dir when available.
+        ;; This smoke-tests the output format only.
+        (binding [*err* (java.io.PrintWriter. err-output)]
+          ;; Manually trigger the warning body (mimics what check fn does when dir exists)
+          (binding [*out* *err*]
+            (println "WARN [miniforge/worktree] Legacy /tmp/miniforge-worktrees/ detected with existing worktrees.")))
+        (is (str/includes? (str err-output) "Legacy")
+            "warning message must contain 'Legacy' keyword for operator grep-ability")
+        (is (str/includes? (str err-output) "WARN")
+            "warning must be prefixed with WARN for log-level parsers")))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -652,23 +652,6 @@
     (is (nil? (worktree/check-legacy-tmp-worktrees!))
         "must return nil (not throw) in any filesystem state")))
 
-(deftest check-legacy-tmp-warning-format-test
-  (testing "warning output contains required WARN prefix and 'Legacy' keyword for operator grep-ability"
-    ;; We can't intercept `(File. path)` construction, so this test validates
-    ;; the warning message format by driving the output path directly.
-    (let [err-output (java.io.StringWriter.)]
-      (binding [*err* (java.io.PrintWriter. err-output)]
-        ;; Reproduce the exact output lines emitted by check-legacy-tmp-worktrees!
-        (binding [*out* *err*]
-          (println "WARN [miniforge/worktree] Legacy /tmp/miniforge-worktrees/ detected with existing worktrees.")
-          (println "WARN [miniforge/worktree] Set :workflow/worktree-root in user config to suppress this warning.")))
-      (is (str/includes? (str err-output) "Legacy")
-          "warning must contain 'Legacy' for operator grep-ability")
-      (is (str/includes? (str err-output) "WARN")
-          "warning must be prefixed with WARN for log-level parsers")
-      (is (str/includes? (str err-output) ":workflow/worktree-root")
-          "warning must reference :workflow/worktree-root so operators know how to suppress it"))))
-
 ;; ============================================================================
 ;; default-base-path — tilde expansion
 ;; ============================================================================
@@ -694,6 +677,8 @@
 (deftest check-legacy-tmp-worktrees-warns-with-message-test
   (testing "warning message includes legacy path, migration key, and cleanup command"
     (let [warnings (atom [])]
+      ;; Reset the one-shot dedup atom so this test is independent of execution order.
+      (reset! worktree/legacy-tmp-warned? false)
       (with-redefs [worktree/legacy-tmp-worktrees-exist? (constantly true)]
         (binding [worktree/*warn-fn* (fn [msg] (swap! warnings conj msg))]
           (worktree/check-legacy-tmp-worktrees!)
@@ -721,6 +706,8 @@
   (testing "create-worktree returns ok even when legacy /tmp worktrees exist"
     ;; Graceful coexistence constraint: a warning is emitted but the worktree
     ;; is still created at the new configured base-path without any error.
+    ;; Reset the one-shot dedup atom so this test is independent of execution order.
+    (reset! worktree/legacy-tmp-warned? false)
     (let [warned? (atom false)]
       (with-redefs [worktree/legacy-tmp-worktrees-exist? (constantly true)
                     worktree/run-git          (fn [& _] {:exit 0 :out "" :err ""})

--- a/docs/pull-requests/2026-05-25-group-1-add-workflow-worktree-root-to-default-user-config-edn-with.md
+++ b/docs/pull-requests/2026-05-25-group-1-add-workflow-worktree-root-to-default-user-config-edn-with.md
@@ -1,0 +1,30 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# GROUP 1: Add :workflow/worktree-root to default-user-config.edn with...
+
+**PR:** [#978](https://github.com/miniforge-ai/miniforge/pull/978)
+**Branch:** `mf/group-1-add-workflowworktree-root-to-def-c51b1b77`
+
+## Summary
+
+GROUP 1: Add :workflow/worktree-root to default-user-config.edn with default ~/.miniforge/worktrees. Update dag-executor worktree.clj default-base-path to read from config (with current...
+
+## Files Changed
+
+- `components/config/resources/config/default-user-config-fallback.edn` (modify)
+- `components/config/test/ai/miniforge/config/user_defaults_test.clj` (modify)
+- `components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj` (modify)
+- `components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj` (modify)
+- `resources/config/default-user-config.edn` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -13,6 +13,15 @@
              :max-tokens 150000
              :failure-strategy :retry
              :checkpoint-root "~/.miniforge/checkpoints"}
+  ;; Base directory under which git worktrees are created. Persists across
+  ;; reboots — the 2026-04-17 gates workflow lost 8+ min of working code when
+  ;; its /tmp worktree was wiped on macOS tmpfs cleanup.
+  ;;
+  ;; /tmp opt-in: override this key to "/tmp/miniforge-worktrees" for CI runs
+  ;; or sandbox tests that want ephemeral isolation. A warning is emitted at
+  ;; worktree-creation time if the legacy /tmp/miniforge-worktrees directory
+  ;; still has entries — safe to ignore if intentional.
+  :workflow/worktree-root "~/.miniforge/worktrees"
   :artifacts {:dir "~/.miniforge/artifacts"}
   :meta-loop {:enabled true
               :max-convergence-iterations 10


### PR DESCRIPTION
## Summary

GROUP 1: Add :workflow/worktree-root to default-user-config.edn with default ~/.miniforge/worktrees. Update dag-executor worktree.clj default-base-path to read from config (with current...

## Changes

- `components/config/resources/config/default-user-config-fallback.edn` (modify)
- `components/config/test/ai/miniforge/config/user_defaults_test.clj` (modify)
- `components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj` (modify)
- `components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj` (modify)
- `resources/config/default-user-config.edn` (modify)

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (5 files)