### PR TITLE
fix(observe): wire single-PR release→observe handoff so PRs self-monitor

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -738,6 +738,11 @@
    Returns DAG result with :prs vector of PR info maps."
   poller/poll-open-prs)
 
+(def current-github-login
+  "Resolve the authenticated GitHub login (default :self-author for PR
+   monitoring), or nil. See `pr-poller/current-github-login`."
+  poller/current-github-login)
+
 (def fetch-pr-comments
   "Fetch all comments for a PR (review + issue comments).
    Returns DAG result with :comments vector."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/pr_poller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/pr_poller.clj
@@ -180,6 +180,18 @@
           (dag/err :json-parse-error (.getMessage e))))
       result)))
 
+(defn current-github-login
+  "Resolve the authenticated GitHub login via `gh api user --jq .login`.
+
+   Used as the default `:self-author` for PR monitoring so the monitor loop
+   can find PRs this instance authored when no self-author is configured.
+   Returns the login string, or nil when gh is unauthenticated/unavailable."
+  [worktree-path]
+  (let [result (run-gh ["gh" "api" "user" "--jq" ".login"] worktree-path)]
+    (when (dag/ok? result)
+      (let [login (str/trim (:output (:data result) ""))]
+        (when (seq login) login)))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Comment fetching
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/pr_poller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/pr_poller_test.clj
@@ -19,7 +19,19 @@
 (ns ai.miniforge.pr-lifecycle.pr-poller-test
   (:require
    [ai.miniforge.pr-lifecycle.pr-poller :as sut]
+   [ai.miniforge.dag-executor.interface :as dag]
    [clojure.test :refer [deftest is testing]]))
+
+(deftest current-github-login-test
+  (testing "returns the trimmed login on success"
+    (with-redefs [sut/run-gh (fn [_args _wt] (dag/ok {:output "  octocat\n"}))]
+      (is (= "octocat" (sut/current-github-login "/tmp/repo")))))
+  (testing "returns nil when gh errors (e.g. unauthenticated)"
+    (with-redefs [sut/run-gh (fn [_args _wt] (dag/err :gh-command-failed "not logged in"))]
+      (is (nil? (sut/current-github-login "/tmp/repo")))))
+  (testing "returns nil on blank output"
+    (with-redefs [sut/run-gh (fn [_args _wt] (dag/ok {:output "   "}))]
+      (is (nil? (sut/current-github-login "/tmp/repo"))))))
 
 (deftest parse-gh-comments-test
   (testing "normalizes review comments with file context"

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -99,7 +99,13 @@
             {:worktree-path worktree-path
              :self-author (or (get-in ctx [:execution/self-author])
                               (get-in ctx [:config :github/self-author])
-                              (:self-author shared-defaults))
+                              (:self-author shared-defaults)
+                              ;; Default to the authenticated gh login so the
+                              ;; monitor loop can find PRs this instance opened
+                              ;; when no self-author is configured. Without this,
+                              ;; poll-open-prs filters by a nil author and finds
+                              ;; nothing.
+                              (pr-lifecycle/current-github-login worktree-path))
              :generate-fn generate-fn
              :event-bus event-bus
              :logger logger}
@@ -111,6 +117,23 @@
               (get-in ctx [:config :pr-monitor/max-total-fix-attempts-per-pr])
               :abandon-after-hours
               (get-in ctx [:config :pr-monitor/abandon-after-hours])})))))
+
+(defn resolve-pr-infos
+  "Resolve the PR(s) to observe from the execution context.
+
+   DAG runs populate `[:execution/dag-pr-infos]`. For a single-PR run, the
+   release phase stores PR info at `[:execution/phase-results :release :result
+   :output :workflow/pr-info]` (with a `[:metrics :release :pr-info]`
+   fallback) — the SAME paths `dag-orchestrator/extract-pr-info-from-result`
+   reads. The prior single-PR fallback read `[:release :pr-info]` (one level
+   too shallow, wrong key), so observe always saw nil and skipped — a
+   single-PR dogfood opened its PR and exited without ever monitoring it."
+  [ctx]
+  (or (seq (get-in ctx [:execution/dag-pr-infos]))
+      (when-let [pr-info (or (get-in ctx [:execution/phase-results :release
+                                          :result :output :workflow/pr-info])
+                             (get-in ctx [:metrics :release :pr-info]))]
+        [pr-info])))
 
 (defn enter-observe
   "Execute the Observe phase.
@@ -124,10 +147,7 @@
 
    pr-lifecycle is a direct dependency of the workflow component."
   [ctx]
-  (let [pr-infos (or (get-in ctx [:execution/dag-pr-infos])
-                     ;; Single PR from release phase
-                     (when-let [pr-info (get-in ctx [:execution/phase-results :release :pr-info])]
-                       [pr-info]))
+  (let [pr-infos (resolve-pr-infos ctx)
         start-time (System/currentTimeMillis)]
 
     (if (empty? pr-infos)

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -28,7 +28,8 @@
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
             [clojure.edn :as edn]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Config loading + defaults
@@ -118,8 +119,9 @@
               :abandon-after-hours
               (get-in ctx [:config :pr-monitor/abandon-after-hours])})))))
 
-(defn resolve-pr-infos
-  "Resolve the PR(s) to observe from the execution context.
+(defn- resolve-pr-infos
+  "Resolve the PR(s) to observe from the execution context. Returns a vector
+   of pr-info maps, or nil when there is nothing to observe.
 
    DAG runs populate `[:execution/dag-pr-infos]`. For a single-PR run, the
    release phase stores PR info at `[:execution/phase-results :release :result
@@ -129,11 +131,13 @@
    too shallow, wrong key), so observe always saw nil and skipped — a
    single-PR dogfood opened its PR and exited without ever monitoring it."
   [ctx]
-  (or (seq (get-in ctx [:execution/dag-pr-infos]))
-      (when-let [pr-info (or (get-in ctx [:execution/phase-results :release
-                                          :result :output :workflow/pr-info])
-                             (get-in ctx [:metrics :release :pr-info]))]
-        [pr-info])))
+  (let [dag-prs (get-in ctx [:execution/dag-pr-infos])]
+    (cond
+      (seq dag-prs) (vec dag-prs)
+      :else (when-let [pr-info (or (get-in ctx [:execution/phase-results :release
+                                                :result :output :workflow/pr-info])
+                                   (get-in ctx [:metrics :release :pr-info]))]
+              [pr-info]))))
 
 (defn enter-observe
   "Execute the Observe phase.
@@ -163,12 +167,23 @@
             generate-fn (get-in ctx [:execution/generate-fn])
             event-bus (get-in ctx [:execution/event-bus])
             monitor-config (resolve-monitor-config ctx logger generate-fn event-bus)
-            self-author (:self-author monitor-config)
+            self-author (:self-author monitor-config)]
+       (if (str/blank? self-author)
+         ;; Without a self-author, poll-open-prs would shell `gh pr list
+         ;; --author <nil>` and the loop would retry forever. Skip with an
+         ;; explicit reason instead of spinning — surfaces as data, not a hang.
+         (-> ctx
+             (assoc-in [:phase :name] :observe)
+             (assoc-in [:phase :started-at] start-time)
+             (assoc-in [:phase :status] :completed)
+             (assoc-in [:phase :result]
+                       (response/success
+                        {:observe/status :skipped
+                         :observe/reason "No self-author resolved (gh unauthenticated?) — cannot poll PRs"})))
+         (let [monitor (pr-lifecycle/create-pr-monitor monitor-config)
+               evidence (pr-lifecycle/run-pr-monitor-loop monitor self-author)
 
-            monitor (pr-lifecycle/create-pr-monitor monitor-config)
-            evidence (pr-lifecycle/run-pr-monitor-loop monitor self-author)
-
-            result-data {:observe/status :completed
+               result-data {:observe/status :completed
                          :observe/evidence evidence
                          :observe/prs-monitored (count pr-infos)
                          :observe/duration-hours (:duration-hours evidence)
@@ -182,7 +197,7 @@
             (assoc-in [:phase :started-at] start-time)
             (assoc-in [:phase :status] :completed)
             (assoc-in [:phase :result] (response/success result-data))
-            (assoc :execution/pr-lifecycle-evidence evidence))))))
+            (assoc :execution/pr-lifecycle-evidence evidence))))))))
 
 (defn leave-observe
   "Post-processing for Observe phase. Records evidence and duration metrics."

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -27,23 +27,23 @@
 (deftest resolve-pr-infos-test
   (testing "DAG path: returns the populated dag-pr-infos"
     (is (= [sample-pr]
-           (vec (sut/resolve-pr-infos {:execution/dag-pr-infos [sample-pr]})))))
+           (vec (#'sut/resolve-pr-infos {:execution/dag-pr-infos [sample-pr]})))))
   (testing "single-PR: reads release result output :workflow/pr-info (the real release path)"
     (is (= [sample-pr]
-           (sut/resolve-pr-infos
+           (#'sut/resolve-pr-infos
             {:execution/phase-results
              {:release {:result {:output {:workflow/pr-info sample-pr}}}}}))))
   (testing "single-PR: metrics fallback path"
     (is (= [sample-pr]
-           (sut/resolve-pr-infos {:metrics {:release {:pr-info sample-pr}}}))))
+           (#'sut/resolve-pr-infos {:metrics {:release {:pr-info sample-pr}}}))))
   (testing "REGRESSION (the #979 handoff bug): the old shallow [:release :pr-info] key is NOT read"
-    (is (nil? (sut/resolve-pr-infos
+    (is (nil? (#'sut/resolve-pr-infos
                {:execution/phase-results {:release {:pr-info sample-pr}}}))))
   (testing "no PR anywhere -> nil (phase skips)"
-    (is (nil? (sut/resolve-pr-infos {}))))
+    (is (nil? (#'sut/resolve-pr-infos {}))))
   (testing "empty dag-pr-infos falls through to single-PR resolution"
     (is (= [sample-pr]
-           (sut/resolve-pr-infos
+           (#'sut/resolve-pr-infos
             {:execution/dag-pr-infos []
              :execution/phase-results
              {:release {:result {:output {:workflow/pr-info sample-pr}}}}})))))

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -21,6 +21,33 @@
    [ai.miniforge.workflow.observe-phase :as sut]
    [clojure.test :refer [deftest is testing]]))
 
+(def ^:private sample-pr
+  {:pr-number 42 :pr-url "https://github.com/o/r/pull/42" :pr-branch "mf/x"})
+
+(deftest resolve-pr-infos-test
+  (testing "DAG path: returns the populated dag-pr-infos"
+    (is (= [sample-pr]
+           (vec (sut/resolve-pr-infos {:execution/dag-pr-infos [sample-pr]})))))
+  (testing "single-PR: reads release result output :workflow/pr-info (the real release path)"
+    (is (= [sample-pr]
+           (sut/resolve-pr-infos
+            {:execution/phase-results
+             {:release {:result {:output {:workflow/pr-info sample-pr}}}}}))))
+  (testing "single-PR: metrics fallback path"
+    (is (= [sample-pr]
+           (sut/resolve-pr-infos {:metrics {:release {:pr-info sample-pr}}}))))
+  (testing "REGRESSION (the #979 handoff bug): the old shallow [:release :pr-info] key is NOT read"
+    (is (nil? (sut/resolve-pr-infos
+               {:execution/phase-results {:release {:pr-info sample-pr}}}))))
+  (testing "no PR anywhere -> nil (phase skips)"
+    (is (nil? (sut/resolve-pr-infos {}))))
+  (testing "empty dag-pr-infos falls through to single-PR resolution"
+    (is (= [sample-pr]
+           (sut/resolve-pr-infos
+            {:execution/dag-pr-infos []
+             :execution/phase-results
+             {:release {:result {:output {:workflow/pr-info sample-pr}}}}})))))
+
 (deftest default-config-loaded-from-edn-test
   (testing "observe phase defaults come from resource config"
     (is (= :default (:agent sut/default-config)))


### PR DESCRIPTION
## Summary

Closes the gap where a miniforge dogfood run **opens a PR but never monitors it** for review comments (gap b from the #979 post-mortem). The terminal `observe` phase — which drives the full `pr-lifecycle` poll→fix→reply→resolve loop — was silently skipping on single-PR runs.

**Root cause:** `enter-observe`'s single-PR fallback read `[:execution/phase-results :release :pr-info]`, but the release phase stores PR info at `[:release :result :output :workflow/pr-info]` (with a `[:metrics :release :pr-info]` fallback) — the *same* paths `dag-orchestrator/extract-pr-info-from-result` already reads on the DAG path. So observe resolved nil → `"No PRs to observe"` → the run exited without monitoring (e.g. PR #979). A secondary issue: `:self-author` had no default, and `poll-open-prs` filters by `gh pr list --author <login>`, so even once the PR was found the loop matched nothing.

**Fix:**
- Extract `resolve-pr-infos` with the corrected single-PR paths (mirrors the DAG extractor); empty `dag-pr-infos` now falls through to single-PR resolution.
- Default `:self-author` to the authenticated gh login (`pr-lifecycle/current-github-login` → `gh api user --jq .login`) when unconfigured.

This makes miniforge self-monitor the PRs it opens — including the upcoming policy-enforcement dogfood PRs.

## Test plan
- [x] `bb pre-commit` green
- [x] `resolve-pr-infos` unit tests: DAG path, single-PR `:workflow/pr-info` path, `:metrics` fallback, empty-dag fallthrough, no-PR→nil
- [x] **Regression guard**: asserts the old shallow `[:release :pr-info]` key is no longer read
- [ ] End-to-end: confirmed by the next dogfood run actually entering observe and monitoring its PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)