### PR TITLE
spec: policy-enforcement theme + policy→gate compiler & phase-wiring specs

### DIFF
--- a/work/QUEUE.md
+++ b/work/QUEUE.md
@@ -15,13 +15,15 @@ Make miniforge capable of running miniforge without paying for
 
 | tier | r | theme | spec | axes |
 |---|---|---|---|---|
-| blocker | ● | dogfood-resilience | `event-log-tool-visibility.spec.edn` — Event log — capture tool name / args / result on every agent tool call | observation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `agent-stream-watchdog-and-resume.spec.edn` — Agent stream watchdog + session-resume for hang recovery | tokenconservation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `dogfood-handoff-redirect-loop.spec.edn` — Dogfood: stop degraded handoff redirect loops | correctness+tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `planner-convergence-and-artifact-submission.spec.edn` — Planner convergence — container-promoted plan artifact + forced context-MCP usage | correctness+observation+tokenconservation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `workflow-resume-fsm-advance-investigation.spec.edn` — Workflow resume — make FSM advance from production checkpoints, not just synthetic ones | observation+tokenconservation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `workflow-resume-status-handling.spec.edn` — Workflow resume — fail loud when the resumed run never enters a terminal status | observation+tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `worktree-persistence-scratch-branch.spec.edn` — Persist worktrees outside /tmp + scratch-branch commits on every write | dogfoodenabler |
 | high | ● | dogfood-resilience | `pedestal-interceptor-chain.spec.edn` — Pedestal-style interceptor chain for phase lifecycle | correctness+dogfoodenabler |
 | high | ● | dogfood-resilience | `tech-registry-doctor-repo-scoped-bootstrap.spec.edn` — Tech-registry-driven runtime bootstrap — repo-scoped, print-don't-install | correctness+ux+dogfoodenabler |
 | high | ○ | dogfood-resilience | `workflow-dependency-declarations.spec.edn` — Workflow dependency declarations — supervisor sequencing + DAG dependencies | dogfoodenabler |
-| blocker | ○ | dogfood-resilience | `agent-stream-watchdog-and-resume.spec.edn` — Agent stream watchdog + session-resume for hang recovery | tokenconservation+dogfoodenabler |
 | blocker | ○ | dogfood-resilience | `workflow-phase-checkpoint-and-resume.spec.edn` — Workflow phase checkpoint + resume | tokenconservation+dogfoodenabler |
 
 ## Theme — Multi-backend CLI parity (`multi-backend-parity`, status: planned)
@@ -39,6 +41,26 @@ Miniforge is an agent-CLI-agnostic platform. Every supported CLI
 | tier | r | theme | spec | axes |
 |---|---|---|---|---|
 | blocker | ● | multi-backend-parity | `multi-backend-cli-parity.spec.edn` — Multi-backend CLI parity — make codex / cursor-agent / copilot / open-codex first-class planners and implementers | correctness+scale+dogfoodenabler |
+
+## Theme — Policy enforcement (applied + guaranteed) (`policy-enforcement`, status: planned)
+
+Miniforge's reason for existence: policy-as-code that is APPLIED and
+   GUARANTEED, not merely suggested. Today standards-pack rules are authored
+   and compiled but carry no executable check (most detection rules are
+   :custom with no :custom-fn), and the only pack-derived gate (:behavioral)
+   is wired solely to :observe — so a normal SDLC run never enforces them.
+   Rules reach agents as advisory prompt text; nothing fails a run for a DRY,
+   dead-code, lint, or format violation (dogfood PR #979 shipped exactly those
+   with the pack present). Close the binding seam N4-delta deferred: compile
+   pack rules into N4 §3.1 check-fns, execute the pack-derived gate set in
+   verify/review keyed off :applies-to {:phases} with :error -> block, model
+   the mechanical tool gates (lint/format) as policy capabilities, and emit
+   per-rule evidence per run.
+
+| tier | r | theme | spec | axes |
+|---|---|---|---|---|
+| blocker | ● | policy-enforcement | `policy-gate-compiler.spec.edn` — Compile policy-pack rules into executable check-fns | correctness+observation+dogfoodenabler |
+| blocker | ○ | policy-enforcement | `policy-gate-phase-wiring-and-evidence.spec.edn` — Execute pack-derived policy gates in verify/review + emit per-rule evidence | correctness+observation+tokenconservation+dogfoodenabler |
 
 ## Theme — Operational Policy Synthesis (OPSV) (`operational-policy-synthesis`, status: planned)
 
@@ -68,6 +90,18 @@ Miniforge's DAG executor exists and is wired but never fires for
 | blocker | ● | dag-orchestration | `plan-from-agent-dag-wiring.spec.edn` — plan-from-agent must emit :plan/id so the DAG orchestrator activates | observation+tokenconservation+dogfoodenabler |
 | high | ● | dag-orchestration | `per-task-base-chaining.spec.edn` — Per-Task Base Chaining for DAG Sub-Workflows | workfloworchestration+dagexecution+localmodefidelity |
 
+## Theme — Polylith compliance (`polylith-compliance`, status: in-flight)
+
+`poly check` currently reports 13 structural errors + 9 warnings.
+   Pre-commit's structural gate rejects commits because of them, which
+   blocks every dogfood run's release phase. Get to a clean workspace
+   and keep it clean by wiring the gate into CI and workflow-dep
+   ordering.
+
+| tier | r | theme | spec | axes |
+|---|---|---|---|---|
+| high | ● | polylith-compliance | `tui-phase-loader-classpath.spec.edn` — Fix miniforge-tui phase loader classpath drift | correctness+dogfoodenabler |
+
 ## Theme — unassigned (`unassigned`, status: planned)
 
 (no theme description)
@@ -87,6 +121,7 @@ Miniforge's DAG executor exists and is wired but never fires for
 | medium | ● | unassigned | `gitlab-support-tasks.spec.edn` — GitLab Support — Detailed Implementation Tasks | - |
 | medium | ● | unassigned | `gitlab-support.spec.edn` — Add GitLab Support for MR Lifecycle Management | - |
 | medium | ● | unassigned | `knowledge-mcp-query.spec.edn` — Agent-driven rule query via lookup_policy MCP tool | - |
+| medium | ● | unassigned | `meta-agent-repair-loop-intervention.spec.edn` — Meta-agent intervention on repair-loop temporal stagnation | - |
 | medium | ● | unassigned | `migrate-runner-println-to-structured-logging.spec.edn` — Migrate workflow runner println calls to structured logging | - |
 | medium | ● | unassigned | `n04-knowledge-safety-pack.spec.edn` — N4: Knowledge-safety policy pack with prompt-injection detection | - |
 | medium | ● | unassigned | `n04-kubernetes-diff-parsing.spec.edn` — N4: Kubernetes manifest diff parsing for policy gate evaluation | - |

--- a/work/policy-gate-compiler.spec.edn
+++ b/work/policy-gate-compiler.spec.edn
@@ -1,0 +1,96 @@
+;; =============================================================================
+;; Spec: Compile policy-pack rules into executable check-fns
+;; =============================================================================
+;;
+;; Why this exists (dogfood evidence, 2026-05-25, PR #979):
+;;   Miniforge's thesis is policy-as-code that is APPLIED and GUARANTEED.
+;;   N4-policy-packs.md §3 mandates every rule provide a check-fn and §2.3.1
+;;   mandates :error severity blocks phase completion. But N4-delta deferred
+;;   the executable realization, and it was never built: in the compiled
+;;   standards pack (components/phase/resources/packs/miniforge-standards.pack.edn)
+;;   the large majority of detection rules are {:type :custom} with NO
+;;   :custom-fn symbol, so policy-pack/detection `detect-custom` returns nil →
+;;   the rule can never produce a violation. Rules reach agents only as
+;;   advisory prompt text. Result: PR #979 shipped a dead duplicate namespace,
+;;   an unwired CLI command, and a lying docstring even though DRY / dead-code
+;;   rules exist in the pack — because no rule is enforceable.
+;;
+;;   This spec builds the missing binding seam: a compiler that turns each
+;;   enabled pack rule into an N4 §3.1 check-fn. The phase wiring + per-run
+;;   evidence land in the dependent spec policy-gate-phase-wiring-and-evidence.
+
+{:spec/title "Compile policy-pack rules into executable check-fns"
+
+ :spec/description
+ "Build the rule -> enforcement binding the standards pack lacks. Every
+  enabled pack rule must resolve to an executable check-fn matching the
+  N4 §3.1 contract: (fn [artifacts context] -> {:passed? bool :violations
+  [...] :metadata {...}}). No enabled rule may silently no-op.
+
+  GROUP 1: Detection-typed rule -> check-fn compiler
+  Add a compiler in the policy-pack component that, given a compiled rule,
+  returns a check-fn dispatched on the rule's :detection :type:
+    - :content-scan / pattern rules -> deterministic content/regex check
+      over the artifact's changed files (pure, per N4 §3.1.1).
+    - mechanical/tool rules (see GROUP 2) -> bind to the named tool gate
+      capability (clj-kondo, cljfmt, reader-parse, poly-check, bb-load,
+      no-secrets) and adapt its result into the N4 violation shape.
+    - :custom / heuristic rules with no deterministic detector -> a
+      semantic check-fn backed by components/semantic-analyzer
+      (LLM-as-judge), classified :heuristic per N4-delta's enforceability
+      classes (NOT subject to the §3.1.1 pure/deterministic clause).
+  Back-fill or auto-derive so that every ENABLED rule produces a non-nil
+  check-fn. A rule that cannot be bound to any mechanism MUST be reported
+  at compile time (fail loud), not silently dropped.
+
+  GROUP 2: Mechanical tool gates as policy capabilities
+  The existing tool gates (loop/gates.clj clj-kondo lint, reader syntax,
+  no-secrets; gate/format.clj cljfmt; poly check; the graalvm/bb-load
+  gate) are real but hardcoded standalone and NOT discoverable as policy.
+  Introduce a capability registry that names each mechanical check and the
+  tool it invokes, so a pack rule can declare `:detection {:type :capability
+  :capability :lint}` (etc.) and the GROUP 1 compiler binds it to that
+  tool. Model lint AND format as first-class policy capabilities so they
+  are governed pipeline policy, not bb tasks beside it. Replace the
+  ad-hoc :custom-fn stubs for mechanical rules with capability bindings.
+
+  Out of scope (dependent spec): executing the pack-derived gate set in
+  verify/review and per-run rule-application evidence."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/policy-pack/src"
+          "components/gate/src"
+          "components/loop/src"
+          "components/semantic-analyzer/src"
+          "components/phase/resources/packs"
+          "standards/miniforge"]}
+
+ :spec/constraints
+ ["Conform to N4 §3.1: every check-fn is (fn [artifacts context] -> {:passed? :violations :metadata})"
+  "Deterministic (mechanical/content-scan) check-fns MUST be pure per N4 §3.1.1; heuristic (semantic-analyzer) checks are classified :heuristic per N4-delta and are exempt from the pure/deterministic clause"
+  "No ENABLED rule may compile to a no-op (nil/never-violates) check-fn; an unbindable enabled rule fails compilation loudly"
+  "Rule :severity is preserved end-to-end onto the produced violations (no downgrade in the compiler)"
+  "Mechanical capabilities wrap the EXISTING tool gates (clj-kondo, cljfmt, poly, bb-load, no-secrets) — do not reimplement linters"
+  "Compiler changes are additive: do not break the existing :behavioral gate / policy-pack check-artifact callers"
+  "Exceptions are data at component interfaces — the compiler returns anomalies, not throws, except at boundaries"]
+
+ :spec/acceptance-criteria
+ ["Given the compiled miniforge-standards pack, compiling its enabled rules yields a check-fn for 100% of them (zero enabled rules resolve to nil)"
+  "A unit test feeds a sample artifact with a DRY/duplication violation and the compiled rule's check-fn returns :passed? false with a violation naming the rule-id"
+  "A unit test feeds a clean artifact and the same check-fn returns :passed? true with empty :violations"
+  "A :capability :lint rule binds to clj-kondo and a lint error surfaces as an N4 violation with the rule's :severity"
+  "A :capability :format rule binds to cljfmt and an unformatted artifact yields a violation"
+  "A heuristic :custom rule with no deterministic detector binds to a semantic-analyzer check-fn that returns the N4 result shape"
+  "Compiling a pack containing an enabled rule with no bindable detection mechanism fails with a clear compile-time error naming the rule-id"
+  "Mechanical check-fns are pure: called twice on identical inputs they return equal results"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:correctness :dogfood-enabler :observation}
+  :theme :policy-enforcement
+  :rationale "The binding seam is the foundation of policy enforcement; without executable check-fns no policy can ever gate a run (PR #979 shipped pack-covered defects)."
+  :blocks ["policy-gate-phase-wiring-and-evidence.spec.edn"]
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/policy-gate-phase-wiring-and-evidence.spec.edn
+++ b/work/policy-gate-phase-wiring-and-evidence.spec.edn
@@ -1,0 +1,85 @@
+;; =============================================================================
+;; Spec: Execute pack-derived policy gates in verify/review + per-run evidence
+;; =============================================================================
+;;
+;; Depends on policy-gate-compiler.spec.edn (which makes every enabled rule
+;; resolve to an N4 §3.1 check-fn). This spec makes those checks actually
+;; RUN and BLOCK at the right phases, and proves per run which policies were
+;; applied.
+;;
+;; Why this exists (dogfood evidence, 2026-05-25, PR #979):
+;;   The one pack-derived gate (gate/behavioral.clj) is wired only into the
+;;   :observe phase via workflow/behavioral_harness.clj, gated on a
+;;   :spec/behavioral-harness flag — so a normal canonical-sdlc run NEVER
+;;   evaluates the pack. verify runs tests only; review's gates are a
+;;   hardcoded [syntax, implementation-handoff, lint, no-secrets] set, none
+;;   pack-derived. And there is no per-run evidence of which rules were
+;;   applied (project_agent_rule_visibility). So even with enforceable
+;;   check-fns, nothing enforces them on the path a PR takes.
+
+{:spec/title "Execute pack-derived policy gates in verify/review + emit per-rule evidence"
+
+ :spec/description
+ "Wire the compiled, pack-derived gate set into the SDLC phases and make
+  enforcement observable per run.
+
+  GROUP 1: Phase-scoped pack-gate execution
+  Build a pack-gate evaluator that, for a given phase, selects the enabled
+  rules whose :applies-to {:phases} includes that phase, runs their
+  compiled check-fns over the phase artifact, and aggregates violations by
+  severity. Wire it into the verify AND review phase gate sets (in addition
+  to the existing test/secrets gates), not only :observe. Enforcement per
+  N4 §2.3.1: an :error-severity violation MUST block phase completion
+  (route to the existing repair/redirect path); :warning SHOULD block
+  unless auto-repaired; :info records only. Do not regress existing passing
+  workflows when the pack yields no violations.
+
+  GROUP 2: Per-run rule-application evidence
+  Every pack-gate evaluation emits per-rule-id telemetry through
+  event-stream: which rules were considered (matched :applies-to), which
+  passed, which failed (with violation detail + severity), for each phase
+  of each workflow run. Extend the existing gate event surface
+  (emit-gate-event!) rather than inventing a parallel channel. The result
+  is that a human (and automation) can answer 'which policies gated run X,
+  and what did each decide?' — closing the rule-visibility gap.
+
+  Non-goals: authoring new rules (theme owns the standards pack); the
+  rule->check-fn compiler (dependency spec); changing severities."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/phase-software-factory/src"
+          "components/gate/src"
+          "components/policy-pack/src"
+          "components/workflow/src"
+          "components/event-stream/src"
+          "components/phase/resources/config"]}
+
+ :spec/constraints
+ ["Phase rule selection MUST honor each rule's :applies-to {:phases}; a rule not targeting the phase is not evaluated there"
+  ":error blocks phase completion per N4 §2.3.1; :warning blocks unless auto-repaired; :info is record-only"
+  "Observe-only when the pack yields no violations — existing green workflows MUST NOT regress (acceptance criterion of N4 + the watchdog precedent)"
+  "Reuse the existing gate-execution path (gate/check-gate, apply-gate-validation) and event surface (emit-gate-event!) — no parallel enforcement channel"
+  "Per-rule evidence MUST include rule-id, phase, severity, passed?/failed, and violation detail; emitted for considered AND skipped-by-phase rules so 'applied set' is reconstructable"
+  "Heuristic (semantic-analyzer) rules default to :warning unless the pack marks them :error — do not hard-block a run on a non-deterministic judge by default"
+  "Exceptions are data at interfaces; a check-fn that throws is reported as a gate error, not a silent pass (fail-safe, mirroring the reviewer fix in #977)"]
+
+ :spec/acceptance-criteria
+ ["A dogfood/integration run whose artifact violates an :error-severity pack rule (e.g. an unused/duplicate namespace) fails the verify or review phase before release — regression guard for PR #979"
+  "A clean artifact passes the pack gate set in verify and review with zero violations and the workflow proceeds (no regression)"
+  "The pack gate in verify evaluates only rules whose :applies-to {:phases} includes :verify (and likewise for :review)"
+  "An :error violation routes to the repair/redirect path (back to implement) rather than opening a PR"
+  "A :warning violation does not block when auto-repair succeeds; blocks when it does not"
+  "After a run, the event log contains a per-rule-id record (passed/failed + severity) for each rule applied in each phase"
+  "A gate whose check-fn throws is recorded as a failed gate (fail-safe), not a pass"
+  "With the pack producing no violations, an existing passing fixture workflow still reaches :done unchanged"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:correctness :dogfood-enabler :observation :token-conservation}
+  :theme :policy-enforcement
+  :rationale "Turns enforceable rules into actual guarantees on the PR path; without it the compiler's check-fns never run where it matters."
+  :blocks []
+  :blocked-by ["policy-gate-compiler.spec.edn"]}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/policy-gate-phase-wiring-and-evidence.spec.edn
+++ b/work/policy-gate-phase-wiring-and-evidence.spec.edn
@@ -26,13 +26,16 @@
   GROUP 1: Phase-scoped pack-gate execution
   Build a pack-gate evaluator that, for a given phase, selects the enabled
   rules whose :applies-to {:phases} includes that phase, runs their
-  compiled check-fns over the phase artifact, and aggregates violations by
-  severity. Wire it into the verify AND review phase gate sets (in addition
-  to the existing test/secrets gates), not only :observe. Enforcement per
-  N4 §2.3.1: an :error-severity violation MUST block phase completion
-  (route to the existing repair/redirect path); :warning SHOULD block
-  unless auto-repaired; :info records only. Do not regress existing passing
-  workflows when the pack yields no violations.
+  compiled check-fns over the phase artifact, and aggregates the resulting
+  violations by their originating rule's :rule/severity. Wire it into the
+  verify AND review phase gate sets (in addition to the existing
+  test/secrets gates), not only :observe. Enforcement keys off rule severity
+  per N4 §2.3.1 (distinct from the per-violation severity scale in N4 §3.3):
+  a violation from a rule with :rule/severity :error MUST block phase
+  completion (route to the existing repair/redirect path); :rule/severity
+  :warning SHOULD block unless auto-repaired; :info records only. When
+  evaluation yields zero violations, gating behavior MUST be identical to
+  today (no regression — existing workflows stay green).
 
   GROUP 2: Per-run rule-application evidence
   Every pack-gate evaluation emits per-rule-id telemetry through
@@ -57,19 +60,19 @@
 
  :spec/constraints
  ["Phase rule selection MUST honor each rule's :applies-to {:phases}; a rule not targeting the phase is not evaluated there"
-  ":error blocks phase completion per N4 §2.3.1; :warning blocks unless auto-repaired; :info is record-only"
-  "Observe-only when the pack yields no violations — existing green workflows MUST NOT regress (acceptance criterion of N4 + the watchdog precedent)"
+  "Enforcement keys off the originating rule's :rule/severity per N4 §2.3.1 (not the per-violation severity scale of N4 §3.3): :rule/severity :error blocks phase completion; :warning blocks unless auto-repaired; :info is record-only"
+  "When evaluation yields zero violations, gating behavior is identical to today and existing green workflows stay green (no regression — N4 + the watchdog precedent)"
   "Reuse the existing gate-execution path (gate/check-gate, apply-gate-validation) and event surface (emit-gate-event!) — no parallel enforcement channel"
   "Per-rule evidence MUST include rule-id, phase, severity, passed?/failed, and violation detail; emitted for considered AND skipped-by-phase rules so 'applied set' is reconstructable"
   "Heuristic (semantic-analyzer) rules default to :warning unless the pack marks them :error — do not hard-block a run on a non-deterministic judge by default"
   "Exceptions are data at interfaces; a check-fn that throws is reported as a gate error, not a silent pass (fail-safe, mirroring the reviewer fix in #977)"]
 
  :spec/acceptance-criteria
- ["A dogfood/integration run whose artifact violates an :error-severity pack rule (e.g. an unused/duplicate namespace) fails the verify or review phase before release — regression guard for PR #979"
+ ["A dogfood/integration run whose artifact violates a pack rule with :rule/severity :error (e.g. an unused/duplicate namespace) fails the verify or review phase before release — regression guard for PR #979"
   "A clean artifact passes the pack gate set in verify and review with zero violations and the workflow proceeds (no regression)"
   "The pack gate in verify evaluates only rules whose :applies-to {:phases} includes :verify (and likewise for :review)"
-  "An :error violation routes to the repair/redirect path (back to implement) rather than opening a PR"
-  "A :warning violation does not block when auto-repair succeeds; blocks when it does not"
+  "A violation from a :rule/severity :error rule routes to the repair/redirect path (back to implement) rather than opening a PR"
+  "A violation from a :rule/severity :warning rule does not block when auto-repair succeeds; blocks when it does not"
   "After a run, the event log contains a per-rule-id record (passed/failed + severity) for each rule applied in each phase"
   "A gate whose check-fn throws is recorded as a failed gate (fail-safe), not a pass"
   "With the pack producing no violations, an existing passing fixture workflow still reaches :done unchanged"]

--- a/work/themes.edn
+++ b/work/themes.edn
@@ -188,7 +188,7 @@
     :relation :supporting}]
   :theme/completion-criteria
   ["Every enabled pack rule resolves to an executable check-fn of shape [artifacts context] -> {:passed? :violations} per N4 §3.1 — zero enabled rules with no enforcement mechanism"
-   "verify and review execute the pack-derived gate set filtered by the rule's :applies-to {:phases}; an :error-severity violation blocks phase completion per N4 §2.3.1"
+   "verify and review execute the pack-derived gate set filtered by the rule's :applies-to {:phases}; a violation from a rule with :rule/severity :error blocks phase completion per N4 §2.3.1"
    "lint and format are modeled as policy capabilities bound to clj-kondo / cljfmt, not standalone bb tasks outside the governed pipeline"
    "a DRY / dead-code / unwired-command violation fails a dogfood run before the PR opens (regression guard for PR #979)"
    "every run emits per-rule-id applied/passed/failed evidence; a human can see which policies gated a given workflow"]

--- a/work/themes.edn
+++ b/work/themes.edn
@@ -161,4 +161,36 @@
    "A conformance test suite replays one fixture spec per backend and asserts equivalent phase outcomes"
    "Backend selection is first-class in user config and session-resume works across all supported backends"]
   :theme/status :planned
+  :theme/owner :christopher}
+
+ :policy-enforcement
+ {:theme/id :policy-enforcement
+  :theme/title "Policy enforcement (applied + guaranteed)"
+  :theme/description
+  "Miniforge's reason for existence: policy-as-code that is APPLIED and
+   GUARANTEED, not merely suggested. Today standards-pack rules are authored
+   and compiled but carry no executable check (most detection rules are
+   :custom with no :custom-fn), and the only pack-derived gate (:behavioral)
+   is wired solely to :observe — so a normal SDLC run never enforces them.
+   Rules reach agents as advisory prompt text; nothing fails a run for a DRY,
+   dead-code, lint, or format violation (dogfood PR #979 shipped exactly those
+   with the pack present). Close the binding seam N4-delta deferred: compile
+   pack rules into N4 §3.1 check-fns, execute the pack-derived gate set in
+   verify/review keyed off :applies-to {:phases} with :error -> block, model
+   the mechanical tool gates (lint/format) as policy capabilities, and emit
+   per-rule evidence per run."
+  :theme/informative-spec nil
+  :theme/normative-refs
+  [{:doc "specs/normative/N4-policy-packs.md"
+    :section "§3 Gate Execution Contract; §2.3.1 Rule Severity Levels"
+    :relation :primary}
+   {:doc "specs/normative/N4-delta-policy-compilation-contract.md"
+    :relation :supporting}]
+  :theme/completion-criteria
+  ["Every enabled pack rule resolves to an executable check-fn of shape [artifacts context] -> {:passed? :violations} per N4 §3.1 — zero enabled rules with no enforcement mechanism"
+   "verify and review execute the pack-derived gate set filtered by the rule's :applies-to {:phases}; an :error-severity violation blocks phase completion per N4 §2.3.1"
+   "lint and format are modeled as policy capabilities bound to clj-kondo / cljfmt, not standalone bb tasks outside the governed pipeline"
+   "a DRY / dead-code / unwired-command violation fails a dogfood run before the PR opens (regression guard for PR #979)"
+   "every run emits per-rule-id applied/passed/failed evidence; a human can see which policies gated a given workflow"]
+  :theme/status :planned
   :theme/owner :christopher}}


### PR DESCRIPTION
## Summary

Adds the foundational workstream for miniforge's core thesis — **policy-as-code that is applied AND guaranteed**, not merely suggested. Grounded in the 2026-05-25 dogfood post-mortem: the standards pack is authored and compiled, but **no rule is enforceable** (most detection rules are `:custom` with no `:custom-fn`) and the only pack-derived gate fires solely in `:observe` — so a normal SDLC run can't fail on a DRY / dead-code / lint violation. PR #979 shipped exactly those defects with the pack present.

The design already exists in **N4-policy-packs.md §3 (Gate Execution Contract) + §2.3.1**; **N4-delta deferred the executable realization and it was never built.** This PR queues the work to build it.

- **New `:policy-enforcement` theme** (`work/themes.edn`), anchored to N4 §3 / §2.3.1.
- **`policy-gate-compiler.spec.edn`** (blocker): bind every enabled pack rule to an N4 §3.1 `[artifacts context] → {:passed? :violations}` check-fn — content-scan for pattern rules, the existing tool gates for mechanical rules, `semantic-analyzer` (LLM-judge) for heuristic `:custom` rules. Model lint + format as policy capabilities. No enabled rule may silently no-op.
- **`policy-gate-phase-wiring-and-evidence.spec.edn`** (blocker, blocked-by the compiler): execute the pack-derived gate set in **verify + review** keyed off each rule's `:applies-to {:phases}`, `:error` → block per §2.3.1; emit **per-rule applied/passed/failed evidence** per run.

These are dogfood inputs — miniforge will implement them. (Until the layer lands, standards enforcement on the resulting PRs is handled manually; PR monitoring is now self-served via the #980 observe fix.)

## Test plan
- [x] All three EDN files parse
- [x] `bb work:queue` renders the theme + both specs with correct dependency ordering (compiler `●` ready, wiring `○` blocked-by compiler)
- [x] Specs satisfy the work-spec authoring contract (required fields, theme membership, normative anchor, testable acceptance criteria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)