### PR TITLE
fix(policy-pack): tree-sitter pipe-buffer deadlock hung the implement phase

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
@@ -121,6 +121,13 @@
                     :text    (nth m 5)})))
          vec)))
 
+(def ^:const tree-sitter-query-timeout-ms
+  "Wall-clock cap on a single `tree-sitter query` invocation. A query over a
+   well-formed source file completes in well under a second; the cap exists so
+   a wedged/runaway tree-sitter process fails the check instead of hanging the
+   JVM (which previously stalled an entire dogfood implement phase)."
+  30000)
+
 (defn run-query
   "Execute a tree-sitter query against source content.
 
@@ -143,15 +150,32 @@
                  (.getAbsolutePath source-file)])
             _    (-> (.environment pb) (.put "TREE_SITTER_LANGUAGE" lang))
             proc (.start pb)
-            out  (slurp (.getInputStream proc))
-            err  (slurp (.getErrorStream proc))
-            _    (.waitFor proc)
-            exit (.exitValue proc)]
-        (if (zero? exit)
-          (schema/success :matches (or (parse-query-output out) []) {})
-          (schema/failure :matches
-                          (str "tree-sitter query failed (exit " exit "): "
-                               (str/trim err)))))
+            ;; Drain stdout AND stderr on separate threads. tree-sitter writes
+            ;; to both pipes; reading one fully before the other deadlocks
+            ;; when the unread pipe's kernel buffer (~64KB) fills — the child
+            ;; blocks on write, the JVM blocks on read, forever and
+            ;; uninterruptibly. (Observed: a dogfood implement phase wedged
+            ;; here in state U at 0% CPU with no timeout.)
+            out-future (future (slurp (.getInputStream proc)))
+            err-future (future (slurp (.getErrorStream proc)))
+            finished?  (.waitFor proc tree-sitter-query-timeout-ms
+                                 java.util.concurrent.TimeUnit/MILLISECONDS)]
+        (if-not finished?
+          (do
+            (.destroyForcibly proc)
+            (future-cancel out-future)
+            (future-cancel err-future)
+            (schema/failure :matches
+                            (str "tree-sitter query timed out after "
+                                 tree-sitter-query-timeout-ms "ms")))
+          (let [out  @out-future
+                err  @err-future
+                exit (.exitValue proc)]
+            (if (zero? exit)
+              (schema/success :matches (or (parse-query-output out) []) {})
+              (schema/failure :matches
+                              (str "tree-sitter query failed (exit " exit "): "
+                                   (str/trim err)))))))
       (catch Exception e
         (schema/failure :matches (.getMessage e)))
       (finally

--- a/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
@@ -163,6 +163,11 @@
         (if-not finished?
           (do
             (.destroyForcibly proc)
+            ;; destroyForcibly is asynchronous — wait (briefly, bounded) for the
+            ;; process to actually exit before the finally block deletes the temp
+            ;; files, otherwise the delete can fail (notably on Windows, where an
+            ;; open file can't be removed) and leak temp files.
+            (.waitFor proc 2000 java.util.concurrent.TimeUnit/MILLISECONDS)
             (future-cancel out-future)
             (future-cancel err-future)
             (schema/failure :matches

--- a/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
@@ -65,8 +65,13 @@
           elapsed (- (System/currentTimeMillis) start)]
       (is (map? result))
       (is (contains? result :success?))
-      (is (< elapsed sut/tree-sitter-query-timeout-ms)
-          "completes well under the timeout cap"))))
+      ;; Assert no TRUE hang: even if run-query hit its timeout, total wall time
+      ;; stays within the cap plus generous slack for cleanup/scheduling jitter.
+      ;; (In practice tree-sitter either fails fast when absent or succeeds fast,
+      ;; so this won't reach the boundary — the slack only guards against timing
+      ;; flake, not a real hang.)
+      (is (< elapsed (+ sut/tree-sitter-query-timeout-ms 10000))
+          "returns within the timeout cap (+ slack) — never hangs"))))
 
 (deftest state-comparison-detection-test
   (testing "detects drift between desired and current state"

--- a/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
@@ -52,6 +52,22 @@
   (testing "returns boolean"
     (is (boolean? (sut/tree-sitter-available?)))))
 
+(deftest run-query-returns-gracefully-without-hanging-test
+  ;; Regression guard for the pipe-buffer deadlock: run-query drained stdout
+  ;; fully before stderr, so a tree-sitter process flooding stderr wedged the
+  ;; JVM in an uninterruptible read with no timeout. It now drains both pipes
+  ;; concurrently and caps the wait at tree-sitter-query-timeout-ms. This test
+  ;; asserts the contract that matters regardless of tree-sitter presence:
+  ;; run-query always returns a :success?-keyed map, never throws or hangs.
+  (testing "returns a bounded result map (never hangs/throws)"
+    (let [start   (System/currentTimeMillis)
+          result  (sut/run-query "(ns x)" "(sym_lit) @s" "clojure" "clj")
+          elapsed (- (System/currentTimeMillis) start)]
+      (is (map? result))
+      (is (contains? result :success?))
+      (is (< elapsed sut/tree-sitter-query-timeout-ms)
+          "completes well under the timeout cap"))))
+
 (deftest state-comparison-detection-test
   (testing "detects drift between desired and current state"
     (let [detect (requiring-resolve 'ai.miniforge.policy-pack.detection/detect-state-comparison)


### PR DESCRIPTION
## Summary

Root-causes and fixes the **reproducible dogfood hang** seen building `policy-gate-compiler` (the implement phase wedged in uninterruptible sleep, 0% CPU, no recovery).

**Root cause:** `policy-pack/ast.clj` `run-query` shelled `tree-sitter query` and `(slurp stdout)` to EOF *before* `(slurp stderr)`, with no timeout. stdout and stderr are separate OS pipes (~64KB kernel buffer). On a large changeset, tree-sitter fills the unread stderr buffer → child blocks on `write(stderr)` → never closes stdout → the JVM blocks forever in the stdout `slurp` (a native pipe `read`, hence state `U` / 0% CPU). The chain into it: implement inner-loop `:lint` gate → `gate/lint.clj` → `policy-pack/core/check-artifact` → AST queries. The #974 watchdog only arms around the *agent stream*, not this post-agent gate path, so nothing recovered it.

**Fix:** drain stdout **and** stderr on separate futures, bound the wait with `.waitFor(tree-sitter-query-timeout-ms, MILLISECONDS)`, and `destroyForcibly` + fail the query on timeout. Pure java interop — no new component dependency, graalvm/bb-safe.

(Credit: confirmed the gate ordering rules out clj-kondo/scratch-gc-queue/git-fallback as the culprit; this `ProcessBuilder` drain-order is the only path that yields an uninterruptible I/O wait with no timeout.)

## Test plan
- [x] `bb pre-commit` green (compile + graalvm/bb-load + smoke)
- [x] `run-query-returns-gracefully-without-hanging-test`: asserts `run-query` always returns a `:success?`-keyed map within the timeout — never throws or hangs (portable; holds whether or not tree-sitter is installed)
- [x] Existing ast tests unaffected
- [ ] End-to-end: the previously-stalling dogfood phase no longer hangs (validated when the policy-gate dogfood is re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)