### PR TITLE
feat(gate): run standards-pack rules as gates in verify + review (phase-wiring GROUP 1)

### DIFF
--- a/components/gate/deps.edn
+++ b/components/gate/deps.edn
@@ -2,7 +2,8 @@
  :deps {ai.miniforge/connector-linter {:local/root "../connector-linter"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}
-        ai.miniforge/response {:local/root "../response"}}
+        ai.miniforge/response {:local/root "../response"}
+        ai.miniforge/semantic-analyzer {:local/root "../semantic-analyzer"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {}}}}

--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -22,4 +22,19 @@
 
   ;; Behavioral gate — programmer-error guard for non-callable :check-fn.
   :behavioral/check-fn-not-function
-  ":check-fn must be a function, got: {class}"}}
+  ":check-fn must be a function, got: {class}"
+
+  ;; Policy-pack gate — registry descriptions (phase-scoped).
+  :policy-pack/description-verify
+  "Runs standards-pack rules targeting the verify phase against the artifact"
+
+  :policy-pack/description-review
+  "Runs standards-pack rules targeting the review phase against the artifact"
+
+  ;; Policy-pack gate — no-packs warning (pack resource missing / none loaded).
+  :policy-pack/no-policy-packs
+  "No policy packs loaded — pack gate skipped"
+
+  ;; Policy-pack gate — repair-required result message.
+  :policy-pack/repair-required
+  "Policy violations require redirect to :implement phase — no in-place repair"}}

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -38,6 +38,9 @@
    [ai.miniforge.gate.policy]
    [ai.miniforge.gate.precommit-discipline]
    [ai.miniforge.gate.behavioral]
+   ;; Phase-scoped pack gates (:policy-verify / :policy-review), registered
+   ;; for side effects so apply-gate-validation can resolve them per phase.
+   [ai.miniforge.gate.policy-pack]
    ;; Injects the mechanical tool gates into the policy-pack capability
    ;; registry on load, so pack-gate evaluation sees :lint/:format/:syntax/
    ;; :no-secrets capabilities without an explicit caller.

--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -1,0 +1,188 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.policy-pack
+  "Phase-scoped policy-pack gate.
+
+   Closes PR #979's enforcement gap: the only pack-derived gate (`:behavioral`)
+   was wired solely into the `:observe` phase, so a normal canonical-sdlc run
+   NEVER evaluated the standards pack on the path a PR actually takes. This
+   gate runs the shipped standards pack's enabled rules — those whose
+   `:applies-to {:phases}` includes the current phase — against the phase
+   artifact, and BLOCKS on `:hard-halt` enforcement (a failed gate routes to
+   the existing repair/redirect path via `apply-gate-validation`).
+
+   Registered as two phase-baked gates, `:policy-verify` and `:policy-review`,
+   so the generic `apply-gate-validation` path runs the right rule subset per
+   phase. The whole evaluation delegates to
+   `policy-pack/check-artifact`, which already does phase filtering,
+   detection, and severity/enforcement classification — this gate adds no
+   parallel enforcement channel (N4 reuse constraint).
+
+   Pack source: `ctx :policy-packs` when provided (tests / repo packs), else
+   the classpath-shipped `packs/miniforge-standards.pack.edn`.
+
+   Semantic seam: when the run carries an `:llm-client` and `:complete-fn` in
+   ctx, this gate INJECTS `semantic-analyzer/analyze-rule` under
+   `:semantic-analyze-fn` so heuristic (`:custom` rules with no resolvable
+   `:custom-fn`) reach the LLM judge. Absent that wiring such rules no-op
+   gracefully (see `policy-pack.detection/detect-semantic`) — they default to
+   non-blocking enforcement, so a run is never hard-blocked on a
+   non-deterministic judge by default.
+
+   Fail-safe: a check that throws is converted to a failed gate by
+   `gate.interface/check-gate` (mirrors the reviewer fix in #977) — never a
+   silent pass."
+  (:require
+   [ai.miniforge.gate.messages :as msg]
+   [ai.miniforge.gate.registry :as registry]
+   [ai.miniforge.policy-pack.interface :as policy-pack]
+   [ai.miniforge.semantic-analyzer.interface :as semantic]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pack source
+
+(def ^:private standards-pack-resource
+  "Classpath location of the compiled standards pack (emitted by
+   `bb standards:pack`, placed on the classpath at build time)."
+  "packs/miniforge-standards.pack.edn")
+
+(defn- load-standards-pack
+  "Read the shipped standards pack manifest from the classpath, or nil when
+   the resource is missing/unreadable. Fail-safe — never throws."
+  []
+  (try
+    (some-> (io/resource standards-pack-resource) slurp edn/read-string)
+    (catch Exception _ nil)))
+
+(defn- packs-for-gate
+  "Packs to evaluate. When ctx carries an explicit `:policy-packs` key, that
+   value is authoritative — even an empty vector (a run that disabled all
+   packs is respected, not silently re-seeded). When the key is absent (the
+   normal SDLC path), the shipped standards pack is loaded from the classpath
+   so the gate actually evaluates. Empty when no pack is available."
+  [ctx]
+  (if (contains? ctx :policy-packs)
+    (vec (:policy-packs ctx))
+    (if-let [pack (load-standards-pack)] [pack] [])))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Context wiring
+
+(defn- with-semantic-wiring
+  "Inject the LLM-judge seam when the run carries an `:llm-client` and
+   `:complete-fn` but no explicit `:semantic-analyze-fn`. Also normalizes the
+   repo path the judge scans (`:repo-path`, falling back to the execution
+   worktree). When the LLM seam is absent, leaves ctx untouched — semantic
+   rules then no-op in detection."
+  [ctx]
+  (let [ctx (assoc ctx :repo-path (or (:repo-path ctx)
+                                      (:execution/worktree-path ctx)
+                                      "."))]
+    (if (and (:llm-client ctx)
+             (:complete-fn ctx)
+             (not (:semantic-analyze-fn ctx)))
+      (assoc ctx :semantic-analyze-fn semantic/analyze-rule)
+      ctx)))
+
+(defn- no-policy-packs-warning
+  []
+  {:type :no-policy-packs
+   :message (msg/t :policy-pack/no-policy-packs)})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Phase-scoped check
+
+(defn check-policy-pack-for-phase
+  "Evaluate the pack against `artifact` for `phase`.
+
+   Selects the enabled rules whose `:applies-to {:phases}` includes `phase`
+   (via `policy-pack/check-artifact`'s context filtering), runs their
+   detection, and maps the result to a gate result:
+     :errors   — blocking (`:hard-halt`) violations as gate errors
+     :warnings — require-approval / warn / audit violations (record-only here)
+     :passed?  — true iff no blocking violations
+
+   When no pack is available, passes with a no-packs warning (no regression on
+   repos without a standards pack)."
+  [phase artifact ctx]
+  (let [packs (packs-for-gate ctx)]
+    (if (empty? packs)
+      {:passed? true :warnings [(no-policy-packs-warning)]}
+      (let [context (-> ctx with-semantic-wiring (assoc :phase phase))
+            result  (policy-pack/check-artifact packs artifact context)]
+        {:passed?  (:passed? result)
+         :errors   (vec (:blocking result))
+         :warnings (vec (concat (:require-approval result)
+                                (:warnings result)
+                                (:audits result)))}))))
+
+(defn check-policy-verify
+  "Pack gate for the verify phase."
+  [artifact ctx]
+  (check-policy-pack-for-phase :verify artifact ctx))
+
+(defn check-policy-review
+  "Pack gate for the review phase."
+  [artifact ctx]
+  (check-policy-pack-for-phase :review artifact ctx))
+
+(defn repair-policy-pack
+  "Policy violations cannot be fixed in-place; the workflow must redirect to
+   :implement for an agent to address the root cause (mirrors the behavioral
+   gate)."
+  [artifact errors _ctx]
+  {:success? false
+   :artifact artifact
+   :errors   errors
+   :message  (msg/t :policy-pack/repair-required)})
+
+;------------------------------------------------------------------------------ Layer 3
+;; Registry
+
+(registry/register-gate! :policy-verify)
+(registry/register-gate! :policy-review)
+
+(defmethod registry/get-gate :policy-verify
+  [_]
+  {:name        :policy-verify
+   :description (msg/t :policy-pack/description-verify)
+   :check       check-policy-verify
+   :repair      repair-policy-pack})
+
+(defmethod registry/get-gate :policy-review
+  [_]
+  {:name        :policy-review
+   :description (msg/t :policy-pack/description-review)
+   :check       check-policy-review
+   :repair      repair-policy-pack})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; No pack available — passes with a warning.
+  (check-policy-pack-for-phase :verify {} {:policy-packs []})
+
+  ;; Against the shipped pack for the review phase.
+  (check-policy-pack-for-phase
+   :review
+   {:artifact/content "(def x 1)" :artifact/path "core.clj"}
+   {})
+
+  :leave-this-here)

--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -64,24 +64,34 @@
    `bb standards:pack`, placed on the classpath at build time)."
   "packs/miniforge-standards.pack.edn")
 
-(defn- load-standards-pack
-  "Read the shipped standards pack manifest from the classpath, or nil when
-   the resource is missing/unreadable. Fail-safe — never throws."
+(defn- read-standards-pack
+  "Read the shipped standards pack manifest from the classpath.
+
+   Returns nil ONLY when the resource is absent (a repo legitimately without a
+   compiled pack). A present-but-malformed/unreadable pack THROWS — so
+   `gate.interface/check-gate` converts it into a failed gate (fail-closed),
+   rather than letting a corrupt pack masquerade as 'no pack' and silently
+   skip enforcement."
   []
-  (try
-    (some-> (io/resource standards-pack-resource) slurp edn/read-string)
-    (catch Exception _ nil)))
+  (when-let [res (io/resource standards-pack-resource)]
+    (edn/read-string (slurp res))))
+
+(def ^:private standards-pack
+  "Memoized shipped pack — read once per JVM (the classpath is stable for a
+   process). A read failure is cached as a thrown deref, keeping enforcement
+   fail-closed on every evaluation."
+  (delay (read-standards-pack)))
 
 (defn- packs-for-gate
   "Packs to evaluate. When ctx carries an explicit `:policy-packs` key, that
    value is authoritative — even an empty vector (a run that disabled all
    packs is respected, not silently re-seeded). When the key is absent (the
-   normal SDLC path), the shipped standards pack is loaded from the classpath
-   so the gate actually evaluates. Empty when no pack is available."
+   normal SDLC path), the shipped standards pack is used so the gate actually
+   evaluates. Empty when no pack resource is present."
   [ctx]
   (if (contains? ctx :policy-packs)
     (vec (:policy-packs ctx))
-    (if-let [pack (load-standards-pack)] [pack] [])))
+    (if-let [pack @standards-pack] [pack] [])))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Context wiring

--- a/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
@@ -1,0 +1,131 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.policy-pack-test
+  "Tests for the phase-scoped policy-pack gate (:policy-verify / :policy-review)."
+  (:require
+   [ai.miniforge.gate.interface :as gate]
+   [ai.miniforge.gate.policy-pack :as sut]
+   [ai.miniforge.gate.registry :as registry]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Factories
+
+(defn- content-scan-rule
+  "A content-scan rule. Overrides merge over sensible defaults."
+  [& {:keys [id phases action pattern severity]
+      :or   {id       :test/forbidden
+             phases   #{:verify :review}
+             action   :hard-halt
+             pattern  "FORBIDDEN"
+             severity :critical}}]
+  {:rule/id         id
+   :rule/enabled?   true
+   :rule/severity   severity
+   :rule/applies-to {:phases phases}
+   :rule/detection  {:type :content-scan :pattern pattern}
+   :rule/enforcement {:action action :message (str "rule " id " fired")}})
+
+(defn- pack
+  "A single-rule (or supplied-rules) pack manifest."
+  [& rules]
+  {:pack/id    "test-pack"
+   :pack/name  "Test Pack"
+   :pack/rules (vec rules)})
+
+(defn- ctx-with
+  "Gate context carrying the given packs (bypasses the classpath standards
+   pack so tests are hermetic)."
+  [packs]
+  {:policy-packs packs})
+
+(def ^:private dirty-artifact
+  {:artifact/content "(def x \"FORBIDDEN\")" :artifact/path "core.clj"})
+
+(def ^:private clean-artifact
+  {:artifact/content "(def x 42)" :artifact/path "core.clj"})
+
+;------------------------------------------------------------------------------ No packs
+
+(deftest no-packs-passes-with-warning-test
+  (testing "with no packs the gate passes and records a no-packs warning (no regression)"
+    (let [result (sut/check-policy-pack-for-phase :verify clean-artifact (ctx-with []))]
+      (is (:passed? result))
+      (is (= :no-policy-packs (-> result :warnings first :type))))))
+
+;------------------------------------------------------------------------------ Blocking
+
+(deftest hard-halt-rule-blocks-test
+  (testing "a :hard-halt rule matching the artifact fails the gate with an error"
+    (let [ctx    (ctx-with [(pack (content-scan-rule :phases #{:verify}))])
+          result (sut/check-policy-verify dirty-artifact ctx)]
+      (is (not (:passed? result)))
+      (is (seq (:errors result)))
+      (is (= :test/forbidden (-> result :errors first :code))))))
+
+(deftest clean-artifact-passes-test
+  (testing "a clean artifact yields zero violations and passes"
+    (let [ctx    (ctx-with [(pack (content-scan-rule :phases #{:verify}))])
+          result (sut/check-policy-verify clean-artifact ctx)]
+      (is (:passed? result))
+      (is (empty? (:errors result))))))
+
+;------------------------------------------------------------------------------ Phase scoping
+
+(deftest phase-scoping-test
+  (testing "a rule targeting only :review does NOT fire in verify, but DOES in review"
+    (let [ctx (ctx-with [(pack (content-scan-rule :phases #{:review}))])]
+      (is (:passed? (sut/check-policy-verify dirty-artifact ctx))
+          "review-only rule must not gate verify")
+      (is (not (:passed? (sut/check-policy-review dirty-artifact ctx)))
+          "review-only rule must gate review"))))
+
+;------------------------------------------------------------------------------ Severity / enforcement routing
+
+(deftest warn-rule-records-warning-not-error-test
+  (testing "a :warn rule surfaces as a warning and does not block"
+    (let [ctx    (ctx-with [(pack (content-scan-rule :phases #{:verify} :action :warn))])
+          result (sut/check-policy-verify dirty-artifact ctx)]
+      (is (:passed? result) "a :warn rule must not block")
+      (is (empty? (:errors result)))
+      (is (seq (:warnings result))))))
+
+;------------------------------------------------------------------------------ Registry wiring
+
+(deftest gates-registered-test
+  (testing "both phase gates resolve through the registry with check + repair fns"
+    (doseq [gate-kw [:policy-verify :policy-review]]
+      (is (contains? (registry/list-gates) gate-kw))
+      (let [{:keys [check repair]} (registry/get-gate gate-kw)]
+        (is (fn? check))
+        (is (fn? repair))))))
+
+(deftest end-to-end-through-check-gate-test
+  (testing "a :hard-halt violation fails when run through gate/check-gate (the real path)"
+    (let [ctx    (assoc (ctx-with [(pack (content-scan-rule :phases #{:review}))])
+                        :event-stream nil)
+          result (gate/check-gate :policy-review dirty-artifact ctx)]
+      (is (not (gate/passed? result))))))
+
+;------------------------------------------------------------------------------ Repair
+
+(deftest repair-is-redirect-test
+  (testing "repair never fixes in-place — it signals a redirect"
+    (let [result (sut/repair-policy-pack dirty-artifact [{:code :test/forbidden}] {})]
+      (is (false? (:success? result)))
+      (is (string? (:message result))))))

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -12,7 +12,7 @@
   ;; No agent: verify runs the test suite directly in the executor environment.
   :verify
   {:agent nil
-   :gates [:pre-verify-lint :tests-pass :coverage]
+   :gates [:pre-verify-lint :tests-pass :coverage :policy-verify]
    :budget {:tokens 0
             :iterations 3
             :time-seconds 300}
@@ -21,7 +21,7 @@
   ;; Review phase defaults.
   :review
   {:agent :reviewer
-   :gates [:review-approved :quality-check]
+   :gates [:review-approved :quality-check :policy-review]
    :budget {:tokens 20000
             :iterations 2
             :time-seconds 180}


### PR DESCRIPTION
## Summary

GROUP 1 of `work/policy-gate-phase-wiring-and-evidence.spec.edn`. Builds on the policy→gate compiler (#984/#985, merged), which made every enabled pack rule bind to a detector. This makes those checks **actually run and block** on the path a PR takes.

**The gap (PR #979):** the only pack-derived gate (`:behavioral`) was wired solely into the `:observe` phase, gated on a `:spec/behavioral-harness` flag — so a normal canonical-sdlc run **never evaluated the standards pack**. verify ran tests only; review's gates were a hardcoded set; none pack-derived.

**This PR:**
- New `gate/policy_pack.clj` registers two phase-baked gates, `:policy-verify` and `:policy-review`. Each delegates to `policy-pack/check-artifact` — which already filters rules by `:applies-to {:phases}`, runs detection, and classifies by enforcement action — so there's **no parallel enforcement channel** (N4 reuse constraint). `:hard-halt` violations fail the gate (→ the existing `apply-gate-validation` repair/redirect path); warn/approval/audit are recorded as warnings.
- Wired into the `verify` and `review` `:gates` in phase `defaults.edn`.
- **Pack source:** `ctx :policy-packs` when the key is present (authoritative — an explicit empty vector is respected, not silently re-seeded), else the classpath-shipped `packs/miniforge-standards.pack.edn`. So the gate evaluates on the normal path while a no-pack repo stays green.
- **Semantic seam:** when the run carries an `:llm-client` + `:complete-fn`, the gate injects `semantic-analyzer/analyze-rule` under `:semantic-analyze-fn` (gate already depends on policy-pack; adds a **no-cycle** dep on semantic-analyzer). Absent that wiring, heuristic rules no-op — a run is **never hard-blocked on a non-deterministic judge** by default.
- Fail-safe: a check that throws is converted to a failed gate by `gate/check-gate` (mirrors #977) — never a silent pass.

> Single commit uses `MINIFORGE_COMMIT_BUDGET_OVERRIDE` (not `--no-verify`): the gate (133) + its behavior test (86) are one cohesive unit, 23 over budget; slicing creates a dead intermediate. All other gates (poly, clj-kondo, graalvm load-compat, md, precommit smoke) green.

Next (GROUP 2): per-rule application evidence events through `emit-gate-event!` so a human can answer "which policies gated run X, and what did each decide?"

## Test plan
- [x] `bb pre-commit` gates green (poly check, clj-kondo 0/0, graalvm 510 assertions, precommit smoke 315 tests) — budget overridden
- [x] no-pack → pass + warning (no regression)
- [x] `:hard-halt` rule matching artifact → gate fails with the rule id as error code
- [x] clean artifact → pass, zero errors
- [x] phase scoping: a `:review`-only rule is ignored in verify, fires in review
- [x] `:warn` rule → recorded as warning, does not block
- [x] both gates resolve through the registry; real `gate/check-gate :policy-review` path fails on a `:hard-halt` violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)