### PR TITLE
fix(workflow): abort on consecutive same-phase retries (runaway guard)

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -15,7 +15,7 @@
   :status/gate-failed        "Gate validation failed"
   :status/no-phases          "Workflow has no phases"
   :status/max-phases         "Exceeded maximum phase count: {max-phases}"
-  :status/phase-retries-exhausted "Phase :{phase} failed {retries} times in a row — aborting to avoid a retry runaway"
+  :status/phase-retries-exhausted "Phase {phase} failed {retries} times in a row — aborting to avoid a retry runaway"
   :status/empty-pipeline     "Workflow pipeline is empty"
   :status/duplicate-phases   "Duplicate phase ids make transition targets ambiguous"
   :status/paused             "⏸  Workflow paused, waiting for resume..."

--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -15,6 +15,7 @@
   :status/gate-failed        "Gate validation failed"
   :status/no-phases          "Workflow has no phases"
   :status/max-phases         "Exceeded maximum phase count: {max-phases}"
+  :status/phase-retries-exhausted "Phase :{phase} failed {retries} times in a row — aborting to avoid a retry runaway"
   :status/empty-pipeline     "Workflow pipeline is empty"
   :status/duplicate-phases   "Duplicate phase ids make transition targets ambiguous"
   :status/paused             "⏸  Workflow paused, waiting for resume..."

--- a/components/workflow/resources/config/workflow/runner/defaults.edn
+++ b/components/workflow/resources/config/workflow/runner/defaults.edn
@@ -2,6 +2,7 @@
  {;; Pipeline execution limits
   :max-phases             50
   :max-redirects          5
+  :max-consecutive-phase-retries 3
   :max-backoff-ms         30000
   :backoff-base-ms        1000
   :pause-poll-interval-ms 1000

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -120,6 +120,23 @@
                 :anomalies.workflow/max-phases {:error msg :max-phases max-phases})
         (ctx/transition-to-failed))))
 
+(defn handle-phase-retry-exhausted
+  "Runaway guard: the same phase has run in too many consecutive pipeline
+   iterations (in-place retries — e.g. implement re-entering on every agent
+   stall). Fail the workflow loud with a typed anomaly so the loop stops now
+   instead of grinding up to `max-phases` iterations (hours of tokens)."
+  [context phase retries]
+  (let [msg (messages/t :status/phase-retries-exhausted
+                        {:phase (name phase) :retries retries})]
+    (-> context
+        (update :execution/errors conj
+                (make-execution-error :phase-retries-exhausted msg))
+        (update :execution/response-chain
+                response/add-failure :pipeline
+                :anomalies.workflow/phase-retries-exhausted
+                {:error msg :phase phase :retries retries})
+        (ctx/transition-to-failed))))
+
 (defn terminal-state?
   "Check if workflow is in terminal state."
   [context]
@@ -406,13 +423,27 @@
   [pipeline initial-ctx callbacks control-state max-phases]
   (if (empty? pipeline)
     (handle-empty-pipeline initial-ctx)
-    (loop [context initial-ctx
-           iteration 0]
-      (cond
-        (terminal-state? context)      context
-        (>= iteration max-phases)      (handle-max-phases-exceeded context max-phases)
-        :else (recur (execute-single-iteration pipeline context callbacks iteration control-state)
-                     (inc iteration))))))
+    (let [max-phase-retries (defaults/max-consecutive-phase-retries)]
+      ;; `consecutive` counts how many times the phase about to run has been
+      ;; the active phase in immediately consecutive iterations. A healthy
+      ;; workflow advances to a new phase each iteration, so a count > the cap
+      ;; means one phase is stuck retrying in place — abort before it grinds
+      ;; up to `max-phases` (the runaway that burned ~17h overnight).
+      (loop [context     initial-ctx
+             iteration   0
+             prev-phase  nil
+             consecutive 1]
+        (let [phase       (:execution/current-phase context)
+              consecutive (if (= phase prev-phase) (inc consecutive) 1)]
+          (cond
+            (terminal-state? context)      context
+            (>= iteration max-phases)      (handle-max-phases-exceeded context max-phases)
+            (and phase (> consecutive max-phase-retries))
+            (handle-phase-retry-exhausted context phase max-phase-retries)
+            :else (recur (execute-single-iteration pipeline context callbacks iteration control-state)
+                         (inc iteration)
+                         phase
+                         consecutive)))))))
 
 (defn- validate-completion
   "Warn when a succeeded workflow produced no results."

--- a/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
@@ -31,6 +31,14 @@
 
 (defn max-phases           [] (get @defaults :max-phases 50))
 (defn max-redirects        [] (get @defaults :max-redirects 5))
+(defn max-consecutive-phase-retries
+  "Cap on how many times the SAME phase may run in immediately consecutive
+   pipeline iterations before the workflow fails loud. Distinct from
+   `max-phases` (total steps) and `max-redirects` (phase→phase redirects):
+   this catches a single phase retrying itself in place (e.g. implement
+   failing + re-entering on every agent stall), which would otherwise burn
+   up to `max-phases` iterations — hours of tokens — before stopping."
+  [] (get @defaults :max-consecutive-phase-retries 3))
 (defn max-backoff-ms       [] (get @defaults :max-backoff-ms 30000))
 (defn backoff-base-ms      [] (get @defaults :backoff-base-ms 1000))
 (defn pause-poll-interval-ms [] (get @defaults :pause-poll-interval-ms 1000))

--- a/components/workflow/test/ai/miniforge/workflow/runner_pipeline_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_pipeline_test.clj
@@ -73,6 +73,28 @@
           result (execute-pipeline-loop [] ctx {} (atom {}) 50)]
       (is (some? result)))))
 
+(deftest execute-pipeline-loop-aborts-on-consecutive-phase-retries-test
+  (testing "a phase that re-runs every iteration aborts loud well before max-phases (the overnight runaway guard)"
+    (let [stuck-ctx {:execution/status        :running   ; non-terminal so the loop proceeds
+                     :execution/current-phase :implement ; never advances → in-place retry
+                     :execution/phase-results {}
+                     :execution/errors        []
+                     :execution/response-chain {}
+                     :execution/started-at    (System/currentTimeMillis)}
+          calls     (atom 0)]
+      ;; Stub one iteration to return the same stuck (same-phase, non-terminal)
+      ;; context, simulating implement failing + re-entering forever.
+      (with-redefs [runner/execute-single-iteration
+                    (fn [_pipeline ctx _callbacks _iteration _control] (swap! calls inc) ctx)]
+        (let [result (execute-pipeline-loop [{:phase :implement}] stuck-ctx {} (atom {}) 50)]
+          (is (= :failed (:execution/status result))
+              "the loop must terminate the workflow, not spin to max-phases")
+          (is (some #(= :phase-retries-exhausted (:type %)) (:execution/errors result))
+              "failure is the typed consecutive-retry anomaly, not max-phases")
+          ;; Default cap is 3 — must abort within a handful of iterations, nowhere near 50.
+          (is (<= @calls 3)
+              (str "expected ≤3 iterations before the breaker fired, got " @calls)))))))
+
 (deftest wrap-phase-callbacks-creates-both-keys-test
   (testing "wraps both on-phase-start and on-phase-complete"
     (let [callbacks (wrap-phase-callbacks nil {})]


### PR DESCRIPTION
## Summary

A dogfood run (`knowledge-mcp-query`) **burned ~17 hours overnight** — roughly half a weekly Max-20 allotment. Root cause of the runaway:

- The `implement` phase failed and **re-entered itself on every agent stall** — 27+ consecutive failures, ~30 min each.
- The only backstop was `max-phases` (**50**, counting *total* phase steps). At ~30 min per failed iteration that's **~25 hours** before the workflow gives up.
- `max-redirects` (5) didn't catch it because re-entering a phase *after it fails* isn't a redirect (redirects are phase-X → phase-Y).

So nothing was watching for "the same phase keeps failing in place."

**This PR** adds a consecutive-same-phase circuit breaker in `execute-pipeline-loop`. A healthy workflow advances to a *new* phase each iteration, so the same phase recurring in immediately consecutive iterations is unambiguous evidence it's stuck retrying. After `max-consecutive-phase-retries` (default **3**) the workflow **fails loud** with a typed `:anomalies.workflow/phase-retries-exhausted` anomaly instead of grinding to `max-phases`.

- Bounds blast radius to ~3 iterations **regardless of the underlying failure's root cause**.
- Distinct from and tighter than `max-phases` (total steps) and `max-redirects` (redirect transitions).
- Configurable via `runner/defaults.edn` (`:max-consecutive-phase-retries`).
- The rate-limit path is unaffected — it writes a terminal + resumes out-of-process, so it never manifests as an in-loop same-phase repeat.

### Not fixed here (separate follow-up)
This caps the *runaway*, not the *root cause*. `implement` keeps failing because the `llm-stream-reader` thread deadlocks on `LinkedBlockingQueue.put` — the stream consumer stops draining, the bounded queue fills, the #974 watchdog sees no progress and interrupts it → `agent/invoke-failed`. That stream-pipeline deadlock (and a per-iteration `mcp-context-server` leak) is a deeper bug worth its own spec.

## Test plan
- [x] `bb pre-commit` green (poly, clj-kondo 0/0, graalvm 511 assertions, precommit smoke)
- [x] New test: a phase re-running every iteration aborts with `:phase-retries-exhausted` within ≤3 iterations (not 50) — `execute-pipeline-loop-aborts-on-consecutive-phase-retries-test`
- [x] Existing pipeline-loop / max-phases tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)