### PR TITLE
fix(agent): make stream watchdog a backstop above the LLM idle timeout

### DIFF
--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -75,10 +75,12 @@
      2. Global :agent/stream-gap-threshold-ms in config
      3. `default-gap-threshold-ms` (420 000 ms)
 
-   Any override MUST honor the same invariant as `default-gap-threshold-ms`:
-   keep it >= the LLM client's stream-line-timeout-ms (360 000 ms) so the
-   watchdog stays a backstop and does not false-fire on legitimate model
-   silence.
+   In production/real runs an override MUST honor the same invariant as
+   `default-gap-threshold-ms`: keep it >= the LLM client's
+   stream-line-timeout-ms (360 000 ms) so the watchdog stays a backstop and
+   does not false-fire on legitimate model silence. (Tests deliberately set
+   tiny sub-threshold values — e.g. 1 ms — to force a fast stall; that is an
+   intentional exception, not a real-run configuration.)
 
    Example config:
      {:agent/stream-gap-threshold-ms 420000
@@ -206,7 +208,7 @@
   "Create and start a stream-gap watchdog.
 
    Options map:
-     :threshold-ms      — gap in ms before the kill fires (default 90 000)
+     :threshold-ms      — gap in ms before the kill fires (default 420 000)
      :check-interval-ms — how often to check for a stall (default 5 000)
      :phase-id          — keyword or string identifying the current phase
      :backend           — keyword identifying the agent backend (e.g. :claude-code)

--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -46,8 +46,22 @@
   (log/create-logger {:min-level :info :output :edn}))
 
 (def ^:const default-gap-threshold-ms
-  "Default stream-gap threshold in milliseconds (90 seconds)."
-  90000)
+  "Default stream-gap threshold in milliseconds (420 seconds).
+
+   INVARIANT: this MUST stay >= the LLM client's stream-line-timeout-ms
+   (currently 360 000 ms; see components/llm/resources/llm/client-defaults.edn).
+   The watchdog and that idle timeout watch the SAME signal — agent stdout
+   activity — so the watchdog is a BACKSTOP for a wedged consumer thread, not a
+   primary stall detector. When it is shorter than the idle timeout it FALSE-
+   FIRES on legitimate model silence: Opus on a large first-turn prompt goes
+   silent on stdout for 180-300s by design, which the 360 000 ms idle timeout
+   deliberately tolerates. The old 90 000 ms default killed those legitimate
+   turns every iteration, and (pre-#988) the workflow retried forever — a 17h
+   overnight token burn. 420 000 = 360 000 idle + 60 000 margin, so the clean
+   in-stream idle timeout (which yields a resumable :stream-idle terminal)
+   fires first and the watchdog only catches the case the idle timeout cannot:
+   the stream consumer loop itself wedged."
+  420000)
 
 (def ^:const default-check-interval-ms
   "Default watchdog check interval in milliseconds (5 seconds)."
@@ -59,11 +73,16 @@
    Precedence (highest wins):
      1. Backend-specific entry in :agent/per-backend-gap-thresholds
      2. Global :agent/stream-gap-threshold-ms in config
-     3. `default-gap-threshold-ms` (90 000 ms)
+     3. `default-gap-threshold-ms` (420 000 ms)
+
+   Any override MUST honor the same invariant as `default-gap-threshold-ms`:
+   keep it >= the LLM client's stream-line-timeout-ms (360 000 ms) so the
+   watchdog stays a backstop and does not false-fire on legitimate model
+   silence.
 
    Example config:
-     {:agent/stream-gap-threshold-ms 60000
-      :agent/per-backend-gap-thresholds {:claude-code 120000}}"
+     {:agent/stream-gap-threshold-ms 420000
+      :agent/per-backend-gap-thresholds {:claude-code 480000}}"
   [config backend]
   (let [base      (get config :agent/stream-gap-threshold-ms default-gap-threshold-ms)
         overrides (get config :agent/per-backend-gap-thresholds {})]

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -92,6 +92,22 @@
     (is (= sut/default-gap-threshold-ms
            (sut/resolve-gap-threshold {} :any-backend)))))
 
+(def ^:private llm-stream-line-timeout-ms
+  "The LLM client's tuned stdout-silence tolerance
+   (components/llm/resources/llm/client-defaults.edn :line-timeout-ms). The
+   watchdog must not false-fire inside this window — keep this mirror in sync
+   if that config changes."
+  360000)
+
+(deftest default-gap-threshold-is-a-backstop-above-llm-idle-timeout
+  (testing "the watchdog default must stay >= the LLM idle timeout so it is a
+            backstop, not a primary that kills legitimate model silence
+            (regression guard for the 90s-default 17h-runaway)"
+    (is (>= sut/default-gap-threshold-ms llm-stream-line-timeout-ms)
+        (str "default-gap-threshold-ms (" sut/default-gap-threshold-ms
+             ") must be >= the LLM stream-line-timeout-ms ("
+             llm-stream-line-timeout-ms ")"))))
+
 (deftest resolve-gap-threshold-returns-global-override
   (testing "global :agent/stream-gap-threshold-ms overrides the default"
     (is (= 60000
@@ -110,9 +126,9 @@
                   :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
       (is (= 60000 (sut/resolve-gap-threshold config :other-backend))))))
 
-(deftest resolve-gap-threshold-default-constant-is-90s
-  (testing "default constant is 90 000 ms"
-    (is (= 90000 sut/default-gap-threshold-ms))))
+(deftest resolve-gap-threshold-default-constant-is-420s
+  (testing "default constant is 420 000 ms — a backstop above the 360 000 ms LLM idle timeout"
+    (is (= 420000 sut/default-gap-threshold-ms))))
 
 ;; ---------------------------------------------------------------------------
 ;; create-watchdog structure

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -19,6 +19,8 @@
 (ns ai.miniforge.agent.stream-watchdog-test
   "Tests for the per-phase stream-gap watchdog timer."
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.agent.stream-watchdog :as sut]
    [ai.miniforge.event-stream.interface :as event-stream-iface])
@@ -92,21 +94,26 @@
     (is (= sut/default-gap-threshold-ms
            (sut/resolve-gap-threshold {} :any-backend)))))
 
-(def ^:private llm-stream-line-timeout-ms
-  "The LLM client's tuned stdout-silence tolerance
-   (components/llm/resources/llm/client-defaults.edn :line-timeout-ms). The
-   watchdog must not false-fire inside this window — keep this mirror in sync
-   if that config changes."
-  360000)
+(defn- llm-stream-line-timeout-ms
+  "The LLM client's tuned stdout-silence tolerance, read live from
+   components/llm/resources/llm/client-defaults.edn so this guard can't drift
+   from the real configured value. The watchdog must not false-fire inside
+   this window."
+  []
+  (-> (io/resource "llm/client-defaults.edn")
+      slurp
+      edn/read-string
+      (get-in [:stream :line-timeout-ms])))
 
 (deftest default-gap-threshold-is-a-backstop-above-llm-idle-timeout
   (testing "the watchdog default must stay >= the LLM idle timeout so it is a
             backstop, not a primary that kills legitimate model silence
             (regression guard for the 90s-default 17h-runaway)"
-    (is (>= sut/default-gap-threshold-ms llm-stream-line-timeout-ms)
-        (str "default-gap-threshold-ms (" sut/default-gap-threshold-ms
-             ") must be >= the LLM stream-line-timeout-ms ("
-             llm-stream-line-timeout-ms ")"))))
+    (let [idle-ms (llm-stream-line-timeout-ms)]
+      (is (some? idle-ms) "llm client-defaults must expose :stream :line-timeout-ms")
+      (is (>= sut/default-gap-threshold-ms idle-ms)
+          (str "default-gap-threshold-ms (" sut/default-gap-threshold-ms
+               ") must be >= the LLM stream-line-timeout-ms (" idle-ms ")")))))
 
 (deftest resolve-gap-threshold-returns-global-override
   (testing "global :agent/stream-gap-threshold-ms overrides the default"


### PR DESCRIPTION
## Summary

Root-cause fix for the overnight dogfood runaway (#988 capped the *retries*; this fixes *why* `implement` kept failing).

**The "deadlock" was a misdiagnosis.** The stream watchdog pings on every `on-chunk` (`implement.clj:336`) and fires at a **90s** gap (`default-gap-threshold-ms`). But the LLM client's in-stream idle timeout is deliberately **360s**, with this comment in `client-defaults.edn`:

> "Opus on a 100k-token first-turn prompt empirically goes silent on stdout for 180–300s."

Both timers watch the **same signal** (agent stdout activity), so the 90s watchdog fired **4× sooner** than the silence the system was explicitly tuned to tolerate — killing legitimate long model turns on *every* `implement` iteration. The `InterruptedException` at `LinkedBlockingQueue.put` was just where the watchdog's thread-interrupt landed in the reader thread, not a real deadlock. (The idle `mcp-context-server` orphans were a separate cleanup nit, not the cause.)

**Fix:** raise `default-gap-threshold-ms` `90000 → 420000` (360 000 idle + 60 000 margin) so the watchdog is a true **backstop**:
- The clean in-stream idle timeout (which yields a resumable `:stream-idle` terminal) fires first on normal silence.
- The watchdog only fires for what the idle timeout *cannot* catch — a wedged stream-**consumer** thread.
- Documents the invariant (`watchdog ≥ llm stream-line-timeout-ms`) on the constant and on `resolve-gap-threshold`, with a regression-guard test asserting it.

With #988 capping consecutive retries, a genuine hang now terminates in ~3×420s instead of looping for hours.

## Test plan
- [x] `bb pre-commit` green (poly, clj-kondo, graalvm, smoke)
- [x] 35 `stream_watchdog_test` assertions pass; default-constant test updated 90s→420s
- [x] New `default-gap-threshold-is-a-backstop-above-llm-idle-timeout` regression guard (≥ 360 000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)