### PR TITLE
feat(anomaly): add let-ok railway-threading macro

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -15,6 +15,7 @@
  ;; See `.cursor/rules/languages/clojure-railway-binding.mdc` (dewey 211)
  ;; for the macro semantics; for kondo it's enough that the bindings
  ;; are in scope of the body, exactly like `let`.
- :lint-as {ai.miniforge.dag-executor.interface/when-let-ok clojure.core/let}
+ :lint-as {ai.miniforge.dag-executor.interface/when-let-ok clojure.core/let
+           ai.miniforge.anomaly.interface/let-ok clojure.core/let}
 
  :linters {:underscore-in-namespace {:level :off}}}

--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -116,17 +116,18 @@
 
    Returns the first anomaly encountered, otherwise the body's value."
   [bindings & body]
-  (assert (vector? bindings) "let-ok requires a binding vector")
-  (assert (even? (count bindings)) "let-ok requires an even number of binding forms")
-  (if (empty? bindings)
-    `(do ~@body)
-    (let [[binding expr & more] bindings
-          result (gensym "result__")]
-      `(let [~result ~expr]
-         (if (anomaly? ~result)
-           ~result
-           (let [~binding ~result]
-             (let-ok [~@more] ~@body)))))))
+  (when-not (vector? bindings)
+    (throw (IllegalArgumentException. "let-ok requires a binding vector")))
+  (when-not (even? (count bindings))
+    (throw (IllegalArgumentException. "let-ok requires an even number of binding forms")))
+  (reduce
+   (fn [acc [sym expr]]
+     `(let [~sym ~expr]
+        (if (anomaly? ~sym)
+          ~sym
+          ~acc)))
+   `(do ~@body)
+   (reverse (partition 2 bindings))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 

--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -96,6 +96,38 @@
   (and (map? x)
        (contract/valid? x)))
 
+;------------------------------------------------------------------------------ Macros
+;; Compile-time control flow; expansion composes the Layer 2 predicate.
+
+(defmacro let-ok
+  "Sequential `let`-style bindings that short-circuit on the first
+   anomaly. Each right-hand expression is evaluated and bound
+   left-to-right; if one evaluates to an anomaly (per `anomaly?`), that
+   anomaly is returned immediately and the remaining bindings and
+   `body` are skipped. When no binding yields an anomaly, evaluates
+   `body` like `let`.
+
+   Use for railway-style pipelines over anomaly-returning steps in
+   place of nested `(if (anomaly? x) x (let [...] ...))` pyramids:
+
+     (let-ok [user    (lookup id)
+              account (account-for user)]
+       (summarize account))
+
+   Returns the first anomaly encountered, otherwise the body's value."
+  [bindings & body]
+  (assert (vector? bindings) "let-ok requires a binding vector")
+  (assert (even? (count bindings)) "let-ok requires an even number of binding forms")
+  (if (empty? bindings)
+    `(do ~@body)
+    (let [[binding expr & more] bindings
+          result (gensym "result__")]
+      `(let [~result ~expr]
+         (if (anomaly? ~result)
+           ~result
+           (let [~binding ~result]
+             (let-ok [~@more] ~@body)))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 
 (comment

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/let_ok_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/let_ok_test.clj
@@ -1,0 +1,58 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.let-ok-test
+  "let-ok threads anomaly-returning steps: it binds left-to-right,
+   returns the first anomaly without evaluating later bindings, and
+   otherwise evaluates its body like let."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest let-ok-runs-body-when-no-anomaly
+  (testing "all bindings ok -> body evaluates like let, seeing the bindings"
+    (is (= 3 (anomaly/let-ok [a 1 b 2] (+ a b))))
+    (is (= 6 (anomaly/let-ok [a 1 b (+ a 2)] (* a b 2))))))
+
+(deftest let-ok-returns-first-anomaly
+  (testing "the first binding that yields an anomaly is returned"
+    (let [boom (anomaly/anomaly :not-found "missing" {})]
+      (is (= boom (anomaly/let-ok [a 1 b boom c 9] (+ a b c)))))))
+
+(deftest let-ok-short-circuits-remaining-bindings
+  (testing "bindings after the first anomaly are not evaluated"
+    (let [boom (anomaly/anomaly :fault "boom" {})
+          seen (atom [])]
+      (is (= boom
+             (anomaly/let-ok [a (do (swap! seen conj :a) 1)
+                              b (do (swap! seen conj :b) boom)
+                              c (do (swap! seen conj :c) 9)]
+               (+ a c))))
+      (is (= [:a :b] @seen)
+          "the :c binding must not run once :b is an anomaly"))))
+
+(deftest let-ok-does-not-evaluate-body-on-anomaly
+  (testing "the body is skipped when any binding is an anomaly"
+    (let [boom (anomaly/anomaly :fault "boom" {})
+          body-ran (atom false)]
+      (is (= boom (anomaly/let-ok [a boom] (reset! body-ran true) a)))
+      (is (false? @body-ran)))))
+
+(deftest let-ok-empty-bindings-runs-body
+  (testing "an empty binding vector simply evaluates the body"
+    (is (= :ok (anomaly/let-ok [] :ok)))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/let_ok_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/let_ok_test.clj
@@ -42,7 +42,8 @@
              (anomaly/let-ok [a (do (swap! seen conj :a) 1)
                               b (do (swap! seen conj :b) boom)
                               c (do (swap! seen conj :c) 9)]
-               (+ a c))))
+               ;; body references all three; it never runs (b short-circuits)
+               (+ a b c))))
       (is (= [:a :b] @seen)
           "the :c binding must not run once :b is an anomaly"))))
 
@@ -56,3 +57,36 @@
 (deftest let-ok-empty-bindings-runs-body
   (testing "an empty binding vector simply evaluates the body"
     (is (= :ok (anomaly/let-ok [] :ok)))))
+
+(defn- cause-chain-message
+  "Walk the cause chain of `t`, returning the first message matching
+   `pattern`, or nil. `macroexpand` wraps the IllegalArgumentException
+   in a CompilerException, so the useful message is down the chain."
+  [^Throwable t pattern]
+  (loop [^Throwable t t]
+    (cond
+      (nil? t)                                  nil
+      (re-find pattern (or (.getMessage t) "")) (.getMessage t)
+      :else                                     (recur (.getCause t)))))
+
+(defn- throws-on-expand?
+  "True when `(macroexpand form)` throws with a cause-chain message
+   matching `pattern`; false when nothing throws."
+  [form pattern]
+  (try
+    #_:clj-kondo/ignore (macroexpand form)
+    false
+    (catch Throwable t
+      (some? (cause-chain-message t pattern)))))
+
+(deftest let-ok-rejects-non-vector-bindings
+  (testing "a non-vector binding form throws at macroexpansion"
+    (is (throws-on-expand?
+         '(ai.miniforge.anomaly.interface/let-ok (a 1) :x)
+         #"binding vector"))))
+
+(deftest let-ok-rejects-odd-binding-count
+  (testing "an odd-length binding vector throws at macroexpansion"
+    (is (throws-on-expand?
+         '(ai.miniforge.anomaly.interface/let-ok [a 1 b] :x)
+         #"even number"))))


### PR DESCRIPTION
## Summary

Adds `let-ok` to the shared `ai.miniforge.anomaly` component — a `let`-style macro that threads anomaly-returning steps and short-circuits on the first anomaly. Each binding is evaluated left-to-right; if one yields an anomaly (per `anomaly?`), that anomaly is returned immediately and the remaining bindings + body are skipped. Otherwise the body evaluates like `let`.

It replaces the nested `(if (anomaly? x) x (let [...] ...))` pyramids that recur across products with a flat pipeline:

```clojure
(anomaly/let-ok [user    (lookup id)
                 account (account-for user)]
  (summarize account))
```

Placed in the shared anomaly component so every product (Thesium Career, the risk app, …) adopts one primitive. Sits under a "Macros" banner after the Layer 2 `anomaly?` predicate it expands against — the numbered strata stay at 3.

## Test plan

- New `let_ok_test.clj` (one-file-per-concern): threading + body value, first-anomaly return, short-circuit of later bindings, body-skip on anomaly, empty-bindings. **16 anomaly-interface tests / 46 assertions, 0 failures.**
- `bb poly:check` — OK.

## Note

The commit is **unsigned** — this environment can't drive the 1Password signing agent non-interactively. If the branch ruleset requires signed commits, it'll need a signed re-commit (happy to amend once signing is available, or you can re-sign on merge).