### PR TITLE
fix(test): update verify-test gate expectations for the policy-verify gate

### DIFF
--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
@@ -79,7 +79,7 @@
   (testing "default config has correct structure"
     (is (nil? (:agent verify/default-config))
         "Verify phase has no agent — runs tests directly")
-    (is (= [:pre-verify-lint :tests-pass :coverage] (:gates verify/default-config)))
+    (is (= [:pre-verify-lint :tests-pass :coverage :policy-verify] (:gates verify/default-config)))
     (is (map? (:budget verify/default-config)))
     (is (= 3 (get-in verify/default-config [:budget :iterations])))))
 
@@ -89,7 +89,7 @@
       (is (some? defaults))
       (is (nil? (:agent defaults))
           "Verify has no agent in the new environment model")
-      (is (= [:pre-verify-lint :tests-pass :coverage] (:gates defaults))))))
+      (is (= [:pre-verify-lint :tests-pass :coverage :policy-verify] (:gates defaults))))))
 
 ;------------------------------------------------------------------------------ Layer 1: Interceptor enter tests
 
@@ -104,7 +104,7 @@
             (is (= :verify (get-in result [:phase :name])))
             (is (nil? (get-in result [:phase :agent]))
                 "No agent in new environment model")
-            (is (= [:pre-verify-lint :tests-pass :coverage] (get-in result [:phase :gates])))
+            (is (= [:pre-verify-lint :tests-pass :coverage :policy-verify] (get-in result [:phase :gates])))
             (is (= :running (get-in result [:phase :status])))
             (is (number? (get-in result [:phase :started-at]))))
 


### PR DESCRIPTION
## Summary

#986 added `:policy-verify` to the verify phase's default `:gates`, but three `verify-test` assertions still expected the old `[:pre-verify-lint :tests-pass :coverage]` list — leaving them **red on main**. The pre-commit smoke set doesn't include `verify-test`, so it slipped through CI.

**Found by the dogfood reviewer on a live run** (`knowledge-mcp-query`): the review phase flagged that verify reported `:success` despite these three red tests. (Nice side-validation that the review gate works — but main needs the fix.)

Updated the three assertions to expect `[:pre-verify-lint :tests-pass :coverage :policy-verify]`:
- `default-config-test`
- `phase-defaults-registration-test`
- `enter-verify-basic-test`

> Follow-up (separate, not in this PR): the reviewer also noted the verify phase runner reports `:result/status :success` / "All 15 test(s) passed" *despite* red tests — a false-success/observability bug worth its own investigation (relates to the known SDLC quality-gate gaps).

## Test plan
- [x] `verify-test` green (14 tests / 40 assertions)
- [x] `bb pre-commit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)