### PR TITLE
Implement policy_lookup.clj in the knowledge component with a pure...

### DIFF
--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -38,7 +38,9 @@
    [ai.miniforge.knowledge.learning :as learning]
    [ai.miniforge.knowledge.loader :as loader]
    [ai.miniforge.knowledge.messages :as messages]
-   [ai.miniforge.knowledge.trust]))
+   [ai.miniforge.knowledge.policy-lookup :as policy-lookup]
+   [ai.miniforge.knowledge.trust]
+   [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
@@ -62,6 +64,10 @@
 ;; producer-side share-learning gate can reference it without
 ;; reaching into `knowledge.schema` directly.
 (def TrustLevel     schema/TrustLevel)
+;; Policy-pack rule lookup schemas. Callers may validate their own
+;; inputs against PolicyQuery before passing to lookup-policy-rules.
+(def PolicyQuery    schema/PolicyQuery)
+(def PolicyResult   schema/PolicyResult)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Store creation
@@ -222,6 +228,31 @@
   "Full-text search across zettel titles and content.
    Returns matching zettels sorted by relevance."
   store/search)
+
+(defn lookup-policy-rules
+  "Search loaded policy-pack rules by keyword, dewey code, or tag.
+
+   Only :rule-type zettels are searched — those loaded from .mdc rule files
+   or compiled policy packs. Validates the query against PolicyQuery schema
+   before delegating; returns an empty vector when the query is invalid.
+
+   Arguments:
+   - knowledge-store  KnowledgeStore instance (nil-safe — returns [])
+   - policy-query     {:query string :tags [keyword] :dewey-prefix string}
+                      All fields are optional. Multiple criteria are ANDed.
+
+   Returns a vector of {:rule/title string :rule/content string}.
+   Returns an empty vector on no match or invalid / nil store.
+
+   Examples:
+     (lookup-policy-rules store {:query \"try+\"})
+     (lookup-policy-rules store {:tags [:clojure]})
+     (lookup-policy-rules store {:dewey-prefix \"210\"})
+     (lookup-policy-rules store {:query \"namespace\" :tags [:clojure]})"
+  [knowledge-store policy-query]
+  (if (m/validate schema/PolicyQuery (or policy-query {}))
+    (policy-lookup/lookup-policy-rules knowledge-store (or policy-query {}))
+    []))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Agent injection

--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -250,9 +250,10 @@
      (lookup-policy-rules store {:dewey-prefix \"210\"})
      (lookup-policy-rules store {:query \"namespace\" :tags [:clojure]})"
   [knowledge-store policy-query]
-  (if (m/validate schema/PolicyQuery (or policy-query {}))
-    (policy-lookup/lookup-policy-rules knowledge-store (or policy-query {}))
-    []))
+  (let [q (or policy-query {})]
+    (if (m/validate schema/PolicyQuery q)
+      (policy-lookup/lookup-policy-rules knowledge-store q)
+      [])))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Agent injection

--- a/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
@@ -43,22 +43,19 @@
   "Return nil for nil/blank query, otherwise the trimmed string.
    Ensures the store text-search filter is skipped when no keyword was given."
   [q]
-  (when (seq (str/trim (or q "")))
-    (str/trim q)))
+  (let [trimmed (str/trim (or q ""))]
+    (when (seq trimmed) trimmed)))
 
 (defn- build-store-query
   "Translate a PolicyQuery map to the KnowledgeStore query map.
    Always restricts to :rule type so only policy-pack rules are searched."
   [{:keys [query tags dewey-prefix]}]
-  (cond-> {:include-types [:rule]}
-    (normalise-query-string query)
-    (assoc :text-search (normalise-query-string query))
-
-    (seq tags)
-    (assoc :tags (vec tags))
-
-    (dewey-prefixes dewey-prefix)
-    (assoc :dewey-prefixes (dewey-prefixes dewey-prefix))))
+  (let [text-search (normalise-query-string query)
+        prefixes    (dewey-prefixes dewey-prefix)]
+    (cond-> {:include-types [:rule]}
+      text-search (assoc :text-search text-search)
+      (seq tags)  (assoc :tags (vec tags))
+      prefixes    (assoc :dewey-prefixes prefixes))))
 
 (defn- zettel->policy-result
   "Project a zettel into the compact {:rule/title :rule/content} shape."

--- a/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
@@ -34,7 +34,7 @@
 
 (defn- dewey-prefixes
   "Coerce a scalar dewey-prefix string into the list form the store expects.
-   Returns nil when the prefix is nil or blank."
+   Returns nil when the prefix is nil, blank, or whitespace-only."
   [dewey-prefix]
   (let [trimmed (str/trim (or dewey-prefix ""))]
     (when (seq trimmed)
@@ -91,7 +91,7 @@
 
 (comment
   ;; Example: search for all Clojure-tagged rules
-  (require '[ai.miniforge.knowledge.store :as store])
+  ;; (store ns already required above; alias available as `store`)
   (def s (store/create-store))
   (lookup-policy-rules s {:tags [:clojure]})
 

--- a/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
@@ -36,8 +36,9 @@
   "Coerce a scalar dewey-prefix string into the list form the store expects.
    Returns nil when the prefix is nil or blank."
   [dewey-prefix]
-  (when (seq dewey-prefix)
-    [dewey-prefix]))
+  (let [trimmed (str/trim (or dewey-prefix ""))]
+    (when (seq trimmed)
+      [trimmed])))
 
 (defn- normalise-query-string
   "Return nil for nil/blank query, otherwise the trimmed string.

--- a/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
@@ -1,0 +1,112 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.knowledge.policy-lookup
+  "Pure query functions for searching loaded policy-pack rules.
+
+   Searches only :rule-type zettels (those loaded from .mdc rule files
+   or policy packs). All criteria are optional; omitting all returns all rules.
+   Multiple criteria are ANDed.
+
+   Layer 0: query translation + result projection
+   Layer 1: lookup orchestration"
+  (:require
+   [ai.miniforge.knowledge.store :as store]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Query translation and result projection
+
+(defn- dewey-prefixes
+  "Coerce a scalar dewey-prefix string into the list form the store expects.
+   Returns nil when the prefix is nil or blank."
+  [dewey-prefix]
+  (when (seq dewey-prefix)
+    [dewey-prefix]))
+
+(defn- normalise-query-string
+  "Return nil for nil/blank query, otherwise the trimmed string.
+   Ensures the store text-search filter is skipped when no keyword was given."
+  [q]
+  (when (seq (str/trim (or q "")))
+    (str/trim q)))
+
+(defn- build-store-query
+  "Translate a PolicyQuery map to the KnowledgeStore query map.
+   Always restricts to :rule type so only policy-pack rules are searched."
+  [{:keys [query tags dewey-prefix]}]
+  (cond-> {:include-types [:rule]}
+    (normalise-query-string query)
+    (assoc :text-search (normalise-query-string query))
+
+    (seq tags)
+    (assoc :tags (vec tags))
+
+    (dewey-prefixes dewey-prefix)
+    (assoc :dewey-prefixes (dewey-prefixes dewey-prefix))))
+
+(defn- zettel->policy-result
+  "Project a zettel into the compact {:rule/title :rule/content} shape."
+  [zettel]
+  {:rule/title   (:zettel/title zettel)
+   :rule/content (:zettel/content zettel)})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Lookup orchestration
+
+(defn lookup-policy-rules
+  "Search loaded policy-pack rules by keyword, dewey code, or tag.
+
+   Only :rule-type zettels are searched — those loaded from .mdc rule files
+   or compiled policy packs. The search is case-insensitive; all criteria
+   are ANDed; any criterion may be omitted.
+
+   Arguments:
+   - knowledge-store  KnowledgeStore instance with rules loaded
+   - policy-query     Map satisfying ai.miniforge.knowledge.schema/PolicyQuery
+                      {:query        string  — substring match on title + body
+                       :tags         [kw]    — zettel must carry at least one
+                       :dewey-prefix string  — e.g. \"210\" or \"21\"}
+
+   Returns a vector of {:rule/title string :rule/content string} maps.
+   Returns an empty vector when no rules match or store is nil."
+  [knowledge-store policy-query]
+  (if (nil? knowledge-store)
+    []
+    (->> (store/query knowledge-store (build-store-query policy-query))
+         (mapv zettel->policy-result))))
+
+(comment
+  ;; Example: search for all Clojure-tagged rules
+  (require '[ai.miniforge.knowledge.store :as store])
+  (def s (store/create-store))
+  (lookup-policy-rules s {:tags [:clojure]})
+
+  ;; Search by keyword
+  (lookup-policy-rules s {:query "try+"})
+
+  ;; Search by Dewey prefix
+  (lookup-policy-rules s {:dewey-prefix "210"})
+
+  ;; Combined
+  (lookup-policy-rules s {:query "namespace" :tags [:clojure] :dewey-prefix "210"})
+
+  ;; nil store → empty vector (safe to call unconditionally)
+  (lookup-policy-rules nil {})
+  ;; => []
+  :end)

--- a/components/knowledge/src/ai/miniforge/knowledge/schema.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/schema.clj
@@ -207,7 +207,8 @@
    :query        Case-insensitive substring matched against rule title + body.
    :tags         Vector of keywords; a rule matches if it carries at least one.
    :dewey-prefix Prefix string matched at the start of the rule's Dewey code
-                 (e.g. \"210\" matches \"210\" and \"211\")."
+                 (e.g. \"21\" matches \"210\" and \"211\"; \"210\" matches
+                 \"210\" but not \"211\")."
   [:map
    [:query        {:optional true} [:string {:min 1}]]
    [:tags         {:optional true} [:vector keyword?]]

--- a/components/knowledge/src/ai/miniforge/knowledge/schema.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/schema.clj
@@ -199,6 +199,27 @@
 ;------------------------------------------------------------------------------ Layer 3
 ;; Query schemas
 
+(def PolicyQuery
+  "Input schema for policy-pack rule lookup.
+   All fields are optional; omitting all returns every loaded :rule zettel.
+   Multiple criteria are ANDed.
+
+   :query        Case-insensitive substring matched against rule title + body.
+   :tags         Vector of keywords; a rule matches if it carries at least one.
+   :dewey-prefix Prefix string matched at the start of the rule's Dewey code
+                 (e.g. \"210\" matches \"210\" and \"211\")."
+  [:map
+   [:query        {:optional true} [:string {:min 1}]]
+   [:tags         {:optional true} [:vector keyword?]]
+   [:dewey-prefix {:optional true} [:string {:min 1}]]])
+
+(def PolicyResult
+  "Compact rule result returned by lookup-policy-rules.
+   Contains only the title and full markdown content of the matched rule."
+  [:map
+   [:rule/title   string?]
+   [:rule/content string?]])
+
 (def KnowledgeQuery
   "Query specification for retrieving relevant knowledge."
   [:map

--- a/components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj
@@ -1,0 +1,228 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.knowledge.policy-lookup-test
+  (:require
+   [ai.miniforge.knowledge.interface :as knowledge]
+   [ai.miniforge.knowledge.policy-lookup :as sut]
+   [ai.miniforge.knowledge.store :as store]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures and factories
+
+(defn- make-store
+  "Create an empty in-memory store with no logger noise."
+  []
+  (store/create-store))
+
+(defn- rule-zettel
+  "Build a minimal :rule zettel for testing. All keys required by the store."
+  [uid title content & {:as overrides}]
+  (merge {:zettel/id      (random-uuid)
+          :zettel/uid     uid
+          :zettel/title   title
+          :zettel/content content
+          :zettel/type    :rule
+          :zettel/tags    []
+          :zettel/links   []
+          :zettel/author  "test"
+          :zettel/created (java.util.Date.)}
+         overrides))
+
+(defn- non-rule-zettel
+  "Build a :learning zettel (should be excluded from policy lookup)."
+  [uid title]
+  {:zettel/id      (random-uuid)
+   :zettel/uid     uid
+   :zettel/title   title
+   :zettel/content "A learning, not a rule."
+   :zettel/type    :learning
+   :zettel/tags    [:clojure]
+   :zettel/links   []
+   :zettel/author  "test"
+   :zettel/created (java.util.Date.)})
+
+(defn- store-with-rules
+  "Create a store pre-populated with several rules."
+  []
+  (doto (make-store)
+    (store/put-zettel (rule-zettel "210-clojure-ns"
+                                  "Clojure Namespace Conventions"
+                                  "Follow Polylith conventions for namespace naming."
+                                  :zettel/dewey "210"
+                                  :zettel/tags [:clojure :namespace]))
+    (store/put-zettel (rule-zettel "001-stratified-design"
+                                  "Stratified Design"
+                                  "Use a single-direction DAG for code dependencies."
+                                  :zettel/dewey "001"
+                                  :zettel/tags [:architecture :design]))
+    (store/put-zettel (rule-zettel "211-exception-handling"
+                                  "Clojure Exception Handling"
+                                  "Prefer slingshot try+ over plain try."
+                                  :zettel/dewey "211"
+                                  :zettel/tags [:clojure :exceptions]))
+    (store/put-zettel (non-rule-zettel "learning-42" "A captured learning"))))
+
+(defn- titles
+  "Extract rule titles from lookup results for easy assertion."
+  [results]
+  (mapv :rule/title results))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Unit tests — policy-lookup/lookup-policy-rules (pure function)
+
+(deftest test-nil-store-returns-empty-vector
+  (testing "nil knowledge-store → safe, returns []"
+    (is (= [] (sut/lookup-policy-rules nil {})))))
+
+(deftest test-empty-store-returns-empty-vector
+  (testing "empty store with any query → []"
+    (is (= [] (sut/lookup-policy-rules (make-store) {})))))
+
+(deftest test-empty-query-returns-all-rules
+  (testing "empty query map → all :rule zettels, no learnings"
+    (let [results (sut/lookup-policy-rules (store-with-rules) {})]
+      (is (= 3 (count results)))
+      (is (every? #(contains? % :rule/title) results))
+      (is (every? #(contains? % :rule/content) results)))))
+
+(deftest test-result-shape
+  (testing "each result has only :rule/title and :rule/content"
+    (let [[first-result] (sut/lookup-policy-rules (store-with-rules) {})]
+      (is (string? (:rule/title first-result)))
+      (is (string? (:rule/content first-result)))
+      ;; No zettel internals leaked
+      (is (nil? (:zettel/id first-result)))
+      (is (nil? (:zettel/type first-result))))))
+
+(deftest test-non-rule-zettels-excluded
+  (testing "learnings and other types are not returned"
+    (let [results (sut/lookup-policy-rules (store-with-rules) {})
+          result-titles (titles results)]
+      (is (not (some #{"A captured learning"} result-titles))))))
+
+(deftest test-keyword-query-matches-title
+  (testing ":query matches title substring (case-insensitive)"
+    (let [results (sut/lookup-policy-rules (store-with-rules) {:query "Namespace"})]
+      (is (= 1 (count results)))
+      (is (= "Clojure Namespace Conventions" (:rule/title (first results)))))))
+
+(deftest test-keyword-query-matches-content
+  (testing ":query matches body content (case-insensitive)"
+    (let [results (sut/lookup-policy-rules (store-with-rules) {:query "slingshot"})]
+      (is (= 1 (count results)))
+      (is (= "Clojure Exception Handling" (:rule/title (first results)))))))
+
+(deftest test-keyword-query-case-insensitive
+  (testing ":query match is case-insensitive"
+    (let [upper (sut/lookup-policy-rules (store-with-rules) {:query "POLYLITH"})
+          lower (sut/lookup-policy-rules (store-with-rules) {:query "polylith"})]
+      (is (= (count upper) (count lower)))
+      (is (= 1 (count lower))))))
+
+(deftest test-keyword-query-no-match-returns-empty
+  (testing ":query with no matches → []"
+    (is (= [] (sut/lookup-policy-rules (store-with-rules) {:query "xyzzy-nonexistent"})))))
+
+(deftest test-tags-filter-single-tag
+  (testing ":tags with one tag returns matching rules"
+    (let [results (sut/lookup-policy-rules (store-with-rules) {:tags [:clojure]})]
+      (is (= 2 (count results)))
+      (is (= #{"Clojure Namespace Conventions" "Clojure Exception Handling"}
+             (set (titles results)))))))
+
+(deftest test-tags-filter-no-match
+  (testing ":tags with no matching zettel → []"
+    (is (= [] (sut/lookup-policy-rules (store-with-rules) {:tags [:python]})))))
+
+(deftest test-dewey-prefix-exact-match
+  (testing ":dewey-prefix exact match returns the matching rule"
+    (let [results (sut/lookup-policy-rules (store-with-rules) {:dewey-prefix "001"})]
+      (is (= 1 (count results)))
+      (is (= "Stratified Design" (:rule/title (first results)))))))
+
+(deftest test-dewey-prefix-matches-children
+  (testing ":dewey-prefix \"21\" matches dewey \"210\" and \"211\""
+    (let [results (sut/lookup-policy-rules (store-with-rules) {:dewey-prefix "21"})]
+      (is (= 2 (count results)))
+      (is (= #{"Clojure Namespace Conventions" "Clojure Exception Handling"}
+             (set (titles results)))))))
+
+(deftest test-dewey-prefix-no-match
+  (testing ":dewey-prefix with no matching rules → []"
+    (is (= [] (sut/lookup-policy-rules (store-with-rules) {:dewey-prefix "999"})))))
+
+(deftest test-combined-query-and-tags
+  (testing "combined :query + :tags → intersection"
+    (let [results (sut/lookup-policy-rules (store-with-rules)
+                                           {:query "slingshot" :tags [:clojure]})]
+      (is (= 1 (count results)))
+      (is (= "Clojure Exception Handling" (:rule/title (first results)))))))
+
+(deftest test-combined-tags-and-dewey
+  (testing "combined :tags + :dewey-prefix → intersection"
+    (let [results (sut/lookup-policy-rules (store-with-rules)
+                                           {:tags [:clojure] :dewey-prefix "210"})]
+      (is (= 1 (count results)))
+      (is (= "Clojure Namespace Conventions" (:rule/title (first results)))))))
+
+(deftest test-all-criteria-combined
+  (testing "all three criteria combined → most specific match"
+    (let [results (sut/lookup-policy-rules (store-with-rules)
+                                           {:query "slingshot"
+                                            :tags [:clojure]
+                                            :dewey-prefix "211"})]
+      (is (= 1 (count results)))
+      (is (= "Clojure Exception Handling" (:rule/title (first results)))))))
+
+(deftest test-all-criteria-combined-no-match
+  (testing "conflicting criteria → []"
+    (is (= [] (sut/lookup-policy-rules (store-with-rules)
+                                       {:query "slingshot"
+                                        :tags [:architecture]})))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Interface-level tests — knowledge/lookup-policy-rules (boundary + validation)
+
+(deftest test-interface-nil-store-safe
+  (testing "interface: nil store → []"
+    (is (= [] (knowledge/lookup-policy-rules nil {})))))
+
+(deftest test-interface-nil-query-treated-as-empty
+  (testing "interface: nil query → treated as empty, returns all rules"
+    (let [results (knowledge/lookup-policy-rules (store-with-rules) nil)]
+      (is (= 3 (count results))))))
+
+(deftest test-interface-invalid-query-returns-empty
+  (testing "interface: query failing PolicyQuery schema → []"
+    ;; :tags must be a vector of keywords, not a string
+    (is (= [] (knowledge/lookup-policy-rules (store-with-rules) {:tags "clojure"})))))
+
+(deftest test-interface-valid-query-delegates
+  (testing "interface: valid query delegates to lookup-policy-rules"
+    (let [results (knowledge/lookup-policy-rules (store-with-rules) {:tags [:clojure]})]
+      (is (= 2 (count results))))))
+
+(deftest test-policy-query-schema-exported
+  (testing "PolicyQuery schema is exported from the interface namespace"
+    (is (some? knowledge/PolicyQuery))))
+
+(deftest test-policy-result-schema-exported
+  (testing "PolicyResult schema is exported from the interface namespace"
+    (is (some? knowledge/PolicyResult))))

--- a/docs/pull-requests/2026-05-26-implement-policy-lookup-clj-in-the-knowledge-component-with-a-pure.md
+++ b/docs/pull-requests/2026-05-26-implement-policy-lookup-clj-in-the-knowledge-component-with-a-pure.md
@@ -4,23 +4,22 @@
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
 
-# Implement policy_lookup.clj in the knowledge component with a pure...
+# Implement policy_lookup.clj in the knowledge component with a pure
 
 **PR:** [#992](https://github.com/miniforge-ai/miniforge/pull/992)
 **Branch:** `mf/implement-policylookupclj-in-the-knowled-6600b36d`
 
 ## Summary
 
-Implement policy_lookup.clj in the knowledge component with a pure query function that searches loaded policy-pack rules by keyword, dewey code, or tag. Returns compact results (title + content...
+Implement policy_lookup.clj in the knowledge component with a pure query function that searches loaded policy-pack rules
+by keyword, dewey code, or tag. Returns compact results (title + content...
 
 ## Files Changed
 
-- `components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj` (modify)
-- `components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj` (create)
-- `docs/pull-requests/2026-05-26-task-c1b44bd7.md` (modify)
-- `components/knowledge/src/ai/miniforge/knowledge/interface.clj` (modify)
-- `components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj` (modify)
+- `components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj` (create)
 - `components/knowledge/src/ai/miniforge/knowledge/schema.clj` (modify)
+- `components/knowledge/src/ai/miniforge/knowledge/interface.clj` (modify)
+- `components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj` (create)
 - `docs/pull-requests/2026-05-26-task-c1b44bd7.md` (modify)
 
 ## Test Results

--- a/docs/pull-requests/2026-05-26-implement-policy-lookup-clj-in-the-knowledge-component-with-a-pure.md
+++ b/docs/pull-requests/2026-05-26-implement-policy-lookup-clj-in-the-knowledge-component-with-a-pure.md
@@ -1,0 +1,32 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Implement policy_lookup.clj in the knowledge component with a pure...
+
+**PR:** [#992](https://github.com/miniforge-ai/miniforge/pull/992)
+**Branch:** `mf/implement-policylookupclj-in-the-knowled-6600b36d`
+
+## Summary
+
+Implement policy_lookup.clj in the knowledge component with a pure query function that searches loaded policy-pack rules by keyword, dewey code, or tag. Returns compact results (title + content...
+
+## Files Changed
+
+- `components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj` (modify)
+- `components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj` (create)
+- `docs/pull-requests/2026-05-26-task-c1b44bd7.md` (modify)
+- `components/knowledge/src/ai/miniforge/knowledge/interface.clj` (modify)
+- `components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj` (modify)
+- `components/knowledge/src/ai/miniforge/knowledge/schema.clj` (modify)
+- `docs/pull-requests/2026-05-26-task-c1b44bd7.md` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._

--- a/docs/pull-requests/2026-05-26-task-c1b44bd7.md
+++ b/docs/pull-requests/2026-05-26-task-c1b44bd7.md
@@ -73,8 +73,25 @@ layer in future, the catalog should be introduced at that time.
 clojure -M:poly test :project miniforge :only ai.miniforge.knowledge.policy-lookup-test
 ```
 
-All 26 tests cover happy path, edge cases (nil inputs, empty store), and
-all three query criteria individually and in combination.
+24 tests across two layers cover happy path, edge cases (nil inputs, empty
+store), and all three query criteria individually and in combination.
+
+### Pre-existing test failures (unrelated to this PR)
+
+The test suite contains 3 pre-existing failures in
+`ai.miniforge.phase-software-factory.verify-test`:
+
+- `default-config-test`
+- `phase-defaults-registration-test`
+- `enter-verify-basic-test`
+
+All three fail on a `:policy-verify` gate expectation that was added to the
+production code after the test expectations were last updated. These failures
+pre-date this branch and are not caused by any change in this PR. The verify
+phase runner's `:result/status :success` / `"All 15 test(s) passed"` summary
+refers to a different metric (test namespaces or sub-sets, not individual
+assertions) and does not reflect these 3 assertion failures. This is a known
+gap in the verify-phase summary logic; it should be tracked separately.
 
 ## Deployment Plan
 

--- a/docs/pull-requests/2026-05-26-task-c1b44bd7.md
+++ b/docs/pull-requests/2026-05-26-task-c1b44bd7.md
@@ -1,0 +1,97 @@
+# feat: policy-pack rule lookup for the knowledge component
+
+## Overview
+
+Adds `policy_lookup.clj` to the knowledge component with a pure query function
+that searches loaded policy-pack rules by keyword, Dewey code, or tag.
+Returns compact `{:rule/title :rule/content}` results; always returns an empty
+vector on no match or nil store.
+
+## Motivation
+
+Agent prompts and the CLI `policy` command need a focused, lightweight way to
+query the policy-pack rules that have been loaded into a knowledge store.
+The existing `query-knowledge` function returns full zettel maps; this task
+calls for a dedicated, compact API that surfaces only title + content and
+restricts the search to `:rule`-type zettels.
+
+## Changes in Detail
+
+### New: `components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj`
+
+Pure namespace (no I/O, no side effects):
+
+- `build-store-query` — translates a `PolicyQuery` map to the store's query format
+  (`text-search`, `tags`, `dewey-prefixes`, `include-types [:rule]`).
+- `zettel->policy-result` — projects a zettel to `{:rule/title :rule/content}`.
+- `lookup-policy-rules` — orchestrates: calls `store/query`, projects results.
+  Nil-safe: returns `[]` when the store is nil.
+
+### Modified: `components/knowledge/src/ai/miniforge/knowledge/schema.clj`
+
+Added two new schemas at Layer 3:
+
+- `PolicyQuery` — `[:map [:query?] [:tags?] [:dewey-prefix?]]`  — all optional,
+  multiple criteria are ANDed.
+- `PolicyResult` — `[:map [:rule/title string?] [:rule/content string?]]`.
+
+### Modified: `components/knowledge/src/ai/miniforge/knowledge/interface.clj`
+
+- Added `[malli.core :as m]` and `[ai.miniforge.knowledge.policy-lookup]` to
+  requires.
+- Exported `PolicyQuery` and `PolicyResult` at Layer 0.
+- Added `lookup-policy-rules` at Layer 4 (after `search`):
+  - Validates `policy-query` against `PolicyQuery` before delegating.
+  - Treats a nil `policy-query` as an empty map (return all rules).
+  - Returns `[]` on schema validation failure (no anomaly — consistent with the
+    existing defensive style of this interface).
+
+### New: `components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj`
+
+26 tests across two layers:
+
+- Layer 1 — pure function tests (`sut/lookup-policy-rules`):
+  nil store, empty store, empty query, result shape, non-rule exclusion,
+  keyword query (title match, body match, case-insensitivity, no-match),
+  tag filter (match, no-match), Dewey-prefix filter (exact, prefix, no-match),
+  combined criteria (AND semantics).
+- Layer 2 — interface tests (`knowledge/lookup-policy-rules`):
+  nil store, nil query, invalid query schema, valid query delegation,
+  schema re-exports.
+
+### Note on system.edn
+
+No `system.edn` catalog was created. The implementation is a pure query function
+with no emitted strings (no log calls, no anomaly messages). The localization
+rule requires catalog entries only "for any emitted strings"; zero emitted
+strings means zero required entries. If logging is added to the interface
+layer in future, the catalog should be introduced at that time.
+
+## Testing Plan
+
+```
+clojure -M:poly test :project miniforge :only ai.miniforge.knowledge.policy-lookup-test
+```
+
+All 26 tests cover happy path, edge cases (nil inputs, empty store), and
+all three query criteria individually and in combination.
+
+## Deployment Plan
+
+Drop-in addition to the knowledge component. No schema migrations, no
+config changes, no new dependencies beyond `malli.core` (already on the
+component's classpath).
+
+## Checklist
+
+- [x] Pure function in `policy_lookup.clj` (no I/O)
+- [x] `PolicyQuery` + `PolicyResult` Malli schemas in `schema.clj`
+- [x] Schemas re-exported from `interface.clj`
+- [x] `lookup-policy-rules` exposed through `interface.clj`
+- [x] Input validation in interface wrapper (nil-safe)
+- [x] Returns `[]` on no match / nil store / invalid input
+- [x] Tests cover all query criteria and edge cases
+- [x] No magic literals (Dewey codes come from test data, not code)
+- [x] No dead code introduced
+- [x] Stratified layers labelled in source files
+- [x] PR doc created

--- a/docs/pull-requests/2026-05-26-task-c1b44bd7.md
+++ b/docs/pull-requests/2026-05-26-task-c1b44bd7.md
@@ -32,7 +32,8 @@ Pure namespace (no I/O, no side effects):
 Added two new schemas at Layer 3:
 
 - `PolicyQuery` — `[:map [:query?] [:tags?] [:dewey-prefix?]]`  — all optional,
-  multiple criteria are ANDed.
+  multiple criteria are ANDed. `:dewey-prefix` uses `starts-with?` semantics
+  (e.g. `"21"` matches `"210"` and `"211"`; `"210"` matches `"210"` but not `"211"`).
 - `PolicyResult` — `[:map [:rule/title string?] [:rule/content string?]]`.
 
 ### Modified: `components/knowledge/src/ai/miniforge/knowledge/interface.clj`
@@ -48,7 +49,7 @@ Added two new schemas at Layer 3:
 
 ### New: `components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj`
 
-26 tests across two layers:
+24 tests across two layers:
 
 - Layer 1 — pure function tests (`sut/lookup-policy-rules`):
   nil store, empty store, empty query, result shape, non-rule exclusion,
@@ -69,7 +70,7 @@ layer in future, the catalog should be introduced at that time.
 
 ## Testing Plan
 
-```
+```shell
 clojure -M:poly test :project miniforge :only ai.miniforge.knowledge.policy-lookup-test
 ```
 


### PR DESCRIPTION
## Summary

Implement policy_lookup.clj in the knowledge component with a pure query function that searches loaded policy-pack rules by keyword, dewey code, or tag. Returns compact results (title + content...

## Changes

- `components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj` (modify)
- `components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj` (create)
- `docs/pull-requests/2026-05-26-task-c1b44bd7.md` (modify)
- `components/knowledge/src/ai/miniforge/knowledge/interface.clj` (modify)
- `components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj` (modify)
- `components/knowledge/src/ai/miniforge/knowledge/schema.clj` (modify)
- `docs/pull-requests/2026-05-26-task-c1b44bd7.md` (modify)

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (7 files)