### PR TITLE
docs+specs: state-ownership/phase-graph architecture + 4 dogfood/phase specs

### DIFF
--- a/docs/architecture/state-ownership-and-phase-graph.md
+++ b/docs/architecture/state-ownership-and-phase-graph.md
@@ -1,0 +1,314 @@
+# State Ownership and the Phase Graph
+
+Status: design note / direction (2026-05-27)
+
+Two of the worst structural problems in the codebase are related:
+
+1. **Too many state machines, no formal ownership.** Task/FSM state, DAG
+   frontier, budget counters, lock pools, git, and GitHub all hold pieces of
+   "the truth," and there is no written rule for *who answers which question*
+   or *who wins when they disagree*.
+2. **The phase graph is data-driven and opaque.** Phase chains are EDN composed
+   at load time with dynamic interceptor middleware. The most complex behavior
+   emerges from the most data-driven configuration — powerful, but no static
+   analysis can see the runtime graph, so ordering / termination / retry-bound
+   errors surface only at runtime (the 2026-05-26 overnight retry runaway was
+   one symptom).
+
+This note fixes ownership on paper, defines the invariants that must hold, and
+specifies the static guard (the phase transition graph validator) plus the
+sequenced opacity fixes.
+
+---
+
+## 1. Canonical Sources
+
+Every fact has exactly one owner and one resolution rule.
+
+| Fact                     | Owner       | Resolution rule                |
+|--------------------------|-------------|--------------------------------|
+| Code content             | Git         | Git always wins                |
+| PR status                | Git/GitHub  | External; poll, don't cache    |
+| Task phase / FSM state   | Datalevin   | Datalevin always wins          |
+| Dependency edges         | Datalevin   | Derived in-memory at startup   |
+| Budget counters          | Datalevin   | Single writer per task         |
+| Scheduling frontier      | In-memory   | Derived; rehydrate on crash    |
+| Lock pools               | In-memory   | Derived; never authoritative   |
+
+Rule of thumb: **persistent truth lives in Datalevin or Git; in-memory state is
+always derived and rebuildable.** Anything in-memory that cannot be rebuilt from
+Datalevin + Git is a latent data-loss bug.
+
+### Conflict Resolution
+
+- **In-memory diverges from Datalevin** → Datalevin wins; in-memory is rebuilt.
+- **Datalevin diverges from Git** → surface as an invariant violation, **halt
+  the task**, a human resolves. (These two should never disagree; if they do,
+  something wrote state without doing the work, or vice versa.)
+
+---
+
+## 2. Crash Recovery Protocol
+
+A crash must be recoverable purely from the canonical sources:
+
+1. Rehydrate task records from Datalevin.
+2. Rebuild the DAG frontier from task dependency edges.
+3. Reacquire locks for tasks in `:running` state.
+4. Git worktree state is ground truth for code; re-export if missing.
+
+No step may depend on in-memory state that was not first rebuilt from Datalevin
+or Git.
+
+---
+
+## 3. Invariant Checker
+
+A per-task checker that asserts the canonical sources agree. Run it at phase
+boundaries and on resume; a failing invariant halts the task loud.
+
+```clojure
+(defn check-task-invariants [task-id]
+  {:state-coherent?  (= (git/branch-exists? task-id)
+                        (task/state-running-or-later? task-id))
+   :budget-not-over?  (<= (budget/actual-spend task-id)
+                          (budget/allocated task-id))
+   :retry-bounded?    (< (task/retry-count task-id)
+                         (phase/max-retries (task/current-phase task-id)))
+   :phase-not-stuck?  (< (task/time-in-current-phase task-id)
+                         phase/stuck-threshold)
+   :dag-coherent?     (every? task/exists? (dag/dependencies task-id))})
+```
+
+`:retry-bounded?` and `:phase-not-stuck?` are the runtime counterparts of the
+static checks in §4 — they catch at runtime what the validator catches at load
+time.
+
+---
+
+## 4. Phase Transition Graph Validator (most urgent)
+
+A static analysis pass over the phase EDN configs. Treat every phase as a node
+and every transition (`:next`, `:on-failure`, `:on-budget-exhausted`) as a
+directed edge. Build the graph; check properties.
+
+### What to validate
+
+1. **Existence** — every referenced phase name resolves to a loaded impl.
+2. **Termination** — every chain has at least one reachable terminal state
+   (`:done`/`:completed`/`:failed`/`:escalated`).
+3. **Cycle detection** — flag any cycle that lacks a bounded exit condition.
+4. **Retry bounds** — any back-edge (`A → A`, or `A → B → A`) must have an
+   explicit `max-retries` with a transition to a terminal when count exhausted.
+5. **Failure paths** — every non-terminal phase has an `:on-failure`
+   transition; none dangling.
+6. **Budget paths** — every non-terminal phase has an `:on-budget-exhausted`
+   transition; none dangling.
+7. **Interceptors** — every interceptor hook references a fn that exists at
+   load time.
+
+```clojure
+;; bb phases:validate   or   mf phases:validate
+(defn build-transition-graph [phase-configs]
+  ;; => {:nodes #{phase-name} :edges #{[from to label]}}
+  )
+
+(defn validate-graph [graph]
+  {:unresolved-refs   (find-dangling-refs graph)
+   :unbounded-cycles  (find-cycles-without-exit-condition graph)
+   :missing-failure   (phases-without-failure-path graph)
+   :missing-budget    (phases-without-budget-path graph)
+   :unreachable       (find-unreachable-terminals graph)})
+```
+
+Run at two points:
+
+- **Load time** — fail fast on startup if the active phase pack's graph is
+  invalid.
+- **`bb phases:validate`** — standalone, runs in CI and before deploying a new
+  phase pack.
+
+This is the static analog of the `#988` runaway guard: an unbounded back-edge
+is a config-time error, not a 17-hour runtime discovery.
+
+> Spec: `work/phase-transition-graph-validator.spec.edn`.
+
+---
+
+## 5. Dynamic Phase Composition Opacity — three problems, three fixes
+
+Phase plugins load at runtime from EDN; chains are configured in data;
+interceptor middleware is applied dynamically. The result is three distinct
+opacity problems wearing one coat.
+
+### Problem 1 — Can't see the graph
+
+The phase graph exists at load time but nobody renders it; it lives in memory,
+invisible.
+
+**Fix 1 — make the graph visible (1–2 days).** The validator (§4) already
+*builds* the graph; rendering it is trivial additional work.
+
+```text
+bb phases:graph                    # full graph, all chains
+bb phases:graph --chain software   # one chain
+bb phases:graph --task abc123      # the path this task took (from event stream)
+```
+
+Output Mermaid or DOT (renders in GitHub PRs natively, zero tooling cost). Each
+node shows name, attached interceptors, and `max-retries` if it has a back-edge;
+each edge shows its transition label. Additionally, **log the resolved chain at
+load time**:
+
+```text
+[phases] Loaded chain: software-factory
+  :explore   interceptors: [audit knowledge-inject budget-gate]
+  :plan      interceptors: [audit knowledge-inject conflict-check budget-gate]
+  :implement interceptors: [audit knowledge-inject secrets-scan budget-gate]
+  ...
+```
+
+"Opaque" becomes "one command away from a diagram."
+
+### Problem 2 — Contracts aren't declared
+
+Phases don't formally state the input shape they need or the output shape they
+guarantee, so chain compatibility is implicit and wrong shapes flow silently
+until something crashes downstream.
+
+**Fix 2 — declare contracts, check chain compatibility (3–4 days).**
+
+```edn
+{:phase/name   :implement
+ :phase/input  :schema/explore-output    ;; what I need from upstream
+ :phase/output :schema/implement-output  ;; what I guarantee downstream
+ :on-failure   {:next :implement :max-retries 3 :on-exhausted :escalate}}
+```
+
+At chain load time, walk the edges: for each `A → B`, does `A`'s `:phase/output`
+satisfy `B`'s `:phase/input`? A Malli compatibility check, failing **at load
+time** with a clear message:
+
+```text
+ERROR: Chain 'software-factory' transition :explore -> :plan is invalid.
+  :explore produces :schema/explore-output
+  :plan expects :schema/plan-input
+  Missing keys: [:plan/task-decomposition :plan/file-candidates]
+```
+
+A type system for the pipeline — Malli does this today. Also register the
+schemas for clj-kondo hooks / Calva so the EDN config gets autocomplete and
+inline validation in the editor.
+
+#### Boundary enforcement — the Ixi two-level pattern, reimplemented
+
+Declaring `:phase/input` / `:phase/output` schemas is half of it; the other
+half is *enforcing* them at the phase boundary with the right cost profile in
+dev vs production. The Ixi `custom-flow-control` pattern maps cleanly and is
+worth reimplementing as a new miniforge `boundary-validation` component (note:
+the existing `boundary` component is exception→anomaly→chain handling, *not*
+schema validation — this is additive, not a duplicate).
+
+Two levels, used together:
+
+- **Level 1 — `asserting-passthru` (dev/test, compiles out).** Wraps the call
+  in an elide-able hard assertion of the input/output schema. Under
+  `:elide-asserts true` (release builds) it is *literally gone from bytecode* —
+  zero cost. Use it where a schema violation is a programmer error that should
+  throw loudly in dev.
+- **Level 2 — `conforming-passthru` (runtime, dynamic-var gated).** A
+  `^:dynamic *validate-boundaries*` toggle: when `false` (production fast path)
+  the validation is skipped entirely; when `true` it runs the Malli check.
+
+```clojure
+(def ^:dynamic *validate-boundaries* true)
+
+;; dev / test — full validation, throws on violation
+(asserting-passthru execute-phase [[PhaseInputSchema input-data]])
+
+;; production — *validate-boundaries* false → zero overhead
+(conforming-passthru execute-phase [[PhaseInputSchema input-data]])
+```
+
+A `defphase` macro encodes both: phase authors declare `:input`/`:output`
+schemas and the boundary wrappers are generated.
+
+**Two deliberate departures from the ixi original:**
+
+1. **Reimplement; do not copy.** Per the IP boundary (miniforge stays
+   documented-clean; no ixi source moves in before a written mutual release),
+   build this fresh. The *pattern* is uncopyrightable and reimplementable
+   freely — the code is not imported.
+2. **Malli-only.** Ixi's `conforming-passthru` is a mixed spec+malli DSL;
+   miniforge is malli-single-source (the standing architectural verdict was to
+   leave the spec+malli DSL behind). Drop the spec dispatch in `process-tuple`;
+   keep the Malli path.
+
+**One addition ixi lacks (the production third level):** on a Level-2
+production validation failure, don't merely log — emit a structured
+`:phase/schema-violation` event to the N3 event stream. Telemetry without
+crashing, observable in the observe loop, and overlayable on the phase graph
+(Fix 3). So the strategy is three-tier: dev throws (Level 1), production-with-
+validation emits an event and continues degraded (Level 2 + N3), production
+fast-path skips (Level 2 off).
+
+### Problem 3 — Can't see what happened at runtime
+
+Even given the static graph, you can't observe which path a specific task took,
+which interceptors fired, or which guard chose `:on-failure` over `:next`. This
+is the N3 event-stream gap.
+
+**Fix 3 — runtime trace (N3 completion).** Every transition emits:
+
+```clojure
+{:event/type      :phase/transition
+ :task/id         task-id
+ :phase/from      :explore
+ :phase/to        :plan
+ :transition/kind :next             ;; or :on-failure, :on-budget-exhausted
+ :interceptors    [:audit :knowledge-inject :budget-gate]
+ :duration-ms     4821
+ :retry-count     0}
+```
+
+`bb phases:graph --task abc123` then overlays the actual execution path on the
+static graph: green edges taken, grey not taken, red failed. Map + route.
+
+---
+
+## 6. The Deeper Tension
+
+Data-driven configuration is flexible because it defers decisions to runtime —
+which is exactly why it's opaque: the shape of the system isn't knowable until
+it runs.
+
+**Resolution: make common paths typed and visible; make extension points
+data-driven but bounded.**
+
+- The core chain (`Explore → Plan → Implement → Verify → Review → Release →
+  Observe`) becomes a **first-class typed construct** — a declared structure
+  with a known shape, not just EDN.
+- Custom phases and interceptors extend it through data, but extension points
+  are **well-typed slots**, not arbitrary composition.
+- Adding an interceptor requires satisfying a declared interface, not just
+  dropping in a function reference.
+
+This narrows the surface where opacity can hide. Less flexible than fully
+arbitrary composition — but the rigid parts are the parts that bite when they go
+wrong. A bigger architectural conversation (RFC first), not a sprint.
+
+---
+
+## 7. Sequencing
+
+| When        | Work                                                          |
+|-------------|---------------------------------------------------------------|
+| This week   | Graph validator + interceptor load-time logging + graph render |
+| Next sprint | Malli input/output contracts + chain compatibility check      |
+| Ongoing     | Phase transition events as part of N3 completion              |
+| Later (RFC) | Typed core chain + bounded extension points                  |
+
+The validator makes misconfiguration a load-time error; the renderer makes the
+system debuggable; contracts make wrong-shape flow a load-time error; runtime
+events make production incidents diagnosable; the typed core chain is the
+long-term play.

--- a/work/QUEUE.md
+++ b/work/QUEUE.md
@@ -18,13 +18,17 @@ Make miniforge capable of running miniforge without paying for
 | blocker | ● | dogfood-resilience | `agent-stream-watchdog-and-resume.spec.edn` — Agent stream watchdog + session-resume for hang recovery | tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `dogfood-handoff-redirect-loop.spec.edn` — Dogfood: stop degraded handoff redirect loops | correctness+tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `planner-convergence-and-artifact-submission.spec.edn` — Planner convergence — container-promoted plan artifact + forced context-MCP usage | correctness+observation+tokenconservation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `release-opens-real-pr.spec.edn` — Release phase opens a real PR even in deterministic (no-LLM) mode | correctness+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `workflow-resume-fsm-advance-investigation.spec.edn` — Workflow resume — make FSM advance from production checkpoints, not just synthetic ones | observation+tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `workflow-resume-status-handling.spec.edn` — Workflow resume — fail loud when the resumed run never enters a terminal status | observation+tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `worktree-persistence-scratch-branch.spec.edn` — Persist worktrees outside /tmp + scratch-branch commits on every write | dogfoodenabler |
 | high | ● | dogfood-resilience | `pedestal-interceptor-chain.spec.edn` — Pedestal-style interceptor chain for phase lifecycle | correctness+dogfoodenabler |
+| high | ● | dogfood-resilience | `phase-transition-graph-validator.spec.edn` — Phase transition graph validator — static checks over phase EDN configs | correctness+observation+dogfoodenabler |
 | high | ● | dogfood-resilience | `tech-registry-doctor-repo-scoped-bootstrap.spec.edn` — Tech-registry-driven runtime bootstrap — repo-scoped, print-don't-install | correctness+ux+dogfoodenabler |
 | high | ○ | dogfood-resilience | `workflow-dependency-declarations.spec.edn` — Workflow dependency declarations — supervisor sequencing + DAG dependencies | dogfoodenabler |
+| blocker | ○ | dogfood-resilience | `review-redirect-convergence.spec.edn` — Review redirect convergence — stop nit-churn from blocking release | correctness+tokenconservation+dogfoodenabler |
 | blocker | ○ | dogfood-resilience | `workflow-phase-checkpoint-and-resume.spec.edn` — Workflow phase checkpoint + resume | tokenconservation+dogfoodenabler |
+| high | ○ | dogfood-resilience | `phase-boundary-contracts.spec.edn` — Phase boundary contracts — declare + enforce :phase/input/:output (Ixi pattern, re-derived) | correctness+observation+dogfoodenabler |
 
 ## Theme — Multi-backend CLI parity (`multi-backend-parity`, status: planned)
 

--- a/work/phase-boundary-contracts.spec.edn
+++ b/work/phase-boundary-contracts.spec.edn
@@ -1,0 +1,95 @@
+;; =============================================================================
+;; Spec: Phase boundary contracts — declared :input/:output schemas + enforcement
+;; =============================================================================
+;;
+;; Design: docs/architecture/state-ownership-and-phase-graph.md §5 Fix 2.
+;; Reimplements the Ixi custom-flow-control two-level boundary pattern FRESH
+;; (the pattern is uncopyrightable and re-derived from scratch; NO ixi source is
+;; copied — miniforge stays documented-clean). Malli-only (miniforge is
+;; malli-single-source; the spec+malli DSL is deliberately left behind).
+;;
+;; Depends on phase-transition-graph-validator.spec.edn: that spec builds the
+;; transition graph this one walks for chain compatibility, and adds the
+;; :phase/input / :phase/output declarations to the phase config shape.
+
+{:spec/title "Phase boundary contracts — declare + enforce :phase/input/:output (Ixi pattern, re-derived)"
+
+ :spec/description
+ "Give phases formal contracts and enforce them at the boundary with the right
+  cost profile in dev vs production. Two parts.
+
+  PART A — Declare + load-time chain compatibility.
+  Phase configs gain `:phase/input` and `:phase/output` Malli schema refs.
+  At chain load time, walk each `A -> B` edge (graph from the transition-graph
+  validator) and check that A's `:phase/output` satisfies B's `:phase/input`.
+  An incompatible transition FAILS AT LOAD TIME with an actionable message
+  naming the chain, the edge, and the missing/mismatched keys — turning
+  'wrong shape flows silently until a downstream crash' into a startup error.
+
+  PART B — Runtime boundary enforcement (new `boundary-validation` component).
+  Reimplement the Ixi two-level pattern, malli-only:
+    - asserting-passthru: wraps a phase call in an ELIDE-ABLE hard schema
+      assertion (compiles out under :elide-asserts true → zero bytecode cost).
+      Dev/test: a contract violation throws loudly (programmer error).
+    - conforming-passthru: gated by `^:dynamic *validate-boundaries*`. When
+      false (production fast path) validation is skipped; when true it runs the
+      Malli check.
+    - defphase macro: phase authors declare :input/:output; the boundary
+      wrappers are generated so authors don't hand-wire them.
+
+  PART C — Production third tier (the ixi-lacks addition).
+  On a Level-2 (conforming-passthru) production validation FAILURE, do not
+  merely log: emit a structured `:phase/schema-violation` event to the
+  event-stream (telemetry without crashing), observable in the observe loop and
+  overlayable on the phase graph. Net strategy: dev throws (Level 1);
+  production-with-validation emits an event and continues degraded (Level 2 +
+  N3); production fast-path skips (Level 2 off).
+
+  NOTE on provenance: this is a clean-room re-derivation of a pattern, not a
+  port. Do NOT copy ixi `custom-flow-control` / `malli-common` source.
+
+  NOTE on the existing `boundary` component: that is exception->anomaly->chain
+  handling (H-series), NOT schema validation. This `boundary-validation`
+  component is additive and distinct — do not conflate or merge them.
+
+  Non-goals: the transition-graph validator itself (dependency spec); graph
+  rendering (doc Fix 1); runtime path overlay (doc Fix 3); registering schemas
+  with clj-kondo/Calva (nice-to-have, can be a follow-up)."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/boundary-validation/src"
+          "components/phase/src"
+          "components/phase/resources/config"
+          "components/event-stream/src"]}
+
+ :spec/constraints
+ ["Clean-room re-derivation — NO ixi source (custom-flow-control / malli-common) is copied; the pattern is reimplemented from scratch"
+  "Malli-only — no clojure.spec dispatch (miniforge is malli-single-source; the spec+malli DSL is deliberately left behind)"
+  "New `boundary-validation` component is DISTINCT from the existing `boundary` component (which is exception->anomaly->chain, not schema validation) — do not merge or rename"
+  "asserting-passthru MUST compile out under :elide-asserts true (zero runtime cost in release builds)"
+  "conforming-passthru MUST honor `*validate-boundaries*`: false = skip all validation (fast path); true = full Malli check"
+  "A production (Level-2) validation failure emits a :phase/schema-violation event and continues degraded — it does NOT throw/crash the run (telemetry, not a hard stop); dev (Level-1) still throws"
+  "Load-time chain compatibility failure is LOUD and fails fast (refuse to start), naming chain + edge + missing keys"
+  "Exceptions are data at the component interface; the elide-able dev assert is the only sanctioned throw, scoped to dev/test"
+  "Loads under babashka (graalvm-compat gate) so phase config loading stays bb-safe"]
+
+ :spec/acceptance-criteria
+ ["Phase configs accept :phase/input and :phase/output Malli schema refs; the shipped canonical-sdlc phases declare them"
+  "At load time, an A->B edge where A's :output does not satisfy B's :input fails with a message naming the chain, the edge, and the missing keys"
+  "A compatible shipped chain loads cleanly (baseline — no regression)"
+  "asserting-passthru throws on a bad shape in dev/test, and compiles to a no-op under :elide-asserts true (verified zero-cost)"
+  "conforming-passthru with *validate-boundaries* false skips validation (fast path); with true it validates"
+  "A Level-2 production validation failure emits a :phase/schema-violation event (task-id, phase, expected schema, offending keys) and the run continues — no crash"
+  "defphase declares :input/:output and generates the boundary wrappers (a phase authored via defphase is validated without hand-wiring)"
+  "boundary-validation is a separate component from boundary; poly check passes; loads under babashka"]
+
+ :spec/priority
+ {:tier :high
+  :axes #{:correctness :observation :dogfood-enabler}
+  :theme :dogfood-resilience
+  :rationale "Turns implicit phase chain compatibility into a load-time type check and gives a dev-throw / prod-event / prod-skip enforcement strategy. Closes the 'wrong shape flows silently' failure mode the data-driven phase graph hides."
+  :blocks []
+  :blocked-by ["phase-transition-graph-validator.spec.edn"]}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/phase-transition-graph-validator.spec.edn
+++ b/work/phase-transition-graph-validator.spec.edn
@@ -16,8 +16,20 @@
 {:spec/title "Phase transition graph validator — static checks over phase EDN configs"
 
  :spec/description
- "Build a directed graph from the loaded phase configs (nodes = phase names;
-  edges = transitions labelled :next / :on-failure / :on-budget-exhausted) and
+ "FIRST locate the canonical transition source, THEN validate it. NOTE: the
+  phase config EDN (phase-software-factory/resources/config/phase/defaults.edn)
+  does NOT currently carry explicit :next / :on-failure / :on-budget-exhausted
+  edge keys — transitions are derived elsewhere: the linear pipeline/phase
+  sequence gives the :next edges, and redirects/failure edges come from the FSM
+  compilation (workflow/fsm.clj redirect-event / redirect-transition, driven by
+  a phase's :on-fail and the pipeline) plus budget handling. Task 0 of this
+  spec is to identify/define that canonical source and, if edges are implicit,
+  either (a) derive the graph from the pipeline + FSM transition definitions,
+  or (b) introduce explicit transition keys in the phase config and migrate the
+  shipped pack to declare them. Do not assume the keys already exist.
+
+  Build a directed graph (nodes = phase names; edges = derived transitions
+  labelled by kind: :next / :on-failure / :on-budget-exhausted / :redirect) and
   validate structural properties:
 
     1. Existence    — every referenced phase name resolves to a loaded impl
@@ -61,7 +73,8 @@
           "components/phase/resources/config"]}
 
  :spec/constraints
- ["All public fns return data (graph map / report map / anomaly); no throws at the component interface (exceptions-as-data)"
+ ["Derive edges from the ACTUAL transition source (pipeline sequence + workflow/fsm.clj redirect/on-fail compilation + budget handling), NOT from assumed :next/:on-failure/:on-budget-exhausted keys in the phase EDN (those keys do not exist today) — see Task 0 in the description"
+  "All public fns return data (graph map / report map / anomaly); no throws at the component interface (exceptions-as-data)"
   "bb.edn stays a thin wrapper — validation logic in a component, bb task delegates (feedback_bb_edn_thin_wrapper)"
   "Load-time validation fails LOUD (refuse to start with an actionable anomaly naming the offending phase/edge), never a silent skip"
   "Terminal states are configurable/derivable, not hardcoded to one keyword — recognize :done/:completed/:failed/:escalated"

--- a/work/phase-transition-graph-validator.spec.edn
+++ b/work/phase-transition-graph-validator.spec.edn
@@ -1,0 +1,91 @@
+;; =============================================================================
+;; Spec: Phase transition graph validator (static analysis over phase configs)
+;; =============================================================================
+;;
+;; Motivation (docs/architecture/state-ownership-and-phase-graph.md): phase
+;; chains are data-driven EDN composed at load time — powerful but opaque. No
+;; static analysis sees the runtime transition graph, so ordering/termination/
+;; retry-bound errors surface only at runtime. This validator treats every
+;; phase as a node and every transition (:next, :on-failure,
+;; :on-budget-exhausted) as a directed edge, builds the graph, and checks
+;; structural invariants — at load time (fail fast) and as a standalone CI
+;; check (bb phases:validate). It would have caught, e.g., a phase config that
+;; re-enters a phase with no bounded exit, or a transition target that doesn't
+;; resolve.
+
+{:spec/title "Phase transition graph validator — static checks over phase EDN configs"
+
+ :spec/description
+ "Build a directed graph from the loaded phase configs (nodes = phase names;
+  edges = transitions labelled :next / :on-failure / :on-budget-exhausted) and
+  validate structural properties:
+
+    1. Existence    — every referenced phase name resolves to a loaded impl
+    2. Termination  — every chain has at least one reachable terminal state
+                      (:done/:completed/:failed/:escalated)
+    3. Cycles       — flag any cycle lacking a bounded exit condition
+    4. Retry bounds — any back-edge (A→A or A→B→A) MUST carry an explicit
+                      max-retries with a transition to a terminal when exhausted
+    5. Failure paths — every non-terminal phase has an :on-failure transition;
+                       none dangling
+    6. Budget paths  — every non-terminal phase has an :on-budget-exhausted
+                       transition; none dangling
+    7. Interceptors  — every interceptor hook referenced resolves to a fn that
+                       exists at load time
+
+  Public API (data-returning, exceptions-as-data):
+    build-transition-graph : phase-configs -> {:nodes #{name} :edges #{[from to label]}}
+    validate-graph         : graph -> {:unresolved-refs [] :unbounded-cycles []
+                                       :missing-failure [] :missing-budget []
+                                       :unreachable [] :unbounded-back-edges []
+                                       :missing-interceptors []}
+    valid? / a single aggregate predicate over the report.
+
+  Wire at TWO points:
+    - Load time: fail fast (loud anomaly, refuse to start) when the graph of
+      the active phase pack is invalid.
+    - bb phases:validate (and mf phases:validate): standalone, runs in CI and
+      before deploying a new phase pack. Non-zero exit on invalid.
+
+  bb.edn must stay a thin wrapper (feedback_bb_edn_thin_wrapper): the validation
+  logic lives in a component; bb:validate calls it.
+
+  Non-goals: graph RENDERING (bb phases:graph — follow-up in the doc's Fix 1),
+  Malli input/output contract checking (doc Fix 2), runtime trace overlay
+  (doc Fix 3 / N3). This spec is the structural validator only."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/phase/src"
+          "components/phase-software-factory/src"
+          "components/phase/resources/config"]}
+
+ :spec/constraints
+ ["All public fns return data (graph map / report map / anomaly); no throws at the component interface (exceptions-as-data)"
+  "bb.edn stays a thin wrapper — validation logic in a component, bb task delegates (feedback_bb_edn_thin_wrapper)"
+  "Load-time validation fails LOUD (refuse to start with an actionable anomaly naming the offending phase/edge), never a silent skip"
+  "Terminal states are configurable/derivable, not hardcoded to one keyword — recognize :done/:completed/:failed/:escalated"
+  "A back-edge without an explicit max-retries + exhaustion-to-terminal is a validation FAILURE (this is the static analog of the #988 runaway guard)"
+  "The validator loads under babashka for bb phases:validate (graalvm-compat gate) — keep it on the bb-loadable class set"
+  "Report is per-property and actionable: each finding names the phase/edge and the rule violated"]
+
+ :spec/acceptance-criteria
+ ["build-transition-graph returns the correct nodes + labelled edges for the shipped canonical-sdlc phase pack"
+  "validate-graph on the shipped pack returns a clean report (the current config is valid) — establishing the baseline"
+  "A config referencing a non-existent phase target is reported under :unresolved-refs"
+  "A config with a phase that has no path to any terminal is reported under :unreachable / termination"
+  "A back-edge without explicit max-retries + exhaustion transition is reported under :unbounded-back-edges"
+  "A non-terminal phase missing :on-failure or :on-budget-exhausted is reported under :missing-failure / :missing-budget"
+  "An interceptor hook naming an unresolvable fn is reported under :missing-interceptors"
+  "Load-time init refuses to start (loud anomaly) on an invalid graph; a valid graph starts normally"
+  "bb phases:validate exits non-zero on an invalid pack, zero on a valid one, and loads under babashka"]
+
+ :spec/priority
+ {:tier :high
+  :axes #{:correctness :dogfood-enabler :observation}
+  :theme :dogfood-resilience
+  :rationale "Static guard over the most data-driven, opaque part of the system (phase chains). Catches termination/retry/failure-path defects at load/CI time instead of as runtime runaways — the static analog of #988."
+  :blocks []
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/release-opens-real-pr.spec.edn
+++ b/work/release-opens-real-pr.spec.edn
@@ -13,34 +13,46 @@
 {:spec/title "Release phase opens a real PR even in deterministic (no-LLM) mode"
 
  :spec/description
- "Decouple PR-opening (mechanical: push branch + gh pr create) from
-  PR-narrative generation (LLM-or-fallback metadata). Today release-executor
-  falls back to deterministic metadata when no releaser agent/LLM is available
-  (release-executor/metadata.clj ~279) and the run ends with a PR *doc* but no
-  opened PR. Opening the PR does NOT require an LLM — the branch push and
-  `gh pr create` are deterministic and already implemented in
-  pr-lifecycle/controller.clj (push-and-create-pr! / create-pr!). Wire the
-  release phase so that, whenever :create-pr? is true (release.clj default),
-  it pushes the task's scratch/worktree branch and opens a real GitHub PR
-  using the generated metadata (LLM narrative when available, deterministic
-  title/body otherwise), and populates :workflow/pr-info with the real
-  pr-number/url. Fallback metadata must degrade the PR *prose*, never skip the
-  PR itself.
+ "DIAGNOSE-THEN-FIX: release-executor ALREADY has a full PR pipeline — its
+  step chain is step-push -> step-create-pr (-> sandbox/create-pr!) ->
+  step-generate-pr-doc -> step-update-pr-body (release-executor/core.clj
+  ~647-672), each gated on :create-pr? (default true, release.clj ~297).
+  Metadata generation falling back to deterministic mode
+  (release-executor/metadata.clj ~279) is SEPARATE from PR creation — fallback
+  metadata only changes the PR prose, it does not itself skip step-create-pr.
+  So the dogfood run producing a doc but no PR is NOT 'release lacks PR
+  creation'; it is 'step-create-pr did not open a PR on this run'.
 
-  Non-goals: changing the PR-doc generator; the observe-phase PR monitoring
+  FIRST, find the real cause (do NOT replace working release-executor plumbing,
+  and do NOT route through pr-lifecycle/controller — that is a different
+  surface): candidates to check on the 2026-05-27 local dogfood configuration —
+  (a) was :create-pr? actually true on the adhoc/dogfood path? (b) did
+  step-push push a real feature branch, or did the run commit to the main
+  checkout's worktree (the run logged 'Branch: main, Worktree: <repo>') with
+  nothing to PR? (c) does sandbox/create-pr! actually open a PR for the LOCAL
+  executor used in a `bb dogfood` run, or is it a no-op outside a Docker/sandbox
+  executor? (d) did a step short-circuit (skip) silently?
+
+  THEN fix so that a successful run with :create-pr? true opens a real GitHub
+  PR (push a real branch, invoke the existing create-pr step against an
+  executor that can reach GitHub) and populates :workflow/pr-info with the real
+  pr-number/url — with deterministic metadata still producing a usable
+  title/body. Whatever the cause, a green local dogfood must end with an open
+  PR.
+
+  Non-goals: changing the PR-doc generator; observe-phase PR monitoring
   (separate, already built); GitHub auth setup (GITHUB_TOKEN is already
-  resolved for dogfood runs)."
+  resolved for dogfood runs); introducing a second PR-creation path."
 
  :spec/intent
- {:type :feature
+ {:type :fix
   :scope ["components/release-executor/src"
-          "components/phase-software-factory/src"
-          "components/pr-lifecycle/src"]}
+          "components/phase-software-factory/src"]}
 
  :spec/constraints
- ["PR-opening is mechanical and MUST run in deterministic mode — absence of a releaser agent/LLM degrades only the PR title/body prose, never whether a PR is opened"
-  "Reuse pr-lifecycle/controller push-and-create-pr! / create-pr! — do not add a second PR-creation path"
-  "Honor :create-pr? (release.clj config / :execution/opts) — when false, keep today's doc-only behavior (e.g. local-only runs)"
+ ["Fix the EXISTING release-executor PR pipeline (step-push/step-create-pr/sandbox/create-pr!); do NOT replace it or route release through pr-lifecycle/controller (a different surface) — no second PR-creation path"
+  "PR-opening is mechanical and MUST run in deterministic mode — absence of a releaser agent/LLM degrades only the PR title/body prose (metadata), never whether step-create-pr opens a PR"
+  "Honor :create-pr? (release.clj config / :execution/opts, default true) — when explicitly false, keep doc-only behavior (e.g. local-only runs)"
   "On success populate :workflow/pr-info with the real {:pr-number :url :branch} so the observe phase hand-off (project_observe_phase_pr_handoff_bug) and metrics see it"
   "Exceptions are data: a push/create-pr failure returns an anomaly that fails the release phase loud (with the partial state), not a silent fallback to doc-only"
   "No duplicate PRs on retry: if a PR already exists for the task branch, reuse/update it rather than opening a second"]

--- a/work/release-opens-real-pr.spec.edn
+++ b/work/release-opens-real-pr.spec.edn
@@ -1,0 +1,64 @@
+;; =============================================================================
+;; Spec: Release phase opens a real PR (not a fallback doc-only release)
+;; =============================================================================
+;;
+;; Dogfood evidence (2026-05-27, knowledge-mcp-query run): a task drove the full
+;; SDLC to :done, but the release phase logged
+;;   release-executor/using-fallback-metadata
+;;   "No releaser agent or LLM available, using deterministic metadata"
+;; and produced ONLY a PR doc (docs/pull-requests/<date>-task-<id>.md) + a
+;; checkpoint bundle. No GitHub PR was opened. So even a fully successful
+;; autonomous run cannot actually SHIP — the dogfood loop dead-ends at a doc.
+
+{:spec/title "Release phase opens a real PR even in deterministic (no-LLM) mode"
+
+ :spec/description
+ "Decouple PR-opening (mechanical: push branch + gh pr create) from
+  PR-narrative generation (LLM-or-fallback metadata). Today release-executor
+  falls back to deterministic metadata when no releaser agent/LLM is available
+  (release-executor/metadata.clj ~279) and the run ends with a PR *doc* but no
+  opened PR. Opening the PR does NOT require an LLM — the branch push and
+  `gh pr create` are deterministic and already implemented in
+  pr-lifecycle/controller.clj (push-and-create-pr! / create-pr!). Wire the
+  release phase so that, whenever :create-pr? is true (release.clj default),
+  it pushes the task's scratch/worktree branch and opens a real GitHub PR
+  using the generated metadata (LLM narrative when available, deterministic
+  title/body otherwise), and populates :workflow/pr-info with the real
+  pr-number/url. Fallback metadata must degrade the PR *prose*, never skip the
+  PR itself.
+
+  Non-goals: changing the PR-doc generator; the observe-phase PR monitoring
+  (separate, already built); GitHub auth setup (GITHUB_TOKEN is already
+  resolved for dogfood runs)."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/release-executor/src"
+          "components/phase-software-factory/src"
+          "components/pr-lifecycle/src"]}
+
+ :spec/constraints
+ ["PR-opening is mechanical and MUST run in deterministic mode — absence of a releaser agent/LLM degrades only the PR title/body prose, never whether a PR is opened"
+  "Reuse pr-lifecycle/controller push-and-create-pr! / create-pr! — do not add a second PR-creation path"
+  "Honor :create-pr? (release.clj config / :execution/opts) — when false, keep today's doc-only behavior (e.g. local-only runs)"
+  "On success populate :workflow/pr-info with the real {:pr-number :url :branch} so the observe phase hand-off (project_observe_phase_pr_handoff_bug) and metrics see it"
+  "Exceptions are data: a push/create-pr failure returns an anomaly that fails the release phase loud (with the partial state), not a silent fallback to doc-only"
+  "No duplicate PRs on retry: if a PR already exists for the task branch, reuse/update it rather than opening a second"]
+
+ :spec/acceptance-criteria
+ ["A run that reaches release with :create-pr? true opens a real GitHub PR (verifiable pr-number/url in :workflow/pr-info) — not just a docs/pull-requests/*.md file"
+  "With no releaser agent/LLM, the PR is STILL opened; only the title/body fall back to deterministic metadata"
+  "With :create-pr? false, behavior is unchanged (doc-only, no PR)"
+  "A push or gh-pr-create failure fails the release phase with an anomaly carrying the cause — it does not silently report success"
+  "Re-running release for a task whose branch already has an open PR does not create a duplicate"
+  "A dogfood run on a small spec ends with an actual open PR on GitHub"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:dogfood-enabler :correctness}
+  :theme :dogfood-resilience
+  :rationale "Without this a fully successful autonomous run cannot ship — the loop dead-ends at a doc. PR-opening is mechanical and must not depend on an LLM being present."
+  :blocks []
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/review-redirect-convergence.spec.edn
+++ b/work/review-redirect-convergence.spec.edn
@@ -18,14 +18,14 @@
 
   (a) The :review-approved gate blocks on :warning-severity findings, so the
   reviewer can hold a PR hostage over nits indefinitely. Per N4 §2.3.1 only
-  :error MUST block; :warning SHOULD block ONLY when not auto-repaired.
+  :blocking severity MUST block; :warning SHOULD block ONLY when not auto-repaired.
   Decide and implement the policy: warnings are advisory after the first
   redirect (mirroring the #977 fix that made :lint advisory), or block only
   when severity >= a configured floor.
 
   (b) Even with a severity floor, review can fail to converge if each pass
   surfaces NEW findings. Add a bounded review-iteration policy: track review
-  attempts per task; once non-:error findings persist across N review→implement
+  attempts per task; once non-:blocking findings persist across N review→implement
   cycles (config, small default), STOP redirecting — either accept-with-
   warnings (open the PR carrying the unresolved nits as PR comments / known
   issues) or emit a :needs-decomposition signal (per
@@ -33,7 +33,7 @@
   rather than burning redirects to max-redirects.
 
   Crucially the meta-agent must be able to DISTINGUISH causes before acting
-  (user, 2026-05-26): persistent :error findings = real defect (keep
+  (user, 2026-05-26): persistent :blocking findings = real defect (keep
   blocking/redirecting); persistent :warning churn = either accept-with-
   warnings or under-decomposition — never blindly decompose.
 
@@ -49,16 +49,16 @@
           "components/phase/resources/config"]}
 
  :spec/constraints
- [":error findings always block and redirect — convergence policy applies ONLY to non-:error (warning/nit/audit) findings"
+ ["Use the EXISTING reviewer severity vocabulary :blocking/:warning/:nit (components/agent/.../reviewer.clj ~65, :blocking checked ~246-254) — do NOT introduce a new :error level. :blocking findings always block and redirect; the convergence policy applies ONLY to non-:blocking (:warning/:nit) findings"
   "A review-iteration counter is tracked per task (not global) and is distinct from max-redirects and from #988's consecutive-same-phase counter (review↔implement alternates, so #988 never fires here)"
-  "On giving up on nit-churn, the outcome is explicit and observable: either accept-with-warnings (PR opened, unresolved nits recorded) or a :needs-decomposition signal — never a silent infinite redirect, never a silent pass that hides an :error"
+  "On giving up on nit-churn, the outcome is explicit and observable: either accept-with-warnings (PR opened, unresolved nits recorded) or a :needs-decomposition signal — never a silent infinite redirect, never a silent pass that hides a :blocking"
   "The cause must be classified before the terminal decision (error vs warning-churn vs stall) — the decision and its reason are emitted as an event"
   "No regression: a task whose review passes cleanly (task-1 in the dogfood run) is unaffected; warnings on a first pass still trigger one repair attempt"
   "Reuse the existing reviewer gate-feedback shape and emit-gate-event! surface"]
 
  :spec/acceptance-criteria
  ["A task whose review yields only :warning findings on every pass converges to a terminal outcome (accept-with-warnings or :needs-decomposition) within the configured review-iteration cap — it does not run to max-redirects"
-  "A task with an :error finding still blocks and redirects to implement every time (no weakening of real-defect gating)"
+  "A task with a :blocking finding still blocks and redirects to implement every time (no weakening of real-defect gating)"
   "Accept-with-warnings opens the PR (per release-opens-real-pr) carrying the unresolved warnings as recorded known-issues/comments"
   "The terminal review decision (pass / accept-with-warnings / needs-decomposition / blocked-on-error) and its classification reason are emitted as a structured event"
   "A clean first-pass review still reaches release unchanged (no regression)"

--- a/work/review-redirect-convergence.spec.edn
+++ b/work/review-redirect-convergence.spec.edn
@@ -1,0 +1,75 @@
+;; =============================================================================
+;; Spec: Review→implement redirect convergence policy
+;; =============================================================================
+;;
+;; Dogfood evidence (2026-05-27, knowledge-mcp-query run): task-b3e1c6d4 never
+;; converged. The :reviewer surfaced fresh :warning-severity findings on each
+;; pass (with-redefs anon-fn bodies, redundant ns-resolve, doc-count nits), the
+;; :review-approved gate blocked on them, the workflow redirected review→
+;; implement, the agent fixed some, the next review found new ones — churning
+;; toward max-redirects (5) without ever shipping. Task-1 in the same run took
+;; one redirect and passed; task-2 flailed. We need a principled convergence
+;; policy so non-blocking nitpicks don't gate a release indefinitely.
+
+{:spec/title "Review redirect convergence — stop nit-churn from blocking release"
+
+ :spec/description
+ "Make the review phase converge. Two coupled problems observed:
+
+  (a) The :review-approved gate blocks on :warning-severity findings, so the
+  reviewer can hold a PR hostage over nits indefinitely. Per N4 §2.3.1 only
+  :error MUST block; :warning SHOULD block ONLY when not auto-repaired.
+  Decide and implement the policy: warnings are advisory after the first
+  redirect (mirroring the #977 fix that made :lint advisory), or block only
+  when severity >= a configured floor.
+
+  (b) Even with a severity floor, review can fail to converge if each pass
+  surfaces NEW findings. Add a bounded review-iteration policy: track review
+  attempts per task; once non-:error findings persist across N review→implement
+  cycles (config, small default), STOP redirecting — either accept-with-
+  warnings (open the PR carrying the unresolved nits as PR comments / known
+  issues) or emit a :needs-decomposition signal (per
+  project_retry_cap_as_decomposition_signal) for the meta-agent to consider,
+  rather than burning redirects to max-redirects.
+
+  Crucially the meta-agent must be able to DISTINGUISH causes before acting
+  (user, 2026-05-26): persistent :error findings = real defect (keep
+  blocking/redirecting); persistent :warning churn = either accept-with-
+  warnings or under-decomposition — never blindly decompose.
+
+  Non-goals: changing what the reviewer detects; the compiler/gate plumbing
+  (#984-987); the consecutive-phase cap (#988, which does not catch
+  review↔implement flapping because the phase alternates)."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/agent/src"
+          "components/phase-software-factory/src"
+          "components/workflow/src"
+          "components/phase/resources/config"]}
+
+ :spec/constraints
+ [":error findings always block and redirect — convergence policy applies ONLY to non-:error (warning/nit/audit) findings"
+  "A review-iteration counter is tracked per task (not global) and is distinct from max-redirects and from #988's consecutive-same-phase counter (review↔implement alternates, so #988 never fires here)"
+  "On giving up on nit-churn, the outcome is explicit and observable: either accept-with-warnings (PR opened, unresolved nits recorded) or a :needs-decomposition signal — never a silent infinite redirect, never a silent pass that hides an :error"
+  "The cause must be classified before the terminal decision (error vs warning-churn vs stall) — the decision and its reason are emitted as an event"
+  "No regression: a task whose review passes cleanly (task-1 in the dogfood run) is unaffected; warnings on a first pass still trigger one repair attempt"
+  "Reuse the existing reviewer gate-feedback shape and emit-gate-event! surface"]
+
+ :spec/acceptance-criteria
+ ["A task whose review yields only :warning findings on every pass converges to a terminal outcome (accept-with-warnings or :needs-decomposition) within the configured review-iteration cap — it does not run to max-redirects"
+  "A task with an :error finding still blocks and redirects to implement every time (no weakening of real-defect gating)"
+  "Accept-with-warnings opens the PR (per release-opens-real-pr) carrying the unresolved warnings as recorded known-issues/comments"
+  "The terminal review decision (pass / accept-with-warnings / needs-decomposition / blocked-on-error) and its classification reason are emitted as a structured event"
+  "A clean first-pass review still reaches release unchanged (no regression)"
+  "Re-running the dogfood spec that previously churned (knowledge-mcp-query task-2 shape) now terminates review deterministically instead of flapping"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:dogfood-enabler :correctness :token-conservation}
+  :theme :dogfood-resilience
+  :rationale "Non-converging review churn burns tokens to max-redirects and blocks shipping over nits. This is the user's retry-cap-as-decomposition-signal applied to review."
+  :blocks []
+  :blocked-by ["release-opens-real-pr.spec.edn"]}
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
## Summary

Captures the architectural direction discussed after the 2026-05-27 dogfood run (the first full multi-task SDLC pass) and the runnable work that fell out of it.

**Doc** — `docs/architecture/state-ownership-and-phase-graph.md`:
- Canonical-sources ownership table (who answers which question; who wins on conflict), conflict-resolution rules, crash-recovery protocol, the per-task invariant checker.
- The **phase transition graph validator** (static analog of #988 — catch unbounded back-edges / dangling failure paths / unreachable terminals at load + CI time, not as a runtime runaway).
- The three **dynamic-composition opacity** problems and their fixes: (1) graph render, (2) Malli input/output contracts via a **re-derived** Ixi two-level boundary pattern, (3) runtime trace.
- The "typed core chain + bounded extension points" tension, and a sequencing table.

**Specs** (`work/*.spec.edn`, runnable via `bb dogfood`; cross-linked by `:blocked-by`):
| spec | tier | gist |
|---|---|---|
| `release-opens-real-pr` | blocker | release opens a *real* PR even in no-LLM/fallback mode (today it dead-ends at a doc) |
| `review-redirect-convergence` | blocker | `:error` always blocks; non-`:error` warning-churn converges within a bounded cap (accept-with-warnings or `:needs-decomposition`, cause diagnosed first) |
| `phase-transition-graph-validator` | high | static checks over phase EDN at load time + `bb phases:validate` |
| `phase-boundary-contracts` | high | declared `:phase/input`/`:output` + load-time chain compatibility + the Ixi asserting/conforming-passthru pattern **re-derived clean** (malli-only) with a `:phase/schema-violation` N3 event |

### Provenance note
`phase-boundary-contracts` re-derives the Ixi `custom-flow-control` pattern **from scratch** — no ixi source is copied (patterns aren't copyrightable; miniforge stays documented-clean), and it's malli-only (the spec+malli DSL is deliberately left behind). It's also distinct from the existing `boundary` component (which is exception→anomaly→chain, not schema validation).

> Single commit uses `MINIFORGE_COMMIT_BUDGET_OVERRIDE`: this is a design doc (239 lines of prose) + four declarative EDN specs, no executable code — the budget's reviewer-defect rationale doesn't apply and slicing prose/specs is pure churn.

## Test plan
- [x] doc is markdownlint-clean
- [x] all four specs parse as EDN
- [x] `bb pre-commit` (budget overridden; nothing else to run — no code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)