### PR TITLE
feat(anomaly): add validation-anomaly + exception-anomaly helpers (convergence W0)

### DIFF
--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -105,12 +105,13 @@
   ([type message ex]
    (exception-anomaly type message {} ex))
   ([type message data ex]
-   (anomaly type
-            message
-            (cond-> (assoc data
-                           :anomaly/ex-message (ex-message ex)
-                           :anomaly/ex-class   (.getName (class ex)))
-              (ex-data ex) (assoc :anomaly/ex-data (ex-data ex))))))
+   (let [ed (ex-data ex)]
+     (anomaly type
+              message
+              (cond-> (assoc data
+                             :anomaly/ex-message (ex-message ex)
+                             :anomaly/ex-class   (.getName (class ex)))
+                ed (assoc :anomaly/ex-data ed))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Predicate

--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -84,6 +84,34 @@
    :anomaly/data    (or data {})
    :anomaly/at      (now)})
 
+(defn validation-anomaly
+  "Construct an `:invalid-input` anomaly describing a schema-validation
+   failure. The schema name, offending value, and explain data are
+   carried under `:anomaly/data` so callers can inspect why validation
+   failed without re-running it."
+  [message schema-name value explain-data]
+  (anomaly :invalid-input
+           message
+           {:anomaly/schema  schema-name
+            :anomaly/value   value
+            :anomaly/explain explain-data}))
+
+(defn exception-anomaly
+  "Wrap an exception as an anomaly of `type`, preserving the original
+   provenance — exception message and class (plus `ex-data` when
+   present) — under `:anomaly/data`. Any caller `data` is merged in.
+   Use at boundaries that must translate a thrown exception into the
+   data-first anomaly contract."
+  ([type message ex]
+   (exception-anomaly type message {} ex))
+  ([type message data ex]
+   (anomaly type
+            message
+            (cond-> (assoc data
+                           :anomaly/ex-message (ex-message ex)
+                           :anomaly/ex-class   (.getName (class ex)))
+              (ex-data ex) (assoc :anomaly/ex-data (ex-data ex))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Predicate
 

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/exception_anomaly_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/exception_anomaly_test.clj
@@ -1,0 +1,51 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.exception-anomaly-test
+  "exception-anomaly wraps a thrown exception as a canonical anomaly of
+   the given type, preserving the exception's message, class, and
+   ex-data under :anomaly/data."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest exception-anomaly-is-canonical-with-given-type
+  (testing "result satisfies anomaly? and uses the supplied type + message"
+    (let [a (anomaly/exception-anomaly :fault "wrapped" (Exception. "boom"))]
+      (is (anomaly/anomaly? a))
+      (is (= :fault (:anomaly/type a)))
+      (is (= "wrapped" (:anomaly/message a))))))
+
+(deftest exception-anomaly-preserves-provenance
+  (testing "exception message and class survive under :anomaly/data"
+    (let [a (anomaly/exception-anomaly :fault "wrapped" (Exception. "boom"))]
+      (is (= "boom" (get-in a [:anomaly/data :anomaly/ex-message])))
+      (is (= "java.lang.Exception" (get-in a [:anomaly/data :anomaly/ex-class]))))))
+
+(deftest exception-anomaly-captures-ex-data-when-present
+  (testing "ex-data is carried only when the exception has it"
+    (let [with-data (anomaly/exception-anomaly :fault "x" (ex-info "boom" {:k 1}))
+          without   (anomaly/exception-anomaly :fault "x" (Exception. "boom"))]
+      (is (= {:k 1} (get-in with-data [:anomaly/data :anomaly/ex-data])))
+      (is (not (contains? (:anomaly/data without) :anomaly/ex-data))))))
+
+(deftest exception-anomaly-merges-caller-data
+  (testing "the 4-arity merges caller data alongside provenance"
+    (let [a (anomaly/exception-anomaly :fault "x" {:stage :verify} (Exception. "boom"))]
+      (is (= :verify (get-in a [:anomaly/data :stage])))
+      (is (= "boom" (get-in a [:anomaly/data :anomaly/ex-message]))))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/validation_anomaly_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/validation_anomaly_test.clj
@@ -1,0 +1,39 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.validation-anomaly-test
+  "validation-anomaly builds a canonical :invalid-input anomaly that
+   carries the schema name, offending value, and explain data."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest validation-anomaly-is-a-canonical-invalid-input-anomaly
+  (testing "result satisfies anomaly? and is typed :invalid-input"
+    (let [a (anomaly/validation-anomaly "bad input" :career/example {:id nil} {:id ["required"]})]
+      (is (anomaly/anomaly? a))
+      (is (= :invalid-input (:anomaly/type a)))
+      (is (= "bad input" (:anomaly/message a))))))
+
+(deftest validation-anomaly-carries-schema-value-and-explain
+  (testing "schema/value/explain are preserved under :anomaly/data"
+    (let [explain {:id ["required"]}
+          a (anomaly/validation-anomaly "bad" :career/example {:id nil} explain)]
+      (is (= :career/example (get-in a [:anomaly/data :anomaly/schema])))
+      (is (= {:id nil} (get-in a [:anomaly/data :anomaly/value])))
+      (is (= explain (get-in a [:anomaly/data :anomaly/explain]))))))


### PR DESCRIPTION
## Summary

Step **W0** of converging the codebase off the legacy `ai.miniforge.response` anomaly shape (`:anomaly/category`) onto the canonical `ai.miniforge.anomaly` component (`:anomaly/type`). Before migrating ~260 consumer files, the canonical component needs to be a *superset* of the helpers the response path provides, so consumers don't lose ergonomics:

- **`validation-anomaly`** `[message schema-name value explain-data]` — `:invalid-input` anomaly carrying schema/value/explain under `:anomaly/data`.
- **`exception-anomaly`** `([type message ex] [type message data ex])` — wraps a thrown exception as an anomaly of `type`, preserving `:anomaly/ex-message` / `:anomaly/ex-class` (and `:anomaly/ex-data` when present) under `:anomaly/data`; merges caller `data`.

Both compose the existing `anomaly` constructor (no new strata). Purely additive — no existing behavior changes.

## Rule

- `languages/clojure.mdc` (stratified, ≤3 layers), data-first anomaly contract (return, don't throw)

## Test plan

- New `validation_anomaly_test` + `exception_anomaly_test` (one-per-concern): type, message, schema/value/explain, ex provenance, ex-data presence/absence, caller-data merge.
- Anomaly-interface suite **13 tests / 25 assertions, 0 failures**.
- `bb poly:check` OK; `bb lint:clj` clean (0 warnings).

## Context

Convergence roadmap: W0 (this) → W1 migrate miniforge response sites → W2 rewire career-anomaly facade → W3 migrate career sites → W4 adopt `let-ok` (#990) → W5 retire the legacy anomaly path. Decisions: generic helpers live here; career-specific `redact-artifact-row`/`slim-failure-message` stay as a career extension; `:anomalies.gate/*` → `:invalid-input` + `:anomaly/data` detail.