### PR TITLE
fix(spec): release-opens-real-pr intent :type :fix -> :bugfix

### DIFF
--- a/work/release-opens-real-pr.spec.edn
+++ b/work/release-opens-real-pr.spec.edn
@@ -45,7 +45,7 @@
   resolved for dogfood runs); introducing a second PR-creation path."
 
  :spec/intent
- {:type :fix
+ {:type :bugfix
   :scope ["components/release-executor/src"
           "components/phase-software-factory/src"]}
 


### PR DESCRIPTION
One-word fix: the workflow spec validator rejects `:type :fix` (valid: :refactor/:feature/:bugfix/:general/:chore/:docs/:test/:performance). Introduced during the #994 review fixups; caught at dogfood launch (fail-fast). Changed to `:bugfix` so the spec is runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)