### PR TITLE
fix(planner): recover plan artifact on clean-success-without-submission

### DIFF
--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -228,16 +228,34 @@
                     :prior-content prior-content}))
 
 (defn- planner-submission-retry?
-  "True when a failed planner turn produced useful prose but no submitted plan."
-  [llm-response submitted-plan parsed-plan]
-  (let [err (llm/get-error llm-response)
-        stdout (:stdout err)
-        err-type (:type err)]
-    (and (nil? submitted-plan)
-         (nil? parsed-plan)
-         (not (llm/success? llm-response))
-         (seq stdout)
-         (#{"adaptive_timeout" "cli_error"} err-type))))
+  "True when a planner turn produced useful plan prose but delivered NO
+   artifact (neither `.miniforge/plan.edn` nor a parseable final-message EDN
+   fence), so a short submission-only retry can recover the plan that already
+   exists in the agent's output.
+
+   Fires in TWO cases:
+   (a) SUCCESS-but-no-artifact — the planner ended cleanly with prose-only
+       narration and never wrote the file. This was the intermittent dogfood
+       failure: the plan was reasoned out (it's in `response-content`) but no
+       submission channel produced a file, so the phase failed despite a good
+       plan. Previously NO retry fired here because the turn was a success.
+   (b) Recoverable ERROR — an adaptive_timeout / cli_error that still left
+       useful stdout to retry from (the original trigger).
+
+   In both cases the recovery turn re-submits using `response-content` as the
+   prior plan text."
+  [llm-response submitted-plan parsed-plan response-content]
+  (and (nil? submitted-plan)
+       (nil? parsed-plan)
+       (or
+        ;; (a) clean success but no artifact — prose-only narration
+        (and (llm/success? llm-response)
+             (seq response-content))
+        ;; (b) recoverable error with useful stdout
+        (let [err (llm/get-error llm-response)]
+          (and (not (llm/success? llm-response))
+               (seq (:stdout err))
+               (#{"adaptive_timeout" "cli_error"} (:type err)))))))
 
 ;; make-fallback-plan removed — silent fallback masks real failures.
 ;; Plan generation now throws with evidence on failure (see invoke-fn below).
@@ -640,9 +658,11 @@
                                 (:parsed-content normalized))
                   retry-result (when (planner-submission-retry? llm-response
                                                                 submitted-plan
-                                                                parsed-plan)
+                                                                parsed-plan
+                                                                response-content)
                                  (log/info logger :planner :planner/submission-retry
                                            {:data {:reason :missing-plan-submission
+                                                   :llm-success? (llm/success? llm-response)
                                                    :content-length (count response-content)}})
                                  (recover-submitted-plan llm-client spec-text
                                                          effective-system

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -652,6 +652,42 @@
               (is (>= (:max-total-ms state) min-total-budget-ms)
                   "Total budget must be ≥ min-total-budget-ms — covers the longest historical successful planner run"))))))))
 
+;------------------------------------------------------------------------------ Layer 1
+;; planner-submission-retry? — recovery trigger (incl. success-but-no-artifact)
+
+(def ^:private submission-retry? #'planner/planner-submission-retry?)
+
+(deftest planner-submission-retry-fires-on-success-without-artifact
+  (testing "a CLEAN success that produced plan prose but NO artifact triggers recovery
+            (the intermittent dogfood failure — previously no retry fired here)"
+    (is (true? (boolean (submission-retry? {:success true} nil nil "## Plan\nTask A -> B"))))))
+
+(deftest planner-submission-retry-not-on-success-without-prose
+  (testing "a success with no prose content has nothing to recover — no retry"
+    (is (false? (boolean (submission-retry? {:success true} nil nil ""))))
+    (is (false? (boolean (submission-retry? {:success true} nil nil nil))))))
+
+(deftest planner-submission-retry-still-fires-on-recoverable-error
+  (testing "the original trigger survives: adaptive_timeout/cli_error with useful stdout"
+    (is (true? (boolean (submission-retry?
+                         {:success false :error {:stdout "plan prose" :type "cli_error"}}
+                         nil nil ""))))
+    (is (true? (boolean (submission-retry?
+                         {:success false :error {:stdout "plan prose" :type "adaptive_timeout"}}
+                         nil nil ""))))))
+
+(deftest planner-submission-retry-no-fire-when-artifact-present
+  (testing "an artifact (submitted or parsed) means no recovery is needed"
+    (is (false? (boolean (submission-retry? {:success true} {:plan/id 1} nil "prose"))))
+    (is (false? (boolean (submission-retry? {:success true} nil {:plan/id 1} "prose"))))))
+
+(deftest planner-submission-retry-no-fire-on-unrecoverable-error
+  (testing "an error without useful stdout or with a non-retriable type does not retry"
+    (is (false? (boolean (submission-retry?
+                          {:success false :error {:stdout "" :type "cli_error"}} nil nil ""))))
+    (is (false? (boolean (submission-retry?
+                          {:success false :error {:stdout "x" :type "other"}} nil nil ""))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.agent.planner-test)


### PR DESCRIPTION
## Summary

Fixes the **intermittent** plan-artifact-submission failure that gates dogfood runs at the first real phase (observed on the 2026-05-27 `release-opens-real-pr` run, which failed at plan with *"no artifact found after session"* despite the planner producing a perfectly good DAG).

**Root cause:** the planner has two submission channels — write `.miniforge/plan.edn`, or emit a parseable EDN fence in the final message. Intermittently the LLM does *neither* and ends with prose-only narration. A recovery turn already exists (`invoke-planner-submission-retry-session`), but `planner-submission-retry?` only fired when the turn **ended in error** (`adaptive_timeout`/`cli_error`). A **clean success** that produced no artifact slipped straight through to `:anomalies.agent/invoke-failed` — no recovery.

**Fix:** broaden the trigger so the (already bounded, single) recovery turn also fires when the turn **succeeded but delivered no artifact** and there's plan prose in `response-content` to re-submit. The recovery prompt re-feeds that prose and asks only for the Write. The error-path trigger is unchanged; artifact-present still never retries.

This reuses the existing recovery machinery — no new submission channel, no forced-tool dependency, no change to the prompt's "`.miniforge/plan.edn` is the source of truth" contract.

## Test plan
- [x] `bb pre-commit` green (18 planner tests / 86 assertions)
- [x] success-without-artifact → fires; success-without-prose → does not
- [x] original error triggers (`cli_error`/`adaptive_timeout` + stdout) still fire
- [x] artifact present (submitted or parsed) → never retries
- [x] unrecoverable error (no stdout / wrong type) → never retries

> Follow-ups (not in this PR, noted from the same run): the contradictory `✓ plan success` immediately followed by `✗ plan failure` display, and the `Tokens: 0 | Cost: $0.0000` result-shape zeroing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)