### PR TITLE
feat(anomaly): add :anomaly/subtype domain-classification convention (convergence W1)

### DIFF
--- a/components/anomaly/src/ai/miniforge/anomaly/contract.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/contract.clj
@@ -69,12 +69,21 @@
    - :anomaly/type    — keyword from the standard vocabulary
    - :anomaly/message — human-readable description
    - :anomaly/data    — caller-supplied context map (defaults to {})
-   - :anomaly/at      — instant of construction"
+   - :anomaly/at      — instant of construction
+
+   Optionally:
+   - :anomaly/subtype — a finer domain classification keyword (e.g.
+     :gate/validation-failed, :agent/tool-loop) that routing and
+     classification dispatch on. Narrower than the generic
+     :anomaly/type, which stays one of the standard vocabulary while the
+     subtype names the domain-specific failure. Absent for purely
+     generic anomalies."
   [:map {:closed true}
    [:anomaly/type    (into [:enum] anomaly-types)]
    [:anomaly/message :string]
    [:anomaly/data    [:map-of :any :any]]
-   [:anomaly/at      inst?]])
+   [:anomaly/at      inst?]
+   [:anomaly/subtype {:optional true} :keyword]])
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Validation helpers

--- a/components/anomaly/src/ai/miniforge/anomaly/contract.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/contract.clj
@@ -37,7 +37,8 @@
 
 (def anomaly-types
   "Standard anomaly type keywords. Mirrors the cognitect anomalies
-   vocabulary, with `:fatal` added for unrecoverable programmer errors.
+   vocabulary, with `:fatal` (unrecoverable programmer errors) and
+   `:exhausted` (a budget/limit/effort ceiling was reached) added.
 
    Each type encodes a category of failure:
    - :not-found      — referenced entity does not exist
@@ -48,6 +49,9 @@
    - :conflict       — operation conflicts with existing state
    - :timeout        — operation exceeded its time budget
    - :unsupported    — operation not implemented for this case
+   - :exhausted      — a budget, limit, or effort ceiling was reached
+                       (not a bug; the operation ran out of its
+                       allowance — e.g. loop/retry/phase/token budgets)
    - :fatal          — unrecoverable; the process should stop"
   #{:not-found
     :invalid-input
@@ -57,6 +61,7 @@
     :conflict
     :timeout
     :unsupported
+    :exhausted
     :fatal})
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/anomaly/src/ai/miniforge/anomaly/contract.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/contract.clj
@@ -73,11 +73,11 @@
 
    Optionally:
    - :anomaly/subtype — a finer domain classification keyword (e.g.
-     :gate/validation-failed, :agent/tool-loop) that routing and
-     classification dispatch on. Narrower than the generic
-     :anomaly/type, which stays one of the standard vocabulary while the
-     subtype names the domain-specific failure. Absent for purely
-     generic anomalies."
+     :anomalies.gate/validation-failed, :anomalies.agent/tool-loop) that
+     routing and classification dispatch on. It is the established
+     domain category from the :anomalies.* vocabulary, carried
+     alongside the generic :anomaly/type (which stays one of the
+     standard set). Absent for purely generic anomalies."
   [:map {:closed true}
    [:anomaly/type    (into [:enum] anomaly-types)]
    [:anomaly/message :string]

--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -86,11 +86,19 @@
 
 (defn sub-anomaly
   "Construct an anomaly carrying a domain `:anomaly/subtype` — a finer
-   classification (e.g. `:gate/validation-failed`, `:agent/tool-loop`)
-   that routing and classification dispatch on. `type` stays one of the
-   generic vocabulary; `subtype` names the domain-specific failure.
-   Use when a consumer needs more than the generic type to route."
+   classification (e.g. `:anomalies.gate/validation-failed`,
+   `:anomalies.agent/tool-loop`) that routing and classification dispatch
+   on. `type` stays one of the generic vocabulary; `subtype` is the
+   established domain category keyword (the `:anomalies.*` vocabulary).
+   Use when a consumer needs more than the generic type to route.
+
+   `subtype` must be a keyword — a nil or non-keyword would produce a
+   map that fails the `Anomaly` schema, so it throws
+   IllegalArgumentException, mirroring `anomaly`'s guard on `type`."
   [type subtype message data]
+  (when-not (keyword? subtype)
+    (throw (IllegalArgumentException.
+            (str "Anomaly subtype must be a keyword, got: " (pr-str subtype)))))
   (assoc (anomaly type message data) :anomaly/subtype subtype))
 
 (defn subtype

--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -84,6 +84,22 @@
    :anomaly/data    (or data {})
    :anomaly/at      (now)})
 
+(defn sub-anomaly
+  "Construct an anomaly carrying a domain `:anomaly/subtype` — a finer
+   classification (e.g. `:gate/validation-failed`, `:agent/tool-loop`)
+   that routing and classification dispatch on. `type` stays one of the
+   generic vocabulary; `subtype` names the domain-specific failure.
+   Use when a consumer needs more than the generic type to route."
+  [type subtype message data]
+  (assoc (anomaly type message data) :anomaly/subtype subtype))
+
+(defn subtype
+  "The domain `:anomaly/subtype` of `a`, or nil when it carries only a
+   generic `:anomaly/type`. Routing/classification should prefer this
+   over `:anomaly/type` when present."
+  [a]
+  (:anomaly/subtype a))
+
 (defn validation-anomaly
   "Construct an `:invalid-input` anomaly describing a schema-validation
    failure. The schema name, offending value, and explain data are

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/sub_anomaly_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/sub_anomaly_test.clj
@@ -1,0 +1,50 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.sub-anomaly-test
+  "sub-anomaly attaches a domain :anomaly/subtype to an otherwise
+   canonical anomaly; the result still validates, and `subtype` reads
+   it back (nil for generic anomalies)."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest sub-anomaly-is-canonical-with-subtype
+  (testing "result satisfies anomaly?, keeps the generic type, carries the subtype"
+    (let [a (anomaly/sub-anomaly :invalid-input :gate/validation-failed "gate rejected" {:gate "lint"})]
+      (is (anomaly/anomaly? a))
+      (is (= :invalid-input (:anomaly/type a)))
+      (is (= :gate/validation-failed (:anomaly/subtype a)))
+      (is (= "lint" (get-in a [:anomaly/data :gate]))))))
+
+(deftest subtype-reads-domain-classification
+  (testing "subtype returns the keyword, or nil for a generic anomaly"
+    (is (= :agent/tool-loop
+           (anomaly/subtype (anomaly/sub-anomaly :fault :agent/tool-loop "loop" {}))))
+    (is (nil? (anomaly/subtype (anomaly/anomaly :fault "plain" {}))))))
+
+(deftest generic-anomaly-omits-subtype-key
+  (testing "a plain anomaly has no :anomaly/subtype key at all (closed schema stays valid)"
+    (let [a (anomaly/anomaly :fault "plain" {})]
+      (is (not (contains? a :anomaly/subtype)))
+      (is (anomaly/anomaly? a)))))
+
+(deftest subtype-rejects-non-keyword
+  (testing "a non-keyword subtype violates the schema (anomaly? is false)"
+    (is (false? (anomaly/anomaly? (assoc (anomaly/anomaly :fault "x" {})
+                                         :anomaly/subtype "not-a-keyword"))))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/sub_anomaly_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/sub_anomaly_test.clj
@@ -26,16 +26,17 @@
 
 (deftest sub-anomaly-is-canonical-with-subtype
   (testing "result satisfies anomaly?, keeps the generic type, carries the subtype"
-    (let [a (anomaly/sub-anomaly :invalid-input :gate/validation-failed "gate rejected" {:gate "lint"})]
+    (let [a (anomaly/sub-anomaly :invalid-input :anomalies.gate/validation-failed
+                                 "gate rejected" {:gate "lint"})]
       (is (anomaly/anomaly? a))
       (is (= :invalid-input (:anomaly/type a)))
-      (is (= :gate/validation-failed (:anomaly/subtype a)))
+      (is (= :anomalies.gate/validation-failed (:anomaly/subtype a)))
       (is (= "lint" (get-in a [:anomaly/data :gate]))))))
 
 (deftest subtype-reads-domain-classification
   (testing "subtype returns the keyword, or nil for a generic anomaly"
-    (is (= :agent/tool-loop
-           (anomaly/subtype (anomaly/sub-anomaly :fault :agent/tool-loop "loop" {}))))
+    (is (= :anomalies.agent/tool-loop
+           (anomaly/subtype (anomaly/sub-anomaly :fault :anomalies.agent/tool-loop "loop" {}))))
     (is (nil? (anomaly/subtype (anomaly/anomaly :fault "plain" {}))))))
 
 (deftest generic-anomaly-omits-subtype-key
@@ -44,7 +45,9 @@
       (is (not (contains? a :anomaly/subtype)))
       (is (anomaly/anomaly? a)))))
 
-(deftest subtype-rejects-non-keyword
-  (testing "a non-keyword subtype violates the schema (anomaly? is false)"
-    (is (false? (anomaly/anomaly? (assoc (anomaly/anomaly :fault "x" {})
-                                         :anomaly/subtype "not-a-keyword"))))))
+(deftest sub-anomaly-rejects-non-keyword-subtype
+  (testing "a nil or non-keyword subtype throws, never yields a schema-invalid map"
+    (is (thrown? IllegalArgumentException
+                 (anomaly/sub-anomaly :fault "not-a-keyword" "x" {})))
+    (is (thrown? IllegalArgumentException
+                 (anomaly/sub-anomaly :fault nil "x" {})))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/type_vocabulary_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/type_vocabulary_test.clj
@@ -25,9 +25,9 @@
    [ai.miniforge.anomaly.interface :as anomaly]))
 
 (deftest standard-vocabulary-is-locked
-  (testing "the published vocabulary mirrors the cognitect set plus :fatal"
+  (testing "the published vocabulary mirrors the cognitect set plus :fatal and :exhausted"
     (is (= #{:not-found :invalid-input :unauthorized :fault :unavailable
-             :conflict :timeout :unsupported :fatal}
+             :conflict :timeout :unsupported :exhausted :fatal}
            anomaly/anomaly-types))))
 
 (deftest every-standard-type-constructs-cleanly

--- a/docs/runbooks/anomaly-convergence.md
+++ b/docs/runbooks/anomaly-convergence.md
@@ -1,0 +1,136 @@
+<!--
+  Title: Miniforge.ai
+  Subtitle: Anomaly convergence runbook (response → ai.miniforge.anomaly)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under the Apache License, Version 2.0.
+-->
+
+# Anomaly convergence runbook
+
+Retire the legacy `ai.miniforge.response` anomaly representation
+(`:anomaly/category`, a ~60-keyword taxonomy) in favour of the canonical
+`ai.miniforge.anomaly` component (`:anomaly/type` + optional
+`:anomaly/subtype`). `response` keeps its non-anomaly pipeline-result
+responsibilities; only its anomaly *shape* is retired.
+
+The migration is **data-first throughout** (no `try+`/`catch` on
+categories), so it is a mechanical shape + taxonomy change, not a
+control-flow rewrite — but anomalies cross brick boundaries, so producers
+and the routing consumers (`failure-classifier`, `response/translate`)
+must agree on the shape.
+
+## Design decisions
+
+- **Two axes.** Generic `:anomaly/type` stays the cognitect-style
+  vocabulary (now + `:fatal` + `:exhausted`). The original domain
+  category is preserved **verbatim** as `:anomaly/subtype` — so routing
+  code moves from reading `:anomaly/category` to `:anomaly/subtype` with
+  identical keyword values. "gate", "agent", etc. are failure *sources*,
+  not failure *semantics*, so they never enter the type vocabulary.
+- **`:exhausted` added** to the type vocabulary: a budget/limit/effort
+  ceiling was reached (loop/retry/phase/token budgets). The one genuine
+  gap in the cognitect set for this platform.
+- Generic helpers `validation-anomaly` / `exception-anomaly` live in the
+  canonical component (#995); career-specific `redact-artifact-row` /
+  `slim-failure-message` stay as a career-anomaly extension.
+
+## Waves
+
+- **W0** (#995, merged) — canonical superset helpers.
+- **W1** (foundational) — `:anomaly/subtype` convention + `:exhausted`
+  type (#998); then migrate `failure-classifier` (`rules.edn` dispatch)
+  and `response/translate` (`anomaly→http-status / user-message /
+  log-data / event-data`) to dispatch on `subtype` (fall back to `type`).
+- **W2** — flip miniforge producers (~96 files) to canonical, applying
+  the map below. One coordinated branch; full suite is the cross-brick
+  consistency gate.
+- **W3** — rewire the career `career-anomaly` facade + migrate career's
+  ~132 files (`:anomaly/category` reads + construction).
+- **W4** — adopt `let-ok` across canonical sites (folds in career#243).
+- **W5** — delete the legacy response anomaly surface + dead code.
+
+## Category → (type, subtype) map
+
+`subtype = the legacy category keyword verbatim` for every domain/custom
+entry. The eight cognitect-standard categories map 1:1 to a type with **no
+subtype**.
+
+### Generic standard (no subtype)
+
+| legacy category | `:anomaly/type` |
+| --- | --- |
+| `:anomalies/incorrect` | `:invalid-input` |
+| `:anomalies/not-found` | `:not-found` |
+| `:anomalies/fault` | `:fault` |
+| `:anomalies/unavailable` | `:unavailable` |
+| `:anomalies/unsupported` | `:unsupported` |
+| `:anomalies/timeout` | `:timeout` |
+| `:anomalies/forbidden` | `:unauthorized` |
+| `:anomalies/conflict` | `:conflict` |
+
+### Generic custom (subtype = keyword)
+
+| legacy category | `:anomaly/type` |
+| --- | --- |
+| `:anomalies/busy` | `:unavailable` |
+| `:anomalies/interrupted` | `:fault` |
+| `:anomalies/dag-non-forest` | `:conflict` |
+| `:anomalies/dag-multi-parent-conflict` | `:conflict` |
+| `:anomalies/dag-multi-parent-merge-failed` | `:conflict` |
+| `:anomalies/dag-multi-parent-unresolvable` | `:conflict` |
+| `:anomalies/dag-multi-parent-branch-unresolvable` | `:conflict` |
+| `:anomalies/dag-multi-parent-unrelated-histories` | `:conflict` |
+| `:anomalies/dag-multi-parent-strategy-unsupported` | `:unsupported` |
+
+### Domain (subtype = keyword)
+
+| legacy category | `:anomaly/type` |
+| --- | --- |
+| `:anomalies.agent/tool-loop` | `:exhausted` |
+| `:anomalies.agent/runaway` | `:exhausted` |
+| `:anomalies.agent/repeated-failure` | `:exhausted` |
+| `:anomalies.agent/llm-error` | `:fault` |
+| `:anomalies.agent/invoke-failed` | `:fault` |
+| `:anomalies.agent/parse-failed` | `:fault` |
+| `:anomalies.agent/validation-failed` | `:invalid-input` |
+| `:anomalies.agent/unknown-agent` | `:not-found` |
+| `:anomalies.agent/rate-limited` | `:unavailable` |
+| `:anomalies.gate/validation-failed` | `:invalid-input` |
+| `:anomalies.gate/check-failed` | `:invalid-input` |
+| `:anomalies.gate/repair-failed` | `:fault` |
+| `:anomalies.gate/no-repair` | `:fault` |
+| `:anomalies.gate/unknown-gate` | `:not-found` |
+| `:anomalies.workflow/invalid-config` | `:invalid-input` |
+| `:anomalies.workflow/invalid-supervisor` | `:invalid-input` |
+| `:anomalies.workflow/empty-pipeline` | `:invalid-input` |
+| `:anomalies.workflow/invalid-transition` | `:conflict` |
+| `:anomalies.workflow/resume-non-terminal` | `:conflict` |
+| `:anomalies.workflow/no-capsule-executor` | `:not-found` |
+| `:anomalies.workflow/max-phases` | `:exhausted` |
+| `:anomalies.workflow/rollback-limit` | `:exhausted` |
+| `:anomalies.workflow/max-redirects-exceeded` | `:exhausted` |
+| `:anomalies.workflow/halted-by-supervision` | `:fault` |
+| `:anomalies.phase/budget-exceeded` | `:exhausted` |
+| `:anomalies.phase/agent-failed` | `:fault` |
+| `:anomalies.phase/enter-failed` | `:fault` |
+| `:anomalies.phase/leave-failed` | `:fault` |
+| `:anomalies.phase/no-agent` | `:not-found` |
+| `:anomalies.phase/unknown-phase` | `:not-found` |
+| `:anomalies.llm/rate-limited` | `:unavailable` |
+| `:anomalies.llm/unavailable` | `:unavailable` |
+| `:anomalies.llm/timeout` | `:timeout` |
+| `:anomalies.llm/context-exceeded` | `:exhausted` |
+| `:anomalies.review/stagnation` | `:exhausted` |
+| `:anomalies.review/fuzzy-stagnation` | `:exhausted` |
+| `:anomalies.executor/unavailable` | `:unavailable` |
+| `:anomalies.executor/timeout` | `:timeout` |
+| `:anomalies.executor/acquisition-failed` | `:unavailable` |
+| `:anomalies.budget/exceeded` | `:exhausted` |
+| `:anomalies.dashboard/stop` | `:fault` |
+| `:anomalies.custom/something` | `:fault` |
+
+### Cleanup (not real categories)
+
+`:anomalies/fault.`, `:anomalies/not-found.`,
+`:anomalies/dag-multi-parent-strategy-unsupported.` — trailing-dot
+artifacts in prose/comments, not keywords. Fix or ignore; do not map.


### PR DESCRIPTION
## Summary

Foundational step of the response→anomaly convergence. Investigation of the migration (the halted first W1 attempt) surfaced that the codebase routes on a **rich ~60-keyword domain sub-taxonomy** (`:anomalies.gate/*`, `:agent/tool-loop`, `:llm/rate-limited`, `:phase/*`, …), not just the 8 generic cognitect categories. The canonical type vocabulary is intentionally generic, so domain detail needs a home that `failure-classifier` and `response/translate` can dispatch on.

This adds an optional **`:anomaly/subtype`** keyword:
- `:anomaly/type` stays one of the generic vocabulary; `:anomaly/subtype` names the domain-specific failure (e.g. `:gate/validation-failed`).
- Schema gains `[:anomaly/subtype {:optional true} :keyword]` — generic anomalies omit it; closed schema stays valid.
- New `sub-anomaly` constructor + `subtype` accessor.

"Gate" et al. are failure *sources*, not failure *semantics* — so they don't belong in the type vocabulary, but they do need to survive for routing. `:anomaly/subtype` is that axis.

## Rule

- `languages/clojure.mdc`; data-first anomaly contract; cognitect type vocabulary kept generic.

## Test plan

- New `sub_anomaly_test`: canonical+subtype validates, generic omits subtype, accessor reads/nils, non-keyword subtype rejected.
- Anomaly suite **14 tests / 40 assertions, 0 failures**; `bb poly:check` OK; `bb lint:clj` clean.

## Next in this wave

(b) full `:anomalies.*` → `(:anomaly/type, :anomaly/subtype)` mapping table; (c) migrate `failure-classifier` + `response/translate` to dispatch on type+subtype. Then producer flips (W2+) are mechanical and cross-brick-safe.