### PR TITLE
fix(plan): report real cost + outcome on a failed plan phase

### DIFF
--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -702,9 +702,16 @@
                       ;; so external try+ callers see the same shape
                       ;; they did before the data-first migration.
                       plan (if (anomaly/anomaly? plan-or-anom)
+                             ;; Carry the spent-token count into the anomaly
+                             ;; data so the failure path still reports cost
+                             ;; (exception-error preserves ex-data → the phase
+                             ;; surfaces :tokens into :execution/metrics). A
+                             ;; failed plan turn still SPENT tokens; dropping
+                             ;; them made the run summary read $0.0000.
                              (response/throw-anomaly! :anomalies.agent/invoke-failed
                                                      (:anomaly/message plan-or-anom)
-                                                     (:anomaly/data plan-or-anom))
+                                                     (assoc (:anomaly/data plan-or-anom)
+                                                            :tokens tokens))
                              plan-or-anom)
                       plan-final (finalize-plan plan)]
                   ;; Check for already-satisfied response
@@ -725,7 +732,9 @@
                           (log/info logger :planner :planner/already-satisfied-rejected
                                     {:data {:reason (:reason validation)}})
                           (response/error (str "Already-satisfied claim rejected: "
-                                               (:reason validation))))))
+                                               (:reason validation))
+                                          {:tokens tokens
+                                           :metrics {:tokens tokens}}))))
                     (response/success plan-final
                                       {:tokens tokens
                                        :metrics (cond-> {:tasks-created (count (:plan/tasks plan-final))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -159,7 +159,15 @@
               (try
                 (agent/invoke planner-agent task agent-ctx)
                 (catch Exception e
-                  (response/failure e))))
+                  ;; Preserve the spent-token count from the agent's failure
+                  ;; anomaly (planner tags ex-data with :tokens) into the
+                  ;; failure result's :metrics, so leave-plan still merges the
+                  ;; real cost into :execution/metrics instead of reporting $0.
+                  (let [ed   (ex-data e)
+                        toks (get ed :tokens 0)]
+                    (response/failure e {:data ed
+                                         :tokens toks
+                                         :metrics {:tokens toks}})))))
      :rules-manifest rules-manifest}))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -196,28 +204,41 @@
         end-time (System/currentTimeMillis)
         duration-ms (- end-time start-time)
         result (get-in ctx [:phase :result])
-        metrics (-> (get result :metrics {:tokens 0 :duration-ms duration-ms})
+        success? (response/success? result)
+        already-satisfied? (= :already-satisfied (:status result))
+        ;; Read tokens from :metrics, falling back to a top-level :tokens —
+        ;; failure results carry the spent count one or the other way, and we
+        ;; merge cost into :execution/metrics REGARDLESS of success so a failed
+        ;; plan turn no longer reports $0.
+        metrics (-> (get result :metrics {:tokens (get result :tokens 0)
+                                          :duration-ms duration-ms})
                     (assoc :duration-ms duration-ms))
+        ;; already-satisfied is a NEUTRAL success outcome, not a failure.
+        succeeded-or-done? (or success? already-satisfied?)
+        phase-status (cond already-satisfied? :already-satisfied
+                           success?           :completed
+                           :else              :failed)
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
-                        (assoc-in [:phase :status] :completed)
+                        (assoc-in [:phase :status] phase-status)
                         (assoc-in [:phase :metrics] metrics)
-                        (update-in [:execution :phases-completed] (fnil conj []) :plan)
-                        ;; Merge agent metrics into execution metrics
+                        ;; Count a completed OR already-satisfied plan; not a failure.
+                        (cond-> succeeded-or-done?
+                          (update-in [:execution :phases-completed] (fnil conj []) :plan))
+                        ;; Merge agent metrics into execution metrics on EVERY
+                        ;; outcome — tokens were spent whether or not the plan
+                        ;; succeeded.
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
-    ;; Handle :already-satisfied — signal pipeline to skip to :done
-    (let [final-ctx (if (= :already-satisfied (:status result))
-                      (assoc-in updated-ctx [:phase :status] :already-satisfied)
-                      updated-ctx)]
-      ;; Emit phase-completed telemetry with termination reason
-      (phase/emit-phase-completed! final-ctx :plan
-        (merge {:outcome     :success
-                :duration-ms duration-ms
-                :tokens      (get metrics :tokens 0)}
-               (phase-terminal/derive-termination-reason result nil)))
-      final-ctx)))
+    ;; Emit phase-completed with the REAL outcome — never a false :success on a
+    ;; failure result (that produced the ✓-then-✗ double-emit).
+    (phase/emit-phase-completed! updated-ctx :plan
+      (merge {:outcome     (if succeeded-or-done? :success :failure)
+              :duration-ms duration-ms
+              :tokens      (get metrics :tokens 0)}
+             (phase-terminal/derive-termination-reason result nil)))
+    updated-ctx))
 
 (defn error-plan
   "Handle planning phase errors. Retry within budget, then fail in

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/plan_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/plan_test.clj
@@ -24,7 +24,45 @@
    [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
    [ai.miniforge.phase-software-factory.plan :as plan]
    [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.response.interface :as response]
    [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ leave-plan: cost + outcome reporting (regression for 2026-05-27 $0/double-emit)
+
+(defn- leave-plan-ctx
+  [result]
+  {:phase {:started-at (- (System/currentTimeMillis) 1000) :result result}
+   :execution/metrics {}})
+
+(deftest leave-plan-failure-merges-tokens-and-emits-failure-test
+  (testing "a FAILED plan result still merges spent tokens into :execution/metrics
+            (no more $0.0000 on failure) and marks the phase :failed, not a false :completed"
+    (with-redefs [phase/emit-phase-completed! (fn [_ctx _phase _data] nil)]
+      (let [out (plan/leave-plan (leave-plan-ctx
+                                  (response/failure "plan failed"
+                                                    {:tokens 4242 :metrics {:tokens 4242}})))]
+        (is (= :failed (get-in out [:phase :status])))
+        (is (= 4242 (get-in out [:execution/metrics :tokens]))
+            "spent tokens MUST be merged even on failure")
+        (is (not (some #{:plan} (get-in out [:execution :phases-completed])))
+            "a failed plan is not counted as completed")))))
+
+(deftest leave-plan-failure-merges-top-level-tokens-test
+  (testing "tokens are recovered from a top-level :tokens when :metrics is absent"
+    (with-redefs [phase/emit-phase-completed! (fn [_ctx _phase _data] nil)]
+      (let [out (plan/leave-plan (leave-plan-ctx
+                                  (response/failure "boom" {:tokens 99})))]
+        (is (= 99 (get-in out [:execution/metrics :tokens])))))))
+
+(deftest leave-plan-success-merges-tokens-test
+  (testing "a successful plan merges tokens, marks :completed, and counts as completed"
+    (with-redefs [phase/emit-phase-completed! (fn [_ctx _phase _data] nil)]
+      (let [out (plan/leave-plan (leave-plan-ctx
+                                  (response/success {:plan/id (random-uuid) :plan/tasks []}
+                                                    {:tokens 100 :metrics {:tokens 100}})))]
+        (is (= :completed (get-in out [:phase :status])))
+        (is (= 100 (get-in out [:execution/metrics :tokens])))
+        (is (some #{:plan} (get-in out [:execution :phases-completed])))))))
 
 (deftest build-planner-task-threads-behavior-addendum-test
   (testing "build-planner-task computes and attaches :task/behavior-addendum"


### PR DESCRIPTION
## Summary

Fixes the two reporting bugs from the 2026-05-27 dogfood run — **same root cause**: `leave-plan` unconditionally treated the phase result as success.

1. **Cost zeroing** — `Tokens: 0 | Cost: $0.0000` on a real 9.8m LLM run. A failed planner turn threw via `throw-anomaly!` **without** the in-scope token count, so the failure result carried no `:metrics` and `leave-plan` merged 0 tokens. *(This is the one that matters — if our own runs can't report spend, no cost signal is trustworthy.)*
2. **Contradictory `✓ plan success` → `✗ plan failure`** — `leave-plan` emitted `:outcome :success` + `:status :completed` even on a failure result, then the workflow detected the real failure → double-emit.

### Fixes
- **planner.clj** — carry `:tokens` into the `invoke-failed` anomaly data (`exception-error` preserves `ex-data`) and into the already-satisfied-rejected error.
- **plan.clj `plan-from-agent`** — the `catch` surfaces the anomaly's `:tokens` into the failure result's `:metrics`.
- **plan.clj `leave-plan`** — branch `:status`/`:outcome` on `response/success?` (already-satisfied = neutral success); merge spent tokens into `:execution/metrics` on **every** outcome; only count a genuinely-completed plan in `:phases-completed`.

### Follow-up (not in this PR)
`explore`/`release`/`pr_monitor` leave-handlers share the same unconditional `:status :completed` shape and likely under-report cost on their own failures — worth the same treatment.

## Test plan
- [x] `bb pre-commit` green
- [x] new `leave-plan` tests: failure merges tokens (4242) + marks `:failed` + not counted completed; tokens recovered from top-level `:tokens`; success still merges + `:completed` + counted
- [x] planner tests still green (#997's recovery tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)