### PR TITLE
feat(agent): generalize artifact-submission recovery to the implementer

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -181,4 +181,33 @@ plan that never lands as files.
 
 Remember: Your code will be validated, tested, and reviewed by other agents.
 Write code that is easy to understand, test, and maintain. The files on disk
-are what they review — what you say in chat is just narration."}
+are what they review — what you say in chat is just narration."
+
+ ;; Short submission-only recovery turn — used when the main turn produced
+ ;; useful implementation analysis but wrote NO files and submitted no
+ ;; artifact. Re-feeds the prior output and asks only for the Write.
+ :prompt/submission-retry-max-turns 6
+
+ :prompt/submission-retry-template
+ "You already worked out the implementation for this task.
+
+Do NOT explore further. Do NOT call context_read/context_grep/context_glob.
+Your only job is to DELIVER the implementation NOW by writing the files.
+
+Primary submission path:
+  Use the Write (or Edit) tool to create/modify each file. The files on disk
+  ARE the submission.
+
+Fallback only if Write is unavailable:
+  Write `.miniforge/implement.edn` with a `{:code/files [...]}` map, or end your
+  turn with that EDN map in a ```clojure code fence.
+
+No narration. No explanation. Just write the files.
+
+Original task:
+
+{{task-text}}
+
+Prior implementation output to deliver as actual file writes:
+
+{{prior-content}}"}

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -706,25 +706,18 @@
         (file-artifacts/collect-written-files pre-session-snapshot
                                               working-dir))))
 
-(defn- render-template
-  "Render a `{{key}}`-style template with the given substitutions."
-  [template substitutions]
-  (reduce-kv (fn [text k v]
-               (str/replace text (str "{{" (name k) "}}") (or v "")))
-             (or template "")
-             substitutions))
-
 (defn- submission-retry-prompt
   "Submission-only retry prompt: re-feed the task + the prior (prose) output
    and ask the implementer to deliver the actual file writes now."
   [task-text prior-content]
-  (render-template (get @implementer-prompt-data :prompt/submission-retry-template)
-                   {:task-text task-text :prior-content prior-content}))
+  (prompts/render-template (get @implementer-prompt-data :prompt/submission-retry-template)
+                           {:task-text task-text :prior-content prior-content}))
 
 (defn- normalize-implementer-result
   "Re-normalize a session's raw channels into the implementer result shape,
-   re-collecting the file artifact from what was written this turn. Shared by
-   the main turn and the submission-recovery turn."
+   re-collecting the file artifact from what was written this turn. Used by the
+   submission-recovery turn (the main turn normalizes inline so it can also
+   surface the file artifact for its fallback log)."
   [{:keys [llm-result artifact worktree-artifacts pre-session-snapshot session-mode]}
    context working-dir]
   (let [file-artifact (collect-session-artifact context session-mode working-dir
@@ -826,7 +819,11 @@
     ;; Without this, a prose-only implement turn fails "no artifact found",
     ;; which is what stalled redirect-implements in the review-redirect churn.
     (let [submitted (:structured-artifact normalized)
-          parsed    (:parsed-content normalized)
+          ;; Fold the derived artifact (code extracted from final-message
+          ;; fences) into the "artifact already exists" guard so a turn that
+          ;; produced usable code blocks does NOT trigger an unnecessary
+          ;; recovery LLM call.
+          parsed    (or (:parsed-content normalized) (:derived-artifact normalized))
           recovered (when (submission-recovery/submission-retry?
                            response submitted parsed (:content normalized))
                       (recover-implementer-submission

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
+   [ai.miniforge.agent.submission-recovery :as submission-recovery]
    [ai.miniforge.patterns.interface :as patterns]
    [ai.miniforge.repo-index.interface :as messages]
    [ai.miniforge.response.interface :as response]
@@ -705,6 +706,69 @@
         (file-artifacts/collect-written-files pre-session-snapshot
                                               working-dir))))
 
+(defn- render-template
+  "Render a `{{key}}`-style template with the given substitutions."
+  [template substitutions]
+  (reduce-kv (fn [text k v]
+               (str/replace text (str "{{" (name k) "}}") (or v "")))
+             (or template "")
+             substitutions))
+
+(defn- submission-retry-prompt
+  "Submission-only retry prompt: re-feed the task + the prior (prose) output
+   and ask the implementer to deliver the actual file writes now."
+  [task-text prior-content]
+  (render-template (get @implementer-prompt-data :prompt/submission-retry-template)
+                   {:task-text task-text :prior-content prior-content}))
+
+(defn- normalize-implementer-result
+  "Re-normalize a session's raw channels into the implementer result shape,
+   re-collecting the file artifact from what was written this turn. Shared by
+   the main turn and the submission-recovery turn."
+  [{:keys [llm-result artifact worktree-artifacts pre-session-snapshot session-mode]}
+   context working-dir]
+  (let [file-artifact (collect-session-artifact context session-mode working-dir
+                                                pre-session-snapshot)]
+    (result-boundary/normalize-llm-result
+     {:role :implement
+      :response llm-result
+      :worktree-artifacts worktree-artifacts
+      :artifact artifact
+      :fallback-artifact file-artifact
+      :parse-response parse-code-response
+      :derive-artifact code-from-blocks})))
+
+(defn- recover-implementer-submission
+  "When the main turn produced usable analysis but NO artifact, run one short
+   submission-only retry that asks the implementer to write the files now, then
+   re-normalize. Returns the recovered normalized map, or nil when recovery
+   produced no artifact either. Generalizes PR #997's planner recovery."
+  [{:keys [llm-client config context on-chunk working-dir effective-system-prompt
+           input normalized logger]}]
+  (log/info logger :implementer :implementer/submission-retry
+            {:data {:llm-success? (llm/success? (:response normalized))
+                    :content-length (count (:content normalized))}})
+  (let [raw (submission-recovery/run-recovery-session
+             {:context          context
+              :llm-client       llm-client
+              :on-chunk         on-chunk
+              :effective-system effective-system-prompt
+              :retry-prompt     (submission-retry-prompt (task->text input)
+                                                         (:content normalized))
+              :mcp-opts-fn      (fn [session]
+                                  (let [budget-usd      (budget/resolve-cost-budget-usd
+                                                         :implementer config context)
+                                        retry-max-turns (get @implementer-prompt-data
+                                                             :prompt/submission-retry-max-turns 6)]
+                                    (cond-> (artifact-session/session->mcp-opts
+                                             session budget-usd retry-max-turns)
+                                      working-dir (assoc :workdir working-dir))))})
+        recovered (normalize-implementer-result raw context working-dir)]
+    (when (or (:structured-artifact recovered)
+              (:parsed-content recovered)
+              (:derived-artifact recovered))
+      recovered)))
+
 (defn- invoke-with-llm
   "Invoke the implementer via the LLM backend."
   [llm-client user-prompt effective-system-prompt config context on-chunk logger
@@ -755,16 +819,36 @@
     ;; successful stream of edits; the old path discarded a real
     ;; artifact because the LLM response was classified as failure.
     ;; Mirrors the planner fix in `(or worktree-plan (llm/success? …))`.
-    (if (result-boundary/usable-content? normalized)
-      (process-llm-response normalized context logger input)
-      ;; LLM call failed, no artifact — preserve the full llm-error
-      ;; shape into :data so the phase-completed event carries
-      ;; :type (e.g. "cli_error" / "adaptive_timeout"), :stderr /
-      ;; :stdout / :timeout / :exit-code for post-mortem. Iters
-      ;; 11-12 of planner-convergence lost this context and produced
-      ;; undiagnosable "Unknown error" phase errors; same trap here.
-      (result-boundary/error-response normalized
-                                      (messages/t :error/llm-failed)))))
+    ;; Submission recovery: if the turn produced usable analysis but NO
+    ;; artifact (no files, no MCP submit, no parseable code) — the same
+    ;; intermittent failure PR #997 fixed for the planner — run ONE short
+    ;; submission-only retry that asks the implementer to write the files now.
+    ;; Without this, a prose-only implement turn fails "no artifact found",
+    ;; which is what stalled redirect-implements in the review-redirect churn.
+    (let [submitted (:structured-artifact normalized)
+          parsed    (:parsed-content normalized)
+          recovered (when (submission-recovery/submission-retry?
+                           response submitted parsed (:content normalized))
+                      (recover-implementer-submission
+                       {:llm-client llm-client :config config :context context
+                        :on-chunk on-chunk :working-dir working-dir
+                        :effective-system-prompt effective-system-prompt
+                        :input input :normalized normalized :logger logger}))
+          final     (or recovered normalized)]
+      ;; Container-promotion precedence: if the agent wrote files into
+      ;; the worktree (file-artifact via collect-written-files) or
+      ;; submitted via the MCP artifact path, honor that even when the
+      ;; CLI itself terminated with a timeout/error. Iter-20 of the
+      ;; planner-convergence dogfood showed Claude stalling AFTER a
+      ;; successful stream of edits; the old path discarded a real
+      ;; artifact because the LLM response was classified as failure.
+      (if (result-boundary/usable-content? final)
+        (process-llm-response final context logger input)
+        ;; LLM call failed, no artifact (even after recovery) — preserve the
+        ;; full llm-error shape into :data so the phase-completed event carries
+        ;; :type / :stderr / :stdout / :timeout / :exit-code for post-mortem.
+        (result-boundary/error-response final
+                                        (messages/t :error/llm-failed))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
+   [ai.miniforge.agent.submission-recovery :as submission-recovery]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
@@ -245,17 +246,10 @@
    In both cases the recovery turn re-submits using `response-content` as the
    prior plan text."
   [llm-response submitted-plan parsed-plan response-content]
-  (and (nil? submitted-plan)
-       (nil? parsed-plan)
-       (or
-        ;; (a) clean success but no artifact — prose-only narration
-        (and (llm/success? llm-response)
-             (seq response-content))
-        ;; (b) recoverable error with useful stdout
-        (let [err (llm/get-error llm-response)]
-          (and (not (llm/success? llm-response))
-               (seq (:stdout err))
-               (#{"adaptive_timeout" "cli_error"} (:type err)))))))
+  ;; Delegates to the agent-agnostic predicate (single source of truth for the
+  ;; success-vs-error retry trigger, now shared with the implementer et al.).
+  (submission-recovery/submission-retry? llm-response submitted-plan
+                                         parsed-plan response-content))
 
 ;; make-fallback-plan removed — silent fallback masks real failures.
 ;; Plan generation now throws with evidence on failure (see invoke-fn below).

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -157,15 +157,9 @@
                [path content]))
         existing-files))
 
-(defn- render-template
-  "Render a `{{key}}`-style template with the given substitutions.
-   Each substitutions map entry `{kw v}` replaces the literal string
-   \"{{kw}}\" with `v` (nil values render as the empty string)."
-  [template substitutions]
-  (reduce-kv (fn [text k v]
-               (str/replace text (str "{{" (name k) "}}") (or v "")))
-             (or template "")
-             substitutions))
+(def ^:private render-template
+  "Shared `{{key}}` template renderer (single source in the prompts ns)."
+  prompts/render-template)
 
 (defn- existing-files-section
   "Build the planner-prompt section that previews existing in-scope
@@ -506,41 +500,35 @@
       (:num-turns llm-response)
       (assoc :num-turns (:num-turns llm-response)))))
 
-(defn- invoke-planner-submission-retry-session
-  "Run one short follow-up turn that only submits the final plan.
-   Turn cap and progress-monitor thresholds come from
-   resources/prompts/planner.edn (:prompt/submission-retry-max-turns,
-   :prompt/submission-retry-monitor).
-
-   `effective-system` is the same base-plus-addendum string used by the
-   main session, so the retry turn enforces the same compiled policy
-   pack the planner saw on the first call."
-  [session llm-client retry-prompt effective-system config context on-chunk]
-  (let [prompt-data    @planner-prompt-data
-        budget-usd     (budget/resolve-cost-budget-usd :planner config context)
+(defn- planner-retry-mcp-opts
+  "Build the planner's submission-retry session opts from a fresh session.
+   Turn cap + progress-monitor come from planner.edn; model/disallowed-tools
+   match the main planner turn so the retry enforces the same policy pack."
+  [config context session]
+  (let [prompt-data     @planner-prompt-data
+        budget-usd      (budget/resolve-cost-budget-usd :planner config context)
         retry-max-turns (get prompt-data :prompt/submission-retry-max-turns)
-        retry-monitor  (prompts/load-progress-monitor
-                        prompt-data :prompt/submission-retry-monitor)
-        mcp-opts       (cond-> (artifact-session/session->mcp-opts session budget-usd retry-max-turns)
-                         true (assoc :model (model/default-model-for-role :planner)
-                                     :disallowed-tools planner-disallowed-tools
-                                     :progress-monitor retry-monitor)
-                         (:workdir session) (assoc :workdir (:workdir session)))]
-    (if on-chunk
-      (llm/chat-stream llm-client retry-prompt on-chunk
-                       (merge {:system effective-system} mcp-opts))
-      (llm/chat llm-client retry-prompt
-                (merge {:system effective-system} mcp-opts)))))
+        retry-monitor   (prompts/load-progress-monitor
+                         prompt-data :prompt/submission-retry-monitor)]
+    (cond-> (artifact-session/session->mcp-opts session budget-usd retry-max-turns)
+      true (assoc :model (model/default-model-for-role :planner)
+                  :disallowed-tools planner-disallowed-tools
+                  :progress-monitor retry-monitor)
+      (:workdir session) (assoc :workdir (:workdir session)))))
 
 (defn- recover-submitted-plan
   "Retry planner submission once when analysis exists but the final submission
-   did not land. Returns {:llm-response ... :submitted-plan ... :parsed-plan ...}."
+   did not land, via the shared agent-agnostic runner. Returns
+   {:llm-response ... :submitted-plan ... :parsed-plan ...}."
   [llm-client spec-text effective-system config context on-chunk prior-content]
-  (let [retry-prompt   (submission-retry-prompt spec-text prior-content)
-        run-retry      #(invoke-planner-submission-retry-session
-                          % llm-client retry-prompt effective-system config context on-chunk)
-        {:keys [llm-result artifact worktree-artifacts]}
-        (artifact-session/with-session context run-retry)
+  (let [{:keys [llm-result artifact worktree-artifacts]}
+        (submission-recovery/run-recovery-session
+         {:context          context
+          :llm-client       llm-client
+          :on-chunk         on-chunk
+          :effective-system effective-system
+          :retry-prompt     (submission-retry-prompt spec-text prior-content)
+          :mcp-opts-fn      (partial planner-retry-mcp-opts config context)})
         normalized     (normalize-planner-result llm-result worktree-artifacts artifact)
         submitted-plan (:structured-artifact normalized)
         parsed-plan    (when-not submitted-plan

--- a/components/agent/src/ai/miniforge/agent/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/prompts.clj
@@ -23,7 +23,8 @@
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Prompt loading
@@ -112,6 +113,16 @@
   [prompt-data monitor-key]
   (when-let [config (get prompt-data monitor-key)]
     (llm/create-progress-monitor config)))
+
+(defn render-template
+  "Render a `{{key}}`-style template with the given substitutions. Each entry
+   `{kw v}` replaces the literal string \"{{kw}}\" with `v` (nil renders as the
+   empty string). Single source of truth for the agents' prompt templating."
+  [template substitutions]
+  (reduce-kv (fn [text k v]
+               (str/replace text (str "{{" (name k) "}}") (or v "")))
+             (or template "")
+             substitutions))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/submission_recovery.clj
+++ b/components/agent/src/ai/miniforge/agent/submission_recovery.clj
@@ -1,0 +1,94 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.submission-recovery
+  "Agent-agnostic recovery for the 'produced prose but submitted no artifact'
+   failure mode.
+
+   When an agent turn ends with usable plan/code content in its output but
+   NEITHER submission channel delivered an artifact — no MCP submit_artifact
+   and no worktree-promoted `.miniforge/<role>.edn` (and, for the implementer,
+   no files written) — the work exists in the turn's text but the phase has
+   nothing to carry forward, so it fails. This was first fixed for the planner
+   (PR #997); intermittent submission affects EVERY agent, so the trigger and
+   the short retry-turn runner live here and are reused by each agent.
+
+   The recovery is a SINGLE bounded follow-up turn that re-feeds the prior
+   content and asks only for the Write/submit — no further exploration. Each
+   agent supplies its own role-specific retry prompt, mcp-opts, and normalize
+   step; this namespace owns the shared trigger predicate and the retry-session
+   runner."
+  (:require
+   [ai.miniforge.agent.artifact-session :as artifact-session]
+   [ai.miniforge.llm.interface :as llm]))
+
+(def ^:private recoverable-error-types
+  "Backend error classes whose stdout still holds the agent's work, so a
+   submission-only retry can recover it."
+  #{"adaptive_timeout" "cli_error"})
+
+(defn submission-retry?
+  "True when an agent turn produced usable content but delivered NO artifact
+   (no submitted structured artifact AND no parseable final-message content),
+   so a short submission-only retry can recover the work already present in the
+   turn's output.
+
+   Fires in TWO cases:
+   (a) a clean SUCCESS with prose-only narration (`response-content` non-empty)
+       — the agent reasoned out the work but never wrote/submitted it; and
+   (b) a recoverable ERROR (adaptive_timeout / cli_error) that still left
+       useful stdout to retry from.
+
+   `submitted-artifact` and `parsed-content` are the two artifact channels from
+   the normalized result; `response-content` is the agent's prose output."
+  [llm-response submitted-artifact parsed-content response-content]
+  (and (nil? submitted-artifact)
+       (nil? parsed-content)
+       (or
+        ;; (a) clean success but no artifact — prose-only narration
+        (and (llm/success? llm-response)
+             (seq response-content))
+        ;; (b) recoverable error with useful stdout
+        (let [err (llm/get-error llm-response)]
+          (and (not (llm/success? llm-response))
+               (seq (:stdout err))
+               (contains? recoverable-error-types (:type err)))))))
+
+(defn run-recovery-session
+  "Run ONE short submission-only retry turn and return its RAW session channels
+   `{:llm-result :artifact :worktree-artifacts :context-misses
+     :pre-session-snapshot :session-mode}`. The caller re-normalizes
+   (role-specific — e.g. the implementer also re-collects its file artifact).
+
+   `opts`:
+     :context          execution context (threaded into `with-session`)
+     :llm-client       resolved LLM client for the role
+     :retry-prompt     the role's submission-only prompt (prior content folded in)
+     :effective-system the same base+addendum system prompt as the main turn,
+                       so the retry enforces the identical compiled policy pack
+     :on-chunk         optional streaming callback (pings the watchdog)
+     :mcp-opts-fn      (fn [session] -> mcp-opts) — builds the per-role session
+                       opts (model, disallowed-tools, budget, turn cap, workdir)"
+  [{:keys [context llm-client retry-prompt effective-system on-chunk mcp-opts-fn]}]
+  (artifact-session/with-session context
+    (fn [session]
+      (let [mcp-opts (mcp-opts-fn session)
+            opts     (merge {:system effective-system} mcp-opts)]
+        (if on-chunk
+          (llm/chat-stream llm-client retry-prompt on-chunk opts)
+          (llm/chat llm-client retry-prompt opts))))))

--- a/components/agent/src/ai/miniforge/agent/submission_recovery.clj
+++ b/components/agent/src/ai/miniforge/agent/submission_recovery.clj
@@ -25,8 +25,10 @@
    and no worktree-promoted `.miniforge/<role>.edn` (and, for the implementer,
    no files written) — the work exists in the turn's text but the phase has
    nothing to carry forward, so it fails. This was first fixed for the planner
-   (PR #997); intermittent submission affects EVERY agent, so the trigger and
-   the short retry-turn runner live here and are reused by each agent.
+   (PR #997); intermittent submission affects every agent, so the trigger and
+   the short retry-turn runner live here. Both the planner and the implementer
+   route their recovery through `run-recovery-session`; verify/review/release
+   can adopt the same path as they're shown to need it.
 
    The recovery is a SINGLE bounded follow-up turn that re-feeds the prior
    content and asks only for the Write/submit — no further exploration. Each

--- a/components/agent/test/ai/miniforge/agent/submission_recovery_test.clj
+++ b/components/agent/test/ai/miniforge/agent/submission_recovery_test.clj
@@ -1,0 +1,52 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.submission-recovery-test
+  "Tests for the agent-agnostic submission-recovery trigger predicate."
+  (:require
+   [ai.miniforge.agent.submission-recovery :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest fires-on-success-without-artifact
+  (testing "a clean success that produced prose but NO artifact triggers recovery
+            (the intermittent failure — applies to every agent, not just the planner)"
+    (is (true? (boolean (sut/submission-retry? {:success true} nil nil "## Plan\nTask A -> B"))))))
+
+(deftest not-on-success-without-prose
+  (testing "a success with no prose has nothing to recover"
+    (is (false? (boolean (sut/submission-retry? {:success true} nil nil ""))))
+    (is (false? (boolean (sut/submission-retry? {:success true} nil nil nil))))))
+
+(deftest fires-on-recoverable-error-with-stdout
+  (testing "adaptive_timeout / cli_error with useful stdout still retries"
+    (is (true? (boolean (sut/submission-retry?
+                         {:success false :error {:stdout "work" :type "cli_error"}} nil nil ""))))
+    (is (true? (boolean (sut/submission-retry?
+                         {:success false :error {:stdout "work" :type "adaptive_timeout"}} nil nil ""))))))
+
+(deftest no-fire-when-artifact-present
+  (testing "an artifact (submitted or parsed) means no recovery is needed"
+    (is (false? (boolean (sut/submission-retry? {:success true} {:code/files []} nil "prose"))))
+    (is (false? (boolean (sut/submission-retry? {:success true} nil {:code/files []} "prose"))))))
+
+(deftest no-fire-on-unrecoverable-error
+  (testing "an error with no stdout or a non-retriable type does not retry"
+    (is (false? (boolean (sut/submission-retry?
+                          {:success false :error {:stdout "" :type "cli_error"}} nil nil ""))))
+    (is (false? (boolean (sut/submission-retry?
+                          {:success false :error {:stdout "x" :type "other"}} nil nil ""))))))


### PR DESCRIPTION
## Summary

Lifts PR #997's planner-only submission recovery to an **agent-agnostic shared path** and wires the **implementer** — the demonstrated dogfood blocker.

**Why:** the 2026-05-27 `release-opens-real-pr` run reached review, but then churned: review correctly blocked on a missing PR doc, and the redirect-implements kept failing *"no artifact found after session"* — the implementer produced prose but never wrote files/submitted. #997 fixed exactly this for the planner; the implementer (and verify/review/release) had no equivalent.

**Change:**
- **New `agent/submission_recovery.clj`** — `submission-retry?` (the shared trigger: success-with-prose *or* recoverable error with stdout, and no artifact) + `run-recovery-session` (one short submission-only retry turn → raw session channels; callers re-normalize per role).
- **`implementer.clj`** — on a no-artifact turn, run the recovery (a submission-only prompt that asks for the actual file Writes), re-collect the file artifact, re-normalize, and use the recovered artifact when present.
- **`implementer.edn`** — new `:prompt/submission-retry-template` + `:prompt/submission-retry-max-turns`.
- **`planner.clj`** — its predicate now delegates to the shared one (no behavior change; #997's tests stay green).

Bounded single retry per turn (no runaway). Verify/review/release can adopt the same shared path as a follow-up.

## Test plan
- [x] `bb pre-commit` green (poly check, graalvm 511 assertions, smoke)
- [x] new `submission_recovery_test`: trigger matrix (success-no-artifact fires; success-no-prose doesn't; recoverable errors fire; artifact-present never; unrecoverable never)
- [x] planner regression tests still green (predicate delegates)
- [x] implementer tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)