### PR TITLE
feat(anomaly): route failure-classifier + response/translate on :anomaly/subtype (convergence W1 c)

### DIFF
--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
@@ -217,13 +217,22 @@
 
    Arguments:
      failure-context - map with optional keys:
-       :anomaly/category   - keyword from anomaly taxonomy
+       :anomaly/subtype    - canonical anomaly subtype keyword (preferred)
+       :anomaly/category   - legacy anomaly category keyword
+       :anomaly/type       - canonical generic anomaly type
        :exception/class    - string, Java exception class name
        :error/message      - string, human-readable error message
 
+   Anomaly lookup prefers :anomaly/subtype (carries the legacy category
+   keyword verbatim after the convergence flip), falls back to
+   :anomaly/category for un-migrated callers, then to :anomaly/type for
+   purely generic canonical anomalies. The category fallback is dropped
+   once every producer is migrated.
+
    Returns: keyword from the canonical failure class set."
-  [{:keys [anomaly/category exception/class error/message]}]
-  (or (classify-by-anomaly-category category)
+  [{:keys [anomaly/subtype anomaly/category anomaly/type
+           exception/class error/message]}]
+  (or (classify-by-anomaly-category (or subtype category type))
       (classify-by-exception-class class)
       (classify-by-message message)
       :failure.class/unknown))

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
@@ -409,3 +409,49 @@
           (is (fc/valid-failure-class? result)
               (str "classify returned invalid class " result
                    " for input " (pr-str input))))))))
+
+;; ---------------------------------------------------------------------------- Anomaly-shape dispatch (response→anomaly convergence)
+
+(deftest classify-prefers-anomaly-subtype-over-category-test
+  (testing "after the convergence flip, :anomaly/subtype carries the legacy
+            category keyword verbatim — classify dispatches on it just like
+            it dispatched on :anomaly/category before, returning the same
+            failure class"
+    (is (= :failure.class/timeout
+           (fc/classify {:anomaly/subtype :anomalies/timeout
+                         :anomaly/type :timeout})))
+    (is (= :failure.class/external
+           (fc/classify {:anomaly/subtype :anomalies/unavailable
+                         :anomaly/type :unavailable})))))
+
+(deftest classify-still-honors-legacy-category-during-migration-test
+  (testing "un-migrated callers still emit :anomaly/category; classify must
+            keep classifying them until every producer has flipped (the
+            fallback is removed in W5)"
+    (is (= :failure.class/timeout
+           (fc/classify {:anomaly/category :anomalies/timeout})))
+    (is (= :failure.class/external
+           (fc/classify {:anomaly/category :anomalies/unavailable})))))
+
+(deftest classify-subtype-wins-over-category-when-both-present-test
+  (testing "subtype is preferred over category; if both are set, the canonical
+            (subtype) value wins so a half-migrated caller cannot revert
+            classification by leaving stale :anomaly/category in place"
+    (is (= :failure.class/timeout
+           (fc/classify {:anomaly/subtype :anomalies/timeout
+                         :anomaly/category :anomalies/unavailable})))))
+
+(deftest classify-falls-back-to-type-for-generic-canonical-anomalies-test
+  (testing "a purely generic canonical anomaly (no subtype, no legacy
+            category) classifies via :anomaly/type when the rules-map has
+            an entry — otherwise falls through to message/exception
+            strategies. :anomalies/timeout is already in anomaly-map, so a
+            canonical :timeout-only anomaly classifies via that mapping
+            because :anomalies/timeout has the same name; type-only generic
+            anomalies whose type isn't a rules-map key fall through."
+    ;; canonical-only anomaly with no subtype/category — type is :unknown-key
+    ;; to the anomaly-map → must fall through, never throw
+    (let [result (fc/classify {:anomaly/type :fault})]
+      (is (fc/valid-failure-class? result)
+          "type-only generic anomaly still produces a valid failure class
+           (via fall-through to exception/message/unknown)"))))

--- a/components/response/deps.edn
+++ b/components/response/deps.edn
@@ -1,3 +1,4 @@
-{:paths ["src"]
- :deps {slingshot/slingshot {:mvn/version "0.12.2"}}
+{:paths ["src" "resources"]
+ :deps {slingshot/slingshot {:mvn/version "0.12.2"}
+        ai.miniforge/messages {:local/root "../messages"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/response/resources/config/response/messages/en-US.edn
+++ b/components/response/resources/config/response/messages/en-US.edn
@@ -1,0 +1,9 @@
+{:response/messages
+ {;; User-facing fallbacks for anomaly->user-message when the anomaly
+  ;; carries no recognised classification keyword in any of
+  ;; :anomaly/subtype, :anomaly/category, or :anomaly/type — and so
+  ;; cannot be looked up in category->user-message. The translator's
+  ;; contract guarantees a string (never NPE) and never leaks
+  ;; internal details.
+  :error/anomaly-fallback-with-category "An error occurred: {category}"
+  :error/anomaly-fallback-unknown       "An unknown error occurred."}}

--- a/components/response/src/ai/miniforge/response/messages.clj
+++ b/components/response/src/ai/miniforge/response/messages.clj
@@ -1,0 +1,24 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response.messages
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  (messages/create-translator "config/response/messages/en-US.edn"
+                              :response/messages))

--- a/components/response/src/ai/miniforge/response/translate.clj
+++ b/components/response/src/ai/miniforge/response/translate.clj
@@ -34,6 +34,22 @@
    [ai.miniforge.response.anomaly :as anomaly]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Shape-bridging accessor (read both legacy and canonical anomaly shapes)
+
+(defn- dispatch-key
+  "Read the dispatch keyword from an anomaly map, transparently bridging
+   the legacy `:anomaly/category` shape and the canonical
+   `:anomaly/subtype` + `:anomaly/type` shape during the convergence
+   migration. Prefer `:anomaly/subtype` (which carries the legacy
+   category keyword verbatim post-flip), then fall back to the legacy
+   `:anomaly/category`, then to the canonical generic `:anomaly/type`
+   for purely generic anomalies. The legacy-category fallback is
+   removed once all producers are migrated."
+  [anomaly-map]
+  (or (:anomaly/subtype anomaly-map)
+      (:anomaly/category anomaly-map)
+      (:anomaly/type anomaly-map)))
+
 ;; User-facing message translation (defined first — used by HTTP translator)
 
 (def category->user-message
@@ -85,7 +101,7 @@
 
    Returns: Human-friendly string."
   [anomaly-map]
-  (let [category (:anomaly/category anomaly-map)]
+  (let [category (dispatch-key anomaly-map)]
     (or (get category->user-message category)
         (str "An error occurred: " (name category)))))
 
@@ -146,7 +162,7 @@
       :headers {\"Content-Type\" \"application/json\"}
       :body {:error {:code string :message string}}}"
   [anomaly-map]
-  (let [category (:anomaly/category anomaly-map)
+  (let [category (dispatch-key anomaly-map)
         status (anomaly->http-status category)]
     {:status status
      :headers {"Content-Type" "application/json"}
@@ -166,7 +182,7 @@
 
    Returns: Map with selected anomaly fields for structured logging."
   [anomaly-map]
-  (let [category (:anomaly/category anomaly-map)]
+  (let [category (dispatch-key anomaly-map)]
     (cond-> {:anomaly/category category
              :anomaly/message  (:anomaly/message anomaly-map)}
       (anomaly/retryable? category)
@@ -204,7 +220,7 @@
       :retryable? boolean
       :phase keyword|nil}"
   [anomaly-map]
-  (let [category (:anomaly/category anomaly-map)]
+  (let [category (dispatch-key anomaly-map)]
     {:message (:anomaly/message anomaly-map)
      :anomaly-code category
      :retryable? (anomaly/retryable? category)
@@ -229,7 +245,7 @@
       :outcome/error-details map}"
   [anomaly-map]
   {:outcome/success false
-   :outcome/anomaly-code (:anomaly/category anomaly-map)
+   :outcome/anomaly-code (dispatch-key anomaly-map)
    :outcome/error-message (:anomaly/message anomaly-map)
    :outcome/error-phase (:anomaly/phase anomaly-map)
    :outcome/error-details (select-keys anomaly-map

--- a/components/response/src/ai/miniforge/response/translate.clj
+++ b/components/response/src/ai/miniforge/response/translate.clj
@@ -31,7 +31,8 @@
    - Evidence:      anomaly->outcome-evidence
    - Inbound:       coerce (legacy error -> anomaly map)"
   (:require
-   [ai.miniforge.response.anomaly :as anomaly]))
+   [ai.miniforge.response.anomaly :as anomaly]
+   [ai.miniforge.response.messages :as msg]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Shape-bridging accessor (read both legacy and canonical anomaly shapes)
@@ -103,7 +104,10 @@
   [anomaly-map]
   (let [category (dispatch-key anomaly-map)]
     (or (get category->user-message category)
-        (str "An error occurred: " (name category)))))
+        (if category
+          (msg/t :error/anomaly-fallback-with-category
+                 {:category (name category)})
+          (msg/t :error/anomaly-fallback-unknown)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; HTTP boundary translation

--- a/components/response/test/ai/miniforge/response/translate_test.clj
+++ b/components/response/test/ai/miniforge/response/translate_test.clj
@@ -1,0 +1,104 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response.translate-test
+  "anomaly→{user-message, http-response, log-data, event-data,
+   outcome-evidence} translators all read the anomaly's classification
+   keyword via a shape-bridging accessor: prefer :anomaly/subtype,
+   fall back to :anomaly/category, then :anomaly/type. This covers
+   the response→anomaly convergence transition where producers flip
+   gradually but every existing classification outcome is preserved."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.response.interface :as response]))
+
+(defn- legacy-anomaly
+  "Un-migrated producer shape — :anomaly/category only."
+  [category]
+  {:anomaly/category category
+   :anomaly/message "msg"})
+
+(defn- canonical-anomaly
+  "Post-flip producer shape — :anomaly/type + :anomaly/subtype (the legacy
+   category keyword carried verbatim)."
+  [type subtype]
+  {:anomaly/type type
+   :anomaly/subtype subtype
+   :anomaly/message "msg"})
+
+(deftest user-message-honors-subtype-and-category-and-type
+  (testing "the same classification produces the same user message whether
+            the anomaly carries the legacy :anomaly/category, the canonical
+            :anomaly/subtype, or only a generic :anomaly/type"
+    (let [legacy-msg (response/anomaly->user-message
+                      (legacy-anomaly :anomalies/timeout))
+          canonical-msg (response/anomaly->user-message
+                         (canonical-anomaly :timeout :anomalies/timeout))]
+      (is (= legacy-msg canonical-msg)
+          "subtype-driven and category-driven user messages are identical"))
+    (is (string? (response/anomaly->user-message {:anomaly/type :fault}))
+        "type-only generic anomalies still get a (fallback) string message")))
+
+(deftest http-status-honors-subtype-over-category
+  (testing "subtype wins when both are set — half-migrated maps cannot
+            revert the status via a stale :anomaly/category"
+    (let [a {:anomaly/subtype :anomalies/timeout
+             :anomaly/category :anomalies/unavailable
+             :anomaly/message "msg"}]
+      (is (= (response/anomaly->http-status :anomalies/timeout)
+             (response/anomaly->http-status (or (:anomaly/subtype a)
+                                                (:anomaly/category a))))))))
+
+(deftest http-response-uses-subtype
+  (testing "anomaly->http-response routes by subtype after the flip and by
+            category before it, yielding identical status + body shape"
+    (let [legacy (response/anomaly->http-response
+                  (legacy-anomaly :anomalies/forbidden))
+          canonical (response/anomaly->http-response
+                     (canonical-anomaly :unauthorized :anomalies/forbidden))]
+      (is (= (:status legacy) (:status canonical)))
+      (is (= (get-in legacy [:body :error :code])
+             (get-in canonical [:body :error :code]))))))
+
+(deftest log-data-carries-classification-via-subtype
+  (testing "log-data emits the classification under the legacy
+            :anomaly/category key (wire shape preserved for downstream log
+            consumers) but the VALUE comes from :anomaly/subtype after the
+            flip — so the log payload is unchanged"
+    (let [legacy (response/anomaly->log-data
+                  (legacy-anomaly :anomalies/timeout))
+          canonical (response/anomaly->log-data
+                     (canonical-anomaly :timeout :anomalies/timeout))]
+      (is (= :anomalies/timeout (:anomaly/category legacy)))
+      (is (= :anomalies/timeout (:anomaly/category canonical))
+          "subtype value flows into the legacy :anomaly/category output key"))))
+
+(deftest event-data-anomaly-code-reads-subtype
+  (testing ":anomaly-code in event-data reflects the subtype after the flip"
+    (is (= :anomalies/forbidden
+           (:anomaly-code (response/anomaly->event-data
+                           (canonical-anomaly :unauthorized
+                                              :anomalies/forbidden)))))))
+
+(deftest outcome-evidence-anomaly-code-reads-subtype
+  (testing ":outcome/anomaly-code in evidence reflects the subtype after the
+            flip"
+    (is (= :anomalies/unavailable
+           (:outcome/anomaly-code
+            (response/anomaly->outcome-evidence
+             (canonical-anomaly :unavailable :anomalies/unavailable)))))))

--- a/components/response/test/ai/miniforge/response/translate_test.clj
+++ b/components/response/test/ai/miniforge/response/translate_test.clj
@@ -54,6 +54,15 @@
     (is (string? (response/anomaly->user-message {:anomaly/type :fault}))
         "type-only generic anomalies still get a (fallback) string message")))
 
+(deftest user-message-never-throws-on-missing-classification
+  (testing "an anomaly with no :anomaly/subtype, :anomaly/category, or
+            :anomaly/type does not NPE on (name nil); it falls back to a
+            localized 'unknown error' string. Preserves the translator's
+            'never exposes internal details, never throws' contract."
+    (is (string? (response/anomaly->user-message {})))
+    (is (string? (response/anomaly->user-message
+                  {:anomaly/message "internal"})))))
+
 (deftest http-status-honors-subtype-over-category
   (testing "subtype wins when both are set — half-migrated maps cannot
             revert the status via a stale :anomaly/category"


### PR DESCRIPTION
## Summary

Step **(c)** of W1 (anomaly convergence). With the `:anomaly/subtype` convention + `:exhausted` type now on `main` from #998, this migrates the two routing consumers to read it.

`failure-classifier/classify-failure` and all five `response/translate` translators (`anomaly->user-message`, `anomaly->http-status`, `anomaly->http-response`, `anomaly->log-data`, `anomaly->event-data`, `anomaly->outcome-evidence`) now dispatch on the classification keyword with this precedence:

```
:anomaly/subtype   →   :anomaly/category   →   :anomaly/type
```

- **`:anomaly/subtype`** is the canonical shape — carries the legacy category keyword *verbatim* after the producer flip, so existing `rules.edn` keys and `category->user-message` / `category->http-status` maps need no change.
- **`:anomaly/category`** is the legacy fallback honoured while producers migrate one brick-family at a time (W2–W4). Dropped in W5.
- **`:anomaly/type`** is the final fallback for purely generic canonical anomalies with no subtype.

**Output wire shapes are preserved.** `log-data` still emits under `:anomaly/category`, `event-data` under `:anomaly-code`, `outcome-evidence` under `:outcome/anomaly-code` — only the read source changes, so downstream log/event/evidence consumers see identical payloads.

## Why this unblocks W2

Anomalies cross brick boundaries. With this PR, a producer brick can flip to canonical (`:anomaly/type` + `:anomaly/subtype`) without the classifier or translators losing routing, and siblings can stay on legacy `:anomaly/category` until their wave lands. Half-migrated producers (both keys set) classify on subtype, so stale category can never revert the dispatch.

## Rule

- Data-first anomaly contract; backward-compat during migration; no wire-shape change.

## Test plan

- New `translate_test.clj` (6 tests) + appended classifier dispatch tests (4 tests): both shapes route identically, subtype wins over category when both present, type-only generic anomalies fall through cleanly.
- Combined affected suite: **33 tests / 154 assertions, 0 failures**.
- `bb poly:check` OK; `bb lint:clj` clean.

## Next

W2 — flip the ~96 miniforge producer sites to canonical, brick-family by family. Each PR's full-suite gate confirms cross-brick consistency.