### PR TITLE
feat(schema): flip failure helpers to canonical anomaly (W2 leaf 1/3)

### DIFF
--- a/components/schema/src/ai/miniforge/schema/interface.clj
+++ b/components/schema/src/ai/miniforge/schema/interface.clj
@@ -25,8 +25,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.schema.core :as core]
    [ai.miniforge.schema.logging :as logging]
-   [ai.miniforge.schema.supervisory :as supervisory]
-   [ai.miniforge.response.interface :as response]))
+   [ai.miniforge.schema.supervisory :as supervisory]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports (allow other components to reference schemas)
@@ -228,7 +227,7 @@
   ([data-key error opts]
    (let [msg (if (string? error) error (or (:message error) (pr-str error)))]
      (merge {:success? false data-key nil :error error
-             :anomaly (response/make-anomaly :anomalies/fault msg)}
+             :anomaly (anomaly/anomaly :fault msg {})}
             opts))))
 
 (defn failure-with-errors
@@ -273,7 +272,7 @@
    (let [error-map (cond-> {:message (ex-message ex)}
                      (ex-data ex) (assoc :data (ex-data ex)))]
      (merge {:success? false data-key nil :error error-map
-             :anomaly (response/from-exception ex)}
+             :anomaly (anomaly/exception-anomaly :fault (ex-message ex) ex)}
             opts))))
 
 (defn succeeded?

--- a/components/schema/test/ai/miniforge/schema/interface/failure_anomaly_shape_test.clj
+++ b/components/schema/test/ai/miniforge/schema/interface/failure_anomaly_shape_test.clj
@@ -1,0 +1,61 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.schema.interface.failure-anomaly-shape-test
+  "Lock the canonical anomaly shape produced by `schema/failure` and
+   `schema/exception-failure` after the W2 anomaly convergence flip.
+
+   Pre-flip these helpers emitted `:anomaly/category :anomalies/fault`
+   via `response/make-anomaly` / `response/from-exception`. Post-flip
+   they emit `:anomaly/type :fault` via `ai.miniforge.anomaly.interface`
+   with no `:anomaly/subtype` (`:anomalies/fault` is one of the eight
+   cognitect-standard categories that map 1:1 to a generic type)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.schema.interface :as schema]))
+
+(deftest failure-emits-canonical-fault-anomaly
+  (testing "failure/2 attaches an anomaly with :anomaly/type :fault"
+    (let [resp (schema/failure :pack "File not found")
+          a    (:anomaly resp)]
+      (is (anomaly/anomaly? a))
+      (is (= :fault (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a))
+          "generic-standard fault has no domain subtype")))
+
+  (testing "failure carries the diagnostic message"
+    (let [resp (schema/failure :pack "boom")]
+      (is (= "boom" (:anomaly/message (:anomaly resp)))))))
+
+(deftest exception-failure-emits-canonical-fault-anomaly
+  (testing "exception-failure wraps the exception as a :fault anomaly"
+    (let [ex   (ex-info "kaboom" {:phase :extraction})
+          resp (schema/exception-failure :pack ex)
+          a    (:anomaly resp)]
+      (is (anomaly/anomaly? a))
+      (is (= :fault (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a)))))
+
+  (testing "exception provenance is preserved under :anomaly/data"
+    (let [ex   (ex-info "kaboom" {:phase :extraction})
+          resp (schema/exception-failure :pack ex)
+          data (:anomaly/data (:anomaly resp))]
+      (is (= "kaboom" (:anomaly/ex-message data)))
+      (is (= "clojure.lang.ExceptionInfo" (:anomaly/ex-class data)))
+      (is (= {:phase :extraction} (:anomaly/ex-data data))))))

--- a/components/schema/test/ai/miniforge/schema/interface/failure_anomaly_shape_test.clj
+++ b/components/schema/test/ai/miniforge/schema/interface/failure_anomaly_shape_test.clj
@@ -30,9 +30,47 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.schema.interface :as schema]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Fixtures and factories — the canonical-shape post-flip contract.
+
+(def ^:private data-key
+  "Arbitrary domain data-key used by `schema/failure` and
+   `schema/exception-failure`; the shape contract is independent of
+   which data-key the caller passes."
+  :pack)
+
+(def ^:private fault-message
+  "Plain string message exercised by the `failure/2` path."
+  "File not found")
+
+(def ^:private exception-message
+  "Message attached to the test `ex-info` instance; exercised on the
+   `exception-failure` path and asserted on `:anomaly/ex-message`."
+  "kaboom")
+
+(def ^:private exception-ex-data
+  "ex-data carried by the test exception; locked on
+   `:anomaly/ex-data` to prove exception provenance is preserved."
+  {:phase :extraction})
+
+(def ^:private exception-info-class-name
+  "Fully-qualified class name of `clojure.lang.ExceptionInfo`,
+   locked on `:anomaly/ex-class` to prove the class is carried
+   through to the anomaly's data."
+  "clojure.lang.ExceptionInfo")
+
+(defn- make-ex
+  "Build the canonical `ex-info` fixture used by every
+   `exception-failure` assertion in this file."
+  []
+  (ex-info exception-message exception-ex-data))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Shape locks — `:anomaly/type :fault` with no `:anomaly/subtype`.
+
 (deftest failure-emits-canonical-fault-anomaly
   (testing "failure/2 attaches an anomaly with :anomaly/type :fault"
-    (let [resp (schema/failure :pack "File not found")
+    (let [resp (schema/failure data-key fault-message)
           a    (:anomaly resp)]
       (is (anomaly/anomaly? a))
       (is (= :fault (:anomaly/type a)))
@@ -40,22 +78,20 @@
           "generic-standard fault has no domain subtype")))
 
   (testing "failure carries the diagnostic message"
-    (let [resp (schema/failure :pack "boom")]
-      (is (= "boom" (:anomaly/message (:anomaly resp)))))))
+    (let [resp (schema/failure data-key fault-message)]
+      (is (= fault-message (:anomaly/message (:anomaly resp)))))))
 
 (deftest exception-failure-emits-canonical-fault-anomaly
   (testing "exception-failure wraps the exception as a :fault anomaly"
-    (let [ex   (ex-info "kaboom" {:phase :extraction})
-          resp (schema/exception-failure :pack ex)
+    (let [resp (schema/exception-failure data-key (make-ex))
           a    (:anomaly resp)]
       (is (anomaly/anomaly? a))
       (is (= :fault (:anomaly/type a)))
       (is (nil? (:anomaly/subtype a)))))
 
   (testing "exception provenance is preserved under :anomaly/data"
-    (let [ex   (ex-info "kaboom" {:phase :extraction})
-          resp (schema/exception-failure :pack ex)
+    (let [resp (schema/exception-failure data-key (make-ex))
           data (:anomaly/data (:anomaly resp))]
-      (is (= "kaboom" (:anomaly/ex-message data)))
-      (is (= "clojure.lang.ExceptionInfo" (:anomaly/ex-class data)))
-      (is (= {:phase :extraction} (:anomaly/ex-data data))))))
+      (is (= exception-message (:anomaly/ex-message data)))
+      (is (= exception-info-class-name (:anomaly/ex-class data)))
+      (is (= exception-ex-data (:anomaly/ex-data data))))))


### PR DESCRIPTION
## Anomaly convergence W2 — schema brick

First of three leaf-brick flips in the W2 batch (per
`docs/runbooks/anomaly-convergence.md`).

### Sites migrated

Two anomaly construction sites in `schema/interface`:

| before | after |
| --- | --- |
| `(response/make-anomaly :anomalies/fault msg)` | `(anomaly/anomaly :fault msg {})` |
| `(response/from-exception ex)` | `(anomaly/exception-anomaly :fault (ex-message ex) ex)` |

Both used the generic-standard `:anomalies/fault` category, which maps
1:1 to type `:fault` with no `:anomaly/subtype` per the runbook's
"Generic standard (no subtype)" table.

### Independence

The routing consumers (`failure-classifier`, `response/translate`)
already accept both shapes after #1001, so schema can flip on its own.
Response keeps producing legacy-shape anomalies until W5.

### Deps

- Drops `ai.miniforge.response.interface` require from
  `schema/interface` — schema no longer reads or produces
  legacy-shape anomalies.
- `ai.miniforge/anomaly` was already in `schema/deps.edn`.

### Tests

- New: `failure-anomaly-shape-test` locks the canonical shape on
  `failure` and `exception-failure` (4 tests, 10 assertions).
- Existing schema tests unchanged and green.
- Net: tests grew, none failed.

### Gates

- `bb pre-commit` — green (poly:check + 16-ns precommit smoke + GraalVM)
- `bb lint:clj` — only a pre-existing deprecation warning on the
  rich-comment use of the deprecated `validate` thrower (not from
  this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)