### PR TITLE
feat(tool): flip execute failure paths to canonical anomaly (W2 leaf 2/3)

### DIFF
--- a/components/tool/deps.edn
+++ b/components/tool/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../schema"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/schema  {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -139,10 +139,11 @@
                      {:success true
                       :result (handler params context)}
                      (catch Exception e
-                       {:success false
-                        :error {:type "execution_error"
-                                :message (.getMessage e)}
-                        :anomaly (anomaly/exception-anomaly :fault (ex-message e) e)}))
+                       (let [ex-msg (or (ex-message e) (.getName (class e)))]
+                         {:success false
+                          :error {:type "execution_error"
+                                  :message ex-msg}
+                          :anomaly (anomaly/exception-anomaly :fault ex-msg e)})))
                    {:success false
                     :error {:type "validation_error"
                             :errors (:errors validation)}

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -23,8 +23,8 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.response.interface :as response]
    [ai.miniforge.tool.tracking :as tracking]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -142,14 +142,15 @@
                        {:success false
                         :error {:type "execution_error"
                                 :message (.getMessage e)}
-                        :anomaly (response/from-exception e)}))
+                        :anomaly (anomaly/exception-anomaly :fault (ex-message e) e)}))
                    {:success false
                     :error {:type "validation_error"
                             :errors (:errors validation)}
-                    :anomaly (response/make-anomaly
-                              :anomalies/incorrect
+                    :anomaly (anomaly/anomaly
+                              :invalid-input
                               (str "Tool parameter validation failed: "
-                                   (first (:errors validation))))})
+                                   (first (:errors validation)))
+                              {})})
           end-ms (System/currentTimeMillis)
           invocation (tracking/build-invocation id params start-ms end-ms result)]
       (tracking/record-invocation context invocation)
@@ -235,9 +236,10 @@
     {:success false
      :error {:type "not_found"
              :message (str "Tool not found: " tool-id)}
-     :anomaly (response/make-anomaly
-               :anomalies/not-found
-               (str "Tool not found: " tool-id))}))
+     :anomaly (anomaly/anomaly
+               :not-found
+               (str "Tool not found: " tool-id)
+               {})}))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tool/test/ai/miniforge/tool/anomaly_shape_test.clj
+++ b/components/tool/test/ai/miniforge/tool/anomaly_shape_test.clj
@@ -1,0 +1,80 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool.anomaly-shape-test
+  "Lock the canonical anomaly shape produced by the tool component
+   after the W2 anomaly convergence flip.
+
+   The tool component produces anomalies on three failure paths:
+   - parameter validation failure → `:invalid-input`
+   - handler exception           → `:fault`
+   - tool-not-found in registry  → `:not-found`
+
+   All three previously used the legacy `response/make-anomaly` /
+   `response/from-exception` constructors carrying `:anomaly/category`.
+   Post-flip they use `ai.miniforge.anomaly.interface` with canonical
+   `:anomaly/type`; all three are generic-standard cognitect categories
+   with no `:anomaly/subtype` per
+   `docs/runbooks/anomaly-convergence.md`."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.tool.interface :as tool]))
+
+(defn- echo-handler [params _ctx] (:message params))
+(defn- throwing-handler [_params _ctx] (throw (ex-info "boom" {:why :test})))
+
+(deftest execute-validation-error-emits-invalid-input-anomaly
+  (testing "missing required parameter yields :invalid-input anomaly"
+    (let [t (tool/create-tool
+             {:id          :tools/echo
+              :description "echo"
+              :parameters  {:message {:type :string :required true}}
+              :handler     echo-handler})
+          result (tool/execute t {} {})
+          a      (:anomaly result)]
+      (is (false? (:success result)))
+      (is (anomaly/anomaly? a))
+      (is (= :invalid-input (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a))
+          "generic-standard incorrect has no domain subtype"))))
+
+(deftest execute-handler-exception-emits-fault-anomaly
+  (testing "handler exception yields :fault anomaly with provenance"
+    (let [t (tool/create-tool
+             {:id          :tools/throws
+              :description "throws"
+              :parameters  {}
+              :handler     throwing-handler})
+          result (tool/execute t {} {})
+          a      (:anomaly result)]
+      (is (false? (:success result)))
+      (is (anomaly/anomaly? a))
+      (is (= :fault (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a)))
+      (is (= "boom" (:anomaly/ex-message (:anomaly/data a)))))))
+
+(deftest execute-tool-not-found-emits-not-found-anomaly
+  (testing "execute-tool on a missing tool yields :not-found anomaly"
+    (let [reg    (tool/create-registry)
+          result (tool/execute-by-id reg :tools/missing {} {})
+          a      (:anomaly result)]
+      (is (false? (:success result)))
+      (is (anomaly/anomaly? a))
+      (is (= :not-found (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a))))))

--- a/components/tool/test/ai/miniforge/tool/anomaly_shape_test.clj
+++ b/components/tool/test/ai/miniforge/tool/anomaly_shape_test.clj
@@ -36,16 +36,32 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.tool.interface :as tool]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Test factories + handler fixtures.
+
 (defn- echo-handler [params _ctx] (:message params))
 (defn- throwing-handler [_params _ctx] (throw (ex-info "boom" {:why :test})))
+(defn- nil-message-throwing-handler [_params _ctx] (throw (Exception.)))
+
+(defn- make-tool
+  "Factory for a `tool/create-tool` invocation. Always supplies the
+   four-field map shape so each test only varies what it cares about."
+  [{:keys [id description parameters handler]
+    :or   {description "test tool"
+           parameters  {}}}]
+  (tool/create-tool {:id          id
+                     :description description
+                     :parameters  parameters
+                     :handler     handler}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Anomaly-shape tests, one per failure path.
 
 (deftest execute-validation-error-emits-invalid-input-anomaly
   (testing "missing required parameter yields :invalid-input anomaly"
-    (let [t (tool/create-tool
-             {:id          :tools/echo
-              :description "echo"
-              :parameters  {:message {:type :string :required true}}
-              :handler     echo-handler})
+    (let [t      (make-tool {:id         :tools/echo
+                             :parameters {:message {:type :string :required true}}
+                             :handler    echo-handler})
           result (tool/execute t {} {})
           a      (:anomaly result)]
       (is (false? (:success result)))
@@ -56,11 +72,8 @@
 
 (deftest execute-handler-exception-emits-fault-anomaly
   (testing "handler exception yields :fault anomaly with provenance"
-    (let [t (tool/create-tool
-             {:id          :tools/throws
-              :description "throws"
-              :parameters  {}
-              :handler     throwing-handler})
+    (let [t      (make-tool {:id      :tools/throws
+                             :handler throwing-handler})
           result (tool/execute t {} {})
           a      (:anomaly result)]
       (is (false? (:success result)))
@@ -68,6 +81,22 @@
       (is (= :fault (:anomaly/type a)))
       (is (nil? (:anomaly/subtype a)))
       (is (= "boom" (:anomaly/ex-message (:anomaly/data a)))))))
+
+(deftest execute-handler-nil-message-exception-falls-back-to-class-name
+  (testing "handler throwing an exception with no message still yields a schema-valid anomaly"
+    (let [t      (make-tool {:id      :tools/throws-blank
+                             :handler nil-message-throwing-handler})
+          result (tool/execute t {} {})
+          a      (:anomaly result)]
+      (is (false? (:success result)))
+      (is (anomaly/anomaly? a)
+          "nil ex-message must not break the canonical anomaly schema")
+      (is (= :fault (:anomaly/type a)))
+      (is (string? (:anomaly/message a)))
+      (is (= "java.lang.Exception" (:anomaly/message a))
+          "fallback is the exception class name")
+      (is (= "java.lang.Exception" (get-in result [:error :message]))
+          ":error :message stays consistent with the anomaly fallback"))))
 
 (deftest execute-tool-not-found-emits-not-found-anomaly
   (testing "execute-tool on a missing tool yields :not-found anomaly"


### PR DESCRIPTION
## Anomaly convergence W2 — tool brick

Second of three leaf-brick flips in the W2 batch
(`docs/runbooks/anomaly-convergence.md`).

### Sites migrated

Three anomaly construction sites in `tool/core`:

| failure path | before | after |
| --- | --- | --- |
| parameter validation | `(response/make-anomaly :anomalies/incorrect msg)` | `(anomaly/anomaly :invalid-input msg {})` |
| handler exception | `(response/from-exception e)` | `(anomaly/exception-anomaly :fault (ex-message e) e)` |
| tool-not-found | `(response/make-anomaly :anomalies/not-found msg)` | `(anomaly/anomaly :not-found msg {})` |

All three are generic-standard cognitect categories (no
`:anomaly/subtype`) per the runbook table.

### Independence

Routing consumers (`failure-classifier`, `response/translate`)
already accept both shapes after #1001. Tool can flip on its own.

### Deps

- Adds `ai.miniforge/anomaly {:local/root "../anomaly"}` to
  `tool/deps.edn` (it was missing despite the stealth `response`
  require).
- Drops the `response.interface` require from `tool/core`.

### Tests

- New: `anomaly-shape-test` covering all three failure paths
  (3 tests, 13 assertions).
- Existing `tool.interface-test` unchanged (59 assertions).
- Net: 59 → 72 brick assertions, none failing.

### Gates

- `bb pre-commit` — green
- `bb lint:clj` — clean (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)