### PR TITLE
feat(evidence-bundle): dual-shape anomaly detection in outcome builder (W2 leaf 3/3)

### DIFF
--- a/components/evidence-bundle/deps.edn
+++ b/components/evidence-bundle/deps.edn
@@ -1,8 +1,10 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../schema"}
-        ai.miniforge/logging {:local/root "../logging"}
-        ai.miniforge/artifact {:local/root "../artifact"}
-        ai.miniforge/content-hash {:local/root "../content-hash"}}
+ :deps {ai.miniforge/anomaly      {:local/root "../anomaly"}
+        ai.miniforge/artifact     {:local/root "../artifact"}
+        ai.miniforge/content-hash {:local/root "../content-hash"}
+        ai.miniforge/logging      {:local/root "../logging"}
+        ai.miniforge/response     {:local/root "../response"}
+        ai.miniforge/schema       {:local/root "../schema"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}}}}

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -20,9 +20,26 @@
   "Utilities for collecting evidence during workflow execution.
    Provides helpers for gathering phase results, artifacts, and metadata."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.content-hash.interface :as content-hash]
    [ai.miniforge.evidence-bundle.schema :as schema]
    [ai.miniforge.response.interface :as response]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Anomaly detection (dual shape during W2 convergence)
+
+(defn- any-anomaly?
+  "True when `x` is either a canonical anomaly (`:anomaly/type`) or a
+   legacy response anomaly (`:anomaly/category`).
+
+   evidence-bundle reads anomalies from arbitrary upstream producers
+   (workflow/error, error-info :anomaly), so it must detect both
+   shapes until W5 retires the legacy producers. Prefers the canonical
+   predicate; falls back to the legacy one. Mirrors the dispatch-key
+   pattern in `failure-classifier/classify-failure`."
+  [x]
+  (or (anomaly/anomaly? x)
+      (response/anomaly-map? x)))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Intent Collection
@@ -297,9 +314,10 @@
         pr-info (:workflow/pr-info workflow-state)
         error-info (:workflow/error workflow-state)
         ;; Check for anomaly map in error-info or workflow state
+        ;; (dual-shape during W2: matches both canonical and legacy)
         anomaly-map (cond
-                      (response/anomaly-map? error-info) error-info
-                      (response/anomaly-map? (:anomaly error-info)) (:anomaly error-info)
+                      (any-anomaly? error-info) error-info
+                      (any-anomaly? (:anomaly error-info)) (:anomaly error-info)
                       :else nil)]
     (merge
      {:outcome/success (= status :completed)}

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/outcome_anomaly_shape_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/outcome_anomaly_shape_test.clj
@@ -32,6 +32,9 @@
    [ai.miniforge.evidence-bundle.collector :as collector]
    [ai.miniforge.response.interface :as response]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Fixtures + factories
+
 (defn- workflow-state-with-error [error]
   {:workflow/id (random-uuid)
    :workflow/status :failed
@@ -40,7 +43,8 @@
    :workflow/gate-results []
    :workflow/error error})
 
-;------------------------------------------------------------------------------ Canonical anomaly shape (post-W2 producers)
+;------------------------------------------------------------------------------ Layer 1
+;; Canonical anomaly shape (post-W2 producers)
 
 (deftest canonical-anomaly-at-error-info-routes-through-outcome
   (testing "a canonical anomaly map as :workflow/error is detected"
@@ -58,7 +62,7 @@
       (is (false? (:outcome/success outcome)))
       (is (= "agent timed out" (:outcome/error-message outcome))))))
 
-;------------------------------------------------------------------------------ Legacy anomaly shape (pre-W2 producers)
+;; Legacy anomaly shape (pre-W2 producers)
 
 (deftest legacy-anomaly-at-error-info-still-detected
   (testing "a legacy :anomaly/category map as :workflow/error is detected"
@@ -76,7 +80,7 @@
       (is (false? (:outcome/success outcome)))
       (is (= "slow" (:outcome/error-message outcome))))))
 
-;------------------------------------------------------------------------------ Non-anomaly fallback (legacy shape error map)
+;; Non-anomaly fallback (legacy shape error map)
 
 (deftest non-anomaly-error-falls-back-to-legacy-shape
   (testing "a plain error map (no :anomaly/type, no :anomaly/category)

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/outcome_anomaly_shape_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/outcome_anomaly_shape_test.clj
@@ -1,0 +1,89 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.evidence-bundle.outcome-anomaly-shape-test
+  "Lock the dual-shape anomaly detection in `build-outcome-evidence`
+   after the W2 anomaly convergence flip.
+
+   evidence-bundle reads anomalies from arbitrary upstream producers
+   (workflow/error info, nested :anomaly), so it must detect both
+   canonical (`:anomaly/type`) and legacy (`:anomaly/category`) shapes
+   until W5 retires the legacy producers. The dispatch follows
+   `failure-classifier/classify-failure` (prefer canonical; fall back
+   to legacy)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.evidence-bundle.collector :as collector]
+   [ai.miniforge.response.interface :as response]))
+
+(defn- workflow-state-with-error [error]
+  {:workflow/id (random-uuid)
+   :workflow/status :failed
+   :workflow/spec {}
+   :workflow/phases {}
+   :workflow/gate-results []
+   :workflow/error error})
+
+;------------------------------------------------------------------------------ Canonical anomaly shape (post-W2 producers)
+
+(deftest canonical-anomaly-at-error-info-routes-through-outcome
+  (testing "a canonical anomaly map as :workflow/error is detected"
+    (let [a       (anomaly/anomaly :fault "Compilation error" {})
+          outcome (collector/build-outcome-evidence
+                   (workflow-state-with-error a))]
+      (is (false? (:outcome/success outcome)))
+      (is (= "Compilation error" (:outcome/error-message outcome))))))
+
+(deftest canonical-anomaly-nested-under-anomaly-routes-through-outcome
+  (testing "a canonical anomaly under {:anomaly a} is also detected"
+    (let [a       (anomaly/anomaly :timeout "agent timed out" {})
+          outcome (collector/build-outcome-evidence
+                   (workflow-state-with-error {:anomaly a}))]
+      (is (false? (:outcome/success outcome)))
+      (is (= "agent timed out" (:outcome/error-message outcome))))))
+
+;------------------------------------------------------------------------------ Legacy anomaly shape (pre-W2 producers)
+
+(deftest legacy-anomaly-at-error-info-still-detected
+  (testing "a legacy :anomaly/category map as :workflow/error is detected"
+    (let [a       (response/make-anomaly :anomalies/fault "boom")
+          outcome (collector/build-outcome-evidence
+                   (workflow-state-with-error a))]
+      (is (false? (:outcome/success outcome)))
+      (is (= "boom" (:outcome/error-message outcome))))))
+
+(deftest legacy-anomaly-nested-under-anomaly-still-detected
+  (testing "a legacy anomaly under {:anomaly a} is still detected"
+    (let [a       (response/make-anomaly :anomalies/timeout "slow")
+          outcome (collector/build-outcome-evidence
+                   (workflow-state-with-error {:anomaly a}))]
+      (is (false? (:outcome/success outcome)))
+      (is (= "slow" (:outcome/error-message outcome))))))
+
+;------------------------------------------------------------------------------ Non-anomaly fallback (legacy shape error map)
+
+(deftest non-anomaly-error-falls-back-to-legacy-shape
+  (testing "a plain error map (no :anomaly/type, no :anomaly/category)
+            is preserved via the legacy non-anomaly fall-through"
+    (let [outcome (collector/build-outcome-evidence
+                   (workflow-state-with-error
+                    {:message "old style" :phase :verify}))]
+      (is (false? (:outcome/success outcome)))
+      (is (= "old style" (:outcome/error-message outcome)))
+      (is (= :verify (:outcome/error-phase outcome))))))


### PR DESCRIPTION
## Anomaly convergence W2 — evidence-bundle brick

Third of three leaf-brick flips in the W2 batch
(`docs/runbooks/anomaly-convergence.md`).

### Sites migrated

Two predicate sites in `evidence-bundle/collector/build-outcome-evidence`:

```clojure
;; before
(cond
  (response/anomaly-map? error-info)            error-info
  (response/anomaly-map? (:anomaly error-info)) (:anomaly error-info)
  :else                                         nil)

;; after — dual-shape via a brick-local predicate
(cond
  (any-anomaly? error-info)            error-info
  (any-anomaly? (:anomaly error-info)) (:anomaly error-info)
  :else                                nil)
```

where `any-anomaly?` is `(or (anomaly/anomaly? x) (response/anomaly-map? x))`.

### Why dual-shape

evidence-bundle reads anomalies from **arbitrary upstream producers**
(workflow error info, nested `:anomaly` payloads), not from anomalies
it constructs itself. Per the W2 batch instructions, bricks that read
anomalies from other (un-migrated) bricks keep both shapes until W5.
Mirrors the dispatch-key pattern in `failure-classifier/classify-failure`.

The downstream `response/anomaly->outcome-evidence` translator is
unchanged here; it stays the legacy boundary translator until W5.

### Deps

- Adds `ai.miniforge/anomaly` to `evidence-bundle/deps.edn`.
- Adds the previously-stealth `ai.miniforge/response` dep alongside it.

### Tests

- New: `outcome-anomaly-shape-test` (5 tests, 11 assertions) covering
  canonical at top level, canonical nested, legacy at top level, legacy
  nested, and the non-anomaly fall-through.
- Existing brick tests unchanged.
- Net: 195 → 206 brick assertions, none failing.

### Gates

- `bb pre-commit` — green
- `bb lint:clj` — clean (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)