### PR TITLE
feat(phase-software-factory): flip review stagnation to canonical anomaly (W2 batch 2)

### DIFF
--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/messages {:local/root "../messages"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/phase {:local/root "../phase"}
         ai.miniforge/agent {:local/root "../agent"}
         ai.miniforge/knowledge {:local/root "../knowledge"}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -23,6 +23,7 @@
    Agent: :reviewer
    Default gates: [:review-approved :quality-check]"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]
@@ -207,19 +208,22 @@
 
 (defn- terminate-stagnated
   "Mark a stagnated phase as failed and skip the redirect-to-implement
-   path. Carries the fingerprint chain in :phase/error so the
-   workflow runner / evidence bundle can report what didn't move.
-   Sets both :message and :anomaly/message so display / diagnostic
-   consumers that read either key get the localized text."
+   path. The phase `:error` is a canonical anomaly map (W2 convergence):
+   `:anomaly/type :exhausted` (the review repair budget has been
+   spent without progress) carrying the legacy
+   `:anomalies.review/stagnation` keyword as `:anomaly/subtype` and the
+   fingerprint chain under `:anomaly/data` so the workflow runner /
+   evidence bundle can report what didn't move."
   [ctx fingerprint-history]
   (let [msg (messages/t :review/stagnation)]
     (-> ctx
         (assoc-in [:phase :stagnated?] true)
         (assoc-in [:phase :error]
-                  {:message msg
-                   :anomaly/category :anomalies.review/stagnation
-                   :anomaly/message  msg
-                   :review/fingerprint-history (vec fingerprint-history)}))))
+                  (anomaly/sub-anomaly
+                   :exhausted
+                   :anomalies.review/stagnation
+                   msg
+                   {:review/fingerprint-history (vec fingerprint-history)})))))
 
 (defn- redirect-to-implement
   "Update phase to redirect back to :implement with review feedback for

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -23,6 +23,7 @@
    engine redirects back to :implement (not re-running :review in place)."
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.phase-software-factory.review]
@@ -316,12 +317,17 @@
           "phase tagged stagnated when current fingerprint matches prior")
       (is (not (phase/redirect-requested? phase))
           "no redirect to :implement on stagnation — repair loop is the burn we are stopping")
+      (is (anomaly/anomaly? (:error phase))
+          ":phase :error is a canonical anomaly map (W2 convergence)")
+      (is (= :exhausted (get-in phase [:error :anomaly/type]))
+          "stagnation is an :exhausted type (review repair budget spent without progress)")
       (is (= :anomalies.review/stagnation
-             (get-in phase [:error :anomaly/category]))
-          ":anomalies.review/stagnation anomaly attached to :phase :error")
-      (is (some? (get-in phase [:error :message]))
-          "message key set so display/diagnostic consumers don't show blank")
-      (is (>= (count (get-in phase [:error :review/fingerprint-history])) two-fingerprints)
+             (get-in phase [:error :anomaly/subtype]))
+          ":anomalies.review/stagnation preserved as :anomaly/subtype")
+      (is (some? (get-in phase [:error :anomaly/message]))
+          ":anomaly/message set so display/diagnostic consumers don't show blank")
+      (is (>= (count (get-in phase [:error :anomaly/data :review/fingerprint-history]))
+              two-fingerprints)
           "fingerprint history carries the chain that proved stagnation"))))
 
 (deftest non-stagnant-progress-still-redirects-test
@@ -337,7 +343,7 @@
           "different fingerprint ⇒ not stagnated")
       (is (= :implement (phase/transition-target phase))
           "ordinary repair: redirect to implement")
-      (is (nil? (get-in phase [:error :anomaly/category]))
+      (is (nil? (get-in phase [:error :anomaly/subtype]))
           "no stagnation anomaly when progress is detected"))))
 
 (deftest first-iteration-never-stagnates-test


### PR DESCRIPTION
## Anomaly convergence W2 batch 2 — phase-software-factory brick

Migrates the single anomaly construction site in
`phase-software-factory/review` to the canonical `ai.miniforge.anomaly`
component (per `docs/runbooks/anomaly-convergence.md`).

### Site migrated

| before | after |
| --- | --- |
| hand-rolled `{:message msg :anomaly/category :anomalies.review/stagnation :anomaly/message msg :review/fingerprint-history […]}` | `(anomaly/sub-anomaly :exhausted :anomalies.review/stagnation msg {:review/fingerprint-history […]})` |

Runbook entry: `:anomalies.review/stagnation` → `:exhausted` — the review
repair budget has been spent without progress; an effort ceiling, not a
bug.

The legacy category keyword is preserved verbatim as `:anomaly/subtype`
so `failure-classifier` / `response/translate` still dispatch
identically (#1001 already accepts both shapes during convergence).

Fingerprint history moves from a top-level key into `:anomaly/data` —
the canonical schema is closed; only the four canonical keys live at
the top level.

### Deps

Adds `ai.miniforge/anomaly` to `phase-software-factory/deps.edn`.
`ai.miniforge/response` require stays — still used for `response/failure`
in the non-anomaly responsibilities.

### Tests

Updates `review-repair-loop-test` to lock the canonical shape:
- `anomaly/anomaly?` is true on `:phase :error`
- `:anomaly/type :exhausted`
- `:anomaly/subtype :anomalies.review/stagnation`
- `:anomaly/message` is set
- fingerprint chain lives under `:anomaly/data :review/fingerprint-history`

Existing tests unchanged. Net: assertions grow.

### Throw-anomaly! sites

None — this brick is a pure-data producer; no `throw-anomaly!` to defer.

### `any-anomaly?` local predicate

None added — this brick produces and is the sole consumer of this `:phase
:error` map at construction; no upstream legacy anomaly enters here.

### Gates

- `bb pre-commit` — green (poly:check + 16-ns precommit smoke + GraalVM)
- `bb lint:clj` — 0/0 on the diff
- `bb poly:check` — OK

Refs: anomaly-convergence W2 (docs/runbooks/anomaly-convergence.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)