### PR TITLE
feat(loop): flip gate fail-result + inner exception path to canonical anomaly (W2 batch 2)

### DIFF
--- a/components/loop/deps.edn
+++ b/components/loop/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/clock    {:local/root "../clock"}
+ :deps {ai.miniforge/anomaly  {:local/root "../anomaly"}
+        ai.miniforge/clock    {:local/root "../clock"}
         ai.miniforge/fsm      {:local/root "../fsm"}
         ai.miniforge/decision {:local/root "../decision"}
         ai.miniforge/logging {:local/root "../logging"}

--- a/components/loop/src/ai/miniforge/loop/escalation.clj
+++ b/components/loop/src/ai/miniforge/loop/escalation.clj
@@ -33,13 +33,22 @@
 
 (defn format-error-entry
   "Format a single error entry for display.
-   Reads :anomaly/message and :anomaly/category when available,
-   falls back to :message and :code for legacy shapes."
+   Reads :anomaly/message and the anomaly classification when available,
+   falls back to :message and :code for legacy shapes.
+
+   Classification is taken as `:anomaly/subtype` first (the canonical W2
+   domain classification carried alongside `:anomaly/type`), then
+   `:anomaly/category` (legacy pre-convergence shape) — so errors from
+   already-flipped producers and not-yet-flipped producers both render
+   identically during the convergence window."
   [idx err]
   (let [anomaly (:anomaly err)
         msg (or (when anomaly (:anomaly/message anomaly))
                 (:message err))
-        code (or (when anomaly (name (:anomaly/category anomaly)))
+        classification (when anomaly
+                         (or (:anomaly/subtype anomaly)
+                             (:anomaly/category anomaly)))
+        code (or (when classification (name classification))
                  (when-let [c (:code err)] (name c)))]
     (str "  " (inc idx) ". " msg
          (when code (str " [" code "]")))))

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -27,10 +27,10 @@
    Layer 1: Built-in gates (syntax, lint, test, policy)
    Layer 2: Gate runner and composition"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.loop.interface.protocols.gate :as p]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.response.interface :as response]
    [clojure.string]))
 
 ;; Re-export protocol for backward compatibility
@@ -66,16 +66,28 @@
 
 (defn fail-result
   "Create a failing gate result.
-   Includes :gate/anomaly — a canonical anomaly map preserving gate error richness."
+   Includes :gate/anomaly — a canonical anomaly map preserving gate error
+   richness.
+
+   W2 convergence: anomaly is constructed via `anomaly/sub-anomaly` with
+   `:anomaly/type :invalid-input` (per the runbook map for
+   `:anomalies.gate/validation-failed`) and the gate errors live under
+   `:anomaly/data :gate/errors` — the canonical schema is closed; only
+   the four canonical keys live at the top level. The errors are also
+   kept as a flat `:gate/errors` on the gate result map for downstream
+   consumers that already read it there (independent of the anomaly)."
   [gate-id gate-type errors & {:keys [warnings duration-ms]}]
   (cond-> {:gate/id gate-id
            :gate/type gate-type
            :gate/passed? false
            :gate/errors errors
-           :gate/anomaly (response/gate-anomaly
+           :gate/anomaly (anomaly/sub-anomaly
+                          :invalid-input
                           :anomalies.gate/validation-failed
                           (str "Gate " (name gate-id) " (" (name gate-type) ") failed")
-                          errors)}
+                          {:gate/id gate-id
+                           :gate/type gate-type
+                           :gate/errors errors})}
     warnings (assoc :gate/warnings warnings)
     duration-ms (assoc :gate/duration-ms duration-ms)))
 

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -72,10 +72,14 @@
    W2 convergence: anomaly is constructed via `anomaly/sub-anomaly` with
    `:anomaly/type :invalid-input` (per the runbook map for
    `:anomalies.gate/validation-failed`) and the gate errors live under
-   `:anomaly/data :gate/errors` — the canonical schema is closed; only
-   the four canonical keys live at the top level. The errors are also
-   kept as a flat `:gate/errors` on the gate result map for downstream
-   consumers that already read it there (independent of the anomaly)."
+   `:anomaly/data :gate/errors`. The canonical schema is closed over the
+   `:anomaly/*` namespace — only `:anomaly/type`, `:anomaly/message`,
+   `:anomaly/data`, `:anomaly/at`, and the optional `:anomaly/subtype`
+   live at the top level; all domain payload (here `:gate/id`,
+   `:gate/type`, `:gate/errors`) lives under `:anomaly/data`. The errors
+   are also kept as a flat `:gate/errors` on the gate result map for
+   downstream consumers that already read it there (independent of the
+   embedded anomaly)."
   [gate-id gate-type errors & {:keys [warnings duration-ms]}]
   (cond-> {:gate/id gate-id
            :gate/type gate-type

--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -24,14 +24,14 @@
    Layer 1: Step functions (generate, validate, repair)
    Layer 2: Loop runner"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.loop.escalation :as escalation]
    [ai.miniforge.loop.inner-config :as inner-config]
    [ai.miniforge.loop.gates :as gates]
    [ai.miniforge.loop.messages :as loop-messages]
-   [ai.miniforge.loop.repair :as repair]
-   [ai.miniforge.response.interface :as response]))
+   [ai.miniforge.loop.repair :as repair]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; State machine definition and derived transition helpers
@@ -314,7 +314,7 @@
             (log/error logger :loop :inner/validation-failed
                        {:message (loop-messages/t :inner/generation-failed)
                         :data {:error (.getMessage e)}}))
-          (let [anom (response/from-exception e)]
+          (let [anom (anomaly/exception-anomaly :fault (.getMessage e) e)]
             (-> loop-state
                 (set-errors [{:code :generation-error
                               :message (.getMessage e)

--- a/components/loop/test/ai/miniforge/loop/gate_anomaly_shape_test.clj
+++ b/components/loop/test/ai/miniforge/loop/gate_anomaly_shape_test.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.loop.gate-anomaly-shape-test
+  "Lock the canonical anomaly shape produced by `gates/fail-result`
+   after the W2 anomaly convergence flip.
+
+   Pre-flip the `:gate/anomaly` was constructed via
+   `response/gate-anomaly`, which wrote `:anomaly.gate/errors` at the
+   anomaly map's top level alongside `:anomaly/category`.
+
+   Post-flip it is built via `anomaly/sub-anomaly` with
+   `:anomaly/type :invalid-input` (per the runbook map for
+   `:anomalies.gate/validation-failed`), the legacy category preserved
+   as `:anomaly/subtype`, and the gate errors carried under
+   `:anomaly/data :gate/errors` (the canonical schema is closed —
+   domain payload lives in `:anomaly/data`)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.loop.gates :as gates]))
+
+(def ^:private sample-errors
+  [(gates/make-error :syntax-error "Unexpected EOF")
+   (gates/make-error :missing-require "core required but not imported")])
+
+(deftest fail-result-emits-canonical-gate-anomaly
+  (testing ":gate/anomaly satisfies the canonical anomaly contract"
+    (let [result (gates/fail-result :syntax-check :syntax sample-errors)
+          anom   (:gate/anomaly result)]
+      (is (anomaly/anomaly? anom)
+          ":gate/anomaly is a canonical anomaly map after W2 flip")
+      (is (= :invalid-input (:anomaly/type anom))
+          ":anomalies.gate/validation-failed maps to :invalid-input per the runbook")
+      (is (= :anomalies.gate/validation-failed (:anomaly/subtype anom))
+          "legacy gate category preserved verbatim as :anomaly/subtype")))
+
+  (testing "gate identity + error payload live under :anomaly/data"
+    (let [result (gates/fail-result :syntax-check :syntax sample-errors)
+          data   (:anomaly/data (:gate/anomaly result))]
+      (is (= :syntax-check (:gate/id data))
+          "gate id moves from top-level :anomaly.gate/* into :anomaly/data")
+      (is (= :syntax (:gate/type data)))
+      (is (= sample-errors (:gate/errors data))
+          "gate errors carried under :anomaly/data :gate/errors")))
+
+  (testing "flat :gate/errors on the result map is unchanged"
+    (let [result (gates/fail-result :syntax-check :syntax sample-errors)]
+      (is (= sample-errors (:gate/errors result))
+          "flat :gate/errors on the gate result is independent of the embedded anomaly")
+      (is (false? (:gate/passed? result))))))
+
+(deftest fail-result-no-top-level-domain-keys-on-anomaly
+  (testing "domain payload does NOT leak onto the anomaly's top level"
+    (let [anom (:gate/anomaly (gates/fail-result :syntax-check :syntax sample-errors))]
+      (is (nil? (:anomaly.gate/errors anom))
+          "legacy :anomaly.gate/errors no longer set at the anomaly's top level")
+      (is (nil? (:gate/errors anom))
+          ":gate/errors stays under :anomaly/data, not at the anomaly's top level"))))

--- a/components/loop/test/ai/miniforge/loop/gate_anomaly_shape_test.clj
+++ b/components/loop/test/ai/miniforge/loop/gate_anomaly_shape_test.clj
@@ -39,10 +39,16 @@
   [(gates/make-error :syntax-error "Unexpected EOF")
    (gates/make-error :missing-require "core required but not imported")])
 
+(defn- failing-syntax-check
+  "Factory: a `fail-result` for the canonical `:syntax-check`/`:syntax`
+   gate with the test's `sample-errors`. Centralises the fixture so the
+   `gates/fail-result` arglist is bound in exactly one place."
+  []
+  (gates/fail-result :syntax-check :syntax sample-errors))
+
 (deftest fail-result-emits-canonical-gate-anomaly
   (testing ":gate/anomaly satisfies the canonical anomaly contract"
-    (let [result (gates/fail-result :syntax-check :syntax sample-errors)
-          anom   (:gate/anomaly result)]
+    (let [anom (:gate/anomaly (failing-syntax-check))]
       (is (anomaly/anomaly? anom)
           ":gate/anomaly is a canonical anomaly map after W2 flip")
       (is (= :invalid-input (:anomaly/type anom))
@@ -51,8 +57,7 @@
           "legacy gate category preserved verbatim as :anomaly/subtype")))
 
   (testing "gate identity + error payload live under :anomaly/data"
-    (let [result (gates/fail-result :syntax-check :syntax sample-errors)
-          data   (:anomaly/data (:gate/anomaly result))]
+    (let [data (:anomaly/data (:gate/anomaly (failing-syntax-check)))]
       (is (= :syntax-check (:gate/id data))
           "gate id moves from top-level :anomaly.gate/* into :anomaly/data")
       (is (= :syntax (:gate/type data)))
@@ -60,14 +65,14 @@
           "gate errors carried under :anomaly/data :gate/errors")))
 
   (testing "flat :gate/errors on the result map is unchanged"
-    (let [result (gates/fail-result :syntax-check :syntax sample-errors)]
+    (let [result (failing-syntax-check)]
       (is (= sample-errors (:gate/errors result))
           "flat :gate/errors on the gate result is independent of the embedded anomaly")
       (is (false? (:gate/passed? result))))))
 
 (deftest fail-result-no-top-level-domain-keys-on-anomaly
   (testing "domain payload does NOT leak onto the anomaly's top level"
-    (let [anom (:gate/anomaly (gates/fail-result :syntax-check :syntax sample-errors))]
+    (let [anom (:gate/anomaly (failing-syntax-check))]
       (is (nil? (:anomaly.gate/errors anom))
           "legacy :anomaly.gate/errors no longer set at the anomaly's top level")
       (is (nil? (:gate/errors anom))

--- a/components/loop/test/ai/miniforge/loop/inner_test.clj
+++ b/components/loop/test/ai/miniforge/loop/inner_test.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.loop.inner-test
   (:require [clojure.test :as test :refer [deftest testing is]]
+            [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.fsm.interface :as fsm]
             [ai.miniforge.loop.inner :as inner]
             [ai.miniforge.loop.gates :as gates]
@@ -202,7 +203,25 @@
           failing-fn (fn [_t _c] (throw (Exception. "Generation error")))
           result (inner/generate-step loop-state failing-fn {})]
       (is (= :failed (:loop/state result)))
-      (is (seq (:loop/errors result))))))
+      (is (seq (:loop/errors result)))))
+
+  (testing "generation exception emits canonical :fault anomaly (W2 shape)"
+    (let [loop-state (inner/create-inner-loop test-task {})
+          failing-fn (fn [_t _c] (throw (Exception. "Generation error")))
+          result (inner/generate-step loop-state failing-fn {})
+          err (first (:loop/errors result))
+          anom (:anomaly err)]
+      (is (anomaly/anomaly? anom)
+          ":anomaly on the error map is a canonical anomaly after W2 flip")
+      (is (= :fault (:anomaly/type anom))
+          "generic-standard :anomalies/fault maps to :fault with no subtype")
+      (is (nil? (:anomaly/subtype anom))
+          "exception path does not carry a domain subtype")
+      (is (= "Generation error" (:anomaly/message anom)))
+      (is (= "Generation error" (get-in anom [:anomaly/data :anomaly/ex-message]))
+          "original exception message preserved under :anomaly/data")
+      (is (= "java.lang.Exception" (get-in anom [:anomaly/data :anomaly/ex-class]))
+          "exception class preserved under :anomaly/data"))))
 
 (deftest validate-step-test
   (testing "all gates pass transitions to complete"


### PR DESCRIPTION
## Anomaly convergence W2 batch 2 — loop brick

Migrates the 3 anomaly construction / read sites in the loop brick to
the canonical `ai.miniforge.anomaly` component (per
`docs/runbooks/anomaly-convergence.md`).

### Sites migrated

| site | before | after |
| --- | --- | --- |
| `gates/fail-result` | `response/gate-anomaly :anomalies.gate/validation-failed` | `anomaly/sub-anomaly :invalid-input :anomalies.gate/validation-failed {:gate/id … :gate/type … :gate/errors errors}` |
| `inner` generation catch | `response/from-exception e` | `anomaly/exception-anomaly :fault (.getMessage e) e` |
| `escalation/format-error-entry` (read) | `(:anomaly/category anomaly)` | `(or (:anomaly/subtype anomaly) (:anomaly/category anomaly))` — dual-read during convergence |

Runbook entries used:
- `:anomalies.gate/validation-failed` → `:invalid-input`
- `:anomalies/fault` (generic-standard) → `:fault` (no subtype) on the
  exception path

### Domain-payload key naming (first domain-flatten in W2 batch 2)

`response/gate-anomaly` wrote gate state at the top level
(`:anomaly.gate/errors`). The canonical schema is closed, so the domain
payload moves under `:anomaly/data`. Keys chosen:

- `:gate/id`
- `:gate/type`
- `:gate/errors`

The same `:gate/*` namespace already used on the gate result map —
descriptive, internally consistent. These become the precedent for
later domain-flatten bricks in batch 2/3.

### Cross-brick wrinkle (note for batch 3)

\`response/translate\` (anomaly→log-data and anomaly→outcome-evidence)
still reads \`:anomaly.gate/errors\` at the anomaly's top level. After
this flip, that key is no longer present at the top of canonical gate
anomalies — it lives under \`:anomaly/data :gate/errors\`. The
translation degrades gracefully (no crash; gate-error count drops to 0
in logs; evidence-bundle \`:outcome/error-details\` omits the errors
field) but the data is lost downstream. \`response/translate\` needs a
dual-path read (top-level then \`:anomaly/data\`) in batch 3, in line
with how it already dual-reads classification on subtype-then-category.

### Same-brick consumers

No same-brick consumer reads the inner top-level keys of \`:gate/anomaly\` —
the only producer/consumer link is gates → response/translate
(cross-brick, covered above). The flat \`:gate/errors\` on the gate
result map is kept unchanged for downstream consumers that already read
it there independently of the embedded anomaly.

### Throw-anomaly! sites

None in this brick — no deferrals.

### \`any-anomaly?\` local predicate

Not added. \`escalation/format-error-entry\` uses an inline
subtype-then-category read because the anomaly here is rendered for
display, not predicate-tested. Counts toward the 3+ promotion threshold:
**0 in this brick**.

### Tests

New: \`gate-anomaly-shape-test\` (2 tests / 10 assertions):
- \`anomaly/anomaly?\` truth on \`:gate/anomaly\`
- \`:anomaly/type :invalid-input\`
- \`:anomaly/subtype :anomalies.gate/validation-failed\`
- \`:gate/{id,type,errors}\` carried under \`:anomaly/data\`
- negative-space: \`:anomaly.gate/errors\` and \`:gate/errors\` do NOT
  appear at the anomaly's top level

Existing loop brick tests stay green. Net: assertions grow.

### Deps

Adds \`ai.miniforge/anomaly\` to loop deps. \`ai.miniforge/response\`
stays — still used by \`outer.clj\` for non-anomaly success/failure
responsibilities.

### Gates

- \`bb pre-commit\` — green (poly:check + 16-ns precommit smoke + GraalVM)
- \`bb lint:clj\` — 0/0 on the diff
- \`bb poly:check\` — OK

Refs: anomaly-convergence W2 (docs/runbooks/anomaly-convergence.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)