### PR TITLE
feat(llm): flip llm-error + http-post-request + stream paths to canonical anomaly (W2 batch 2)

### DIFF
--- a/components/llm/deps.edn
+++ b/components/llm/deps.edn
@@ -2,6 +2,7 @@
  :deps {babashka/process {:mvn/version "0.5.22"}
         http-kit/http-kit {:mvn/version "2.8.0"}
         cheshire/cheshire {:mvn/version "5.13.0"}
+        ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/logging {:local/root "../logging"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -24,6 +24,7 @@
    [clojure.string :as str]
    [cheshire.core :as json]
    [org.httpkit.client :as http]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.cost :as cost]
    [ai.miniforge.llm.progress-monitor :as pm]
@@ -108,8 +109,61 @@
               :tokens (+ (get usage :input-tokens 0) (get usage :output-tokens 0))}
        (some? exit-code) (assoc :exit-code exit-code)))))
 
+(def ^:private category->type
+  "W2 convergence map (subset). Maps every legacy `:anomalies/*` and
+   `:anomalies.*/*` category this brick actually produces (per
+   `(grep '(llm-error ' …)`) to the canonical `:anomaly/type` from the
+   runbook (`docs/runbooks/anomaly-convergence.md`). Generic-standard
+   categories map to a bare type and emit no subtype; domain categories
+   map to a `(type, subtype)` pair where the subtype is the legacy
+   category keyword verbatim."
+  {:anomalies/fault                  :fault
+   :anomalies/unavailable            :unavailable
+   :anomalies/unsupported            :unsupported
+   :anomalies/timeout                :timeout
+   :anomalies.agent/llm-error        :fault
+   :anomalies.agent/rate-limited     :unavailable
+   :anomalies.llm/rate-limited       :unavailable
+   :anomalies.llm/unavailable        :unavailable
+   :anomalies.llm/timeout            :timeout
+   :anomalies.llm/context-exceeded   :exhausted})
+
+(def ^:private generic-standard-categories
+  "The eight cognitect-standard categories (per the runbook
+   `Generic standard (no subtype)` table) that this brick emits — these
+   map 1:1 to a type and carry no `:anomaly/subtype`."
+  #{:anomalies/fault
+    :anomalies/unavailable
+    :anomalies/unsupported
+    :anomalies/timeout})
+
+(defn- ->canonical-anomaly
+  "Build a canonical anomaly map from the brick's legacy category
+   keyword + message + extra data. Generic-standard categories produce
+   `(anomaly/anomaly type msg data)`; domain categories produce
+   `(anomaly/sub-anomaly type category msg data)`.
+
+   `category` MUST be in `category->type`; an unmapped category is a
+   programmer error (the table must be updated when new categories
+   are introduced)."
+  [category message data]
+  (let [a-type (or (category->type category)
+                   (throw (IllegalArgumentException.
+                           (str "Unmapped LLM anomaly category: "
+                                (pr-str category)
+                                ". Add it to `category->type` in "
+                                "ai.miniforge.llm.protocols.impl.llm-client"))))]
+    (if (contains? generic-standard-categories category)
+      (anomaly/anomaly a-type message data)
+      (anomaly/sub-anomaly a-type category message data))))
+
 (defn llm-error
-  "Build a failed LLM response with anomaly."
+  "Build a failed LLM response with anomaly.
+
+   The `:anomaly` map is canonical (W2 convergence): `:anomaly/type` from
+   the runbook, `:anomaly/subtype` set to the original category for
+   domain categories (so failure-classifier / response/translate dispatch
+   identically). The original `:operation` lives under `:anomaly/data`."
   ([category error-type message]
    (llm-error category error-type message nil))
   ([category error-type message {:keys [exit-code stderr stdout raw-stdout timeout]}]
@@ -119,9 +173,9 @@
                      stdout  (assoc :stdout stdout)
                      raw-stdout (assoc :raw-stdout raw-stdout)
                      timeout (assoc :timeout timeout))
-            :anomaly (response/make-anomaly
+            :anomaly (->canonical-anomaly
                       category message
-                      {:anomaly/operation :llm-complete})}
+                      {:operation :llm-complete})}
      (some? exit-code) (assoc :exit-code exit-code))))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -622,27 +676,33 @@
 (defn http-post-request
   "Make HTTP POST request to LLM API.
 
-   Returns HTTP response map or anomaly map on exception."
+   Returns HTTP response map or canonical anomaly map on exception
+   (W2 convergence: `:anomaly/type :unavailable`, no subtype since
+   `:anomalies/unavailable` is a generic-standard category)."
   [url headers body]
   (try
     @(http/post url
                 {:headers headers
                  :body (json/generate-string body)})
     (catch Exception e
-      (response/make-anomaly
-       :anomalies/unavailable
+      (anomaly/anomaly
+       :unavailable
        (str "HTTP request failed: " (.getMessage e))
-       {:anomaly/operation :http-request
-        :anomaly.llm/url url}))))
+       {:operation :http-request
+        :url url}))))
 
 (defn parse-ollama-response
   "Parse Ollama API response.
 
-   Handles anomaly maps from http-post-request or HTTP response maps."
+   Handles canonical anomaly maps from http-post-request or HTTP
+   response maps. After W2 convergence, http-post-request returns
+   `:anomaly/type :unavailable` (no subtype) on failure — the legacy
+   category `:anomalies/unavailable` is reconstituted explicitly for
+   `llm-error` so downstream classification stays identical."
   [response]
-  ;; If response is already an anomaly map, pass it through
-  (if (response/anomaly-map? response)
-    (llm-error (:anomaly/category response) "http_error" (:anomaly/message response))
+  ;; If response is already a canonical anomaly map, pass it through
+  (if (anomaly/anomaly? response)
+    (llm-error :anomalies/unavailable "http_error" (:anomaly/message response))
     (try
       (let [body (json/parse-string (:body response) true)]
         (if (= 200 (:status response))
@@ -767,7 +827,7 @@
 
 (defn- stream-read-failure
   [ex]
-  (response/from-exception ex))
+  (anomaly/exception-anomaly :fault (or (ex-message ex) (str (type ex))) ex))
 
 (defn- enqueue-stream-line!
   [line-queue line]
@@ -834,7 +894,7 @@
 
 (defn- anomaly-signal?
   [line-or-signal]
-  (response/anomaly-map? line-or-signal))
+  (anomaly/anomaly? line-or-signal))
 
 (defn- eof-signal?
   [line-or-signal]

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -116,22 +116,26 @@
    runbook (`docs/runbooks/anomaly-convergence.md`). Generic-standard
    categories map to a bare type and emit no subtype; domain categories
    map to a `(type, subtype)` pair where the subtype is the legacy
-   category keyword verbatim."
-  {:anomalies/fault                  :fault
-   :anomalies/unavailable            :unavailable
-   :anomalies/unsupported            :unsupported
-   :anomalies/timeout                :timeout
-   :anomalies.agent/llm-error        :fault
-   :anomalies.agent/rate-limited     :unavailable
-   :anomalies.llm/rate-limited       :unavailable
-   :anomalies.llm/unavailable        :unavailable
-   :anomalies.llm/timeout            :timeout
-   :anomalies.llm/context-exceeded   :exhausted})
+   category keyword verbatim.
+
+   Only the categories actually emitted today are listed — an unmapped
+   category throws `IllegalArgumentException` in `->canonical-anomaly`,
+   forcing the table to grow when a new producer site is added (per
+   the no-dead-code policy)."
+  {:anomalies/fault              :fault
+   :anomalies/unavailable        :unavailable
+   :anomalies/unsupported        :unsupported
+   :anomalies/timeout            :timeout
+   :anomalies.agent/llm-error    :fault
+   :anomalies.agent/rate-limited :unavailable})
 
 (def ^:private generic-standard-categories
-  "The eight cognitect-standard categories (per the runbook
+  "Subset of the cognitect-standard categories (per the runbook
    `Generic standard (no subtype)` table) that this brick emits — these
-   map 1:1 to a type and carry no `:anomaly/subtype`."
+   four map 1:1 to a type and carry no `:anomaly/subtype`. The runbook's
+   full set is eight; the other four (`:anomalies/incorrect`,
+   `:anomalies/not-found`, `:anomalies/forbidden`, `:anomalies/conflict`)
+   are not produced by `llm-error` in this brick today."
   #{:anomalies/fault
     :anomalies/unavailable
     :anomalies/unsupported
@@ -673,23 +677,39 @@
      :messages [{:role "user" :content msg-content}]
      :stream (boolean streaming?)}))
 
+(defn- http-failure-anomaly
+  "Build the canonical `:unavailable` anomaly that this brick emits for
+   any HTTP-layer failure on an LLM call (thrown exception or http-kit
+   `{:error <Throwable>}` deref). Centralizes the shape so the throwing
+   and non-throwing failure modes converge."
+  [^Throwable cause url]
+  (anomaly/anomaly
+   :unavailable
+   (str "HTTP request failed: " (.getMessage cause))
+   {:operation :http-request
+    :url url}))
+
 (defn http-post-request
   "Make HTTP POST request to LLM API.
 
-   Returns HTTP response map or canonical anomaly map on exception
+   Returns HTTP response map or canonical anomaly map on failure
    (W2 convergence: `:anomaly/type :unavailable`, no subtype since
-   `:anomalies/unavailable` is a generic-standard category)."
+   `:anomalies/unavailable` is a generic-standard category).
+
+   http-kit signals connection failures via either a thrown exception
+   or a `{:error <Throwable>}` response map (depending on whether the
+   error surfaces before or after the future resolves); both modes
+   collapse to the same canonical anomaly."
   [url headers body]
   (try
-    @(http/post url
-                {:headers headers
-                 :body (json/generate-string body)})
+    (let [response @(http/post url
+                               {:headers headers
+                                :body (json/generate-string body)})]
+      (if-let [cause (:error response)]
+        (http-failure-anomaly cause url)
+        response))
     (catch Exception e
-      (anomaly/anomaly
-       :unavailable
-       (str "HTTP request failed: " (.getMessage e))
-       {:operation :http-request
-        :url url}))))
+      (http-failure-anomaly e url))))
 
 (defn parse-ollama-response
   "Parse Ollama API response.

--- a/components/llm/test/ai/miniforge/llm/llm_anomaly_shape_test.clj
+++ b/components/llm/test/ai/miniforge/llm/llm_anomaly_shape_test.clj
@@ -34,53 +34,106 @@
      `:anomalies.agent/rate-limited`) carry `:anomaly/subtype` equal to
      the legacy category verbatim;
    - domain payload (`:operation`, `:url`) lives under `:anomaly/data` —
-     the canonical schema is closed.
-
-   These tests exercise the public `llm-error` builder (re-exported
-   into the brick interface) and `http-post-request` indirectly via
-   `parse-ollama-response`."
+     the canonical schema is closed."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [org.httpkit.client :as http]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.llm.protocols.impl.llm-client :as client]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Factories and fixtures
+
+(def ^:private test-url
+  "Static target URL used by `http-post-request` failure tests. Never
+   actually dereferenced — `http/post` is stubbed via `with-redefs`."
+  "http://llm-anomaly-shape-test.invalid/llm")
+
+(def ^:private test-headers
+  {"Content-Type" "application/json"})
+
+(defn- error-type-placeholder
+  "Opaque error-type label used by `llm-error` tests. The shape-of-anomaly
+   tests don't assert against the error-type field — they only need a
+   stable, non-blank token to pass the builder's contract."
+  []
+  "shape_test_error_type")
+
+(defn- anomaly-of
+  "Build a canonical anomaly map for the given legacy category by driving
+   the public `llm-error` builder and extracting `:anomaly` from the
+   response. The 2nd/3rd args are opaque placeholders — shape tests
+   only assert on the anomaly map itself."
+  [category]
+  (:anomaly (client/llm-error category (error-type-placeholder) "boom")))
+
+(defn- delivered-future
+  "Wrap a value in an already-resolved future so `@(http/post ...)`
+   returns it synchronously under `with-redefs`."
+  [v]
+  (let [p (promise)]
+    (deliver p v)
+    p))
+
+(defn- stub-http-post-throwing
+  "`http/post` stub whose deref throws the given exception — mirrors
+   http-kit's throwing failure mode (e.g. body serialization or an
+   `IllegalArgumentException` on a malformed URL)."
+  [^Throwable ex]
+  (fn [_url _opts]
+    (reify clojure.lang.IDeref
+      (deref [_] (throw ex)))))
+
+(defn- stub-http-post-error-map
+  "`http/post` stub whose deref returns `{:error <Throwable>}` — mirrors
+   http-kit's non-throwing failure mode (the common case for connection
+   refused / DNS failure)."
+  [^Throwable cause]
+  (fn [_url _opts]
+    (delivered-future {:error cause :opts {}})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Unit tests
+
 (deftest llm-error-generic-standard-category-emits-typed-anomaly-no-subtype
   (testing ":anomalies/unavailable maps to :unavailable with no subtype"
-    (let [resp (client/llm-error :anomalies/unavailable "api_error" "boom")
-          a    (:anomaly resp)]
+    (let [a (anomaly-of :anomalies/unavailable)]
       (is (anomaly/anomaly? a))
       (is (= :unavailable (:anomaly/type a)))
       (is (nil? (:anomaly/subtype a))
           "generic-standard category emits no :anomaly/subtype")))
 
-  (testing ":anomalies/fault → :fault, no subtype"
-    (let [a (:anomaly (client/llm-error :anomalies/fault "parse_error" "boom"))]
+  (testing ":anomalies/fault maps to :fault with no subtype"
+    (let [a (anomaly-of :anomalies/fault)]
       (is (= :fault (:anomaly/type a)))
       (is (nil? (:anomaly/subtype a)))))
 
-  (testing ":anomalies/unsupported → :unsupported, no subtype"
-    (let [a (:anomaly (client/llm-error :anomalies/unsupported "x" "y"))]
+  (testing ":anomalies/unsupported maps to :unsupported with no subtype"
+    (let [a (anomaly-of :anomalies/unsupported)]
       (is (= :unsupported (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a)))))
+
+  (testing ":anomalies/timeout maps to :timeout with no subtype"
+    (let [a (anomaly-of :anomalies/timeout)]
+      (is (= :timeout (:anomaly/type a)))
       (is (nil? (:anomaly/subtype a))))))
 
 (deftest llm-error-domain-category-emits-subtype
   (testing ":anomalies.agent/llm-error → :fault + subtype verbatim"
-    (let [a (:anomaly (client/llm-error :anomalies.agent/llm-error
-                                        "cli_error" "boom"))]
+    (let [a (anomaly-of :anomalies.agent/llm-error)]
       (is (anomaly/anomaly? a))
       (is (= :fault (:anomaly/type a)))
       (is (= :anomalies.agent/llm-error (:anomaly/subtype a))
           "legacy domain category preserved verbatim as :anomaly/subtype")))
 
   (testing ":anomalies.agent/rate-limited → :unavailable + subtype"
-    (let [a (:anomaly (client/llm-error :anomalies.agent/rate-limited
-                                        "rate_limit" "slow down"))]
+    (let [a (anomaly-of :anomalies.agent/rate-limited)]
       (is (= :unavailable (:anomaly/type a)))
       (is (= :anomalies.agent/rate-limited (:anomaly/subtype a))))))
 
 (deftest llm-error-domain-payload-lives-under-anomaly-data
   (testing "the :operation domain field is carried under :anomaly/data"
-    (let [a    (:anomaly (client/llm-error :anomalies/fault "x" "y"))
+    (let [a    (anomaly-of :anomalies/fault)
           data (:anomaly/data a)]
       (is (= :llm-complete (:operation data))
           ":operation lives under :anomaly/data — not at the anomaly's top level")
@@ -89,24 +142,34 @@
       (is (nil? (:operation a))
           ":operation also not at the anomaly's top level"))))
 
-(deftest http-post-request-failure-emits-canonical-unavailable
-  (testing "http-post-request returns a canonical :unavailable anomaly on exception"
-    ;; Provoke a connection failure deterministically by hitting an
-    ;; unroutable port on localhost. http-kit times out / refuses; either
-    ;; way the catch produces a canonical anomaly.
-    (let [a (client/http-post-request "http://127.0.0.1:1/llm-anomaly-shape-test"
-                                      {"Content-Type" "application/json"}
-                                      {})]
-      ;; http-kit may return a {:error <Throwable>} on connection failure
-      ;; rather than throwing; only assert canonical shape when the
-      ;; exception path is taken.
-      (when (anomaly/anomaly? a)
-        (is (= :unavailable (:anomaly/type a)))
-        (is (nil? (:anomaly/subtype a))
-            ":anomalies/unavailable is generic-standard — no subtype")
-        (is (= :http-request (get-in a [:anomaly/data :operation])))
-        (is (= "http://127.0.0.1:1/llm-anomaly-shape-test"
-               (get-in a [:anomaly/data :url]))
-            ":url lives under :anomaly/data, not as :anomaly.llm/url at the top")
-        (is (nil? (:anomaly.llm/url a))
-            "legacy :anomaly.llm/url no longer set at the anomaly's top level")))))
+(deftest http-post-request-throwing-failure-emits-canonical-unavailable
+  (testing "thrown exception on deref → canonical :unavailable anomaly"
+    (let [cause (java.net.ConnectException. "Connection refused")]
+      (with-redefs [http/post (stub-http-post-throwing cause)]
+        (let [a (client/http-post-request test-url test-headers {})]
+          (is (anomaly/anomaly? a)
+              "throwing path must produce a canonical anomaly")
+          (is (= :unavailable (:anomaly/type a)))
+          (is (nil? (:anomaly/subtype a))
+              ":anomalies/unavailable is generic-standard — no subtype")
+          (is (= :http-request (get-in a [:anomaly/data :operation])))
+          (is (= test-url (get-in a [:anomaly/data :url]))
+              ":url lives under :anomaly/data, not at the top level")
+          (is (nil? (:anomaly.llm/url a))
+              "legacy :anomaly.llm/url no longer set at the top level"))))))
+
+(deftest http-post-request-error-map-failure-emits-canonical-unavailable
+  (testing "{:error <Throwable>} deref response → canonical :unavailable anomaly"
+    ;; http-kit's common non-throwing failure mode: the future resolves
+    ;; to a map with `:error` set. Pre-fix this would have flowed through
+    ;; as a non-anomaly map and `parse-ollama-response` would have
+    ;; misclassified it as `:anomalies/fault` (parse_error).
+    (let [cause (java.net.ConnectException. "Connection refused")]
+      (with-redefs [http/post (stub-http-post-error-map cause)]
+        (let [a (client/http-post-request test-url test-headers {})]
+          (is (anomaly/anomaly? a)
+              ":error map must be translated into a canonical anomaly")
+          (is (= :unavailable (:anomaly/type a)))
+          (is (nil? (:anomaly/subtype a)))
+          (is (= :http-request (get-in a [:anomaly/data :operation])))
+          (is (= test-url (get-in a [:anomaly/data :url]))))))))

--- a/components/llm/test/ai/miniforge/llm/llm_anomaly_shape_test.clj
+++ b/components/llm/test/ai/miniforge/llm/llm_anomaly_shape_test.clj
@@ -1,0 +1,112 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.llm.llm-anomaly-shape-test
+  "Lock the canonical anomaly shape produced by `llm-client/llm-error`
+   and `llm-client/http-post-request` after the W2 anomaly convergence
+   flip.
+
+   Pre-flip these emitted `:anomaly/category` via
+   `response/make-anomaly` / `response/from-exception`, with domain keys
+   such as `:anomaly.llm/url` and `:anomaly/operation` at the anomaly
+   map's top level.
+
+   Post-flip:
+   - generic-standard categories (`:anomalies/{fault,unavailable,
+     unsupported,timeout}`) map 1:1 to `:anomaly/type` with no
+     `:anomaly/subtype`;
+   - domain categories (`:anomalies.agent/llm-error`,
+     `:anomalies.agent/rate-limited`) carry `:anomaly/subtype` equal to
+     the legacy category verbatim;
+   - domain payload (`:operation`, `:url`) lives under `:anomaly/data` —
+     the canonical schema is closed.
+
+   These tests exercise the public `llm-error` builder (re-exported
+   into the brick interface) and `http-post-request` indirectly via
+   `parse-ollama-response`."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.llm.protocols.impl.llm-client :as client]))
+
+(deftest llm-error-generic-standard-category-emits-typed-anomaly-no-subtype
+  (testing ":anomalies/unavailable maps to :unavailable with no subtype"
+    (let [resp (client/llm-error :anomalies/unavailable "api_error" "boom")
+          a    (:anomaly resp)]
+      (is (anomaly/anomaly? a))
+      (is (= :unavailable (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a))
+          "generic-standard category emits no :anomaly/subtype")))
+
+  (testing ":anomalies/fault → :fault, no subtype"
+    (let [a (:anomaly (client/llm-error :anomalies/fault "parse_error" "boom"))]
+      (is (= :fault (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a)))))
+
+  (testing ":anomalies/unsupported → :unsupported, no subtype"
+    (let [a (:anomaly (client/llm-error :anomalies/unsupported "x" "y"))]
+      (is (= :unsupported (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a))))))
+
+(deftest llm-error-domain-category-emits-subtype
+  (testing ":anomalies.agent/llm-error → :fault + subtype verbatim"
+    (let [a (:anomaly (client/llm-error :anomalies.agent/llm-error
+                                        "cli_error" "boom"))]
+      (is (anomaly/anomaly? a))
+      (is (= :fault (:anomaly/type a)))
+      (is (= :anomalies.agent/llm-error (:anomaly/subtype a))
+          "legacy domain category preserved verbatim as :anomaly/subtype")))
+
+  (testing ":anomalies.agent/rate-limited → :unavailable + subtype"
+    (let [a (:anomaly (client/llm-error :anomalies.agent/rate-limited
+                                        "rate_limit" "slow down"))]
+      (is (= :unavailable (:anomaly/type a)))
+      (is (= :anomalies.agent/rate-limited (:anomaly/subtype a))))))
+
+(deftest llm-error-domain-payload-lives-under-anomaly-data
+  (testing "the :operation domain field is carried under :anomaly/data"
+    (let [a    (:anomaly (client/llm-error :anomalies/fault "x" "y"))
+          data (:anomaly/data a)]
+      (is (= :llm-complete (:operation data))
+          ":operation lives under :anomaly/data — not at the anomaly's top level")
+      (is (nil? (:anomaly/operation a))
+          "no legacy :anomaly/operation at the anomaly's top level")
+      (is (nil? (:operation a))
+          ":operation also not at the anomaly's top level"))))
+
+(deftest http-post-request-failure-emits-canonical-unavailable
+  (testing "http-post-request returns a canonical :unavailable anomaly on exception"
+    ;; Provoke a connection failure deterministically by hitting an
+    ;; unroutable port on localhost. http-kit times out / refuses; either
+    ;; way the catch produces a canonical anomaly.
+    (let [a (client/http-post-request "http://127.0.0.1:1/llm-anomaly-shape-test"
+                                      {"Content-Type" "application/json"}
+                                      {})]
+      ;; http-kit may return a {:error <Throwable>} on connection failure
+      ;; rather than throwing; only assert canonical shape when the
+      ;; exception path is taken.
+      (when (anomaly/anomaly? a)
+        (is (= :unavailable (:anomaly/type a)))
+        (is (nil? (:anomaly/subtype a))
+            ":anomalies/unavailable is generic-standard — no subtype")
+        (is (= :http-request (get-in a [:anomaly/data :operation])))
+        (is (= "http://127.0.0.1:1/llm-anomaly-shape-test"
+               (get-in a [:anomaly/data :url]))
+            ":url lives under :anomaly/data, not as :anomaly.llm/url at the top")
+        (is (nil? (:anomaly.llm/url a))
+            "legacy :anomaly.llm/url no longer set at the anomaly's top level")))))


### PR DESCRIPTION
## Anomaly convergence W2 batch 2 — llm brick (first llm-anomaly domain-flatten)

Migrates the non-throw anomaly sites in
\`llm/protocols/impl/llm-client\` to the canonical
\`ai.miniforge.anomaly\` component (per
\`docs/runbooks/anomaly-convergence.md\`).

This is the first \`llm-anomaly\` domain-flatten test in W2 batch 2 —
\`response/llm-anomaly\`/\`make-anomaly\` wrote domain keys
(\`:anomaly.llm/url\`, \`:anomaly/operation\`) at the anomaly's top level;
the canonical schema is closed so domain payload moves under
\`:anomaly/data\`.

### Sites migrated (5)

| site | before | after |
| --- | --- | --- |
| \`llm-error\` | \`response/make-anomaly\` | \`->canonical-anomaly\` (private; uses \`anomaly/anomaly\` for generic-standard categories or \`anomaly/sub-anomaly\` for domain categories) |
| \`http-post-request\` | \`response/make-anomaly :anomalies/unavailable msg {:anomaly/operation :http-request :anomaly.llm/url url}\` | \`anomaly/anomaly :unavailable msg {:operation :http-request :url url}\` |
| \`parse-ollama-response\` predicate | \`response/anomaly-map?\` | \`anomaly/anomaly?\` |
| \`parse-ollama-response\` category read | \`(:anomaly/category response)\` | reconstituted \`:anomalies/unavailable\` (http-post-request emits exactly that category) |
| \`stream-read-failure\` | \`response/from-exception ex\` | \`anomaly/exception-anomaly :fault … ex\` |
| \`anomaly-signal?\` predicate | \`response/anomaly-map?\` | \`anomaly/anomaly?\` |

### Domain-payload key naming (precedent for later llm-anomaly flattens)

\`response/llm-anomaly\` wrote backend / URL state at the top level
(\`:anomaly.llm/backend\`, \`:anomaly.llm/url\`). Now they live under
\`:anomaly/data\` as unqualified descriptive keys. Choices for this
brick:

- \`:operation\` (the LLM operation, e.g. \`:llm-complete\`,
  \`:http-request\`)
- \`:url\` (HTTP target URL on http-post-request failures)

i.e. simple, unqualified, descriptive — matching the runbook's payload
guidance. These set the precedent for later llm-anomaly flattens (e.g.
\`:backend\`, \`:model\`, \`:retry-after-ms\` for rate-limit /
context-exceeded paths when those producers come up).

### Local conversion helper

Adds a private \`category->type\` map covering the categories the brick
actually emits today, plus a \`generic-standard-categories\` set so the
helper picks between \`anomaly/anomaly\` (no subtype) and
\`anomaly/sub-anomaly\` (subtype = legacy category verbatim) per the
runbook. An unmapped category throws \`IllegalArgumentException\` — the
table must be updated when a new category is introduced.

### Throw-anomaly! sites — DEFERRED (3)

Per the W2 policy, \`response/throw-anomaly!\` sites are LEFT AS-IS
(throw/catch is a control-flow rewrite that belongs after shape
convergence):

- \`llm-client.impl/llm-complete-with-config\` (\`:anomalies/not-found\`)
- \`model_registry/lookup-model\` (\`:anomalies/not-found\`)
- \`llm-client.records/llm-complete\` (\`:anomalies/incorrect\`)

### Same-brick consumers

Only \`parse-ollama-response\` consumed \`:anomaly/category\` from a
brick-produced anomaly; updated to the canonical predicate + explicit
category reconstitution. No other same-brick consumer reads top-level
\`:anomaly.llm/*\` keys.

### \`any-anomaly?\` local predicate

Not added. After flip, both producers in this brick emit canonical
anomalies, and the predicate sites read those producers' outputs only.
Counts toward the 3+ promotion threshold: **0 in this brick**.

### Tests

New: \`llm-anomaly-shape-test\` (4 tests / 15 assertions):
- generic-standard category → bare \`:anomaly/type\`, no subtype
- domain category → \`:anomaly/type\` + \`:anomaly/subtype = legacy verbatim\`
- \`:operation\` lives under \`:anomaly/data\`, NOT at the anomaly top level
- \`http-post-request\` produces a canonical \`:unavailable\` anomaly with
  \`:operation :http-request\` + \`:url\` under \`:anomaly/data\`

Existing brick tests stay green. Net: assertions grow.

### Deps

Adds \`ai.miniforge/anomaly\` to llm deps. \`ai.miniforge/response\` is
still required by the file for the 3 deferred \`throw-anomaly!\` sites.

### Gates

- \`bb pre-commit\` — green (poly:check + 16-ns precommit smoke + GraalVM)
- \`bb lint:clj\` — 0/0 on the diff
- \`bb poly:check\` — OK

Refs: anomaly-convergence W2 (docs/runbooks/anomaly-convergence.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)