### PR TITLE
feat(agent): flip execution-failure to canonical anomaly (W2 batch 2)

### DIFF
--- a/components/agent/deps.edn
+++ b/components/agent/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/tool {:local/root "../tool"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/tool {:local/root "../tool"}
         ai.miniforge/patterns {:local/root "../patterns"}
         ai.miniforge/repo-index {:local/root "../repo-index"}
         ai.miniforge/response {:local/root "../response"}

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -29,6 +29,7 @@
    [ai.miniforge.agent.memory :as memory]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.task-classifier :as classifier]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.tool.interface :as tool]
@@ -147,11 +148,21 @@ Output execution logs and status reports."})
 
 (defn execution-failure
   "Build a canonical execution failure response from an exception.
-   Uses response/failure as the base and merges domain-specific agent keys."
+   Uses response/failure as the base and merges domain-specific agent
+   keys.
+
+   W2 convergence: the embedded `:anomaly` is a canonical
+   `ai.miniforge.anomaly` map of type `:fault` (per the runbook's
+   generic-standard `:anomalies/fault` → `:fault` mapping) carrying the
+   exception's class + message + ex-data provenance under
+   `:anomaly/data` via `anomaly/exception-anomaly`."
   [^Throwable e & [extra]]
   (merge (response/failure (ex-message e)
                            {:data {:exception-type (str (type e))}})
-         {:anomaly (response/from-exception e)
+         {:anomaly (anomaly/exception-anomaly
+                    :fault
+                    (or (ex-message e) (str (type e)))
+                    e)
           :outputs []
           :decisions [:execution-error]
           :signals [:task-failed]

--- a/components/agent/test/ai/miniforge/agent/execution_failure_anomaly_shape_test.clj
+++ b/components/agent/test/ai/miniforge/agent/execution_failure_anomaly_shape_test.clj
@@ -1,0 +1,76 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.execution-failure-anomaly-shape-test
+  "Lock the canonical anomaly shape produced by `core/execution-failure`
+   after the W2 anomaly convergence flip.
+
+   Pre-flip the embedded `:anomaly` was constructed via
+   `response/from-exception`, emitting `:anomaly/category :anomalies/fault`
+   alongside exception provenance keys (`:anomaly/ex-message`,
+   `:anomaly/ex-class`, `:anomaly/ex-data`) at the anomaly map's top
+   level.
+
+   Post-flip the anomaly is built via `anomaly/exception-anomaly`:
+   `:anomaly/type :fault` (no subtype — the runbook maps the generic
+   `:anomalies/fault` 1:1 to a bare type), with provenance carried
+   under `:anomaly/data` per the closed canonical schema."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.agent.core :as agent-core]))
+
+(deftest execution-failure-embeds-canonical-fault-anomaly
+  (testing "ordinary exceptions yield a canonical :fault anomaly"
+    (let [ex   (Exception. "agent blew up")
+          resp (agent-core/execution-failure ex)
+          a    (:anomaly resp)]
+      (is (anomaly/anomaly? a))
+      (is (= :fault (:anomaly/type a))
+          "the runbook maps generic :anomalies/fault to :fault with no subtype")
+      (is (nil? (:anomaly/subtype a)))
+      (is (= "agent blew up" (:anomaly/message a)))))
+
+  (testing "exception-info provenance is preserved under :anomaly/data"
+    (let [ex   (ex-info "implementer failed" {:role :implementer :iteration 3})
+          resp (agent-core/execution-failure ex)
+          data (:anomaly/data (:anomaly resp))]
+      (is (= "implementer failed" (:anomaly/ex-message data)))
+      (is (= "clojure.lang.ExceptionInfo" (:anomaly/ex-class data)))
+      (is (= {:role :implementer :iteration 3} (:anomaly/ex-data data))
+          "ex-data carried through under :anomaly/data")))
+
+  (testing "the outer execution-failure shape is unchanged"
+    (let [ex   (Exception. "boom")
+          resp (agent-core/execution-failure ex)]
+      (is (= [] (:outputs resp)))
+      (is (= [:execution-error] (:decisions resp)))
+      (is (= [:task-failed] (:signals resp)))
+      (is (map? (:metrics resp))
+          "metrics map still attached for downstream telemetry")
+      (is (false? (:success resp))
+          "response/failure base is preserved by the merge"))))
+
+(deftest execution-failure-no-top-level-domain-keys-on-anomaly
+  (testing "exception provenance keys do NOT leak onto the anomaly's top level"
+    (let [a (:anomaly (agent-core/execution-failure
+                       (ex-info "boom" {:role :reviewer})))]
+      (is (nil? (:anomaly/ex-message a))
+          "legacy :anomaly/ex-message stays under :anomaly/data")
+      (is (nil? (:anomaly/ex-class a)))
+      (is (nil? (:anomaly/ex-data a))))))

--- a/components/agent/test/ai/miniforge/agent/execution_failure_anomaly_shape_test.clj
+++ b/components/agent/test/ai/miniforge/agent/execution_failure_anomaly_shape_test.clj
@@ -35,11 +35,37 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.agent.core :as agent-core]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Factories — keep test bodies focused on what they assert, not on
+;; how to drive `execution-failure` from a Throwable.
+
+(def ^:private boom-message
+  "Reusable plain-exception message — exercises the non-ex-info path
+   without coupling the assertion text to a fresh literal each time."
+  "boom")
+
+(defn- failure-response
+  "Build the failure response `core/execution-failure` produces for
+   `ex`. The single entry point under test in this file."
+  [ex]
+  (agent-core/execution-failure ex))
+
+(defn- failure-anomaly
+  "The `:anomaly` map embedded in the failure response for `ex`."
+  [ex]
+  (:anomaly (failure-response ex)))
+
+(defn- failure-anomaly-data
+  "The `:anomaly/data` map carried by the embedded anomaly for `ex`."
+  [ex]
+  (:anomaly/data (failure-anomaly ex)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Shape-lock tests
+
 (deftest execution-failure-embeds-canonical-fault-anomaly
   (testing "ordinary exceptions yield a canonical :fault anomaly"
-    (let [ex   (Exception. "agent blew up")
-          resp (agent-core/execution-failure ex)
-          a    (:anomaly resp)]
+    (let [a (failure-anomaly (Exception. "agent blew up"))]
       (is (anomaly/anomaly? a))
       (is (= :fault (:anomaly/type a))
           "the runbook maps generic :anomalies/fault to :fault with no subtype")
@@ -47,17 +73,15 @@
       (is (= "agent blew up" (:anomaly/message a)))))
 
   (testing "exception-info provenance is preserved under :anomaly/data"
-    (let [ex   (ex-info "implementer failed" {:role :implementer :iteration 3})
-          resp (agent-core/execution-failure ex)
-          data (:anomaly/data (:anomaly resp))]
+    (let [data (failure-anomaly-data
+                (ex-info "implementer failed" {:role :implementer :iteration 3}))]
       (is (= "implementer failed" (:anomaly/ex-message data)))
-      (is (= "clojure.lang.ExceptionInfo" (:anomaly/ex-class data)))
+      (is (= (.getName clojure.lang.ExceptionInfo) (:anomaly/ex-class data)))
       (is (= {:role :implementer :iteration 3} (:anomaly/ex-data data))
           "ex-data carried through under :anomaly/data")))
 
   (testing "the outer execution-failure shape is unchanged"
-    (let [ex   (Exception. "boom")
-          resp (agent-core/execution-failure ex)]
+    (let [resp (failure-response (Exception. boom-message))]
       (is (= [] (:outputs resp)))
       (is (= [:execution-error] (:decisions resp)))
       (is (= [:task-failed] (:signals resp)))
@@ -68,8 +92,7 @@
 
 (deftest execution-failure-no-top-level-domain-keys-on-anomaly
   (testing "exception provenance keys do NOT leak onto the anomaly's top level"
-    (let [a (:anomaly (agent-core/execution-failure
-                       (ex-info "boom" {:role :reviewer})))]
+    (let [a (failure-anomaly (ex-info boom-message {:role :reviewer}))]
       (is (nil? (:anomaly/ex-message a))
           "legacy :anomaly/ex-message stays under :anomaly/data")
       (is (nil? (:anomaly/ex-class a)))


### PR DESCRIPTION
## Anomaly convergence W2 batch 2 — agent brick (second domain-flatten path)

Migrates the sole non-throw anomaly construction site in the agent brick
to the canonical \`ai.miniforge.anomaly\` component (per
\`docs/runbooks/anomaly-convergence.md\`). The five
\`response/throw-anomaly!\` sites in the brick (planner.clj × 2,
prompts.clj × 2, messaging.clj × 1) are LEFT AS-IS per the W2 policy —
throw→return refactor belongs after shape convergence.

### Site migrated

| site | before | after |
| --- | --- | --- |
| \`core/execution-failure\` | \`(response/from-exception e)\` | \`(anomaly/exception-anomaly :fault (or (ex-message e) (str (type e))) e)\` |

Runbook entry: \`:anomalies/fault\` (generic-standard) → \`:fault\` with no
subtype. Exception provenance (\`:anomaly/ex-message\`,
\`:anomaly/ex-class\`, \`:anomaly/ex-data\`) now lives under
\`:anomaly/data\` per the closed canonical schema.

### Domain-payload key naming (second agent-anomaly path)

\`execution-failure\` did NOT use \`response/agent-anomaly\` (it used
\`from-exception\`), so no \`:anomaly.agent/role\` was at the top level
pre-flip. The exception-anomaly helper already carries provenance under
\`:anomaly/data\` as \`:anomaly/ex-{message,class,data}\` — a precedent
set in W0 (#995) by the \`exception-anomaly\` constructor itself.

For later agent-anomaly flattens that DO go through
\`response/agent-anomaly\` (e.g. the 5 deferred throw sites when their
W3+ refactor lands), the expected \`:anomaly/data\` keys (precedent
from this and earlier bricks):

- \`:role\` (agent role keyword: \`:implementer\`, \`:reviewer\`,
  \`:planner\`, …)
- \`:loop-iterations\` (when relevant)
- \`:tool-name\` (on tool-loop / tool-failure paths)

### Throw-anomaly! sites — DEFERRED (5)

Per W2 policy, left untouched:
- \`planner/create-planner\` (\`:anomalies.agent/llm-error\`)
- \`planner/create-planner\` (\`:anomalies.agent/invoke-failed\`)
- \`prompts/load-prompt\` × 2 (\`:anomalies/fault\`)
- \`protocols/impl/messaging\` (\`:anomalies/incorrect\`)

### Same-brick consumers

No same-brick consumer reads top-level provenance keys on the
\`execution-failure\` \`:anomaly\`; downstream consumers read message /
type / outer keys (\`:outputs\`, \`:decisions\`, \`:signals\`,
\`:metrics\`), all unchanged.

### \`any-anomaly?\` local predicate

Not added — agent core does not predicate-check anomalies in the
data-first flow path here. Counts toward the 3+ promotion threshold:
**0 in this brick**.

### Tests

New: \`execution-failure-anomaly-shape-test\` (2 tests / 14 assertions):
- \`:anomaly\` is a canonical anomaly map (\`anomaly/anomaly?\`)
- \`:anomaly/type :fault\`, no subtype (generic-standard)
- \`:anomaly/message\` preserved
- ex-data / ex-message / ex-class carried under \`:anomaly/data\`
- negative-space: no \`:anomaly/ex-*\` keys at the anomaly top level
- outer execution-failure response shape (\`:outputs\`, \`:decisions\`,
  \`:signals\`, \`:metrics\`, \`:success false\`) unchanged

Existing brick tests stay green. Net: assertions grow.

### Deps

Adds \`ai.miniforge/anomaly\` to agent deps. \`ai.miniforge/response\`
stays — still required by the 5 deferred \`throw-anomaly!\` sites and
the \`response/failure\` base in \`execution-failure\` itself.

### Gates

- \`bb pre-commit\` — green (poly:check + 16-ns precommit smoke + GraalVM)
- \`bb lint:clj\` — 0/0 on the diff
- \`bb poly:check\` — OK

Refs: anomaly-convergence W2 (docs/runbooks/anomaly-convergence.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)