### PR TITLE
feat(response): bridge translate domain-payload reads to :anomaly/data

### DIFF
--- a/components/response/src/ai/miniforge/response/translate.clj
+++ b/components/response/src/ai/miniforge/response/translate.clj
@@ -74,6 +74,18 @@
       (when-let [canonical-key (get domain-key-bridge legacy-key)]
         (get-in anomaly-map [:anomaly/data canonical-key]))))
 
+(defn- assoc-domain-value
+  "Bridge-read `legacy-key` from `anomaly-map` and, when present, assoc it
+   under `out-key` in `target`. Bridges via `domain-value` so both legacy
+   and canonical anomaly shapes hit the same output slot. When `out-key`
+   is omitted it defaults to `legacy-key`."
+  ([target anomaly-map legacy-key]
+   (assoc-domain-value target anomaly-map legacy-key legacy-key))
+  ([target anomaly-map legacy-key out-key]
+   (if-let [v (domain-value anomaly-map legacy-key)]
+     (assoc target out-key v)
+     target)))
+
 ;; User-facing message translation (defined first — used by HTTP translator)
 
 (def category->user-message
@@ -282,23 +294,14 @@
    ;; `domain-value`. `:anomaly/id` is legacy-only — canonical anomalies
    ;; don't carry one and it's simply absent for them.
    :outcome/error-details
-   (cond-> (select-keys anomaly-map [:anomaly/id :anomaly/category])
-     (domain-value anomaly-map :anomaly.gate/errors)
-     (assoc :anomaly.gate/errors (domain-value anomaly-map :anomaly.gate/errors))
-
-     (domain-value anomaly-map :anomaly.agent/role)
-     (assoc :anomaly.agent/role (domain-value anomaly-map :anomaly.agent/role))
-
-     (domain-value anomaly-map :anomaly.llm/model)
-     (assoc :anomaly.llm/model (domain-value anomaly-map :anomaly.llm/model))
-
-     (domain-value anomaly-map :anomaly.repair/strategy)
-     (assoc :anomaly.repair/strategy
-            (domain-value anomaly-map :anomaly.repair/strategy))
-
-     (domain-value anomaly-map :anomaly.repair/attempts)
-     (assoc :anomaly.repair/attempts
-            (domain-value anomaly-map :anomaly.repair/attempts)))})
+   (reduce (fn [details legacy-key]
+             (assoc-domain-value details anomaly-map legacy-key))
+           (select-keys anomaly-map [:anomaly/id :anomaly/category])
+           [:anomaly.gate/errors
+            :anomaly.agent/role
+            :anomaly.llm/model
+            :anomaly.repair/strategy
+            :anomaly.repair/attempts])})
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Error coercion (any shape -> anomaly map)

--- a/components/response/src/ai/miniforge/response/translate.clj
+++ b/components/response/src/ai/miniforge/response/translate.clj
@@ -51,6 +51,29 @@
       (:anomaly/category anomaly-map)
       (:anomaly/type anomaly-map)))
 
+(def ^:private domain-key-bridge
+  "Map of legacy top-level domain payload keys (the shape
+   `response/{gate,agent,llm,executor,repair}-anomaly` wrote) to their
+   canonical placement under `:anomaly/data` after the producer flip.
+   Read sites consult both during the W2-W4 transition; entries are
+   removed in W5 once every producer is migrated."
+  {:anomaly.gate/errors      :gate/errors
+   :anomaly.agent/role       :agent/role
+   :anomaly.llm/model        :llm/model
+   :anomaly.repair/strategy  :repair/strategy
+   :anomaly.repair/attempts  :repair/attempts})
+
+(defn- domain-value
+  "Read a domain payload field, transparently bridging legacy top-level
+   placement (e.g. `:anomaly.gate/errors`) and the canonical placement
+   under `:anomaly/data` (e.g. `:gate/errors`). Output keys in
+   downstream wire shapes (log records, evidence bundles) stay legacy
+   so log/event/evidence consumers aren't broken."
+  [anomaly-map legacy-key]
+  (or (get anomaly-map legacy-key)
+      (when-let [canonical-key (get domain-key-bridge legacy-key)]
+        (get-in anomaly-map [:anomaly/data canonical-key]))))
+
 ;; User-facing message translation (defined first — used by HTTP translator)
 
 (def category->user-message
@@ -198,11 +221,13 @@
       (:anomaly/operation anomaly-map)
       (assoc :anomaly/operation (:anomaly/operation anomaly-map))
 
-      (:anomaly.gate/errors anomaly-map)
-      (assoc :anomaly.gate/error-count (count (:anomaly.gate/errors anomaly-map)))
+      (domain-value anomaly-map :anomaly.gate/errors)
+      (assoc :anomaly.gate/error-count
+             (count (domain-value anomaly-map :anomaly.gate/errors)))
 
-      (:anomaly.agent/role anomaly-map)
-      (assoc :anomaly.agent/role (:anomaly.agent/role anomaly-map))
+      (domain-value anomaly-map :anomaly.agent/role)
+      (assoc :anomaly.agent/role
+             (domain-value anomaly-map :anomaly.agent/role))
 
       (:anomaly/ex-class anomaly-map)
       (assoc :anomaly/ex-class (:anomaly/ex-class anomaly-map)))))
@@ -252,14 +277,28 @@
    :outcome/anomaly-code (dispatch-key anomaly-map)
    :outcome/error-message (:anomaly/message anomaly-map)
    :outcome/error-phase (:anomaly/phase anomaly-map)
-   :outcome/error-details (select-keys anomaly-map
-                            [:anomaly/id
-                             :anomaly/category
-                             :anomaly.gate/errors
-                             :anomaly.agent/role
-                             :anomaly.llm/model
-                             :anomaly.repair/strategy
-                             :anomaly.repair/attempts])})
+   ;; Output wire shape preserved (legacy `:anomaly.<domain>/*` keys); reads
+   ;; bridge to `:anomaly/data` for canonical-shape producers via
+   ;; `domain-value`. `:anomaly/id` is legacy-only — canonical anomalies
+   ;; don't carry one and it's simply absent for them.
+   :outcome/error-details
+   (cond-> (select-keys anomaly-map [:anomaly/id :anomaly/category])
+     (domain-value anomaly-map :anomaly.gate/errors)
+     (assoc :anomaly.gate/errors (domain-value anomaly-map :anomaly.gate/errors))
+
+     (domain-value anomaly-map :anomaly.agent/role)
+     (assoc :anomaly.agent/role (domain-value anomaly-map :anomaly.agent/role))
+
+     (domain-value anomaly-map :anomaly.llm/model)
+     (assoc :anomaly.llm/model (domain-value anomaly-map :anomaly.llm/model))
+
+     (domain-value anomaly-map :anomaly.repair/strategy)
+     (assoc :anomaly.repair/strategy
+            (domain-value anomaly-map :anomaly.repair/strategy))
+
+     (domain-value anomaly-map :anomaly.repair/attempts)
+     (assoc :anomaly.repair/attempts
+            (domain-value anomaly-map :anomaly.repair/attempts)))})
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Error coercion (any shape -> anomaly map)

--- a/components/response/test/ai/miniforge/response/translate_test.clj
+++ b/components/response/test/ai/miniforge/response/translate_test.clj
@@ -111,3 +111,67 @@
            (:outcome/anomaly-code
             (response/anomaly->outcome-evidence
              (canonical-anomaly :unavailable :anomalies/unavailable)))))))
+
+;; ---------------------------------------------------------------------------- Domain-payload dual-shape reads
+
+(deftest log-data-reads-gate-errors-from-both-shapes
+  (testing "anomaly->log-data finds :anomaly.gate/errors whether they live at
+            the legacy top level or under :anomaly/data after the flatten"
+    (let [legacy   {:anomaly/category :anomalies.gate/validation-failed
+                    :anomaly/message "gate"
+                    :anomaly.gate/errors [{:e 1} {:e 2}]}
+          canonical {:anomaly/type :invalid-input
+                     :anomaly/subtype :anomalies.gate/validation-failed
+                     :anomaly/message "gate"
+                     :anomaly/data {:gate/errors [{:e 1} {:e 2}]}}]
+      (is (= 2 (:anomaly.gate/error-count (response/anomaly->log-data legacy))))
+      (is (= 2 (:anomaly.gate/error-count (response/anomaly->log-data canonical)))))))
+
+(deftest log-data-reads-agent-role-from-both-shapes
+  (testing "anomaly->log-data finds :anomaly.agent/role on either shape"
+    (let [legacy {:anomaly/category :anomalies.agent/tool-loop
+                  :anomaly/message "loop"
+                  :anomaly.agent/role :implementer}
+          canonical {:anomaly/type :exhausted
+                     :anomaly/subtype :anomalies.agent/tool-loop
+                     :anomaly/message "loop"
+                     :anomaly/data {:agent/role :implementer}}]
+      (is (= :implementer (:anomaly.agent/role (response/anomaly->log-data legacy))))
+      (is (= :implementer (:anomaly.agent/role (response/anomaly->log-data canonical)))))))
+
+(deftest outcome-evidence-reads-domain-payload-from-both-shapes
+  (testing "anomaly->outcome-evidence :outcome/error-details carries gate /
+            agent / llm / repair payload regardless of whether the producer
+            emitted them at the top level or under :anomaly/data"
+    (let [legacy {:anomaly/category :anomalies.repair/repair-failed
+                  :anomaly/message "boom"
+                  :anomaly.gate/errors [{:e 1}]
+                  :anomaly.agent/role :reviewer
+                  :anomaly.llm/model "gpt-4o"
+                  :anomaly.repair/strategy :rebuild
+                  :anomaly.repair/attempts 3}
+          canonical {:anomaly/type :fault
+                     :anomaly/subtype :anomalies.repair/repair-failed
+                     :anomaly/message "boom"
+                     :anomaly/data {:gate/errors [{:e 1}]
+                                    :agent/role :reviewer
+                                    :llm/model "gpt-4o"
+                                    :repair/strategy :rebuild
+                                    :repair/attempts 3}}
+          legacy-details (:outcome/error-details (response/anomaly->outcome-evidence legacy))
+          canonical-details (:outcome/error-details (response/anomaly->outcome-evidence canonical))]
+      (doseq [k [:anomaly.gate/errors :anomaly.agent/role :anomaly.llm/model
+                 :anomaly.repair/strategy :anomaly.repair/attempts]]
+        (is (= (get legacy-details k) (get canonical-details k))
+            (str k " survives the flatten via :anomaly/data bridge"))))))
+
+(deftest outcome-evidence-omits-domain-payload-when-absent
+  (testing "domain keys are only emitted when present in either shape — no
+            spurious nils in :outcome/error-details when the anomaly carries
+            no domain payload at all"
+    (let [details (:outcome/error-details
+                   (response/anomaly->outcome-evidence
+                    {:anomaly/type :fault :anomaly/message "x"}))]
+      (is (not (contains? details :anomaly.gate/errors)))
+      (is (not (contains? details :anomaly.agent/role)))
+      (is (not (contains? details :anomaly.llm/model))))))

--- a/components/response/test/ai/miniforge/response/translate_test.clj
+++ b/components/response/test/ai/miniforge/response/translate_test.clj
@@ -41,6 +41,28 @@
    :anomaly/subtype subtype
    :anomaly/message "msg"})
 
+;; Domain-payload shape builders. `legacy-payload` puts each :anomaly.<dom>/*
+;; key at the top level (pre-flip producer shape); `canonical-payload` nests
+;; the equivalent :<dom>/* key under :anomaly/data (post-flip shape). Both
+;; share `category` / `type` / `subtype` so the resulting anomalies dispatch
+;; to the same classification.
+
+(defn- legacy-payload
+  "Pre-flip producer shape — domain payload keys live at the top level."
+  [category message payload]
+  (merge {:anomaly/category category
+          :anomaly/message message}
+         payload))
+
+(defn- canonical-payload
+  "Post-flip producer shape — domain payload keys are nested under
+   :anomaly/data with the canonical `:<domain>/*` form."
+  [type subtype message data]
+  {:anomaly/type type
+   :anomaly/subtype subtype
+   :anomaly/message message
+   :anomaly/data data})
+
 (deftest user-message-honors-subtype-and-category-and-type
   (testing "the same classification produces the same user message whether
             the anomaly carries the legacy :anomaly/category, the canonical
@@ -117,25 +139,23 @@
 (deftest log-data-reads-gate-errors-from-both-shapes
   (testing "anomaly->log-data finds :anomaly.gate/errors whether they live at
             the legacy top level or under :anomaly/data after the flatten"
-    (let [legacy   {:anomaly/category :anomalies.gate/validation-failed
-                    :anomaly/message "gate"
-                    :anomaly.gate/errors [{:e 1} {:e 2}]}
-          canonical {:anomaly/type :invalid-input
-                     :anomaly/subtype :anomalies.gate/validation-failed
-                     :anomaly/message "gate"
-                     :anomaly/data {:gate/errors [{:e 1} {:e 2}]}}]
-      (is (= 2 (:anomaly.gate/error-count (response/anomaly->log-data legacy))))
-      (is (= 2 (:anomaly.gate/error-count (response/anomaly->log-data canonical)))))))
+    (let [errors [{:e 1} {:e 2}]
+          legacy (legacy-payload :anomalies.gate/validation-failed "gate"
+                                 {:anomaly.gate/errors errors})
+          canonical (canonical-payload :invalid-input
+                                       :anomalies.gate/validation-failed
+                                       "gate"
+                                       {:gate/errors errors})]
+      (is (= (count errors) (:anomaly.gate/error-count (response/anomaly->log-data legacy))))
+      (is (= (count errors) (:anomaly.gate/error-count (response/anomaly->log-data canonical)))))))
 
 (deftest log-data-reads-agent-role-from-both-shapes
   (testing "anomaly->log-data finds :anomaly.agent/role on either shape"
-    (let [legacy {:anomaly/category :anomalies.agent/tool-loop
-                  :anomaly/message "loop"
-                  :anomaly.agent/role :implementer}
-          canonical {:anomaly/type :exhausted
-                     :anomaly/subtype :anomalies.agent/tool-loop
-                     :anomaly/message "loop"
-                     :anomaly/data {:agent/role :implementer}}]
+    (let [legacy (legacy-payload :anomalies.agent/tool-loop "loop"
+                                 {:anomaly.agent/role :implementer})
+          canonical (canonical-payload :exhausted :anomalies.agent/tool-loop
+                                       "loop"
+                                       {:agent/role :implementer})]
       (is (= :implementer (:anomaly.agent/role (response/anomaly->log-data legacy))))
       (is (= :implementer (:anomaly.agent/role (response/anomaly->log-data canonical)))))))
 
@@ -143,21 +163,19 @@
   (testing "anomaly->outcome-evidence :outcome/error-details carries gate /
             agent / llm / repair payload regardless of whether the producer
             emitted them at the top level or under :anomaly/data"
-    (let [legacy {:anomaly/category :anomalies.repair/repair-failed
-                  :anomaly/message "boom"
-                  :anomaly.gate/errors [{:e 1}]
-                  :anomaly.agent/role :reviewer
-                  :anomaly.llm/model "gpt-4o"
-                  :anomaly.repair/strategy :rebuild
-                  :anomaly.repair/attempts 3}
-          canonical {:anomaly/type :fault
-                     :anomaly/subtype :anomalies.repair/repair-failed
-                     :anomaly/message "boom"
-                     :anomaly/data {:gate/errors [{:e 1}]
-                                    :agent/role :reviewer
-                                    :llm/model "gpt-4o"
-                                    :repair/strategy :rebuild
-                                    :repair/attempts 3}}
+    (let [legacy (legacy-payload :anomalies.repair/repair-failed "boom"
+                                 {:anomaly.gate/errors [{:e 1}]
+                                  :anomaly.agent/role :reviewer
+                                  :anomaly.llm/model "gpt-4o"
+                                  :anomaly.repair/strategy :rebuild
+                                  :anomaly.repair/attempts 3})
+          canonical (canonical-payload :fault :anomalies.repair/repair-failed
+                                       "boom"
+                                       {:gate/errors [{:e 1}]
+                                        :agent/role :reviewer
+                                        :llm/model "gpt-4o"
+                                        :repair/strategy :rebuild
+                                        :repair/attempts 3})
           legacy-details (:outcome/error-details (response/anomaly->outcome-evidence legacy))
           canonical-details (:outcome/error-details (response/anomaly->outcome-evidence canonical))]
       (doseq [k [:anomaly.gate/errors :anomaly.agent/role :anomaly.llm/model


### PR DESCRIPTION
## Summary

Follow-up to #1001 surfaced by W2 batch 2 of the anomaly convergence. `response/translate` already routes the dispatch keyword via subtype→category→type (from #1001), but it still reads the **domain payload** keys at the top level only:

- `:anomaly.gate/errors`
- `:anomaly.agent/role`
- `:anomaly.llm/model`
- `:anomaly.repair/strategy`
- `:anomaly.repair/attempts`

After a producer brick flips (W2 batches), those keys live under `:anomaly/data` (as `:gate/errors`, `:agent/role`, etc., per the convergence runbook). Translation degrades gracefully — no crash, no NPE — but the **domain payload silently disappears from log records and evidence bundles**. Loop's gate flip (#1006) already exposed this; every following batch's domain flips would compound it.

This PR adds the same legacy-or-canonical bridge pattern #1001 used for dispatch, applied to domain payload reads:

- New `domain-key-bridge` table + `domain-value` private reader (Layer 0).
- `anomaly->log-data` and `anomaly->outcome-evidence` read every domain payload field via `domain-value`, falling back to `:anomaly/data` when the top-level key is absent.
- **Output wire shapes unchanged.** Log records still emit `:anomaly.gate/error-count`, evidence bundles still emit `:anomaly.gate/errors` etc., so downstream log/event/evidence consumers see identical payloads.

## Rule

- Same dual-shape adaptation pattern as #1001; output wire-shape preservation; no producer changes.

## Test plan

- 4 new tests cover dual-shape reads for gate/errors and agent/role in `log-data`, the full five-key payload assembly in `outcome-evidence`, and the absent-domain "no spurious nils" case.
- Combined translate suite: **11 tests / 23 assertions, 0 failures**.
- `bb poly:check` OK; `bb lint:clj` clean.

## Why now

W2 batch 1 (#1002 schema, #1003 tool, #1004 evidence-bundle) had no domain payload — clean. W2 batch 2 (#1005–#1008, including loop's `gate-anomaly` flip and llm/agent domain-constructor migrations) flatten payload into `:anomaly/data`. Subsequent batches (failure-classifier, connector, dag-executor, …) will hit more domain constructors. Landing this bridge first means every post-flip anomaly's telemetry survives until W5 retires the legacy path.