### PR TITLE
feat(reviewer): enumeration validator + retry for malformed :rejected

### DIFF
--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -161,4 +161,35 @@ artifact.**
   commented-out blocks (008 no-dead-code). Treat them as blocking
   issues, not style preferences.
 
-Output your review as a Clojure map inside a ```clojure code block."}
+Output your review as a Clojure map inside a ```clojure code block."
+
+ ;; Bounded enumeration-retry turn — used by the review-output validator when a
+ ;; :rejected / :changes-requested decision lands WITHOUT any :blocking items
+ ;; in :review/issues. A rejection without enumerated blockers can't tell the
+ ;; implementer what to fix; the validator rejects that decision and demands a
+ ;; re-review that lists every blocking finding inline.
+ :prompt/enumeration-retry-max-turns 6
+
+ :prompt/enumeration-retry-template
+ "Your last review returned a rejection decision without enumerating any
+:blocking findings in :review/issues. A rejection the implementer cannot act on
+is malformed — the implementer needs the concrete list of blockers to fix.
+
+Re-review NOW and produce a SINGLE comprehensive ReviewArtifact map that:
+- Repeats the decision (:rejected or :changes-requested as appropriate).
+- Lists EVERY blocking finding inline in :review/issues with :severity
+  :blocking, :file, :line (when applicable), :description, and a concrete
+  :suggestion. Walk every changed file; do not stop after the first.
+- Include :warning and :nit findings too in the same map.
+
+If on re-review you find no real blockers, return :approved (or
+:conditionally-approved with only :warning/:nit findings) — do not invent
+blockers to justify the prior rejection.
+
+Your previous (malformed) review output, for reference only — DO NOT just
+repeat it:
+
+{{prior-content}}
+
+Output ONLY the corrected ReviewArtifact map inside a ```clojure code block.
+No prose narration outside the block."}

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -712,6 +712,16 @@
    `blocking-decisions`; defined locally to avoid a cross-component require."
   #{:rejected :changes-requested})
 
+(def ^:private valid-decisions
+  "The full set of `:review/decision` keywords the ReviewArtifact schema
+   allows (see `ReviewArtifact` ~L75). `parse-review-response` does not itself
+   validate the decision enum, so the enumeration-retry validator must — an
+   unexpected decision (`:approve` typo, `nil`, etc.) would otherwise slip
+   past `well-formed-recovery?` as 'non-rejection' and get collapsed
+   downstream to `:changes-requested`, re-introducing the exact malformed
+   rejection the validator exists to prevent."
+  #{:approved :rejected :conditionally-approved :changes-requested})
+
 (defn- review-has-blocking?
   "True when `issues` contains at least one entry with :severity :blocking."
   [issues]
@@ -747,12 +757,16 @@
    rejection in place and re-introduce the churn the validator exists to
    eliminate)."
   [re-review]
-  ;; The raw `:review/decision` is already a ReviewArtifact-schema enum;
-  ;; reading it directly (rather than re-normalizing) keeps this predicate
-  ;; insulated from any future change to `normalize-llm-decision`.
+  ;; The raw `:review/decision` is read directly (not re-normalized) to keep
+  ;; this insulated from future `normalize-llm-decision` changes — but we
+  ;; MUST validate it is one of the ReviewArtifact enums first
+  ;; (`parse-review-response` doesn't check), otherwise a typo or nil decision
+  ;; would slip past as "non-rejection" and get collapsed downstream to
+  ;; :changes-requested — defeating the whole validator.
   (let [dec (:review/decision re-review)]
-    (or (not (contains? rejection-decisions dec))
-        (review-has-blocking? (get re-review :review/issues [])))))
+    (and (contains? valid-decisions dec)
+         (or (not (contains? rejection-decisions dec))
+             (review-has-blocking? (get re-review :review/issues []))))))
 
 (defn- recover-review-enumeration
   "Run ONE bounded enumeration-retry turn and return the re-parsed

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -747,11 +747,9 @@
    rejection in place and re-introduce the churn the validator exists to
    eliminate)."
   [re-review]
-  ;; Use the RAW `:review/decision` (a ReviewArtifact-schema enum), not the
-  ;; normalized decision — `normalize-llm-decision` collapses
-  ;; `:conditionally-approved` into `:changes-requested` via its default
-  ;; fall-through, which would wrongly classify a legitimate
-  ;; "approved with non-blocking warnings" correction as a rejection here.
+  ;; The raw `:review/decision` is already a ReviewArtifact-schema enum;
+  ;; reading it directly (rather than re-normalizing) keeps this predicate
+  ;; insulated from any future change to `normalize-llm-decision`.
   (let [dec (:review/decision re-review)]
     (or (not (contains? rejection-decisions dec))
         (review-has-blocking? (get re-review :review/issues [])))))
@@ -876,13 +874,17 @@
                     counts (calculate-gate-counts gate-feedbacks)
                     timeout-failure-message (backend-failure-message response llm-review)
                     timeout-only-review? (timeout-only-review? llm-review gate-result)
-                    raw-llm-decision (cond
-                                       timeout-only-review? nil
-                                       parse-failed? :rejected
-                                       llm-review (normalize-llm-decision (:review/decision llm-review)))
-                    raw-llm-issues (get llm-review :review/issues [])
-                    raw-llm-strengths (get llm-review :review/strengths [])
-                    raw-llm-summary (:review/summary llm-review)
+                    ;; "initial" = the first-call decision/issues fed into the
+                    ;; enumeration validator. Named to contrast with
+                    ;; `recovered-review` below; these are already normalized,
+                    ;; not literally "raw".
+                    initial-llm-decision (cond
+                                           timeout-only-review? nil
+                                           parse-failed? :rejected
+                                           llm-review (normalize-llm-decision (:review/decision llm-review)))
+                    initial-llm-issues    (get llm-review :review/issues [])
+                    initial-llm-strengths (get llm-review :review/strengths [])
+                    initial-llm-summary   (:review/summary llm-review)
 
                     ;; ENUMERATION VALIDATOR: a rejection without enumerated
                     ;; :blocking findings is malformed — the implementer
@@ -890,31 +892,38 @@
                     ;; nothing" reviews drove the 2026-05-27 dogfood
                     ;; review-redirect churn. Re-run the reviewer ONCE with an
                     ;; enumeration-retry prompt; use the recovered review iff
-                    ;; it now lists blockers. Otherwise the raw rejection
-                    ;; stands as-is.
+                    ;; it now lists blockers OR corrects to a non-rejection.
+                    ;; Otherwise the initial rejection stands as-is.
                     recovered-review (when (enumeration-retry?
-                                            raw-llm-decision raw-llm-issues
+                                            initial-llm-decision initial-llm-issues
                                             (:blocking-issues gate-result))
                                        (log/info logger :reviewer
                                                  :reviewer/enumeration-retry
-                                                 {:data {:raw-decision        raw-llm-decision
-                                                         :raw-issue-count     (count raw-llm-issues)
+                                                 {:data {:initial-decision    initial-llm-decision
+                                                         :initial-issue-count (count initial-llm-issues)
                                                          :gate-blocking-count (count (:blocking-issues gate-result))}})
                                        (recover-review-enumeration
                                         llm-client base-opts on-chunk
                                         user-prompt content))
+                    ;; When recovery succeeds, the first call's parse failure
+                    ;; no longer represents the agent's verdict — clearing
+                    ;; this stops `all-blocking` from appending the parse-
+                    ;; failure message on top of an otherwise-clean recovered
+                    ;; review (could even falsely block a recovered
+                    ;; :approved).
+                    parse-failed? (and parse-failed? (nil? recovered-review))
                     llm-decision  (if recovered-review
                                     (normalize-llm-decision (:review/decision recovered-review))
-                                    raw-llm-decision)
+                                    initial-llm-decision)
                     llm-issues    (if recovered-review
                                     (get recovered-review :review/issues [])
-                                    raw-llm-issues)
+                                    initial-llm-issues)
                     llm-strengths (if recovered-review
                                     (get recovered-review :review/strengths [])
-                                    raw-llm-strengths)
+                                    initial-llm-strengths)
                     llm-summary   (if recovered-review
                                     (:review/summary recovered-review)
-                                    raw-llm-summary)
+                                    initial-llm-summary)
 
                     ;; Merge decisions: gates can override LLM
                     final-decision (if llm-decision

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -420,12 +420,18 @@
       nil)))
 
 (defn normalize-llm-decision
-  "Map LLM decision keywords to ReviewArtifact-compatible decisions."
+  "Map LLM decision keywords to ReviewArtifact-compatible decisions.
+   Preserves every variant the ReviewArtifact schema allows — collapsing
+   `:conditionally-approved` to `:changes-requested` (a rejection-class
+   decision) would misclassify a legitimate conditional approval as a
+   rejection and defeat the enumeration validator + the retry's permitted
+   self-correction to conditionally-approved."
   [decision]
   (case decision
-    :approved :approved
-    :rejected :rejected
-    :changes-requested :changes-requested
+    :approved               :approved
+    :rejected               :rejected
+    :changes-requested      :changes-requested
+    :conditionally-approved :conditionally-approved
     ;; default
     :changes-requested))
 

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -722,19 +722,42 @@
        (empty? gate-blocking)))
 
 (defn- enumeration-retry-prompt
-  "Render the enumeration-retry template with the prior (malformed) review
-   output folded in as reference."
-  [prior-content]
-  (prompts/render-template
-   (get @reviewer-prompt-data :prompt/enumeration-retry-template)
-   {:prior-content prior-content}))
+  "Build the enumeration-retry prompt: the ORIGINAL review user-prompt (so the
+   retry has the same artifact/diff evidence the first call had — `llm/chat`
+   is single-turn with no history) followed by the retry instruction with the
+   prior malformed output for reference."
+  [user-prompt prior-content]
+  (str user-prompt
+       "\n\n---\n\n"
+       (prompts/render-template
+        (get @reviewer-prompt-data :prompt/enumeration-retry-template)
+        {:prior-content prior-content})))
+
+(defn- well-formed-recovery?
+  "True when a re-reviewed ReviewArtifact resolves the malformed-rejection
+   case: either it now enumerates :blocking findings, OR it correctly
+   concludes :approved / :conditionally-approved (the retry template
+   explicitly allows that — discarding it would leave the original malformed
+   rejection in place and re-introduce the churn the validator exists to
+   eliminate)."
+  [re-review]
+  ;; Use the RAW `:review/decision` (a ReviewArtifact-schema enum), not the
+  ;; normalized decision — `normalize-llm-decision` collapses
+  ;; `:conditionally-approved` into `:changes-requested` via its default
+  ;; fall-through, which would wrongly classify a legitimate
+  ;; "approved with non-blocking warnings" correction as a rejection here.
+  (let [dec (:review/decision re-review)]
+    (or (not (contains? rejection-decisions dec))
+        (review-has-blocking? (get re-review :review/issues [])))))
 
 (defn- recover-review-enumeration
   "Run ONE bounded enumeration-retry turn and return the re-parsed
-   ReviewArtifact when recovery now enumerates blockers, or nil when recovery
-   also failed to enumerate (the original rejection then stands as-is)."
-  [llm-client base-opts on-chunk prior-content]
-  (let [retry-prompt (enumeration-retry-prompt prior-content)
+   ReviewArtifact when the recovery is well-formed (enumerates blockers OR
+   corrects to a non-rejection decision), or nil when recovery ALSO produced
+   a malformed rejection — in which case the original raw rejection stands
+   as-is."
+  [llm-client base-opts on-chunk user-prompt prior-content]
+  (let [retry-prompt (enumeration-retry-prompt user-prompt prior-content)
         retry-opts   (assoc base-opts :max-turns
                             (get @reviewer-prompt-data
                                  :prompt/enumeration-retry-max-turns 6))
@@ -744,7 +767,7 @@
         normalized   (result-boundary/normalize-llm-result
                       {:response response :parse-response parse-review-response})
         re-review    (:parsed-content normalized)]
-    (when (review-has-blocking? (get re-review :review/issues []))
+    (when (and re-review (well-formed-recovery? re-review))
       re-review)))
 
 (defn create-reviewer
@@ -872,7 +895,8 @@
                                                          :raw-issue-count     (count raw-llm-issues)
                                                          :gate-blocking-count (count (:blocking-issues gate-result))}})
                                        (recover-review-enumeration
-                                        llm-client base-opts on-chunk content))
+                                        llm-client base-opts on-chunk
+                                        user-prompt content))
                     llm-decision  (if recovered-review
                                     (normalize-llm-decision (:review/decision recovered-review))
                                     raw-llm-decision)

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -693,6 +693,60 @@
 ;------------------------------------------------------------------------------ Layer 5
 ;; Agent creation
 
+;;----------------------------------------------------------------------------- Enumeration-retry validator
+;; A rejection without enumerated :blocking findings is malformed (the
+;; implementer cannot act on it). Mirrors the planner/implementer
+;; submission-recovery pattern but for the reviewer's *output shape* — re-runs
+;; the reviewer once with an enumeration-retry prompt that demands the inline
+;; list. The reviewer doesn't use artifact-session/worktree-promotion, so the
+;; retry is a direct LLM call (not the session-wrapped run-recovery-session).
+
+(def ^:private rejection-decisions
+  "Decisions that mean 'rejected — needs work'. Mirrors review.clj's
+   `blocking-decisions`; defined locally to avoid a cross-component require."
+  #{:rejected :changes-requested})
+
+(defn- review-has-blocking?
+  "True when `issues` contains at least one entry with :severity :blocking."
+  [issues]
+  (boolean (some #(= :blocking (:severity %)) issues)))
+
+(defn- enumeration-retry?
+  "True when the LLM's review decision is a rejection but it enumerated NO
+   :blocking findings AND the deterministic gates have no blocking issues
+   either — a malformed rejection the implementer cannot act on. The validator
+   rejects this review and demands a re-enumeration."
+  [llm-decision llm-issues gate-blocking]
+  (and (contains? rejection-decisions llm-decision)
+       (not (review-has-blocking? llm-issues))
+       (empty? gate-blocking)))
+
+(defn- enumeration-retry-prompt
+  "Render the enumeration-retry template with the prior (malformed) review
+   output folded in as reference."
+  [prior-content]
+  (prompts/render-template
+   (get @reviewer-prompt-data :prompt/enumeration-retry-template)
+   {:prior-content prior-content}))
+
+(defn- recover-review-enumeration
+  "Run ONE bounded enumeration-retry turn and return the re-parsed
+   ReviewArtifact when recovery now enumerates blockers, or nil when recovery
+   also failed to enumerate (the original rejection then stands as-is)."
+  [llm-client base-opts on-chunk prior-content]
+  (let [retry-prompt (enumeration-retry-prompt prior-content)
+        retry-opts   (assoc base-opts :max-turns
+                            (get @reviewer-prompt-data
+                                 :prompt/enumeration-retry-max-turns 6))
+        response     (if on-chunk
+                       (llm/chat-stream llm-client retry-prompt on-chunk retry-opts)
+                       (llm/chat llm-client retry-prompt retry-opts))
+        normalized   (result-boundary/normalize-llm-result
+                      {:response response :parse-response parse-review-response})
+        re-review    (:parsed-content normalized)]
+    (when (review-has-blocking? (get re-review :review/issues []))
+      re-review)))
+
 (defn create-reviewer
   "Create a Reviewer agent with optional configuration overrides.
 
@@ -793,13 +847,44 @@
                     counts (calculate-gate-counts gate-feedbacks)
                     timeout-failure-message (backend-failure-message response llm-review)
                     timeout-only-review? (timeout-only-review? llm-review gate-result)
-                    llm-decision (cond
-                                   timeout-only-review? nil
-                                   parse-failed? :rejected
-                                   llm-review (normalize-llm-decision (:review/decision llm-review)))
-                    llm-issues (get llm-review :review/issues [])
-                    llm-strengths (get llm-review :review/strengths [])
-                    llm-summary (:review/summary llm-review)
+                    raw-llm-decision (cond
+                                       timeout-only-review? nil
+                                       parse-failed? :rejected
+                                       llm-review (normalize-llm-decision (:review/decision llm-review)))
+                    raw-llm-issues (get llm-review :review/issues [])
+                    raw-llm-strengths (get llm-review :review/strengths [])
+                    raw-llm-summary (:review/summary llm-review)
+
+                    ;; ENUMERATION VALIDATOR: a rejection without enumerated
+                    ;; :blocking findings is malformed — the implementer
+                    ;; cannot act on it, and silent "rejected but listed
+                    ;; nothing" reviews drove the 2026-05-27 dogfood
+                    ;; review-redirect churn. Re-run the reviewer ONCE with an
+                    ;; enumeration-retry prompt; use the recovered review iff
+                    ;; it now lists blockers. Otherwise the raw rejection
+                    ;; stands as-is.
+                    recovered-review (when (enumeration-retry?
+                                            raw-llm-decision raw-llm-issues
+                                            (:blocking-issues gate-result))
+                                       (log/info logger :reviewer
+                                                 :reviewer/enumeration-retry
+                                                 {:data {:raw-decision        raw-llm-decision
+                                                         :raw-issue-count     (count raw-llm-issues)
+                                                         :gate-blocking-count (count (:blocking-issues gate-result))}})
+                                       (recover-review-enumeration
+                                        llm-client base-opts on-chunk content))
+                    llm-decision  (if recovered-review
+                                    (normalize-llm-decision (:review/decision recovered-review))
+                                    raw-llm-decision)
+                    llm-issues    (if recovered-review
+                                    (get recovered-review :review/issues [])
+                                    raw-llm-issues)
+                    llm-strengths (if recovered-review
+                                    (get recovered-review :review/strengths [])
+                                    raw-llm-strengths)
+                    llm-summary   (if recovered-review
+                                    (:review/summary recovered-review)
+                                    raw-llm-summary)
 
                     ;; Merge decisions: gates can override LLM
                     final-decision (if llm-decision

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -1084,3 +1084,16 @@
     (is (= :approved          (reviewer/normalize-llm-decision :approved)))
     (is (= :rejected          (reviewer/normalize-llm-decision :rejected)))
     (is (= :changes-requested (reviewer/normalize-llm-decision :changes-requested)))))
+
+(deftest well-formed-recovery-rejects-unknown-decision-keyword
+  (testing "an invalid :review/decision (typo / nil / unknown) is NOT
+            well-formed — parse-review-response doesn't validate the enum,
+            so the validator must, otherwise downstream normalize-llm-decision
+            would collapse the bogus value to :changes-requested and
+            reintroduce the malformed-rejection outcome"
+    (is (false? (well-formed-recovery? {:review/decision :approve  ; typo
+                                        :review/issues []})))
+    (is (false? (well-formed-recovery? {:review/decision nil
+                                        :review/issues []})))
+    (is (false? (well-formed-recovery? {:review/decision :looks-good
+                                        :review/issues []})))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -978,3 +978,35 @@
             ;; The base prompt is unchanged when no addendum is appended;
             ;; assertion is just that we didn't NPE or get nil.
             (is (pos? (count system-prompt)))))))))
+
+;;----------------------------------------------------------------------------- Enumeration-retry validator
+
+(def ^:private enumeration-retry? #'reviewer/enumeration-retry?)
+
+(deftest enumeration-retry-fires-on-rejection-without-blockers
+  (testing "a :rejected (or :changes-requested) decision with NO :blocking
+            findings inline AND no gate blockers is malformed — the validator
+            triggers a re-enumeration"
+    (is (true? (boolean (enumeration-retry? :rejected           [] []))))
+    (is (true? (boolean (enumeration-retry? :changes-requested  [] []))))
+    (is (true? (boolean (enumeration-retry? :rejected
+                                            [{:severity :warning :description "nit"}]
+                                            []))))))
+
+(deftest enumeration-retry-no-fire-when-blockers-enumerated
+  (testing "a rejection with an inline :blocking finding is well-formed"
+    (is (false? (boolean (enumeration-retry?
+                          :rejected
+                          [{:severity :blocking :description "real issue"}]
+                          []))))))
+
+(deftest enumeration-retry-no-fire-when-gate-blocks
+  (testing "a rejection backed by a deterministic gate blocker is well-formed
+            (the implementer has something concrete to fix)"
+    (is (false? (boolean (enumeration-retry?
+                          :rejected [] ["gate-blocking-issue"]))))))
+
+(deftest enumeration-retry-no-fire-on-non-rejection
+  (testing ":approved / :conditionally-approved never trigger the validator"
+    (is (false? (boolean (enumeration-retry? :approved [] []))))
+    (is (false? (boolean (enumeration-retry? :conditionally-approved [] []))))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -1071,3 +1071,16 @@
                                {:success true :content stub})]
         (is (nil? (recover-review-enumeration
                    :stub-client {} nil "orig" "prior")))))))
+
+(deftest normalize-llm-decision-preserves-conditionally-approved
+  (testing "normalize-llm-decision preserves :conditionally-approved (the
+            ReviewArtifact schema allows it, and collapsing it to
+            :changes-requested misclassifies a conditional approval as a
+            rejection — defeating the enumeration validator + retry self-
+            correction)"
+    (is (= :conditionally-approved
+           (reviewer/normalize-llm-decision :conditionally-approved)))
+    ;; Round-trip the other valid enums for completeness.
+    (is (= :approved          (reviewer/normalize-llm-decision :approved)))
+    (is (= :rejected          (reviewer/normalize-llm-decision :rejected)))
+    (is (= :changes-requested (reviewer/normalize-llm-decision :changes-requested)))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -1010,3 +1010,64 @@
   (testing ":approved / :conditionally-approved never trigger the validator"
     (is (false? (boolean (enumeration-retry? :approved [] []))))
     (is (false? (boolean (enumeration-retry? :conditionally-approved [] []))))))
+
+;;----------------------------------------------------------------------------- well-formed-recovery? + recover-review-enumeration
+
+(def ^:private well-formed-recovery? #'reviewer/well-formed-recovery?)
+(def ^:private recover-review-enumeration #'reviewer/recover-review-enumeration)
+
+(deftest well-formed-recovery-accepts-approval-correction
+  (testing ":approved / :conditionally-approved from the retry are well-formed
+            — the retry template explicitly permits self-correction, and
+            DISCARDING those would leave the original malformed rejection
+            in place (the exact churn the validator exists to eliminate)"
+    (is (true? (well-formed-recovery? {:review/decision :approved
+                                       :review/issues []})))
+    (is (true? (well-formed-recovery? {:review/decision :conditionally-approved
+                                       :review/issues [{:severity :nit
+                                                        :description "trivial"}]})))))
+
+(deftest well-formed-recovery-accepts-enumerated-rejection
+  (is (true? (well-formed-recovery?
+              {:review/decision :rejected
+               :review/issues   [{:severity :blocking :description "real issue"}]}))))
+
+(deftest well-formed-recovery-rejects-rejection-without-blockers
+  (is (false? (well-formed-recovery?
+               {:review/decision :rejected :review/issues []}))))
+
+(deftest recover-review-enumeration-returns-approval-correction-test
+  (testing "when the retry corrects to :approved, recovery returns it
+            (regression guard: previously it required :blocking and
+            silently dropped approvals)"
+    (let [calls (atom 0)
+          stub  "```clojure\n{:review/decision :approved
+                              :review/summary \"clean on re-review\"
+                              :review/issues []}\n```"]
+      (with-redefs [llm/chat (fn [_client _prompt _opts]
+                               (swap! calls inc)
+                               {:success true :content stub})]
+        (let [recovered (recover-review-enumeration
+                         :stub-client {} nil "orig user prompt" "prior malformed content")]
+          (is (= 1 @calls) "exactly one retry LLM call")
+          (is (= :approved (:review/decision recovered))))))))
+
+(deftest recover-review-enumeration-returns-enumerated-rejection-test
+  (testing "when the retry enumerates :blocking findings, recovery returns it"
+    (let [stub "```clojure\n{:review/decision :rejected
+                             :review/issues [{:severity :blocking :description \"x\"}]}\n```"]
+      (with-redefs [llm/chat (fn [_client _prompt _opts]
+                               {:success true :content stub})]
+        (let [recovered (recover-review-enumeration
+                         :stub-client {} nil "orig" "prior")]
+          (is (= :rejected (:review/decision recovered)))
+          (is (= 1 (count (:review/issues recovered)))))))))
+
+(deftest recover-review-enumeration-returns-nil-on-still-malformed-test
+  (testing "when the retry ALSO returns a rejection with no blockers,
+            recovery returns nil (the raw rejection stands as-is, logged)"
+    (let [stub "```clojure\n{:review/decision :rejected :review/issues []}\n```"]
+      (with-redefs [llm/chat (fn [_client _prompt _opts]
+                               {:success true :content stub})]
+        (is (nil? (recover-review-enumeration
+                   :stub-client {} nil "orig" "prior")))))))


### PR DESCRIPTION
## Summary

Closes the *root* cause of the 2026-05-27 dogfood review-redirect churn. The reviewer's existing prompt already says *"Do NOT stop after finding the first blocking issue. Report every issue you find in one comprehensive response."* — but the data showed it inconsistently followed: some cycles enumerated 5–8 blockers (the prompt working), others emitted a bare `:rejected` decision with **zero `:blocking` items** in `:review/issues`. Implementer with nothing to fix → another redirect → churn.

**Fix:** add a validator on the reviewer's *output shape*. If the decision is `:rejected`/`:changes-requested` but no `:blocking` is enumerated inline AND the deterministic gates also produced no blocker, the review is malformed. Re-run the reviewer **once** with an enumeration-retry prompt that demands the inline list; use the recovered review iff it now enumerates. Otherwise the raw rejection stands as-is (logged).

Mirrors the planner/implementer submission-recovery pattern (#997/#1000), applied to the reviewer's *output* instead of artifact submission. Reviewer doesn't use `artifact-session`, so the retry is a direct LLM call.

### Not in this PR
A convergence cap (terminate after N non-converging review cycles even when blockers are real, per `work/review-redirect-convergence.spec.edn`) — the follow-on backstop. Exhaustive enumeration is the root fix; the cap catches the residual case where the implementer keeps introducing new violations.

## Test plan
- [x] `bb pre-commit` green (poly check, graalvm, smoke)
- [x] 4 new `enumeration-retry?` predicate tests + 35 existing reviewer tests
- [x] planner / implementer / submission-recovery tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)