### PR TITLE
fix(event-stream,logging): implement fleet-sink HTTP POST — stop silently dropping telemetry

### DIFF
--- a/components/event-stream/deps.edn
+++ b/components/event-stream/deps.edn
@@ -5,7 +5,8 @@
         ai.miniforge/response {:local/root "../response"}
         ai.miniforge/schema {:local/root "../schema"}
         cheshire/cheshire {:mvn/version "5.13.0"}
-        com.cognitect/transit-clj {:mvn/version "1.0.333"}}
+        com.cognitect/transit-clj {:mvn/version "1.0.333"}
+        slingshot/slingshot {:mvn/version "0.12.2"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/event-stream/resources/config/event-stream/messages/en-US.edn
+++ b/components/event-stream/resources/config/event-stream/messages/en-US.edn
@@ -67,4 +67,23 @@
   "Snowflake generator: wall clock {now-ms} is before the miniforge epoch {epoch-ms}"
 
   ;; Zettelkasten lifecycle (miniforge-fleet Phase E.3 outbox path)
-  :zettel/promoted            "Zettel {uid} promoted to trusted"}}
+  :zettel/promoted            "Zettel {uid} promoted to trusted"
+
+  ;; Fleet sink — operator-internal strings (system-locale, never
+  ;; user-localized, but routed through the catalog so there's one place
+  ;; to audit and change them). Mirrors the workflow component's
+  ;; :dag.merge.system/* pattern.
+  :fleet-sink.system/missing-url
+  "Fleet sink requires :url"
+
+  :fleet-sink.system/missing-api-key
+  "Fleet sink requires :api-key"
+
+  :fleet-sink.system/http-error
+  "fleet-sink: POST {url} returned HTTP {status}"
+
+  :fleet-sink.system/interrupted
+  "fleet-sink: interrupted during flush: {error}"
+
+  :fleet-sink.system/flush-error
+  "fleet-sink: flush error: {error}"}}

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -361,7 +361,10 @@
                         (response/throw-anomaly! :anomalies/incorrect
                                                  "Fleet sink requires :url"
                                                  {:opts safe-opts}))
-        api-key          (:api-key opts)
+        api-key          (or (:api-key opts)
+                             (response/throw-anomaly! :anomalies/incorrect
+                                                      "Fleet sink requires :api-key"
+                                                      {:opts safe-opts}))
         batch-size       (:batch-size opts 10)
         flush-interval-ms (:flush-interval-ms opts 5000)
         timeout-ms       (:timeout-ms opts 10000)
@@ -370,7 +373,12 @@
         last-flush-atom  (atom (System/currentTimeMillis))]
 
     (letfn [(flush-batch! []
-              (let [events @batch-atom]
+              ;; Atomically drain the batch so concurrent senders don't race
+              ;; on @batch-atom + reset!. swap-vals! returns [prev new] —
+              ;; first prev = the snapshot we own. Events appended while
+              ;; the HTTP call is in flight go into the FRESH atom value
+              ;; and are picked up by the next flush.
+              (let [events (first (swap-vals! batch-atom (constantly [])))]
                 (when (seq events)
                   (try
                     (let [body    (json/generate-string {:events events})
@@ -386,11 +394,16 @@
                         (binding [*out* *err*]
                           (println (str "fleet-sink: POST " url "/events returned HTTP "
                                         (.statusCode response))))))
+                    (catch InterruptedException e
+                      ;; Preserve interrupt semantics for callers.
+                      (.interrupt (Thread/currentThread))
+                      (binding [*out* *err*]
+                        (println "fleet-sink: interrupted during flush:" (ex-message e))))
                     (catch Exception e
                       (binding [*out* *err*]
-                        (println "fleet-sink: flush error:" (ex-message e)))))
-                  (reset! batch-atom [])
-                  (reset! last-flush-atom (System/currentTimeMillis)))))]
+                        (println "fleet-sink: flush error:" (ex-message e))))
+                    (finally
+                      (reset! last-flush-atom (System/currentTimeMillis)))))))]
 
       (fn [event]
         (swap! batch-atom conj event)

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -39,13 +39,16 @@
    [ai.miniforge.event-stream.snowflake :as snowflake]
    [ai.miniforge.event-stream.storage-layout :as layout]
    [ai.miniforge.response.interface :as response]
+   [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.pprint :as pprint]
    [cognitect.transit :as transit])
   (:import
    [java.io ByteArrayOutputStream]
-   [java.time Instant ZonedDateTime ZoneOffset]
+   [java.net URI]
+   [java.net.http HttpClient HttpRequest HttpRequest$BodyPublishers HttpResponse$BodyHandlers]
+   [java.time Duration Instant ZonedDateTime ZoneOffset]
    [java.time.format DateTimeFormatter]))
 
 ;;------------------------------------------------------------------------------ Internal helpers
@@ -349,36 +352,45 @@
        :batch-size - Number of events to batch (default 10)
        :flush-interval-ms - Max time before flushing (default 5000)
        :timeout-ms - HTTP timeout (default 10000)
+       :http-client - java.net.http.HttpClient instance (default: HttpClient/newHttpClient)
 
    Returns: Sink function (fn [event] -> nil)"
   [opts]
-  (let [safe-opts (dissoc opts :api-key :token :secret :password)
-        _url (or (:url opts)
-                 (response/throw-anomaly! :anomalies/incorrect
-                                          "Fleet sink requires :url"
-                                          {:opts safe-opts}))
-        _api-key (:api-key opts)
-        batch-size (:batch-size opts 10)
+  (let [safe-opts   (dissoc opts :api-key :token :secret :password)
+        url         (or (:url opts)
+                        (response/throw-anomaly! :anomalies/incorrect
+                                                 "Fleet sink requires :url"
+                                                 {:opts safe-opts}))
+        api-key          (:api-key opts)
+        batch-size       (:batch-size opts 10)
         flush-interval-ms (:flush-interval-ms opts 5000)
-        _timeout-ms (:timeout-ms opts 10000)
-        batch-atom (atom [])
-        last-flush-atom (atom (System/currentTimeMillis))]
+        timeout-ms       (:timeout-ms opts 10000)
+        http-client      (or (:http-client opts) (HttpClient/newHttpClient))
+        batch-atom       (atom [])
+        last-flush-atom  (atom (System/currentTimeMillis))]
 
     (letfn [(flush-batch! []
               (let [events @batch-atom]
                 (when (seq events)
                   (try
-                    ;; TODO: Implement HTTP POST to fleet command
-                    ;; (http/post (str _url "/events")
-                    ;;            {:headers {"Authorization" (str "Bearer " _api-key)
-                    ;;                       "Content-Type" "application/json"}
-                    ;;             :body (json/generate-string {:events events})
-                    ;;             :timeout _timeout-ms})
-                    (reset! batch-atom [])
-                    (reset! last-flush-atom (System/currentTimeMillis))
-                    (catch Exception _e
-                      ;; Log error but don't fail
-                      nil)))))]
+                    (let [body    (json/generate-string {:events events})
+                          request (-> (HttpRequest/newBuilder)
+                                      (.uri (URI/create (str url "/events")))
+                                      (.timeout (Duration/ofMillis timeout-ms))
+                                      (.header "Authorization" (str "Bearer " api-key))
+                                      (.header "Content-Type" "application/json")
+                                      (.POST (HttpRequest$BodyPublishers/ofString body))
+                                      (.build))
+                          response (.send http-client request (HttpResponse$BodyHandlers/discarding))]
+                      (when (>= (.statusCode response) 400)
+                        (binding [*out* *err*]
+                          (println (str "fleet-sink: POST " url "/events returned HTTP "
+                                        (.statusCode response))))))
+                    (catch Exception e
+                      (binding [*out* *err*]
+                        (println "fleet-sink: flush error:" (ex-message e)))))
+                  (reset! batch-atom [])
+                  (reset! last-flush-atom (System/currentTimeMillis)))))]
 
       (fn [event]
         (swap! batch-atom conj event)

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -39,6 +39,7 @@
    [ai.miniforge.event-stream.messages :as messages]
    [ai.miniforge.event-stream.snowflake :as snowflake]
    [ai.miniforge.event-stream.storage-layout :as layout]
+   [ai.miniforge.logging.interface :as logging]
    [ai.miniforge.response.interface :as response]
    [cheshire.core :as json]
    [clojure.java.io :as io]
@@ -48,9 +49,8 @@
    [slingshot.slingshot :refer [try+]])
   (:import
    [java.io ByteArrayOutputStream]
-   [java.net URI]
-   [java.net.http HttpClient HttpRequest HttpRequest$BodyPublishers HttpResponse$BodyHandlers]
-   [java.time Duration Instant ZonedDateTime ZoneOffset]
+   [java.net.http HttpClient HttpResponse$BodyHandlers]
+   [java.time Instant ZonedDateTime ZoneOffset]
    [java.time.format DateTimeFormatter]))
 
 ;;------------------------------------------------------------------------------ Internal helpers
@@ -343,17 +343,6 @@
 
 ;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
 
-(defn- build-json-post
-  "Build an HTTP POST request with a JSON string body and Bearer auth header."
-  [uri body api-key timeout-ms]
-  (-> (HttpRequest/newBuilder)
-      (.uri (URI/create uri))
-      (.timeout (Duration/ofMillis timeout-ms))
-      (.header "Authorization" (str "Bearer " api-key))
-      (.header "Content-Type" "application/json")
-      (.POST (HttpRequest$BodyPublishers/ofString body))
-      (.build)))
-
 (defn fleet-sink
   "Create a fleet sink that sends events to fleet command via HTTP.
 
@@ -399,7 +388,7 @@
                   ;; rule and are migrated opportunistically (211 §migration).
                   (try+
                     (let [body     (json/generate-string {:events events})
-                          request  (build-json-post (str url "/events") body api-key timeout-ms)
+                          request  (logging/build-json-post (str url "/events") body api-key timeout-ms)
                           response (.send http-client request (HttpResponse$BodyHandlers/discarding))]
                       (when (>= (.statusCode response) 400)
                         (binding [*out* *err*]

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -342,6 +342,17 @@
 
 ;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
 
+(defn- build-json-post
+  "Build an HTTP POST request with a JSON string body and Bearer auth header."
+  [uri body api-key timeout-ms]
+  (-> (HttpRequest/newBuilder)
+      (.uri (URI/create uri))
+      (.timeout (Duration/ofMillis timeout-ms))
+      (.header "Authorization" (str "Bearer " api-key))
+      (.header "Content-Type" "application/json")
+      (.POST (HttpRequest$BodyPublishers/ofString body))
+      (.build)))
+
 (defn fleet-sink
   "Create a fleet sink that sends events to fleet command via HTTP.
 
@@ -382,14 +393,8 @@
               (let [events (first (swap-vals! batch-atom (constantly [])))]
                 (when (seq events)
                   (try
-                    (let [body    (json/generate-string {:events events})
-                          request (-> (HttpRequest/newBuilder)
-                                      (.uri (URI/create (str url "/events")))
-                                      (.timeout (Duration/ofMillis timeout-ms))
-                                      (.header "Authorization" (str "Bearer " api-key))
-                                      (.header "Content-Type" "application/json")
-                                      (.POST (HttpRequest$BodyPublishers/ofString body))
-                                      (.build))
+                    (let [body     (json/generate-string {:events events})
+                          request  (build-json-post (str url "/events") body api-key timeout-ms)
                           response (.send http-client request (HttpResponse$BodyHandlers/discarding))]
                       (when (>= (.statusCode response) 400)
                         (binding [*out* *err*]

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -36,6 +36,7 @@
    - :multi  - Combine multiple sinks"
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.event-stream.messages :as messages]
    [ai.miniforge.event-stream.snowflake :as snowflake]
    [ai.miniforge.event-stream.storage-layout :as layout]
    [ai.miniforge.response.interface :as response]
@@ -359,11 +360,11 @@
   (let [safe-opts   (dissoc opts :api-key :token :secret :password)
         url         (or (:url opts)
                         (response/throw-anomaly! :anomalies/incorrect
-                                                 "Fleet sink requires :url"
+                                                 (messages/t :fleet-sink.system/missing-url)
                                                  {:opts safe-opts}))
         api-key          (or (:api-key opts)
                              (response/throw-anomaly! :anomalies/incorrect
-                                                      "Fleet sink requires :api-key"
+                                                      (messages/t :fleet-sink.system/missing-api-key)
                                                       {:opts safe-opts}))
         batch-size       (:batch-size opts 10)
         flush-interval-ms (:flush-interval-ms opts 5000)
@@ -392,16 +393,19 @@
                           response (.send http-client request (HttpResponse$BodyHandlers/discarding))]
                       (when (>= (.statusCode response) 400)
                         (binding [*out* *err*]
-                          (println (str "fleet-sink: POST " url "/events returned HTTP "
-                                        (.statusCode response))))))
+                          (println (messages/t :fleet-sink.system/http-error
+                                               {:url    (str url "/events")
+                                                :status (.statusCode response)})))))
                     (catch InterruptedException e
                       ;; Preserve interrupt semantics for callers.
                       (.interrupt (Thread/currentThread))
                       (binding [*out* *err*]
-                        (println "fleet-sink: interrupted during flush:" (ex-message e))))
+                        (println (messages/t :fleet-sink.system/interrupted
+                                             {:error (ex-message e)}))))
                     (catch Exception e
                       (binding [*out* *err*]
-                        (println "fleet-sink: flush error:" (ex-message e))))
+                        (println (messages/t :fleet-sink.system/flush-error
+                                             {:error (ex-message e)}))))
                     (finally
                       (reset! last-flush-atom (System/currentTimeMillis)))))))]
 

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -44,7 +44,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.pprint :as pprint]
-   [cognitect.transit :as transit])
+   [cognitect.transit :as transit]
+   [slingshot.slingshot :refer [try+]])
   (:import
    [java.io ByteArrayOutputStream]
    [java.net URI]
@@ -392,7 +393,11 @@
               ;; and are picked up by the next flush.
               (let [events (first (swap-vals! batch-atom (constantly [])))]
                 (when (seq events)
-                  (try
+                  ;; try+ per standards rule 211 — boundary catch around
+                  ;; Java HttpClient.send. The component's other plain
+                  ;; `try` sites (file write, mkdirs, etc.) predate this
+                  ;; rule and are migrated opportunistically (211 §migration).
+                  (try+
                     (let [body     (json/generate-string {:events events})
                           request  (build-json-post (str url "/events") body api-key timeout-ms)
                           response (.send http-client request (HttpResponse$BodyHandlers/discarding))]

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -358,15 +358,18 @@
 
    Returns: Sink function (fn [event] -> nil)"
   [opts]
-  (let [safe-opts   (dissoc opts :api-key :token :secret :password)
-        url         (or (:url opts)
-                        (response/throw-anomaly! :anomalies/incorrect
-                                                 (messages/t :fleet-sink.system/missing-url)
-                                                 {:opts safe-opts}))
+  ;; Missing-config throws are PROGRAMMER ERROR guards per standards
+  ;; rule 005 §programmer-error-guards: IllegalArgumentException is the
+  ;; rule-prescribed shape (not throw-anomaly! — that's for boundary
+  ;; namespaces, and `event-stream.sinks` is not one). The constructor
+  ;; has no return-value channel to surface an anomaly map without
+  ;; breaking caller expectations of a callable sink.
+  (let [url         (or (:url opts)
+                        (throw (IllegalArgumentException.
+                                 (messages/t :fleet-sink.system/missing-url))))
         api-key          (or (:api-key opts)
-                             (response/throw-anomaly! :anomalies/incorrect
-                                                      (messages/t :fleet-sink.system/missing-api-key)
-                                                      {:opts safe-opts}))
+                             (throw (IllegalArgumentException.
+                                      (messages/t :fleet-sink.system/missing-api-key))))
         batch-size       (:batch-size opts 10)
         flush-interval-ms (:flush-interval-ms opts 5000)
         timeout-ms       (:timeout-ms opts 10000)

--- a/components/event-stream/test/ai/miniforge/event_stream/anomaly/sinks_anomaly_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/anomaly/sinks_anomaly_test.clj
@@ -17,13 +17,15 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.event-stream.anomaly.sinks-anomaly-test
-  "Coverage for `sinks/fleet-sink` and `sinks/create-sink` boundary
-   escalation via `response/throw-anomaly!`.
+  "Coverage for `sinks/fleet-sink` and `sinks/create-sink` configuration
+   validation.
 
-   Configuration validation surfaces as anomalies in `ex-data` rather
-   than ad-hoc throws. Fleet-sink without `:url` → `:anomalies/incorrect`;
-   unknown sink-type in `create-sink` → `:anomalies/unsupported`;
-   non-map non-vector sink-config → `:anomalies/incorrect`."
+   `fleet-sink` constructor validation surfaces as IllegalArgumentException
+   per standards rule 005 §programmer-error-guards (a missing required
+   :url / :api-key is a programmer error, not a runtime anomaly to be
+   recovered from). `create-sink`'s unknown-type / invalid-config paths
+   still throw via `response/throw-anomaly!` because they predate this
+   PR; flagging for opportunistic cleanup per rule 211."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.event-stream.sinks :as sinks])
@@ -32,11 +34,19 @@
 
 ;------------------------------------------------------------------------------ fleet-sink missing :url
 
-(deftest fleet-sink-missing-url-throws-anomaly
-  (testing "fleet-sink without :url raises :anomalies/incorrect"
-    (is (thrown-with-msg? ExceptionInfo
+(deftest fleet-sink-missing-url-rejects-config
+  (testing "fleet-sink without :url throws IllegalArgumentException
+            (programmer-error guard per rule 005)"
+    (is (thrown-with-msg? IllegalArgumentException
                           #"Fleet sink requires :url"
                           (sinks/fleet-sink {:api-key "k"})))))
+
+(deftest fleet-sink-missing-api-key-rejects-config
+  (testing "fleet-sink without :api-key throws IllegalArgumentException
+            (programmer-error guard per rule 005)"
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"Fleet sink requires :api-key"
+                          (sinks/fleet-sink {:url "https://fleet.example.com"})))))
 
 ;------------------------------------------------------------------------------ create-sink unknown type
 

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -377,18 +377,22 @@
     (is (fn? (sinks/fleet-sink {:url "https://fleet.example.com"
                                 :api-key "test-key"}))))
 
-  (testing "batches events according to batch-size"
-    (let [sink (sinks/fleet-sink {:url "https://fleet.example.com"
-                                  :batch-size 3
-                                  :flush-interval-ms 999999})]
-      ;; Should accept events without throwing
+  (testing "batches events and POSTs on flush"
+    (let [posted      (atom nil)
+          mock-resp   (reify java.net.http.HttpResponse
+                        (statusCode [_] 200))
+          mock-client (proxy [java.net.http.HttpClient] []
+                        (send [_req _handler]
+                          (reset! posted true)
+                          mock-resp))
+          sink (sinks/fleet-sink {:url              "https://fleet.example.com"
+                                  :batch-size        3
+                                  :flush-interval-ms 999999
+                                  :http-client       mock-client})]
       (sink (sample-event))
       (sink (sample-event))
-      ;; Third event should trigger a flush attempt
       (sink (sample-event))
-      ;; No assertions on HTTP call since it's stubbed,
-      ;; but verify it doesn't throw
-      (is true))))
+      (is (true? @posted) "flush sends an HTTP POST on batch-size trigger"))))
 
 ;------------------------------------------------------------------------------ Layer 1b
 ;; file-sink error reporting

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -373,7 +373,12 @@
   (testing "requires :url option"
     (is (thrown? Exception (sinks/fleet-sink {}))))
 
-  (testing "creates a function when url is provided"
+  (testing "requires :api-key option"
+    (is (thrown? Exception
+                 (sinks/fleet-sink {:url "https://fleet.example.com"}))
+        "missing :api-key must fail loud at construction so misconfiguration doesn't produce 401 noise at flush time"))
+
+  (testing "creates a function when url and api-key are provided"
     (is (fn? (sinks/fleet-sink {:url "https://fleet.example.com"
                                 :api-key "test-key"}))))
 
@@ -381,11 +386,30 @@
     (let [posted      (atom nil)
           mock-resp   (reify java.net.http.HttpResponse
                         (statusCode [_] 200))
+          ;; `java.net.http.HttpClient` is an abstract class with many
+          ;; abstract methods beyond `send`. Stub the most common ones
+          ;; with safe defaults so an accidental future call from the sink
+          ;; doesn't throw AbstractMethodError. Only `send` matters for
+          ;; the assertion below.
           mock-client (proxy [java.net.http.HttpClient] []
                         (send [_req _handler]
                           (reset! posted true)
-                          mock-resp))
+                          mock-resp)
+                        (sendAsync
+                          ([_req _handler]
+                           (java.util.concurrent.CompletableFuture/completedFuture mock-resp))
+                          ([_req _handler _push]
+                           (java.util.concurrent.CompletableFuture/completedFuture mock-resp)))
+                        (cookieHandler [] (java.util.Optional/empty))
+                        (connectTimeout [] (java.util.Optional/empty))
+                        (followRedirects [] java.net.http.HttpClient$Redirect/NORMAL)
+                        (sslContext [] (javax.net.ssl.SSLContext/getDefault))
+                        (sslParameters [] (javax.net.ssl.SSLParameters.))
+                        (authenticator [] (java.util.Optional/empty))
+                        (version [] java.net.http.HttpClient$Version/HTTP_2)
+                        (executor [] (java.util.Optional/empty)))
           sink (sinks/fleet-sink {:url              "https://fleet.example.com"
+                                  :api-key           "test-key"
                                   :batch-size        3
                                   :flush-interval-ms 999999
                                   :http-client       mock-client})]

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -24,7 +24,8 @@
    [clojure.string :as str]
    [clojure.edn :as edn]
    [cognitect.transit :as transit]
-   [ai.miniforge.event-stream.sinks :as sinks]))
+   [ai.miniforge.event-stream.sinks :as sinks]
+   [ai.miniforge.event-stream.test-helpers.http-mock :as http-mock]))
 
 ;------------------------------------------------------------------------------ Helpers
 
@@ -58,30 +59,10 @@
   (when (.isDirectory dir)
     (vec (.listFiles dir))))
 
-(defn mock-http-client
-  "Construct a minimal `HttpClient` stub for tests.
-   `send-fn` is called as `(send-fn req handler)` and must return an
-   `HttpResponse`; defaults to a 200 no-op.  All other abstract methods
-   return safe defaults so accidental calls don't throw AbstractMethodError."
-  [& [send-fn]]
-  (let [default-resp (reify java.net.http.HttpResponse
-                       (statusCode [_] 200))
-        f            (or send-fn (fn [_req _handler] default-resp))]
-    (proxy [java.net.http.HttpClient] []
-      (send [req handler] (f req handler))
-      (sendAsync
-        ([req handler]
-         (java.util.concurrent.CompletableFuture/completedFuture (f req handler)))
-        ([req handler _push]
-         (java.util.concurrent.CompletableFuture/completedFuture (f req handler))))
-      (cookieHandler   [] (java.util.Optional/empty))
-      (connectTimeout  [] (java.util.Optional/empty))
-      (followRedirects [] java.net.http.HttpClient$Redirect/NORMAL)
-      (sslContext      [] (javax.net.ssl.SSLContext/getDefault))
-      (sslParameters   [] (javax.net.ssl.SSLParameters.))
-      (authenticator   [] (java.util.Optional/empty))
-      (version         [] java.net.http.HttpClient$Version/HTTP_2)
-      (executor        [] (java.util.Optional/empty)))))
+;; `mock-http-client` lives in the shared
+;; `ai.miniforge.event-stream.test-helpers.http-mock` namespace so other
+;; sink tests can reuse the same proxy stubs without re-implementing
+;; HttpClient's ~10 abstract methods.
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; workflow-dir / event-file-path normalisation
@@ -409,7 +390,7 @@
 
   (testing "batches events and POSTs on flush"
     (let [posted      (atom nil)
-          mock-client (mock-http-client
+          mock-client (http-mock/mock-http-client
                        (fn [_req _handler]
                          (reset! posted true)
                          (reify java.net.http.HttpResponse

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -58,6 +58,31 @@
   (when (.isDirectory dir)
     (vec (.listFiles dir))))
 
+(defn mock-http-client
+  "Construct a minimal `HttpClient` stub for tests.
+   `send-fn` is called as `(send-fn req handler)` and must return an
+   `HttpResponse`; defaults to a 200 no-op.  All other abstract methods
+   return safe defaults so accidental calls don't throw AbstractMethodError."
+  [& [send-fn]]
+  (let [default-resp (reify java.net.http.HttpResponse
+                       (statusCode [_] 200))
+        f            (or send-fn (fn [_req _handler] default-resp))]
+    (proxy [java.net.http.HttpClient] []
+      (send [req handler] (f req handler))
+      (sendAsync
+        ([req handler]
+         (java.util.concurrent.CompletableFuture/completedFuture (f req handler)))
+        ([req handler _push]
+         (java.util.concurrent.CompletableFuture/completedFuture (f req handler))))
+      (cookieHandler   [] (java.util.Optional/empty))
+      (connectTimeout  [] (java.util.Optional/empty))
+      (followRedirects [] java.net.http.HttpClient$Redirect/NORMAL)
+      (sslContext      [] (javax.net.ssl.SSLContext/getDefault))
+      (sslParameters   [] (javax.net.ssl.SSLParameters.))
+      (authenticator   [] (java.util.Optional/empty))
+      (version         [] java.net.http.HttpClient$Version/HTTP_2)
+      (executor        [] (java.util.Optional/empty)))))
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; workflow-dir / event-file-path normalisation
 
@@ -384,30 +409,11 @@
 
   (testing "batches events and POSTs on flush"
     (let [posted      (atom nil)
-          mock-resp   (reify java.net.http.HttpResponse
-                        (statusCode [_] 200))
-          ;; `java.net.http.HttpClient` is an abstract class with many
-          ;; abstract methods beyond `send`. Stub the most common ones
-          ;; with safe defaults so an accidental future call from the sink
-          ;; doesn't throw AbstractMethodError. Only `send` matters for
-          ;; the assertion below.
-          mock-client (proxy [java.net.http.HttpClient] []
-                        (send [_req _handler]
-                          (reset! posted true)
-                          mock-resp)
-                        (sendAsync
-                          ([_req _handler]
-                           (java.util.concurrent.CompletableFuture/completedFuture mock-resp))
-                          ([_req _handler _push]
-                           (java.util.concurrent.CompletableFuture/completedFuture mock-resp)))
-                        (cookieHandler [] (java.util.Optional/empty))
-                        (connectTimeout [] (java.util.Optional/empty))
-                        (followRedirects [] java.net.http.HttpClient$Redirect/NORMAL)
-                        (sslContext [] (javax.net.ssl.SSLContext/getDefault))
-                        (sslParameters [] (javax.net.ssl.SSLParameters.))
-                        (authenticator [] (java.util.Optional/empty))
-                        (version [] java.net.http.HttpClient$Version/HTTP_2)
-                        (executor [] (java.util.Optional/empty)))
+          mock-client (mock-http-client
+                       (fn [_req _handler]
+                         (reset! posted true)
+                         (reify java.net.http.HttpResponse
+                           (statusCode [_] 200))))
           sink (sinks/fleet-sink {:url              "https://fleet.example.com"
                                   :api-key           "test-key"
                                   :batch-size        3

--- a/components/event-stream/test/ai/miniforge/event_stream/test_helpers/http_mock.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/test_helpers/http_mock.clj
@@ -1,0 +1,51 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.test-helpers.http-mock
+  "Shared `java.net.http.HttpClient` stub for sink tests.
+
+   Extracted from sinks_test.clj so the test file stays focused on
+   assertions, and so other sink tests (e.g. a future
+   logging/fleet-sink_test) can reuse the same stub shape.")
+
+(defn mock-http-client
+  "Construct a minimal `HttpClient` stub for tests.
+   `send-fn` is called as `(send-fn req handler)` and must return an
+   `HttpResponse`; defaults to a 200 no-op.  All other abstract methods
+   return safe defaults so accidental calls don't throw
+   `AbstractMethodError` (java.net.http.HttpClient has ~10 abstract
+   methods beyond `send`)."
+  [& [send-fn]]
+  (let [default-resp (reify java.net.http.HttpResponse
+                       (statusCode [_] 200))
+        f            (or send-fn (fn [_req _handler] default-resp))]
+    (proxy [java.net.http.HttpClient] []
+      (send [req handler] (f req handler))
+      (sendAsync
+        ([req handler]
+         (java.util.concurrent.CompletableFuture/completedFuture (f req handler)))
+        ([req handler _push]
+         (java.util.concurrent.CompletableFuture/completedFuture (f req handler))))
+      (cookieHandler   [] (java.util.Optional/empty))
+      (connectTimeout  [] (java.util.Optional/empty))
+      (followRedirects [] java.net.http.HttpClient$Redirect/NORMAL)
+      (sslContext      [] (javax.net.ssl.SSLContext/getDefault))
+      (sslParameters   [] (javax.net.ssl.SSLParameters.))
+      (authenticator   [] (java.util.Optional/empty))
+      (version         [] java.net.http.HttpClient$Version/HTTP_2)
+      (executor        [] (java.util.Optional/empty)))))

--- a/components/logging/deps.edn
+++ b/components/logging/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}}
+ :deps {ai.miniforge/config     {:local/root "../config"}
+        cheshire/cheshire        {:mvn/version "5.13.0"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/logging/deps.edn
+++ b/components/logging/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/config     {:local/root "../config"}
+        ai.miniforge/messages    {:local/root "../messages"}
         cheshire/cheshire        {:mvn/version "5.13.0"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/logging/deps.edn
+++ b/components/logging/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/config     {:local/root "../config"}
         ai.miniforge/messages    {:local/root "../messages"}
-        cheshire/cheshire        {:mvn/version "5.13.0"}}
+        cheshire/cheshire        {:mvn/version "5.13.0"}
+        slingshot/slingshot      {:mvn/version "0.12.2"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/logging/resources/config/logging/messages/en-US.edn
+++ b/components/logging/resources/config/logging/messages/en-US.edn
@@ -1,0 +1,19 @@
+{:logging/messages
+ {;; Fleet sink — operator-internal strings (system-locale, never
+  ;; user-localized, but routed through the catalog so we have one place
+  ;; to audit and change them). Mirrors the pattern in workflow's
+  ;; en-US.edn under :dag.merge.system/*.
+  :fleet-sink.system/missing-url
+  "Fleet sink requires :url"
+
+  :fleet-sink.system/missing-api-key
+  "Fleet sink requires :api-key"
+
+  :fleet-sink.system/http-error
+  "fleet-sink: POST {url} returned HTTP {status}"
+
+  :fleet-sink.system/interrupted
+  "fleet-sink: interrupted during flush: {error}"
+
+  :fleet-sink.system/flush-error
+  "fleet-sink: flush error: {error}"}}

--- a/components/logging/src/ai/miniforge/logging/http.clj
+++ b/components/logging/src/ai/miniforge/logging/http.clj
@@ -1,0 +1,43 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.logging.http
+  "JDK `java.net.http` request-builder helper shared by the fleet sinks.
+
+   Lives in the `logging` brick because that's the most semantically
+   aligned existing brick (the fleet sink IS a logging concern) and the
+   `event-stream` brick already depends on `logging`. Promote to a
+   dedicated `http-utils` brick if a third consumer outside the
+   sink-layer arrives."
+  (:import
+   [java.net URI]
+   [java.net.http HttpRequest HttpRequest$BodyPublishers]
+   [java.time Duration]))
+
+(defn build-json-post
+  "Build an HTTP POST request with a JSON string `body` and a Bearer
+   `api-key` header. `timeout-ms` sets the request-level timeout via
+   `HttpRequest.Builder.timeout`."
+  [uri body api-key timeout-ms]
+  (-> (HttpRequest/newBuilder)
+      (.uri (URI/create uri))
+      (.timeout (Duration/ofMillis timeout-ms))
+      (.header "Authorization" (str "Bearer " api-key))
+      (.header "Content-Type" "application/json")
+      (.POST (HttpRequest$BodyPublishers/ofString body))
+      (.build)))

--- a/components/logging/src/ai/miniforge/logging/interface.clj
+++ b/components/logging/src/ai/miniforge/logging/interface.clj
@@ -18,9 +18,14 @@
 
 (ns ai.miniforge.logging.interface
   "Public API for structured EDN logging.
-   Provides logger creation, context management, and level-specific log functions."
+   Provides logger creation, context management, and level-specific log
+   functions, plus the small HTTP-request-builder helper the fleet sink
+   uses (and that event-stream's fleet sink imports — extracted here to
+   avoid duplication; promote to a dedicated http-utils brick if a third
+   consumer arrives)."
   (:require
-   [ai.miniforge.logging.core :as core]))
+   [ai.miniforge.logging.core :as core]
+   [ai.miniforge.logging.http :as http]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Logger creation and configuration
@@ -160,6 +165,17 @@
        (do-expensive-work))"
   [logger level category event & body]
   `(timed ~logger ~level ~category ~event (fn [] ~@body)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; HTTP request builder — used by both the in-brick fleet sink and the
+;; event-stream fleet sink. Pass-through to `ai.miniforge.logging.http`.
+
+(defn build-json-post
+  "Build a `java.net.http.HttpRequest` POST with a JSON-string `body`
+   and a Bearer `api-key` header. `timeout-ms` sets the request-level
+   timeout. Used by every fleet-style HTTP sink (logging + event-stream)."
+  [uri body api-key timeout-ms]
+  (http/build-json-post uri body api-key timeout-ms))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/logging/src/ai/miniforge/logging/messages.clj
+++ b/components/logging/src/ai/miniforge/logging/messages.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.logging.messages
+  "Component-level message catalog for logging.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a logging message by key, with optional param substitution."
+  (messages/create-translator "config/logging/messages/en-US.edn"
+                              :logging/messages))

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -30,7 +30,8 @@
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [ai.miniforge.logging.core :as core])
+   [ai.miniforge.logging.core :as core]
+   [ai.miniforge.logging.messages :as messages])
   (:import
    [java.net URI]
    [java.net.http HttpClient HttpRequest HttpRequest$BodyPublishers HttpResponse$BodyHandlers]
@@ -155,9 +156,10 @@
 
    Returns: Sink function (fn [log-entry] -> nil)"
   [opts]
-  (let [url               (or (:url opts) (throw (ex-info "Fleet sink requires :url" {})))
+  (let [url               (or (:url opts)
+                              (throw (ex-info (messages/t :fleet-sink.system/missing-url) {})))
         api-key           (or (:api-key opts)
-                              (throw (ex-info "Fleet sink requires :api-key" {})))
+                              (throw (ex-info (messages/t :fleet-sink.system/missing-api-key) {})))
         batch-size        (:batch-size opts 50)
         flush-interval-ms (:flush-interval-ms opts 10000)
         timeout-ms        (:timeout-ms opts 10000)
@@ -185,16 +187,19 @@
                           response (.send http-client request (HttpResponse$BodyHandlers/discarding))]
                       (when (>= (.statusCode response) 400)
                         (binding [*out* *err*]
-                          (println (str "fleet-sink: POST " url "/logs returned HTTP "
-                                        (.statusCode response))))))
+                          (println (messages/t :fleet-sink.system/http-error
+                                               {:url    (str url "/logs")
+                                                :status (.statusCode response)})))))
                     (catch InterruptedException e
                       ;; Preserve interrupt semantics for callers.
                       (.interrupt (Thread/currentThread))
                       (binding [*out* *err*]
-                        (println "fleet-sink: interrupted during flush:" (ex-message e))))
+                        (println (messages/t :fleet-sink.system/interrupted
+                                             {:error (ex-message e)}))))
                     (catch Exception e
                       (binding [*out* *err*]
-                        (println "fleet-sink: flush error:" (ex-message e))))
+                        (println (messages/t :fleet-sink.system/flush-error
+                                             {:error (ex-message e)}))))
                     (finally
                       (reset! last-flush-atom (System/currentTimeMillis)))))))]
 

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -27,9 +27,14 @@
    - :multi  - Combine multiple sinks"
   (:require
    [ai.miniforge.config.interface :as config]
+   [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [ai.miniforge.logging.core :as core]))
+   [ai.miniforge.logging.core :as core])
+  (:import
+   [java.net URI]
+   [java.net.http HttpClient HttpRequest HttpRequest$BodyPublishers HttpResponse$BodyHandlers]
+   [java.time Duration]))
 
 ;;------------------------------------------------------------------------------ Layer 0: File Sink
 
@@ -145,28 +150,42 @@
      Optional:
        :batch-size - Number of logs to batch (default 50)
        :flush-interval-ms - Max time before flushing (default 10000)
+       :timeout-ms - HTTP timeout in ms (default 10000)
+       :http-client - java.net.http.HttpClient instance (default: HttpClient/newHttpClient)
 
    Returns: Sink function (fn [log-entry] -> nil)"
   [opts]
-  (let [_url (or (:url opts) (throw (ex-info "Fleet sink requires :url" {})))
-        _api-key (:api-key opts)
-        batch-size (:batch-size opts 50)
+  (let [url               (or (:url opts) (throw (ex-info "Fleet sink requires :url" {})))
+        api-key           (:api-key opts)
+        batch-size        (:batch-size opts 50)
         flush-interval-ms (:flush-interval-ms opts 10000)
-        batch-atom (atom [])
-        last-flush-atom (atom (System/currentTimeMillis))]
+        timeout-ms        (:timeout-ms opts 10000)
+        http-client       (or (:http-client opts) (HttpClient/newHttpClient))
+        batch-atom        (atom [])
+        last-flush-atom   (atom (System/currentTimeMillis))]
 
     (letfn [(flush-batch! []
               (let [logs @batch-atom]
                 (when (seq logs)
                   (try
-                    ;; TODO: Implement HTTP POST to fleet command
-                    ;; (http/post (str _url "/logs")
-                    ;;            {:headers {"Authorization" (str "Bearer " _api-key)}
-                    ;;             :body (json/generate-string {:logs logs})})
-                    (reset! batch-atom [])
-                    (reset! last-flush-atom (System/currentTimeMillis))
-                    (catch Exception _e
-                      nil)))))]
+                    (let [body    (json/generate-string {:logs logs})
+                          request (-> (HttpRequest/newBuilder)
+                                      (.uri (URI/create (str url "/logs")))
+                                      (.timeout (Duration/ofMillis timeout-ms))
+                                      (.header "Authorization" (str "Bearer " api-key))
+                                      (.header "Content-Type" "application/json")
+                                      (.POST (HttpRequest$BodyPublishers/ofString body))
+                                      (.build))
+                          response (.send http-client request (HttpResponse$BodyHandlers/discarding))]
+                      (when (>= (.statusCode response) 400)
+                        (binding [*out* *err*]
+                          (println (str "fleet-sink: POST " url "/logs returned HTTP "
+                                        (.statusCode response))))))
+                    (catch Exception e
+                      (binding [*out* *err*]
+                        (println "fleet-sink: flush error:" (ex-message e)))))
+                  (reset! batch-atom [])
+                  (reset! last-flush-atom (System/currentTimeMillis)))))]
 
       (fn [entry]
         (swap! batch-atom conj entry)

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -156,10 +156,17 @@
 
    Returns: Sink function (fn [log-entry] -> nil)"
   [opts]
+  ;; Missing-config throws are PROGRAMMER ERROR guards per standards
+  ;; rule 005 §programmer-error-guards: IllegalArgumentException is the
+  ;; rule-prescribed shape (not ex-info, not throw-anomaly!) because the
+  ;; constructor has no return-value channel to surface an anomaly map
+  ;; without breaking caller expectations of a callable sink.
   (let [url               (or (:url opts)
-                              (throw (ex-info (messages/t :fleet-sink.system/missing-url) {})))
+                              (throw (IllegalArgumentException.
+                                       (messages/t :fleet-sink.system/missing-url))))
         api-key           (or (:api-key opts)
-                              (throw (ex-info (messages/t :fleet-sink.system/missing-api-key) {})))
+                              (throw (IllegalArgumentException.
+                                       (messages/t :fleet-sink.system/missing-api-key))))
         batch-size        (:batch-size opts 50)
         flush-interval-ms (:flush-interval-ms opts 10000)
         timeout-ms        (:timeout-ms opts 10000)

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -156,7 +156,8 @@
    Returns: Sink function (fn [log-entry] -> nil)"
   [opts]
   (let [url               (or (:url opts) (throw (ex-info "Fleet sink requires :url" {})))
-        api-key           (:api-key opts)
+        api-key           (or (:api-key opts)
+                              (throw (ex-info "Fleet sink requires :api-key" {})))
         batch-size        (:batch-size opts 50)
         flush-interval-ms (:flush-interval-ms opts 10000)
         timeout-ms        (:timeout-ms opts 10000)
@@ -165,7 +166,12 @@
         last-flush-atom   (atom (System/currentTimeMillis))]
 
     (letfn [(flush-batch! []
-              (let [logs @batch-atom]
+              ;; Atomically drain the batch so concurrent senders don't race
+              ;; on @batch-atom + reset!. swap-vals! returns [prev new] —
+              ;; first prev = the snapshot we own. Events appended while
+              ;; the HTTP call is in flight go into the FRESH atom value
+              ;; and are picked up by the next flush.
+              (let [logs (first (swap-vals! batch-atom (constantly [])))]
                 (when (seq logs)
                   (try
                     (let [body    (json/generate-string {:logs logs})
@@ -181,11 +187,16 @@
                         (binding [*out* *err*]
                           (println (str "fleet-sink: POST " url "/logs returned HTTP "
                                         (.statusCode response))))))
+                    (catch InterruptedException e
+                      ;; Preserve interrupt semantics for callers.
+                      (.interrupt (Thread/currentThread))
+                      (binding [*out* *err*]
+                        (println "fleet-sink: interrupted during flush:" (ex-message e))))
                     (catch Exception e
                       (binding [*out* *err*]
-                        (println "fleet-sink: flush error:" (ex-message e)))))
-                  (reset! batch-atom [])
-                  (reset! last-flush-atom (System/currentTimeMillis)))))]
+                        (println "fleet-sink: flush error:" (ex-message e))))
+                    (finally
+                      (reset! last-flush-atom (System/currentTimeMillis)))))))]
 
       (fn [entry]
         (swap! batch-atom conj entry)

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -31,12 +31,11 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.logging.core :as core]
+   [ai.miniforge.logging.http :as http]
    [ai.miniforge.logging.messages :as messages]
    [slingshot.slingshot :refer [try+]])
   (:import
-   [java.net URI]
-   [java.net.http HttpClient HttpRequest HttpRequest$BodyPublishers HttpResponse$BodyHandlers]
-   [java.time Duration]))
+   [java.net.http HttpClient HttpResponse$BodyHandlers]))
 
 ;;------------------------------------------------------------------------------ Layer 0: File Sink
 
@@ -142,17 +141,6 @@
 
 ;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
 
-(defn- build-json-post
-  "Build an HTTP POST request with a JSON string body and Bearer auth header."
-  [uri body api-key timeout-ms]
-  (-> (HttpRequest/newBuilder)
-      (.uri (URI/create uri))
-      (.timeout (Duration/ofMillis timeout-ms))
-      (.header "Authorization" (str "Bearer " api-key))
-      (.header "Content-Type" "application/json")
-      (.POST (HttpRequest$BodyPublishers/ofString body))
-      (.build)))
-
 (defn fleet-sink
   "Create a fleet sink that sends logs to fleet command via HTTP.
 
@@ -193,7 +181,7 @@
                   ;; and are migrated opportunistically (211 §migration).
                   (try+
                     (let [body     (json/generate-string {:logs logs})
-                          request  (build-json-post (str url "/logs") body api-key timeout-ms)
+                          request  (http/build-json-post (str url "/logs") body api-key timeout-ms)
                           response (.send http-client request (HttpResponse$BodyHandlers/discarding))]
                       (when (>= (.statusCode response) 400)
                         (binding [*out* *err*]

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -31,7 +31,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.logging.core :as core]
-   [ai.miniforge.logging.messages :as messages])
+   [ai.miniforge.logging.messages :as messages]
+   [slingshot.slingshot :refer [try+]])
   (:import
    [java.net URI]
    [java.net.http HttpClient HttpRequest HttpRequest$BodyPublishers HttpResponse$BodyHandlers]
@@ -186,7 +187,11 @@
               ;; and are picked up by the next flush.
               (let [logs (first (swap-vals! batch-atom (constantly [])))]
                 (when (seq logs)
-                  (try
+                  ;; try+ per standards rule 211 — boundary catch around
+                  ;; Java HttpClient.send. The component's other plain
+                  ;; `try` sites (file write, mkdirs) predate this rule
+                  ;; and are migrated opportunistically (211 §migration).
+                  (try+
                     (let [body     (json/generate-string {:logs logs})
                           request  (build-json-post (str url "/logs") body api-key timeout-ms)
                           response (.send http-client request (HttpResponse$BodyHandlers/discarding))]

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -141,6 +141,17 @@
 
 ;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
 
+(defn- build-json-post
+  "Build an HTTP POST request with a JSON string body and Bearer auth header."
+  [uri body api-key timeout-ms]
+  (-> (HttpRequest/newBuilder)
+      (.uri (URI/create uri))
+      (.timeout (Duration/ofMillis timeout-ms))
+      (.header "Authorization" (str "Bearer " api-key))
+      (.header "Content-Type" "application/json")
+      (.POST (HttpRequest$BodyPublishers/ofString body))
+      (.build)))
+
 (defn fleet-sink
   "Create a fleet sink that sends logs to fleet command via HTTP.
 
@@ -176,14 +187,8 @@
               (let [logs (first (swap-vals! batch-atom (constantly [])))]
                 (when (seq logs)
                   (try
-                    (let [body    (json/generate-string {:logs logs})
-                          request (-> (HttpRequest/newBuilder)
-                                      (.uri (URI/create (str url "/logs")))
-                                      (.timeout (Duration/ofMillis timeout-ms))
-                                      (.header "Authorization" (str "Bearer " api-key))
-                                      (.header "Content-Type" "application/json")
-                                      (.POST (HttpRequest$BodyPublishers/ofString body))
-                                      (.build))
+                    (let [body     (json/generate-string {:logs logs})
+                          request  (build-json-post (str url "/logs") body api-key timeout-ms)
                           response (.send http-client request (HttpResponse$BodyHandlers/discarding))]
                       (when (>= (.statusCode response) 400)
                         (binding [*out* *err*]


### PR DESCRIPTION
## Problem

Both `event-stream/sinks` and `logging/sinks` had a `fleet-sink` that required a `:url` (threw on construction if absent) but then **silently discarded every event on flush** — the HTTP POST was a TODO comment and the batch atom was reset unconditionally without any delivery. Any observability pipeline configured with `:fleet` appeared healthy while all telemetry was lost.

Concretely:
- `event-stream/sinks.clj:371` — POST commented out, batch cleared, exception swallowed to `nil`
- `logging/sinks.clj:162` — same pattern in the logging fleet-sink

## Fix

Implement the HTTP POST using the JDK 11+ `java.net.http.HttpClient` (no new runtime deps needed; cheshire already in `event-stream` deps, added to `logging` deps for JSON body serialization).

**event-stream/sinks.clj** and **logging/sinks.clj**:
- `HttpClient` created once per sink instance (outer `let`), not per flush
- Batch is drained **outside** the try/catch — always clears on flush (prevents unbounded atom growth on repeated network failure)
- HTTP 4xx/5xx status logged to stderr; transport exceptions caught and logged instead of swallowed
- Optional `:http-client` opts key for test injection without network calls

**event-stream/sinks_test.clj**:
- Replaces the "no assertions since it's stubbed" test with one that injects a `proxy`/`reify` mock client and asserts the POST is actually invoked on a batch-size trigger

## Test plan

- [ ] `bb poly:check` — workspace structure OK
- [ ] `bb test` — event-stream and logging test suites green
- [ ] `bb lint:clj` — no new warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCCZ821WLkG4SXBxAHqgTA)_