### PR TITLE
workflow: add :phase/terminal-fail to bypass :on-fail on terminal markers

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -275,6 +275,22 @@
   (when (phase/redirect-requested? phase-result)
     (phase/transition-target phase-result)))
 
+(defn- terminal-failure?
+  "True when the phase result carries a terminal-failure marker — the phase
+   decided that no amount of further on-fail redirects can make progress
+   (review stagnation; convergence-cap :needs-decomposition). These are
+   distinct from ordinary failure: they MUST bypass `:on-fail`.
+
+   Pre-`:phase/terminal-fail`, setting `:stagnated?` or
+   `:needs-decomposition?` was effectively dead code — the FSM saw
+   `:phase/fail` and followed `:on-fail :implement`, so the review→implement
+   loop burned until `max-redirects` exhaustion regardless. Validated in the
+   2026-05-28 dogfood: convergence cap fired at review #3 but the workflow
+   ran a 4th implement+verify+review cycle anyway."
+  [phase-result]
+  (or (:stagnated? phase-result)
+      (:needs-decomposition? phase-result)))
+
 (defn determine-phase-event
   "Translate a phase result into an execution-machine event."
   [_phase-config phase-result]
@@ -285,6 +301,11 @@
 
       (phase/already-done? phase-result)
       :phase/already-done
+
+      ;; Terminal failure markers must beat the on-fail redirect; check
+      ;; before the redirect branches.
+      (and (phase/failed? phase-result) (terminal-failure? phase-result))
+      :phase/terminal-fail
 
       (phase/succeeded? phase-result)
       :phase/succeed

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -233,6 +233,14 @@
             :phase/succeed success-target
             :phase/already-done already-done-target
             :phase/fail failure-target
+            ;; Terminal failure event: bypasses `:on-fail` and routes
+            ;; straight to `:failed`. Used by phases that have decided the
+            ;; only forward path is escalation (e.g. review stagnation, the
+            ;; convergence-cap :needs-decomposition signal) — without this,
+            ;; setting `:stagnated?` / `:needs-decomposition?` on the phase
+            ;; result is dead code: the FSM still follows on-fail and the
+            ;; review→implement loop burns until `max-redirects`.
+            :phase/terminal-fail :failed
             :pause paused-state-id
             :cancel :cancelled
             :fail :failed

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -244,6 +244,34 @@
       (is (= :verify (fsm/current-phase-id machine s6)))
       (is (= :done (fsm/current-phase-id machine s7))))))
 
+(deftest phase-terminal-fail-bypasses-on-fail-redirect-test
+  (testing ":phase/terminal-fail routes straight to :failed even when the
+            phase has :on-fail configured — this is the whole point of the
+            event. :phase/fail on the same phase follows :on-fail to
+            :implement; :phase/terminal-fail must NOT."
+    (let [workflow {:workflow/id :terminal-fail-test
+                    :workflow/pipeline [{:phase :plan}
+                                        {:phase :implement}
+                                        {:phase :verify}
+                                        {:phase :review :on-fail :implement}
+                                        {:phase :done}]}
+          machine (fsm/compile-execution-machine workflow)
+          at-review (->> (fsm/initialize-execution machine)
+                         (fsm/start-execution machine)
+                         (#(fsm/transition-execution machine % :phase/succeed))   ; plan→implement
+                         (#(fsm/transition-execution machine % :phase/succeed))   ; implement→verify
+                         (#(fsm/transition-execution machine % :phase/succeed)))] ; verify→review
+      (is (= :review (fsm/current-phase-id machine at-review))
+          "fixture parks the FSM at :review so on-fail behavior is observable")
+      (testing ":phase/fail at :review follows on-fail back to :implement (baseline)"
+        (let [after-fail (fsm/transition-execution machine at-review :phase/fail)]
+          (is (= :implement (fsm/current-phase-id machine after-fail))
+              "baseline confirmed — :phase/fail honors :on-fail")))
+      (testing ":phase/terminal-fail at :review goes straight to :failed"
+        (let [after-terminal (fsm/transition-execution machine at-review :phase/terminal-fail)]
+          (is (= :failed (fsm/execution-status machine after-terminal))
+              "terminal-fail MUST bypass :on-fail and land in :failed"))))))
+
 (deftest compiled-execution-machine-reachability-test
   (let [workflow {:workflow/id :test
                   :workflow/pipeline [{:phase :plan}

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -91,6 +91,27 @@
     (is (= :phase/fail
            (exec/determine-phase-event {} {:status :failed})))))
 
+(deftest determine-phase-event-stagnated-emits-terminal-fail
+  (testing "a failed result tagged :stagnated? produces :phase/terminal-fail —
+            this MUST beat the on-fail redirect (review→implement) so a
+            repair loop that has stopped making progress actually terminates"
+    (is (= :phase/terminal-fail
+           (exec/determine-phase-event {} {:status :failed :stagnated? true})))
+    ;; Even when a redirect was also requested (shouldn't happen in
+    ;; practice, but be defensive), terminal-fail still wins.
+    (let [with-redirect (phase-result/request-redirect
+                          {:status :failed :stagnated? true} :implement)]
+      (is (= :phase/terminal-fail
+             (exec/determine-phase-event {} with-redirect))
+          "stagnated? must trump redirect-requested?"))))
+
+(deftest determine-phase-event-needs-decomposition-emits-terminal-fail
+  (testing "the convergence-cap signal `:needs-decomposition?` produces
+            :phase/terminal-fail — without this the cap is dead code because
+            :phase/fail follows :on-fail back to :implement"
+    (is (= :phase/terminal-fail
+           (exec/determine-phase-event {} {:status :failed :needs-decomposition? true})))))
+
 (deftest determine-phase-event-catchall-defaults-to-succeed
   (testing "an unrecognised status falls through to :phase/succeed (catch-all branch)"
     ;; This branch is the safety net for results whose status doesn't


### PR DESCRIPTION
## Summary

- 2026-05-28 dogfood validated that the convergence cap in #1011 was dead code in production: cap set `:phase :needs-decomposition? true` on review #3 as designed, but the workflow ran a 4th implement+verify+review cycle anyway. Root cause: `determine-phase-event` emits `:phase/fail` for any failed phase result, FSM maps `:phase/fail` to the `:on-fail` target (review → `:implement`), and the `:stagnated?` / `:needs-decomposition?` flag bits are never read by the FSM at all.
- The stagnation guard had the same latent bug; rarely fires because identical-fingerprint repeats are rare.
- New `:phase/terminal-fail` event in the FSM, mapped directly to `:failed` (skips on-fail-index). `determine-phase-event` recognizes `:stagnated?` / `:needs-decomposition?` and emits the terminal event.

## Test plan

- [x] `clojure -M:poly test brick:workflow` — all 33 workflow brick tests green
- [x] phase-transitions-test: stagnated + needs-decomposition both produce `:phase/terminal-fail`; stagnated trumps a stray redirect request
- [x] fsm-test: at a `:review` phase with `:on-fail :implement` — `:phase/fail` follows on-fail (baseline), `:phase/terminal-fail` lands in `:failed`
- [ ] Re-run dogfood with this fix in to validate cap actually terminates the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)