### PR TITLE
feat(dag-executor): flip non-forest anomaly to canonical anomaly (W2 batch 3)

### DIFF
--- a/components/dag-executor/deps.edn
+++ b/components/dag-executor/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/config {:local/root "../config"}
         ai.miniforge/dag-primitives {:local/root "../dag-primitives"}
         ai.miniforge/task {:local/root "../task"}
         ai.miniforge/loop {:local/root "../loop"}

--- a/components/dag-executor/src/ai/miniforge/dag_executor/branch_registry.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/branch_registry.clj
@@ -45,7 +45,8 @@
    Layer 3: Multi-parent base resolution primitives (v2 — pure-data
             inputs to the orchestrator's git-using `merge-parent-branches!`).
             Helpers ship in 1A; orchestrator consumes them in 1B."
-  (:require [ai.miniforge.messages.interface :as messages]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.messages.interface :as messages]
             [clojure.string :as str])
   (:import (java.security MessageDigest)))
 
@@ -97,7 +98,19 @@
 ;; Resolution — dep set → base branch decision
 
 (def ^:private dag-non-forest-anomaly
+  "Canonical `:anomaly/subtype` keyword for the multi-parent / non-forest
+   anomaly emitted by this brick. Kept as the legacy `:anomalies/*`
+   namespace verbatim per the anomaly-convergence runbook (the legacy
+   category keyword IS the subtype after the W2 flip)."
   :anomalies/dag-non-forest)
+
+(def ^:private dag-non-forest-anomaly-type
+  "Generic `:anomaly/type` for non-forest anomalies. Per the
+   `docs/runbooks/anomaly-convergence.md` map,
+   `:anomalies/dag-non-forest` is one of the dag-executor's custom
+   subtypes that classifies as `:conflict` (the plan asserts a shape the
+   runtime cannot reconcile single-parent execution against)."
+  :conflict)
 
 (defn- non-forest-anomaly
   "Build the canonical anomaly map for a multi-parent task.
@@ -105,11 +118,19 @@
    Returned as data (not thrown) at the resolve boundary so the
    orchestrator can short-circuit the workflow with the same anomaly
    shape downstream consumers (evidence bundle, dashboard) already
-   expect from other anomaly emitters."
+   expect from other anomaly emitters.
+
+   W2 convergence: produces a canonical `ai.miniforge.anomaly` map with
+   `:anomaly/type :conflict` and the legacy category keyword preserved
+   verbatim as `:anomaly/subtype`. The multi-parent domain payload
+   (`:task/dependencies`) is flattened under `:anomaly/data` per the
+   batch-2 domain-flatten precedent (key name unchanged so telemetry
+   survives once consumers migrate their reads)."
   [task-deps]
-  {:anomaly/category dag-non-forest-anomaly
-   :anomaly/message  (t :resolve/multi-parent)
-   :task/dependencies (vec task-deps)})
+  (anomaly/sub-anomaly dag-non-forest-anomaly-type
+                       dag-non-forest-anomaly
+                       (t :resolve/multi-parent)
+                       {:task/dependencies (vec task-deps)}))
 
 (defn resolve-base-branch
   "Decide which branch a task's scratch worktree should be forked from.
@@ -142,10 +163,16 @@
 (defn resolve-error?
   "True for `resolve-base-branch` outputs that represent an anomaly rather
    than a usable branch name. Lets callers branch on the result without
-   coupling to the anomaly shape."
+   coupling to the anomaly shape.
+
+   Post-W2 the anomaly carries the legacy category keyword verbatim as
+   `:anomaly/subtype` on a canonical `ai.miniforge.anomaly` map; this
+   predicate reads the subtype directly. The producer is own-brick, so a
+   single-shape read is sufficient — no upstream-of-uncertain-shape
+   dual-predicate."
   [resolved]
   (and (map? resolved)
-       (= dag-non-forest-anomaly (:anomaly/category resolved))))
+       (= dag-non-forest-anomaly (:anomaly/subtype resolved))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Plan-time forest validation — reject non-forests before any task runs
@@ -181,9 +208,10 @@
   [tasks]
   (let [violations (multi-parent-tasks tasks)]
     (when (seq violations)
-      {:anomaly/category dag-non-forest-anomaly
-       :anomaly/message  (t :validate/multi-parent)
-       :multi-parent-tasks violations})))
+      (anomaly/sub-anomaly dag-non-forest-anomaly-type
+                           dag-non-forest-anomaly
+                           (t :validate/multi-parent)
+                           {:multi-parent-tasks violations}))))
 
 (defn forest?
   "Predicate form of `validate-forest`. True when the DAG is a forest."
@@ -346,7 +374,11 @@
   ;; => "main"  (single dep, not yet registered, falls back)
 
   (resolve-base-branch (create-registry) [:a :b] "main")
-  ;; => {:anomaly/category :anomalies/dag-non-forest ...}
+  ;; => {:anomaly/type :conflict
+  ;;     :anomaly/subtype :anomalies/dag-non-forest
+  ;;     :anomaly/message "..."
+  ;;     :anomaly/data {:task/dependencies [:a :b]}
+  ;;     :anomaly/at  #inst "..."}
 
   (validate-forest [{:task/id :a :task/dependencies []}
                     {:task/id :b :task/dependencies [:a]}
@@ -356,7 +388,12 @@
   (validate-forest [{:task/id :a :task/dependencies []}
                     {:task/id :b :task/dependencies [:a]}
                     {:task/id :c :task/dependencies [:a :b]}])
-  ;; => {:anomaly/category :anomalies/dag-non-forest
-  ;;     :multi-parent-tasks [{:task/id :c :dep-count 2 :dependencies [:a :b]}]}
+  ;; => {:anomaly/type :conflict
+  ;;     :anomaly/subtype :anomalies/dag-non-forest
+  ;;     :anomaly/message "..."
+  ;;     :anomaly/data
+  ;;       {:multi-parent-tasks
+  ;;          [{:task/id :c :dep-count 2 :dependencies [:a :b]}]}
+  ;;     :anomaly/at #inst "..."}
 
   :leave-this-here)

--- a/components/dag-executor/test/ai/miniforge/dag_executor/branch_registry/dag_non_forest_anomaly_shape_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/branch_registry/dag_non_forest_anomaly_shape_test.clj
@@ -1,0 +1,111 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.branch-registry.dag-non-forest-anomaly-shape-test
+  "Lock the canonical anomaly shape produced by `branch-registry`'s
+   `resolve-base-branch` (multi-parent path) and `validate-forest` after
+   the W2 anomaly convergence flip.
+
+   Pre-flip both helpers emitted a hand-rolled map carrying
+   `:anomaly/category :anomalies/dag-non-forest` alongside the
+   multi-parent payload at the anomaly's top level
+   (`:task/dependencies` / `:multi-parent-tasks`).
+
+   Post-flip the anomaly is built via `anomaly/sub-anomaly` with
+   `:anomaly/type :conflict` (per the runbook's custom-subtype map for
+   `:anomalies/dag-non-forest`) and the original category preserved
+   verbatim as `:anomaly/subtype`. The multi-parent domain payload moves
+   under `:anomaly/data` — same key names so telemetry survives once
+   consumers migrate their reads."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.dag-executor.branch-registry :as br]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test factories and named literals.
+
+(def ^:private non-forest-subtype
+  "The legacy `:anomalies/*` category keyword that survives verbatim as
+   `:anomaly/subtype` post-flip."
+  :anomalies/dag-non-forest)
+
+(def ^:private non-forest-type
+  "Generic `:anomaly/type` for the dag-non-forest anomaly per runbook."
+  :conflict)
+
+(def ^:private diamond-plan
+  "A four-task plan whose terminal task `:d` declares two parents `[:b
+   :c]` — the smallest plan that fails `validate-forest`. Reused across
+   shape assertions so the violations vector is stable."
+  [{:task/id :a :task/dependencies []}
+   {:task/id :b :task/dependencies [:a]}
+   {:task/id :c :task/dependencies [:a]}
+   {:task/id :d :task/dependencies [:b :c]}])
+
+(def ^:private multi-parent-deps
+  "Task-dep vector that triggers the multi-parent path of
+   `resolve-base-branch`."
+  [:a :b])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Shape assertions.
+
+(deftest resolve-base-branch-emits-canonical-conflict-anomaly
+  (testing "multi-parent resolve produces a canonical :conflict anomaly"
+    (let [a (br/resolve-base-branch (br/create-registry) multi-parent-deps "main")]
+      (is (anomaly/anomaly? a)
+          "result satisfies the canonical anomaly schema")
+      (is (= non-forest-type (:anomaly/type a))
+          "type is :conflict per the runbook's dag-* custom-subtype map")
+      (is (= non-forest-subtype (:anomaly/subtype a))
+          "legacy category survives verbatim as :anomaly/subtype")))
+
+  (testing "multi-parent payload moves under :anomaly/data"
+    (let [a (br/resolve-base-branch (br/create-registry) multi-parent-deps "main")]
+      (is (= multi-parent-deps (get-in a [:anomaly/data :task/dependencies]))
+          "task deps flattened under :anomaly/data with the same key")
+      (is (nil? (:task/dependencies a))
+          "no top-level :task/dependencies leakage onto the anomaly"))))
+
+(deftest validate-forest-emits-canonical-conflict-anomaly
+  (testing "diamond plan produces a canonical :conflict anomaly"
+    (let [a (br/validate-forest diamond-plan)]
+      (is (anomaly/anomaly? a))
+      (is (= non-forest-type    (:anomaly/type a)))
+      (is (= non-forest-subtype (:anomaly/subtype a)))))
+
+  (testing "multi-parent violations move under :anomaly/data"
+    (let [a (br/validate-forest diamond-plan)
+          violations (get-in a [:anomaly/data :multi-parent-tasks])]
+      (is (= 1 (count violations)))
+      (is (= :d (:task/id (first violations)))
+          "violation entry shape preserved (same keys as pre-flip)")
+      (is (nil? (:multi-parent-tasks a))
+          "no top-level :multi-parent-tasks leakage onto the anomaly"))))
+
+(deftest resolve-error-predicate-reads-canonical-subtype
+  (testing "resolve-error? matches the post-flip :anomaly/subtype shape"
+    (let [a (br/resolve-base-branch (br/create-registry) multi-parent-deps "main")]
+      (is (true? (br/resolve-error? a)))))
+  (testing "legacy :anomaly/category-only maps no longer satisfy resolve-error?"
+    ;; Once the producer is flipped, the predicate is single-shape — the
+    ;; only emitter of multi-parent anomalies is own-brick so a legacy
+    ;; shape arriving here would indicate a stale caller, not a real
+    ;; upstream variation.
+    (is (false? (br/resolve-error? {:anomaly/category :anomalies/dag-non-forest})))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/branch_registry_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/branch_registry_test.clj
@@ -72,14 +72,18 @@
   (testing "multiple deps: return :anomalies/dag-non-forest as data"
     (let [resolved (br/resolve-base-branch (br/create-registry) [:a :b] "main")]
       (is (br/resolve-error? resolved))
-      (is (= :anomalies/dag-non-forest (:anomaly/category resolved)))
-      (is (= [:a :b] (:task/dependencies resolved)))
+      (is (= :conflict (:anomaly/type resolved))
+          "non-forest classifies as :conflict per the convergence runbook")
+      (is (= :anomalies/dag-non-forest (:anomaly/subtype resolved))
+          "legacy category keyword preserved verbatim as :anomaly/subtype")
+      (is (= [:a :b] (get-in resolved [:anomaly/data :task/dependencies]))
+          "multi-parent domain payload flattened under :anomaly/data")
       (is (string? (:anomaly/message resolved))
           "anomaly carries a human-readable message for downstream display"))))
 
 (deftest resolve-error-predicate-test
   (testing "resolve-error? distinguishes anomaly maps from branch strings"
-    (is (true?  (br/resolve-error? {:anomaly/category :anomalies/dag-non-forest})))
+    (is (true?  (br/resolve-error? {:anomaly/subtype :anomalies/dag-non-forest})))
     (is (false? (br/resolve-error? "task-a")))
     (is (false? (br/resolve-error? nil)))
     (is (false? (br/resolve-error? {:branch "task-a"}))
@@ -119,11 +123,13 @@
                   [{:task/id :a :task/dependencies []}
                    {:task/id :b :task/dependencies [:a]}
                    {:task/id :c :task/dependencies [:a]}
-                   {:task/id :d :task/dependencies [:b :c]}])]
+                   {:task/id :d :task/dependencies [:b :c]}])
+          violations (get-in anomaly [:anomaly/data :multi-parent-tasks])]
       (is (some? anomaly))
-      (is (= :anomalies/dag-non-forest (:anomaly/category anomaly)))
-      (is (= 1 (count (:multi-parent-tasks anomaly))))
-      (let [violation (first (:multi-parent-tasks anomaly))]
+      (is (= :conflict (:anomaly/type anomaly)))
+      (is (= :anomalies/dag-non-forest (:anomaly/subtype anomaly)))
+      (is (= 1 (count violations)))
+      (let [violation (first violations)]
         (is (= :d (:task/id violation)))
         (is (= 2  (:dep-count violation)))
         (is (= [:b :c] (:dependencies violation)))))))
@@ -135,7 +141,8 @@
                    {:task/id :b :task/dependencies []}
                    {:task/id :c :task/dependencies [:a :b]}
                    {:task/id :d :task/dependencies [:a :b :c]}])
-          ids (set (map :task/id (:multi-parent-tasks anomaly)))]
+          violations (get-in anomaly [:anomaly/data :multi-parent-tasks])
+          ids (set (map :task/id violations))]
       (is (= #{:c :d} ids)
           "both offending tasks surface so the user can fix the plan in one pass"))))
 


### PR DESCRIPTION
W2 batch 3 / dag-executor brick. Migrates the 3 anomaly construction / read sites in `branch_registry` to `ai.miniforge.anomaly` per `docs/runbooks/anomaly-convergence.md`.

## Sites migrated

| site | before | after |
| --- | --- | --- |
| `non-forest-anomaly` (multi-parent resolve path) | `{:anomaly/category :anomalies/dag-non-forest :anomaly/message ... :task/dependencies ...}` | `(anomaly/sub-anomaly :conflict :anomalies/dag-non-forest msg {:task/dependencies ...})` |
| `validate-forest` (plan-time non-forest detector) | `{:anomaly/category :anomalies/dag-non-forest :anomaly/message ... :multi-parent-tasks ...}` | `(anomaly/sub-anomaly :conflict :anomalies/dag-non-forest msg {:multi-parent-tasks ...})` |
| `resolve-error?` predicate | reads `:anomaly/category` | reads `:anomaly/subtype` (own-brick producer, single-shape read) |

## Runbook entries used

`:anomalies/dag-non-forest` → `:conflict` (dag-executor custom-subtype block — preserved verbatim as `:anomaly/subtype`).

## Domain-payload key naming

`:task/dependencies` and `:multi-parent-tasks` flatten under `:anomaly/data` with original key names preserved (loop/agent/llm batch-2 precedent).

## Throw-anomaly! sites left untouched (W5)

- `dag_executor/execution_plan.clj:119` (`:anomalies/incorrect`)
- `dag_executor/protocols/impl/runtime/oci_cli.clj:601` (`:anomalies/fault`)

## Cross-brick consumer (workflow)

`workflow/dag_orchestrator.clj`'s `log-multi-parent-detected!` reads `(:multi-parent-tasks non-forest)` at the top level. Post-flip that read returns `nil` until the workflow brick is flipped (batch 4) and reads `(:multi-parent-tasks (:anomaly/data ...))`. Degrades gracefully — no crash; just one log line loses its violations vector during the transition.

## Tests

- New `dag-non-forest-anomaly-shape-test`: 3 deftests / 13 assertions locking type / subtype / payload placement / no top-level domain-key leakage / predicate's canonical read.
- Existing `branch_registry_test` assertions updated to read the new shape.
- Brick: 352 tests / 999 assertions (pre-flip 349 / 992 on this branch — +3 tests / +7 assertions from the shape-lock file).

## Deps

Adds `ai.miniforge/anomaly` to `components/dag-executor/deps.edn`.

## Gates

- `bb pre-commit` — green (329 tests / 1190 assertions precommit smoke; GraalVM 6/511 green)
- `bb lint:clj` — 0/0 on 4 staged files
- `bb poly:check` — OK

`any-anomaly?` local predicate: 0 in this brick (the single own-brick predicate `resolve-error?` is specific to non-forest, not generic).

Refs: anomaly-convergence W2 (docs/runbooks/anomaly-convergence.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)