### PR TITLE
feat(failure-classifier): flip own ex-data hints to canonical anomaly (W2 batch 3)

### DIFF
--- a/components/failure-classifier/resources/config/failure-classifier/rules.edn
+++ b/components/failure-classifier/resources/config/failure-classifier/rules.edn
@@ -125,7 +125,18 @@
   "clojure.lang.ExceptionInfo"            nil}
 
  :anomaly-map
- {:anomalies/timeout                  :failure.class/timeout
+ ;; Lookups receive whichever of :anomaly/subtype, :anomaly/category, or
+ ;; :anomaly/type is present (in that precedence; see classify-failure).
+ ;; Domain subtypes carry the legacy `:anomalies/*` keyword verbatim post-
+ ;; W2 flip — those keys stay legacy-shaped here. Generic-standard types
+ ;; (the cognitect-eight + :exhausted) are added as canonical keys so a
+ ;; producer that has flipped to `(anomaly/anomaly :type msg {})` still
+ ;; routes to the same `:failure.class/*` it did pre-flip. Legacy
+ ;; `:anomalies/*` keys are kept alongside the canonical entries during
+ ;; the W2-W4 convergence window; both rows map to identical classes so
+ ;; behaviour is unchanged. Legacy rows are dropped in W5.
+ {;; Legacy generic-standard categories
+  :anomalies/timeout                  :failure.class/timeout
   :anomalies/unavailable              :failure.class/external
   :anomalies/interrupted              :failure.class/external
   :anomalies/busy                     :failure.class/resource
@@ -135,6 +146,21 @@
   :anomalies/incorrect                nil
   :anomalies/fault                    nil
   :anomalies/unsupported              nil
+  ;; Canonical generic types — match the legacy rows above so post-flip
+  ;; producers dispatch identically. `:exhausted` is the convergence-
+  ;; introduced type (budget/limit/effort ceiling) and routes to the
+  ;; resource class consistent with `:anomalies.phase/budget-exceeded`.
+  :timeout                            :failure.class/timeout
+  :unavailable                        :failure.class/external
+  :invalid-input                      nil
+  :unauthorized                       :failure.class/policy
+  :not-found                          :failure.class/data-integrity
+  :conflict                           :failure.class/concurrency
+  :fault                              nil
+  :unsupported                        nil
+  :exhausted                          :failure.class/resource
+  ;; Domain subtypes — keyword is preserved verbatim from the legacy
+  ;; category, so these rows stay as-is across the W2 flip.
   :anomalies.phase/budget-exceeded    :failure.class/resource
   :anomalies.phase/agent-failed       :failure.class/agent-error
   :anomalies.phase/no-agent           :failure.class/agent-error

--- a/components/failure-classifier/resources/config/failure-classifier/rules.edn
+++ b/components/failure-classifier/resources/config/failure-classifier/rules.edn
@@ -130,11 +130,13 @@
  ;; Domain subtypes carry the legacy `:anomalies/*` keyword verbatim post-
  ;; W2 flip — those keys stay legacy-shaped here. Generic-standard types
  ;; (the cognitect-eight + :exhausted) are added as canonical keys so a
- ;; producer that has flipped to `(anomaly/anomaly :type msg {})` still
- ;; routes to the same `:failure.class/*` it did pre-flip. Legacy
- ;; `:anomalies/*` keys are kept alongside the canonical entries during
- ;; the W2-W4 convergence window; both rows map to identical classes so
- ;; behaviour is unchanged. Legacy rows are dropped in W5.
+ ;; producer that has flipped to `(anomaly/anomaly :not-found msg {})`
+ ;; (or any other cognitect-standard generic type — `:timeout`,
+ ;; `:invalid-input`, …) still routes to the same `:failure.class/*`
+ ;; it did pre-flip. Legacy `:anomalies/*` keys are kept alongside the
+ ;; canonical entries during the W2-W4 convergence window; both rows
+ ;; map to identical classes so behaviour is unchanged. Legacy rows
+ ;; are dropped in W5.
  {;; Legacy generic-standard categories
   :anomalies/timeout                  :failure.class/timeout
   :anomalies/unavailable              :failure.class/external

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
@@ -23,11 +23,19 @@
 ;; Config loading and compilation
 
 (defn- missing-resource
-  "Create a canonical missing-resource exception."
+  "Create a canonical missing-resource exception.
+
+   The ex-data carries the canonical anomaly classification key
+   (`:anomaly/type :not-found`) so any catcher routing through
+   `classify-failure` resolves to the same `:failure.class/*` it would
+   have under the legacy `:anomaly/category :anomalies/not-found` shape.
+   `:anomalies/not-found` is one of the eight cognitect-standard
+   categories the convergence runbook maps 1:1 to a generic
+   `:anomaly/type` with no subtype."
   [resource-path]
   (ex-info (str "Missing EDN resource: " resource-path)
            {:resource/path resource-path
-            :anomaly/category :anomalies/not-found}))
+            :anomaly/type :not-found}))
 
 (defn- load-edn-resource
   "Load a required EDN resource by path."
@@ -241,9 +249,8 @@
   "Convenience: classify a Throwable directly."
   [^Throwable ex]
   (classify-failure
-   {:anomaly/category  nil
-    :exception/class   (str (type ex))
-    :error/message     (.getMessage ex)}))
+   {:exception/class (str (type ex))
+    :error/message   (.getMessage ex)}))
 
 (defn classify-failure-record
   "Classify a failure into a canonical record with optional dependency

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
@@ -268,9 +268,8 @@
   "Convenience: classify a Throwable into a canonical record."
   [^Throwable ex]
   (classify-failure-record
-   {:anomaly/category  nil
-    :exception/class   (str (type ex))
-    :error/message     (.getMessage ex)}))
+   {:exception/class (str (type ex))
+    :error/message   (.getMessage ex)}))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
@@ -154,9 +154,17 @@
     value))
 
 (defn- invalid-constructor-input
-  "Create a canonical ex-info payload for invalid constructor inputs."
+  "Create a canonical ex-info payload for invalid constructor inputs.
+
+   The ex-data carries the canonical anomaly classification key
+   (`:anomaly/type :invalid-input`) so any catcher routing through
+   `classify-failure` resolves to the same `:failure.class/*` it would
+   have under the legacy `:anomaly/category :anomalies/incorrect`
+   shape. `:anomalies/incorrect` is one of the eight cognitect-standard
+   categories the convergence runbook maps 1:1 to a generic
+   `:anomaly/type` with no subtype."
   [message data]
-  (ex-info message (assoc data :anomaly/category :anomalies/incorrect)))
+  (ex-info message (assoc data :anomaly/type :invalid-input)))
 
 (defn- require-field!
   "Require a non-nil field and throw ex-info when missing."

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/exception_anomaly_hint_shape_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/exception_anomaly_hint_shape_test.clj
@@ -82,12 +82,17 @@
       (is (= :invalid-input (:anomaly/type data))
           "canonical :anomaly/type is set per the runbook generic-standard map")))
 
-  (testing "legacy hint keys are not written on the producer side"
+  (testing "legacy hint keys are absent from the producer ex-data"
+    ;; `contains?` (not nil-check) — pre-flip the producer wrote
+    ;; `:anomaly/category :anomalies/incorrect`, and `(:anomaly/category
+    ;; data)` would also return nil when the key were re-introduced with
+    ;; an explicit nil value. Pin absence so a regression to either of
+    ;; the legacy producer shapes is caught.
     (let [data (catch-ex-data #(fc/make-classified-failure incomplete-attribution))]
-      (is (nil? (:anomaly/category data))
-          ":anomaly/category is not written by the post-flip producer")
-      (is (nil? (:anomaly/subtype data))
-          ":anomalies/incorrect is cognitect-standard, no subtype attached"))))
+      (is (false? (contains? data :anomaly/category))
+          ":anomaly/category key is not present on post-flip producer")
+      (is (false? (contains? data :anomaly/subtype))
+          ":anomalies/incorrect is cognitect-standard, no subtype key attached"))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Dispatch equivalence — the canonical hint is sufficient.

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/exception_anomaly_hint_shape_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/exception_anomaly_hint_shape_test.clj
@@ -1,0 +1,112 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.failure-classifier.exception-anomaly-hint-shape-test
+  "Lock the anomaly-classification hint shape written into ex-data by
+   the brick's private `invalid-constructor-input` exception builder
+   (taxonomy.clj) after the W2 anomaly convergence flip, and the
+   dispatch-equivalence of the new shape against the legacy one.
+
+   Pre-flip the builder wrote `:anomaly/category :anomalies/incorrect`
+   into ex-data — the legacy classification key. Post-flip it writes
+   `:anomaly/type :invalid-input` directly, because
+   `:anomalies/incorrect` is one of the cognitect-standard categories
+   that the convergence runbook maps 1:1 to a generic type with no
+   subtype.
+
+   The classifier's `classify` dispatch reads `:anomaly/subtype` →
+   `:anomaly/category` → `:anomaly/type` (#1001), so both producer
+   flips are dispatch-equivalent — this test pins the wire shape so a
+   later edit doesn't silently re-introduce `:anomaly/category` on
+   producer paths, and confirms `:anomaly/type` alone routes to the
+   same `:failure.class/*`.
+
+   `missing-resource` (classifier.clj) is not directly testable —
+   it runs at namespace load against a baked-in resource path — but
+   its ex-data shape is symmetric to `invalid-constructor-input`'s
+   and the dispatch test below pins the canonical-hint-only dispatch
+   path it relies on."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.failure-classifier.interface :as fc]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Named literals + test factories.
+
+(def ^:private incomplete-attribution
+  "Attribution map missing `:failure/class` — triggers
+   `require-field!` → `invalid-constructor-input` through
+   `make-classified-failure`."
+  {:failure/message "boom"})
+
+(def ^:private not-found-canonical-hint
+  "Canonical anomaly hint for the cognitect-standard `:not-found`
+   class — what `missing-resource` writes into ex-data post-flip."
+  {:anomaly/type :not-found})
+
+(def ^:private invalid-input-canonical-hint
+  "Canonical anomaly hint for the cognitect-standard
+   `:invalid-input` class — what `invalid-constructor-input` writes
+   into ex-data post-flip."
+  {:anomaly/type :invalid-input})
+
+(defn- catch-ex-data
+  "Run `thunk`, return the ex-data of any thrown ex-info (nil
+   otherwise). Lets the producer assertions stay flat."
+  [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Shape assertions on the post-flip producers.
+
+(deftest invalid-constructor-input-emits-canonical-invalid-input-hint
+  (testing ":anomaly/type :invalid-input is written into ex-data"
+    (let [data (catch-ex-data #(fc/make-classified-failure incomplete-attribution))]
+      (is (some? data) "incomplete attribution throws ex-info")
+      (is (= :invalid-input (:anomaly/type data))
+          "canonical :anomaly/type is set per the runbook generic-standard map")))
+
+  (testing "legacy hint keys are not written on the producer side"
+    (let [data (catch-ex-data #(fc/make-classified-failure incomplete-attribution))]
+      (is (nil? (:anomaly/category data))
+          ":anomaly/category is not written by the post-flip producer")
+      (is (nil? (:anomaly/subtype data))
+          ":anomalies/incorrect is cognitect-standard, no subtype attached"))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Dispatch equivalence — the canonical hint is sufficient.
+
+(deftest classifier-dispatch-on-canonical-not-found-hint
+  (testing ":anomaly/type :not-found routes identically to :anomalies/not-found"
+    (let [legacy-result (fc/classify {:anomaly/category :anomalies/not-found})
+          canonical-result (fc/classify not-found-canonical-hint)]
+      (is (= :failure.class/data-integrity legacy-result)
+          "pre-flip dispatch contract (regression guard for the rules.edn
+           parallel canonical entries added alongside the producer flip)")
+      (is (= legacy-result canonical-result)
+          "canonical hint alone produces the same failure class — guards
+           the rules.edn change that makes the producer flip safe"))))
+
+(deftest classifier-dispatch-on-canonical-invalid-input-hint
+  (testing ":anomaly/type :invalid-input dispatches to the same class as :anomalies/incorrect"
+    (let [legacy-result (fc/classify {:anomaly/category :anomalies/incorrect})
+          canonical-result (fc/classify invalid-input-canonical-hint)]
+      (is (= legacy-result canonical-result)
+          "post-flip ex-data dispatches to the identical failure class
+           the pre-flip ex-data would have"))))


### PR DESCRIPTION
W2 batch 3 / failure-classifier. Migrates this brick's 4 own producer sites (ex-data anomaly hints) to the canonical `:anomaly/type` shape and adds canonical-type rows to the dispatch rules so the producer flip preserves classification.

The brick's READS were already migrated in #1001 (W1c); this PR completes its own producer side.

## Sites migrated

| site | before | after |
| --- | --- | --- |
| `classifier/missing-resource` (ex-data) | `:anomaly/category :anomalies/not-found` | `:anomaly/type :not-found` (cognitect-standard, no subtype) |
| `taxonomy/invalid-constructor-input` (ex-data) | `:anomaly/category :anomalies/incorrect` | `:anomaly/type :invalid-input` (cognitect-standard, no subtype) |
| `classify-exception` input | explicit `:anomaly/category nil` | key dropped (absence == nil) |
| `classify-exception-record` input | explicit `:anomaly/category nil` | key dropped |

## Runbook entries used

- `:anomalies/not-found` → `:not-found` (generic standard, no subtype)
- `:anomalies/incorrect` → `:invalid-input` (generic standard, no subtype)

## Dispatch-equivalence rule update

`rules.edn`'s `:anomaly-map` was keyed only by legacy `:anomalies/*` keywords. The producer flip to `:anomaly/type :not-found` would have silently regressed classification from `:failure.class/data-integrity` to `:failure.class/unknown` — the dispatch table didn't recognize the canonical type. Added canonical-type rows alongside legacy ones (all nine generic types: the eight cognitect-standard + `:exhausted`) so post-flip producers route identically. Legacy `:anomalies/*` rows kept during the W2-W4 convergence window; both rows map to the same `:failure.class/*`.

This is the same pattern as the translate domain-payload bridge (#1009): supporting work on the consumer side to keep producer flips cross-brick-safe.

## Throw-anomaly! sites left untouched (W5)

None in this brick.

## Tests

- New `exception-anomaly-hint-shape-test`: 3 deftests / 7 assertions locking the post-flip ex-data shape on `invalid-constructor-input` and dispatch-equivalence on both new canonical hints against their legacy counterparts.
- `missing-resource` isn't directly testable from public API (runs at namespace load against a baked-in resource path), so its symmetry is covered indirectly through the dispatch-equivalence test on `:not-found`.
- Brick: 30 tests / 152 assertions (pre-flip 27 — +3 from the new file).

## Deps

No deps.edn change. The ex-data hint write is a plain keyword set; the anomaly constructor isn't needed (ex-data is not itself an anomaly map).

## Gates

- `bb pre-commit` — green (329 / 1190 precommit smoke; GraalVM 6/511 green)
- `bb lint:clj` — 0/0 on 4 staged files
- `bb poly:check` — OK

`any-anomaly?` local predicate: 0 in this brick (consumer brick, not anomaly producer/inspector).

Refs: anomaly-convergence W2 (docs/runbooks/anomaly-convergence.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)