### PR TITLE
fix(workflow): validate that declared entry phase exists in workflow phases

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -37,6 +37,8 @@
   "Compiled workflow machine contains unreachable states: {states}"
   :status/unreachable-machine-phases
   "Compiled workflow machine contains unreachable phases: {phases}"
+  :status/unknown-entry-phase
+  "Entry phase {entry-phase} does not exist in the workflow phases"
   :status/missing-workflow-id "Workflow must have :workflow/id"
   :status/invalid-workflow-registration
   "Workflow {workflow-id} failed registration validation"

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -149,6 +149,13 @@
   {:error :empty-pipeline
    :message (messages/t :status/empty-pipeline)})
 
+(defn- unknown-entry-phase-error
+  [entry-phase]
+  {:error :unknown-entry-phase
+   :entry-phase entry-phase
+   :message (messages/t :status/unknown-entry-phase
+                        {:entry-phase entry-phase})})
+
 (defn- first-phase-index
   [pipeline phase]
   (some (partial matching-phase-index phase)
@@ -378,6 +385,19 @@
                               (filter duplicate-phase?)
                               (map first)
                               vec)
+        ;; Check that an explicitly declared entry phase actually exists in the
+        ;; legacy-phases list. We only validate when the caller declared an entry
+        ;; explicitly (via :workflow/entry or :workflow/entry-phase) AND the
+        ;; workflow uses the legacy :workflow/phases format. If no entry is
+        ;; declared the runtime falls back to the first declared phase, which is
+        ;; always valid.
+        explicit-entry (or (:workflow/entry workflow) (:workflow/entry-phase workflow))
+        phase-ids (when (:workflow/phases workflow)
+                    (set (map :phase/id (:workflow/phases workflow))))
+        bad-entry-phase (when (and explicit-entry
+                                   phase-ids
+                                   (not (contains? phase-ids explicit-entry)))
+                          explicit-entry)
         unresolved-success (->> pipeline
                                 (keep (partial unknown-success-target pipeline))
                                 vec)
@@ -385,6 +405,7 @@
                              (keep (partial unknown-fail-target pipeline))
                              vec)
         machine (when (and (seq pipeline)
+                           (nil? bad-entry-phase)
                            (empty? unresolved-success)
                            (empty? unresolved-fail))
                   (compile-execution-machine normalized-workflow))
@@ -399,6 +420,8 @@
         errors (vec (concat
                      (when (empty? pipeline)
                        [(empty-pipeline-error)])
+                     (when bad-entry-phase
+                       [(unknown-entry-phase-error bad-entry-phase)])
                      unresolved-success
                      unresolved-fail
                      (when (seq unreachable-phases)

--- a/components/workflow/test/ai/miniforge/workflow/validator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/validator_test.clj
@@ -151,27 +151,25 @@
       (is (some #(re-find #"unknown on-success target" %) (:errors result))
           "Should report unknown target")))
 
-  ;; TODO: Validator doesn't currently validate :workflow/entry-phase
-  ;; It just uses first phase by default. Uncomment when implemented.
-  #_(testing "Non-existent entry phase fails validation"
-      (let [config {:workflow/id :test
-                    :workflow/version "1.0.0"
-                    :workflow/name "Test"
-                    :workflow/description "Test"
-                    :workflow/created-at (java.util.Date.)
-                    :workflow/task-types [:test]
-                    :workflow/type :test
-                    :workflow/phases
-                    [{:phase/id :start
-                      :phase/name "Start"
-                      :phase/agent :planner
-                      :phase/next []}]
-                    :workflow/entry-phase :missing  ; Non-existent entry phase
-                    :workflow/exit-phases [:start]}
-            result (validator/validate-dag config)]
-        (is (not (:valid? result)) "Non-existent entry phase should fail")
-        (is (some #(re-find #"Entry phase" %) (:errors result))
-            "Should report entry phase not found")))
+  (testing "Non-existent entry phase fails validation"
+    (let [config {:workflow/id :test
+                  :workflow/version "1.0.0"
+                  :workflow/name "Test"
+                  :workflow/description "Test"
+                  :workflow/created-at (java.util.Date.)
+                  :workflow/task-types [:test]
+                  :workflow/type :test
+                  :workflow/phases
+                  [{:phase/id :start
+                    :phase/name "Start"
+                    :phase/agent :planner
+                    :phase/next []}]
+                  :workflow/entry-phase :missing  ; Non-existent entry phase
+                  :workflow/exit-phases [:start]}
+          result (validator/validate-dag config)]
+      (is (not (:valid? result)) "Non-existent entry phase should fail")
+      (is (some #(re-find #"Entry phase" %) (:errors result))
+          "Should report entry phase not found")))
 
   (testing "Unreachable phases fail validation"
     (let [config {:workflow/id :test


### PR DESCRIPTION
## Problem

`validate-dag` / `validate-execution-machine` accepted a workflow whose `:workflow/entry-phase` (or `:workflow/entry`) pointed to a non-existent phase without raising any error. The runtime's `legacy-phase-order` silently fell back to the first *declared* phase, so execution started from the wrong phase with no diagnostic. The bug was documented in a commented-out test:

```clojure
;; TODO: Validator doesn't currently validate :workflow/entry-phase
;; It just uses first phase by default. Uncomment when implemented.
#_(testing "Non-existent entry phase fails validation" ...)
```

**Why this matters in production:** a mis-typed entry phase in a workflow config passes all validation gates and silently runs phases in declaration order rather than the author's intended order. For a software-factory workflow (plan → implement → review → release) this can mean review or release runs before implementation with no error surfaced until the agent produces wrong output.

## Fix

**`components/workflow/src/ai/miniforge/workflow/fsm.clj`**
- Added `unknown-entry-phase-error` helper (follows the existing `unknown-success-target` / `unknown-fail-target` pattern).
- Added `explicit-entry` / `phase-ids` / `bad-entry-phase` bindings in `validate-execution-machine` that detect when a caller supplies an explicit `:workflow/entry` or `:workflow/entry-phase` pointing to a phase that doesn't exist in `:workflow/phases`.
- Gates `compile-execution-machine` on `(nil? bad-entry-phase)` (same guard already used for unresolved transition targets) so a broken entry never produces a machine.
- Scoped to legacy-phase workflows only (`when (:workflow/phases ...)`) — new-format `workflow/pipeline` workflows have no entry-phase concept.

**`components/workflow/resources/config/workflow/messages/en-US.edn`**
- Added `:status/unknown-entry-phase` message key: `"Entry phase {entry-phase} does not exist in the workflow phases"`.

**`components/workflow/test/ai/miniforge/workflow/validator_test.clj`**
- Removed `#_` reader macro and the TODO comment from the "Non-existent entry phase fails validation" test.

## Scope

3 files changed, 44 insertions, 21 deletions — well within the 400-line budget.

## Test plan

- [ ] `bb poly:check` — workspace structure OK
- [ ] `bb test` — workflow test suite green (existing tests unaffected, new test passes)
- [ ] `bb lint:clj` — no new warnings

https://claude.ai/code/session_01G79G41CBUBmj7h5PXwfqun

---
_Generated by [Claude Code](https://claude.ai/code/session_01G79G41CBUBmj7h5PXwfqun)_