### PR TITLE
feat(pr-lifecycle): dual-shape anomaly detection in merge normalizer (W2 batch 3)

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -22,13 +22,34 @@
    Handles the final step of the PR lifecycle - determining when
    a PR is ready to merge and executing the merge."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
    [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.response.interface :as response]
    [babashka.process :as process]
    [cheshire.core :as json]
    [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Anomaly detection (dual shape during W2 convergence)
+
+(defn- any-anomaly?
+  "True when `x` is either a canonical anomaly (`:anomaly/type`) or a
+   legacy response anomaly (`:anomaly/category`).
+
+   `normalize-resolution-outcome` inspects the return of the injected
+   `resolve-fn` (workflow.merge-resolution/resolve-conflict! today,
+   still legacy-shape pre W2 batch 4). The terminal
+   `:dag-multi-parent-unresolvable` anomaly arrives as a bare map and
+   must be detected by both shape conventions until W5 retires the
+   legacy producers. Prefers the canonical predicate; falls back to
+   the legacy one. Mirrors the dispatch-key pattern in
+   `failure-classifier/classify-failure`."
+  [x]
+  (or (anomaly/anomaly? x)
+      (response/anomaly-map? x)))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Merge policies
@@ -335,8 +356,7 @@
    instead of looping. The original anomaly is preserved under
    :data :anomaly for diagnostic surfacing."
   [outcome]
-  (if (and (map? outcome)
-           (contains? outcome :anomaly/category)
+  (if (and (any-anomaly? outcome)
            (not (dag/ok? outcome))
            (not (dag/err? outcome)))
     (dag/err :conflict-unresolvable

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/normalize_resolution_shape_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/normalize_resolution_shape_test.clj
@@ -1,0 +1,148 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.anomaly.normalize-resolution-shape-test
+  "Locks the dual-shape anomaly detection in
+   `merge/normalize-resolution-outcome` for the W2 anomaly
+   convergence.
+
+   The injected `resolve-fn` (workflow.merge-resolution/resolve-conflict!
+   today) can return a terminal `:dag-multi-parent-unresolvable`
+   anomaly. Until W2 batch 4 flips the workflow brick that source is
+   legacy-shape (`:anomaly/category`); afterwards it is canonical
+   (`:anomaly/type`). `normalize-resolution-outcome` must detect both
+   so the controller never sees a bare anomaly map leak through the
+   dag/ok-or-dag/err contract.
+
+   Mirrors the dual-shape lock added in evidence-bundle (#1004) and
+   the dispatch-key pattern in failure-classifier/classify-failure
+   (#1001)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
+   [ai.miniforge.pr-lifecycle.merge :as merge]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Fixtures + factories
+
+(def ^:private unresolvable-message
+  "Merge conflict could not be auto-resolved")
+
+(def ^:private conflicting-readiness
+  "Readiness map shaped like evaluate-merge-readiness output where the
+   branch check failed via CONFLICTING (DIRTY mergeStateStatus) — the
+   shape that triggers `attempt-conflict-resolution!`'s dispatch into
+   the injected `resolve-fn`."
+  {:ready?   false
+   :checks   {:branch (dag/ok {:up-to-date? false
+                               :raw "{\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\"}"})}
+   :blocking [:branch-not-up-to-date]})
+
+(def ^:private gh-pr-info-output
+  (str "{\"number\":123,"
+       "\"headRefName\":\"feat/x\","
+       "\"baseRefName\":\"main\","
+       "\"headRefOid\":\"abc1234\","
+       "\"baseRefOid\":\"def5678\"}"))
+
+(defn- legacy-unresolvable-anomaly
+  "Legacy-shape (`:anomaly/category`) terminal anomaly — what
+   workflow.merge-resolution returns today, pre W2 batch 4."
+  []
+  {:anomaly/category  :anomalies/dag-multi-parent-unresolvable
+   :anomaly/message   unresolvable-message
+   :resolution/reason :budget-exhausted})
+
+(defn- canonical-unresolvable-anomaly
+  "Canonical-shape (`:anomaly/type` + `:anomaly/subtype`) terminal
+   anomaly — what workflow.merge-resolution returns after W2 batch 4
+   flips the workflow brick."
+  []
+  (anomaly/sub-anomaly :conflict
+                       :anomalies/dag-multi-parent-unresolvable
+                       unresolvable-message
+                       {:resolution/reason :budget-exhausted}))
+
+(defn- merge-context
+  "Context map for `merge/attempt-merge` with an injected no-op
+   resolve-fn (the real one is stubbed via with-redefs of
+   `conflict-resolution/resolve-pr-conflicts!`)."
+  []
+  {:dag-id     (random-uuid)
+   :run-id     (random-uuid)
+   :task-id    (random-uuid)
+   :pr-id      123
+   :resolve-fn (fn [_] (dag/ok {}))})
+
+(defn- attempt-merge-with-resolution
+  "Run `merge/attempt-merge` with `resolve-pr-conflicts!` stubbed to
+   return the supplied terminal anomaly. Returns the attempt-merge
+   result for the caller to assert on."
+  [terminal-anomaly]
+  (with-redefs [merge/evaluate-merge-readiness
+                (fn [_ _ _] conflicting-readiness)
+                conflict-resolution/resolve-pr-conflicts!
+                (fn [_] terminal-anomaly)
+                merge/run-gh-command
+                (fn [_ _] (dag/ok {:output gh-pr-info-output}))]
+    (merge/attempt-merge "/tmp" 123
+                         merge/default-merge-policy
+                         (merge-context))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Dual-shape detection
+
+(deftest legacy-shape-anomaly-normalizes-to-conflict-unresolvable
+  (testing "legacy `:anomaly/category` terminal anomaly normalizes
+            to a dag/err with :conflict-unresolvable code"
+    (let [terminal (legacy-unresolvable-anomaly)
+          result   (attempt-merge-with-resolution terminal)]
+      (is (dag/err? result))
+      (is (= :conflict-unresolvable (:code (:error result))))
+      (is (= terminal (get-in result [:error :data :anomaly]))
+          "original anomaly preserved for diagnostic surfacing"))))
+
+(deftest canonical-shape-anomaly-normalizes-to-conflict-unresolvable
+  (testing "canonical `:anomaly/type` terminal anomaly (post W2
+            batch 4 workflow flip) also normalizes to a dag/err with
+            :conflict-unresolvable code"
+    (let [terminal (canonical-unresolvable-anomaly)
+          result   (attempt-merge-with-resolution terminal)]
+      (is (dag/err? result))
+      (is (= :conflict-unresolvable (:code (:error result))))
+      (is (= terminal (get-in result [:error :data :anomaly]))
+          "original anomaly preserved for diagnostic surfacing")
+      (is (= unresolvable-message (:message (:error result)))
+          ":anomaly/message carries through to the dag/err message"))))
+
+(deftest canonical-and-legacy-shapes-both-detected-by-any-anomaly
+  (testing "both shapes that `any-anomaly?` must recognise yield the
+            same downstream :conflict-unresolvable normalization. This
+            locks the dual-shape contract: if a future change drops
+            one of the two predicate branches, the corresponding
+            terminal anomaly leaks through and one of these
+            assertions fires."
+    (doseq [terminal [(legacy-unresolvable-anomaly)
+                      (canonical-unresolvable-anomaly)]]
+      (let [result (attempt-merge-with-resolution terminal)]
+        (is (dag/err? result)
+            "terminal anomaly is normalized into dag/err for both shapes")
+        (is (= :conflict-unresolvable (:code (:error result)))
+            ":conflict-unresolvable code is emitted for both shapes")))))


### PR DESCRIPTION
## Summary

W2 batch 3 leftover (4th of 5): flip `pr-lifecycle/merge`'s
`normalize-resolution-outcome` from a single-shape `:anomaly/category`
membership check to a brick-local dual-shape predicate `any-anomaly?`
that recognises both canonical (`:anomaly/type`) and legacy
(`:anomaly/category`) anomaly maps.

Mirrors the dispatch-key pattern in `failure-classifier/classify-failure`
(#1001) and the dual-shape lock in `evidence-bundle/collector` (#1004).

Runbook: `docs/runbooks/anomaly-convergence.md`.

## Why dual-shape and not a straight flip

merge.clj reads anomalies from an injected `resolve-fn` whose source
(`workflow.merge-resolution/resolve-conflict!`) lives in the **workflow**
brick — a W2 batch 4 target, still legacy-shape today. The terminal
`:dag-multi-parent-unresolvable` anomaly arrives as a bare map and
must be detected by both shape conventions until W5 retires the legacy
producers.

## Sites migrated (1)

| Site | Form before | Form after |
| --- | --- | --- |
| `merge.clj` line ~339 (`normalize-resolution-outcome`) | `(contains? outcome :anomaly/category)` | `(any-anomaly? outcome)` |

`any-anomaly?` is the new brick-local predicate (Layer 0) — third such
usage in W2 (failure-classifier, evidence-bundle, pr-lifecycle),
carrying toward the 3+ promotion threshold for a shared helper.

## Sites left untouched (W5 throw-anomaly! effort)

Per the batch-3 rules, every `response/throw-anomaly!` site stays for
W5. Noting them here so the next pass picks them up:

- `controller.clj:426` — `handle-ci-failure!` rethrow on iter-budget anomaly
- `controller.clj:460` — `handle-review-feedback!` rethrow on iter-budget anomaly
- `controller.clj:563` — `run-lifecycle!` rethrow on pr-creation anomaly
- `responder.clj:239` — `fetch-actionable-comments` rethrow on fetch anomaly
- `responder.clj:279` — `respond-to-comments!` rethrow on parse-pr-url anomaly

Matching test fixtures that simulate the upstream legacy shape also
stay until workflow flips:

- `conflict_resolution_test.clj:340` — `:dag-multi-parent-unresolvable` legacy fixture
- `merge_test.clj:263` — same fixture, exercising the merge normalizer

## Connector brick

The companion brick in batch 3 (`components/connector/`) had only
`response/throw-anomaly!` sites and matching throwing-compat tests
reading `:anomaly/category` from `ex-data`. All sites are W5 effort
per the rules. No production code or tests need to flip — flagged in
the closing report.

## Domain-payload key choices

None — this PR only changes a predicate, not any anomaly construction.

## Tests delta

New `normalize-resolution-shape-test` (3 tests / 11 assertions):

- legacy-shape anomaly → dag/err with `:conflict-unresolvable`
- canonical-shape anomaly (post W2 batch 4 workflow flip) → same
- parameterised dual-shape lock: both shapes via the same flow; if
  either branch of `any-anomaly?` is dropped, one of the assertions
  fires.

Existing `merge_test.clj`'s `attempt-merge-conflicting-unresolvable-anomaly-becomes-dag-err-test`
stays as the PR #805 regression lock for the legacy shape.

`pr-lifecycle` brick total: 400 tests / 2321 assertions, 0 failures
(was 397/2310). Net +3 tests / +11 assertions.

## Gates

- `bb pre-commit` — green (329 / 1190 smoke + 6 / 511 graalvm)
- `bb lint:clj` (touched files only via clj-kondo) — 0 warnings
- `bb poly:check` — OK
- brick tests (`clojure -M:test`) — 400 tests / 2321 assertions, 0 failures
- commit verification — `verified: true, reason: valid`

## Foundation references

- `:anomaly/subtype` convention (#998)
- consumer dual-dispatch (#1001, #1009)
- nil-message fallback to class name precedent (#1003)
- evidence-bundle dual-shape lock (#1004)

🤖 Generated with [Claude Code](https://claude.com/claude-code)