### PR TITLE
feat(anomaly): promote dual-shape any-anomaly? predicate to canonical interface

### DIFF
--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -149,6 +149,25 @@
   (and (map? x)
        (contract/valid? x)))
 
+(defn any-anomaly?
+  "Transitional dual-shape predicate. True for both the canonical
+   `ai.miniforge.anomaly` map (`:anomaly/type` key) and the legacy
+   `ai.miniforge.response` anomaly map (`:anomaly/category` key) that
+   un-migrated producers still emit during the convergence wave.
+   Removed in W5 once every producer is canonical; until then,
+   readers consult this when their upstream's shape is uncertain.
+
+   The legacy half is detected with `contains?` rather than a value
+   check so the anomaly component need not depend on `response`. A
+   map with `:anomaly/category` bound to nil is therefore treated as
+   the caller's bug, not as 'not an anomaly': the key is present so
+   `contains?` returns true. Downstream classifiers see the same
+   degenerate map either way; this predicate flags it instead of
+   silently dropping it."
+  [x]
+  (or (anomaly? x)
+      (and (map? x) (contains? x :anomaly/category))))
+
 ;------------------------------------------------------------------------------ Macros
 ;; Compile-time control flow; expansion composes the Layer 2 predicate.
 

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/any_anomaly_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/any_anomaly_test.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.any-anomaly-test
+  "Transitional dual-shape predicate behavior. `any-anomaly?` must say
+   yes for both the canonical anomaly map (`:anomaly/type`) and the
+   legacy response anomaly map (`:anomaly/category`) while the W2
+   convergence wave still has un-migrated producers. Removed in W5
+   once every producer is canonical."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest any-anomaly?-true-for-canonical-anomaly
+  (testing "any-anomaly? accepts a constructed canonical anomaly"
+    (is (true? (anomaly/any-anomaly?
+                (anomaly/anomaly :fault "boom" {}))))))
+
+(deftest any-anomaly?-true-for-legacy-response-anomaly
+  (testing "any-anomaly? accepts a legacy response anomaly carrying
+            `:anomaly/category` — the shape un-migrated producers
+            still emit during the W2 convergence wave"
+    (is (true? (anomaly/any-anomaly?
+                {:anomaly/category :anomalies/fault
+                 :anomaly/message  "x"})))))
+
+(deftest any-anomaly?-false-for-non-anomaly-map
+  (testing "any-anomaly? rejects a plain map carrying neither shape"
+    (is (false? (anomaly/any-anomaly? {:some/key "value"})))))
+
+(deftest any-anomaly?-false-for-nil
+  (testing "any-anomaly? rejects nil"
+    (is (false? (anomaly/any-anomaly? nil)))))
+
+(deftest any-anomaly?-false-for-non-map
+  (testing "any-anomaly? rejects non-map inputs"
+    (is (false? (anomaly/any-anomaly? "not a map")))
+    (is (false? (anomaly/any-anomaly? 42)))
+    (is (false? (anomaly/any-anomaly? :keyword)))
+    (is (false? (anomaly/any-anomaly? [])))
+    (is (false? (anomaly/any-anomaly? #{})))))
+
+(deftest any-anomaly?-true-for-legacy-key-with-nil-value
+  (testing "a map carrying `:anomaly/category` bound to nil is treated
+            as the caller's bug, not as 'not an anomaly': the predicate
+            uses `contains?`, which returns true when the key is
+            present regardless of its value. Documented choice — the
+            degenerate map flows through to the classifier so the
+            upstream producer's bug surfaces rather than being silently
+            dropped here. W5 retirement will delete this branch."
+    (is (true? (anomaly/any-anomaly? {:anomaly/category nil})))))


### PR DESCRIPTION
## Summary

Three bricks carry brick-local copies of a dual-shape `any-anomaly?` predicate that accepts both the canonical anomaly map (`:anomaly/type`) and the legacy response anomaly map (`:anomaly/category`) emitted by un-migrated producers during the W2 convergence wave:

- `failure-classifier` (#1001) — dispatch-key fallback in `classify-failure`
- `evidence-bundle/collector` (#1004) — `any-anomaly?` reading anomalies from arbitrary upstream producers
- `pr-lifecycle/merge` (#1020) — `any-anomaly?` in `normalize-resolution-outcome` for the terminal `:dag-multi-parent-unresolvable` map

Threshold met (three independent copies, same shape, same rationale). Promote to `ai.miniforge.anomaly.interface` as a public transitional helper so the brick-local copies can converge on one definition and the W5 retirement has a single deletion site.

## Placement

Layer 2 in `components/anomaly/src/ai/miniforge/anomaly/interface.clj`, alongside the canonical `anomaly?` predicate it composes.

## Design choice — `contains?` for the legacy half

The legacy half is detected with `contains?` rather than a value predicate so the anomaly component need not depend on `response`. The current direction is `response -> anomaly`; the reverse would invert that edge. A consequence: a map carrying `:anomaly/category` bound to nil yields true — the key is present, so the degenerate map flows downstream to the classifier where the upstream producer's bug surfaces, rather than being silently dropped at the predicate. Documented in the docstring and in the test for that case.

## Follow-up

A sweep PR will replace the three brick-local `any-anomaly?` copies with `ai.miniforge.anomaly.interface/any-anomaly?` after this lands. The helper carries a W5 retirement marker — removed once every producer is canonical and the legacy `:anomaly/category` shape no longer exists.

## Gates

- `bb lint:clj` clean (0 errors, 0 warnings)
- `bb poly:check` OK
- `bb pre-commit` green (329 tests / 1190 assertions, 0 failures, 0 errors; GraalVM compat 6 tests / 511 assertions, 0 failures, 0 errors)
- New `any-anomaly-test` suite — 6 tests, 10 assertions, 0 failures
- Commit signed (`heimdall@miniforge.ai`, verified: true, reason: valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)