### PR TITLE
fix(web-dashboard): add missing window.miniforge.filters object

### DIFF
--- a/components/web-dashboard/resources/public/js/app.js
+++ b/components/web-dashboard/resources/public/js/app.js
@@ -337,6 +337,46 @@ window.miniforge = {
     discoverRepos: fleetDiscoverRepos,
     syncPrs: fleetSyncPrs,
     discoverAndSync: fleetDiscoverAndSync
+  },
+  filters: {
+    addFilter(field, op, value, _scope) {
+      addFilterChip(field, value, `${field} ${op} ${value}`);
+    },
+    toggleFilter(field, value, _scope) {
+      const filterKey = `${field}:${value}`;
+      if (activeFilters.has(filterKey)) {
+        removeFilterChip(filterKey);
+      } else {
+        addFilterChip(field, value, `${field}: ${value}`);
+      }
+    },
+    setTextFilter(field, value) {
+      const existingKey = `text:${field}`;
+      if (activeFilters.has(existingKey)) {
+        removeFilterChip(existingKey);
+      }
+      if (value && value.trim()) {
+        addFilterChip('text', `${field}:${value}`, `${field}: "${value.trim()}"`);
+      }
+    },
+    clearFilters(_scope) {
+      Array.from(activeFilters.keys()).forEach(key => removeFilterChip(key));
+    },
+    shareCurrentView() {
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(window.location.href)
+          .then(() => showToast('Link copied to clipboard', 'info', 2000))
+          .catch(() => {});
+      }
+    },
+    toggleCloudFilter(el) {
+      const filterKey = 'cloud:enabled';
+      if (el && el.checked) {
+        addFilterChip('cloud', 'enabled', 'Cloud only');
+      } else {
+        removeFilterChip(filterKey);
+      }
+    }
   }
 };
 

--- a/components/web-dashboard/resources/public/js/app.js
+++ b/components/web-dashboard/resources/public/js/app.js
@@ -340,23 +340,27 @@ window.miniforge = {
   },
   filters: {
     addFilter(field, op, value, _scope) {
-      addFilterChip(field, value, `${field} ${op} ${value}`);
+      addFilterChip(`${field} ${op} ${value}`, field, value);
     },
     toggleFilter(field, value, _scope) {
       const filterKey = `${field}:${value}`;
       if (activeFilters.has(filterKey)) {
         removeFilterChip(filterKey);
       } else {
-        addFilterChip(field, value, `${field}: ${value}`);
+        addFilterChip(`${field}: ${value}`, field, value);
       }
     },
     setTextFilter(field, value) {
+      // key is always text:<field> so only one text filter per field exists at a time
       const existingKey = `text:${field}`;
       if (activeFilters.has(existingKey)) {
         removeFilterChip(existingKey);
       }
       if (value && value.trim()) {
-        addFilterChip('text', `${field}:${value}`, `${field}: "${value.trim()}"`);
+        const trimmed = value.trim();
+        // HTML-escape user input before it reaches addFilterChip's innerHTML label
+        const escaped = trimmed.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        addFilterChip(`${field}: "${escaped}"`, 'text', field);
       }
     },
     clearFilters(_scope) {
@@ -372,7 +376,7 @@ window.miniforge = {
     toggleCloudFilter(el) {
       const filterKey = 'cloud:enabled';
       if (el && el.checked) {
-        addFilterChip('cloud', 'enabled', 'Cloud only');
+        addFilterChip('Cloud only', 'cloud', 'enabled');
       } else {
         removeFilterChip(filterKey);
       }

--- a/components/web-dashboard/resources/public/js/app.js
+++ b/components/web-dashboard/resources/public/js/app.js
@@ -349,6 +349,7 @@ window.miniforge = {
       } else {
         addFilterChip(`${field}: ${value}`, field, value);
       }
+    }
     },
     setTextFilter(field, value) {
       // key is always text:<field> so only one text filter per field exists at a time

--- a/components/web-dashboard/resources/public/js/app.js
+++ b/components/web-dashboard/resources/public/js/app.js
@@ -349,7 +349,6 @@ window.miniforge = {
       } else {
         addFilterChip(`${field}: ${value}`, field, value);
       }
-    }
     },
     setTextFilter(field, value) {
       // key is always text:<field> so only one text filter per field exists at a time


### PR DESCRIPTION
## Problem

All server-rendered views (`views/dag.clj`, `views.clj`) wire filter buttons to methods on `window.miniforge.filters`:

```javascript
window.miniforge.filters.addFilter('entity-status', ':=', 'pending', 'global')
window.miniforge.filters.toggleFilter(field, value, 'global')
window.miniforge.filters.setTextFilter(field, value)
window.miniforge.filters.clearFilters('global')
window.miniforge.filters.shareCurrentView()
window.miniforge.filters.toggleCloudFilter(el)
```

But `window.miniforge` (defined at line 324 of `app.js`) had no `filters` key. Every click on a kanban status column, repository chip, or filter toggle threw:

```
TypeError: Cannot read properties of undefined (reading 'addFilter')
```

silently breaking all filter interactions in the fleet and DAG views.

## Fix

Adds a `filters` sub-object to the `window.miniforge` export. Each method is wired to the existing `addFilterChip` / `removeFilterChip` / `applyFilters` infrastructure already in `app.js`:

- `addFilter(field, op, value, scope)` → `addFilterChip` with a `field op value` label
- `toggleFilter(field, value, scope)` → add or remove the chip by key
- `setTextFilter(field, value)` → replace any existing chip for that field
- `clearFilters(scope)` → remove all chips
- `shareCurrentView()` → copies `window.location.href` to clipboard via `navigator.clipboard`
- `toggleCloudFilter(el)` → add/remove a `cloud:enabled` chip based on checkbox state

`applyFilters()` (called by `addFilterChip` / `removeFilterChip`) already dispatches an HTMX refresh, so server-side re-renders fire after each filter change.

## Scope

Single file: `components/web-dashboard/resources/public/js/app.js`. 40 insertions, 0 deletions — well within the 400-line budget.

## Test plan

- [ ] Open the fleet or DAG view, click a kanban column header — filter chip appears, no console error
- [ ] Click the × on the chip — chip removed, no console error
- [ ] Click "Clear filters" — all chips removed
- [ ] Click a repository link in a kanban card — `repository: repo-name` chip appears

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKFScJKtWrwX8ei6pnu4Pb)_