### PR TITLE
fix(llm): send Codex prompts via stdin

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -479,15 +479,18 @@
 
 (defn- codex-args
   "Build CLI arguments for the Codex backend."
-  [{:keys [prompt model system]}]
-  (cond-> ["exec"
-           "--json"
-           "--sandbox=workspace-write"
-           "--skip-git-repo-check"]
-    true   (into ["-c" "approval_policy=never"])
-    model  (into ["-m" model])
-    system (into ["-c" (str "system_prompt=" (json/generate-string system))])
-    true   (conj prompt)))
+  [{:keys [prompt model system prompt-via]
+    :or {prompt-via :argv}}]
+  (let [stdin? (= prompt-via :stdin)]
+    (cond-> ["exec"
+             "--json"
+             "--sandbox=workspace-write"
+             "--skip-git-repo-check"]
+      true   (into ["-c" "approval_policy=never"])
+      model  (into ["-m" model])
+      system (into ["-c" (str "system_prompt=" (json/generate-string system))])
+      stdin? (conj "-")
+      (not stdin?) (conj prompt))))
 
 (defn- cursor-args
   "Build CLI arguments for the Cursor backend (binary `agent`).
@@ -557,9 +560,9 @@
            :requires-cli? true
            :stream-parser parse-codex-stream-line
            :args-fn codex-args
-           ;; Prompt delivery: argv. Codex CLI takes a positional prompt;
-           ;; flip to :stdin if its prompt envelope grows past ARG_MAX.
-           :prompt-via :argv}
+           ;; Prompt delivery: stdin. Codex supports `-` as the prompt
+           ;; placeholder; this keeps large synthesis prompts off argv.
+           :prompt-via :stdin}
 
    :ollama {:cmd "http"
             :streaming? true

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -168,6 +168,13 @@
       (is (some #(= "--skip-git-repo-check" %) args))
       (is (= "fix bug" (last args))))))
 
+(deftest codex-args-stdin-test
+  (testing "stdin prompt delivery keeps prompt content out of argv"
+    (let [args ((private-fn 'codex-args)
+                {:prompt "fix bug" :prompt-via :stdin})]
+      (is (not (some #{"fix bug"} args)))
+      (is (= "-" (last args))))))
+
 (deftest codex-args-preflight-safe-config-test
   (testing "config overrides are safe before artifact MCP config exists"
     (let [args ((private-fn 'codex-args) {:prompt "p"})]

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -903,9 +903,9 @@
     (is (= :stdin (:prompt-via (get impl/backends :claude)))
         "claude must default to stdin to avoid POSIX ARG_MAX overflow")))
 
-(deftest non-claude-backends-default-to-argv-test
-  (testing "codex / cursor / opencode / echo backends keep :prompt-via :argv"
-    (is (= :argv (:prompt-via (get impl/backends :codex))))
+(deftest cli-backends-declare-safe-prompt-delivery-test
+  (testing "codex and claude use stdin; other CLI backends remain argv"
+    (is (= :stdin (:prompt-via (get impl/backends :codex))))
     (is (= :argv (:prompt-via (get impl/backends :cursor))))
     (is (= :argv (:prompt-via (get impl/backends :opencode))))
     (is (= :argv (:prompt-via (get impl/backends :echo))))))


### PR DESCRIPTION
## Summary

- Send Codex CLI prompts through stdin with `codex exec -`.
- Keep other LLM backends on their existing prompt delivery paths.
- Cover Codex stdin argument construction and backend prompt delivery in LLM tests.

## Verification

- `clojure -M:dev:test -e "(require 'ai.miniforge.llm.args-fn-test 'ai.miniforge.llm.interface-test 'clojure.test) (let [r (clojure.test/run-tests 'ai.miniforge.llm.args-fn-test 'ai.miniforge.llm.interface-test)] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))"`
