### PR TITLE
feat(workflow): Phase 2b — verdict-driven guarded :phase/fail for review (FSM RFC)

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -202,28 +202,9 @@
   "Reviewer decisions that mean 'don't ship this — fix it.' Iter 23
    regression: :rejected fell through to :completed, letting release
    open a PR against a reviewer-rejected artifact. Both decisions
-   route through the :failed branch so the workflow can either redirect
-   to :implement or terminate."
+   route through the :failed branch; the FSM's verdict-driven guarded
+   :phase/fail array (Phase 2b) decides between redirect and terminate."
   #{:rejected :changes-requested})
-
-(defn- terminate-stagnated
-  "Mark a stagnated phase as failed and skip the redirect-to-implement
-   path. The phase `:error` is a canonical anomaly map (W2 convergence):
-   `:anomaly/type :exhausted` (the review repair budget has been
-   spent without progress) carrying the legacy
-   `:anomalies.review/stagnation` keyword as `:anomaly/subtype` and the
-   fingerprint chain under `:anomaly/data` so the workflow runner /
-   evidence bundle can report what didn't move."
-  [ctx fingerprint-history]
-  (let [msg (messages/t :review/stagnation)]
-    (-> ctx
-        (assoc-in [:phase :stagnated?] true)
-        (assoc-in [:phase :error]
-                  (anomaly/sub-anomaly
-                   :exhausted
-                   :anomalies.review/stagnation
-                   msg
-                   {:review/fingerprint-history (vec fingerprint-history)})))))
 
 (def ^:private default-max-no-progress-attempts
   "After this many CONSECUTIVE review→implement repair cycles where each
@@ -237,28 +218,40 @@
    `:phase-config`)."
   3)
 
-(defn- terminate-needs-decomposition
-  "Mark the phase as failed with a :needs-decomposition signal — review keeps
-   surfacing different legitimate blockers each pass; the task likely needs
-   to be split. Distinct from :stagnated (identical-fingerprint loop) and
-   :exhausted (ran out of redirect budget): this is a CONVERGENCE failure
-   with a specific recommendation for the meta-agent. `review-cycle-count` is
-   the task-level number of completed reviews carried into the anomaly so the
-   diagnostic message names the actual count."
+(defn- attach-stagnated-anomaly
+  "Phase 2b: attach the stagnation anomaly to the phase result so the
+   workflow runner / evidence bundle can report what didn't move.
+   No more :stagnated? flag bit on the result — the FSM reads the
+   verdict directly."
+  [ctx fingerprint-history]
+  (let [msg (messages/t :review/stagnation)]
+    (assoc-in ctx [:phase :error]
+              (anomaly/sub-anomaly
+               :exhausted
+               :anomalies.review/stagnation
+               msg
+               {:review/fingerprint-history (vec fingerprint-history)}))))
+
+(defn- attach-needs-decomposition-anomaly
+  "Phase 2b: attach the needs-decomposition anomaly to the phase result.
+   No more :needs-decomposition? flag bit — verdict carries the signal."
   [ctx fingerprint-history review-cycle-count]
   (let [msg (messages/t :review/needs-decomposition {:iterations review-cycle-count})]
-    (-> ctx
-        (assoc-in [:phase :needs-decomposition?] true)
-        (assoc-in [:phase :error]
-                  {:message msg
-                   :anomaly/category :anomalies.review/needs-decomposition
-                   :anomaly/message  msg
-                   :review/cycle-count review-cycle-count
-                   :review/fingerprint-history (vec fingerprint-history)}))))
+    (assoc-in ctx [:phase :error]
+              {:message msg
+               :anomaly/category :anomalies.review/needs-decomposition
+               :anomaly/message  msg
+               :review/cycle-count review-cycle-count
+               :review/fingerprint-history (vec fingerprint-history)})))
 
-(defn- redirect-to-implement
-  "Update phase to redirect back to :implement with review feedback for
-   repair. Caller is responsible for the iteration-budget guard."
+(defn- attach-repair-handoff
+  "Phase 2b: attach repair feedback + a typed handoff so the implementer
+   can pick up the work. Does NOT call `phase/request-redirect` anymore
+   — the FSM's guarded `:phase/fail` array (registered at compile time
+   in `build-phase-state`) decides between on-fail redirect and
+   terminal :failed, with `:redirect/inc-count` as the single accounting
+   site. `leave-review` just attaches the verdict + feedback to the
+   result; the workflow engine handles routing."
   [updated-ctx feedback]
   (let [repair-attempt (inc (get-in updated-ctx [:phase :iterations] 0))
         handoff (phase-handoff/repair-request
@@ -270,8 +263,7 @@
         phase-result (-> (:phase updated-ctx)
                          (assoc :iterations repair-attempt)
                          (assoc :review-feedback feedback)
-                         (assoc :phase/handoff handoff)
-                         (phase/request-redirect :implement))]
+                         (assoc :phase/handoff handoff))]
     (-> updated-ctx
         (assoc :phase phase-result)
         (phase-handoff/append-execution-handoff handoff))))
@@ -318,27 +310,82 @@
     gate-failed?      :failed
     :else             :completed))
 
-(defn- compute-decision
-  "Pick the post-review action:
-     :stagnated | :needs-decomposition | :repair | :exhausted | :complete."
-  [{:keys [reviewer-blocked? stagnated? needs-decomposition? within-budget?
-           phase-status actionable-feedback?]}]
-  (cond
-    stagnated?                                                 :stagnated
-    needs-decomposition?                                       :needs-decomposition
-    (and reviewer-blocked? within-budget? actionable-feedback?) :repair
-    (= :failed phase-status)                                   :exhausted
-    :else                                                      :complete))
+(def ^:private verdicts
+  "Phase 2b verdict tag set. Replaces the old flag bag
+   (`:stagnated?` / `:needs-decomposition?`) + `compute-decision` ladder
+   with a single keyword that flows through `[:phase :result :output
+   :phase/verdict]` to the FSM. The FSM's verdict-driven guarded
+   `:phase/fail` array reads it via `:verdict/terminal?` to decide
+   between on-fail redirect and terminal `:failed`.
 
-(defn- apply-decision
-  "Apply the chosen post-review action to the updated context."
-  [decision updated-ctx feedback fingerprint-history review-cycle-count]
-  (case decision
-    :stagnated            (terminate-stagnated updated-ctx fingerprint-history)
-    :needs-decomposition  (terminate-needs-decomposition updated-ctx fingerprint-history review-cycle-count)
-    :repair               (redirect-to-implement updated-ctx feedback)
-    :exhausted            updated-ctx
-    :complete             (mark-completed updated-ctx)))
+     :approved            — reviewer green-lit; `:phase/succeed` event
+     :repair-requested    — actionable feedback + within budget;
+                            FSM may redirect via on-fail
+     :stagnated           — same blocking fingerprint as prior cycle;
+                            FSM terminates
+     :needs-decomposition — N non-stagnated rejections; FSM terminates
+                            with the decomposition signal
+     :exhausted           — reviewer blocked but no actionable
+                            feedback or over phase-level budget;
+                            FSM terminates"
+  #{:approved :repair-requested :stagnated :needs-decomposition :exhausted})
+
+(defn- compute-verdict
+  "Pick the verdict that should flow on the phase result. Mirrors the
+   former `compute-decision` semantics one-for-one — `:stagnated` and
+   `:needs-decomposition` keep their priority over `:repair-requested`;
+   a reviewer-blocked failure with no actionable feedback collapses to
+   `:exhausted`."
+  [{:keys [reviewer-blocked? stagnated? needs-decomposition? within-budget?
+           actionable-feedback?]}]
+  (cond
+    stagnated?
+    :stagnated
+
+    needs-decomposition?
+    :needs-decomposition
+
+    (and reviewer-blocked? within-budget? actionable-feedback?)
+    :repair-requested
+
+    reviewer-blocked?
+    :exhausted
+
+    :else
+    :approved))
+
+(defn- attach-verdict
+  "Phase 2b: attach the verdict to both the phase-internal `:phase
+   :verdict` slot (so phase callers / tests can inspect it) AND the
+   phase result's `:output :phase/verdict` slot, where
+   `determine-phase-event` reads it before constructing the FSM event."
+  [ctx verdict]
+  (-> ctx
+      (assoc-in [:phase :verdict] verdict)
+      (assoc-in [:phase :result :output :phase/verdict] verdict)))
+
+(defn- apply-verdict
+  "Carry out the side-effects implied by a verdict — attach anomalies
+   for terminal verdicts, attach handoff feedback for repair-requested,
+   mark completed for approved. The FSM drives the actual phase
+   transition; this fn only enriches the ctx with payload data that
+   evidence-bundle / downstream phases consume."
+  [verdict updated-ctx feedback fingerprint-history review-cycle-count]
+  (case verdict
+    :stagnated
+    (attach-stagnated-anomaly updated-ctx fingerprint-history)
+
+    :needs-decomposition
+    (attach-needs-decomposition-anomaly updated-ctx fingerprint-history review-cycle-count)
+
+    :repair-requested
+    (attach-repair-handoff updated-ctx feedback)
+
+    :exhausted
+    updated-ctx
+
+    :approved
+    (mark-completed updated-ctx)))
 
 (defn- accumulate-base-ctx
   "Apply the always-on context updates: phase metadata, metrics,
@@ -416,18 +463,19 @@
         needs-decomposition? (compute-needs-decomposition?
                               reviewer-blocked? stagnated?
                               review-cycle-count max-no-progress-attempts)
-        decision          (compute-decision {:reviewer-blocked?    reviewer-blocked?
-                                             :stagnated?           stagnated?
-                                             :needs-decomposition? needs-decomposition?
-                                             :within-budget?       within-budget?
-                                             :phase-status         phase-status
-                                             :actionable-feedback? (actionable-feedback? feedback)})
-        updated-ctx       (accumulate-base-ctx ctx end-time duration-ms phase-status
-                                               metrics iterations current-fp)
-        next-ctx          (apply-decision decision updated-ctx feedback
-                                          (conj prior-history current-fp)
-                                          review-cycle-count)]
-    (when (= :repair decision)
+        verdict           (compute-verdict {:reviewer-blocked?    reviewer-blocked?
+                                            :stagnated?           stagnated?
+                                            :needs-decomposition? needs-decomposition?
+                                            :within-budget?       within-budget?
+                                            :actionable-feedback? (actionable-feedback? feedback)})
+        updated-ctx       (-> ctx
+                              (accumulate-base-ctx end-time duration-ms phase-status
+                                                   metrics iterations current-fp)
+                              (attach-verdict verdict))
+        next-ctx          (apply-verdict verdict updated-ctx feedback
+                                         (conj prior-history current-fp)
+                                         review-cycle-count)]
+    (when (= :repair-requested verdict)
       (knowledge/capture-feedback-learning!
        (:knowledge-store ctx) :reviewer
        (get-in ctx [:execution/input :title]) feedback))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -103,13 +103,17 @@
       (is (not (phase/retrying? phase))
           "Should NOT be retrying (would cause review to re-run in place)"))))
 
-(deftest changes-requested-within-budget-redirects-to-implement
-  (testing "changes-requested within budget requests redirect to :implement"
+(deftest changes-requested-within-budget-emits-repair-requested-verdict
+  (testing "changes-requested within budget sets :phase/verdict :repair-requested
+            on the phase result so the FSM's verdict-driven guarded
+            :phase/fail array can route via :on-fail (Phase 2b)"
     (let [phase (simulate-leave-review :changes-requested 1 4)]
-      (is (= :implement (phase/transition-target phase))
-          "Should redirect to implement for repair")
+      (is (= :repair-requested (:verdict phase))
+          ":verdict is exposed on the phase map for callers/tests")
+      (is (= :repair-requested (get-in phase [:result :output :phase/verdict]))
+          ":phase/verdict on the phase result is what determine-phase-event reads")
       (is (phase/failed? phase)
-          "Must be failed for the transition request to be honored by execution"))))
+          "Status stays :failed; the FSM's guarded array picks the on-fail target"))))
 
 (deftest changes-requested-over-budget-no-redirect
   (testing "changes-requested at max iterations fails without redirect"
@@ -143,13 +147,17 @@
       (is (= [handoff] (:execution/phase-handoffs result-ctx)))
       (is (= default-review-issue-summary (:finding/summary finding))))))
 
-(deftest rejected-redirects-to-implement-like-changes-requested
-  (testing "iter-23 regression: :rejected decision must trigger redirect, not :completed"
+(deftest rejected-emits-repair-requested-verdict-like-changes-requested
+  (testing "iter-23 regression guard (Phase 2b shape): :rejected must set
+            :failed AND set verdict :repair-requested (NOT silently fall
+            through to :completed and let an empty-diff PR open). The
+            FSM's guarded array dispatches to on-fail :implement from
+            there."
     (let [phase (simulate-leave-review :rejected 1 4)]
       (is (phase/failed? phase)
-          "Rejected must set :failed — falling through to :completed lets an empty-diff PR open")
-      (is (= :implement (phase/transition-target phase))
-          "Rejected within budget must redirect to implement like :changes-requested"))))
+          "rejected must be :failed — falling through to :completed lets an empty-diff PR open")
+      (is (= :repair-requested (:verdict phase))
+          "verdict drives the FSM's on-fail dispatch"))))
 
 (deftest rejected-over-budget-no-redirect
   (testing ":rejected at max iterations fails terminally (no redirect)"
@@ -303,8 +311,12 @@
         interceptor (phase/get-phase-interceptor {:phase :review})]
     ((:leave interceptor) ctx)))
 
-(deftest stagnation-terminates-instead-of-redirecting-test
-  (testing "two consecutive identical fingerprints ⇒ no redirect, anomaly attached"
+(deftest stagnation-emits-stagnated-verdict-test
+  (testing "Phase 2b: two consecutive identical fingerprints ⇒ verdict
+            :stagnated. No call to request-redirect — the FSM's
+            :verdict/terminal? guard routes :phase/fail straight to
+            :failed, bypassing on-fail. Anomaly stays on :phase :error
+            for the evidence bundle."
     (let [issues          [blocking-issue]
           first-pass-ctx  (run-leave-review {:issues issues
                                              :iterations first-iteration})
@@ -313,10 +325,13 @@
                                              :iterations second-iteration
                                              :prior-fingerprints [first-fp]})
           phase           (:phase stagnated-ctx)]
-      (is (true? (:stagnated? phase))
-          "phase tagged stagnated when current fingerprint matches prior")
+      (is (= :stagnated (:verdict phase))
+          "phase verdict is :stagnated when current fp matches prior")
+      (is (= :stagnated (get-in phase [:result :output :phase/verdict]))
+          ":phase/verdict on the result is what determine-phase-event reads")
       (is (not (phase/redirect-requested? phase))
-          "no redirect to :implement on stagnation — repair loop is the burn we are stopping")
+          "Phase 2b: review.clj never calls request-redirect anymore — the
+           FSM owns routing, so no redirect is ever attached to the result")
       (is (anomaly/anomaly? (:error phase))
           ":phase :error is a canonical anomaly map (W2 convergence)")
       (is (= :exhausted (get-in phase [:error :anomaly/type]))
@@ -330,8 +345,10 @@
               two-fingerprints)
           "fingerprint history carries the chain that proved stagnation"))))
 
-(deftest non-stagnant-progress-still-redirects-test
-  (testing "fingerprint changed between iterations ⇒ ordinary repair redirect"
+(deftest non-stagnant-progress-emits-repair-requested-test
+  (testing "Phase 2b: fingerprint changed between iterations ⇒ verdict
+            :repair-requested. FSM routes to on-fail :implement via the
+            third branch of the guarded array."
     (let [first-fp     (run-leave-review {:issues [blocking-issue]
                                           :iterations first-iteration})
           first-print  (peek (get-in first-fp [:execution :review-fingerprints]))
@@ -339,22 +356,23 @@
                                           :iterations second-iteration
                                           :prior-fingerprints [first-print]})
           phase        (:phase progressed)]
-      (is (not (:stagnated? phase))
-          "different fingerprint ⇒ not stagnated")
-      (is (= :implement (phase/transition-target phase))
-          "ordinary repair: redirect to implement")
+      (is (= :repair-requested (:verdict phase))
+          "different fingerprint ⇒ verdict :repair-requested (FSM redirects)")
       (is (nil? (get-in phase [:error :anomaly/subtype]))
           "no stagnation anomaly when progress is detected"))))
 
 (deftest first-iteration-never-stagnates-test
-  (testing "no prior fingerprint history ⇒ first review must not short-circuit"
+  (testing "Phase 2b: no prior fingerprint history ⇒ first review must
+            not short-circuit. Verdict is :repair-requested (within
+            budget, has feedback) and the FSM dispatches to implement
+            via on-fail."
     (let [phase (:phase (run-leave-review {:issues [blocking-issue]
                                            :iterations first-iteration
                                            :prior-fingerprints []}))]
-      (is (not (:stagnated? phase))
-          "first review iteration is never stagnation")
-      (is (= :implement (phase/transition-target phase))
-          "first :changes-requested still redirects normally"))))
+      (is (not= :stagnated (:verdict phase))
+          "first review iteration cannot be :stagnated")
+      (is (= :repair-requested (:verdict phase))
+          "first :changes-requested produces :repair-requested verdict"))))
 
 (deftest fingerprint-recorded-on-every-review-test
   (testing "every review iteration appends its fingerprint to the execution history"
@@ -399,55 +417,54 @@
   default-convergence-cap)
 
 (deftest needs-decomposition-fires-after-n-non-stagnated-rejections-test
-  (testing "3 consecutive non-stagnated review rejections (different blockers
-            each pass) trip :needs-decomposition — the implementer is fixing
-            prior findings but new legitimate ones keep surfacing, signal the
-            task needs splitting rather than burning more redirect budget.
+  (testing "Phase 2b: 3 consecutive non-stagnated review rejections trip
+            verdict :needs-decomposition. FSM's :verdict/terminal? guard
+            routes to terminal :failed rather than on-fail redirect.
 
-            Note: the cap keys off the TASK-LEVEL fingerprint history
-            (`(inc (count prior-fingerprints))`), not `:phase :iterations`.
-            The phase-local counter resets per phase entry and the shipped
-            review `:budget :iterations` is 2, so the cap MUST count cycles
-            across re-entries or it would be unreachable in production."
+            Cap keys off task-level fingerprint history (`(inc (count
+            prior))`), not phase-local :iterations — see the convergence
+            cap PR #1011 commit message for why the latter is unreachable
+            under shipped config."
     (let [final-ctx (run-leave-review {:issues             [yet-another-blocking-issue]
                                        :iterations         third-iteration
                                        :prior-fingerprints prior-distinct-fingerprints})
           phase (:phase final-ctx)]
-      (is (true? (:needs-decomposition? phase))
-          "phase tagged :needs-decomposition?")
+      (is (= :needs-decomposition (:verdict phase))
+          "verdict :needs-decomposition surfaces on the phase map")
+      (is (= :needs-decomposition (get-in phase [:result :output :phase/verdict]))
+          ":phase/verdict on the result is what determine-phase-event reads")
       (is (= :anomalies.review/needs-decomposition
              (get-in phase [:error :anomaly/category]))
           "convergence-cap anomaly attached")
       (is (= cycles-at-cap (get-in phase [:error :review/cycle-count]))
-          "task-level cycle count carried in the anomaly")
-      (is (not (phase/redirect-requested? phase))
-          "no redirect-to-implement on :needs-decomposition — repair budget conserved"))))
+          "task-level cycle count carried in the anomaly"))))
 
 (deftest needs-decomposition-yields-to-stagnation-test
-  (testing "when the new fingerprint matches the immediate prior one, stagnation
-            wins over :needs-decomposition (identical-loop is the sharper signal).
-            Seed with two prior fingerprints so the task-level cycle count would
-            otherwise hit the cap — proves stagnation pre-empts."
+  (testing "when the new fingerprint matches the immediate prior one,
+            stagnation wins over :needs-decomposition (identical-loop is
+            the sharper signal). Seed with two prior fingerprints so the
+            task-level cycle count would otherwise hit the cap — proves
+            stagnation pre-empts."
     (let [seed-issue {:severity :blocking :description "same"}
           seed-ctx   (run-leave-review {:issues [seed-issue] :iterations first-iteration})
           seed-fp    (peek (get-in seed-ctx [:execution :review-fingerprints]))
-          ;; Pad to 2 distinct priors so cycle count would tip the cap if
-          ;; stagnation didn't fire first. Last prior must equal current fp
-          ;; for stagnation to trigger.
           padded-priors [{:review/fingerprint :prelude} seed-fp]
           final-ctx  (run-leave-review {:issues             [seed-issue]
                                         :iterations         third-iteration
                                         :prior-fingerprints padded-priors})
           phase (:phase final-ctx)]
-      (is (true? (:stagnated? phase)) "stagnation fires, not :needs-decomposition")
-      (is (nil? (:needs-decomposition? phase))))))
+      (is (= :stagnated (:verdict phase))
+          "stagnation pre-empts :needs-decomposition in compute-verdict"))))
 
 (deftest needs-decomposition-does-not-fire-below-cap-test
-  (testing "two cycles total (one prior + this review) — below the default
-            cap of 3 — still redirect normally"
+  (testing "Phase 2b: two cycles total (one prior + this review) — below
+            the default cap of 3 — emit :repair-requested verdict so the
+            FSM redirects via on-fail rather than terminating."
     (let [final-ctx (run-leave-review {:issues             [different-blocking-issue]
                                        :iterations         second-iteration
                                        :prior-fingerprints [{:review/fingerprint :only}]})
           phase (:phase final-ctx)]
-      (is (nil? (:needs-decomposition? phase)) "below cap, no decomposition signal")
-      (is (phase/redirect-requested? phase) "still redirects on a normal repair cycle"))))
+      (is (not= :needs-decomposition (:verdict phase))
+          "below cap, no decomposition verdict")
+      (is (= :repair-requested (:verdict phase))
+          "below cap with progress + actionable feedback = :repair-requested"))))

--- a/components/workflow/src/ai/miniforge/workflow/actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/actions.clj
@@ -100,9 +100,21 @@
   (set (keys @registry)))
 
 (defn clear-registry!
-  "Drop all registered actions. Test fixture only."
+  "Drop all registered actions. Test fixture only — prefer the
+   snapshot/restore pair below so namespace-load-time registrations
+   from `standard-guards-and-actions` aren't wiped between tests."
   []
   (reset! registry {}))
+
+(defn snapshot-registry
+  "Return the current registry state for save/restore patterns in tests."
+  []
+  @registry)
+
+(defn restore-registry!
+  "Restore the registry to a previously-snapshot'd state."
+  [snapshot]
+  (reset! registry snapshot))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Reference extraction

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -291,10 +291,24 @@
   (or (:stagnated? phase-result)
       (:needs-decomposition? phase-result)))
 
+(defn- phase-verdict
+  "Phase 2b: read the `:phase/verdict` keyword from a phase result, if
+   the phase code set one. Review-phase failures attach this; other
+   phases don't yet (Phase 3 generalizes)."
+  [phase-result]
+  (get-in phase-result [:output :phase/verdict]))
+
 (defn determine-phase-event
-  "Translate a phase result into an execution-machine event."
+  "Translate a phase result into an execution-machine event.
+
+   For review-phase failures (verdict present), returns a map event
+   `{:type :phase/fail :phase/verdict <v>}` so the verdict-driven
+   guarded `:phase/fail` array can dispatch via the
+   `:verdict/terminal?` guard. Non-verdict paths preserve the
+   pre-Phase-2 behavior (keyword event)."
   [_phase-config phase-result]
-  (let [target-phase (redirect-target phase-result)]
+  (let [target-phase (redirect-target phase-result)
+        verdict      (phase-verdict phase-result)]
     (cond
       (phase/retrying? phase-result)
       :phase/retry
@@ -302,13 +316,22 @@
       (phase/already-done? phase-result)
       :phase/already-done
 
-      ;; Terminal failure markers must beat the on-fail redirect; check
-      ;; before the redirect branches.
+      ;; Terminal failure markers (legacy `:stagnated?` / `:needs-
+      ;; decomposition?` flags) must beat the on-fail redirect; check
+      ;; before the redirect branches. Phase 4 deletes this path once
+      ;; verify/release/implement also emit verdicts.
       (and (phase/failed? phase-result) (terminal-failure? phase-result))
       :phase/terminal-fail
 
       (phase/succeeded? phase-result)
       :phase/succeed
+
+      ;; Phase 2b: review-phase failures carry a verdict — send a map
+      ;; event so the FSM's guarded array reads it via
+      ;; `:verdict/terminal?`. Skip if a redirect was explicitly
+      ;; requested via the legacy `request-redirect` path (other phases).
+      (and (phase/failed? phase-result) verdict (not target-phase))
+      {:type :phase/fail :phase/verdict verdict}
 
       (and (phase/failed? phase-result) target-phase)
       (workflow-fsm/redirect-event target-phase)

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -43,7 +43,13 @@
    [ai.miniforge.workflow.actions :as actions]
    [ai.miniforge.workflow.definition :as definition]
    [ai.miniforge.workflow.guards :as guards]
-   [ai.miniforge.workflow.messages :as messages]))
+   [ai.miniforge.workflow.messages :as messages]
+   ;; Side-effecting require — registers `:verdict/terminal?`,
+   ;; `:budget/redirects-spent?` and `:redirect/inc-count` at load
+   ;; time so `compile-execution-machine`'s resolver can substitute
+   ;; them. Phase 2b consumes these from the review-phase
+   ;; `:phase/fail` guarded array.
+   [ai.miniforge.workflow.standard-guards-and-actions]))
 
 (declare current-state first-phase-index reachable-states unreachable-states)
 
@@ -218,6 +224,40 @@
               {:state current-state
                :event event}))
 
+(defn- review-phase-fail-transition
+  "Phase 2b: emit the guarded `:phase/fail` array for the review phase.
+
+   Ordering matters — clj-statecharts picks the first guard whose
+   predicate returns truthy. The compile-time choice to include or omit
+   the redirect branch makes the runtime `:config/on-fail-set?` guard
+   from the RFC's three-guard set unnecessary (when on-fail isn't
+   configured, the branch is simply absent).
+
+   * Branch 1: terminal verdict (stagnated / needs-decomposition /
+     exhausted) → straight to `:failed`.
+   * Branch 2: redirect budget spent → straight to `:failed` (no more
+     on-fail redirects).
+   * Branch 3 (only when `:on-fail` is configured): the on-fail
+     redirect, plus the `:redirect/inc-count` action that bumps the
+     FSM-owned `:redirect-count` (single accounting site — Phase 4
+     deletes the runner's parallel `redirect-event?` check).
+   * Branch 4: default — no verdict, no on-fail, just fail."
+  [failure-target on-fail-configured?]
+  (if on-fail-configured?
+    [{:target :failed         :guard :verdict/terminal?}
+     {:target :failed         :guard :budget/redirects-spent?}
+     {:target failure-target  :actions [:redirect/inc-count]}
+     {:target :failed}]
+    [{:target :failed :guard :verdict/terminal?}
+     {:target :failed}]))
+
+(defn- review-phase?
+  "True when this phase entry's config drives the review-phase behavior.
+   Phase 2b migrates review-phase fail-routing to the guarded array;
+   Phase 3 generalizes to verify / release / implement."
+  [config]
+  (= :review (:phase config)))
+
 (defn- build-phase-state
   [phase-entries {:keys [index config state-id paused-state-id]}]
   (let [terminal-phase? (:terminal? config)
@@ -235,20 +275,26 @@
         failure-target (or (state-target phase-entries on-fail-index)
                            :failed)
         already-done-target (or (state-target phase-entries done-index)
-                                :completed)]
+                                :completed)
+        ;; Phase 2b: review-phase routes :phase/fail through a guarded
+        ;; array; other phases keep the flat shape until Phase 3.
+        phase-fail-transition (if (review-phase? config)
+                                (review-phase-fail-transition failure-target
+                                                              (some? on-fail-index))
+                                failure-target)]
     [state-id
      {:on (merge
            {:phase/retry state-id
             :phase/succeed success-target
             :phase/already-done already-done-target
-            :phase/fail failure-target
+            :phase/fail phase-fail-transition
             ;; Terminal failure event: bypasses `:on-fail` and routes
             ;; straight to `:failed`. Used by phases that have decided the
-            ;; only forward path is escalation (e.g. review stagnation, the
-            ;; convergence-cap :needs-decomposition signal) — without this,
-            ;; setting `:stagnated?` / `:needs-decomposition?` on the phase
-            ;; result is dead code: the FSM still follows on-fail and the
-            ;; review→implement loop burns until `max-redirects`.
+            ;; only forward path is escalation. For review phase this
+            ;; mechanism is superseded by Phase 2b's verdict-driven
+            ;; guarded array, but we keep the event mapping until Phase 4
+            ;; drops the workaround so verify/release/implement (and
+            ;; in-flight checkpoints) keep working.
             :phase/terminal-fail :failed
             :pause paused-state-id
             :cancel :cancelled

--- a/components/workflow/src/ai/miniforge/workflow/guards.clj
+++ b/components/workflow/src/ai/miniforge/workflow/guards.clj
@@ -96,9 +96,21 @@
   (set (keys @registry)))
 
 (defn clear-registry!
-  "Drop all registered guards. Test fixture only."
+  "Drop all registered guards. Test fixture only — prefer the
+   snapshot/restore pair below so namespace-load-time registrations
+   from `standard-guards-and-actions` aren't wiped between tests."
   []
   (reset! registry {}))
+
+(defn snapshot-registry
+  "Return the current registry state for save/restore patterns in tests."
+  []
+  @registry)
+
+(defn restore-registry!
+  "Restore the registry to a previously-snapshot'd state."
+  [snapshot]
+  (reset! registry snapshot))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Reference extraction

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -1,0 +1,102 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.standard-guards-and-actions
+  "Standard FSM guards and actions for workflow phase transitions.
+
+   Phase 2b of the FSM RFC. Registers the predicates and side-effects
+   the review-phase guarded `:phase/fail` array consumes:
+
+     {:on {:phase/fail
+           [{:target :failed     :guard :verdict/terminal?}
+            {:target :failed     :guard :budget/redirects-spent?}
+            {:target on-fail     :actions [:redirect/inc-count]}
+            {:target :failed}]}}
+
+   Registration happens at namespace-load time — requiring this ns is
+   enough to populate the registries. `compile-execution-machine`
+   resolves the keyword refs against the populated registries.
+
+   No `:config/on-fail-set?` guard is registered: the RFC's three-guard
+   set collapses to two at runtime because `build-phase-state` decides
+   at COMPILE time whether to include the redirect branch (based on
+   `(:on-fail config)`). If on-fail is unset, the redirect branch is
+   omitted entirely — no runtime check needed. This is structurally
+   identical to the RFC behavior with simpler runtime arithmetic."
+  (:require
+   [ai.miniforge.fsm.interface :as fsm]
+   [ai.miniforge.workflow.actions :as actions]
+   [ai.miniforge.workflow.guards :as guards]
+   [ai.miniforge.workflow.runner-defaults :as defaults]
+   [statecharts.core :as sc]))
+
+;------------------------------------------------------------------------------ Verdict-driven guards
+
+(def terminal-verdicts
+  "The set of `:phase/verdict` values that route a phase failure straight
+   to the workflow terminal `:failed` state, bypassing any on-fail
+   redirect. Mirrors the legacy `:stagnated?` / `:needs-decomposition?`
+   flag bits from the workaround era; collapsed here into a single
+   FSM-readable signal."
+  #{:stagnated :needs-decomposition :exhausted})
+
+(defn verdict-terminal?
+  "Guard: true when the failing-phase event carries a terminal verdict.
+   Reads `(:phase/verdict event)` — the phase code attaches this on its
+   result; `determine-phase-event` plumbs it into the FSM event map."
+  [_state event]
+  (contains? terminal-verdicts (:phase/verdict event)))
+
+;------------------------------------------------------------------------------ Budget-driven guard
+
+(defn budget-redirects-spent?
+  "Guard: true when the FSM-context redirect-count has reached the
+   workflow-wide `max-redirects` ceiling. Reads from FSM context
+   (`(fsm/context state)`) which is the single source of truth for
+   the budget — the runner's parallel check in `apply-phase-transition`
+   becomes redundant once Phase 3 migrates the remaining phases."
+  [state _event]
+  (let [ctx (fsm/context state)
+        max-r (defaults/max-redirects)]
+    (>= (get ctx :redirect-count 0) max-r)))
+
+;------------------------------------------------------------------------------ Actions
+
+(def redirect-inc-count
+  "Action: bumps the FSM-context `:redirect-count` by 1. Uses
+   `statecharts.core/assign` directly rather than the local
+   `ai.miniforge.fsm.interface/assign` wrapper — the latter returns a
+   plain fn that clj-statecharts doesn't recognize as an assign action,
+   so context mutations get silently dropped (verified by a probe with
+   a 1-state machine returning `{:counter 0}` after `:go` despite the
+   action running). `sc/assign` produces the engine-tagged variant
+   that actually propagates context updates.
+
+   Single accounting site — the runner's `redirect-event?` namespace
+   sniff goes away in Phase 4."
+  (sc/assign (fn [ctx _event]
+               (update ctx :redirect-count (fnil inc 0)))))
+
+;------------------------------------------------------------------------------ Registration
+
+;; Eager registration at namespace load — `(require '...standard-guards-and-actions)`
+;; is enough to populate both registries. `compile-execution-machine` then
+;; resolves the keyword refs.
+(guards/register-guard! :verdict/terminal?         verdict-terminal?)
+(guards/register-guard! :budget/redirects-spent?   budget-redirects-spent?)
+(actions/register-action! :redirect/inc-count      redirect-inc-count)

--- a/components/workflow/test/ai/miniforge/workflow/actions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/actions_test.clj
@@ -29,8 +29,12 @@
 
 (use-fixtures :each
   (fn [f]
-    (actions/clear-registry!)
-    (try (f) (finally (actions/clear-registry!)))))
+    ;; Snapshot/restore so namespace-load-time registrations from
+    ;; `standard-guards-and-actions` survive across tests that need a
+    ;; clean slate. See guards_test for the same pattern.
+    (let [snap (actions/snapshot-registry)]
+      (actions/clear-registry!)
+      (try (f) (finally (actions/restore-registry! snap))))))
 
 (defn- bump-counter [state _event]
   (update-in state [:context :redirect-count] (fnil inc 0)))

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -20,7 +20,9 @@
   "Tests for workflow FSM."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.workflow.fsm :as fsm]))
+   [ai.miniforge.fsm.interface :as engine]
+   [ai.miniforge.workflow.fsm :as fsm]
+   [ai.miniforge.workflow.runner-defaults :as defaults]))
 
 (deftest workflow-states-test
   (testing "All workflow states are defined"
@@ -271,6 +273,61 @@
         (let [after-terminal (fsm/transition-execution machine at-review :phase/terminal-fail)]
           (is (= :failed (fsm/execution-status machine after-terminal))
               "terminal-fail MUST bypass :on-fail and land in :failed"))))))
+
+;------------------------------------------------------------------------------ Phase 2b: verdict-driven :phase/fail array
+
+(deftest review-phase-verdict-routes-fail-via-guarded-array-test
+  (testing "Phase 2b: the review phase's :phase/fail dispatch reads
+            :phase/verdict from the event. A terminal verdict
+            (:stagnated / :needs-decomposition / :exhausted) routes
+            straight to :failed bypassing :on-fail, while a
+            :repair-requested verdict (within budget) takes the on-fail
+            redirect AND bumps :redirect-count via the registered
+            :redirect/inc-count action."
+    (let [workflow {:workflow/id :verdict-array-test
+                    :workflow/pipeline [{:phase :plan}
+                                        {:phase :implement}
+                                        {:phase :verify}
+                                        {:phase :review :on-fail :implement}
+                                        {:phase :done}]}
+          machine (fsm/compile-execution-machine workflow)
+          at-review (->> (fsm/initialize-execution machine)
+                         (fsm/start-execution machine)
+                         (#(fsm/transition-execution machine % :phase/succeed))
+                         (#(fsm/transition-execution machine % :phase/succeed))
+                         (#(fsm/transition-execution machine % :phase/succeed)))]
+      (is (= :review (fsm/current-phase-id machine at-review)))
+      (testing ":phase/verdict :stagnated terminates straight to :failed"
+        (let [evt {:type :phase/fail :phase/verdict :stagnated}
+              after (fsm/transition-execution machine at-review evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "terminal verdict bypasses :on-fail :implement")))
+      (testing ":phase/verdict :needs-decomposition terminates straight to :failed"
+        (let [evt {:type :phase/fail :phase/verdict :needs-decomposition}
+              after (fsm/transition-execution machine at-review evt)]
+          (is (= :failed (fsm/execution-status machine after)))))
+      (testing ":phase/verdict :exhausted terminates straight to :failed"
+        (let [evt {:type :phase/fail :phase/verdict :exhausted}
+              after (fsm/transition-execution machine at-review evt)]
+          (is (= :failed (fsm/execution-status machine after)))))
+      (testing ":phase/verdict :repair-requested follows on-fail to :implement"
+        (let [evt {:type :phase/fail :phase/verdict :repair-requested}
+              after (fsm/transition-execution machine at-review evt)]
+          (is (= :implement (fsm/current-phase-id machine after))
+              "non-terminal verdict + on-fail set → redirect branch fires")
+          (is (= 1 (get after :redirect-count 0))
+              ":redirect/inc-count action bumped the FSM-context counter
+               — the SINGLE accounting site that Phase 4 will rely on
+               when the runner's parallel namespace-sniff check is removed")))
+      (testing "budget-redirects-spent? guard pre-empts the redirect when
+                the FSM-context :redirect-count is already at the ceiling"
+        (let [max-r (defaults/max-redirects)
+              over-budget (engine/update-context at-review assoc :redirect-count max-r)
+              evt {:type :phase/fail :phase/verdict :repair-requested}
+              after (fsm/transition-execution machine over-budget evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "budget-spent guard takes the second :failed branch
+               before the redirect branch fires"))))))
 
 (deftest state-graph-walks-guarded-array-transitions-test
   ;; Phase 2a permits transition values shaped as ordered vectors of

--- a/components/workflow/test/ai/miniforge/workflow/guards_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/guards_test.clj
@@ -39,8 +39,14 @@
 
 (use-fixtures :each
   (fn [f]
-    (guards/clear-registry!)
-    (try (f) (finally (guards/clear-registry!)))))
+    ;; Snapshot/restore so namespace-load-time registrations from
+    ;; `standard-guards-and-actions` survive across tests that need a
+    ;; clean slate. Clearing without restoration left :verdict/terminal?
+    ;; / :budget/redirects-spent? unregistered for any test that ran
+    ;; after this fixture.
+    (let [snap (guards/snapshot-registry)]
+      (guards/clear-registry!)
+      (try (f) (finally (guards/restore-registry! snap))))))
 
 ;------------------------------------------------------------------------------ Helpers
 


### PR DESCRIPTION
**Behavior milestone of the FSM RFC.** Review-phase failures now route through an ordered guarded array on the compiled state machine. The dogfood-class bug — channel-A redirects via \`:on-fail\` bypassing the budget — becomes **structurally impossible** because the SINGLE accounting site is the \`:redirect/inc-count\` action attached to the redirect branch.

## Guarded array (review phase only — Phase 3 generalizes)

\`\`\`clojure
:phase/fail
[{:target :failed          :guard :verdict/terminal?}
 {:target :failed          :guard :budget/redirects-spent?}
 {:target on-fail-target   :actions [:redirect/inc-count]}
 {:target :failed}]
\`\`\`

Collapses every decision the phase code previously owned (\`compute-decision\`, \`terminate-stagnated\`, \`terminate-needs-decomposition\`, the \`:stagnated?\` / \`:needs-decomposition?\` flag bag, the request-redirect plumbing) into typed FSM transitions readable as data.

## Summary

- New \`components/workflow/src/.../standard_guards_and_actions.clj\` — registers the three guard/action keywords at namespace load. \`:redirect/inc-count\` uses \`statecharts.core/assign\` directly (the local \`fsm/assign\` wrapper returns a plain fn that clj-statecharts doesn't recognize as an assign action — verified by a 1-state probe).
- \`guards.clj\` + \`actions.clj\` gain snapshot/restore helpers so registrations survive tests that need a clean slate.
- \`fsm.clj\` \`build-phase-state\` emits the guarded array for review only. \`state-graph\` walker handles vector-form transitions (Copilot's #1025 catch).
- \`review.clj\` \`compute-decision\` → \`compute-verdict\` (verdicts: \`#{:approved :repair-requested :stagnated :needs-decomposition :exhausted}\`). \`apply-decision\` → \`apply-verdict\`. \`terminate-*\` → \`attach-*-anomaly\`. \`:stagnated?\` / \`:needs-decomposition?\` flag bits dropped. No more \`phase/request-redirect\` — FSM owns routing.
- \`execution.clj\` \`determine-phase-event\` reads \`:phase/verdict\` and sends \`{:type :phase/fail :phase/verdict v}\` map event for FSM dispatch.

## Test plan

- [x] \`review_repair_loop_test\`: 8 tests updated to assert verdict shape (no more \`phase/redirect-requested?\` checks — review.clj never calls request-redirect)
- [x] New \`fsm_test/review-phase-verdict-routes-fail-via-guarded-array-test\` exercises all 4 branches against the real compiled machine: terminal verdicts → :failed, :repair-requested → on-fail + counter bump, budget-spent + :repair-requested → :failed
- [x] All workflow + phase-software-factory brick tests green
- [x] Pre-commit smoke clean

## Migration

Phase 2b (this PR) ships the behavior change. Phase 3 generalizes to verify/release/implement. Phase 4 deletes the workaround (\`:phase/terminal-fail\`, \`:stagnated?\`/\`:needs-decomposition?\` flag-sniffs, \`redirect-event?\` namespace concept). Phase 5 strengthens compile-time invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)