### PR TITLE
feat(workflow,verify): Phase 3a — verify joins guarded :phase/fail array (FSM RFC)

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -325,12 +325,81 @@
 
     (phase/enter-context ctx :verify nil gates budget start-time result)))
 
+(def ^:private verdicts
+  "Phase 3 verdict tag set for verify. Mirrors review's shape (Phase 2b)
+   with verify-specific terminal kinds:
+
+     :approved            — gates passed; `:phase/succeed` event
+     :repair-requested    — generic test failure with `:on-fail` set;
+                            FSM redirects to implement (subject to
+                            budget)
+     :verify/timeout      — test process timed out (hung BB/cargo); FSM
+                            terminates because retrying implement won't
+                            unstick the process
+     :verify/rate-limited — provider quota blocked the phase; FSM
+                            terminates because retrying implement won't
+                            change LLM quota
+     :exhausted           — failed but no redirect target configured"
+  #{:approved :repair-requested :verify/timeout :verify/rate-limited :exhausted})
+
+(defn- compute-verdict
+  "Pick the verdict that should flow on the phase result.
+
+   `:verify/timeout` and `:verify/rate-limited` take priority over
+   `:repair-requested` — those failure modes are not code-quality
+   issues, so retrying implement is wasted work (this was the
+   2026-05-28 dogfood's bottleneck: verify hit a 30-min timeout, the
+   loop redirected to implement, implement wrote a recovery, verify
+   timed out AGAIN, repeat. The FSM's `:verdict/terminal?` guard now
+   short-circuits the loop)."
+  [{:keys [phase-failed? on-fail-configured? timeout? rate-limited?]}]
+  (cond
+    timeout?
+    :verify/timeout
+
+    rate-limited?
+    :verify/rate-limited
+
+    (and phase-failed? on-fail-configured?)
+    :repair-requested
+
+    phase-failed?
+    :exhausted
+
+    :else
+    :approved))
+
+(defn- attach-verify-error
+  "Attach the verify error map to the phase result for the evidence
+   bundle. Carries the legacy `:timeout?` / `:rate-limited?` flag bits
+   too so consumers reading those keys keep working until Phase 4
+   removes them."
+  [ctx error-message agent-status timeout? rate-limited? gate-failed?]
+  (assoc-in ctx [:phase :error]
+            {:message       error-message
+             :agent-status  agent-status
+             :timeout?      timeout?
+             :rate-limited? rate-limited?
+             :gate-failed?  gate-failed?}))
+
 (defn leave-verify
   "Post-processing for verification phase.
 
    Records test metrics: count, pass rate, coverage.
-   When verification fails and :on-fail is configured, requests a redirect
-   so the execution engine jumps to the target phase (typically :implement)."
+
+   Phase 3 (Phase 2b shape generalized to verify): when verification
+   fails, attaches a `:phase/verdict` to the result so the FSM's
+   verdict-driven guarded `:phase/fail` array (see
+   `workflow/fsm/build-phase-state` and
+   `workflow/standard-guards-and-actions`) decides between an on-fail
+   redirect and a terminal `:failed`. No more `phase/request-redirect`
+   — the FSM owns routing.
+
+   `:verify/timeout` and `:verify/rate-limited` are TERMINAL verdicts:
+   the FSM bypasses on-fail and lands on `:failed` because retrying
+   the implement target wouldn't help (a hung test process is a
+   process issue; a provider rate-limit is a quota issue; implementing
+   different code doesn't fix either)."
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
@@ -355,50 +424,42 @@
                     (assoc :duration-ms duration-ms))
         iterations (get-in ctx [:phase :iterations] 1)
         on-fail (get-in ctx [:phase-config :on-fail])
+        error-message (or (not-empty (get-in result [:error :message]))
+                          (when gate-failed? (messages/t :verify/gate-failed))
+                          (messages/t :verify/failed))
+        verdict (compute-verdict {:phase-failed?       (= :failed phase-status)
+                                  :on-fail-configured? (some? on-fail)
+                                  :timeout?            timeout?
+                                  :rate-limited?       rate-limited?})
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
                         (assoc-in [:phase :status] phase-status)
                         (assoc-in [:phase :metrics] metrics)
+                        (assoc-in [:phase :verdict] verdict)
+                        (assoc-in [:phase :result :output :phase/verdict] verdict)
                         (assoc-in [:metrics :verification :duration-ms] duration-ms)
                         (assoc-in [:metrics :verification :repair-cycles] (dec iterations))
-                        ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))
-        error-message (or (not-empty (get-in result [:error :message]))
-                          (when gate-failed? (messages/t :verify/gate-failed))
-                          (messages/t :verify/failed))]
-    ;; When verify failed and on-fail is configured, redirect to target phase.
-    ;; Timeout and rate-limit failures are not code quality issues — retrying
-    ;; implement won't help, so we do not redirect in those cases.
-    (doto (if (and (= :failed phase-status) on-fail
-                     (not timeout?) (not rate-limited?))
-              (let [phase-result (-> (:phase updated-ctx)
-                                     (assoc :error
-                                            {:message      error-message
-                                             :agent-status agent-status
-                                             :gate-failed? gate-failed?})
-                                     (phase/request-redirect on-fail))]
-                (assoc updated-ctx :phase phase-result))
-              (cond-> updated-ctx
-                (= :completed phase-status)
-                (update-in [:execution :phases-completed] (fnil conj []) :verify)
-                (= :failed phase-status)
-                (assoc-in [:phase :error]
-                          {:message       error-message
-                           :agent-status  agent-status
-                           :timeout?      timeout?
-                           :rate-limited? rate-limited?
-                           :gate-failed?  gate-failed?})))
-        (phase/emit-phase-completed! :verify
-          (merge {:outcome     (if (= :completed phase-status) :success :failure)
-                  :duration-ms duration-ms
-                  :tokens      (get metrics :tokens 0)}
-                 ;; :stalled? true when the test process timed out (hung BB/cargo)
-                 ;; :rate-limited? true when provider quota blocked the phase
-                 (phase-terminal/derive-termination-reason result
-                   {:stalled?      timeout?
-                    :rate-limited? rate-limited?}))))))
+        next-ctx (cond
+                   (= :completed phase-status)
+                   (update-in updated-ctx [:execution :phases-completed] (fnil conj []) :verify)
+
+                   (= :failed phase-status)
+                   (attach-verify-error updated-ctx error-message agent-status
+                                        timeout? rate-limited? gate-failed?)
+
+                   :else
+                   updated-ctx)]
+    (phase/emit-phase-completed! next-ctx :verify
+      (merge {:outcome     (if (= :completed phase-status) :success :failure)
+              :duration-ms duration-ms
+              :tokens      (get metrics :tokens 0)}
+             (phase-terminal/derive-termination-reason result
+               {:stalled?      timeout?
+                :rate-limited? rate-limited?})))
+    next-ctx))
 
 (defn error-verify
   "Handle verification phase errors. Retries within budget; on

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
@@ -199,60 +199,79 @@
            :execution/metrics {:tokens 0 :duration-ms 0}}
     on-fail (assoc :phase-config {:on-fail on-fail})))
 
-(deftest leave-verify-redirects-on-normal-failure-test
-  (testing "normal verify failure with :on-fail configured requests a redirect"
+(deftest leave-verify-normal-failure-emits-repair-requested-verdict-test
+  (testing "Phase 3: normal verify failure with :on-fail configured sets
+            verdict :repair-requested on the phase result. FSM's
+            guarded :phase/fail array dispatches to on-fail :implement
+            from there."
     (let [ctx (make-leave-ctx {:status :error
                                :error {:message "Tests failed: 3 assertions"}}
                               :implement)
           result (verify/leave-verify ctx)]
-      (is (= :implement (phase/transition-target (get result :phase))))
+      (is (= :repair-requested (get-in result [:phase :verdict]))
+          "verdict :repair-requested drives FSM on-fail redirect")
+      (is (= :repair-requested (get-in result [:phase :result :output :phase/verdict]))
+          ":phase/verdict on the result is what determine-phase-event reads")
       (is (phase/failed? (get result :phase))))))
 
-(deftest leave-verify-redirects-parse-error-output-with-provider-words-test
-  (testing "parse-error previews are actionable even when test output contains provider-like fragments"
+(deftest leave-verify-parse-error-with-provider-words-emits-repair-requested-test
+  (testing "parse-error previews are actionable even when test output
+            contains provider-like fragments. Verdict :repair-requested
+            because the failure isn't a real timeout/rate-limit."
     (let [ctx (make-leave-ctx {:status :error
                                :error {:message (str (messages/t :verify/output-unparseable)
                                                      "\nHTTP 429 from project test output timed out")}
                                :metrics {:parse-error? true}}
                               :implement)
           result (verify/leave-verify ctx)]
-      (is (= :implement (phase/transition-target (get result :phase))))
+      (is (= :repair-requested (get-in result [:phase :verdict])))
       (is (phase/failed? (get result :phase))))))
 
-(deftest leave-verify-no-redirect-on-timeout-test
-  (testing "timeout error does NOT redirect even with :on-fail configured"
+(deftest leave-verify-emits-verify-timeout-verdict-test
+  (testing "Phase 3: timeout error sets verdict :verify/timeout. The
+            FSM's :verdict/terminal? guard routes :phase/fail straight
+            to :failed, bypassing :on-fail :implement — retrying the
+            implementer wouldn't unblock a hung test process. This was
+            the 2026-05-28 dogfood's biggest token sink."
     (let [ctx (make-leave-ctx {:status :error
                                :error {:message "Agent timed out after 600000ms"}}
                               :implement)
           result (verify/leave-verify ctx)]
-      (is (not (phase/redirect-requested? (get result :phase))))
+      (is (= :verify/timeout (get-in result [:phase :verdict])))
+      (is (= :verify/timeout (get-in result [:phase :result :output :phase/verdict])))
       (is (phase/failed? (get result :phase)))
-      (is (true? (get-in result [:phase :error :timeout?]))))))
+      (is (true? (get-in result [:phase :error :timeout?]))
+          "legacy :timeout? flag still in the error map (Phase 4 removes)"))))
 
-(deftest leave-verify-no-redirect-on-rate-limit-test
-  (testing "rate-limit error does NOT redirect even with :on-fail configured"
+(deftest leave-verify-emits-verify-rate-limited-verdict-test
+  (testing "Phase 3: rate-limit error sets verdict :verify/rate-limited.
+            FSM terminates rather than redirecting to implement —
+            retrying the implementer doesn't change the provider quota."
     (let [ctx (make-leave-ctx {:status :error
                                :error {:message "429 rate limit exceeded"}}
                               :implement)
           result (verify/leave-verify ctx)]
-      (is (not (phase/redirect-requested? (get result :phase))))
+      (is (= :verify/rate-limited (get-in result [:phase :verdict])))
       (is (phase/failed? (get result :phase)))
-      (is (some? (get-in result [:phase :error :rate-limited?]))))
+      (is (some? (get-in result [:phase :error :rate-limited?]))
+          "legacy :rate-limited? flag still in error map until Phase 4"))
 
-    (testing "rate-limit variant: you've hit your limit"
+    (testing "rate-limit variant: 'you've hit your limit'"
       (let [ctx (make-leave-ctx {:status :error
                                  :error {:message "You've hit your limit · resets 7pm"}}
                                 :implement)
             result (verify/leave-verify ctx)]
-        (is (not (phase/redirect-requested? (get result :phase))))))))
+        (is (= :verify/rate-limited (get-in result [:phase :verdict])))))))
 
-(deftest leave-verify-no-redirect-without-on-fail-test
-  (testing "normal failure without :on-fail does not request a redirect"
+(deftest leave-verify-emits-exhausted-when-no-on-fail-test
+  (testing "Phase 3: failed verify without :on-fail set emits verdict
+            :exhausted. FSM has no redirect target to take — the
+            guarded array's third branch is absent at compile time."
     (let [ctx (make-leave-ctx {:status :error
                                :error {:message "Tests failed"}}
                               nil)
           result (verify/leave-verify ctx)]
-      (is (not (phase/redirect-requested? (get result :phase))))
+      (is (= :exhausted (get-in result [:phase :verdict])))
       (is (phase/failed? (get result :phase))))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -224,8 +224,8 @@
               {:state current-state
                :event event}))
 
-(defn- review-phase-fail-transition
-  "Phase 2b: emit the guarded `:phase/fail` array for the review phase.
+(defn- guarded-fail-transition
+  "Emit the verdict-driven guarded `:phase/fail` array.
 
    Ordering matters — clj-statecharts picks the first guard whose
    predicate returns truthy. The compile-time choice to include or omit
@@ -233,8 +233,9 @@
    from the RFC's three-guard set unnecessary (when on-fail isn't
    configured, the branch is simply absent).
 
-   * Branch 1: terminal verdict (stagnated / needs-decomposition /
-     exhausted) → straight to `:failed`.
+   * Branch 1: terminal verdict (`:stagnated` / `:needs-decomposition`
+     / `:exhausted` / `:verify/timeout` / `:verify/rate-limited`) →
+     straight to `:failed`. Bypasses on-fail.
    * Branch 2: redirect budget spent → straight to `:failed` (no more
      on-fail redirects).
    * Branch 3 (only when `:on-fail` is configured): the on-fail
@@ -251,12 +252,19 @@
     [{:target :failed :guard :verdict/terminal?}
      {:target :failed}]))
 
-(defn- review-phase?
-  "True when this phase entry's config drives the review-phase behavior.
-   Phase 2b migrates review-phase fail-routing to the guarded array;
-   Phase 3 generalizes to verify / release / implement."
+(def ^:private guarded-phases
+  "Phases whose `:phase/fail` dispatch routes through the verdict-driven
+   guarded array. Phase 2b started with :review; Phase 3 adds :verify
+   (where `:verify/timeout` and `:verify/rate-limited` are terminal
+   verdicts the on-fail-to-:implement loop must NOT swallow — retrying
+   implement does not unblock a hung test process or a provider quota).
+   Phase 3b will add :release and :implement; Phase 4 drops this set
+   and applies the guarded form to every phase unconditionally."
+  #{:review :verify})
+
+(defn- guarded-phase?
   [config]
-  (= :review (:phase config)))
+  (contains? guarded-phases (:phase config)))
 
 (defn- build-phase-state
   [phase-entries {:keys [index config state-id paused-state-id]}]
@@ -276,11 +284,13 @@
                            :failed)
         already-done-target (or (state-target phase-entries done-index)
                                 :completed)
-        ;; Phase 2b: review-phase routes :phase/fail through a guarded
-        ;; array; other phases keep the flat shape until Phase 3.
-        phase-fail-transition (if (review-phase? config)
-                                (review-phase-fail-transition failure-target
-                                                              (some? on-fail-index))
+        ;; Phase 2b/3: review + verify route :phase/fail through the
+        ;; verdict-driven guarded array; release + implement keep the
+        ;; flat shape until Phase 3b. Phase 4 drops the per-phase
+        ;; opt-in and applies the guarded form unconditionally.
+        phase-fail-transition (if (guarded-phase? config)
+                                (guarded-fail-transition failure-target
+                                                         (some? on-fail-index))
                                 failure-target)]
     [state-id
      {:on (merge

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -53,7 +53,14 @@
    redirect. Mirrors the legacy `:stagnated?` / `:needs-decomposition?`
    flag bits from the workaround era; collapsed here into a single
    FSM-readable signal."
-  #{:stagnated :needs-decomposition :exhausted})
+  #{;; Convergence-failure verdicts (review phase)
+    :stagnated
+    :needs-decomposition
+    :exhausted
+    ;; Verify-specific (Phase 3): retrying implement does not unblock a
+    ;; timed-out test process or a provider rate-limit. Both terminate.
+    :verify/timeout
+    :verify/rate-limited})
 
 (defn verdict-terminal?
   "Guard: true when the failing-phase event carries a terminal verdict.

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -329,6 +329,42 @@
               "budget-spent guard takes the second :failed branch
                before the redirect branch fires"))))))
 
+(deftest verify-phase-verdict-routes-fail-via-guarded-array-test
+  (testing "Phase 3: verify phase now ALSO uses the guarded :phase/fail
+            array. :verify/timeout and :verify/rate-limited are terminal
+            verdicts that bypass on-fail :implement — fixes the
+            2026-05-28 dogfood bottleneck where verify timed out, looped
+            to implement, implementer wrote a recovery, verify timed out
+            again, repeat for hours."
+    (let [workflow {:workflow/id :verify-verdict-test
+                    :workflow/pipeline [{:phase :plan}
+                                        {:phase :implement}
+                                        {:phase :verify :on-fail :implement}
+                                        {:phase :review}
+                                        {:phase :done}]}
+          machine (fsm/compile-execution-machine workflow)
+          at-verify (->> (fsm/initialize-execution machine)
+                         (fsm/start-execution machine)
+                         (#(fsm/transition-execution machine % :phase/succeed))
+                         (#(fsm/transition-execution machine % :phase/succeed)))]
+      (is (= :verify (fsm/current-phase-id machine at-verify)))
+      (testing ":verify/timeout terminates straight to :failed"
+        (let [evt {:type :phase/fail :phase/verdict :verify/timeout}
+              after (fsm/transition-execution machine at-verify evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "verify timeout MUST NOT redirect to implement — retrying
+               the implementer cannot unblock a hung test process")))
+      (testing ":verify/rate-limited terminates straight to :failed"
+        (let [evt {:type :phase/fail :phase/verdict :verify/rate-limited}
+              after (fsm/transition-execution machine at-verify evt)]
+          (is (= :failed (fsm/execution-status machine after)))))
+      (testing ":repair-requested follows on-fail to :implement (baseline)"
+        (let [evt {:type :phase/fail :phase/verdict :repair-requested}
+              after (fsm/transition-execution machine at-verify evt)]
+          (is (= :implement (fsm/current-phase-id machine after)))
+          (is (= 1 (get after :redirect-count 0))
+              "single accounting site bumps for verify→implement too"))))))
+
 (deftest state-graph-walks-guarded-array-transitions-test
   ;; Phase 2a permits transition values shaped as ordered vectors of
   ;; map entries (guarded arrays — first matching guard wins; each


### PR DESCRIPTION
**Biggest dogfood-bottleneck fix in the RFC migration.** Generalizes Phase 2b's verdict-driven guarded \`:phase/fail\` to the verify phase. The 2026-05-28 run burned ~2.5h in a verify→implement loop where verify timed out at 30 min, on-fail redirected to implement, implement wrote a "recovery", verify timed out AGAIN.

## Guarded array at \`:verify\` (with \`:on-fail :implement\`)

\`\`\`clojure
:phase/fail
[{:target :failed         :guard :verdict/terminal?}        ; :verify/timeout, :verify/rate-limited
 {:target :failed         :guard :budget/redirects-spent?}
 {:target :phase-N-implement :actions [:redirect/inc-count]} ; only fires for :repair-requested
 {:target :failed}]
\`\`\`

\`:verify/timeout\` and \`:verify/rate-limited\` are terminal verdicts: the FSM bypasses on-fail because retrying the implementer cannot unblock a hung test process or change a provider quota.

## Summary

- \`standard_guards_and_actions.clj\`: add \`:verify/timeout\` and \`:verify/rate-limited\` to terminal-verdicts.
- \`fsm.clj\`: \`review-phase?\` → \`guarded-phase?\`, backed by \`guarded-phases #{:review :verify}\`. Phase 3b adds \`:release\`/\`:implement\`; Phase 4 drops the opt-in.
- \`verify.clj\`: \`leave-verify\` emits \`:phase/verdict\` and stops calling \`phase/request-redirect\` — FSM owns routing. Verdict precedence preserves the legacy "do NOT redirect on timeout/rate-limit" semantics.

## Test plan

- [x] 4 verify_failure_modes tests updated to assert verdict shape
- [x] New \`fsm_test/verify-phase-verdict-routes-fail-via-guarded-array-test\` exercises all three failure modes against the real compiled machine
- [x] All workflow + phase-software-factory brick tests green
- [x] Pre-commit smoke clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)