### PR TITLE
feat(workflow,release): Phase 3b — release joins guarded :phase/fail array

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -469,16 +469,26 @@
                         agent-status iterations max-iterations))
         pr-info (get-in ctx [:workflow/pr-info])
         on-fail (get-in ctx [:phase-config :on-fail])
-        verdict (compute-verdict {:phase-failed?       (= :failed phase-status)
-                                  :on-fail-configured? (some? on-fail)
-                                  :zero-files?         zero-files?})
-        updated-ctx (-> ctx
-                        (assoc-in [:phase :ended-at] end-time)
-                        (assoc-in [:phase :duration-ms] duration-ms)
-                        (assoc-in [:phase :status] phase-status)
-                        (assoc-in [:phase :metrics] metrics)
-                        (assoc-in [:phase :verdict] verdict)
-                        (assoc-in [:phase :result :output :phase/verdict] verdict)
+        ;; Verdict is only meaningful for terminal phase statuses
+        ;; (:completed → :approved; :failed → one of the failure
+        ;; verdicts). For :retrying the runner handles the in-phase
+        ;; loop and the FSM never sees a transition, so skip the
+        ;; verdict attachment — leaving the prior verdict in place if
+        ;; the phase has been around the loop before, else nothing.
+        verdict (when (contains? #{:completed :failed} phase-status)
+                  (compute-verdict {:phase-failed?       (= :failed phase-status)
+                                    :on-fail-configured? (some? on-fail)
+                                    :zero-files?         zero-files?}))
+        updated-ctx (cond-> ctx
+                      true
+                      (-> (assoc-in [:phase :ended-at] end-time)
+                          (assoc-in [:phase :duration-ms] duration-ms)
+                          (assoc-in [:phase :status] phase-status)
+                          (assoc-in [:phase :metrics] metrics))
+                      verdict
+                      (-> (assoc-in [:phase :verdict] verdict)
+                          (assoc-in [:phase :result :output :phase/verdict] verdict)))
+        updated-ctx (-> updated-ctx
                         (assoc-in [:metrics :release :duration-ms] duration-ms)
                         (assoc-in [:metrics :release :repair-cycles] (dec iterations))
                         (cond-> pr-info

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -405,10 +405,50 @@
         (cond-> (phase/result-succeeded? result)
           (assoc-in [:workflow/pr-info] (get-in (:output result) [:workflow/pr-info]))))))))
 
+(def ^:private verdicts
+  "Phase 3b verdict tag set for release.
+
+     :approved            — PR opened or release artifact persisted;
+                            `:phase/succeed` event
+     :repair-requested    — release failed with `:on-fail` set; FSM
+                            redirects (subject to budget)
+     :release/zero-files  — curator's empty-diff verdict; FSM
+                            terminates because retrying implement
+                            won't change the curator's decision
+     :exhausted           — release failed without `:on-fail` set"
+  #{:approved :repair-requested :release/zero-files :exhausted})
+
+(defn- compute-verdict
+  "Pick the verdict that should flow on the phase result.
+
+   `:release/zero-files` pre-empts `:repair-requested` — when the curator
+   reports an empty diff, retrying the implementer is wasted work: the
+   next pass would just produce another empty diff. Make this FSM-visible
+   so the verdict-driven guarded array terminates the loop."
+  [{:keys [phase-failed? on-fail-configured? zero-files?]}]
+  (cond
+    zero-files?
+    :release/zero-files
+
+    (and phase-failed? on-fail-configured?)
+    :repair-requested
+
+    phase-failed?
+    :exhausted
+
+    :else
+    :approved))
+
 (defn leave-release
   "Post-processing for release phase.
 
-   Records release metrics and PR info."
+   Records release metrics and PR info.
+
+   Phase 3b: attaches a `:phase/verdict` to the phase result so the
+   FSM's verdict-driven guarded `:phase/fail` array picks the right
+   target. `:release/zero-files` is a TERMINAL verdict — the FSM
+   bypasses `:on-fail` and lands on `:failed` because the curator's
+   empty-diff signal means the implementer has nothing left to do."
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
@@ -428,21 +468,24 @@
                        (phase/determine-phase-status
                         agent-status iterations max-iterations))
         pr-info (get-in ctx [:workflow/pr-info])
+        on-fail (get-in ctx [:phase-config :on-fail])
+        verdict (compute-verdict {:phase-failed?       (= :failed phase-status)
+                                  :on-fail-configured? (some? on-fail)
+                                  :zero-files?         zero-files?})
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
                         (assoc-in [:phase :status] phase-status)
                         (assoc-in [:phase :metrics] metrics)
+                        (assoc-in [:phase :verdict] verdict)
+                        (assoc-in [:phase :result :output :phase/verdict] verdict)
                         (assoc-in [:metrics :release :duration-ms] duration-ms)
                         (assoc-in [:metrics :release :repair-cycles] (dec iterations))
-                        ;; Include PR info in metrics for evidence bundle
                         (cond-> pr-info
                           (assoc-in [:metrics :release :pr-info] pr-info))
                         (update-in [:execution :phases-completed] (fnil conj []) :release)
-                        ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
-    ;; Handle retrying: increment iteration counter, then emit telemetry
     (doto (cond-> updated-ctx
             (phase/retrying? (:phase updated-ctx))
             (-> (update-in [:phase :iterations] (fnil inc 1))
@@ -452,39 +495,58 @@
         (merge {:outcome     (if (= :completed phase-status) :success :failure)
                 :duration-ms duration-ms
                 :tokens      (:tokens metrics 0)}
-               ;; :release/zero-files is treated as curator-rejected (nothing to ship)
                (phase-terminal/derive-termination-reason result nil))))))
 
+(defn- attach-error-verdict
+  "Phase 3b: when error-release fails terminally, attach the verdict to
+   the result so the FSM's guarded :phase/fail array reads it. The
+   `:release/zero-files` case is terminal; everything else is either
+   :repair-requested (on-fail set, FSM will redirect) or :exhausted
+   (no on-fail target)."
+  [ctx zero-files? on-fail-configured?]
+  (let [verdict (cond
+                  zero-files?            :release/zero-files
+                  on-fail-configured?    :repair-requested
+                  :else                  :exhausted)]
+    (-> ctx
+        (assoc-in [:phase :verdict] verdict)
+        (assoc-in [:phase :result :output :phase/verdict] verdict))))
+
 (defn error-release
-  "Handle release phase errors."
+  "Handle release phase errors.
+
+   Phase 3b: failures no longer call `phase/fail-and-request-redirect`
+   — the FSM's verdict-driven guarded :phase/fail array routes via
+   `:on-fail` if configured, or to `:failed` otherwise. error-release
+   stays responsible for the phase-level retry budget; once that's
+   exhausted it just attaches the verdict + error and lets the FSM
+   dispatch."
   [ctx ex]
   (let [iterations (get-in ctx [:phase :iterations] 0)
         max-iterations (get-in ctx [:phase :budget :iterations] 2)
         on-fail (get-in ctx [:phase-config :on-fail])
-        error-map (phase/exception-error ex)]
+        error-map (phase/exception-error ex)
+        zero-files? (= :release/zero-files (get (ex-data ex) :type))]
     (cond
-      (= :release/zero-files (get (ex-data ex) :type))
-      (assoc ctx :phase (phase/fail-phase (:phase ctx) error-map))
+      zero-files?
+      (-> ctx
+          (assoc :phase (phase/fail-phase (:phase ctx) error-map))
+          (attach-error-verdict true (some? on-fail)))
 
-      ;; Within budget - retry
+      ;; Within phase-level retry budget — retry in place. The FSM
+      ;; doesn't see this as a transition.
       (< iterations max-iterations)
       (-> ctx
           (update-in [:phase :iterations] (fnil inc 0))
           (assoc-in [:phase :last-error] (ex-message ex))
           (assoc-in [:phase :status] :retrying))
 
-      ;; Has on-fail transition - redirect
-      on-fail
-      (let [phase-result (-> (:phase ctx)
-                             (phase/fail-and-request-redirect
-                              error-map
-                              on-fail))]
-        (assoc ctx :phase phase-result))
-
-      ;; No recovery - propagate
+      ;; Out of retries — attach verdict and let the FSM dispatch
+      ;; (:repair-requested when on-fail set, :exhausted otherwise).
       :else
       (-> ctx
-          (assoc :phase (phase/fail-phase (:phase ctx) error-map)))))) 
+          (assoc :phase (phase/fail-phase (:phase ctx) error-map))
+          (attach-error-verdict false (some? on-fail))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Registry methods

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -701,6 +701,29 @@
           result ((:leave interceptor) ctx)]
       (is (= :failed (get-in result [:phase :status]))))))
 
+(deftest leave-release-skips-verdict-on-retrying-status-test
+  ;; Phase 3b regression guard. compute-verdict's `phase-failed?`
+  ;; predicate is false when status is :retrying — without the
+  ;; only-on-terminal-status guard, the verdict would fall through to
+  ;; :approved and silently mark the result as approved during in-phase
+  ;; retries. The FSM never sees :retrying transitions; the runner
+  ;; handles them — so the verdict must be NIL until the phase finishes.
+  (testing "leave-release does NOT attach :phase/verdict during :retrying"
+    (let [interceptor (phase/get-phase-interceptor {:phase :release})
+          ctx {:phase {:started-at (System/currentTimeMillis)
+                       :result {:status :error
+                                :error {:message "transient blip"}}
+                       :budget {:iterations 4}
+                       :iterations 1}
+               :execution/metrics {:tokens 0 :duration-ms 0}}
+          result ((:leave interceptor) ctx)]
+      (is (= :retrying (get-in result [:phase :status]))
+          "fixture must be inside the retry budget so status is :retrying")
+      (is (nil? (get-in result [:phase :verdict]))
+          ":phase :verdict not attached during :retrying")
+      (is (nil? (get-in result [:phase :result :output :phase/verdict]))
+          ":phase/verdict on the result not attached during :retrying"))))
+
 (deftest error-release-treats-zero-files-as-terminal-test
   (testing "zero-files exceptions fail instead of retrying the release phase"
     (let [interceptor (phase/get-phase-interceptor {:phase :release})

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -254,13 +254,13 @@
 
 (def ^:private guarded-phases
   "Phases whose `:phase/fail` dispatch routes through the verdict-driven
-   guarded array. Phase 2b started with :review; Phase 3 adds :verify
-   (where `:verify/timeout` and `:verify/rate-limited` are terminal
-   verdicts the on-fail-to-:implement loop must NOT swallow — retrying
-   implement does not unblock a hung test process or a provider quota).
-   Phase 3b will add :release and :implement; Phase 4 drops this set
-   and applies the guarded form to every phase unconditionally."
-  #{:review :verify})
+   guarded array. Phase 2b started with :review; Phase 3a added :verify
+   (where `:verify/timeout` / `:verify/rate-limited` are terminal
+   verdicts); Phase 3b adds :release (where `:release/zero-files` —
+   the curator's empty-diff verdict — is terminal). Phase 3c adds
+   :implement. Phase 4 drops this set and applies the guarded form to
+   every phase unconditionally."
+  #{:review :verify :release})
 
 (defn- guarded-phase?
   [config]

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -57,10 +57,15 @@
     :stagnated
     :needs-decomposition
     :exhausted
-    ;; Verify-specific (Phase 3): retrying implement does not unblock a
+    ;; Verify-specific (Phase 3a): retrying implement does not unblock a
     ;; timed-out test process or a provider rate-limit. Both terminate.
     :verify/timeout
-    :verify/rate-limited})
+    :verify/rate-limited
+    ;; Release-specific (Phase 3b): curator-rejected (no files to ship).
+    ;; Retrying implement won't change the curator's decision — the
+    ;; diff is empty and the next pass would just produce another empty
+    ;; diff. Terminal.
+    :release/zero-files})
 
 (defn verdict-terminal?
   "Guard: true when the failing-phase event carries a terminal verdict.

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -365,6 +365,39 @@
           (is (= 1 (get after :redirect-count 0))
               "single accounting site bumps for verify→implement too"))))))
 
+(deftest release-phase-verdict-routes-fail-via-guarded-array-test
+  (testing "Phase 3b: release phase joins the guarded :phase/fail array.
+            `:release/zero-files` (curator's empty-diff verdict) is
+            terminal — bypasses on-fail because retrying the implementer
+            wouldn't change the curator's decision (the diff is empty;
+            the next pass would just produce another empty diff)."
+    (let [workflow {:workflow/id :release-verdict-test
+                    :workflow/pipeline [{:phase :plan}
+                                        {:phase :implement}
+                                        {:phase :verify}
+                                        {:phase :review}
+                                        {:phase :release :on-fail :implement}
+                                        {:phase :done}]}
+          machine (fsm/compile-execution-machine workflow)
+          at-release (->> (fsm/initialize-execution machine)
+                          (fsm/start-execution machine)
+                          (#(fsm/transition-execution machine % :phase/succeed))
+                          (#(fsm/transition-execution machine % :phase/succeed))
+                          (#(fsm/transition-execution machine % :phase/succeed))
+                          (#(fsm/transition-execution machine % :phase/succeed)))]
+      (is (= :release (fsm/current-phase-id machine at-release)))
+      (testing ":release/zero-files terminates straight to :failed"
+        (let [evt {:type :phase/fail :phase/verdict :release/zero-files}
+              after (fsm/transition-execution machine at-release evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "curator's empty-diff verdict MUST NOT redirect")))
+      (testing ":repair-requested follows on-fail to :implement"
+        (let [evt {:type :phase/fail :phase/verdict :repair-requested}
+              after (fsm/transition-execution machine at-release evt)]
+          (is (= :implement (fsm/current-phase-id machine after)))
+          (is (= 1 (get after :redirect-count 0))
+              "single accounting site bumps for release→implement too"))))))
+
 (deftest state-graph-walks-guarded-array-transitions-test
   ;; Phase 2a permits transition values shaped as ordered vectors of
   ;; map entries (guarded arrays — first matching guard wins; each


### PR DESCRIPTION
Generalizes Phase 2b/3a's verdict-driven guarded \`:phase/fail\` to the release phase.

## Summary

- \`:release/zero-files\` (curator's empty-diff verdict) becomes a terminal verdict — the FSM bypasses on-fail because retrying the implementer won't change the curator's decision (the diff is empty; the next pass would produce another empty diff).
- \`workflow/standard_guards_and_actions.clj\`: add \`:release/zero-files\` to terminal-verdicts.
- \`workflow/fsm.clj\`: \`guarded-phases\` → \`#{:review :verify :release}\`.
- \`release.clj\`: new \`compute-verdict\`; \`leave-release\` attaches \`:phase/verdict\`; \`error-release\` drops \`fail-and-request-redirect\` (FSM owns routing) but keeps the phase-level retry budget.

## Test plan

- [x] New \`fsm_test/release-phase-verdict-routes-fail-via-guarded-array-test\`: \`:release/zero-files\` → terminal :failed; \`:repair-requested\` → on-fail :implement + counter bump
- [x] All workflow + phase-software-factory brick tests green

## Migration

Phase 3a (verify) merged as #1027. **This PR (3b) covers release.** Phase 3c will tackle implement — left as a separate PR because implement has more failure modes (stalled, gate-failed, curator-empty-diff, rate-limited, already-implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)