### PR TITLE
feat(workflow,implement): Phase 3c — implement joins guarded :phase/fail array (FSM RFC)

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -622,14 +622,44 @@
         summary (or (get-in result [:output :code/summary])
                     (when (string? (:output result)) (:output result))
                     (messages/t :implement/summary-default))
-        updated-ctx (-> ctx
-                        (assoc-in [:phase :ended-at] end-time)
-                        (assoc-in [:phase :duration-ms] duration-ms)
-                        (assoc-in [:phase :status] phase-status)
-                        (assoc-in [:phase :metrics] metrics)
+        on-fail (get-in ctx [:phase-config :on-fail])
+        ;; Phase 3c verdict — only meaningful for terminal phase
+        ;; statuses (:completed → :approved; :failed → one of the
+        ;; failure verdicts). During :retrying / :already-implemented
+        ;; the FSM doesn't see a transition that needs verdict input.
+        verdict (cond
+                  (= :completed phase-status)
+                  :approved
+
+                  (not= :failed phase-status)
+                  nil
+
+                  rate-limited?
+                  :implement/rate-limited
+
+                  curator-empty-diff?
+                  :implement/empty-diff
+
+                  invalid-already-implemented?
+                  :implement/already-implemented-invalid
+
+                  (some? on-fail)
+                  :repair-requested
+
+                  :else
+                  :exhausted)
+        updated-ctx (cond-> ctx
+                      true
+                      (-> (assoc-in [:phase :ended-at] end-time)
+                          (assoc-in [:phase :duration-ms] duration-ms)
+                          (assoc-in [:phase :status] phase-status)
+                          (assoc-in [:phase :metrics] metrics))
+                      verdict
+                      (-> (assoc-in [:phase :verdict] verdict)
+                          (assoc-in [:phase :result :output :phase/verdict] verdict)))
+        updated-ctx (-> updated-ctx
                         (assoc-in [:metrics :implementation :duration-ms] duration-ms)
                         (assoc-in [:metrics :implementation :repair-cycles] (dec iterations))
-                        ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :cost-usd] (fnil + 0.0) cost-usd)
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -254,13 +254,13 @@
 
 (def ^:private guarded-phases
   "Phases whose `:phase/fail` dispatch routes through the verdict-driven
-   guarded array. Phase 2b started with :review; Phase 3a added :verify
-   (where `:verify/timeout` / `:verify/rate-limited` are terminal
-   verdicts); Phase 3b adds :release (where `:release/zero-files` —
-   the curator's empty-diff verdict — is terminal). Phase 3c adds
-   :implement. Phase 4 drops this set and applies the guarded form to
-   every phase unconditionally."
-  #{:review :verify :release})
+   guarded array. Phase 2b started with :review; Phase 3a added :verify;
+   Phase 3b added :release; Phase 3c adds :implement (where
+   `:implement/rate-limited`, `:implement/empty-diff`, and
+   `:implement/already-implemented-invalid` are terminal verdicts).
+   Phase 4 drops this set and applies the guarded form to every phase
+   unconditionally."
+  #{:review :verify :release :implement})
 
 (defn- guarded-phase?
   [config]

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -65,7 +65,19 @@
     ;; Retrying implement won't change the curator's decision — the
     ;; diff is empty and the next pass would just produce another empty
     ;; diff. Terminal.
-    :release/zero-files})
+    :release/zero-files
+    ;; Implement-specific (Phase 3c). All three are cases where the
+    ;; on-fail :implement loop would just re-enter and hit the same
+    ;; wall — terminate the workflow instead.
+    ;;   :rate-limited — provider quota; budget retries won't change it
+    ;;   :empty-diff   — curator: no files written; retry would produce
+    ;;                   another empty diff
+    ;;   :already-implemented-invalid — the implementer claimed done
+    ;;                   but verify hadn't passed; retry won't fix the
+    ;;                   stale claim
+    :implement/rate-limited
+    :implement/empty-diff
+    :implement/already-implemented-invalid})
 
 (defn verdict-terminal?
   "Guard: true when the failing-phase event carries a terminal verdict.

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -398,6 +398,46 @@
           (is (= 1 (get after :redirect-count 0))
               "single accounting site bumps for release→implement too"))))))
 
+(deftest implement-phase-verdict-routes-fail-via-guarded-array-test
+  (testing "Phase 3c: implement joins the guarded :phase/fail array.
+            :implement/rate-limited, :implement/empty-diff, and
+            :implement/already-implemented-invalid are terminal —
+            FSM bypasses on-fail because retrying would hit the same
+            wall."
+    (let [workflow {:workflow/id :impl-verdict-test
+                    :workflow/pipeline [{:phase :plan}
+                                        {:phase :implement :on-fail :plan}
+                                        {:phase :verify}
+                                        {:phase :review}
+                                        {:phase :done}]}
+          machine (fsm/compile-execution-machine workflow)
+          at-implement (->> (fsm/initialize-execution machine)
+                            (fsm/start-execution machine)
+                            (#(fsm/transition-execution machine % :phase/succeed)))]
+      (is (= :implement (fsm/current-phase-id machine at-implement)))
+      (testing ":implement/rate-limited terminates straight to :failed"
+        (let [evt {:type :phase/fail :phase/verdict :implement/rate-limited}
+              after (fsm/transition-execution machine at-implement evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "implement rate-limit MUST NOT redirect — provider quota
+               won't change between attempts")))
+      (testing ":implement/empty-diff terminates straight to :failed"
+        (let [evt {:type :phase/fail :phase/verdict :implement/empty-diff}
+              after (fsm/transition-execution machine at-implement evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "curator's no-files-written verdict MUST NOT redirect")))
+      (testing ":implement/already-implemented-invalid terminates"
+        (let [evt {:type :phase/fail
+                   :phase/verdict :implement/already-implemented-invalid}
+              after (fsm/transition-execution machine at-implement evt)]
+          (is (= :failed (fsm/execution-status machine after)))))
+      (testing ":repair-requested follows on-fail (here :plan) + counter"
+        (let [evt {:type :phase/fail :phase/verdict :repair-requested}
+              after (fsm/transition-execution machine at-implement evt)]
+          (is (= :plan (fsm/current-phase-id machine after)))
+          (is (= 1 (get after :redirect-count 0))
+              "single accounting site for implement→on-fail too"))))))
+
 (deftest state-graph-walks-guarded-array-transitions-test
   ;; Phase 2a permits transition values shaped as ordered vectors of
   ;; map entries (guarded arrays — first matching guard wins; each

--- a/components/workflow/test/ai/miniforge/workflow/guards_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/guards_test.clj
@@ -219,16 +219,21 @@
 ;; workflow validation time.
 
 (deftest validate-execution-machine-passes-on-no-guards-test
-  (testing "the current production-shape workflow (no guard refs) validates
-            cleanly — Phase 1 must be behavior-neutral"
+  (testing "a workflow whose pipeline uses no guarded phases still
+            validates cleanly — Phase 1 baseline. Post-Phase-3c the
+            usual production phases (:review, :verify, :release,
+            :implement) all reference standard guards by keyword; this
+            test deliberately uses a NON-guarded-phase shape so it
+            still exercises the 'no guard refs in the pipeline' path
+            (the fixture wipes the registry for isolation, so any
+            guarded phase would trip the dangling-ref check)."
     (let [workflow {:workflow/id :plain
                     :workflow/pipeline [{:phase :plan}
-                                        {:phase :implement}
                                         {:phase :done}]}
           result (workflow-fsm/validate-execution-machine workflow)]
       (is (:valid? result))
       (is (empty? (:errors result))
-          "no :dangling-guard-references entry in :errors when no guards present"))))
+          "no :dangling-guard-references entry when no guarded phase is in the pipeline"))))
 
 ;------------------------------------------------------------------------------ Resolver (Phase 2a)
 ;;


### PR DESCRIPTION
**Completes the Phase 3 migration.** All four work-loop phases (\`:review\`, \`:verify\`, \`:release\`, \`:implement\`) now route \`:phase/fail\` through the verdict-driven guarded array. Phase 4 drops the per-phase opt-in and applies the guarded form unconditionally.

## Implement-specific terminal verdicts

| Verdict | Cause | Why terminal |
|---|---|---|
| \`:implement/rate-limited\` | provider quota | budget retries won't change quota |
| \`:implement/empty-diff\` | curator: no files written | next pass would produce another empty diff |
| \`:implement/already-implemented-invalid\` | implementer claimed done but verify hadn't passed | retry won't fix the stale claim |

All three bypass on-fail (typically \`:plan\` or \`:review\`) — the loop would just re-enter and hit the same wall.

## Summary

- \`standard_guards_and_actions.clj\`: add the three new terminal verdicts
- \`fsm.clj\`: \`guarded-phases\` → \`#{:review :verify :release :implement}\`
- \`implement.clj\`: compute verdict in \`leave-implement\`. Only attach when phase-status is \`:completed\` or \`:failed\` (during \`:retrying\` / \`:already-implemented\` the FSM doesn't see a transition). Pre-empt order: rate-limited > empty-diff > already-implemented-invalid > repair-requested (with on-fail) > exhausted.

## Test plan

- [x] New \`fsm_test/implement-phase-verdict-routes-fail-via-guarded-array-test\` exercises all 4 verdict branches against the real compiled machine
- [x] \`guards_test/validate-execution-machine-passes-on-no-guards-test\` switched to a non-guarded-phase workflow (just \`:plan\` + \`:done\`) so it still tests the Phase 1 baseline shape post-Phase-3c
- [x] All workflow + phase-software-factory brick tests green

## Migration

Phase 3 is complete: 3a (verify) + 3b (release) + 3c (implement). Next is **Phase 4** — drop the workarounds (\`:phase/terminal-fail\` event, \`:stagnated?\` / \`:needs-decomposition?\` flag-sniffs, \`redirect-event?\` namespace concept, \`compute-decision\` legacy) and the per-phase opt-in. Then **Phase 5** strengthens compile-time validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)