### PR TITLE
feat(workflow): Phase 4b — drop channel-A redirect machinery (FSM RFC)

### DIFF
--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -245,8 +245,15 @@
    phase-software-factory interceptor used to repeat verbatim:
 
        within iteration budget                         → retry
-       past budget AND `:on-fail` set AND redirect?    → fail and redirect
+       past budget AND `:on-fail` set AND redirect?    → fail with verdict
        otherwise                                       → fail and propagate
+
+   Phase 4b: when the phase-level retry budget is exhausted AND
+   `redirect?` is true AND `:on-fail` is set, the handler attaches
+   `:phase/verdict :repair-requested` to the phase result instead of
+   calling `phase/fail-and-request-redirect`. The FSM's verdict-driven
+   guarded `:phase/fail` array (Phase 2b/3) handles routing from there
+   — single accounting site, same as the normal-flow path.
 
    Iteration count is read from `[:phase :iterations]`, the budget
    ceiling from `[:phase :budget :iterations]` (falling back to
@@ -277,8 +284,15 @@
            (assoc-in  [:phase :status]     :retrying))
 
        on-fail
-       (assoc ctx :phase (fail-and-request-redirect
-                          (:phase ctx) error-map on-fail))
+       ;; Phase 4b: emit verdict instead of request-redirect. The FSM's
+       ;; guarded `:phase/fail` array dispatches via the
+       ;; `:verdict/terminal?` guard (false for :repair-requested) and
+       ;; takes the on-fail branch with the `:redirect/inc-count`
+       ;; action — the SINGLE accounting site.
+       (-> ctx
+           (assoc :phase (fail-phase (:phase ctx) error-map))
+           (assoc-in [:phase :verdict] :repair-requested)
+           (assoc-in [:phase :result :output :phase/verdict] :repair-requested))
 
        :else
        (assoc ctx :phase (fail-phase (:phase ctx) error-map))))))

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -270,10 +270,11 @@
       (record-phase-artifacts phase-result)
       (track-phase-files phase-result)))
 
-(defn- redirect-target
-  [phase-result]
-  (when (phase/redirect-requested? phase-result)
-    (phase/transition-target phase-result)))
+;; Phase 4b removed `redirect-target`. With handle-error refactored
+;; to emit `:phase/verdict :repair-requested` (the last in-production
+;; caller of `phase/request-redirect`), no phase result carries a
+;; redirect-target marker anymore. `determine-phase-event` reads the
+;; verdict instead.
 
 (defn- phase-verdict
   "Read the `:phase/verdict` keyword from a phase result.
@@ -308,8 +309,7 @@
    that now emits a verdict; the flag bits are no longer set anywhere
    in production code."
   [_phase-config phase-result]
-  (let [target-phase (redirect-target phase-result)
-        verdict      (phase-verdict phase-result)]
+  (let [verdict (phase-verdict phase-result)]
     (cond
       (phase/retrying? phase-result)
       :phase/retry
@@ -321,15 +321,9 @@
       :phase/succeed
 
       ;; Failed phase with a verdict — send a map event so the FSM's
-      ;; guarded array reads it via `:verdict/terminal?`. Skip if a
-      ;; redirect was explicitly requested via the legacy
-      ;; request-redirect path (used by handle-error in some flows
-      ;; — Phase 4c migrates those to verdict too).
-      (and (phase/failed? phase-result) verdict (not target-phase))
+      ;; guarded array reads it via `:verdict/terminal?`.
+      (and (phase/failed? phase-result) verdict)
       {:type :phase/fail :phase/verdict verdict}
-
-      (and (phase/failed? phase-result) target-phase)
-      (workflow-fsm/redirect-event target-phase)
 
       (phase/failed? phase-result)
       :phase/fail
@@ -344,35 +338,27 @@
 (defn apply-phase-transition
   "Apply a phase-outcome event through the execution machine.
 
-   Returns updated context with refreshed machine projections or terminal failure."
-  [ctx event _pipeline _transition-to-completed-fn transition-to-failed-fn]
-  (let [redirect-count (get ctx :execution/redirect-count 0)
-        is-redirect? (workflow-fsm/redirect-event? event)]
-    (cond
-      ;; Redirect cycle limit exceeded
-      (and is-redirect? (>= redirect-count max-redirects))
-      (let [anom (max-redirects-exceeded-anomaly)]
-        (-> ctx
-            (update :execution/errors conj
-                    {:type :max-redirects-exceeded
-                     :message (messages/t :status/max-redirects-hit
-                                          {:max-redirects max-redirects})
-                     :anomaly anom})
-            (update :execution/response-chain
-                    response/add-failure :pipeline anom
-                    {:redirect-count redirect-count})
-            (transition-to-failed-fn)))
+   Phase 4b: dropped the parallel `is-redirect?` budget check. The
+   FSM's `:budget/redirects-spent?` guard on the guarded `:phase/fail`
+   array enforces the same `max-redirects` ceiling, and the
+   `:redirect/inc-count` action on the redirect branch is the SINGLE
+   accounting site that bumps the counter. With Phase 4b's verdict-
+   driven handle-error path, no event ever reaches this fn with the
+   former `workflow.event/redirect-to-*` shape that the runner check
+   keyed off.
 
-      :else
-      (let [prior-state (:execution/fsm-state ctx)
-            next-ctx (context/transition-execution ctx event)
-            state-changed? (not= prior-state (:execution/fsm-state next-ctx))]
-        (if (or state-changed? (= :phase/retry event))
-          next-ctx
-          (phase-transition-failure ctx
-                                    event
-                                    (invalid-phase-transition-anomaly event)
-                                    transition-to-failed-fn))))))
+   Returns updated context with refreshed machine projections or
+   terminal failure."
+  [ctx event _pipeline _transition-to-completed-fn transition-to-failed-fn]
+  (let [prior-state (:execution/fsm-state ctx)
+        next-ctx (context/transition-execution ctx event)
+        state-changed? (not= prior-state (:execution/fsm-state next-ctx))]
+    (if (or state-changed? (= :phase/retry event))
+      next-ctx
+      (phase-transition-failure ctx
+                                event
+                                (invalid-phase-transition-anomaly event)
+                                transition-to-failed-fn))))
 
 ;------------------------------------------------------------------------------ Layer 1.5: DAG integration helpers
 

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -57,9 +57,12 @@
 ;; FSM Definition using clj-statecharts
 ;; ============================================================================
 
-(def redirect-event-namespace
-  "Namespace used for redirect events in the compiled execution machine."
-  "workflow.event")
+;; Phase 4b removed `redirect-event-namespace`. The original
+;; per-target redirect events (`workflow.event/redirect-to-<phase>`)
+;; were the channel-A redirect mechanism the dogfood-class bug
+;; exploited. Phase 2b/3 replaced them with the verdict-driven
+;; guarded `:phase/fail` array; Phase 4b deletes the now-dead
+;; per-target event keywords.
 
 (def phase-state-prefix
   "Prefix used for active phase state identifiers."
@@ -106,11 +109,6 @@
   "Build the paused execution-machine state id for a pipeline phase."
   [index phase]
   (keyword (phase-state-name paused-phase-state-prefix index phase)))
-
-(defn redirect-event
-  "Build the event keyword used to redirect to a named phase."
-  [phase]
-  (keyword redirect-event-namespace (str "redirect-to-" (name phase))))
 
 (defn- increment-redirect-count
   [redirect-count]
@@ -182,33 +180,22 @@
   [phase-entries index]
   (some-> (get phase-entries index) :state-id))
 
-(defn- redirect-transition
-  [phase-entries {:keys [config]}]
-  (when-let [target-phase (:on-fail config)]
-    (when-let [target-index (first-phase-index phase-entries target-phase)]
-      {(redirect-event target-phase)
-       {:target (state-target phase-entries target-index)}})))
-
-(defn redirect-event?
-  "True when an event keyword represents a workflow phase redirect."
-  [event-key]
-  (= redirect-event-namespace (namespace event-key)))
-
-(defn- machine-transition-defined?
-  [machine state event-key]
-  (contains? (get-in machine [:states (current-state state) :on] {})
-             event-key))
+;; Phase 4b removed `redirect-transition` and `redirect-event?`.
+;; The verdict-driven guarded `:phase/fail` array (Phase 2b/3) is the
+;; only redirect mechanism now; budget accounting lives in the
+;; `:redirect/inc-count` action on the guarded array's redirect branch
+;; — the SINGLE accounting site the RFC's compile-time invariant will
+;; enforce in Phase 5.
 
 (defn transition-execution
-  "Apply an event to a compiled execution machine snapshot."
+  "Apply an event to a compiled execution machine snapshot.
+
+   Pure delegation to the underlying FSM. Phase 4b removed the parallel
+   `redirect-event?` namespace check that bumped `:redirect-count` for
+   channel-A redirects — the FSM action `:redirect/inc-count` on the
+   guarded `:phase/fail` array now handles every budget increment."
   [machine state event]
-  (let [event-key (if (keyword? event) event (:type event))
-        transition-defined? (machine-transition-defined? machine state event-key)
-        next-state (fsm/transition machine state event)]
-    (if (and transition-defined?
-             (redirect-event? event-key))
-      (fsm/update-context next-state update :redirect-count increment-redirect-count)
-      next-state)))
+  (fsm/transition machine state event))
 
 (defn- terminal-state-message
   [current-state]
@@ -300,16 +287,14 @@
     ;; code no longer sets the `:stagnated?` / `:needs-decomposition?`
     ;; flag bits the workaround read.
     [state-id
-     {:on (merge
-           {:phase/retry state-id
-            :phase/succeed success-target
-            :phase/already-done already-done-target
-            :phase/fail phase-fail-transition
-            :pause paused-state-id
-            :cancel :cancelled
-            :fail :failed
-            :complete :completed}
-           (redirect-transition phase-entries {:config config}))}]))
+     {:on {:phase/retry state-id
+           :phase/succeed success-target
+           :phase/already-done already-done-target
+           :phase/fail phase-fail-transition
+           :pause paused-state-id
+           :cancel :cancelled
+           :fail :failed
+           :complete :completed}}]))
 
 (defn- build-paused-state
   [{:keys [state-id paused-state-id]}]

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -227,7 +227,14 @@
         s0 (fsm/start-execution machine (fsm/initialize-execution machine))
         s1 (fsm/transition-execution machine s0 :phase/succeed)
         s2 (fsm/transition-execution machine s1 :phase/succeed)
-        s3 (fsm/transition-execution machine s2 (fsm/redirect-event :implement))
+        ;; Phase 4b: redirect now flows through the verdict-driven
+        ;; guarded `:phase/fail` array — non-terminal verdict +
+        ;; configured on-fail → on-fail target + counter bump via the
+        ;; `:redirect/inc-count` action. No more per-target
+        ;; redirect-to-X event keyword.
+        s3 (fsm/transition-execution machine s2
+                                     {:type :phase/fail
+                                      :phase/verdict :repair-requested})
         s4 (fsm/transition-execution machine s3 :pause)
         s5 (fsm/transition-execution machine s4 :resume)
         s6 (fsm/transition-execution machine s5 :phase/succeed)

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -34,38 +34,26 @@
    [ai.miniforge.workflow.execution :as exec]
    [ai.miniforge.workflow.fsm :as workflow-fsm]))
 
-;; -------------------------------------------------------------------------- redirect-target
-
-(deftest redirect-target-returns-target-when-redirect-requested
-  (testing "redirect-target returns the target phase when transition-request is set"
-    (let [result (phase-result/request-redirect {:status :failed} :implement)]
-      (is (= :implement (#'exec/redirect-target result))
-          "redirect-target must extract the target from the transition-request"))))
-
-(deftest redirect-target-returns-nil-when-no-redirect
-  (testing "redirect-target returns nil on results that don't request redirect"
-    (is (nil? (#'exec/redirect-target {:status :success})))
-    (is (nil? (#'exec/redirect-target {:status :failed}))
-        "a bare :failed result with no transition-request must not look like a redirect")
-    (is (nil? (#'exec/redirect-target {:status :failed
-                                       :phase/transition-request
-                                       {:transition/type :transition/retry}}))
-        "non-redirect transition requests must NOT match")))
+;; Phase 4b removed `exec/redirect-target` and the
+;; `determine-phase-event-failure-with-redirect-target` test (which
+;; pinned the per-target `workflow.redirect/redirect-to-X` event
+;; keyword that the channel-A path used to emit). With handle-error
+;; now emitting `:phase/verdict :repair-requested` instead of
+;; `phase/request-redirect`, no production path produces a
+;; redirect-target marker — the FSM's guarded `:phase/fail` array
+;; reads the verdict instead. See
+;; `determine-phase-event-verdict-failure-emits-map-event` below
+;; for the superseding assertion.
 
 ;; -------------------------------------------------------------------------- determine-phase-event
 ;;
-;; Six branches in priority order. Test in priority order so a regression
+;; Branches in priority order. Test in priority order so a regression
 ;; that swaps two adjacent branches surfaces clearly.
 
 (deftest determine-phase-event-retrying-wins-over-success
-  (testing "retrying status produces :phase/retry — even if later branches would also match"
+  (testing "retrying status produces :phase/retry"
     (is (= :phase/retry
-           (exec/determine-phase-event {} {:status :retrying})))
-    ;; Retrying should win over a redirect signal too.
-    (is (= :phase/retry
-           (exec/determine-phase-event
-             {}
-             (phase-result/request-redirect {:status :retrying} :implement))))))
+           (exec/determine-phase-event {} {:status :retrying})))))
 
 (deftest determine-phase-event-already-done
   (testing ":already-implemented and :already-satisfied both produce :phase/already-done"
@@ -78,13 +66,6 @@
   (testing "a :completed result with no transition request produces :phase/succeed"
     (is (= :phase/succeed
            (exec/determine-phase-event {} {:status :completed})))))
-
-(deftest determine-phase-event-failure-with-redirect-target
-  (testing "a failed result that requested a redirect produces the redirect event for the target"
-    (let [result (phase-result/request-redirect {:status :failed} :implement)]
-      (is (= (workflow-fsm/redirect-event :implement)
-             (exec/determine-phase-event {} result))
-          "redirect-event keyword must be in the workflow.redirect/redirect-to-X namespace"))))
 
 (deftest determine-phase-event-failure-without-redirect-target
   (testing "a failed result with NO redirect target produces :phase/fail"
@@ -162,18 +143,13 @@
   (assoc ctx :execution/status :failed
              :test/transition-to-failed-called? true))
 
-(deftest apply-phase-transition-redirect-over-budget-transitions-to-failed
-  (testing "redirect event past max-redirects skips the FSM and flips to failed via transition-to-failed-fn"
-    (let [ctx (-> (ctx-at-plan-active)
-                  (assoc :execution/redirect-count exec/max-redirects))
-          redirect-event (workflow-fsm/redirect-event :implement)
-          out (exec/apply-phase-transition ctx redirect-event [] identity always-fail)]
-      (is (true? (:test/transition-to-failed-called? out))
-          "redirect-over-budget MUST route through transition-to-failed-fn — silent FSM advance was the regression")
-      (is (some #(= :max-redirects-exceeded (:type %)) (:execution/errors out))
-          ":max-redirects-exceeded error must land in :execution/errors")
-      (is (= :failed (:execution/status out))
-          "ctx status must be :failed after over-budget redirect"))))
+;; Phase 4b removed `apply-phase-transition-redirect-over-budget-
+;; transitions-to-failed`. The runner's parallel `is-redirect?` check
+;; that the test pinned was deleted — the FSM's
+;; `:budget/redirects-spent?` guard on the guarded `:phase/fail` array
+;; enforces the same `max-redirects` ceiling, and the verdict-routes
+;; integration tests in fsm_test.clj exercise it end-to-end with the
+;; real compiled machine.
 
 (deftest apply-phase-transition-state-changing-event-returns-next-ctx
   (testing "a valid event that moves the FSM forward returns the advanced ctx (no failure routing)"
@@ -222,15 +198,12 @@
 
 ;; -------------------------------------------------------------------------- end-to-end determine→apply
 
-(deftest determine-then-apply-redirect-chain-fails-at-max-budget
-  (testing "running determine-phase-event into apply-phase-transition over budget routes to failed"
-    (let [result (phase-result/request-redirect {:status :failed} :implement)
-          event (exec/determine-phase-event {} result)
-          ctx (-> (ctx-at-plan-active)
-                  (assoc :execution/redirect-count exec/max-redirects))
-          out (exec/apply-phase-transition ctx event [] identity always-fail)]
-      (is (true? (:test/transition-to-failed-called? out))
-          "end-to-end: redirect-requested + over-budget → :failed"))))
+;; Phase 4b removed `determine-then-apply-redirect-chain-fails-at-max-budget`.
+;; The runner's parallel max-budget check is gone; the same end-to-end
+;; assertion (over-budget redirect → terminal :failed) now lives in
+;; fsm_test.clj's per-phase verdict-routes integration tests, where it
+;; runs against the real compiled FSM with the guarded `:phase/fail`
+;; array's `:budget/redirects-spent?` guard doing the work.
 
 (deftest determine-then-apply-success-path-advances-fsm
   (testing "running determine then apply on a clean success result advances the FSM"


### PR DESCRIPTION
Closes the loop on the channel-A redirect path. Phase 4a removed the legacy \`:phase/terminal-fail\` event; **Phase 4b refactors the last \`phase/request-redirect\` call site** (in \`phase/interface/handle-error\`) to emit \`:phase/verdict :repair-requested\` instead. With no production code left producing the per-target \`workflow.redirect/redirect-to-X\` event keyword, the entire channel-A path is dead.

## Deleted

| Symbol | File | Why |
|---|---|---|
| \`redirect-event-namespace\` | \`workflow/fsm.clj\` | no parallel namespace anymore |
| \`redirect-event\` fn | \`workflow/fsm.clj\` | no per-target event keyword |
| \`redirect-event?\` predicate | \`workflow/fsm.clj\` | no namespace to sniff |
| \`redirect-transition\` | \`workflow/fsm.clj\` | guarded \`:phase/fail\` array is the only path |
| Parallel \`:redirect-count\` bump in \`transition-execution\` | \`workflow/fsm.clj\` | the FSM action \`:redirect/inc-count\` does it now (SINGLE accounting site) |
| \`redirect-target\` + \`target-phase\` branch in \`determine-phase-event\` | \`workflow/execution.clj\` | verdict drives every redirect decision |
| \`is-redirect?\` budget check in \`apply-phase-transition\` | \`workflow/execution.clj\` | the FSM's \`:budget/redirects-spent?\` guard enforces the same ceiling |
| 4 obsolete tests | \`phase_transitions_test.clj\` | pinned the deleted shapes; supersession in \`fsm_test.clj\` integration tests |

## Refactored

- \`phase/interface/handle-error\`: when phase-retry budget is exhausted AND \`:on-fail\` is configured, attaches \`:phase/verdict :repair-requested\` to the phase result instead of calling \`phase/fail-and-request-redirect\`.

## Net delete

~140 LOC removed, ~70 LOC added (mostly comments/migration notes).

## The structural guarantee

**One event channel. One accounting site. No parallel keyword namespace to bypass.** The dogfood-class bug class is now structurally impossible across the entire SDLC.

## Test plan

- [x] All workflow + phase-software-factory + pre-commit smoke green
- [x] Updated canonical follow-phase-transitions test in \`fsm_test.clj\` uses verdict-driven redirect for the verify→implement step
- [x] End-to-end budget enforcement now tested via the per-phase verdict-routes-fail-via-guarded-array tests in \`fsm_test.clj\` against the real compiled FSM

## Migration

Phase 5 next will add the compile-time invariants that lock this in: at-most-one \`:redirect/inc-count\` action per machine; budget guard precedes redirect branch in document order; every state has a terminal escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)