### PR TITLE
feat(workflow): Phase 5 — compile-time structural invariants (FSM RFC)

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -55,6 +55,12 @@
   "Action value must be a function; got {value} (class {class}) under key {action-key}"
   :actions/unregistered-at-resolve
   "Action {action} survived validation but is not registered at resolve time"
+  :structural/guarded-fail-missing-default
+  "State {state}: guarded :phase/fail array has no default (no-guard) branch — a failed transition with no matching guard would be silently dropped"
+  :structural/multiple-redirect-counting-actions
+  "State {state}: guarded :phase/fail array has {count} :redirect/inc-count action sites; at most one is allowed per array (else the counter double-bumps on the same transition)"
+  :structural/budget-guard-misordered
+  "State {state}: redirect branch precedes :budget/redirects-spent? guard in document order — the budget check would never fire"
   :status/missing-workflow-id "Workflow must have :workflow/id"
   :status/invalid-workflow-registration
   "Workflow {workflow-id} failed registration validation"

--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -60,7 +60,9 @@
   :structural/multiple-redirect-counting-actions
   "State {state}: guarded :phase/fail array has {count} :redirect/inc-count action sites; at most one is allowed per array (else the counter double-bumps on the same transition)"
   :structural/budget-guard-misordered
-  "State {state}: redirect branch precedes :budget/redirects-spent? guard in document order — the budget check would never fire"
+  "State {state}: redirect branch (index {redirect-index}) precedes :budget/redirects-spent? guard (index {budget-index}) in document order — the budget check would never fire"
+  :structural/budget-guard-missing
+  "State {state}: guarded :phase/fail array has a :redirect/inc-count action (index {redirect-index}) but no :budget/redirects-spent? guard — the redirect ceiling would never fire"
   :status/missing-workflow-id "Workflow must have :workflow/id"
   :status/invalid-workflow-registration
   "Workflow {workflow-id} failed registration validation"

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -383,6 +383,162 @@
    :message (messages/t :status/unreachable-machine-states
                         {:states states})})
 
+;------------------------------------------------------------------------------ Phase 5: structural invariants
+;;
+;; Three compile-time invariants on the guarded `:phase/fail` arrays
+;; locked in by Phase 2b/3 and Phase 4. Future regressions where a
+;; contributor adds a second redirect-counting path or forgets the
+;; default branch fail at workflow-validation time — at runner startup,
+;; not at the next dogfood.
+
+(def ^:private redirect-action
+  "Sentinel action keyword whose presence in a `:phase/fail` array means
+   THAT entry is the on-fail redirect branch. Defined here so the
+   document-order invariant can find it without coupling to
+   `standard-guards-and-actions` (which depends on this module
+   transitively via fsm.clj's `:require`)."
+  :redirect/inc-count)
+
+(def ^:private redirect-budget-guard
+  "Sentinel guard keyword that must precede the redirect branch in
+   document order — the redirect-budget check."
+  :budget/redirects-spent?)
+
+(defn- phase-fail-entries
+  "Return the vector entries of a state's `:phase/fail` transition, or
+   nil when the transition is the flat (keyword) form. Only `:phase/fail`
+   is inspected — other transitions are simpler and have their own
+   walker-based validators (reachability, ref coverage)."
+  [state-config]
+  (let [t (get-in state-config [:on :phase/fail])]
+    (when (sequential? t) (vec t))))
+
+(defn- guarded-fail-states
+  "Return a seq of `[state-id entries]` for every state whose
+   `:phase/fail` transition is the guarded-array form."
+  [compiled-states]
+  (keep (fn [[state-id config]]
+          (when-let [entries (phase-fail-entries config)]
+            [state-id entries]))
+        compiled-states))
+
+(defn- entry-has-action?
+  [entry action-kw]
+  (and (map? entry)
+       (some #(= action-kw %) (get entry :actions []))))
+
+(defn- entry-default?
+  "A 'default' entry in a guarded array has NO `:guard` slot — it always
+   matches when reached. clj-statecharts picks the first matching
+   branch in document order; without a default at the end, a transition
+   that fails every guard is silently dropped."
+  [entry]
+  (and (map? entry)
+       (not (contains? entry :guard))))
+
+;; ---- Invariant 1: each guarded `:phase/fail` array has a default branch ----
+
+(defn- guarded-fail-missing-default-error
+  [state-id]
+  {:error :guarded-fail-missing-default
+   :state state-id
+   :message (messages/t :structural/guarded-fail-missing-default
+                        {:state state-id})})
+
+(defn- missing-default-branches
+  "Return the seq of state-ids whose guarded `:phase/fail` array has no
+   default (no-guard) branch."
+  [compiled-states]
+  (for [[state-id entries] (guarded-fail-states compiled-states)
+        :when (not (some entry-default? entries))]
+    state-id))
+
+;; ---- Invariant 2: at most one `:redirect/inc-count` per guarded array ----
+;;
+;; RFC §Phase 5: "At most one action across the vector increments
+;; redirect-count." The scope is the per-state `:phase/fail` array —
+;; each work-loop phase legitimately has its own (review, verify,
+;; release, implement); what we lock OUT is a single state's array
+;; bumping the counter twice on the same transition, which would
+;; double-count and silently halve the effective ceiling.
+
+(defn- multiple-redirect-actions-error
+  [state-id indices]
+  {:error :multiple-redirect-counting-actions
+   :state state-id
+   :entry-indices indices
+   :message (messages/t :structural/multiple-redirect-counting-actions
+                        {:state state-id :count (count indices)})})
+
+(defn- multiple-redirect-actions-states
+  "Return `[{:state :entry-indices}, ...]` for every state whose
+   `:phase/fail` array has MORE THAN ONE entry with the
+   `:redirect/inc-count` action. Single occurrence is normal — every
+   guarded-phase array has one redirect-counting branch."
+  [compiled-states]
+  (for [[state-id entries] (guarded-fail-states compiled-states)
+        :let [idxs (vec (keep-indexed
+                          (fn [i e] (when (entry-has-action? e redirect-action) i))
+                          entries))]
+        :when (> (count idxs) 1)]
+    {:state state-id :entry-indices idxs}))
+
+;; ---- Invariant 3: budget guard precedes redirect branch in document order ----
+
+(defn- budget-precedence-error
+  [state-id redirect-idx budget-idx]
+  {:error :budget-guard-misordered
+   :state state-id
+   :redirect-index redirect-idx
+   :budget-guard-index budget-idx
+   :message (messages/t :structural/budget-guard-misordered
+                        {:state state-id})})
+
+(defn- budget-guard-misordered-states
+  "Return the seq of {:state :redirect-index :budget-guard-index} entries
+   where the redirect branch fires BEFORE the budget-check branch in
+   document order. clj-statecharts picks the first matching guard, so a
+   redirect branch ahead of the budget check effectively bypasses the
+   ceiling."
+  [compiled-states]
+  (for [[state-id entries] (guarded-fail-states compiled-states)
+        :let [redirect-idx (->> entries
+                                (keep-indexed
+                                 (fn [i e] (when (entry-has-action? e redirect-action) i)))
+                                first)
+              budget-idx   (->> entries
+                                (keep-indexed
+                                 (fn [i e] (when (and (map? e)
+                                                       (= redirect-budget-guard (:guard e)))
+                                             i)))
+                                first)]
+        :when (and (some? redirect-idx)
+                   (or (nil? budget-idx)
+                       (> budget-idx redirect-idx)))]
+    {:state state-id
+     :redirect-index redirect-idx
+     :budget-guard-index budget-idx}))
+
+(defn- structural-invariant-errors
+  "Phase 5 RFC-prescribed structural invariants. Operates on the RAW
+   (pre-resolve) states map so it sees keyword refs.
+
+   Returns a vector of error maps (possibly empty) in the same shape
+   as the rest of the validator's errors."
+  [compiled-states]
+  (let [missing-defaults (missing-default-branches compiled-states)
+        multi-redirects  (multiple-redirect-actions-states compiled-states)
+        budget-misorders (budget-guard-misordered-states compiled-states)]
+    (vec
+     (concat
+      (map guarded-fail-missing-default-error missing-defaults)
+      (map (fn [{:keys [state entry-indices]}]
+             (multiple-redirect-actions-error state entry-indices))
+           multi-redirects)
+      (map (fn [{:keys [state redirect-index budget-guard-index]}]
+             (budget-precedence-error state redirect-index budget-guard-index))
+           budget-misorders)))))
+
 (defn- build-raw-states
   "Construct the unresolved states map from a workflow pipeline. Returns
    `{:states <raw-states-map> :phase-entries <vec>}`. Extracted from
@@ -513,6 +669,11 @@
                           (guards/validate-guard-references raw-states))
         dangling-actions (when raw-states
                            (actions/validate-action-references raw-states))
+        ;; Phase 5: structural invariants on guarded `:phase/fail`
+        ;; arrays. Locks in the SINGLE-accounting-site / default-branch
+        ;; / budget-precedes-redirect guarantees from Phase 2b/3/4.
+        structural-errors (when raw-states
+                            (structural-invariant-errors raw-states))
         ref-errors (filterv some? [dangling-guards dangling-actions])
         ;; Only compile (with keyword resolution) if ref validation is
         ;; clean — otherwise compile would throw IllegalStateException
@@ -535,6 +696,7 @@
                      unresolved-success
                      unresolved-fail
                      ref-errors
+                     structural-errors
                      (when (seq unreachable-phases)
                        [(unreachable-phase-error unreachable-phases)])
                      (when (seq unreachable-state-set)

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -483,23 +483,42 @@
         :when (> (count idxs) 1)]
     {:state state-id :entry-indices idxs}))
 
-;; ---- Invariant 3: budget guard precedes redirect branch in document order ----
+;; ---- Invariant 3: budget guard must exist and precede the redirect branch ----
+;;
+;; Split into two distinct error keywords so the user's diagnostic
+;; message names the actual problem:
+;;   * `:budget-guard-misordered` — present but in the wrong place
+;;   * `:budget-guard-missing`    — absent entirely
 
-(defn- budget-precedence-error
+(defn- budget-misordered-error
   [state-id redirect-idx budget-idx]
   {:error :budget-guard-misordered
    :state state-id
    :redirect-index redirect-idx
    :budget-guard-index budget-idx
    :message (messages/t :structural/budget-guard-misordered
-                        {:state state-id})})
+                        {:state state-id
+                         :redirect-index redirect-idx
+                         :budget-index budget-idx})})
+
+(defn- budget-missing-error
+  [state-id redirect-idx]
+  {:error :budget-guard-missing
+   :state state-id
+   :redirect-index redirect-idx
+   :message (messages/t :structural/budget-guard-missing
+                        {:state state-id
+                         :redirect-index redirect-idx})})
 
 (defn- budget-guard-misordered-states
-  "Return the seq of {:state :redirect-index :budget-guard-index} entries
-   where the redirect branch fires BEFORE the budget-check branch in
-   document order. clj-statecharts picks the first matching guard, so a
-   redirect branch ahead of the budget check effectively bypasses the
-   ceiling."
+  "Return per-state error data for arrays where the redirect branch is
+   present but the budget guard either does not exist or fires AFTER
+   the redirect. clj-statecharts picks the first matching guard, so a
+   missing or misordered budget check effectively bypasses the ceiling.
+
+   Returns a vector of `{:state ... :kind :missing|:misordered
+                         :redirect-index ... :budget-index ...}` for
+   the aggregator to convert into typed errors."
   [compiled-states]
   (for [[state-id entries] (guarded-fail-states compiled-states)
         :let [redirect-idx (->> entries
@@ -515,9 +534,10 @@
         :when (and (some? redirect-idx)
                    (or (nil? budget-idx)
                        (> budget-idx redirect-idx)))]
-    {:state state-id
-     :redirect-index redirect-idx
-     :budget-guard-index budget-idx}))
+    (if (nil? budget-idx)
+      {:state state-id :kind :missing      :redirect-index redirect-idx}
+      {:state state-id :kind :misordered   :redirect-index redirect-idx
+       :budget-index budget-idx})))
 
 (defn- structural-invariant-errors
   "Phase 5 RFC-prescribed structural invariants. Operates on the RAW
@@ -528,16 +548,18 @@
   [compiled-states]
   (let [missing-defaults (missing-default-branches compiled-states)
         multi-redirects  (multiple-redirect-actions-states compiled-states)
-        budget-misorders (budget-guard-misordered-states compiled-states)]
+        budget-problems  (budget-guard-misordered-states compiled-states)]
     (vec
      (concat
       (map guarded-fail-missing-default-error missing-defaults)
       (map (fn [{:keys [state entry-indices]}]
              (multiple-redirect-actions-error state entry-indices))
            multi-redirects)
-      (map (fn [{:keys [state redirect-index budget-guard-index]}]
-             (budget-precedence-error state redirect-index budget-guard-index))
-           budget-misorders)))))
+      (map (fn [{:keys [state kind redirect-index budget-index]}]
+             (case kind
+               :missing    (budget-missing-error state redirect-index)
+               :misordered (budget-misordered-error state redirect-index budget-index)))
+           budget-problems)))))
 
 (defn- build-raw-states
   "Construct the unresolved states map from a workflow pipeline. Returns

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -443,6 +443,136 @@
            returned #{} because (keep transition-target) discarded the
            vector"))))
 
+;------------------------------------------------------------------------------ Phase 5: structural invariants
+
+(defn- production-shape-workflow
+  "A workflow that includes all four work-loop guarded phases so the
+   structural-invariant tests can synthesize per-state mutations
+   (extra :redirect/inc-count action, removed default branch, etc.)
+   against a realistic compile target."
+  []
+  {:workflow/id :phase5-structural-test
+   :workflow/pipeline [{:phase :plan}
+                       {:phase :implement :on-fail :plan}
+                       {:phase :verify    :on-fail :implement}
+                       {:phase :review    :on-fail :implement}
+                       {:phase :release   :on-fail :implement}
+                       {:phase :done}]})
+
+(deftest structural-invariants-clean-on-production-workflow-test
+  (testing "the production-shape workflow (every guarded phase) emits a
+            machine that passes ALL three Phase 5 structural invariants.
+            Phase 5 is locking IN the post-Phase-4 shape — the baseline
+            must validate."
+    (let [result (fsm/validate-execution-machine (production-shape-workflow))]
+      (is (:valid? result)
+          (str "production workflow must validate; errors: " (:errors result)))
+      (is (empty? (filter (comp #{:guarded-fail-missing-default
+                                  :multiple-redirect-counting-actions
+                                  :budget-guard-misordered}
+                                :error)
+                          (:errors result)))
+          "no structural-invariant errors on the production shape"))))
+
+(deftest structural-invariant-guarded-fail-missing-default-test
+  (testing "if a state's guarded :phase/fail array has no default
+            (no-guard) branch, the validator surfaces a
+            :guarded-fail-missing-default error so the regression is
+            caught at workflow validation, not at the next dogfood.
+
+            clj-statecharts picks the FIRST matching guard in document
+            order; without a default branch a transition that fails
+            every guard would be silently dropped."
+    (with-redefs [;; Force a guarded-phase to emit an array with no
+                  ;; default branch by overriding the helper.
+                  fsm/validate-execution-machine
+                  (fn [workflow]
+                    ;; Simulate by injecting a bad workflow through the
+                    ;; raw-states pipeline.
+                    (let [{:keys [states]} (#'fsm/build-raw-states workflow)
+                          ;; Strip the default branch (last entry, no
+                          ;; :guard) from review-phase's :phase/fail
+                          ;; array.
+                          review-state (first (keep #(when (= :phase-3-review (first %)) %) states))
+                          bad-states (when review-state
+                                       (let [[sid scfg] review-state
+                                             entries (get-in scfg [:on :phase/fail])
+                                             bad-entries (vec (remove #(and (map? %) (not (contains? % :guard))) entries))]
+                                         (assoc states sid
+                                                (assoc-in scfg [:on :phase/fail] bad-entries))))
+                          errs (when bad-states
+                                 (#'fsm/structural-invariant-errors bad-states))]
+                      {:valid? (empty? errs)
+                       :errors (vec errs)
+                       :warnings []}))]
+      (let [result (fsm/validate-execution-machine (production-shape-workflow))
+            errs   (:errors result)]
+        (is (some #(= :guarded-fail-missing-default (:error %)) errs)
+            "missing-default error must surface")
+        (is (not (:valid? result))
+            "workflow with a default-less guarded array is invalid")))))
+
+(deftest structural-invariant-multiple-redirect-actions-test
+  (testing "if a single state's guarded :phase/fail array lists
+            :redirect/inc-count on more than one entry, the validator
+            surfaces a :multiple-redirect-counting-actions error.
+            Locks out double-counting (channel-A's regression vector)."
+    (let [bad-states
+          {:phase-0-review
+           {:on {:phase/fail [{:target :failed
+                               :guard :verdict/terminal?}
+                              ;; TWO entries with the redirect action
+                              {:target :phase-1-implement
+                               :actions [:redirect/inc-count]}
+                              {:target :phase-1-implement
+                               :actions [:redirect/inc-count :review/record-fingerprint]}
+                              {:target :failed}]}}}
+          errs (#'fsm/structural-invariant-errors bad-states)]
+      (is (some #(= :multiple-redirect-counting-actions (:error %)) errs)
+          "multi-redirect error must surface")
+      (let [err (first (filter #(= :multiple-redirect-counting-actions (:error %)) errs))]
+        (is (= :phase-0-review (:state err))
+            "error names the offending state")
+        (is (= [1 2] (:entry-indices err))
+            "error lists the indices of the offending entries")))))
+
+(deftest structural-invariant-budget-guard-misordered-test
+  (testing "if the redirect branch precedes the :budget/redirects-spent?
+            guard in document order, the budget check would never fire
+            (clj-statecharts picks the first matching branch). Validator
+            surfaces a :budget-guard-misordered error."
+    (let [bad-states
+          {:phase-0-review
+           {:on {:phase/fail [{:target :failed :guard :verdict/terminal?}
+                              ;; redirect FIRST — wrong order
+                              {:target :phase-1-implement
+                               :actions [:redirect/inc-count]}
+                              ;; budget check AFTER, would never fire
+                              {:target :failed :guard :budget/redirects-spent?}
+                              {:target :failed}]}}}
+          errs (#'fsm/structural-invariant-errors bad-states)]
+      (is (some #(= :budget-guard-misordered (:error %)) errs)
+          "budget-misordered error must surface")
+      (let [err (first (filter #(= :budget-guard-misordered (:error %)) errs))]
+        (is (= :phase-0-review (:state err)))
+        (is (< (:redirect-index err) (:budget-guard-index err))
+            "the error data names the redirect-before-budget mismatch"))))
+
+  (testing "budget-misordered also fires when the redirect branch is
+            present but there's NO budget-check at all — the redirect
+            branch could fire without an upstream ceiling, defeating
+            the purpose"
+    (let [bad-states
+          {:phase-0-review
+           {:on {:phase/fail [{:target :failed :guard :verdict/terminal?}
+                              ;; No budget-check guard anywhere; just redirect
+                              {:target :phase-1-implement
+                               :actions [:redirect/inc-count]}
+                              {:target :failed}]}}}
+          errs (#'fsm/structural-invariant-errors bad-states)]
+      (is (some #(= :budget-guard-misordered (:error %)) errs)
+          "missing-budget-check is misordered too"))))
+
 (deftest compiled-execution-machine-reachability-test
   (let [workflow {:workflow/id :test
                   :workflow/pipeline [{:phase :plan}

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -476,41 +476,75 @@
 
 (deftest structural-invariant-guarded-fail-missing-default-test
   (testing "if a state's guarded :phase/fail array has no default
-            (no-guard) branch, the validator surfaces a
-            :guarded-fail-missing-default error so the regression is
-            caught at workflow validation, not at the next dogfood.
+            (no-guard) branch, the structural-invariant aggregator
+            surfaces a :guarded-fail-missing-default error so the
+            regression is caught at workflow validation time, not at
+            the next dogfood.
 
             clj-statecharts picks the FIRST matching guard in document
-            order; without a default branch a transition that fails
-            every guard would be silently dropped."
-    (with-redefs [;; Force a guarded-phase to emit an array with no
-                  ;; default branch by overriding the helper.
-                  fsm/validate-execution-machine
-                  (fn [workflow]
-                    ;; Simulate by injecting a bad workflow through the
-                    ;; raw-states pipeline.
-                    (let [{:keys [states]} (#'fsm/build-raw-states workflow)
-                          ;; Strip the default branch (last entry, no
-                          ;; :guard) from review-phase's :phase/fail
-                          ;; array.
-                          review-state (first (keep #(when (= :phase-3-review (first %)) %) states))
-                          bad-states (when review-state
-                                       (let [[sid scfg] review-state
-                                             entries (get-in scfg [:on :phase/fail])
-                                             bad-entries (vec (remove #(and (map? %) (not (contains? % :guard))) entries))]
-                                         (assoc states sid
-                                                (assoc-in scfg [:on :phase/fail] bad-entries))))
-                          errs (when bad-states
-                                 (#'fsm/structural-invariant-errors bad-states))]
-                      {:valid? (empty? errs)
-                       :errors (vec errs)
-                       :warnings []}))]
-      (let [result (fsm/validate-execution-machine (production-shape-workflow))
-            errs   (:errors result)]
-        (is (some #(= :guarded-fail-missing-default (:error %)) errs)
-            "missing-default error must surface")
-        (is (not (:valid? result))
-            "workflow with a default-less guarded array is invalid")))))
+            order; without a default a transition that fails every
+            guard would be silently dropped."
+    (let [bad-states
+          ;; Every entry has a `:guard`. clj-statecharts picks the
+          ;; first matching guard in document order; if every entry
+          ;; specifies a guard and the runtime event matches none of
+          ;; them, the transition is silently dropped. The structural
+          ;; invariant catches this by requiring AT LEAST ONE entry
+          ;; without a `:guard` slot — the catch-all.
+          {:phase-0-review
+           {:on {:phase/fail [{:target :failed :guard :verdict/terminal?}
+                              {:target :failed :guard :budget/redirects-spent?}
+                              {:target :phase-1-implement
+                               :guard   :config/on-fail-set?
+                               :actions [:redirect/inc-count]}
+                              ;; NO catch-all entry — every branch
+                              ;; conditional, so a non-matching event
+                              ;; would slip through.
+                              ]}}}
+          errs (#'fsm/structural-invariant-errors bad-states)]
+      (is (some #(= :guarded-fail-missing-default (:error %)) errs)
+          "missing-default error must surface")
+      (let [err (first (filter #(= :guarded-fail-missing-default (:error %)) errs))]
+        (is (= :phase-0-review (:state err))
+            "error names the offending state"))))
+
+  (testing "end-to-end via validate-execution-machine: a workflow that
+            produces a default-less guarded array is invalid. The
+            structural-invariant errors flow through the same
+            :errors vector the existing validator surfaces."
+    ;; Synthesize the bad-states map and inject it via with-redefs of
+    ;; build-raw-states so validate-execution-machine wires it through
+    ;; the real error-aggregation path (not just the inner helper).
+    (let [base-workflow {:workflow/id :phase5-missing-default-e2e
+                         :workflow/pipeline [{:phase :plan}
+                                             {:phase :review :on-fail :plan}
+                                             {:phase :done}]}
+          original-build-raw @#'fsm/build-raw-states
+          strip-default      (fn [build]
+                               (let [states (:states build)
+                                     review-id (some #(when (= :review (-> (val %) (get-in [:on :phase/fail])
+                                                                            (as-> t (when (sequential? t) :unused))))
+                                                        (key %))
+                                                     states)
+                                     ;; Find any guarded :phase/fail state and strip default
+                                     fixed-states
+                                     (into {}
+                                           (map (fn [[sid scfg]]
+                                                  (let [t (get-in scfg [:on :phase/fail])]
+                                                    (if (sequential? t)
+                                                      [sid (assoc-in scfg [:on :phase/fail]
+                                                                     (vec (remove #(and (map? %)
+                                                                                        (not (contains? % :guard)))
+                                                                                  t)))]
+                                                      [sid scfg]))))
+                                           states)]
+                                 (assoc build :states fixed-states)))]
+      (with-redefs [fsm/build-raw-states (fn [wf] (strip-default (original-build-raw wf)))]
+        (let [result (fsm/validate-execution-machine base-workflow)]
+          (is (not (:valid? result))
+              "workflow with a default-less guarded array must validate as invalid")
+          (is (some #(= :guarded-fail-missing-default (:error %)) (:errors result))
+              "the structural error flows through :errors"))))))
 
 (deftest structural-invariant-multiple-redirect-actions-test
   (testing "if a single state's guarded :phase/fail array lists
@@ -558,10 +592,11 @@
         (is (< (:redirect-index err) (:budget-guard-index err))
             "the error data names the redirect-before-budget mismatch"))))
 
-  (testing "budget-misordered also fires when the redirect branch is
-            present but there's NO budget-check at all — the redirect
-            branch could fire without an upstream ceiling, defeating
-            the purpose"
+  (testing "a redirect branch with NO :budget/redirects-spent? guard
+            anywhere in the array surfaces :budget-guard-missing
+            (distinct from :budget-guard-misordered so the diagnostic
+            message names the actual problem — Copilot caught the
+            single-error-keyword shape was confusing)."
     (let [bad-states
           {:phase-0-review
            {:on {:phase/fail [{:target :failed :guard :verdict/terminal?}
@@ -570,8 +605,11 @@
                                :actions [:redirect/inc-count]}
                               {:target :failed}]}}}
           errs (#'fsm/structural-invariant-errors bad-states)]
-      (is (some #(= :budget-guard-misordered (:error %)) errs)
-          "missing-budget-check is misordered too"))))
+      (is (some #(= :budget-guard-missing (:error %)) errs)
+          ":budget-guard-missing (not :budget-guard-misordered) when no
+           budget guard is present at all")
+      (is (not (some #(= :budget-guard-misordered (:error %)) errs))
+          "missing and misordered are distinct error keywords"))))
 
 (deftest compiled-execution-machine-reachability-test
   (let [workflow {:workflow/id :test


### PR DESCRIPTION
Locks in the post-Phase-4 guarantees. Future regressions where a contributor adds a second redirect-counting path or forgets the default branch **fail at workflow compile time** — at runner startup, not at the next dogfood.

## Three invariants

| Error | Catches |
|---|---|
| \`:guarded-fail-missing-default\` | guarded \`:phase/fail\` array with no default (no-\`:guard\`) branch — clj-statecharts picks the first matching guard in document order, so a transition that fails every guard would be silently dropped |
| \`:multiple-redirect-counting-actions\` | a SINGLE state's array with multiple \`:redirect/inc-count\` entries — double-counting on the same transition. The four guarded phases each legitimately have their own; this catches the regression |
| \`:budget-guard-misordered\` | redirect branch precedes \`:budget/redirects-spent?\` guard in document order (the ceiling would never fire), OR redirect branch with no upstream budget check at all |

All three checks run against the RAW (pre-resolve) states map — same path as the Phase 1/2a dangling-ref checks.

## Summary

- \`workflow/fsm.clj\`: ~150 LOC for the 3 invariant fns, their error builders, the aggregator, and the validate-execution-machine wiring
- Workflow messages catalog: 3 new \`:structural/*\` entries
- \`fsm_test.clj\`: 4 new structural-invariant tests pinning each error shape, plus a baseline asserting the production workflow validates cleanly

## Test plan

- [x] Production-shape workflow (all four guarded phases + on-fail :implement wiring) passes ALL three invariants — Phase 5 locks in what Phase 2b/3/4 PROVED is true, so the invariants are baseline behavior
- [x] All workflow brick tests green
- [x] Pre-commit smoke clean

## Completes the RFC migration

| Phase | PR | Status |
|---|---|---|
| 1 | #1022 | merged |
| 2a | #1025 | merged |
| 2b | #1026 | merged |
| 3a | #1027 | merged |
| 3b | #1028 | merged |
| 3c | #1029 | merged |
| 4a | #1030 | merged |
| 4b | #1031 | merged |
| **5** | **this PR** | **in flight** |
| 6 (optional) | TBD | Mermaid export |

🤖 Generated with [Claude Code](https://claude.com/claude-code)