### PR TITLE
refactor(workflow): extract pipeline anon fns from FSM RFC code

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/actions.clj
@@ -168,11 +168,19 @@
         action                 (action-refs-in-transition entry)]
     {:state state-id :event event-key :action action}))
 
+(defn- state-entry->action-refs
+  "Pipeline helper: from a `[state-id state-config]` tuple, return the
+   action-ref location records for that state. Extracted from the
+   `action-references-with-locations` walker per standards rule
+   `No Inline Anonymous Functions in Pipelines`."
+  [[state-id state-config]]
+  (state-action-refs-with-location state-id state-config))
+
 (defn action-references-with-locations
   "Return every action reference with its source `{:state :event}` tuple."
   [compiled-states]
   (->> compiled-states
-       (mapcat (fn [[state-id config]] (state-action-refs-with-location state-id config)))
+       (mapcat state-entry->action-refs)
        vec))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -192,7 +200,7 @@
   [compiled-states]
   (let [known (registered-keys)]
     (->> (action-references-with-locations compiled-states)
-         (remove (fn [{:keys [action]}] (contains? known action)))
+         (remove (comp known :action))
          vec)))
 
 (defn validate-action-references
@@ -241,21 +249,27 @@
                                     transition)
     :else                    transition))
 
+(defn- resolve-event-transition
+  "Resolve a single `[event-key transition]` map-entry into a vector
+   pair with the transition's keyword refs substituted."
+  [[event-key transition]]
+  [event-key (resolve-actions-in-transition transition)])
+
+(defn- resolve-state-actions
+  "Resolve every keyword-form `:actions` reference within a single
+   `[state-id state-config]` pair, returning a `[state-id new-config]`
+   tuple suitable for `into {}`."
+  [[state-id state-config]]
+  (let [resolved-on (into {} (map resolve-event-transition) (get state-config :on {}))]
+    [state-id (assoc state-config :on resolved-on)]))
+
 (defn resolve-action-keywords
   "Walk `compiled-states` and substitute every keyword-form `:actions`
    reference with its registered fn. Idempotent — entries with no
    keyword refs pass through. Validator should have run first to ensure
    coverage."
   [compiled-states]
-  (into {}
-        (map (fn [[state-id state-config]]
-               (let [on (get state-config :on {})
-                     resolved-on (into {}
-                                       (map (fn [[event-key t]]
-                                              [event-key (resolve-actions-in-transition t)]))
-                                       on)]
-                 [state-id (assoc state-config :on resolved-on)])))
-        compiled-states))
+  (into {} (map resolve-state-actions) compiled-states))
 
 ;------------------------------------------------------------------------------ Rich comment
 

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -539,6 +539,22 @@
       {:state state-id :kind :misordered   :redirect-index redirect-idx
        :budget-index budget-idx})))
 
+(defn- ->multiple-redirect-error
+  "Pipeline helper: build the typed error map from a multi-redirect
+   walker record. Extracted to satisfy `No Inline Anonymous Functions
+   in Pipelines` and so each branch of the aggregator reads as a one-
+   liner."
+  [{:keys [state entry-indices]}]
+  (multiple-redirect-actions-error state entry-indices))
+
+(defn- ->budget-error
+  "Pipeline helper: dispatch on `:kind` and build the appropriate
+   typed error for a budget-guard walker record."
+  [{:keys [state kind redirect-index budget-index]}]
+  (case kind
+    :missing    (budget-missing-error state redirect-index)
+    :misordered (budget-misordered-error state redirect-index budget-index)))
+
 (defn- structural-invariant-errors
   "Phase 5 RFC-prescribed structural invariants. Operates on the RAW
    (pre-resolve) states map so it sees keyword refs.
@@ -552,14 +568,8 @@
     (vec
      (concat
       (map guarded-fail-missing-default-error missing-defaults)
-      (map (fn [{:keys [state entry-indices]}]
-             (multiple-redirect-actions-error state entry-indices))
-           multi-redirects)
-      (map (fn [{:keys [state kind redirect-index budget-index]}]
-             (case kind
-               :missing    (budget-missing-error state redirect-index)
-               :misordered (budget-misordered-error state redirect-index budget-index)))
-           budget-problems)))))
+      (map ->multiple-redirect-error multi-redirects)
+      (map ->budget-error budget-problems)))))
 
 (defn- build-raw-states
   "Construct the unresolved states map from a workflow pipeline. Returns

--- a/components/workflow/src/ai/miniforge/workflow/guards.clj
+++ b/components/workflow/src/ai/miniforge/workflow/guards.clj
@@ -173,11 +173,18 @@
         :when g]
     {:state state-id :event event-key :guard g}))
 
+(defn- state-entry->guard-refs
+  "Pipeline helper: from a `[state-id state-config]` tuple, return the
+   guard-ref location records for that state. Parallels actions.clj's
+   `state-entry->action-refs`."
+  [[state-id state-config]]
+  (state-guard-refs-with-location state-id state-config))
+
 (defn guard-references-with-locations
   "Return every guard reference with its source `{:state :event}` tuple."
   [compiled-states]
   (->> compiled-states
-       (mapcat (fn [[state-id config]] (state-guard-refs-with-location state-id config)))
+       (mapcat state-entry->guard-refs)
        vec))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -197,7 +204,7 @@
   [compiled-states]
   (let [known (registered-keys)]
     (->> (guard-references-with-locations compiled-states)
-         (remove (fn [{:keys [guard]}] (contains? known guard)))
+         (remove (comp known :guard))
          vec)))
 
 (defn validate-guard-references
@@ -246,21 +253,27 @@
                                     transition)
     :else                    transition))
 
+(defn- resolve-event-transition
+  "Resolve a single `[event-key transition]` map-entry into a vector
+   pair with the transition's keyword guards substituted."
+  [[event-key transition]]
+  [event-key (resolve-guards-in-transition transition)])
+
+(defn- resolve-state-guards
+  "Resolve every keyword-form `:guard` reference within a single
+   `[state-id state-config]` pair, returning a `[state-id new-config]`
+   tuple suitable for `into {}`."
+  [[state-id state-config]]
+  (let [resolved-on (into {} (map resolve-event-transition) (get state-config :on {}))]
+    [state-id (assoc state-config :on resolved-on)]))
+
 (defn resolve-guard-keywords
   "Walk `compiled-states` and substitute every keyword-form `:guard`
    reference with its registered fn. Idempotent — entries with no
    keyword refs pass through. Validator should have run first to ensure
    coverage."
   [compiled-states]
-  (into {}
-        (map (fn [[state-id state-config]]
-               (let [on (get state-config :on {})
-                     resolved-on (into {}
-                                       (map (fn [[event-key t]]
-                                              [event-key (resolve-guards-in-transition t)]))
-                                       on)]
-                 [state-id (assoc state-config :on resolved-on)])))
-        compiled-states))
+  (into {} (map resolve-state-guards) compiled-states))
 
 ;------------------------------------------------------------------------------ Rich comment
 


### PR DESCRIPTION
Post-RFC simplification pass. Standards gap-analysis triage.

## Headline

**Standards scanner gap-analysis findings on FSM RFC files:**
- ✅ Anon-fn-in-pipeline flags introduced by Phase 2a / 5: **fixed in this PR (8 extractions)**
- ✅ My new code's only remaining flags are rule-005 IAE programmer-error guards — false positives per the rule's exemption #2 (scanner can't semantically distinguish)
- ⏸️ Pre-existing across the codebase: 120 \`requiring-resolve\` (agent-smell), 258 rule-005 IAE flags (mostly false positives), 28 TODO/FIXME markers — **out of scope, separate cleanup**

## Changes

| File | Helper extracted | Where |
|---|---|---|
| \`actions.clj\` | \`state-entry->action-refs\` | \`action-references-with-locations\` mapcat |
| \`actions.clj\` | \`resolve-event-transition\`, \`resolve-state-actions\` | \`resolve-action-keywords\` walker |
| \`actions.clj\` | \`(comp known :action)\` swap | \`dangling-action-references\` |
| \`guards.clj\` | parallel three-fn extraction | walker + resolver |
| \`guards.clj\` | \`(comp known :guard)\` swap | dangling check |
| \`fsm.clj\` | \`->multiple-redirect-error\`, \`->budget-error\` | structural-invariant aggregator |

## Test plan

- [x] All workflow brick tests green
- [x] Pre-commit smoke clean
- [x] \`bb review\` confirms zero anon-fn flags on my touched files (actions/guards/fsm); rule-005 flags remain as rule-permitted IAE programmer-error guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)