### PR TITLE
feat(reviewer): scope-bound verdict — out-of-scope findings are advisory

### DIFF
--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -6,7 +6,7 @@
 ;; and error handling.
 
 {:prompt/id :reviewer
- :prompt/version "1.2.0"
+ :prompt/version "1.3.0"
  :prompt/agent :reviewer
 
  ;; Turn cap for the reviewer's main session. Reviewer reads the
@@ -59,6 +59,7 @@ You must output a structured review as a Clojure map:
                    :line 42
                    :description \"Division by zero when input is empty\"
                    :suggestion \"Add a guard clause: (when (seq items) ...)\"}]
+ :review/out-of-scope-observations [] ; advisory findings outside the task's :scope; see Scope Boundary
  :review/summary \"Brief human-readable review summary\"
  :review/strengths [\"Good use of protocols for extensibility\"
                     \"Comprehensive error messages with ex-info\"]}
@@ -106,6 +107,30 @@ You must output a structured review as a Clojure map:
 - **:approved** — No blocking issues. Code is ready to proceed.
 - **:changes-requested** — Has blocking or multiple warning issues. Needs revision.
 - **:rejected** — Fundamental design problems. Needs significant rework.
+
+## Scope Boundary (CRITICAL)
+
+The user prompt may include a `## Scope` section listing path prefixes
+or file paths the implementer was asked to change. When that section is
+present:
+
+- **In-scope findings** — anything matching a listed path/prefix — go
+  in `:review/issues` with normal severities (:blocking / :warning /
+  :nit). These drive the verdict.
+- **Out-of-scope findings** — anything else, including standards
+  violations in files the implementer did not introduce — go in
+  `:review/out-of-scope-observations`. Use the same map shape
+  (`:severity` / `:file` / `:line` / `:description` / `:suggestion`).
+  They are advisory only.
+- **Approval is decided strictly on `:review/issues`.** Do not down-vote
+  the verdict for adjacent-file findings; they belong to separate
+  cleanup work and are not part of this task's bar.
+- A violation of a Standards Enforcement rule (next section) outside
+  the scope is STILL out-of-scope — report it under
+  `:review/out-of-scope-observations`, not as a blocking issue.
+
+When the `## Scope` section is absent or empty, review every file in
+the artifact (legacy behavior).
 
 ## CRITICAL: Exhaustive Single-Pass Review
 

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -419,8 +419,11 @@
            (str "## Intent\n\n" (if (string? intent) intent (pr-str intent)) "\n\n"))
          (when scope
            (str "## Scope\n\n"
-                "Findings inside these paths/prefixes are in-scope and block approval.\n"
-                "Findings outside are out-of-scope — report them in\n"
+                "Findings inside these paths/prefixes are in-scope; report them in\n"
+                "`:review/issues` with the appropriate severity\n"
+                "(`:blocking` / `:warning` / `:nit`). Normal severity rules apply —\n"
+                "only `:blocking` issues actually block the verdict.\n\n"
+                "Findings outside the scope are out-of-scope — report them in\n"
                 "`:review/out-of-scope-observations`, NOT in `:review/issues`.\n\n"
                 (str/join "\n" (map #(str "- " %) scope))
                 "\n\n"))
@@ -441,6 +444,24 @@
   (and (map? issue)
        (every? review-issue-keys (keys issue))
        (m/validate ReviewIssue issue)))
+
+(defn sanitize-review-issues
+  "Filter an LLM-supplied issue collection down to the entries that match
+   the canonical `ReviewIssue` shape.
+
+   Returns a vector — empty when input is nil, not a collection, or every
+   entry is malformed. Use at every point where unvalidated LLM output
+   would otherwise reach `ReviewArtifact`'s malli check (the schema
+   rejects the whole artifact on a single bad issue map, which would
+   silently fail the entire review). The pattern came out of the
+   `:review/issues` parse-validator (`valid-review-issues?`); this helper
+   exists so additional issue-shaped fields (currently
+   `:review/out-of-scope-observations`) don't reinvent the same filter at
+   every call site."
+  [issues]
+  (->> issues
+       (filter valid-review-issue-map?)
+       vec))
 
 (defn- valid-review-issues?
   "True when parsed LLM review issues are absent or structurally canonical."
@@ -946,7 +967,8 @@
                     initial-llm-issues    (get llm-review :review/issues [])
                     initial-llm-strengths (get llm-review :review/strengths [])
                     initial-llm-summary   (:review/summary llm-review)
-                    initial-llm-out-of-scope (get llm-review :review/out-of-scope-observations [])
+                    initial-llm-out-of-scope (sanitize-review-issues
+                                               (get llm-review :review/out-of-scope-observations))
 
                     ;; ENUMERATION VALIDATOR: a rejection without enumerated
                     ;; :blocking findings is malformed — the implementer
@@ -987,7 +1009,8 @@
                                     (:review/summary recovered-review)
                                     initial-llm-summary)
                     llm-out-of-scope (if recovered-review
-                                       (get recovered-review :review/out-of-scope-observations [])
+                                       (sanitize-review-issues
+                                         (get recovered-review :review/out-of-scope-observations))
                                        initial-llm-out-of-scope)
 
                     ;; Merge decisions: gates can override LLM

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -83,6 +83,12 @@
    [:review/warnings {:optional true} [:vector :string]]
    [:review/recommendations {:optional true} [:vector :string]]
    [:review/issues {:optional true} [:vector ReviewIssue]]
+   ;; Findings outside the task's :scope. Advisory only — these MUST NOT
+   ;; appear in :review/issues and do NOT drive the verdict. Carried on
+   ;; the artifact so the implementer's redirect feedback (and any
+   ;; downstream evidence consumer) can still see what the reviewer
+   ;; observed in adjacent code.
+   [:review/out-of-scope-observations {:optional true} [:vector ReviewIssue]]
    [:review/strengths {:optional true} [:vector :string]]
    [:review/created-at {:optional true} inst?]])
 
@@ -362,6 +368,37 @@
     :else
     (pr-str artifact)))
 
+(defn- clean-scope-paths
+  "Drop blank and non-string entries, trim whitespace, dedupe."
+  [paths]
+  (->> paths
+       (keep #(when (string? %) (not-empty (str/trim %))))
+       distinct
+       vec
+       not-empty))
+
+(defn effective-review-scope
+  "Resolve the effective scope vector for a review task.
+
+   Strict priority — uses the most specific signal available and ignores
+   broader ones underneath it. Order:
+
+   1. `:task/scope` — set explicitly by the dispatch layer for this task.
+   2. `:task/files-in-scope` — a DAG sub-task's per-task scope from the
+      planner (`dag-orchestrator/task-sub-input`).
+   3. `(:scope task/intent)` — the spec-level scope, when intent is an
+      EDN map carrying it.
+
+   Merging across levels would dilute per-task narrowness with the broader
+   spec scope, which defeats the purpose. Returns a deduped vector of
+   non-blank strings, or nil when no scope signal is present (legacy
+   behavior: review every file)."
+  [input]
+  (let [intent (:task/intent input)]
+    (or (clean-scope-paths (:task/scope input))
+        (clean-scope-paths (:task/files-in-scope input))
+        (when (map? intent) (clean-scope-paths (:scope intent))))))
+
 (defn build-review-prompt
   "Construct the user prompt for LLM review from task data."
   [input]
@@ -371,6 +408,7 @@
         intent (or (:task/intent input) "")
         constraints (or (:task/constraints input) "")
         tests (:task/tests input)
+        scope (effective-review-scope input)
         artifact-text (format-artifact-for-review artifact)]
     (str "Review the following code implementation.\n\n"
          (when (seq title)
@@ -379,6 +417,13 @@
            (str "## Description\n\n" description "\n\n"))
          (when (and intent (not (str/blank? (str intent))))
            (str "## Intent\n\n" (if (string? intent) intent (pr-str intent)) "\n\n"))
+         (when scope
+           (str "## Scope\n\n"
+                "Findings inside these paths/prefixes are in-scope and block approval.\n"
+                "Findings outside are out-of-scope — report them in\n"
+                "`:review/out-of-scope-observations`, NOT in `:review/issues`.\n\n"
+                (str/join "\n" (map #(str "- " %) scope))
+                "\n\n"))
          (when (and constraints (not (str/blank? (str constraints))))
            (str "## Constraints\n\n" (if (string? constraints) constraints (pr-str constraints)) "\n\n"))
          "## Code to Review\n\n"
@@ -583,7 +628,7 @@
 (defn build-review-artifact
   "Build the review artifact from gate results, LLM feedback, and decision."
   [gate-feedbacks decision blocking-issues warnings artifact-id counts
-   & {:keys [issues strengths summary]}]
+   & {:keys [issues strengths summary out-of-scope-observations]}]
   (cond-> {:review/id (random-uuid)
            :review/decision decision
            :review/gate-results gate-feedbacks
@@ -597,7 +642,9 @@
            :review/recommendations (generate-recommendations gate-feedbacks)
            :review/created-at (java.util.Date.)}
     (seq issues) (assoc :review/issues issues)
-    (seq strengths) (assoc :review/strengths strengths)))
+    (seq strengths) (assoc :review/strengths strengths)
+    (seq out-of-scope-observations)
+    (assoc :review/out-of-scope-observations out-of-scope-observations)))
 
 (defn build-review-result
   "Build the final result map with metrics."
@@ -899,6 +946,7 @@
                     initial-llm-issues    (get llm-review :review/issues [])
                     initial-llm-strengths (get llm-review :review/strengths [])
                     initial-llm-summary   (:review/summary llm-review)
+                    initial-llm-out-of-scope (get llm-review :review/out-of-scope-observations [])
 
                     ;; ENUMERATION VALIDATOR: a rejection without enumerated
                     ;; :blocking findings is malformed — the implementer
@@ -938,6 +986,9 @@
                     llm-summary   (if recovered-review
                                     (:review/summary recovered-review)
                                     initial-llm-summary)
+                    llm-out-of-scope (if recovered-review
+                                       (get recovered-review :review/out-of-scope-observations [])
+                                       initial-llm-out-of-scope)
 
                     ;; Merge decisions: gates can override LLM
                     final-decision (if llm-decision
@@ -966,7 +1017,8 @@
                                     artifact-id counts
                                     :issues llm-issues
                                     :strengths llm-strengths
-                                    :summary summary)
+                                    :summary summary
+                                    :out-of-scope-observations llm-out-of-scope)
                              (seq llm-recs) (update :review/recommendations
                                                     (fn [existing] (into (or existing []) llm-recs))))
 

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -1160,3 +1160,27 @@
                     :task/artifact {:code/files []}})]
       (is (not (re-find #"## Scope" prompt))
           "no Scope section when scope is nil"))))
+
+(deftest sanitize-review-issues-test
+  (testing "valid canonical issue maps pass through"
+    (is (= [{:severity :blocking :description "x"}]
+           (reviewer/sanitize-review-issues
+             [{:severity :blocking :description "x"}]))))
+
+  (testing "malformed entries are dropped, valid ones kept"
+    ;; Without the sanitizer, a single bad entry would fail malli
+    ;; validation on the whole ReviewArtifact (see ReviewIssue schema's
+    ;; docstring on the 2026-05-16 :rejected-on-nil-line incident).
+    (let [issues [{:severity :blocking :description "good"}
+                  {:severity :not-an-enum :description "bad severity"}
+                  {:severity :warning :description "good 2"}
+                  {:extra-key "extras get rejected too" :severity :nit :description "x"}
+                  "string instead of map"
+                  nil]]
+      (is (= [{:severity :blocking :description "good"}
+              {:severity :warning :description "good 2"}]
+             (reviewer/sanitize-review-issues issues)))))
+
+  (testing "nil and non-collection inputs return empty vec"
+    (is (= [] (reviewer/sanitize-review-issues nil)))
+    (is (= [] (reviewer/sanitize-review-issues [])))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -1097,3 +1097,66 @@
                                         :review/issues []})))
     (is (false? (well-formed-recovery? {:review/decision :looks-good
                                         :review/issues []})))))
+
+;------------------------------------------------------------------------------ Scope-boundary tests
+;; The reviewer prompt and helper resolve a per-task scope so adjacent-file
+;; findings can't drive the verdict on tightly-scoped refactors. The 2026-06-04
+;; eliminate-requiring-resolve dogfood failed 20/20 tasks because the reviewer
+;; held every diff to the FULL standards bar across all changed files; pin the
+;; new scope plumbing so a future "simplification" can't quietly drop it.
+
+(deftest effective-review-scope-priority-test
+  (testing "task/scope wins over task/files-in-scope and intent/scope"
+    (is (= ["explicit/path.clj"]
+           (reviewer/effective-review-scope
+             {:task/scope ["explicit/path.clj"]
+              :task/files-in-scope ["dag/path.clj"]
+              :task/intent {:scope ["intent/path.clj"]}}))))
+
+  (testing "task/files-in-scope wins over intent/scope when task/scope absent"
+    (is (= ["dag/per-task.clj"]
+           (reviewer/effective-review-scope
+             {:task/files-in-scope ["dag/per-task.clj"]
+              :task/intent {:scope ["broad/spec-level.clj"]}}))))
+
+  (testing "intent/scope is the final fallback"
+    (is (= ["broad/spec-level/src"]
+           (reviewer/effective-review-scope
+             {:task/intent {:type :refactor
+                            :scope ["broad/spec-level/src"]}}))))
+
+  (testing "nil when no scope signal is present (legacy behavior)"
+    (is (nil? (reviewer/effective-review-scope {:task/intent "free-form prose"})))
+    (is (nil? (reviewer/effective-review-scope {})))
+    (is (nil? (reviewer/effective-review-scope {:task/intent {:type :feature}}))))
+
+  (testing "blank and non-string entries are filtered out"
+    (is (= ["good/path.clj"]
+           (reviewer/effective-review-scope
+             {:task/scope ["good/path.clj" "" "   " nil 42]}))))
+
+  (testing "duplicates within the winning source are collapsed"
+    (is (= ["a.clj" "b.clj"]
+           (reviewer/effective-review-scope
+             {:task/scope ["a.clj" "a.clj" "b.clj" "a.clj"]})))))
+
+(deftest build-review-prompt-renders-scope-section-test
+  (testing "Scope section appears with bulleted paths when scope is resolved"
+    (let [prompt (reviewer/build-review-prompt
+                   {:task/title "Test"
+                    :task/intent {:type :refactor
+                                  :scope ["components/foo/src" "components/bar/src"]}
+                    :task/artifact {:code/files []}})]
+      (is (re-find #"## Scope" prompt))
+      (is (re-find #"- components/foo/src" prompt))
+      (is (re-find #"- components/bar/src" prompt))
+      (is (re-find #":review/out-of-scope-observations" prompt)
+          "must instruct the LLM where to put out-of-scope findings")))
+
+  (testing "Scope section is omitted when no scope signal is present"
+    (let [prompt (reviewer/build-review-prompt
+                   {:task/title "Test"
+                    :task/intent "free-form prose"
+                    :task/artifact {:code/files []}})]
+      (is (not (re-find #"## Scope" prompt))
+          "no Scope section when scope is nil"))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -161,6 +161,12 @@
                       :task/constraints (:constraints input)
                       :task/artifact artifact
                       :task/tests (build-verify-review-input verify-phase-result)}
+               ;; DAG sub-workflows carry per-task scope at `:files-in-scope`
+               ;; (set by `dag-orchestrator/task-sub-input`); pass it through so
+               ;; `agent.reviewer/effective-review-scope` can prefer it over the
+               ;; broader spec-level `:scope` nested in intent.
+               (seq (:files-in-scope input))
+               (assoc :task/files-in-scope (vec (:files-in-scope input)))
                formatted
                (assoc :task/knowledge-context formatted)
                behavior-addendum

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -163,8 +163,10 @@
                       :task/tests (build-verify-review-input verify-phase-result)}
                ;; DAG sub-workflows carry per-task scope at `:files-in-scope`
                ;; (set by `dag-orchestrator/task-sub-input`); pass it through so
-               ;; `agent.reviewer/effective-review-scope` can prefer it over the
-               ;; broader spec-level `:scope` nested in intent.
+               ;; the reviewer agent's `effective-review-scope`
+               ;; (in `ai.miniforge.agent.reviewer`, not the `agent` interface
+               ;; alias above) can prefer it over the broader spec-level
+               ;; `:scope` nested in intent.
                (seq (:files-in-scope input))
                (assoc :task/files-in-scope (vec (:files-in-scope input)))
                formatted


### PR DESCRIPTION
## Summary

The 2026-06-04 `eliminate-requiring-resolve` dogfood failed 20/20 sub-tasks because the reviewer LLM held every diff to the FULL standards bar across all changed files. Each task touched 1–2 files for a narrow refactor, but the reviewer flagged adjacent-file violations (localization gaps in error strings the task didn't introduce, magic numbers in unrelated config maps, anon-fn-in-config, etc). Implementer "fixed" the adjacent code, introduced new adjacent issues, looped 3 cycles, hit the verdict cap, sub-workflow died as `:needs-decomposition`. The FSM RFC worked exactly as designed; the gap was upstream — the LLM had `:scope` in its prompt (as part of `(pr-str intent)`) but no instruction to treat it as a review boundary.

This is the **prompt-side half of a two-layer fix**. A structural post-LLM path filter lands in a follow-up so a prompt drift can't quietly reintroduce scope creep (the FSM RFC pattern: don't trust the LLM to honor instructions; enforce structurally).

### Changes

1. **`agent.reviewer/effective-review-scope`** — strict-priority helper that resolves a per-task scope from `:task/scope` → `:task/files-in-scope` → `(:scope task/intent)`. Returns nil when no signal present (backwards-compatible: legacy specs continue to review every file). Strict priority — merging would dilute per-task narrowness with the broader spec scope, defeating the purpose.

2. **`build-review-prompt`** renders a dedicated `## Scope` section with the resolved paths and explicit instructions on where in-scope vs out-of-scope findings belong.

3. **`reviewer.edn` system prompt v1.2.0 → v1.3.0:**
   - Output-format example shows `:review/out-of-scope-observations [...]`
   - New `Scope Boundary (CRITICAL)` section: in-scope findings drive the verdict via `:review/issues`; out-of-scope findings (including Standards Enforcement violations in adjacent files) are advisory and go in `:review/out-of-scope-observations`.

4. **Schema + pipeline plumbing** — `ReviewArtifact` allows `:review/out-of-scope-observations` as optional; the LLM-response processing path captures it from initial + enumeration-retry reviews and threads it through `build-review-artifact`.

5. **`phase-software-factory/review/build-review-task`** propagates `:files-in-scope` (the DAG sub-task scope from `dag-orchestrator/task-sub-input`) into the reviewer task as `:task/files-in-scope` so per-task narrowness reaches the prompt.

## Test plan

- [x] `bb pre-commit` — 323 tests / 1185 assertions / 0 failures, GraalVM compat green
- [x] New scope-boundary tests in `reviewer_test`:
  - `effective-review-scope-priority-test` — strict priority + dedup + nil-on-no-signal
  - `build-review-prompt-renders-scope-section-test` — Scope section present with scope, absent without it
- [x] Full reviewer test suite — 49 tests / 183 assertions / 0 failures, 0 errors
- [ ] Validated on a live dogfood run (deferred to after PR-B lands)

## Follow-up

PR-B: structural post-LLM path filter — drop any `:review/issues` entry whose `:file` doesn't match an in-scope prefix, so a prompt drift can't reintroduce scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)