### PR TITLE
fix(llm): harden Codex dogfood diagnostics

### DIFF
--- a/components/llm/deps.edn
+++ b/components/llm/deps.edn
@@ -3,6 +3,7 @@
         http-kit/http-kit {:mvn/version "2.8.0"}
         cheshire/cheshire {:mvn/version "5.13.0"}
         ai.miniforge/anomaly {:local/root "../anomaly"}
-        ai.miniforge/logging {:local/root "../logging"}}
+        ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/messages {:local/root "../messages"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/llm/resources/config/llm/messages/en-US.edn
+++ b/components/llm/resources/config/llm/messages/en-US.edn
@@ -1,0 +1,42 @@
+{:llm/messages
+ {;; System-locale diagnostics. These are operator/developer-facing and
+  ;; should remain stable for tests, logs, and anomaly inspection.
+  :streaming-error.system/no-output
+  "Process failed with no output"
+
+  ;; System-locale test fixtures for rate-limit classifier regressions.
+  :rate-limit-test.system/claude-limit-la
+  "You've hit your limit - resets 7pm (America/Los_Angeles)"
+
+  :rate-limit-test.system/claude-limit-utc
+  "You've hit your limit - resets 3am (UTC)"
+
+  :rate-limit-test.system/generic-exceeded
+  "rate limit exceeded"
+
+  :rate-limit-test.system/generic-limited
+  "backend rate limited"
+
+  :rate-limit-test.system/http-429
+  "HTTP 429 too many requests"
+
+  :rate-limit-test.system/clojure-content
+  "(ns example.core)\n(defn hello [] \"world\")"
+
+  :rate-limit-test.system/normal-implementation
+  "Here is the implementation..."
+
+  :rate-limit-test.system/waf-claim
+  "WAF-based rate limiting on mobile auth endpoints remained in progress."
+
+  :rate-limit-test.system/waf-snippet
+  "WAF-based rate limiting on mobile auth endpoints remains in progress"
+
+  :rate-limit-test.system/security-tag
+  "security"
+
+  :rate-limit-test.system/in-progress-tag
+  "in-progress"
+
+  :rate-limit-test.system/risk-tag
+  "risk"}}

--- a/components/llm/src/ai/miniforge/llm/messages.clj
+++ b/components/llm/src/ai/miniforge/llm/messages.clj
@@ -1,0 +1,25 @@
+;; Title: Miniforge.ai
+;; Subtitle: LLM message catalog
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.llm.messages
+  "Message catalog for the LLM component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up an LLM message by key, with optional param substitution."
+  (messages/create-translator "config/llm/messages/en-US.edn" :llm/messages))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -538,7 +538,7 @@
 (defn- codex-args
   "Build CLI arguments for the Codex backend."
   [{:keys [prompt model system prompt-via]
-    :or {prompt-via :argv}}]
+    :or {prompt-via :stdin}}]
   (let [stdin? (= prompt-via :stdin)]
     (cond-> ["exec"
              "--json"

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -542,6 +542,7 @@
   (let [stdin? (= prompt-via :stdin)]
     (cond-> ["exec"
              "--json"
+             "--ignore-user-config"
              "--sandbox=workspace-write"
              "--skip-git-repo-check"]
       true   (into ["-c" "approval_policy=never"])
@@ -781,7 +782,8 @@
    Claude CLI returns exit 0 but emits a rate limit message as content."
   [content]
   (and (string? content)
-       (re-find #"(?i)you've hit your limit|rate limit|resets \d+[ap]m" content)))
+       (re-find #"(?i)you've hit your limit|too many requests|\b429\b|rate limit(?:ed| exceeded)?\b|resets \d+[ap]m"
+                content)))
 
 (defn success-response
   ([output exit-code]
@@ -1428,9 +1430,10 @@
    - :tool-call-count      — total number of tool invocations during the run
    - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)"
   [content exit-code err-result raw-stdout timeout-info stop-reason num-turns tool-call-count final-message-preview]
-  (let [error-message (or err-result
-                          (when (str/blank? content) "Process failed with no output")
-                          "Process failed")
+  (let [error-message (or (not-empty (str/trim (or err-result "")))
+                          (when-not (str/blank? content) content)
+                          (not-empty (str/trim (or raw-stdout "")))
+                          "Process failed with no output")
         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
         error-type (if timeout-info "adaptive_timeout" "cli_error")]
     (cond-> (llm-error category error-type (str/trim error-message)

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.cost :as cost]
+   [ai.miniforge.llm.messages :as msg]
    [ai.miniforge.llm.progress-monitor :as pm]
    [ai.miniforge.response.interface :as response]
    [slingshot.slingshot :refer [throw+ try+]])
@@ -1433,7 +1434,7 @@
   (let [error-message (or (not-empty (str/trim (or err-result "")))
                           (when-not (str/blank? content) content)
                           (not-empty (str/trim (or raw-stdout "")))
-                          "Process failed with no output")
+                          (msg/t :streaming-error.system/no-output))
         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
         error-type (if timeout-info "adaptive_timeout" "cli_error")]
     (cond-> (llm-error category error-type (str/trim error-message)

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -163,6 +163,7 @@
       (is (some #(= "--json" %) args))
       ;; Explicit sandbox + approval-policy config replaces the deprecated
       ;; --full-auto alias.
+      (is (some #(= "--ignore-user-config" %) args))
       (is (some #(= "--sandbox=workspace-write" %) args))
       (is (some #(re-matches #"approval_policy=\"?never\"?" %) args))
       (is (some #(= "--skip-git-repo-check" %) args))

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -158,7 +158,8 @@
 
 (deftest codex-args-minimal-test
   (testing "minimal prompt produces exec with explicit sandbox + approval flags"
-    (let [args ((private-fn 'codex-args) {:prompt "fix bug"})]
+    (let [args ((private-fn 'codex-args) {:prompt "fix bug"
+                                          :prompt-via :argv})]
       (is (= "exec" (first args)))
       (is (some #(= "--json" %) args))
       ;; Explicit sandbox + approval-policy config replaces the deprecated
@@ -168,6 +169,12 @@
       (is (some #(re-matches #"approval_policy=\"?never\"?" %) args))
       (is (some #(= "--skip-git-repo-check" %) args))
       (is (= "fix bug" (last args))))))
+
+(deftest codex-args-defaults-to-stdin-test
+  (testing "default prompt delivery follows the backend stdin shape"
+    (let [args ((private-fn 'codex-args) {:prompt "fix bug"})]
+      (is (not (some #{"fix bug"} args)))
+      (is (= "-" (last args))))))
 
 (deftest codex-args-stdin-test
   (testing "stdin prompt delivery keeps prompt content out of argv"

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -559,11 +559,19 @@
     (is (impl/rate-limited? "You've hit your limit · resets 3am (UTC)")))
 
   (testing "detects generic rate limit phrasing"
-    (is (impl/rate-limited? "rate limit exceeded")))
+    (is (impl/rate-limited? "rate limit exceeded"))
+    (is (impl/rate-limited? "backend rate limited"))
+    (is (impl/rate-limited? "HTTP 429 too many requests")))
 
   (testing "does not flag normal content"
     (is (not (impl/rate-limited? "(ns example.core)\n(defn hello [] \"world\")")))
     (is (not (impl/rate-limited? "Here is the implementation...")))
+    (is (not (impl/rate-limited?
+              (json/generate-string
+               {:claims [{:claim "WAF-based rate limiting on mobile auth endpoints remained in progress."
+                          :snippet "WAF-based rate limiting on mobile auth endpoints remains in progress"
+                          :confidence 1.0
+                          :tags ["security" "in-progress" "risk"]}]}))))
     (is (not (impl/rate-limited? nil)))))
 
 (deftest rate-limited-success-response-test
@@ -671,7 +679,14 @@
                                               {:type :stagnation :message "stalled" :elapsed-ms 1000}
                                               nil nil nil nil)]
       (is (not (:success resp)))
-      (is (= "{\"type\":\"system\"}" (get-in resp [:error :raw-stdout]))))))
+      (is (= "{\"type\":\"system\"}" (get-in resp [:error :raw-stdout])))))
+
+  (testing "raw stdout becomes the message when stderr and parsed content are blank"
+    (let [raw "{\"type\":\"error\",\"message\":\"model unavailable\"}"
+          resp (impl/streaming-error-response "" 1 "" raw nil nil nil nil nil)]
+      (is (not (:success resp)))
+      (is (= raw (get-in resp [:error :message])))
+      (is (= raw (get-in resp [:error :raw-stdout]))))))
 
 (deftest process-stream-lines-eof-is-not-timeout-test
   (testing "clean EOF with no lines does not synthesize a stream-idle timeout"

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -20,6 +20,7 @@
   (:require [clojure.test :as test :refer [deftest testing is]]
             [clojure.string :as str]
             [ai.miniforge.llm.interface :as llm]
+            [ai.miniforge.llm.messages :as msg]
             [ai.miniforge.llm.protocols.records.llm-client]
             [ai.miniforge.llm.protocols.impl.llm-client :as impl]
             [ai.miniforge.llm.progress-monitor :as pm]
@@ -555,23 +556,25 @@
 
 (deftest rate-limited?-test
   (testing "detects Claude CLI rate limit message"
-    (is (impl/rate-limited? "You've hit your limit · resets 7pm (America/Los_Angeles)"))
-    (is (impl/rate-limited? "You've hit your limit · resets 3am (UTC)")))
+    (is (impl/rate-limited? (msg/t :rate-limit-test.system/claude-limit-la)))
+    (is (impl/rate-limited? (msg/t :rate-limit-test.system/claude-limit-utc))))
 
   (testing "detects generic rate limit phrasing"
-    (is (impl/rate-limited? "rate limit exceeded"))
-    (is (impl/rate-limited? "backend rate limited"))
-    (is (impl/rate-limited? "HTTP 429 too many requests")))
+    (is (impl/rate-limited? (msg/t :rate-limit-test.system/generic-exceeded)))
+    (is (impl/rate-limited? (msg/t :rate-limit-test.system/generic-limited)))
+    (is (impl/rate-limited? (msg/t :rate-limit-test.system/http-429))))
 
   (testing "does not flag normal content"
-    (is (not (impl/rate-limited? "(ns example.core)\n(defn hello [] \"world\")")))
-    (is (not (impl/rate-limited? "Here is the implementation...")))
+    (is (not (impl/rate-limited? (msg/t :rate-limit-test.system/clojure-content))))
+    (is (not (impl/rate-limited? (msg/t :rate-limit-test.system/normal-implementation))))
     (is (not (impl/rate-limited?
               (json/generate-string
-               {:claims [{:claim "WAF-based rate limiting on mobile auth endpoints remained in progress."
-                          :snippet "WAF-based rate limiting on mobile auth endpoints remains in progress"
+               {:claims [{:claim (msg/t :rate-limit-test.system/waf-claim)
+                          :snippet (msg/t :rate-limit-test.system/waf-snippet)
                           :confidence 1.0
-                          :tags ["security" "in-progress" "risk"]}]}))))
+                          :tags [(msg/t :rate-limit-test.system/security-tag)
+                                 (msg/t :rate-limit-test.system/in-progress-tag)
+                                 (msg/t :rate-limit-test.system/risk-tag)]}]}))))
     (is (not (impl/rate-limited? nil)))))
 
 (deftest rate-limited-success-response-test

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -919,7 +919,7 @@
         "claude must default to stdin to avoid POSIX ARG_MAX overflow")))
 
 (deftest cli-backends-declare-safe-prompt-delivery-test
-  (testing "codex and claude use stdin; other CLI backends remain argv"
+  (testing "codex uses stdin; other non-Claude CLI backends remain argv"
     (is (= :stdin (:prompt-via (get impl/backends :codex))))
     (is (= :argv (:prompt-via (get impl/backends :cursor))))
     (is (= :argv (:prompt-via (get impl/backends :opencode))))


### PR DESCRIPTION
## Summary
- includes the existing Codex stdin prompt commit currently referenced by thesium-workflows
- isolate Codex CLI calls from user MCP config with --ignore-user-config
- tighten rate-limit detection so evidence text like rate limiting does not trip false positives
- surface raw stdout as the failure message when stderr and parsed content are blank

## Verification
- clojure -M:dev:test -e "(require 'ai.miniforge.llm.interface-test 'ai.miniforge.llm.args-fn-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.llm.interface-test 'ai.miniforge.llm.args-fn-test)"