### PR TITLE
refactor(web-dashboard): filters/ui.js createFilterChip via DOM + addEventListener (JS-004, JS-008)

### DIFF
--- a/components/web-dashboard/resources/public/js/filters/ui.js
+++ b/components/web-dashboard/resources/public/js/filters/ui.js
@@ -95,19 +95,49 @@
     label.className = 'filter-label';
     label.textContent = formatFilterLabel(clause);
 
+    const filterId = clause['filter/id'];
+    const filterValue = clause.value;
+
     const menu = document.createElement('div');
     menu.className = 'filter-chip-menu';
 
-    const encodedValue = runtime.escapeJSString(clause.value);
-    menu.innerHTML = `
-      <button class="filter-chip-menu-btn" onclick="event.stopPropagation(); this.nextElementSibling.classList.toggle('show')">⋮</button>
-      <div class="filter-chip-menu-items">
-        ${scope === 'local' ? '<button onclick="window.miniforge.filters.promoteToGlobal(\'' + clause['filter/id'] + '\')">📌 Pin to Global</button>' : ''}
-        ${scope === 'global' ? '<button onclick="window.miniforge.filters.demoteToLocal(\'' + clause['filter/id'] + '\')">📍 Make Pane-Local</button>' : ''}
-        <button onclick="window.miniforge.filters.showCopyMenu(\'' + clause['filter/id'] + '\')">📋 Copy to Pane</button>
-        <button onclick="window.miniforge.filters.removeFilter(\'' + clause['filter/id'] + '\', '\'' + scope + '\', '\'' + encodedValue + '\')">🗑️ Remove</button>
-      </div>
-    `;
+    const items = document.createElement('div');
+    items.className = 'filter-chip-menu-items';
+
+    const toggleBtn = document.createElement('button');
+    toggleBtn.className = 'filter-chip-menu-btn';
+    toggleBtn.textContent = '⋮';
+    toggleBtn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      items.classList.toggle('show');
+    });
+
+    if (scope === 'local') {
+      const pinBtn = document.createElement('button');
+      pinBtn.textContent = '📌 Pin to Global';
+      pinBtn.addEventListener('click', () => window.miniforge.filters.promoteToGlobal(filterId));
+      items.appendChild(pinBtn);
+    }
+
+    if (scope === 'global') {
+      const makeLocalBtn = document.createElement('button');
+      makeLocalBtn.textContent = '📍 Make Pane-Local';
+      makeLocalBtn.addEventListener('click', () => window.miniforge.filters.demoteToLocal(filterId));
+      items.appendChild(makeLocalBtn);
+    }
+
+    const copyBtn = document.createElement('button');
+    copyBtn.textContent = '📋 Copy to Pane';
+    copyBtn.addEventListener('click', () => window.miniforge.filters.showCopyMenu(filterId));
+    items.appendChild(copyBtn);
+
+    const removeMenuBtn = document.createElement('button');
+    removeMenuBtn.textContent = '🗑️ Remove';
+    removeMenuBtn.addEventListener('click', () => window.miniforge.filters.removeFilter(filterId, scope, filterValue));
+    items.appendChild(removeMenuBtn);
+
+    menu.appendChild(toggleBtn);
+    menu.appendChild(items);
 
     const removeBtn = document.createElement('button');
     removeBtn.className = 'filter-remove';


### PR DESCRIPTION
## Summary

Sibling fix to [#1023](https://github.com/miniforge-ai/miniforge/pull/1023) follow-up branch `chris/web-dashboard-filter-chip-dom`, which fixed the same class of structural standards violation in `addFilterChip` (app.js). That PR's commit body explicitly carved this out as the next surface:

> components/web-dashboard/resources/public/js/filters/ui.js:102 has the same class of violation in createFilterChip (multi-line innerHTML + 4 inline onclick handlers). Larger surface, separate PR.

`createFilterChip` built its dropdown menu via `menu.innerHTML = \`...\`` with the ⋮ toggle and up to four conditional buttons (Pin to Global / Make Pane-Local / Copy to Pane / Remove) bound through `onclick="window.miniforge.filters.X('...')"` strings interpolating `clause['filter/id']`, `scope`, and a JS-string-escaped `clause.value`.

This PR replaces that block with `createElement` + `textContent` + `addEventListener`, mirroring the pattern landed in `addFilterChip` ([app.js:107-124](https://github.com/miniforge-ai/miniforge/blob/chris/web-dashboard-filter-chip-dom/components/web-dashboard/resources/public/js/app.js#L107-L124)).

## Standards

- **JS-004 (no inline event handlers)** — all five buttons now bind via `addEventListener`. Closures over `filterId` / `filterValue` / `items` preserve the ⋮ toggle's `nextElementSibling.classList.toggle('show')` semantics without leaking `this` into HTML.
- **JS-008 (no untrusted-HTML injection)** — menu body is built from DOM nodes. `textContent` is XSS-safe by construction; the JS-string-escape of `clause.value` is no longer needed because the value flows through `addEventListener` callback args, never through a JS-string-in-HTML context.

The conditional Pin / Make-local buttons are appended through `if` checks, not template-string toggles.

## Out of scope

`runtime.escapeJSString` (components/web-dashboard/resources/public/js/filters/runtime.js:82) has **no remaining callers** after this PR — `createFilterChip` was its only consumer. Left in place; deletion belongs in a separate cleanup PR.

`removeBtn.onclick = …` (the trailing × outside the menu) is a DOM-property assignment, not inline HTML, so it doesn't violate JS-004 and is untouched.

## Test plan

- [x] `node -c components/web-dashboard/resources/public/js/filters/ui.js`
- [x] Pre-commit hooks (Polylith, 327-test smoke, GraalVM/bb compat) green
- [ ] Manual smoke: open a global filter chip, ⋮ toggles the menu, Make Pane-Local + Copy to Pane + Remove each invoke their API
- [ ] Manual smoke: open a local filter chip, ⋮ toggles the menu, Pin to Global + Copy to Pane + Remove each invoke their API

🤖 Generated with [Claude Code](https://claude.com/claude-code)