### PR TITLE
refactor(agent): extract reviewer.llm-response ns (PR-F of decomp stack)

### DIFF
--- a/components/agent/resources/config/agent/messages/en-US.edn
+++ b/components/agent/resources/config/agent/messages/en-US.edn
@@ -41,4 +41,21 @@
   ;; Reviewer gates — gate-execution exception. {cause} is the underlying
   ;; exception message; used as the :message on a fail-closed feedback entry.
   :reviewer.gates/exception
-  "Gate execution failed: {cause}"}}
+  "Gate execution failed: {cause}"
+
+  ;; Reviewer LLM-response — the LLM returned content but it could not be
+  ;; parsed into the canonical ReviewArtifact shape. Surfaces as a blocking
+  ;; issue on the resulting review.
+  :reviewer.llm-response/unparseable
+  "Reviewer LLM output could not be parsed into a review artifact"
+
+  ;; Reviewer LLM-response — the LLM invocation itself failed before any
+  ;; content reached the parser (network error, missing API key, etc.).
+  :reviewer.llm-response/invocation-failed-pre-parse
+  "Reviewer LLM invocation failed before producing a review artifact"
+
+  ;; Reviewer LLM-response — the LLM produced parseable content but the
+  ;; underlying invocation still flagged failure (used as a fallback when
+  ;; no other error message and no inline :review/blocking-issues exist).
+  :reviewer.llm-response/invocation-failed-post-parse
+  "Reviewer LLM invocation failed after producing a review artifact"}}

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.reviewer.gates :as gates]
    [ai.miniforge.agent.reviewer.issues :as issues]
+   [ai.miniforge.agent.reviewer.llm-response :as llm-response]
    [ai.miniforge.agent.reviewer.prompts :as reviewer-prompts]
    [ai.miniforge.agent.reviewer.scope :as scope]
    [ai.miniforge.agent.role-config :as role-config]
@@ -33,8 +34,6 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.loop.interface :as loop]
-   [clojure.string :as str]
-   [clojure.edn :as edn]
    [malli.core :as m]))
 
 ;; Schemas (GateFeedback, ReviewIssue, ReviewArtifact) moved to
@@ -60,76 +59,11 @@
 ;; Issue-shape validation / sanitization / decision normalization / issue-text
 ;; extraction moved to ai.miniforge.agent.reviewer.issues (PR-C decomposition).
 
-(defn parse-review-response
-  "Parse the LLM response to extract review feedback.
-   Handles EDN in code blocks and plain EDN."
-  [response-content]
-  (try
-    (let [parsed (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
-                   (edn/read-string (second match))
-                   (edn/read-string response-content))]
-      (when (and (map? parsed)
-                 (issues/valid-review-issues? parsed))
-        parsed))
-    (catch Exception _
-      nil)))
-
-(def ^:private unparseable-review-message
-  "Blocking issue used when the reviewer LLM returns content that cannot be parsed
-   into the canonical review artifact shape."
-  "Reviewer LLM output could not be parsed into a review artifact")
-
-(defn- review-failure-message
-  "Derive the blocking issue recorded when the reviewer LLM response cannot
-   be converted into a canonical review artifact."
-  [response content]
-  (let [content-present? (not (str/blank? (or content "")))
-        llm-error (llm/get-error response)]
-    (cond
-      content-present? unparseable-review-message
-      (string? (:message llm-error)) (:message llm-error)
-      :else "Reviewer LLM invocation failed before producing a review artifact")))
-
-(defn- backend-failure-message
-  "Derive the backend failure message when the reviewer LLM response parsed,
-   but the underlying invocation still failed."
-  [response llm-review]
-  (if-let [message (:message (llm/get-error response))]
-    message
-    (or (first (:review/blocking-issues llm-review))
-        "Reviewer LLM invocation failed after producing a review artifact")))
-
-(defn- backend-timeout-issue?
-  [message]
-  (boolean
-   (and (string? message)
-        (re-find #"(?i)(adaptive timeout|stagnation timeout|timed out|stream-idle|timeout)"
-                 message))))
-
-(defn- timeout-only-review?
-  "True when a parsed review artifact is just reflecting the reviewer backend's
-   own timeout rather than providing actionable code-review findings."
-  [llm-review gate-result]
-  (let [blocking-issues (vec (:review/blocking-issues llm-review))
-        recommendations (vec (:review/recommendations llm-review))
-        issues (vec (:review/issues llm-review))
-        negative-decision? (contains? #{:rejected :changes-requested}
-                                      (:review/decision llm-review))]
-    (and negative-decision?
-         (= :approved (:decision gate-result))
-         (seq blocking-issues)
-         (empty? recommendations)
-         (empty? issues)
-         (every? backend-timeout-issue? blocking-issues))))
-
-(defn llm-issues->recommendations
-  "Extract suggestions from LLM issues as recommendations."
-  [issues]
-  (->> issues
-       (filter :suggestion)
-       (mapv (fn [{:keys [file description suggestion]}]
-               (str (when file (str "[" file "] "))
-                    description " -> " suggestion)))))
+;; LLM-response parsing, failure-message resolution, backend-timeout
+;; detection, and enumeration-retry validator/recovery moved to
+;; ai.miniforge.agent.reviewer.llm-response (PR-F decomposition).
+;; llm-issues->recommendations moved to reviewer.issues (PR-F) — same
+;; shape as its blocking/warning siblings already there.
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Review validation and repair
@@ -306,67 +240,9 @@
 ;------------------------------------------------------------------------------ Layer 5
 ;; Agent creation
 
-;;----------------------------------------------------------------------------- Enumeration-retry validator
-;; A rejection without enumerated :blocking findings is malformed (the
-;; implementer cannot act on it). Mirrors the planner/implementer
-;; submission-recovery pattern but for the reviewer's *output shape* — re-runs
-;; the reviewer once with an enumeration-retry prompt that demands the inline
-;; list. The reviewer doesn't use artifact-session/worktree-promotion, so the
-;; retry is a direct LLM call (not the session-wrapped run-recovery-session).
-
-;; Decision enums + `review-has-blocking?` moved to
-;; ai.miniforge.agent.reviewer.issues (PR-C decomposition).
-
-(defn- enumeration-retry?
-  "True when the LLM's review decision is a rejection but it enumerated NO
-   :blocking findings AND the deterministic gates have no blocking issues
-   either — a malformed rejection the implementer cannot act on. The validator
-   rejects this review and demands a re-enumeration."
-  [llm-decision llm-issues gate-blocking]
-  (and (contains? issues/rejection-decisions llm-decision)
-       (not (issues/review-has-blocking? llm-issues))
-       (empty? gate-blocking)))
-
-;; enumeration-retry-prompt moved to reviewer.prompts (PR-E).
-
-(defn- well-formed-recovery?
-  "True when a re-reviewed ReviewArtifact resolves the malformed-rejection
-   case: either it now enumerates :blocking findings, OR it correctly
-   concludes :approved / :conditionally-approved (the retry template
-   explicitly allows that — discarding it would leave the original malformed
-   rejection in place and re-introduce the churn the validator exists to
-   eliminate)."
-  [re-review]
-  ;; The raw `:review/decision` is read directly (not re-normalized) to keep
-  ;; this insulated from future `normalize-llm-decision` changes — but we
-  ;; MUST validate it is one of the ReviewArtifact enums first
-  ;; (`parse-review-response` doesn't check), otherwise a typo or nil decision
-  ;; would slip past as "non-rejection" and get collapsed downstream to
-  ;; :changes-requested — defeating the whole validator.
-  (let [dec (:review/decision re-review)]
-    (and (contains? issues/valid-decisions dec)
-         (or (not (contains? issues/rejection-decisions dec))
-             (issues/review-has-blocking? (get re-review :review/issues []))))))
-
-(defn- recover-review-enumeration
-  "Run ONE bounded enumeration-retry turn and return the re-parsed
-   ReviewArtifact when the recovery is well-formed (enumerates blockers OR
-   corrects to a non-rejection decision), or nil when recovery ALSO produced
-   a malformed rejection — in which case the original raw rejection stands
-   as-is."
-  [llm-client base-opts on-chunk user-prompt prior-content]
-  (let [retry-prompt (reviewer-prompts/enumeration-retry-prompt user-prompt prior-content)
-        retry-opts   (assoc base-opts :max-turns
-                            (get @reviewer-prompts/reviewer-prompt-data
-                                 :prompt/enumeration-retry-max-turns 6))
-        response     (if on-chunk
-                       (llm/chat-stream llm-client retry-prompt on-chunk retry-opts)
-                       (llm/chat llm-client retry-prompt retry-opts))
-        normalized   (result-boundary/normalize-llm-result
-                      {:response response :parse-response parse-review-response})
-        re-review    (:parsed-content normalized)]
-    (when (and re-review (well-formed-recovery? re-review))
-      re-review)))
+;; Enumeration-retry validator + well-formed-recovery? +
+;; recover-review-enumeration moved to ai.miniforge.agent.reviewer.llm-response
+;; (PR-F decomposition).
 
 (defn create-reviewer
   "Create a Reviewer agent with optional configuration overrides.
@@ -448,7 +324,7 @@
                              (llm/chat llm-client user-prompt base-opts))
                   normalized (result-boundary/normalize-llm-result
                               {:response response
-                               :parse-response parse-review-response})
+                               :parse-response llm-response/parse-review-response})
                   content (:content normalized)
                   tokens (:tokens normalized)
                   cost-usd (:cost-usd normalized)]
@@ -460,14 +336,14 @@
 
               (let [;; Parse LLM review
                     llm-review (:parsed-content normalized)
-                    parse-failure-message (review-failure-message response content)
+                    parse-failure-message (llm-response/review-failure-message response content)
                     parse-failed? (nil? llm-review)
                     ;; Run deterministic gates
                     gate-feedbacks (gates/run-gates-on-artifact gates artifact context logger)
                     gate-result (gates/make-review-decision gate-feedbacks config)
                     counts (gates/calculate-gate-counts gate-feedbacks)
-                    timeout-failure-message (backend-failure-message response llm-review)
-                    timeout-only-review? (timeout-only-review? llm-review gate-result)
+                    timeout-failure-message (llm-response/backend-failure-message response llm-review)
+                    timeout-only-review? (llm-response/timeout-only-review? llm-review gate-result)
                     ;; "initial" = the first-call decision/issues fed into the
                     ;; enumeration validator. Named to contrast with
                     ;; `recovered-review` below; these are already normalized,
@@ -510,7 +386,7 @@
                     ;; enumeration-retry prompt; use the recovered review iff
                     ;; it now lists blockers OR corrects to a non-rejection.
                     ;; Otherwise the initial rejection stands as-is.
-                    recovered-review (when (enumeration-retry?
+                    recovered-review (when (llm-response/enumeration-retry?
                                             initial-llm-decision initial-llm-issues
                                             (:blocking-issues gate-result))
                                        (log/info logger :reviewer
@@ -518,7 +394,7 @@
                                                  {:data {:initial-decision    initial-llm-decision
                                                          :initial-issue-count (count initial-llm-issues)
                                                          :gate-blocking-count (count (:blocking-issues gate-result))}})
-                                       (recover-review-enumeration
+                                       (llm-response/recover-review-enumeration
                                         llm-client base-opts on-chunk
                                         user-prompt content))
                     ;; When recovery succeeds, the first call's parse failure
@@ -577,7 +453,7 @@
                                        (issues/llm-issues->warning-strings llm-issues))
 
                     ;; Merge recommendations
-                    llm-recs (llm-issues->recommendations llm-issues)
+                    llm-recs (issues/llm-issues->recommendations llm-issues)
 
                     ;; Build summary
                     summary (or llm-summary

--- a/components/agent/src/ai/miniforge/agent/reviewer/issues.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/issues.clj
@@ -196,3 +196,19 @@
   (->> issues
        (filter #(= :warning (:severity %)))
        (mapv :description)))
+
+(defn llm-issues->recommendations
+  "Render LLM issues that carry a `:suggestion` into single-line
+   recommendation strings.
+
+   Format: `[file] description -> suggestion` (file segment omitted when
+   `:file` is absent). Issues with no `:suggestion` are dropped — they're
+   already captured as blocking/warning strings via the siblings above,
+   and a recommendation without a remediation is just noise on the
+   final artifact."
+  [issues]
+  (->> issues
+       (filter :suggestion)
+       (mapv (fn [{:keys [file description suggestion]}]
+               (str (when file (str "[" file "] "))
+                    description " -> " suggestion)))))

--- a/components/agent/src/ai/miniforge/agent/reviewer/llm_response.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/llm_response.clj
@@ -1,0 +1,205 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.reviewer.llm-response
+  "Reviewer LLM response processing.
+
+   Extracted from `ai.miniforge.agent.reviewer` as PR-F of the
+   decomposition stack (#1039 scope → #1041 issues → #1042 gates →
+   #1044 prompts → this).
+
+   Holds everything that happens to the LLM's raw response between the
+   `llm/chat` call and the assembled `ReviewArtifact`:
+   - `parse-review-response` — EDN extraction from code-block or plain text
+   - Failure-message resolution for the assorted failure paths
+     (`review-failure-message`, `backend-failure-message`)
+   - Backend-timeout detection (`backend-timeout-issue?`,
+     `timeout-only-review?`) — distinguishes a real `:rejected` verdict
+     from the reviewer LLM hitting its own progress-monitor timeout
+   - Enumeration-retry validator + recovery (`enumeration-retry?`,
+     `well-formed-recovery?`, `recover-review-enumeration`) — re-runs
+     the LLM once when a rejection lands without inline blockers"
+  (:require [ai.miniforge.agent.messages :as msg]
+            [ai.miniforge.agent.result-boundary :as result-boundary]
+            [ai.miniforge.agent.reviewer.issues :as issues]
+            [ai.miniforge.agent.reviewer.prompts :as reviewer-prompts]
+            [ai.miniforge.llm.interface :as llm]
+            [clojure.edn :as edn]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Parsing
+
+(defn parse-review-response
+  "Parse the LLM response to extract review feedback.
+   Handles EDN in code blocks and plain EDN."
+  [response-content]
+  (try
+    (let [parsed (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
+                   (edn/read-string (second match))
+                   (edn/read-string response-content))]
+      (when (and (map? parsed)
+                 (issues/valid-review-issues? parsed))
+        parsed))
+    (catch Exception _
+      nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Failure messages
+
+(defn review-failure-message
+  "Derive the blocking-issue text recorded when the reviewer LLM response
+   cannot be converted into a canonical review artifact.
+
+   Three cases, in priority order:
+   1. The LLM returned content but parsing failed → the canonical
+      `:reviewer.llm-response/unparseable` message.
+   2. No content but the LLM client surfaced an error message → that
+      error's `:message` verbatim (already operator-facing).
+   3. Neither → the generic pre-parse invocation-failed message."
+  [response content]
+  (let [content-present? (not (str/blank? (or content "")))
+        llm-error (llm/get-error response)]
+    (cond
+      content-present?
+      (msg/t :reviewer.llm-response/unparseable)
+
+      (string? (:message llm-error))
+      (:message llm-error)
+
+      :else
+      (msg/t :reviewer.llm-response/invocation-failed-pre-parse))))
+
+(defn backend-failure-message
+  "Derive the backend failure message when the reviewer LLM response parsed
+   but the underlying invocation still flagged failure.
+
+   Prefers the LLM client's error message, then the first inline
+   `:review/blocking-issues` entry (the LLM may have enumerated the
+   failure itself), then a generic post-parse fallback."
+  [response llm-review]
+  (if-let [message (:message (llm/get-error response))]
+    message
+    (or (first (:review/blocking-issues llm-review))
+        (msg/t :reviewer.llm-response/invocation-failed-post-parse))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Backend-timeout detection
+
+(defn backend-timeout-issue?
+  "True when `message` looks like a reviewer-backend timeout / stagnation
+   message rather than a code-review finding. Matched as a regex against
+   the strings the runner / progress-monitor emit."
+  [message]
+  (boolean
+   (and (string? message)
+        (re-find #"(?i)(adaptive timeout|stagnation timeout|timed out|stream-idle|timeout)"
+                 message))))
+
+(defn timeout-only-review?
+  "True when a parsed review artifact is just reflecting the reviewer
+   backend's own timeout rather than providing actionable code-review
+   findings.
+
+   Conditions (all must hold):
+   - LLM decision is a rejection-class verdict
+     (`:rejected` / `:changes-requested`)
+   - Deterministic gates are otherwise approved
+   - `:review/blocking-issues` is present (the LLM enumerated something)
+   - `:review/recommendations` and `:review/issues` are both empty
+   - Every entry in `:review/blocking-issues` is a timeout-shaped string
+     per `backend-timeout-issue?`"
+  [llm-review gate-result]
+  (let [blocking-issues (vec (:review/blocking-issues llm-review))
+        recommendations (vec (:review/recommendations llm-review))
+        issue-vec (vec (:review/issues llm-review))
+        negative-decision? (contains? issues/rejection-decisions
+                                      (:review/decision llm-review))]
+    (and negative-decision?
+         (= :approved (:decision gate-result))
+         (seq blocking-issues)
+         (empty? recommendations)
+         (empty? issue-vec)
+         (every? backend-timeout-issue? blocking-issues))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Enumeration-retry validator + recovery
+;;
+;; A rejection without enumerated :blocking findings is malformed (the
+;; implementer cannot act on it). Mirrors the planner/implementer
+;; submission-recovery pattern but for the reviewer's *output shape* — re-runs
+;; the reviewer once with an enumeration-retry prompt that demands the inline
+;; list. The reviewer doesn't use artifact-session/worktree-promotion, so the
+;; retry is a direct LLM call (not the session-wrapped run-recovery-session).
+
+(defn enumeration-retry?
+  "True when the LLM's review decision is a rejection but it enumerated NO
+   :blocking findings AND the deterministic gates have no blocking issues
+   either — a malformed rejection the implementer cannot act on. The
+   validator rejects this review and demands a re-enumeration."
+  [llm-decision llm-issues gate-blocking]
+  (and (contains? issues/rejection-decisions llm-decision)
+       (not (issues/review-has-blocking? llm-issues))
+       (empty? gate-blocking)))
+
+(defn well-formed-recovery?
+  "True when a re-reviewed ReviewArtifact resolves the malformed-rejection
+   case: either it now enumerates :blocking findings, OR it correctly
+   concludes :approved / :conditionally-approved (the retry template
+   explicitly allows that — discarding it would leave the original
+   malformed rejection in place and re-introduce the churn the validator
+   exists to eliminate).
+
+   The raw `:review/decision` is read directly (not re-normalized) to
+   keep this insulated from future `issues/normalize-llm-decision`
+   changes — but the decision MUST be one of the ReviewArtifact enums
+   first (`parse-review-response` doesn't check), otherwise a typo or
+   nil decision would slip past as 'non-rejection' and get collapsed
+   downstream to `:changes-requested` — defeating the whole validator."
+  [re-review]
+  (let [dec (:review/decision re-review)]
+    (and (contains? issues/valid-decisions dec)
+         (or (not (contains? issues/rejection-decisions dec))
+             (issues/review-has-blocking? (get re-review :review/issues []))))))
+
+(def ^:private default-enumeration-retry-max-turns
+  "Fallback when reviewer.edn omits :prompt/enumeration-retry-max-turns.
+   Authority is the EDN; this constant only protects against malformed
+   prompt resources."
+  6)
+
+(defn recover-review-enumeration
+  "Run ONE bounded enumeration-retry turn and return the re-parsed
+   ReviewArtifact when the recovery is well-formed (enumerates blockers
+   OR corrects to a non-rejection decision), or nil when recovery ALSO
+   produced a malformed rejection — in which case the original raw
+   rejection stands as-is."
+  [llm-client base-opts on-chunk user-prompt prior-content]
+  (let [retry-prompt (reviewer-prompts/enumeration-retry-prompt user-prompt prior-content)
+        retry-opts   (assoc base-opts :max-turns
+                            (get @reviewer-prompts/reviewer-prompt-data
+                                 :prompt/enumeration-retry-max-turns
+                                 default-enumeration-retry-max-turns))
+        response     (if on-chunk
+                       (llm/chat-stream llm-client retry-prompt on-chunk retry-opts)
+                       (llm/chat llm-client retry-prompt retry-opts))
+        normalized   (result-boundary/normalize-llm-result
+                      {:response response :parse-response parse-review-response})
+        re-review    (:parsed-content normalized)]
+    (when (and re-review (well-formed-recovery? re-review))
+      re-review)))

--- a/components/agent/test/ai/miniforge/agent/reviewer/llm_response_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/llm_response_test.clj
@@ -1,0 +1,293 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.reviewer.llm-response-test
+  "Tests for `ai.miniforge.agent.reviewer.llm-response` — extracted from
+   `ai.miniforge.agent.reviewer-test` as part of the PR-F decomposition.
+
+   Covers EDN parsing of reviewer responses, the failure-message ladder,
+   backend-timeout detection, and the enumeration-retry validator +
+   recovery loop."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.agent.messages :as msg]
+   [ai.miniforge.agent.reviewer.llm-response :as llm-response]
+   [ai.miniforge.llm.interface :as llm]))
+
+;------------------------------------------------------------------------------ Fixtures
+
+(def ^:private approved-review-content
+  "```clojure
+{:review/decision :approved
+ :review/summary \"clean\"
+ :review/issues []}
+```")
+
+(def ^:private approved-with-nil-line-content
+  ;; The 2026-05-16 nil-line incident: a file-level concern with
+  ;; explicit :line nil; the pre-fix schema silently rejected it.
+  "```clojure
+{:review/decision :approved
+ :review/summary \"clean except a file-level concern\"
+ :review/issues [{:severity :warning
+                  :file \"src/example.clj\"
+                  :line nil
+                  :description \"missing top-of-file docstring\"
+                  :suggestion \"add a one-line ns docstring\"}
+                 {:severity :nit
+                  :file \"src/example.clj\"
+                  :line 10
+                  :description \"minor\"}]}
+```")
+
+(def ^:private approved-with-nil-optional-fields-content
+  "```clojure
+{:review/decision :approved
+ :review/summary \"file-level concern only\"
+ :review/issues [{:severity :warning
+                  :file nil
+                  :line nil
+                  :description \"some general note\"
+                  :suggestion nil}]}
+```")
+
+(def ^:private malformed-review-issue-content
+  ;; Issue severity is not an allowed enum value — parse must reject.
+  "```clojure
+{:review/decision :rejected
+ :review/summary \"x\"
+ :review/issues [{:severity :critical :description \"bad enum\"}]}
+```")
+
+;------------------------------------------------------------------------------ parse-review-response
+
+(deftest parse-review-response-test
+  (testing "valid EDN inside a ```clojure code block round-trips"
+    (let [parsed (llm-response/parse-review-response approved-review-content)]
+      (is (= :approved (:review/decision parsed)))))
+
+  (testing "valid bare EDN (no fence) also parses"
+    (let [parsed (llm-response/parse-review-response
+                   "{:review/decision :approved :review/summary \"ok\"}")]
+      (is (= :approved (:review/decision parsed)))))
+
+  (testing "valid EDN with malformed issue maps is treated as unparseable"
+    (is (nil? (llm-response/parse-review-response malformed-review-issue-content))))
+
+  (testing "issue with :line nil parses with :review/decision intact (2026-05-16 regression)"
+    (let [parsed (llm-response/parse-review-response approved-with-nil-line-content)]
+      (is (some? parsed) "parser must not return nil for a nil-line issue")
+      (is (= :approved (:review/decision parsed)))
+      (is (= 2 (count (:review/issues parsed))))
+      (is (nil? (:line (first (:review/issues parsed))))
+          ":line nil must round-trip, not get dropped")))
+
+  (testing "issue with :file nil, :line nil, :suggestion nil parses cleanly"
+    (let [parsed (llm-response/parse-review-response approved-with-nil-optional-fields-content)]
+      (is (some? parsed))
+      (is (= :approved (:review/decision parsed)))))
+
+  (testing "garbage in → nil out (parse failure)"
+    (is (nil? (llm-response/parse-review-response "not edn at all")))
+    (is (nil? (llm-response/parse-review-response "")))
+    (is (nil? (llm-response/parse-review-response "```clojure\n{:not :a :review}\n```")))))
+
+;------------------------------------------------------------------------------ Failure messages
+
+(deftest review-failure-message-test
+  (testing "content-present + parse failure → :unparseable catalog text"
+    (is (= (msg/t :reviewer.llm-response/unparseable)
+           (llm-response/review-failure-message {} "some unparseable content"))))
+
+  (testing "no content + LLM-client error → the error's :message verbatim"
+    (with-redefs [llm/get-error (fn [_] {:message "rate limited at upstream"})]
+      (is (= "rate limited at upstream"
+             (llm-response/review-failure-message {} "")))))
+
+  (testing "neither content nor LLM error → generic pre-parse catalog text"
+    (with-redefs [llm/get-error (fn [_] nil)]
+      (is (= (msg/t :reviewer.llm-response/invocation-failed-pre-parse)
+             (llm-response/review-failure-message {} ""))))))
+
+(deftest backend-failure-message-test
+  (testing "LLM-client error message wins"
+    (with-redefs [llm/get-error (fn [_] {:message "5xx upstream"})]
+      (is (= "5xx upstream"
+             (llm-response/backend-failure-message {} {:review/blocking-issues ["enumerated"]})))))
+
+  (testing "without an LLM error, the first inline :review/blocking-issues wins"
+    (with-redefs [llm/get-error (fn [_] nil)]
+      (is (= "enumerated"
+             (llm-response/backend-failure-message {} {:review/blocking-issues ["enumerated"]})))))
+
+  (testing "without either, falls back to the generic post-parse catalog text"
+    (with-redefs [llm/get-error (fn [_] nil)]
+      (is (= (msg/t :reviewer.llm-response/invocation-failed-post-parse)
+             (llm-response/backend-failure-message {} {}))))))
+
+;------------------------------------------------------------------------------ Backend-timeout detection
+
+(deftest backend-timeout-issue?-test
+  (testing "true for known timeout / stagnation patterns (case-insensitive)"
+    (is (llm-response/backend-timeout-issue? "Stagnation timeout: no progress for 120119ms"))
+    (is (llm-response/backend-timeout-issue? "Adaptive timeout fired"))
+    (is (llm-response/backend-timeout-issue? "STREAM-IDLE limit reached"))
+    (is (llm-response/backend-timeout-issue? "request timed out"))
+    (is (llm-response/backend-timeout-issue? "exceeded 600000ms TIMEOUT")))
+
+  (testing "false for ordinary review findings"
+    (is (not (llm-response/backend-timeout-issue? "missing docstring on public defn")))
+    (is (not (llm-response/backend-timeout-issue? nil)))
+    (is (not (llm-response/backend-timeout-issue? "")))))
+
+(deftest timeout-only-review?-test
+  (let [timeout-llm-review {:review/decision :rejected
+                            :review/blocking-issues ["Stagnation timeout fired"]
+                            :review/recommendations []
+                            :review/issues []}
+        approved-gate-result {:decision :approved
+                              :blocking-issues []
+                              :warnings []}]
+    (testing "rejected verdict + approved gates + only-timeout blockers → timeout-only"
+      (is (llm-response/timeout-only-review? timeout-llm-review approved-gate-result)))
+
+    (testing "non-rejection decision → not timeout-only"
+      (is (not (llm-response/timeout-only-review?
+                 (assoc timeout-llm-review :review/decision :approved)
+                 approved-gate-result))))
+
+    (testing "deterministic gate already rejecting → not timeout-only"
+      (is (not (llm-response/timeout-only-review?
+                 timeout-llm-review
+                 {:decision :rejected :blocking-issues ["real"]}))))
+
+    (testing "non-timeout blockers present → not timeout-only"
+      (is (not (llm-response/timeout-only-review?
+                 {:review/decision :rejected
+                  :review/blocking-issues ["real code issue"]
+                  :review/recommendations []
+                  :review/issues []}
+                 approved-gate-result))))
+
+    (testing "presence of :review/issues → not timeout-only"
+      (is (not (llm-response/timeout-only-review?
+                 (assoc timeout-llm-review
+                        :review/issues [{:severity :blocking :description "x"}])
+                 approved-gate-result))))
+
+    (testing "presence of :review/recommendations → not timeout-only"
+      (is (not (llm-response/timeout-only-review?
+                 (assoc timeout-llm-review :review/recommendations ["something"])
+                 approved-gate-result))))))
+
+;------------------------------------------------------------------------------ Enumeration-retry validator
+
+(deftest enumeration-retry?-test
+  (testing "rejection without blockers AND no gate blockers → fires"
+    (is (true? (boolean (llm-response/enumeration-retry? :rejected           [] []))))
+    (is (true? (boolean (llm-response/enumeration-retry? :changes-requested  [] []))))
+    (is (true? (boolean (llm-response/enumeration-retry?
+                          :rejected
+                          [{:severity :warning :description "nit"}]
+                          [])))))
+
+  (testing "rejection with inline :blocking finding → does NOT fire"
+    (is (false? (boolean (llm-response/enumeration-retry?
+                           :rejected
+                           [{:severity :blocking :description "real issue"}]
+                           []))))
+    "the implementer has a concrete blocker to fix")
+
+  (testing "rejection backed by deterministic gate blocker → does NOT fire"
+    (is (false? (boolean (llm-response/enumeration-retry?
+                           :rejected [] ["gate-blocking-issue"])))))
+
+  (testing ":approved / :conditionally-approved never fire the validator"
+    (is (false? (boolean (llm-response/enumeration-retry? :approved [] []))))
+    (is (false? (boolean (llm-response/enumeration-retry? :conditionally-approved [] []))))))
+
+;------------------------------------------------------------------------------ well-formed-recovery?
+
+(deftest well-formed-recovery?-test
+  (testing ":approved / :conditionally-approved from the retry are well-formed
+            (the retry template explicitly permits self-correction)"
+    (is (true? (llm-response/well-formed-recovery?
+                 {:review/decision :approved
+                  :review/issues []})))
+    (is (true? (llm-response/well-formed-recovery?
+                 {:review/decision :conditionally-approved
+                  :review/issues [{:severity :nit :description "trivial"}]}))))
+
+  (testing "rejection with enumerated :blocking findings is well-formed"
+    (is (true? (llm-response/well-formed-recovery?
+                 {:review/decision :rejected
+                  :review/issues   [{:severity :blocking :description "real issue"}]}))))
+
+  (testing "rejection without blockers is NOT well-formed"
+    (is (false? (llm-response/well-formed-recovery?
+                  {:review/decision :rejected :review/issues []}))))
+
+  (testing "unknown :review/decision (typo / nil / unrecognized) is NOT well-formed"
+    ;; parse-review-response doesn't validate the enum, so the validator
+    ;; must — otherwise a typo or nil slips past as 'non-rejection' and
+    ;; gets collapsed downstream to :changes-requested, reintroducing
+    ;; the malformed rejection.
+    (is (false? (llm-response/well-formed-recovery? {:review/decision :approve  ; typo
+                                                     :review/issues []})))
+    (is (false? (llm-response/well-formed-recovery? {:review/decision nil
+                                                     :review/issues []})))
+    (is (false? (llm-response/well-formed-recovery? {:review/decision :looks-good
+                                                     :review/issues []})))))
+
+;------------------------------------------------------------------------------ recover-review-enumeration
+
+(deftest recover-review-enumeration-returns-approval-correction-test
+  (testing "when the retry corrects to :approved, recovery returns it
+            (regression guard: previously it required :blocking and
+            silently dropped approvals)"
+    (let [calls (atom 0)
+          stub  "```clojure\n{:review/decision :approved
+                              :review/summary \"clean on re-review\"
+                              :review/issues []}\n```"]
+      (with-redefs [llm/chat (fn [_client _prompt _opts]
+                               (swap! calls inc)
+                               {:success true :content stub})]
+        (let [recovered (llm-response/recover-review-enumeration
+                         :stub-client {} nil "orig user prompt" "prior malformed content")]
+          (is (= 1 @calls) "exactly one retry LLM call")
+          (is (= :approved (:review/decision recovered))))))))
+
+(deftest recover-review-enumeration-returns-enumerated-rejection-test
+  (testing "when the retry enumerates :blocking findings, recovery returns it"
+    (let [stub "```clojure\n{:review/decision :rejected
+                             :review/issues [{:severity :blocking :description \"x\"}]}\n```"]
+      (with-redefs [llm/chat (fn [_client _prompt _opts]
+                               {:success true :content stub})]
+        (let [recovered (llm-response/recover-review-enumeration
+                         :stub-client {} nil "orig" "prior")]
+          (is (= :rejected (:review/decision recovered)))
+          (is (= 1 (count (:review/issues recovered)))))))))
+
+(deftest recover-review-enumeration-returns-nil-on-still-malformed-test
+  (testing "when the retry ALSO returns a rejection with no blockers,
+            recovery returns nil (the raw rejection stands as-is, logged)"
+    (let [stub "```clojure\n{:review/decision :rejected :review/issues []}\n```"]
+      (with-redefs [llm/chat (fn [_client _prompt _opts]
+                               {:success true :content stub})]
+        (is (nil? (llm-response/recover-review-enumeration
+                    :stub-client {} nil "orig" "prior")))))))

--- a/components/agent/test/ai/miniforge/agent/reviewer/llm_response_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/llm_response_test.clj
@@ -210,8 +210,8 @@
     (is (false? (boolean (llm-response/enumeration-retry?
                            :rejected
                            [{:severity :blocking :description "real issue"}]
-                           []))))
-    "the implementer has a concrete blocker to fix")
+                           [])))
+        "the implementer has a concrete blocker to fix"))
 
   (testing "rejection backed by deterministic gate blocker → does NOT fire"
     (is (false? (boolean (llm-response/enumeration-retry?

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -337,32 +337,8 @@
         (is (= parseable-backend-failure-token-count
                (get-in result [:metrics :tokens])))))))
 
-(deftest test-reviewer-rejects-structurally-corrupt-llm-issues
-  (testing "valid EDN with malformed issue maps is treated as unparseable"
-    (is (nil? (reviewer/parse-review-response malformed-review-issue-content)))))
-
-(deftest test-reviewer-accepts-issues-with-nil-line
-  ;; Reproduces the 2026-05-16 event-log-tool-visibility dogfood
-  ;; gate-vs-verdict mismatch: the LLM emitted :line nil on a
-  ;; file-level issue. The schema's pre-fix shape
-  ;; (`{:optional true} [:int {:min 1}]`) silently rejected the issue,
-  ;; parser returned nil, parse-failed? flipped llm-decision to
-  ;; :rejected, and the :review-approved gate correctly rejected a
-  ;; decision that should have been :approved. With :line wrapped in
-  ;; :maybe, explicit nil now round-trips through the parser.
-  (testing "issue with :line nil parses with :review/decision intact"
-    (let [parsed (reviewer/parse-review-response approved-with-nil-line-content)]
-      (is (some? parsed) "parser must not return nil for a nil-line issue")
-      (is (= :approved (:review/decision parsed)))
-      (is (= 2 (count (:review/issues parsed))))
-      (is (nil? (:line (first (:review/issues parsed))))
-          ":line nil must round-trip through the parser, not get dropped"))))
-
-(deftest test-reviewer-accepts-issues-with-all-optional-fields-nil
-  (testing "issue with :file nil, :line nil, :suggestion nil parses cleanly"
-    (let [parsed (reviewer/parse-review-response approved-with-nil-optional-fields-content)]
-      (is (some? parsed))
-      (is (= :approved (:review/decision parsed))))))
+;; parse-review-response tests (incl. malformed-issue, nil-line, all-nil-
+;; optional) moved to reviewer/llm_response_test.clj (PR-F).
 
 (deftest test-reviewer-timeout-only-parseable-failure-is-agent-error
   (testing "timeout-only parsed review failures do not become rejected code-review artifacts"
@@ -886,113 +862,9 @@
             ;; assertion is just that we didn't NPE or get nil.
             (is (pos? (count system-prompt)))))))))
 
-;;----------------------------------------------------------------------------- Enumeration-retry validator
-
-(def ^:private enumeration-retry? #'reviewer/enumeration-retry?)
-
-(deftest enumeration-retry-fires-on-rejection-without-blockers
-  (testing "a :rejected (or :changes-requested) decision with NO :blocking
-            findings inline AND no gate blockers is malformed — the validator
-            triggers a re-enumeration"
-    (is (true? (boolean (enumeration-retry? :rejected           [] []))))
-    (is (true? (boolean (enumeration-retry? :changes-requested  [] []))))
-    (is (true? (boolean (enumeration-retry? :rejected
-                                            [{:severity :warning :description "nit"}]
-                                            []))))))
-
-(deftest enumeration-retry-no-fire-when-blockers-enumerated
-  (testing "a rejection with an inline :blocking finding is well-formed"
-    (is (false? (boolean (enumeration-retry?
-                          :rejected
-                          [{:severity :blocking :description "real issue"}]
-                          []))))))
-
-(deftest enumeration-retry-no-fire-when-gate-blocks
-  (testing "a rejection backed by a deterministic gate blocker is well-formed
-            (the implementer has something concrete to fix)"
-    (is (false? (boolean (enumeration-retry?
-                          :rejected [] ["gate-blocking-issue"]))))))
-
-(deftest enumeration-retry-no-fire-on-non-rejection
-  (testing ":approved / :conditionally-approved never trigger the validator"
-    (is (false? (boolean (enumeration-retry? :approved [] []))))
-    (is (false? (boolean (enumeration-retry? :conditionally-approved [] []))))))
-
-;;----------------------------------------------------------------------------- well-formed-recovery? + recover-review-enumeration
-
-(def ^:private well-formed-recovery? #'reviewer/well-formed-recovery?)
-(def ^:private recover-review-enumeration #'reviewer/recover-review-enumeration)
-
-(deftest well-formed-recovery-accepts-approval-correction
-  (testing ":approved / :conditionally-approved from the retry are well-formed
-            — the retry template explicitly permits self-correction, and
-            DISCARDING those would leave the original malformed rejection
-            in place (the exact churn the validator exists to eliminate)"
-    (is (true? (well-formed-recovery? {:review/decision :approved
-                                       :review/issues []})))
-    (is (true? (well-formed-recovery? {:review/decision :conditionally-approved
-                                       :review/issues [{:severity :nit
-                                                        :description "trivial"}]})))))
-
-(deftest well-formed-recovery-accepts-enumerated-rejection
-  (is (true? (well-formed-recovery?
-              {:review/decision :rejected
-               :review/issues   [{:severity :blocking :description "real issue"}]}))))
-
-(deftest well-formed-recovery-rejects-rejection-without-blockers
-  (is (false? (well-formed-recovery?
-               {:review/decision :rejected :review/issues []}))))
-
-(deftest recover-review-enumeration-returns-approval-correction-test
-  (testing "when the retry corrects to :approved, recovery returns it
-            (regression guard: previously it required :blocking and
-            silently dropped approvals)"
-    (let [calls (atom 0)
-          stub  "```clojure\n{:review/decision :approved
-                              :review/summary \"clean on re-review\"
-                              :review/issues []}\n```"]
-      (with-redefs [llm/chat (fn [_client _prompt _opts]
-                               (swap! calls inc)
-                               {:success true :content stub})]
-        (let [recovered (recover-review-enumeration
-                         :stub-client {} nil "orig user prompt" "prior malformed content")]
-          (is (= 1 @calls) "exactly one retry LLM call")
-          (is (= :approved (:review/decision recovered))))))))
-
-(deftest recover-review-enumeration-returns-enumerated-rejection-test
-  (testing "when the retry enumerates :blocking findings, recovery returns it"
-    (let [stub "```clojure\n{:review/decision :rejected
-                             :review/issues [{:severity :blocking :description \"x\"}]}\n```"]
-      (with-redefs [llm/chat (fn [_client _prompt _opts]
-                               {:success true :content stub})]
-        (let [recovered (recover-review-enumeration
-                         :stub-client {} nil "orig" "prior")]
-          (is (= :rejected (:review/decision recovered)))
-          (is (= 1 (count (:review/issues recovered)))))))))
-
-(deftest recover-review-enumeration-returns-nil-on-still-malformed-test
-  (testing "when the retry ALSO returns a rejection with no blockers,
-            recovery returns nil (the raw rejection stands as-is, logged)"
-    (let [stub "```clojure\n{:review/decision :rejected :review/issues []}\n```"]
-      (with-redefs [llm/chat (fn [_client _prompt _opts]
-                               {:success true :content stub})]
-        (is (nil? (recover-review-enumeration
-                   :stub-client {} nil "orig" "prior")))))))
-
+;; Enumeration-retry validator, well-formed-recovery?, recover-review-
+;; enumeration tests moved to reviewer/llm_response_test.clj (PR-F).
 ;; normalize-llm-decision tests moved to reviewer/issues_test.clj (PR-C).
-
-(deftest well-formed-recovery-rejects-unknown-decision-keyword
-  (testing "an invalid :review/decision (typo / nil / unknown) is NOT
-            well-formed — parse-review-response doesn't validate the enum,
-            so the validator must, otherwise downstream normalize-llm-decision
-            would collapse the bogus value to :changes-requested and
-            reintroduce the malformed-rejection outcome"
-    (is (false? (well-formed-recovery? {:review/decision :approve  ; typo
-                                        :review/issues []})))
-    (is (false? (well-formed-recovery? {:review/decision nil
-                                        :review/issues []})))
-    (is (false? (well-formed-recovery? {:review/decision :looks-good
-                                        :review/issues []})))))
 
 ;------------------------------------------------------------------------------ Scope-boundary tests
 ;; The reviewer prompt and helper resolve a per-task scope so adjacent-file


### PR DESCRIPTION
## Summary

**Stack position:** PR-F of the reviewer-decomp stack. Based on \`chris/reviewer-prompts-ns\` (PR-E, #1044).

Lifts the LLM-response processing path out of \`reviewer.clj\` so the \`create-reviewer\` orchestrator can shrink in PR-G to just wiring.

### Moved to \`reviewer.llm-response\`

| Group | Defs |
|---|---|
| Parsing | \`parse-review-response\` (EDN extraction from code block or plain text) |
| Failure messages | \`review-failure-message\`, \`backend-failure-message\` (now localized via 3 new catalog keys) |
| Backend-timeout detection | \`backend-timeout-issue?\`, \`timeout-only-review?\` |
| Enumeration retry | \`enumeration-retry?\`, \`well-formed-recovery?\`, \`recover-review-enumeration\` (all promoted from private to public — invoke-fn callers in reviewer.clj need them) |

### Also moved to \`reviewer.issues\` (consistency)

- \`llm-issues->recommendations\` — same shape as \`llm-issues->blocking-strings\` / \`llm-issues->warning-strings\` already in issues; co-locating keeps the "extract strings from LLM-emitted issues" trio together.

### Localization (standards pass)

3 new keys for the 3 previously-raw operator-facing strings in the failure-message ladder.

### Tests

New \`reviewer/llm_response_test.clj\` — moved the \`parse-review-response\` tests (incl. 2026-05-16 nil-line regression anchor), all \`enumeration-retry?\` / \`well-formed-recovery?\` / \`recover-review-enumeration\` tests, plus new coverage:
- \`review-failure-message\` ladder (3 cases)
- \`backend-failure-message\` ladder (3 cases)
- \`backend-timeout-issue?\` pattern matching
- \`timeout-only-review?\` all 5 falsy conditions + the happy path

## Test plan

- [x] \`bb pre-commit\` — 327 / 1203 + 6 GraalVM / 511, all green
- [x] 65 reviewer tests / 283 assertions across the six reviewer test files

## Line counts

- \`reviewer.clj\`: 767 → **643**
- \`reviewer_test.clj\`: 1075 → ~890
- New \`reviewer/llm_response.clj\`: 205 lines
- New \`reviewer/llm_response_test.clj\`: ~270 lines

## Stack rest queued

- PR-G: \`reviewer.artifact\` + slim \`create-reviewer\` orchestrator (final PR — reviewer.clj should end up <300 lines as a thin wiring layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)