### PR TITLE
fix(workflow): validate branch ref name before git rev-parse

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -108,6 +108,7 @@
   :env/restore-failed       "Workspace restore failed: {error}"
 
   ;; v2 multi-parent merge (DAG orchestrator) — anomaly + log messages
+  :dag.merge/branch-name-invalid      "Parent branch name is structurally invalid (empty, leading dash, or whitespace)"
   :dag.merge/branch-unresolvable     "Parent branch could not be resolved to a commit"
   :dag.merge/unrelated-histories     "Parents share no common ancestor — refusing to merge"
   :dag.merge/strategy-unsupported    "Merge strategy {strategy} is not supported in this stage"

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -336,13 +336,15 @@
   "no-run-id")
 
 (defn- valid-ref-name?
-  "True when `s` is safe to pass as a git refspec: non-empty, no leading
-   dash (which git may misparse as a flag), and no embedded whitespace."
+  "True when `s` is a structurally legal git ref name per git-check-ref-format(1):
+   non-empty, no leading dash (flag risk), no whitespace, and none of the
+   characters or sequences that git treats as revision operators or prohibits
+   in ref names (~, ^, :, ?, *, [, ], \\, .., @{, //)."
   [s]
   (and (string? s)
        (pos? (count s))
        (not (str/starts-with? s "-"))
-       (not (re-find #"\s" s))))
+       (not (re-find #"[\s~\^:\?\*\[\]\\]|\.\.|@\{|//" s))))
 
 ;; Anomaly factories ---------------------------------------------------
 ;; Each factory takes the minimum data needed and produces the canonical
@@ -1048,7 +1050,9 @@
      parents) — callers branch on these for observability but the
      `:branch` is uniformly the right value to use as the sub-workflow
      base.
-   - An anomaly map — `:dag-multi-parent-conflict`,
+   - An anomaly map — `:dag-multi-parent-branch-name-invalid` (branch name
+     structurally invalid before git is invoked),
+     `:dag-multi-parent-conflict`,
      `:dag-multi-parent-unrelated-histories`,
      `:dag-multi-parent-branch-unresolvable`,
      `:dag-multi-parent-strategy-unsupported`,

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -335,11 +335,30 @@
    The merge ref namespace requires a non-nil run-id segment."
   "no-run-id")
 
+(defn- valid-ref-name?
+  "True when `s` is safe to pass as a git refspec: non-empty, no leading
+   dash (which git may misparse as a flag), and no embedded whitespace."
+  [s]
+  (and (string? s)
+       (pos? (count s))
+       (not (str/starts-with? s "-"))
+       (not (re-find #"\s" s))))
+
 ;; Anomaly factories ---------------------------------------------------
 ;; Each factory takes the minimum data needed and produces the canonical
 ;; anomaly shape (`:anomaly/category` + `:anomaly/message` + rich data
 ;; under `:merge/*` and `:git/*` keys). All messages route through the
 ;; workflow message catalog.
+
+(defn- branch-name-invalid-anomaly
+  "Anomaly: a parent's branch name is structurally invalid — empty,
+   starts with `-` (git flag risk), or contains whitespace. Rejected
+   before reaching git so git never receives a potentially malformed
+   refspec."
+  [parent]
+  {:anomaly/category :anomalies/dag-multi-parent-branch-name-invalid
+   :anomaly/message  (messages/t :dag.merge/branch-name-invalid)
+   :merge/parent     parent})
 
 (defn- branch-unresolvable-anomaly
   "Anomaly: a parent's registered branch could not be rev-parsed in
@@ -529,11 +548,13 @@
   (loop [remaining parents
          out (transient [])]
     (if-let [p (first remaining)]
-      (let [r (run-git host-repo "rev-parse" "--verify" (str (:branch p) "^{commit}"))]
-        (if (zero? (:exit r))
-          (recur (rest remaining)
-                 (conj! out (assoc p :commit-sha (str/trim (:out r)))))
-          (branch-unresolvable-anomaly p r)))
+      (if-not (valid-ref-name? (:branch p))
+        (branch-name-invalid-anomaly p)
+        (let [r (run-git host-repo "rev-parse" "--verify" (str (:branch p) "^{commit}"))]
+          (if (zero? (:exit r))
+            (recur (rest remaining)
+                   (conj! out (assoc p :commit-sha (str/trim (:out r)))))
+            (branch-unresolvable-anomaly p r))))
       {:parents (persistent! out)})))
 
 (defn- ancestor-of?

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -264,6 +264,23 @@
           "branch-unresolvable is the right category — branches don't exist in
            the test repo, so rev-parse fails before any merge is attempted"))))
 
+(deftest task-sub-opts-multi-dep-rejects-invalid-branch-name-test
+  (testing "Multi-parent task: a parent whose registered branch starts with '-'
+            is rejected before git is invoked, surfacing a typed
+            :anomalies/dag-multi-parent-branch-name-invalid anomaly."
+    (let [task-def {:task/id id-c :task/description "C" :task/deps #{id-a id-b}}
+          ctx (registry-context {id-a {:branch "-flag-injection"}
+                                 id-b {:branch "task-b"}}
+                                "main")
+          opts (dag-orch/task-sub-opts ctx task-def)]
+      (is (not (contains? opts :branch))
+          "invalid branch name must not produce a usable :branch")
+      (is (some? (:dag/merge-anomaly opts))
+          "anomaly is surfaced for run-mini-workflow to short-circuit on")
+      (is (= :anomalies/dag-multi-parent-branch-name-invalid
+             (get-in opts [:dag/merge-anomaly :anomaly/category]))
+          "leading-dash branch returns branch-name-invalid before any git invocation"))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; v2 multi-parent: forest gate is dropped (informational logging only).
 ;; Diamond plans run end-to-end via merge-parent-branches!. With no

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -281,6 +281,40 @@
              (get-in opts [:dag/merge-anomaly :anomaly/category]))
           "leading-dash branch returns branch-name-invalid before any git invocation"))))
 
+(deftest task-sub-opts-multi-dep-rejects-all-invalid-ref-shapes-test
+  ;; Coverage extension after Copilot review on PR #1048: the
+  ;; strengthened `valid-ref-name?` rejects more than just leading-dash
+  ;; (revision operators, whitespace, ref-format-forbidden sequences,
+  ;; empty string). Pin each rejection class so the predicate cannot
+  ;; quietly weaken back to letting e.g. `"HEAD~1"` through to
+  ;; `git rev-parse`.
+  (testing "structurally invalid ref shapes each trigger branch-name-invalid"
+    (doseq [[label bad-branch]
+            [["empty string"            ""]
+             ["leading dash (flag risk)" "-flag-injection"]
+             ["whitespace"               "feat branch"]
+             ["tilde (revision op)"      "HEAD~1"]
+             ["caret (revision op)"      "HEAD^"]
+             ["colon (refspec sep)"      "refs/heads:foo"]
+             ["question mark glob"       "feat?"]
+             ["asterisk glob"            "feat*"]
+             ["open bracket"             "feat["]
+             ["close bracket"            "feat]"]
+             ["backslash"                "feat\\bad"]
+             ["double dot range"         "main..feat"]
+             ["at-brace reflog syntax"   "main@{1}"]
+             ["double slash"             "feat//inner"]]]
+      (let [task-def {:task/id id-c :task/description "C" :task/deps #{id-a id-b}}
+            ctx (registry-context {id-a {:branch bad-branch}
+                                   id-b {:branch "task-b"}}
+                                  "main")
+            opts (dag-orch/task-sub-opts ctx task-def)]
+        (is (not (contains? opts :branch))
+            (str label ": invalid branch must not produce a usable :branch"))
+        (is (= :anomalies/dag-multi-parent-branch-name-invalid
+               (get-in opts [:dag/merge-anomaly :anomaly/category]))
+            (str label ": surfaces branch-name-invalid before git invocation"))))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; v2 multi-parent: forest gate is dropped (informational logging only).
 ;; Diamond plans run end-to-end via merge-parent-branches!. With no


### PR DESCRIPTION
## Summary

- Branch names from the task registry were passed directly to `git rev-parse --verify` without any structural validation in `snapshot-parent-shas` (dag_orchestrator.clj).
- A name starting with `-` could be misread by git as a flag argument; an empty or whitespace-only name produces an unintelligible git error rather than a typed anomaly.
- Adds `valid-ref-name?` predicate and `branch-name-invalid-anomaly` factory so structurally invalid names short-circuit with a clear `:anomalies/dag-multi-parent-branch-name-invalid` anomaly before any git invocation.
- Adds the corresponding `dag.merge/branch-name-invalid` message key to `en-US.edn`.

## What changed

| File | Change |
|------|--------|
| `dag_orchestrator.clj` | `valid-ref-name?` predicate + `branch-name-invalid-anomaly` factory + guard in `snapshot-parent-shas` loop |
| `en-US.edn` | New `:dag.merge/branch-name-invalid` message key |

## Test plan

- [ ] Existing tests pass (`bb test` — bb not available in this container; run locally before merge)
- [ ] Manually verify that a parent with `branch: "-flag"` returns the new anomaly category instead of crashing git
- [ ] Verify a parent with a valid branch name still resolves normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4Wwqn9vBX1ncNphWwCN2Z)_