### PR TITLE
chore(web-dashboard): drop dead escapeJSString + addEventListener for chip ×

### DIFF
--- a/components/web-dashboard/resources/public/js/filters/runtime.js
+++ b/components/web-dashboard/resources/public/js/filters/runtime.js
@@ -79,12 +79,6 @@
     return JSON.parse(JSON.stringify(value));
   };
 
-  runtime.escapeJSString = function escapeJSString(value) {
-    return String(value)
-      .replace(/\\/g, '\\\\')
-      .replace(/'/g, "\\'");
-  };
-
   runtime.callApi = function callApi(name) {
     const fn = runtime.api[name];
     if (typeof fn !== 'function') {

--- a/components/web-dashboard/resources/public/js/filters/ui.js
+++ b/components/web-dashboard/resources/public/js/filters/ui.js
@@ -143,7 +143,7 @@
     removeBtn.className = 'filter-remove';
     removeBtn.textContent = '×';
     removeBtn.title = 'Remove filter';
-    removeBtn.onclick = () => runtime.callApi('removeFilter', clause['filter/id'], scope, clause.value);
+    removeBtn.addEventListener('click', () => runtime.callApi('removeFilter', clause['filter/id'], scope, clause.value));
 
     chip.appendChild(label);
     chip.appendChild(menu);


### PR DESCRIPTION
## Summary

Two follow-ups from [#1043](https://github.com/miniforge-ai/miniforge/pull/1043), both flagged out-of-scope in that PR's body.

- **`runtime.escapeJSString` removed.** Zero callers repo-wide after #1043 dropped the last consumer in `createFilterChip`. The helper only existed to sanitise values being interpolated into `onclick="..."` string contexts; those contexts no longer exist.
- **Chip × button** now binds via `addEventListener('click', …)` instead of `removeBtn.onclick = …`. Not a JS-004 violation (DOM property, not inline HTML), but the chip is now uniformly bound — matches the menu buttons landed in #1043 and the `addFilterChip` pattern from [#1040](https://github.com/miniforge-ai/miniforge/pull/1040).

## Test plan

- [x] `node -c` clean on both touched files
- [x] `grep -rn escapeJSString components/web-dashboard/` returns no hits
- [x] Pre-commit (Polylith + 327-test smoke + GraalVM/bb compat) green
- [ ] Manual smoke: open a filter chip, click the trailing × — filter removes

🤖 Generated with [Claude Code](https://claude.com/claude-code)