### PR TITLE
feat(web-dashboard): JS localization via inline window.MINIFORGE_MESSAGES hydration

### DIFF
--- a/components/messages/src/ai/miniforge/messages/core.clj
+++ b/components/messages/src/ai/miniforge/messages/core.clj
@@ -58,6 +58,14 @@
                   params)
        template))))
 
+(defn all
+  "Return the full message map from a catalog delay.
+
+   Useful for bulk export — e.g. hydrating a browser-side translator
+   with the same catalog the server uses."
+  [catalog]
+  (or @catalog {}))
+
 (defn create-translator
   "Create a translator function for a specific component's message catalog.
 

--- a/components/messages/src/ai/miniforge/messages/interface.clj
+++ b/components/messages/src/ai/miniforge/messages/interface.clj
@@ -35,6 +35,15 @@
   ([catalog k] (core/t catalog k))
   ([catalog k params] (core/t catalog k params)))
 
+(defn all
+  "Return the full message map from a loaded catalog.
+
+   Used by callers that need to bulk-export every key/value pair —
+   e.g. serializing the catalog into a browser-side translator at
+   page-render time."
+  [catalog]
+  (core/all catalog))
+
 (defn create-translator
   "Create a `t` function bound to a specific component's message catalog.
 

--- a/components/messages/test/ai/miniforge/messages/interface_test.clj
+++ b/components/messages/test/ai/miniforge/messages/interface_test.clj
@@ -35,3 +35,11 @@
   (testing "t falls back to key name for missing keys"
     (let [catalog (delay {})]
       (is (= "missing-key" (messages/t catalog :missing-key))))))
+
+(deftest all-returns-full-catalog
+  (testing "all returns the full deref'd catalog map"
+    (let [catalog (delay {:a "alpha" :b "beta"})]
+      (is (= {:a "alpha" :b "beta"} (messages/all catalog)))))
+
+  (testing "all returns empty map for missing/nil catalog"
+    (is (= {} (messages/all (delay nil))))))

--- a/components/web-dashboard/resources/config/web-dashboard/messages/en-US.edn
+++ b/components/web-dashboard/resources/config/web-dashboard/messages/en-US.edn
@@ -139,4 +139,56 @@
   :status/failed-label         "Failed"
 
   ;; table headers
-  :table/status-header         "Status"}}
+  :table/status-header         "Status"
+
+  ;; shared bool/unknown labels (used by JS chip rendering + workflow events)
+  :value/yes                   "Yes"
+  :value/no                    "No"
+  :value/unknown               "unknown"
+  :value/unknown-error         "unknown error"
+
+  ;; websocket status labels (browser updateConnectionStatus)
+  :ws/status-connected         "Connected"
+  :ws/status-disconnected      "Disconnected"
+  :ws/status-reconnecting      "Reconnecting..."
+  :ws/status-error             "Error"
+
+  ;; toast notifications — fleet + control plane
+  :toast/command-sent          "Command sent: {command}"
+  :toast/command-failed        "Failed to send command: {error}"
+  :toast/error-with-detail     "Error: {detail}"
+  :toast/sync-error            "Sync error: {detail}"
+  :toast/repo-added            "Added: {repo}"
+  :toast/repo-existing         "Already configured: {repo}"
+  :toast/discover-done         "Discovered {discovered} repos, added {added}."
+  :toast/sync-done             "Synced repos: {synced}, tracked PRs: {tracked}"
+  :toast/discover-and-sync-done "Discovery and PR sync completed."
+  :toast/link-copied           "Link copied to clipboard"
+  :toast/workflow-started      "Workflow started: {name}"
+  :toast/workflow-completed    "Workflow completed"
+  :toast/workflow-failed       "Workflow failed: {reason}"
+  :toast/phase-started         "Phase started: {phase}"
+  :toast/phase-completed       "Phase completed: {phase}"
+
+  ;; fleet error fallbacks (api response missing :error/:message)
+  :fleet/error-add-repo        "Unable to add repo"
+  :fleet/error-discover        "Repository discovery failed"
+  :fleet/error-sync            "Sync failed for {count} repo(s)"
+  :fleet/error-sync-fallback   "Unable to synchronize PRs"
+
+  ;; browser prompts
+  :prompt/repo-input           "Repository (owner/name):"
+  :prompt/discover-owner       "Owner/org (leave blank for current user):"
+  :prompt/copy-which-pane      "Copy to which pane?\n{options}"
+
+  ;; filter chip — labels + menu
+  :filter/remove-title         "Remove filter"
+  :filter/cloud-only-label     "Cloud only"
+  :filter/menu-pin-global      "📌 Pin to Global"
+  :filter/menu-make-local      "📍 Make Pane-Local"
+  :filter/menu-copy            "📋 Copy to Pane"
+  :filter/menu-remove          "🗑️ Remove"
+  :filter/copied-to-pane       "Filter copied to {pane}"
+  :filter/chip-label-op        "{field} {op} {value}"
+  :filter/chip-label-value     "{field}: {value}"
+  :filter/chip-label-text      "{field}: \"{value}\""}}

--- a/components/web-dashboard/resources/public/js/app.js
+++ b/components/web-dashboard/resources/public/js/app.js
@@ -115,8 +115,9 @@ function addFilterChip(label, type, value) {
 
   const removeBtn = document.createElement('button');
   removeBtn.className = 'filter-remove';
-  removeBtn.title = 'Remove filter';
-  removeBtn.setAttribute('aria-label', 'Remove filter');
+  const removeLabel = window.miniforge.t('filter/remove-title');
+  removeBtn.title = removeLabel;
+  removeBtn.setAttribute('aria-label', removeLabel);
   removeBtn.textContent = '×';
   removeBtn.addEventListener('click', () => removeFilterChip(filterKey));
 
@@ -161,11 +162,11 @@ function postWorkflowCommand(workflowId, command) {
   })
   .then(r => r.json())
   .then(data => {
-    showToast('Command sent: ' + command, 'info', 3000);
+    showToast(window.miniforge.t('toast/command-sent', { command }), 'info', 3000);
     console.log('Command queued:', data);
   })
   .catch(err => {
-    showToast('Failed to send command: ' + err.message, 'error');
+    showToast(window.miniforge.t('toast/command-failed', { error: err.message }), 'error');
     console.error('Error sending command:', err);
   });
 }
@@ -253,40 +254,47 @@ function apiErrorMessage(res, fallback) {
   return (res && (res.error || res.message)) || fallback;
 }
 
+function toastError(detail) {
+  showToast(window.miniforge.t('toast/error-with-detail', { detail }), 'error');
+}
+
 function fleetAddRepo() {
-  const repo = prompt('Repository (owner/name):');
+  const repo = prompt(window.miniforge.t('prompt/repo-input'));
   if (!repo) return;
 
   postJson('/api/fleet/repos/add?repo=' + encodeURIComponent(repo))
     .then((res) => {
       if (res.success) {
-        const prefix = res['added?'] ? 'Added: ' : 'Already configured: ';
-        showToast(prefix + (res.repo || repo), 'success');
+        const messageKey = res['added?'] ? 'toast/repo-added' : 'toast/repo-existing';
+        showToast(window.miniforge.t(messageKey, { repo: res.repo || repo }), 'success');
         dispatchRefresh();
         return;
       }
-      showToast('Error: ' + apiErrorMessage(res, 'Unable to add repo'), 'error');
+      toastError(apiErrorMessage(res, window.miniforge.t('fleet/error-add-repo')));
     })
-    .catch((err) => showToast('Error: ' + err.message, 'error'));
+    .catch((err) => toastError(err.message));
 }
 
 function fleetDiscoverRepos() {
-  const owner = prompt('Owner/org (leave blank for current user):', '') || '';
+  const owner = prompt(window.miniforge.t('prompt/discover-owner'), '') || '';
   const suffix = owner.trim() ? ('?owner=' + encodeURIComponent(owner.trim())) : '';
 
   postJson('/api/fleet/repos/discover' + suffix)
     .then((res) => {
       if (res.success) {
         showToast(
-          'Discovered ' + (res.discovered || 0) + ' repos, added ' + (res.added || 0) + '.',
+          window.miniforge.t('toast/discover-done', {
+            discovered: res.discovered || 0,
+            added: res.added || 0
+          }),
           'success'
         );
         dispatchRefresh();
         return;
       }
-      showToast('Error: ' + apiErrorMessage(res, 'Repository discovery failed'), 'error');
+      toastError(apiErrorMessage(res, window.miniforge.t('fleet/error-discover')));
     })
-    .catch((err) => showToast('Error: ' + err.message, 'error'));
+    .catch((err) => toastError(err.message));
 }
 
 function fleetSyncPrs() {
@@ -295,37 +303,39 @@ function fleetSyncPrs() {
       if (res.success) {
         const summary = res.summary || {};
         showToast(
-          'Synced repos: ' + (res.synced || 0) + ', tracked PRs: ' + (summary['tracked-prs'] || 0),
+          window.miniforge.t('toast/sync-done', {
+            synced: res.synced || 0,
+            tracked: summary['tracked-prs'] || 0
+          }),
           'success'
         );
       } else {
-        showToast(
-          'Error: ' + apiErrorMessage(res, 'Sync failed for ' + (res.failed || 0) + ' repo(s)'),
-          'error'
-        );
+        const fallback = window.miniforge.t('fleet/error-sync', { count: res.failed || 0 });
+        toastError(apiErrorMessage(res, fallback));
       }
       dispatchRefresh();
     })
-    .catch((err) => showToast('Error: ' + err.message, 'error'));
+    .catch((err) => toastError(err.message));
 }
 
 function fleetDiscoverAndSync() {
   postJson('/api/fleet/repos/discover')
     .then((res) => {
       if (!res.success) {
-        throw new Error(apiErrorMessage(res, 'Discovery failed'));
+        throw new Error(apiErrorMessage(res, window.miniforge.t('fleet/error-discover')));
       }
       return postJson('/api/fleet/prs/sync');
     })
     .then((syncRes) => {
       if (syncRes.success) {
-        showToast('Discovery and PR sync completed.', 'success');
+        showToast(window.miniforge.t('toast/discover-and-sync-done'), 'success');
       } else {
-        showToast('Sync error: ' + apiErrorMessage(syncRes, 'Unable to synchronize PRs'), 'error');
+        const detail = apiErrorMessage(syncRes, window.miniforge.t('fleet/error-sync-fallback'));
+        showToast(window.miniforge.t('toast/sync-error', { detail }), 'error');
       }
       dispatchRefresh();
     })
-    .catch((err) => showToast('Error: ' + err.message, 'error'));
+    .catch((err) => toastError(err.message));
 }
 
 // Export functions for global use
@@ -348,14 +358,14 @@ window.miniforge = {
   },
   filters: {
     addFilter(field, op, value, _scope) {
-      addFilterChip(`${field} ${op} ${value}`, field, value);
+      addFilterChip(window.miniforge.t('filter/chip-label-op', { field, op, value }), field, value);
     },
     toggleFilter(field, value, _scope) {
       const filterKey = `${field}:${value}`;
       if (activeFilters.has(filterKey)) {
         removeFilterChip(filterKey);
       } else {
-        addFilterChip(`${field}: ${value}`, field, value);
+        addFilterChip(window.miniforge.t('filter/chip-label-value', { field, value }), field, value);
       }
     },
     setTextFilter(field, value) {
@@ -366,7 +376,7 @@ window.miniforge = {
       }
       if (value && value.trim()) {
         const trimmed = value.trim();
-        addFilterChip(`${field}: "${trimmed}"`, 'text', field);
+        addFilterChip(window.miniforge.t('filter/chip-label-text', { field, value: trimmed }), 'text', field);
       }
     },
     clearFilters(_scope) {
@@ -375,14 +385,14 @@ window.miniforge = {
     shareCurrentView() {
       if (navigator.clipboard) {
         navigator.clipboard.writeText(window.location.href)
-          .then(() => showToast('Link copied to clipboard', 'info', 2000))
+          .then(() => showToast(window.miniforge.t('toast/link-copied'), 'info', 2000))
           .catch(() => {});
       }
     },
     toggleCloudFilter(el) {
       const filterKey = 'cloud:enabled';
       if (el && el.checked) {
-        addFilterChip('Cloud only', 'cloud', 'enabled');
+        addFilterChip(window.miniforge.t('filter/cloud-only-label'), 'cloud', 'enabled');
       } else {
         removeFilterChip(filterKey);
       }
@@ -467,13 +477,15 @@ function updateConnectionStatus(status) {
 
   const statusText = document.getElementById('ws-text');
   if (statusText) {
-    const statusLabels = {
-      connected: 'Connected',
-      disconnected: 'Disconnected',
-      reconnecting: 'Reconnecting...',
-      error: 'Error'
+    const statusKeys = {
+      connected: 'ws/status-connected',
+      disconnected: 'ws/status-disconnected',
+      reconnecting: 'ws/status-reconnecting',
+      error: 'ws/status-error'
     };
-    statusText.textContent = statusLabels[status] || status;
+    statusText.textContent = statusKeys[status]
+      ? window.miniforge.t(statusKeys[status])
+      : status;
   }
 }
 
@@ -646,28 +658,35 @@ function handleWorkflowEvent(event) {
   }
 
   switch (eventType) {
-    case 'workflow/started':
-      showToast('Workflow started: ' + (event['workflow/spec']?.name || 'unknown'), 'info');
+    case 'workflow/started': {
+      var startedName = event['workflow/spec']?.name || window.miniforge.t('value/unknown');
+      showToast(window.miniforge.t('toast/workflow-started', { name: startedName }), 'info');
       break;
+    }
 
-    case 'workflow/phase-started':
-      showToast('Phase started: ' + (event['workflow/phase'] || 'unknown'), 'info');
+    case 'workflow/phase-started': {
+      var startedPhase = event['workflow/phase'] || window.miniforge.t('value/unknown');
+      showToast(window.miniforge.t('toast/phase-started', { phase: startedPhase }), 'info');
       break;
+    }
 
     case 'workflow/phase-completed': {
       var outcome = event['phase/outcome'] || 'completed';
       var toastType = outcome === 'success' ? 'success' : 'warning';
-      showToast('Phase completed: ' + (event['workflow/phase'] || 'unknown'), toastType);
+      var completedPhase = event['workflow/phase'] || window.miniforge.t('value/unknown');
+      showToast(window.miniforge.t('toast/phase-completed', { phase: completedPhase }), toastType);
       break;
     }
 
     case 'workflow/completed':
-      showToast('Workflow completed', 'success');
+      showToast(window.miniforge.t('toast/workflow-completed'), 'success');
       break;
 
-    case 'workflow/failed':
-      showToast('Workflow failed: ' + (event['workflow/failure-reason'] || 'unknown error'), 'error', 8000);
+    case 'workflow/failed': {
+      var failureReason = event['workflow/failure-reason'] || window.miniforge.t('value/unknown-error');
+      showToast(window.miniforge.t('toast/workflow-failed', { reason: failureReason }), 'error', 8000);
       break;
+    }
 
     case 'agent/started':
     case 'agent/completed':

--- a/components/web-dashboard/resources/public/js/filters/ui.js
+++ b/components/web-dashboard/resources/public/js/filters/ui.js
@@ -75,14 +75,21 @@
     };
 
     if (typeof value === 'boolean') {
-      return `${id}: ${value ? 'Yes' : 'No'}`;
+      const yesNo = window.miniforge.t(value ? 'value/yes' : 'value/no');
+      return window.miniforge.t('filter/chip-label-value', { field: id, value: yesNo });
     }
 
     if (Array.isArray(value)) {
-      return `${id}: ${value.map(normalizeDisplay).join(', ')}`;
+      return window.miniforge.t('filter/chip-label-value', {
+        field: id,
+        value: value.map(normalizeDisplay).join(', ')
+      });
     }
 
-    return `${id}: ${normalizeDisplay(value)}`;
+    return window.miniforge.t('filter/chip-label-value', {
+      field: id,
+      value: normalizeDisplay(value)
+    });
   }
 
   function createFilterChip(clause, scope) {
@@ -114,25 +121,25 @@
 
     if (scope === 'local') {
       const pinBtn = document.createElement('button');
-      pinBtn.textContent = '📌 Pin to Global';
+      pinBtn.textContent = window.miniforge.t('filter/menu-pin-global');
       pinBtn.addEventListener('click', () => window.miniforge.filters.promoteToGlobal(filterId));
       items.appendChild(pinBtn);
     }
 
     if (scope === 'global') {
       const makeLocalBtn = document.createElement('button');
-      makeLocalBtn.textContent = '📍 Make Pane-Local';
+      makeLocalBtn.textContent = window.miniforge.t('filter/menu-make-local');
       makeLocalBtn.addEventListener('click', () => window.miniforge.filters.demoteToLocal(filterId));
       items.appendChild(makeLocalBtn);
     }
 
     const copyBtn = document.createElement('button');
-    copyBtn.textContent = '📋 Copy to Pane';
+    copyBtn.textContent = window.miniforge.t('filter/menu-copy');
     copyBtn.addEventListener('click', () => window.miniforge.filters.showCopyMenu(filterId));
     items.appendChild(copyBtn);
 
     const removeMenuBtn = document.createElement('button');
-    removeMenuBtn.textContent = '🗑️ Remove';
+    removeMenuBtn.textContent = window.miniforge.t('filter/menu-remove');
     removeMenuBtn.addEventListener('click', () => window.miniforge.filters.removeFilter(filterId, scope, filterValue));
     items.appendChild(removeMenuBtn);
 
@@ -142,8 +149,10 @@
     const removeBtn = document.createElement('button');
     removeBtn.className = 'filter-remove';
     removeBtn.textContent = '×';
-    removeBtn.title = 'Remove filter';
-    removeBtn.onclick = () => runtime.callApi('removeFilter', clause['filter/id'], scope, clause.value);
+    const removeLabel = window.miniforge.t('filter/remove-title');
+    removeBtn.title = removeLabel;
+    removeBtn.setAttribute('aria-label', removeLabel);
+    removeBtn.addEventListener('click', () => runtime.callApi('removeFilter', clause['filter/id'], scope, clause.value));
 
     chip.appendChild(label);
     chip.appendChild(menu);
@@ -177,10 +186,8 @@
   function showCopyMenu(filterId) {
     const panes = runtime.DEFAULT_PANES.filter((pane) => pane !== runtime.currentPane);
 
-    const menu = prompt(
-      'Copy to which pane?\n' + panes.map((pane, idx) => `${idx + 1}. ${pane}`).join('\n'),
-      '1'
-    );
+    const options = panes.map((pane, idx) => `${idx + 1}. ${pane}`).join('\n');
+    const menu = prompt(window.miniforge.t('prompt/copy-which-pane', { options }), '1');
 
     if (!menu) {
       return;
@@ -189,7 +196,7 @@
     const idx = parseInt(menu, 10) - 1;
     if (idx >= 0 && idx < panes.length) {
       runtime.callApi('copyToPane', filterId, panes[idx]);
-      alert(`Filter copied to ${panes[idx]}`);
+      alert(window.miniforge.t('filter/copied-to-pane', { pane: panes[idx] }));
     }
   }
 

--- a/components/web-dashboard/resources/public/js/i18n.js
+++ b/components/web-dashboard/resources/public/js/i18n.js
@@ -1,0 +1,41 @@
+/* Miniforge Web Dashboard — browser-side message translator.
+ *
+ * Mirrors ai.miniforge.messages.core/t:
+ *   - Look up `key` (e.g. "ws/status-connected") in window.MINIFORGE_MESSAGES.
+ *   - Substitute {param-name} tokens from the optional params object.
+ *   - Fall back to the key name itself when missing, so untranslated keys
+ *     surface visibly rather than rendering empty.
+ *
+ * The catalog is hydrated inline in page-head before this script loads;
+ * see ai.miniforge.web-dashboard.views/messages-hydration-script.
+ */
+
+(function (global) {
+  const PLACEHOLDER = /\{([^{}]+)\}/g;
+
+  function lookupTemplate(key) {
+    const catalog = global.MINIFORGE_MESSAGES;
+    if (catalog && Object.prototype.hasOwnProperty.call(catalog, key)) {
+      return catalog[key];
+    }
+    return key;
+  }
+
+  function substitute(template, params) {
+    if (typeof template !== 'string' || !params) {
+      return template;
+    }
+    return template.replace(PLACEHOLDER, function (match, name) {
+      return Object.prototype.hasOwnProperty.call(params, name)
+        ? String(params[name])
+        : match;
+    });
+  }
+
+  function t(key, params) {
+    return substitute(lookupTemplate(key), params);
+  }
+
+  global.miniforge = global.miniforge || {};
+  global.miniforge.t = t;
+})(window);

--- a/components/web-dashboard/resources/public/js/i18n.js
+++ b/components/web-dashboard/resources/public/js/i18n.js
@@ -21,13 +21,19 @@
     return key;
   }
 
+  function stringify(value) {
+    // Mirror Clojure's (str nil) → "" so missing params don't render as
+    // the literal "null" / "undefined".
+    return value == null ? '' : String(value);
+  }
+
   function substitute(template, params) {
     if (typeof template !== 'string' || !params) {
       return template;
     }
     return template.replace(PLACEHOLDER, function (match, name) {
       return Object.prototype.hasOwnProperty.call(params, name)
-        ? String(params[name])
+        ? stringify(params[name])
         : match;
     });
   }

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/messages.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/messages.clj
@@ -17,18 +17,14 @@
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def ^:private catalog-path
-  "config/web-dashboard/messages/en-US.edn")
-
-(def ^:private catalog-section
-  :web-dashboard/messages)
-
 (def ^:private catalog
-  (messages/load-catalog catalog-path catalog-section))
+  (messages/load-catalog "config/web-dashboard/messages/en-US.edn"
+                         :web-dashboard/messages))
 
-(def t
+(defn t
   "Look up a web-dashboard message by key, with optional param substitution."
-  (messages/create-translator catalog-path catalog-section))
+  ([k] (messages/t catalog k))
+  ([k params] (messages/t catalog k params)))
 
 (defn all-as-json-map
   "Return the full catalog with keyword keys flattened to ns/name strings,

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/messages.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/messages.clj
@@ -17,7 +17,24 @@
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
+(def ^:private catalog-path
+  "config/web-dashboard/messages/en-US.edn")
+
+(def ^:private catalog-section
+  :web-dashboard/messages)
+
+(def ^:private catalog
+  (messages/load-catalog catalog-path catalog-section))
+
 (def t
   "Look up a web-dashboard message by key, with optional param substitution."
-  (messages/create-translator "config/web-dashboard/messages/en-US.edn"
-                              :web-dashboard/messages))
+  (messages/create-translator catalog-path catalog-section))
+
+(defn all-as-json-map
+  "Return the full catalog with keyword keys flattened to ns/name strings,
+   suitable for direct JSON serialization into window.MINIFORGE_MESSAGES."
+  []
+  (into {}
+        (map (fn [[k v]]
+               [(subs (str k) 1) v]))
+        (messages/all catalog)))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/views.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/views.clj
@@ -18,7 +18,10 @@
    Tableau-inspired dense visualization with terminal aesthetic.
    No build step required - pure server-side rendering."
   (:require
+   [cheshire.core :as json]
+   [clojure.string :as str]
    [hiccup.page :as page]
+   [hiccup.util :as hutil]
    [ai.miniforge.web-dashboard.messages :as messages]
    [ai.miniforge.web-dashboard.views.dashboard :as dashboard]
    [ai.miniforge.web-dashboard.views.fleet :as fleet]
@@ -40,6 +43,9 @@
 (def ^:private htmx-ws-script-path
   "/js/htmx-ws.js")
 
+(def ^:private i18n-script-path
+  "/js/i18n.js")
+
 (def ^:private app-script-path
   "/js/app.js")
 
@@ -50,6 +56,19 @@
    "/js/filters/apply.js"
    "/js/filters/ui.js"
    "/js/filters/init.js"])
+
+(defn- messages-hydration-script
+  "Serialize the loaded message catalog into an inline <script> block so
+   the browser-side translator has the same strings the server uses.
+
+   Locale today is en-US only. When a second locale lands, this is the
+   place to negotiate Accept-Language → catalog → emit."
+  []
+  (let [payload (json/generate-string (messages/all-as-json-map))
+        ;; Standard JSON-in-HTML escape: prevent the JSON from terminating
+        ;; the <script> early if a string value ever contains `</`.
+        safe (str/replace payload "</" "<\\/")]
+    [:script (hutil/raw-string (str "window.MINIFORGE_MESSAGES = " safe ";"))]))
 
 (def ^:private sidebar-nav-items
   [{:pane :dashboard     :href "/"              :label-key :layout/nav-dashboard}
@@ -77,6 +96,8 @@
    [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
    [:title (messages/t :layout/page-title {:title title})]
    [:link {:rel "stylesheet" :href stylesheet-path}]
+   (messages-hydration-script)
+   [:script {:src i18n-script-path}]
    [:script {:src htmx-script-path}]
    [:script {:src htmx-ws-script-path}]])
 


### PR DESCRIPTION
## Summary

Server side had a mature translator (`messages/t` + `en-US.edn`). JS layer had none — every toast body, prompt, status label, button title was hardcoded English. Now flows through the same catalog the views use.

## Mechanism

- [`messages-hydration-script`](components/web-dashboard/src/ai/miniforge/web_dashboard/views.clj) in `views/page-head` serializes the loaded catalog to JSON and inlines it as `<script>window.MINIFORGE_MESSAGES = {...}</script>`. JSON-in-script `</` → `<\/` escape applied so a future value containing `</script>` cannot terminate the block early.
- [`i18n.js`](components/web-dashboard/resources/public/js/i18n.js) loads next, defines `window.miniforge.t(key, params)` — catalog lookup + `{placeholder}` substitution + key-name fallback on miss. Semantics mirror `ai.miniforge.messages.core/t` exactly. Unit test added on the Clojure side (`messages/all`).

## Catalog growth

105 → 144 keys ([`en-US.edn`](components/web-dashboard/resources/config/web-dashboard/messages/en-US.edn)). New namespaces:

- `:ws/...` — WebSocket status labels.
- `:toast/...` — Notification bodies including parameterised `command-sent` / `workflow-started` / `sync-done` etc.
- `:fleet/...` — Error fallbacks when `/api/fleet/*` responses omit `:error`/`:message`.
- `:prompt/...` — Browser `prompt()` inputs.
- `:filter/...` — Chip labels, menu items, copy-to-pane confirmation.
- `:value/...` — Shared `yes` / `no` / `unknown` / `unknown-error`.

## Folded follow-up

[`filters/ui.js`](components/web-dashboard/resources/public/js/filters/ui.js) carried the same class of JS-004/JS-008 violation as the pre-#1040 `addFilterChip` — multi-line `innerHTML` + inline `onclick=`. Rebuilt via `createElement` + `addEventListener` + catalog-driven `textContent`. Residual `removeBtn.onclick = ...` in that file likewise migrated to `addEventListener`.

## Locale today

en-US only. Catalog file naming already supports `fr-FR.edn` etc.; second locale would add Accept-Language negotiation in `messages-hydration-script`. Not threaded yet — page `layout`/handlers take no request map. Follow-up when a second locale lands.

## Out of scope

Other JS files under `components/web-dashboard/resources/public/js/filters/` (`runtime.js`, `state.js`, `persistence.js`, `apply.js`, `init.js`) inventoried; no user-visible English strings outside `ui.js` + `app.js`. Vendor `htmx.min.js` untouched.

## Standards pass (per `feedback_standards_review_per_pr.md`)

- `miniforge-standards/languages/javascript.mdc` — JS-004 + JS-008 cleared in `filters/ui.js` (the second site flagged during #1040 review). JS-002 unaffected — `window.miniforge` already the documented namespace; `i18n.js` extends it via existence-check guard.
- `miniforge-standards/foundations/code-quality.mdc` — DRY via extracted `toastError` helper in `app.js`; new `messages/all` removes per-component re-implementations of bulk catalog access.

## Commit-budget note

225 reportable lines, over the 200-line soft cap. Override applied: this is a cross-layer feature where every slice would ship broken intermediate state (`i18n.js` defines `window.miniforge.t`; migrated `app.js`/`ui.js` call it; hydration populates the catalog — all three required at runtime). Catalog file already excluded from the count.

## Test plan

- [x] `node -c` exits 0 on `i18n.js`, `app.js`, `filters/ui.js`.
- [x] `bb poly:check` clean.
- [x] Pre-commit smoke (302 tests / 1114 assertions, 0 failures) passed.
- [x] EDN catalog parses; 144 keys; new keys (`:ws/status-connected`, `:filter/menu-remove`, `:toast/repo-added`, `:prompt/copy-which-pane`) resolve.
- [ ] Manual smoke: page loads, `window.MINIFORGE_MESSAGES` populated, `window.miniforge.t(":ws/status-connected")` returns `Connected`.
- [ ] Manual smoke: add a chip, click ×, status indicator transitions — all strings render from catalog.
- [ ] Manual smoke: unknown key returns the key string (no empty render).

Discovery: [#1040](https://github.com/miniforge-ai/miniforge/pull/1040) review feedback on hardcoded JS strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)