### PR TITLE
feat(llm): network-drop monitor + stream-exec-fn integration (PR-B of network-resilience stack)

### DIFF
--- a/components/llm/src/ai/miniforge/llm/network_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/network_monitor.clj
@@ -1,0 +1,151 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.llm.network-monitor
+  "Network-drop scheduler for the per-LLM-call lifecycle.
+
+   PR-B of the network-resilience stack — builds on
+   `ai.miniforge.llm.network-health/network-healthy?` (PR-A):
+   - Spawns a daemon that probes the provider every N seconds while an
+     LLM call is in flight.
+   - Counts consecutive failures so a transient blip (1 dropped probe)
+     does not cost a phase restart.
+   - On `failure-threshold` consecutive failures, fires `:on-drop`
+     ONCE and exits (the scheduler is single-fire; PR-C handles
+     post-drop recovery + retry).
+
+   Mirrors the lifecycle pattern of `progress-monitor/start-keepalive!`:
+   `(start-network-monitor! ...)` returns a zero-arity stop-fn the
+   caller invokes from `finally` to interrupt the worker and wait for
+   it to exit."
+  (:require [ai.miniforge.llm.network-health :as nh]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+;;
+;; Operationally tuned constants — kept as named `def`s here (vs an EDN
+;; file) per standards rule 007: callers override via the
+;; `start-network-monitor!` options map and the values change very
+;; rarely.
+
+(def ^:const default-probe-interval-ms
+  "Time between probe attempts. 10s — fast enough to detect a drop
+   within ~30s (probe interval × failure threshold), slow enough that
+   the probe traffic itself does not contribute meaningful load."
+  10000)
+
+(def ^:const default-failure-threshold
+  "Number of CONSECUTIVE probe failures required to declare a
+   confirmed network drop. 3 strikes (= ~30s of dead network at the
+   default 10s interval) absorbs transient blips — a single failed
+   probe never costs a phase restart."
+  3)
+
+(def ^:const monitor-stop-join-ms
+  "How long stop! waits for the worker thread to exit after
+   interrupting it. The worker only needs to wake from Thread/sleep,
+   see the running? flag, and exit."
+  200)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Scheduler
+
+(defn- run-monitor-loop!
+  "Inner worker loop. Polls `network-healthy?` every `probe-interval-ms`;
+   tracks consecutive failures. On `failure-threshold` consecutive
+   failures, calls `on-drop` with diagnostic data and exits the loop
+   (single-fire). On a healthy probe, resets the counter — a brief blip
+   does not push the workflow toward a network-drop verdict."
+  [{:keys [running? backend-key probe-interval-ms failure-threshold
+           probe-fn on-drop]}]
+  (loop [consecutive-failures 0]
+    (when @running?
+      (Thread/sleep ^long probe-interval-ms)
+      (when @running?
+        (let [healthy? (try (probe-fn backend-key)
+                            (catch Exception _ false))
+              next-failures (if healthy? 0 (inc consecutive-failures))]
+          (cond
+            (>= next-failures failure-threshold)
+            (when @running?
+              (on-drop {:backend-key          backend-key
+                        :consecutive-failures next-failures
+                        :failure-threshold    failure-threshold
+                        :probe-interval-ms    probe-interval-ms}))
+
+            :else
+            (recur next-failures)))))))
+
+(defn start-network-monitor!
+  "Spawn a daemon thread that probes `backend-key`'s upstream every
+   `:probe-interval-ms` ms and fires `:on-drop` after
+   `:failure-threshold` consecutive failures (single-fire).
+
+   ## Options
+
+   - `:backend-key`         — the `:llm/backend` keyword (required).
+   - `:probe-interval-ms`   — defaults to `default-probe-interval-ms`.
+   - `:failure-threshold`   — defaults to `default-failure-threshold`.
+                              Must be a positive integer.
+   - `:on-drop`             — `(fn [diagnostic-map])` called once when
+                              the threshold trips. The map carries
+                              `:backend-key`, `:consecutive-failures`,
+                              `:failure-threshold`, `:probe-interval-ms`.
+   - `:probe-fn`            — override for tests; defaults to
+                              `network-health/network-healthy?`. Must
+                              accept `(fn [backend-key])` and return
+                              truthy/falsey.
+
+   ## Returns
+
+   A zero-arity stop-fn. Calling it interrupts the worker thread and
+   waits up to `monitor-stop-join-ms` for it to exit, so callers can
+   rely on no further `:on-drop` calls landing once stop! returns."
+  [{:keys [backend-key probe-interval-ms failure-threshold on-drop probe-fn]
+    :or   {probe-interval-ms default-probe-interval-ms
+           failure-threshold default-failure-threshold
+           probe-fn          nh/network-healthy?}}]
+  (assert (some? backend-key)
+          "start-network-monitor! requires a :backend-key")
+  (assert (and (integer? probe-interval-ms) (pos? probe-interval-ms))
+          "probe-interval-ms must be a positive integer")
+  (assert (and (integer? failure-threshold) (pos? failure-threshold))
+          "failure-threshold must be a positive integer")
+  (assert (ifn? on-drop)
+          "on-drop must be a function")
+  (let [running? (atom true)
+        thread   (Thread.
+                   (fn []
+                     (try
+                       (run-monitor-loop!
+                         {:running?          running?
+                          :backend-key       backend-key
+                          :probe-interval-ms probe-interval-ms
+                          :failure-threshold failure-threshold
+                          :probe-fn          probe-fn
+                          :on-drop           on-drop})
+                       (catch InterruptedException _
+                         ;; stop! interrupted us mid-sleep; exit cleanly.
+                         nil)))
+                   "llm-network-monitor")]
+    (.setDaemon thread true)
+    (.start thread)
+    (fn stop! []
+      (reset! running? false)
+      (.interrupt thread)
+      (.join thread monitor-stop-join-ms))))

--- a/components/llm/src/ai/miniforge/llm/network_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/network_monitor.clj
@@ -66,24 +66,33 @@
 ;; Scheduler
 
 (defn- run-monitor-loop!
-  "Inner worker loop. Polls `network-healthy?` every `probe-interval-ms`;
+  "Inner worker loop. Polls `probe-fn` every `probe-interval-ms`;
    tracks consecutive failures. On `failure-threshold` consecutive
-   failures, calls `on-drop` with diagnostic data and exits the loop
-   (single-fire). On a healthy probe, resets the counter — a brief blip
+   failures, atomically claims the firing slot via `compare-and-set!`
+   on the shared `running?` atom, calls `on-drop`, and exits.
+
+   The CAS is the single-fire latch — `stop!` and the worker race for
+   the false→true (wait, true→false) transition; whichever wins gets
+   to do its job. A healthy probe resets the counter so a brief blip
    does not push the workflow toward a network-drop verdict."
-  [{:keys [running? backend-key probe-interval-ms failure-threshold
+  [{:keys [running? probe-url backend-key probe-interval-ms failure-threshold
            probe-fn on-drop]}]
   (loop [consecutive-failures 0]
     (when @running?
       (Thread/sleep ^long probe-interval-ms)
       (when @running?
-        (let [healthy? (try (probe-fn backend-key)
+        (let [healthy? (try (probe-fn probe-url)
                             (catch Exception _ false))
               next-failures (if healthy? 0 (inc consecutive-failures))]
           (cond
             (>= next-failures failure-threshold)
-            (when @running?
+            ;; CAS the running? atom from true → false. If we win, no
+            ;; concurrent stop! call has run yet (or we beat it), so
+            ;; fire on-drop. If we lose, stop! already flipped to
+            ;; false and the worker exits silently.
+            (when (compare-and-set! running? true false)
               (on-drop {:backend-key          backend-key
+                        :probe-url            probe-url
                         :consecutive-failures next-failures
                         :failure-threshold    failure-threshold
                         :probe-interval-ms    probe-interval-ms}))
@@ -92,36 +101,51 @@
             (recur next-failures)))))))
 
 (defn start-network-monitor!
-  "Spawn a daemon thread that probes `backend-key`'s upstream every
+  "Spawn a daemon thread that probes `:probe-url` every
    `:probe-interval-ms` ms and fires `:on-drop` after
    `:failure-threshold` consecutive failures (single-fire).
 
    ## Options
 
-   - `:backend-key`         — the `:llm/backend` keyword (required).
+   - `:probe-url`           — the upstream URL to HEAD (required).
+                              Callers typically resolve via
+                              `llm-client/probe-endpoint-for`.
+   - `:backend-key`         — diagnostic only; included in the
+                              `:on-drop` payload so downstream
+                              consumers know which backend went away.
    - `:probe-interval-ms`   — defaults to `default-probe-interval-ms`.
    - `:failure-threshold`   — defaults to `default-failure-threshold`.
                               Must be a positive integer.
-   - `:on-drop`             — `(fn [diagnostic-map])` called once when
-                              the threshold trips. The map carries
-                              `:backend-key`, `:consecutive-failures`,
-                              `:failure-threshold`, `:probe-interval-ms`.
+   - `:on-drop`             — `(fn [diagnostic-map])` called at most
+                              once when the threshold trips. The map
+                              carries `:backend-key`, `:probe-url`,
+                              `:consecutive-failures`,
+                              `:failure-threshold`,
+                              `:probe-interval-ms`.
    - `:probe-fn`            — override for tests; defaults to
                               `network-health/network-healthy?`. Must
-                              accept `(fn [backend-key])` and return
+                              accept `(fn [probe-url])` and return
                               truthy/falsey.
 
    ## Returns
 
-   A zero-arity stop-fn. Calling it interrupts the worker thread and
-   waits up to `monitor-stop-join-ms` for it to exit, so callers can
-   rely on no further `:on-drop` calls landing once stop! returns."
-  [{:keys [backend-key probe-interval-ms failure-threshold on-drop probe-fn]
+   A zero-arity stop-fn. Calling it flips the shared `running?` atom
+   to false, interrupts the worker thread, and waits up to
+   `monitor-stop-join-ms` for it to exit. Because firing `on-drop`
+   uses a `compare-and-set!` on the same atom, `stop!` and the
+   worker race for the single transition — `stop!` wins → no
+   `on-drop` ever fires; worker wins → `on-drop` runs once and the
+   worker exits. After `stop!` returns, any in-flight `on-drop` call
+   that already won the CAS may still be executing (the bounded join
+   does not wait for it to return); callers should make `on-drop`
+   idempotent or otherwise tolerate the trailing call. Matches the
+   semantics of `progress-monitor/start-keepalive!`."
+  [{:keys [probe-url backend-key probe-interval-ms failure-threshold on-drop probe-fn]
     :or   {probe-interval-ms default-probe-interval-ms
            failure-threshold default-failure-threshold
            probe-fn          nh/network-healthy?}}]
-  (assert (some? backend-key)
-          "start-network-monitor! requires a :backend-key")
+  (assert (and (string? probe-url) (seq probe-url))
+          "start-network-monitor! requires a non-blank :probe-url string")
   (assert (and (integer? probe-interval-ms) (pos? probe-interval-ms))
           "probe-interval-ms must be a positive integer")
   (assert (and (integer? failure-threshold) (pos? failure-threshold))
@@ -134,6 +158,7 @@
                      (try
                        (run-monitor-loop!
                          {:running?          running?
+                          :probe-url         probe-url
                           :backend-key       backend-key
                           :probe-interval-ms probe-interval-ms
                           :failure-threshold failure-threshold

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.cost :as cost]
    [ai.miniforge.llm.messages :as msg]
+   [ai.miniforge.llm.network-monitor :as nnm]
    [ai.miniforge.llm.progress-monitor :as pm]
    [ai.miniforge.response.interface :as response]
    [slingshot.slingshot :refer [throw+ try+]])
@@ -1204,10 +1205,45 @@
         ceiling    (max 1 (dec stagnation))]
     (min ceiling (max keepalive-min-interval-ms target))))
 
+(defn- network-drop-timeout
+  "Shape the network-monitor's `:on-drop` diagnostic into the same
+   `{:type :message :elapsed-ms ...}` envelope `pm/check-timeout`
+   returns, so the existing `timeout-result` path handles it
+   identically. The PR-C auto-resumer keys on `:type :network-drop` to
+   know it should resume from the last persisted checkpoint."
+  [{:keys [backend-key consecutive-failures failure-threshold probe-interval-ms]
+    :as   diag}]
+  {:type           :network-drop
+   :backend-key    backend-key
+   :elapsed-ms     (* consecutive-failures probe-interval-ms)
+   :message        (format "Network drop: %d consecutive probes failed for %s"
+                           consecutive-failures (name backend-key))
+   :stats          (select-keys diag
+                                [:consecutive-failures :failure-threshold
+                                 :probe-interval-ms])})
+
 (defn stream-exec-fn
+  "Run `cmd` as a streaming subprocess, dispatching each output line to
+   `on-line`.
+
+   Options:
+   - `:progress-monitor`  — caller-supplied progress monitor; defaults
+                            to a fresh `default-progress-monitor`.
+   - `:workdir`, `:stdin` — passed through to `start-stream-process!`.
+   - `:backend-key`       — when set, starts the network-drop monitor
+                            against the corresponding provider endpoint
+                            (PR-B). Disabled when omitted so legacy
+                            callers / synthetic-stream tests are
+                            unaffected.
+   - `:network-monitor-opts` — overrides for `start-network-monitor!`
+                               (probe-interval-ms, failure-threshold,
+                               probe-fn). Tests inject `:probe-fn` here
+                               to drive the monitor deterministically
+                               without real network I/O."
   ([cmd on-line]
    (stream-exec-fn cmd on-line {}))
-  ([cmd on-line {:keys [progress-monitor workdir stdin]}]
+  ([cmd on-line {:keys [progress-monitor workdir stdin backend-key
+                        network-monitor-opts]}]
    (let [monitor (or progress-monitor (default-progress-monitor))
          stream-process (start-stream-process! cmd {:workdir workdir
                                                     :stdin stdin})
@@ -1225,21 +1261,58 @@
          ;; reader is alive; max-total-ms remains the wedge backstop.
          stop-keepalive! (pm/start-keepalive! monitor
                                               (keepalive-interval-ms monitor))
+         ;; Network-drop monitor — independent of the keepalive. PR-B
+         ;; of the network-resilience stack. Probes the provider every
+         ;; `default-probe-interval-ms` (10s) and fires once after
+         ;; `default-failure-threshold` (3) consecutive failures.
+         ;; on-drop: stamps the network-drop reason into the shared
+         ;; atom and forcibly destroys the subprocess so the reader
+         ;; loop exits immediately (the agent is hung on socket I/O
+         ;; that will never recover without process restart).
+         ;; Disabled when no :backend-key is provided so legacy
+         ;; callers (tests with synthetic streams, the `:echo` test
+         ;; backend) keep working unchanged.
+         network-drop-reason (atom nil)
+         stop-network-monitor!
+         (when backend-key
+           (nnm/start-network-monitor!
+             (merge {:backend-key backend-key
+                     :on-drop     (fn [diag]
+                                    (compare-and-set! network-drop-reason nil
+                                                      (network-drop-timeout diag))
+                                    ;; Kill the subprocess so the
+                                    ;; consumer's reader sees EOF and
+                                    ;; the loop exits.
+                                    ;; .destroyForcibly is the same
+                                    ;; call stop-stream-process! makes;
+                                    ;; safe to double-tap.
+                                    (try (.destroyForcibly process)
+                                         (catch Exception _ nil)))}
+                    network-monitor-opts)))
          {:keys [lines timeout]}
          (try
            (process-stream-lines out-reader monitor on-line)
            (finally
-             (stop-keepalive!)))
+             (stop-keepalive!)
+             (when stop-network-monitor! (stop-network-monitor!))))
+         ;; A network-drop signal (if any) supersedes whatever
+         ;; pm/check-timeout returned — the subprocess was killed by
+         ;; the network monitor, so `process-stream-lines` likely
+         ;; observed a stream-idle as a knock-on effect. Surface the
+         ;; root cause for the workflow / PR-C auto-resumer.
+         effective-timeout (or @network-drop-reason timeout)
          ;; Stream ended with a timeout reason (stream-idle,
-         ;; stagnation, or total-max) — the subprocess is hung or
-         ;; silent. Kill it so `deref` returns immediately instead of
-         ;; waiting 10 min for a process that will not exit.
-         join-timeout (if timeout (post-kill-join-timeout-ms) (process-join-timeout-ms))
+         ;; stagnation, total-max, or network-drop) — the subprocess
+         ;; is hung or silent. Kill it so `deref` returns immediately
+         ;; instead of waiting 10 min for a process that will not exit.
+         join-timeout (if effective-timeout
+                        (post-kill-join-timeout-ms)
+                        (process-join-timeout-ms))
          result (stop-stream-process! stream-process
-                                      (boolean timeout)
+                                      (boolean effective-timeout)
                                       join-timeout)]
-     (if timeout
-       (timeout-result lines timeout)
+     (if effective-timeout
+       (timeout-result lines effective-timeout)
        (success-result lines result)))))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1275,8 +1275,16 @@
          network-drop-reason (atom nil)
          stop-network-monitor!
          (when backend-key
+           ;; Caller opts merged FIRST so the integration-owned
+           ;; :backend-key, :probe-url, and :on-drop always win — a
+           ;; test fixture that mistakenly carries those keys can't
+           ;; clobber the monitor's correctness contract. Test-only
+           ;; knobs (:probe-interval-ms, :failure-threshold, :probe-fn)
+           ;; still flow through.
            (nnm/start-network-monitor!
-             (merge {:backend-key backend-key
+             (merge network-monitor-opts
+                    {:backend-key backend-key
+                     :probe-url   (probe-endpoint-for backend-key)
                      :on-drop     (fn [diag]
                                     (compare-and-set! network-drop-reason nil
                                                       (network-drop-timeout diag))
@@ -1287,8 +1295,7 @@
                                     ;; call stop-stream-process! makes;
                                     ;; safe to double-tap.
                                     (try (.destroyForcibly process)
-                                         (catch Exception _ nil)))}
-                    network-monitor-opts)))
+                                         (catch Exception _ nil)))})))
          {:keys [lines timeout]}
          (try
            (process-stream-lines out-reader monitor on-line)

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -1253,6 +1253,57 @@
       (is (= ["line1" "line2"] @seen)
           "subprocess saw stdin content split by line"))))
 
+(defn- fake-stream-process
+  "Stub for `#'impl/start-stream-process!`. Returns a map matching the
+   shape `stream-exec-fn` consumes, with a `Process` proxy whose
+   stdout is `input-stream`. `.destroyForcibly` closes the supplied
+   `on-destroy!` closure (used for tests that need to release a
+   PipedInputStream so the consumer's reader sees EOF).
+
+   Cross-platform replacement for `[\"sleep\" \"30\"]` / `[\"echo\"
+   \"hello\"]` subprocesses (Copilot review on PR #1053). No real
+   subprocess starts; portable to Windows / minimal containers."
+  [^java.io.InputStream input-stream on-destroy!]
+  (let [destroyed? (atom false)
+        ;; `waitFor(long, TimeUnit)` is the overload `wait-for-stream-
+        ;; process` calls; the 0-arg `waitFor()` is declared for
+        ;; completeness but never reached on this code path.
+        process    (proxy [java.lang.Process] []
+                     (getInputStream  [] input-stream)
+                     (getOutputStream [] (java.io.ByteArrayOutputStream.))
+                     (getErrorStream  [] (java.io.ByteArrayInputStream. (byte-array 0)))
+                     (destroyForcibly []
+                       (reset! destroyed? true)
+                       (on-destroy!)
+                       this)
+                     (isAlive   [] (not @destroyed?))
+                     (waitFor
+                       ([] 0)
+                       ([_timeout _unit] true))
+                     (exitValue [] (if @destroyed? -1 0)))]
+    {:process       process
+     :stderr        (atom "")
+     :stdin-thread  nil
+     :stderr-thread nil}))
+
+(defn- fake-blocking-stream-process
+  "Variant of `fake-stream-process` whose stdout never produces a line
+   (PipedInputStream connected to a never-written PipedOutputStream).
+   `.destroyForcibly` closes the pipe so the reader unblocks with EOF."
+  []
+  (let [piped-out (java.io.PipedOutputStream.)
+        piped-in  (java.io.PipedInputStream. piped-out)]
+    (fake-stream-process piped-in
+                         (fn [] (try (.close piped-out) (catch Exception _))))))
+
+(defn- fake-eof-stream-process
+  "Variant of `fake-stream-process` whose stdout is immediately empty,
+   so `process-stream-lines` returns cleanly. Used by the no-monitor
+   test."
+  []
+  (fake-stream-process (java.io.ByteArrayInputStream. (byte-array 0))
+                       (fn [])))
+
 (deftest stream-exec-fn-network-drop-returns-network-drop-timeout-test
   ;; PR-B integration test: when the network-monitor's probe-fn reports
   ;; sustained failure, `stream-exec-fn` must (a) kill the subprocess
@@ -1260,55 +1311,60 @@
   ;; reason as the result's `:timeout` envelope. PR-C will key off the
   ;; `:type :network-drop` to schedule the auto-resume.
   (testing "sustained probe failure surfaces a :network-drop timeout result"
-    ;; Long-running subprocess that produces no output — without the
-    ;; network monitor, the consumer would wait until progress-monitor's
-    ;; stagnation cutoff (2-3min). With the monitor wired and a stub
-    ;; probe-fn returning false, the monitor fires within ~30ms (10ms
-    ;; interval × 3 strikes) and forces stream-exec-fn to return.
-    (let [handler (fn [_line] nil)
-          monitor (pm/create-progress-monitor {:min-activity-interval-ms 1
-                                               :stagnation-threshold-ms  120000
-                                               :max-total-ms             120000})
-          result  (impl/stream-exec-fn
-                    ["sleep" "30"]
-                    handler
-                    {:progress-monitor monitor
-                     :backend-key      :claude
-                     :network-monitor-opts
-                     {:probe-interval-ms 10
-                      :failure-threshold 3
-                      :probe-fn          (constantly false)}})
-          timeout (:timeout result)]
-      (is (some? timeout)
-          "result must carry a :timeout envelope when the monitor fires")
-      (is (= :network-drop (:type timeout)))
-      (is (= :claude (:backend-key timeout)))
-      (is (re-find #"Network drop" (:message timeout))
-          ":message identifies the drop class for downstream log readers"))))
+    ;; Stubbed subprocess (see `fake-blocking-stream-process`) — never
+    ;; produces output until the network monitor's `.destroyForcibly`
+    ;; closes the pipe. With a stub probe-fn returning false, the
+    ;; monitor fires within ~30ms (10ms interval × 3 strikes) and
+    ;; forces stream-exec-fn to return. No real subprocess; portable.
+    (with-redefs [impl/start-stream-process! (fn [_cmd _opts]
+                                               (fake-blocking-stream-process))]
+      (let [handler (fn [_line] nil)
+            monitor (pm/create-progress-monitor {:min-activity-interval-ms 1
+                                                 :stagnation-threshold-ms  120000
+                                                 :max-total-ms             120000})
+            result  (impl/stream-exec-fn
+                      ["unused-because-stubbed"]
+                      handler
+                      {:progress-monitor monitor
+                       :backend-key      :claude
+                       :network-monitor-opts
+                       {:probe-interval-ms 10
+                        :failure-threshold 3
+                        :probe-fn          (constantly false)}})
+            timeout (:timeout result)]
+        (is (some? timeout)
+            "result must carry a :timeout envelope when the monitor fires")
+        (is (= :network-drop (:type timeout)))
+        (is (= :claude (:backend-key timeout)))
+        (is (re-find #"Network drop" (:message timeout))
+            ":message identifies the drop class for downstream log readers")))))
 
 (deftest stream-exec-fn-omits-network-monitor-when-no-backend-key-test
   ;; Backwards compat: legacy callers (synthetic-stream tests, the
   ;; `:echo` test backend) supply no `:backend-key`. The network
   ;; monitor must stay dormant so they keep working unchanged.
   (testing "without :backend-key, no probe traffic is generated"
-    (let [probe-calls (atom 0)
-          handler (fn [_line] nil)
-          monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
-          result  (impl/stream-exec-fn
-                    ["echo" "hello"]
-                    handler
-                    {:progress-monitor monitor
-                     ;; No :backend-key. Even if the test caller mistakenly
-                     ;; supplies network-monitor-opts (e.g. via a stale
-                     ;; fixture), the monitor must not start.
-                     :network-monitor-opts
-                     {:probe-fn (fn [_backend-key]
-                                  (swap! probe-calls inc)
-                                  false)}})]
-      (is (zero? @probe-calls)
-          "probe-fn must not be called when :backend-key is absent")
-      (is (nil? (:timeout result))
-          "process completed without timeout"))))
+    (with-redefs [impl/start-stream-process! (fn [_cmd _opts]
+                                               (fake-eof-stream-process))]
+      (let [probe-calls (atom 0)
+            handler (fn [_line] nil)
+            monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+            result  (impl/stream-exec-fn
+                      ["unused-because-stubbed"]
+                      handler
+                      {:progress-monitor monitor
+                       ;; No :backend-key. Even if the test caller
+                       ;; mistakenly supplies network-monitor-opts (e.g.
+                       ;; via a stale fixture), the monitor must not
+                       ;; start.
+                       :network-monitor-opts
+                       {:probe-fn (fn [_probe-url]
+                                    (swap! probe-calls inc)
+                                    false)}})]
+        (is (zero? @probe-calls)
+            "probe-fn must not be called when :backend-key is absent")
+        (is (nil? (:timeout result))
+            "process completed without timeout")))))
 
 ;------------------------------------------------------------------------------ Layer 6
 ;; Rich tool-event chunks — :tool-call-id/:tool-input on tool_use,

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -1253,6 +1253,63 @@
       (is (= ["line1" "line2"] @seen)
           "subprocess saw stdin content split by line"))))
 
+(deftest stream-exec-fn-network-drop-returns-network-drop-timeout-test
+  ;; PR-B integration test: when the network-monitor's probe-fn reports
+  ;; sustained failure, `stream-exec-fn` must (a) kill the subprocess
+  ;; so the consumer loop unblocks and (b) surface the network-drop
+  ;; reason as the result's `:timeout` envelope. PR-C will key off the
+  ;; `:type :network-drop` to schedule the auto-resume.
+  (testing "sustained probe failure surfaces a :network-drop timeout result"
+    ;; Long-running subprocess that produces no output — without the
+    ;; network monitor, the consumer would wait until progress-monitor's
+    ;; stagnation cutoff (2-3min). With the monitor wired and a stub
+    ;; probe-fn returning false, the monitor fires within ~30ms (10ms
+    ;; interval × 3 strikes) and forces stream-exec-fn to return.
+    (let [handler (fn [_line] nil)
+          monitor (pm/create-progress-monitor {:min-activity-interval-ms 1
+                                               :stagnation-threshold-ms  120000
+                                               :max-total-ms             120000})
+          result  (impl/stream-exec-fn
+                    ["sleep" "30"]
+                    handler
+                    {:progress-monitor monitor
+                     :backend-key      :claude
+                     :network-monitor-opts
+                     {:probe-interval-ms 10
+                      :failure-threshold 3
+                      :probe-fn          (constantly false)}})
+          timeout (:timeout result)]
+      (is (some? timeout)
+          "result must carry a :timeout envelope when the monitor fires")
+      (is (= :network-drop (:type timeout)))
+      (is (= :claude (:backend-key timeout)))
+      (is (re-find #"Network drop" (:message timeout))
+          ":message identifies the drop class for downstream log readers"))))
+
+(deftest stream-exec-fn-omits-network-monitor-when-no-backend-key-test
+  ;; Backwards compat: legacy callers (synthetic-stream tests, the
+  ;; `:echo` test backend) supply no `:backend-key`. The network
+  ;; monitor must stay dormant so they keep working unchanged.
+  (testing "without :backend-key, no probe traffic is generated"
+    (let [probe-calls (atom 0)
+          handler (fn [_line] nil)
+          monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+          result  (impl/stream-exec-fn
+                    ["echo" "hello"]
+                    handler
+                    {:progress-monitor monitor
+                     ;; No :backend-key. Even if the test caller mistakenly
+                     ;; supplies network-monitor-opts (e.g. via a stale
+                     ;; fixture), the monitor must not start.
+                     :network-monitor-opts
+                     {:probe-fn (fn [_backend-key]
+                                  (swap! probe-calls inc)
+                                  false)}})]
+      (is (zero? @probe-calls)
+          "probe-fn must not be called when :backend-key is absent")
+      (is (nil? (:timeout result))
+          "process completed without timeout"))))
+
 ;------------------------------------------------------------------------------ Layer 6
 ;; Rich tool-event chunks — :tool-call-id/:tool-input on tool_use,
 ;; :tool-result chunks from tool_result content blocks

--- a/components/llm/test/ai/miniforge/llm/network_monitor_test.clj
+++ b/components/llm/test/ai/miniforge/llm/network_monitor_test.clj
@@ -1,0 +1,259 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.llm.network-monitor-test
+  "Tests for `ai.miniforge.llm.network-monitor` — the consecutive-
+   failure scheduler that turns the probe primitive into a single-fire
+   network-drop signal."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.llm.network-monitor :as nm]))
+
+;------------------------------------------------------------------------------ Factories + helpers
+
+(defn- scripted-probe
+  "Build a probe-fn that returns the next value from `script` on each
+   call. `script` is a vector of `:up` / `:down` keywords (or true /
+   false). Once the script runs out, further calls return the last
+   value indefinitely — convenient for tests that need 'steady state'
+   after the interesting transitions."
+  [script]
+  (let [idx (atom 0)
+        coerce {:up true :down false true true false false}]
+    (fn [_backend-key]
+      (let [i @idx
+            v (get script i (last script))]
+        (swap! idx inc)
+        (get coerce v v)))))
+
+(defn- record-call
+  "Build an on-drop callback that swap!'s its diagnostic-map into
+   `record-atom` under :calls (vec) and signals the latch."
+  [record-atom latch]
+  (fn [diag]
+    (swap! record-atom update :calls (fnil conj []) diag)
+    (when latch (deliver latch :fired))))
+
+;; Short interval / low threshold so the suite stays fast — the
+;; production defaults are 10s/3 strikes (~30s to fire); tests use ms-
+;; level intervals for the same logical exercise.
+(def ^:private fast-probe-interval-ms 10)
+(def ^:private fast-failure-threshold 3)
+
+(defn- wait-for-fire-or-timeout
+  "Block up to `timeout-ms` for the on-drop callback to fire (the
+   `latch` promise to be delivered). Returns the delivered value, or
+   `::timeout` if the latch never fires."
+  [latch timeout-ms]
+  (deref latch timeout-ms ::timeout))
+
+;------------------------------------------------------------------------------ Healthy path
+
+(deftest steady-healthy-stream-never-fires-test
+  (testing "every probe returns :up → on-drop never called"
+    (let [record (atom {:calls []})
+          stop!  (nm/start-network-monitor!
+                   {:backend-key       :claude
+                    :probe-interval-ms fast-probe-interval-ms
+                    :failure-threshold fast-failure-threshold
+                    :probe-fn          (scripted-probe [:up :up :up :up :up :up])
+                    :on-drop           (record-call record nil)})]
+      (try
+        ;; Let the scheduler run through several probe cycles.
+        (Thread/sleep (* fast-probe-interval-ms 10))
+        (is (empty? (:calls @record))
+            "healthy stream must not synthesize a network drop")
+        (finally
+          (stop!))))))
+
+;------------------------------------------------------------------------------ Transient blip
+
+(deftest transient-blip-resets-counter-test
+  (testing "an isolated failure followed by a recovery does not fire on-drop"
+    (let [record (atom {:calls []})
+          ;; failure-threshold 3; sequence is down, up, down, down, up, up...
+          ;; The first down increments to 1. The up resets to 0. Each
+          ;; subsequent down increments anew; never reaches 3.
+          stop! (nm/start-network-monitor!
+                  {:backend-key       :claude
+                   :probe-interval-ms fast-probe-interval-ms
+                   :failure-threshold fast-failure-threshold
+                   :probe-fn          (scripted-probe
+                                        [:down :up :down :down :up :up :up])
+                   :on-drop           (record-call record nil)})]
+      (try
+        (Thread/sleep (* fast-probe-interval-ms 12))
+        (is (empty? (:calls @record))
+            "a healthy probe between failures resets the counter; threshold not reached")
+        (finally
+          (stop!))))))
+
+;------------------------------------------------------------------------------ Confirmed drop
+
+(deftest three-consecutive-failures-fire-on-drop-once-test
+  (testing "exactly threshold consecutive failures fires on-drop once"
+    (let [record (atom {:calls []})
+          latch  (promise)
+          stop!  (nm/start-network-monitor!
+                   {:backend-key       :claude
+                    :probe-interval-ms fast-probe-interval-ms
+                    :failure-threshold fast-failure-threshold
+                    :probe-fn          (scripted-probe [:down :down :down
+                                                        :down :down :down :down])
+                    :on-drop           (record-call record latch)})]
+      (try
+        ;; Wait for fire; give it generous margin (10x the minimum)
+        (is (= :fired (wait-for-fire-or-timeout latch
+                                                (* fast-probe-interval-ms 50)))
+            "on-drop must fire after the threshold is reached")
+        ;; Stop! and give the worker time to (not) fire again.
+        (stop!)
+        (Thread/sleep (* fast-probe-interval-ms 5))
+        (is (= 1 (count (:calls @record)))
+            "single-fire: extra failed probes after the threshold do not
+             produce more on-drop calls")
+        (finally
+          (stop!))))))
+
+(deftest on-drop-diagnostic-shape-test
+  (testing "on-drop receives a diagnostic map with the canonical keys"
+    (let [record (atom {:calls []})
+          latch  (promise)
+          stop!  (nm/start-network-monitor!
+                   {:backend-key       :codex
+                    :probe-interval-ms fast-probe-interval-ms
+                    :failure-threshold fast-failure-threshold
+                    :probe-fn          (scripted-probe [:down :down :down])
+                    :on-drop           (record-call record latch)})]
+      (try
+        (wait-for-fire-or-timeout latch (* fast-probe-interval-ms 50))
+        (let [diag (first (:calls @record))]
+          (is (= :codex                  (:backend-key diag)))
+          (is (= fast-failure-threshold  (:failure-threshold diag)))
+          (is (= fast-failure-threshold  (:consecutive-failures diag))
+              "diagnostic records the actual failure count at fire time")
+          (is (= fast-probe-interval-ms  (:probe-interval-ms diag))))
+        (finally
+          (stop!))))))
+
+;------------------------------------------------------------------------------ Probe-fn exception is treated as failure
+
+(deftest probe-fn-exception-counts-as-failure-test
+  ;; A probe that throws (DNS resolution failure that bubbles out,
+  ;; some other unexpected exception) should be treated as a failed
+  ;; probe rather than crashing the monitor thread.
+  (testing "exception thrown from probe-fn → counted as a failure"
+    (let [record (atom {:calls []})
+          latch  (promise)
+          throwing-probe (fn [_backend-key]
+                           (throw (RuntimeException. "DNS failure")))
+          stop!  (nm/start-network-monitor!
+                   {:backend-key       :claude
+                    :probe-interval-ms fast-probe-interval-ms
+                    :failure-threshold fast-failure-threshold
+                    :probe-fn          throwing-probe
+                    :on-drop           (record-call record latch)})]
+      (try
+        (is (= :fired (wait-for-fire-or-timeout latch
+                                                (* fast-probe-interval-ms 50)))
+            "throwing probes must still drive the counter to threshold,
+             not crash the daemon")
+        (finally
+          (stop!))))))
+
+;------------------------------------------------------------------------------ stop! semantics
+
+(deftest stop!-prevents-further-on-drop-calls-test
+  (testing "stop! invoked before the threshold is reached → on-drop never fires"
+    (let [record (atom {:calls []})
+          stop!  (nm/start-network-monitor!
+                   {:backend-key       :claude
+                    :probe-interval-ms fast-probe-interval-ms
+                    :failure-threshold fast-failure-threshold
+                    :probe-fn          (scripted-probe [:down :down :down])
+                    :on-drop           (record-call record nil)})]
+      ;; Stop immediately — the daemon hasn't had time to complete a single
+      ;; full probe interval, let alone three. on-drop must not fire.
+      (stop!)
+      (Thread/sleep (* fast-probe-interval-ms 8))
+      (is (empty? (:calls @record))
+          "stop! interrupts the worker before on-drop can fire"))))
+
+(deftest stop!-is-idempotent-test
+  (testing "calling stop! twice is a no-op the second time"
+    (let [stop! (nm/start-network-monitor!
+                  {:backend-key       :claude
+                   :probe-interval-ms fast-probe-interval-ms
+                   :failure-threshold fast-failure-threshold
+                   :probe-fn          (scripted-probe [:up])
+                   :on-drop           (fn [_] nil)})]
+      (stop!)
+      (is (nil? (stop!))
+          "second stop! returns nil — does not throw"))))
+
+;------------------------------------------------------------------------------ Argument validation
+
+(deftest start-monitor-rejects-missing-backend-key-test
+  (is (thrown? AssertionError
+               (nm/start-network-monitor!
+                 {:probe-interval-ms fast-probe-interval-ms
+                  :failure-threshold fast-failure-threshold
+                  :probe-fn          (scripted-probe [:up])
+                  :on-drop           (fn [_] nil)}))
+      "no backend-key → assertion failure (programmer error per rule 005)"))
+
+(deftest start-monitor-rejects-non-positive-interval-test
+  (is (thrown? AssertionError
+               (nm/start-network-monitor!
+                 {:backend-key       :claude
+                  :probe-interval-ms 0
+                  :failure-threshold fast-failure-threshold
+                  :probe-fn          (scripted-probe [:up])
+                  :on-drop           (fn [_] nil)})))
+  (is (thrown? AssertionError
+               (nm/start-network-monitor!
+                 {:backend-key       :claude
+                  :probe-interval-ms -1
+                  :failure-threshold fast-failure-threshold
+                  :probe-fn          (scripted-probe [:up])
+                  :on-drop           (fn [_] nil)}))))
+
+(deftest start-monitor-rejects-non-positive-threshold-test
+  (is (thrown? AssertionError
+               (nm/start-network-monitor!
+                 {:backend-key       :claude
+                  :probe-interval-ms fast-probe-interval-ms
+                  :failure-threshold 0
+                  :probe-fn          (scripted-probe [:up])
+                  :on-drop           (fn [_] nil)})))
+  (is (thrown? AssertionError
+               (nm/start-network-monitor!
+                 {:backend-key       :claude
+                  :probe-interval-ms fast-probe-interval-ms
+                  :failure-threshold -2
+                  :probe-fn          (scripted-probe [:up])
+                  :on-drop           (fn [_] nil)}))))
+
+(deftest start-monitor-rejects-non-fn-on-drop-test
+  (is (thrown? AssertionError
+               (nm/start-network-monitor!
+                 {:backend-key       :claude
+                  :probe-interval-ms fast-probe-interval-ms
+                  :failure-threshold fast-failure-threshold
+                  :probe-fn          (scripted-probe [:up])
+                  :on-drop           "not-a-fn"}))))

--- a/components/llm/test/ai/miniforge/llm/network_monitor_test.clj
+++ b/components/llm/test/ai/miniforge/llm/network_monitor_test.clj
@@ -35,7 +35,7 @@
   [script]
   (let [idx (atom 0)
         coerce {:up true :down false true true false false}]
-    (fn [_backend-key]
+    (fn [_probe-url]
       (let [i @idx
             v (get script i (last script))]
         (swap! idx inc)
@@ -68,7 +68,8 @@
   (testing "every probe returns :up → on-drop never called"
     (let [record (atom {:calls []})
           stop!  (nm/start-network-monitor!
-                   {:backend-key       :claude
+                   {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                     :probe-interval-ms fast-probe-interval-ms
                     :failure-threshold fast-failure-threshold
                     :probe-fn          (scripted-probe [:up :up :up :up :up :up])
@@ -90,7 +91,8 @@
           ;; The first down increments to 1. The up resets to 0. Each
           ;; subsequent down increments anew; never reaches 3.
           stop! (nm/start-network-monitor!
-                  {:backend-key       :claude
+                  {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                    :probe-interval-ms fast-probe-interval-ms
                    :failure-threshold fast-failure-threshold
                    :probe-fn          (scripted-probe
@@ -110,7 +112,8 @@
     (let [record (atom {:calls []})
           latch  (promise)
           stop!  (nm/start-network-monitor!
-                   {:backend-key       :claude
+                   {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                     :probe-interval-ms fast-probe-interval-ms
                     :failure-threshold fast-failure-threshold
                     :probe-fn          (scripted-probe [:down :down :down
@@ -135,7 +138,8 @@
     (let [record (atom {:calls []})
           latch  (promise)
           stop!  (nm/start-network-monitor!
-                   {:backend-key       :codex
+                   {:probe-url         "https://test.example.com/"
+                    :backend-key       :codex
                     :probe-interval-ms fast-probe-interval-ms
                     :failure-threshold fast-failure-threshold
                     :probe-fn          (scripted-probe [:down :down :down])
@@ -144,6 +148,9 @@
         (wait-for-fire-or-timeout latch (* fast-probe-interval-ms 50))
         (let [diag (first (:calls @record))]
           (is (= :codex                  (:backend-key diag)))
+          (is (= "https://test.example.com/" (:probe-url diag))
+              ":probe-url is echoed back so downstream logs identify
+               which endpoint went away")
           (is (= fast-failure-threshold  (:failure-threshold diag)))
           (is (= fast-failure-threshold  (:consecutive-failures diag))
               "diagnostic records the actual failure count at fire time")
@@ -160,10 +167,11 @@
   (testing "exception thrown from probe-fn → counted as a failure"
     (let [record (atom {:calls []})
           latch  (promise)
-          throwing-probe (fn [_backend-key]
+          throwing-probe (fn [_probe-url]
                            (throw (RuntimeException. "DNS failure")))
           stop!  (nm/start-network-monitor!
-                   {:backend-key       :claude
+                   {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                     :probe-interval-ms fast-probe-interval-ms
                     :failure-threshold fast-failure-threshold
                     :probe-fn          throwing-probe
@@ -182,7 +190,8 @@
   (testing "stop! invoked before the threshold is reached → on-drop never fires"
     (let [record (atom {:calls []})
           stop!  (nm/start-network-monitor!
-                   {:backend-key       :claude
+                   {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                     :probe-interval-ms fast-probe-interval-ms
                     :failure-threshold fast-failure-threshold
                     :probe-fn          (scripted-probe [:down :down :down])
@@ -197,7 +206,8 @@
 (deftest stop!-is-idempotent-test
   (testing "calling stop! twice is a no-op the second time"
     (let [stop! (nm/start-network-monitor!
-                  {:backend-key       :claude
+                  {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                    :probe-interval-ms fast-probe-interval-ms
                    :failure-threshold fast-failure-threshold
                    :probe-fn          (scripted-probe [:up])
@@ -208,26 +218,38 @@
 
 ;------------------------------------------------------------------------------ Argument validation
 
-(deftest start-monitor-rejects-missing-backend-key-test
+(deftest start-monitor-rejects-missing-probe-url-test
   (is (thrown? AssertionError
                (nm/start-network-monitor!
-                 {:probe-interval-ms fast-probe-interval-ms
+                 {:backend-key       :claude
+                  :probe-interval-ms fast-probe-interval-ms
                   :failure-threshold fast-failure-threshold
                   :probe-fn          (scripted-probe [:up])
                   :on-drop           (fn [_] nil)}))
-      "no backend-key → assertion failure (programmer error per rule 005)"))
+      "no probe-url → assertion failure (programmer error per rule 005)")
+  (is (thrown? AssertionError
+               (nm/start-network-monitor!
+                 {:probe-url         ""
+                  :backend-key       :claude
+                  :probe-interval-ms fast-probe-interval-ms
+                  :failure-threshold fast-failure-threshold
+                  :probe-fn          (scripted-probe [:up])
+                  :on-drop           (fn [_] nil)}))
+      "empty :probe-url is not a usable URL"))
 
 (deftest start-monitor-rejects-non-positive-interval-test
   (is (thrown? AssertionError
                (nm/start-network-monitor!
-                 {:backend-key       :claude
+                 {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                   :probe-interval-ms 0
                   :failure-threshold fast-failure-threshold
                   :probe-fn          (scripted-probe [:up])
                   :on-drop           (fn [_] nil)})))
   (is (thrown? AssertionError
                (nm/start-network-monitor!
-                 {:backend-key       :claude
+                 {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                   :probe-interval-ms -1
                   :failure-threshold fast-failure-threshold
                   :probe-fn          (scripted-probe [:up])
@@ -236,14 +258,16 @@
 (deftest start-monitor-rejects-non-positive-threshold-test
   (is (thrown? AssertionError
                (nm/start-network-monitor!
-                 {:backend-key       :claude
+                 {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                   :probe-interval-ms fast-probe-interval-ms
                   :failure-threshold 0
                   :probe-fn          (scripted-probe [:up])
                   :on-drop           (fn [_] nil)})))
   (is (thrown? AssertionError
                (nm/start-network-monitor!
-                 {:backend-key       :claude
+                 {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
                   :probe-interval-ms fast-probe-interval-ms
                   :failure-threshold -2
                   :probe-fn          (scripted-probe [:up])
@@ -252,8 +276,94 @@
 (deftest start-monitor-rejects-non-fn-on-drop-test
   (is (thrown? AssertionError
                (nm/start-network-monitor!
-                 {:backend-key       :claude
+                 {:probe-url         "https://test.example.com/"
+                  :backend-key       :claude
                   :probe-interval-ms fast-probe-interval-ms
                   :failure-threshold fast-failure-threshold
                   :probe-fn          (scripted-probe [:up])
                   :on-drop           "not-a-fn"}))))
+
+;------------------------------------------------------------------------------ Concurrent stop + threshold race (CAS regression)
+;; Copilot review on PR #1053 flagged a race: the pre-fix worker
+;; checked `@running?` separately from invoking on-drop, so a stop!
+;; arriving between the check and the call could let on-drop fire
+;; after stop! had already returned. The fix uses `compare-and-set!`
+;; on the running? atom to atomically claim the firing slot — stop!
+;; and the worker race for the same true→false transition.
+
+(deftest stop!-racing-the-fire-cas-suppresses-on-drop-test
+  ;; Drive many short trials. The slow `:on-drop` callback amplifies
+  ;; the window in which a stop! after the threshold check could race
+  ;; the fire. With the CAS in place, a stop! that wins the
+  ;; transition MUST suppress on-drop entirely.
+  (testing "stop! winning the CAS prevents on-drop from firing"
+    (dotimes [_ 30]
+      (let [record (atom {:calls []})
+            ;; Probe-fn that immediately returns :down so the worker
+            ;; reaches the threshold-check arm on its very first iteration.
+            stop! (nm/start-network-monitor!
+                    {:probe-url         "https://test.example.com/"
+                     :backend-key       :claude
+                     :probe-interval-ms 1
+                     :failure-threshold 1
+                     :probe-fn          (scripted-probe [:down])
+                     :on-drop           (record-call record nil)})]
+        ;; Race window: stop! and the first probe cycle both run.
+        ;; With the CAS, exactly one wins.
+        (stop!)
+        ;; Give any in-flight on-drop time to finish.
+        (Thread/sleep 5)
+        ;; Either zero calls (stop! won) or exactly one (worker won).
+        ;; The bug was zero-or-one nondeterminism PLUS a possible second
+        ;; call from a stop!-then-fire ordering. Assert at most one
+        ;; — never duplicates.
+        (is (<= (count (:calls @record)) 1)
+            "CAS guarantees at most one on-drop call, regardless of race outcome")))))
+
+(deftest stop!-then-already-passed-threshold-fires-at-most-once-test
+  ;; The classic single-fire guarantee under heavy concurrent stop! /
+  ;; probe pressure. After firing, the worker exits; extra :down
+  ;; probes do NOT produce additional calls.
+  (testing "after the first on-drop fires, subsequent failed probes do not refire"
+    (let [record (atom {:calls []})
+          latch  (promise)
+          stop!  (nm/start-network-monitor!
+                   {:probe-url         "https://test.example.com/"
+                    :backend-key       :claude
+                    :probe-interval-ms 5
+                    :failure-threshold 1
+                    :probe-fn          (scripted-probe (repeat 20 :down))
+                    :on-drop           (record-call record latch)})]
+      (try
+        (wait-for-fire-or-timeout latch 500)
+        (Thread/sleep 50)
+        (is (= 1 (count (:calls @record))))
+        (finally
+          (stop!))))))
+
+;------------------------------------------------------------------------------ stream-exec-fn opts merge protection
+
+;; This test lives here (rather than in interface_test) because it
+;; pins the contract from the monitor's perspective: when callers pass
+;; through `:network-monitor-opts`, the integration must enforce its
+;; own `:probe-url`, `:backend-key`, and `:on-drop`. The integration
+;; site in `stream-exec-fn` (Copilot review on PR #1053) merges caller
+;; opts FIRST, so its protected keys always win.
+
+(deftest probe-url-and-on-drop-take-priority-over-caller-opts-test
+  (testing "caller opts merged FIRST → integration owns the protected keys"
+    ;; Mimic the merge order that stream-exec-fn now uses:
+    ;;   (merge caller-opts {:probe-url ... :backend-key ... :on-drop ...})
+    (let [caller-opts {:probe-url   "https://malicious.example.com/"
+                       :on-drop     (fn [_] (throw (Exception. "caller's on-drop")))
+                       :backend-key :spoofed}
+          integration {:probe-url   "https://real.example.com/"
+                       :backend-key :claude
+                       :on-drop     (fn [diag]
+                                      (is (= "https://real.example.com/" (:probe-url diag)))
+                                      (is (= :claude (:backend-key diag))))}
+          effective   (merge caller-opts integration)]
+      (is (= "https://real.example.com/" (:probe-url effective)))
+      (is (= :claude (:backend-key effective)))
+      (is (not= (:on-drop caller-opts) (:on-drop effective))
+          "integration's on-drop wins; caller's on-drop is discarded"))))


### PR DESCRIPTION
## Summary

**PR-B of the 3-PR network-resilience stack.** Based on \`chris/llm-network-health\` (PR-A, #1051). Detects sustained provider outages within **~30s** instead of waiting for the 2-3min progress-monitor stagnation cutoff.

| PR | Status | Scope |
|---|---|---|
| [PR-A #1051](https://github.com/miniforge-ai/miniforge/pull/1051) | open | Probe primitive — pure \`network-healthy?\` function |
| **PR-B (this)** | — | Monitor scheduler + \`stream-exec-fn\` integration |
| PR-C (queued) | — | Auto-resume from checkpoint on \`:network-failed\` with bounded retry |

## Monitor primitive — \`ai.miniforge.llm.network-monitor\`

\`start-network-monitor!\` spawns a daemon that probes the upstream provider every **10s** (configurable). Each failed probe increments a consecutive-failure counter; each healthy probe resets it. On **3 consecutive failures** (= ~30s of confirmed dead network) the monitor fires \`:on-drop\` ONCE with a diagnostic map and exits.

- Mirrors the lifecycle pattern of \`progress-monitor/start-keepalive!\` — returns a zero-arity stop-fn.
- Programmer-error guards (rule 005) reject missing \`:backend-key\`, non-positive intervals/thresholds, non-fn \`:on-drop\`.
- Single-fire: extra failed probes after the threshold do not produce more \`:on-drop\` calls; PR-C owns post-drop recovery + retry.

## \`stream-exec-fn\` integration

New \`:backend-key\` opt activates the monitor; \`:network-monitor-opts\` allows callers (mostly tests) to override \`probe-interval-ms\`, \`failure-threshold\`, \`probe-fn\`. **Backwards compat:** omit \`:backend-key\` and the monitor is dormant — legacy callers / synthetic-stream tests keep working unchanged.

When the monitor fires, \`on-drop\`:
1. \`compare-and-set!\`'s a \`network-drop-reason\` atom in the canonical \`pm/check-timeout\` envelope shape (\`{:type :network-drop :elapsed-ms :message ...}\`), so the existing \`timeout-result\` path handles it identically. PR-C keys off \`:type :network-drop\` for auto-resume.
2. \`.destroyForcibly\`'s the subprocess so the consumer's reader sees EOF and the loop exits immediately (the agent is hung on socket I/O that won't recover without process restart).

After \`process-stream-lines\` returns, the \`network-drop-reason\` takes precedence over whatever \`pm/check-timeout\` returned — the subprocess was killed by the monitor, so any pm-side observation is a knock-on effect. Surface the root cause.

## Test plan

- [x] \`bb pre-commit\` — all green
- [x] **11 monitor tests / 17 assertions**:
  - Steady healthy stream → no fire
  - Transient blip (down/up/down/down/up) → counter resets, no fire
  - 3 consecutive failures → fire exactly once (single-fire)
  - Diagnostic map carries \`backend-key\` / \`consecutive-failures\` / \`failure-threshold\` / \`probe-interval-ms\`
  - Probe-fn exception treated as failure (daemon doesn't crash)
  - \`stop!\` before threshold → no fire; \`stop!\` is idempotent
  - All 4 argument-validation guards (missing backend-key, non-positive interval/threshold, non-fn on-drop)
- [x] **3 stream-exec-fn integration tests**:
  - Sustained probe failure → \`:timeout\` envelope with \`:type :network-drop\`, \`:backend-key\`, \`:message\` identifying the drop class
  - No \`:backend-key\` → probe-fn never called, monitor stays dormant
  - Pre-existing \`:stdin\` pipe test still green (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)