### PR TITLE
feat(agent): detect boundary-level stream-idle in reviewer (PR-A of phase-timeout stack)

### DIFF
--- a/components/agent/src/ai/miniforge/agent/result_boundary.clj
+++ b/components/agent/src/ai/miniforge/agent/result_boundary.clj
@@ -75,6 +75,64 @@
   [{:keys [structured-artifact parsed-content derived-artifact]}]
   (or structured-artifact parsed-content derived-artifact))
 
+;------------------------------------------------------------------------------ LLM-timeout classification
+;;
+;; `llm-client/timeout-result` packs an adaptive-timeout reason into the
+;; LLM-error's `:timeout` field. The `:type` keyword inside that field is
+;; the canonical taxonomy: `:stream-idle`, `:stagnation`, `:hard-limit`,
+;; `:network-drop` (PR-B of network-resilience).
+;;
+;; The reviewer's existing `timeout-only-review?` reads from the PARSED
+;; review map, which is nil whenever the LLM call itself errored (no
+;; response to parse). The 2026-06-05 dogfood (workflow `adhoc-944448986`)
+;; failed at exactly that path — reviewer-LLM stream-idle'd at 360s, no
+;; parsed review, the framework's parse-failed branch promoted the
+;; timeout text into `:review/blocking-issues` and synthesized a false
+;; `:rejected`. These helpers detect the same condition at the BOUNDARY
+;; level (the normalized result), so callers can branch on infra timeouts
+;; even when the parser produced nothing.
+
+(defn llm-timeout-type
+  "Return the timeout-type keyword from a normalized boundary, or nil if
+   the response carries no timeout envelope.
+
+   The LLM-client's `streaming-error-response` packs the timeout reason
+   produced by `stream-idle-timeout` / `stagnation-timeout` / etc. into
+   the error's `:timeout` field; this helper just pulls the canonical
+   `:type` keyword out of it.
+
+   Reads `(:llm-error normalized)` (the map produced by `llm/get-error`)
+   for `[:timeout :type]`. Returns nil for non-error responses, for
+   error responses without a `:timeout` envelope, and for normalized
+   maps where `:llm-error` is missing entirely."
+  [normalized]
+  (get-in normalized [:llm-error :timeout :type]))
+
+(defn stream-idle-error?
+  "True when the normalized boundary carries an LLM-client adaptive
+   timeout of `:type :stream-idle` — i.e. the provider connected but
+   stopped producing stream output for the configured idle threshold.
+
+   Distinct from `network-drop-error?` (TCP/TLS reachability lost) and
+   from a real LLM rejection (parsed content with `:rejected` verdict).
+   Callers should treat this as an INFRA failure — retry from the
+   last persisted checkpoint, do not promote into the artifact's
+   blocking-issues / repair-request channel."
+  [normalized]
+  (= :stream-idle (llm-timeout-type normalized)))
+
+(defn network-drop-error?
+  "True when the normalized boundary carries an LLM-client adaptive
+   timeout of `:type :network-drop` — the connectivity-lost verdict
+   emitted by PR-B's network-monitor after `failure-threshold`
+   consecutive probe failures.
+
+   Distinct from `stream-idle-error?` (provider connected, no tokens)
+   and from a real LLM rejection. Callers should retry from the last
+   persisted checkpoint once connectivity is restored."
+  [normalized]
+  (= :network-drop (llm-timeout-type normalized)))
+
 (defn error-response
   "Build a failure response that preserves the backend error shape plus
    common response metadata for post-mortem."

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -175,12 +175,29 @@
                     counts (gates/calculate-gate-counts gate-feedbacks)
                     timeout-failure-message (llm-response/backend-failure-message response llm-review)
                     timeout-only-review? (llm-response/timeout-only-review? llm-review gate-result)
+                    ;; `timeout-only-review?` only fires when the LLM
+                    ;; parsed a `:rejected` whose `:review/blocking-
+                    ;; issues` are all timeout-shaped — it cannot fire
+                    ;; when the LLM call itself errored, because
+                    ;; `llm-review` is nil and every condition in the
+                    ;; predicate reads from it. The 2026-06-05 dogfood
+                    ;; (workflow adhoc-944448986) reviewer stream-idle'd
+                    ;; at 360s with no parsed response; the framework
+                    ;; promoted the timeout text into `:review/blocking-
+                    ;; issues` via the parse-failed branch and synthesized
+                    ;; a false `:rejected`. Adding the boundary-level
+                    ;; stream-idle check covers that path so a real
+                    ;; infra timeout takes the `timeout-only-error-result`
+                    ;; exit instead of masquerading as a code-review
+                    ;; rejection.
+                    backend-stream-idle? (result-boundary/stream-idle-error? normalized)
+                    backend-timeout? (or timeout-only-review? backend-stream-idle?)
                     ;; "initial" = the first-call decision/issues fed into the
                     ;; enumeration validator. Named to contrast with
                     ;; `recovered-review` below; these are already normalized,
                     ;; not literally "raw".
                     initial-llm-decision (cond
-                                           timeout-only-review? nil
+                                           backend-timeout? nil
                                            parse-failed? :rejected
                                            llm-review (issues/normalize-llm-decision (:review/decision llm-review)))
                     ;; Resolve the task's scope once; partitioning happens
@@ -273,10 +290,17 @@
                                      (gates/merge-gate-overrides llm-decision (:decision gate-result) config)
                                      (:decision gate-result))
 
-                    ;; Merge issues from both sources
+                    ;; Merge issues from both sources. `parse-failed?`
+                    ;; gates the parse-failure-message append so a
+                    ;; backend-timeout (taking the early exit below)
+                    ;; does NOT carry the timeout text into the
+                    ;; artifact's blocking-issues — it would otherwise
+                    ;; mislead downstream consumers into treating an
+                    ;; infra timeout as a code-review defect, the exact
+                    ;; pathology the 2026-06-05 dogfood revealed.
                     all-blocking (cond-> (into (vec (:blocking-issues gate-result))
                                                (issues/llm-issues->blocking-strings llm-issues))
-                                   parse-failed?
+                                   (and parse-failed? (not backend-timeout?))
                                    (conj parse-failure-message)
                                    timeout-only-review?
                                    (conj timeout-failure-message))
@@ -302,7 +326,7 @@
 
                     duration (- (System/currentTimeMillis) start-time)]
 
-                (if timeout-only-review?
+                (if backend-timeout?
                   (artifact/timeout-only-error-result
                    logger normalized llm-review gate-result counts duration tokens cost-usd
                    timeout-failure-message)
@@ -325,6 +349,7 @@
                                         :llm-decision llm-decision
                                         :llm-parse-failed? parse-failed?
                                         :timeout-only-review? timeout-only-review?
+                                        :backend-stream-idle? backend-stream-idle?
                                         :gates-passed (:passed counts)
                                         :gates-failed (:failed counts)
                                         :failing-gate-ids failing-gate-ids

--- a/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
@@ -188,35 +188,43 @@
 
    This preserves backend timeout metadata, emits the standard phase-completed
    telemetry, and reports the deterministic gate outcome instead of converting
-   the backend failure into a bogus code-review rejection."
+   the backend failure into a bogus code-review rejection.
+
+   `llm-review` may be nil — PR-A of the phase-timeout stack added a
+   boundary-level stream-idle path where the LLM call errors before
+   producing any parseable review. The defaulted vector keeps the
+   `:blocking-issues` field a vector across both invocation shapes so
+   downstream telemetry / error consumers that pattern-match on
+   sequential data don't see a surprise nil from the new path."
   [logger normalized llm-review gate-result counts duration tokens cost-usd timeout-failure-message]
-  (log/warn logger :reviewer :reviewer/backend-timeout-only
-            {:data {:llm-decision (:review/decision llm-review)
-                    :gate-decision (:decision gate-result)
-                    :blocking-issues (:review/blocking-issues llm-review)
-                    :duration-ms duration}})
-  (leave-review logger {:review/decision (:decision gate-result)
-                        :duration-ms duration
-                        :gates-passed (:passed counts)
-                        :gates-failed (:failed counts)
-                        :llm? true
-                        :status :error
-                        :error-code :reviewer/backend-timeout})
-  (assoc
-   (result-boundary/error-response
-    normalized
-    timeout-failure-message
-    {:data (merge (or (some-> normalized :llm-error :data) {})
-                  {:code :reviewer/backend-timeout
-                   :blocking-issues (:review/blocking-issues llm-review)})})
-   :metrics
-   (cond-> {:decision (:decision gate-result)
-            :gates-passed (:passed counts)
-            :gates-failed (:failed counts)
-            :gates-total (:total counts)
-            :duration-ms duration
-            :tokens tokens}
-     cost-usd (assoc :cost-usd cost-usd))))
+  (let [blocking-issues (vec (:review/blocking-issues llm-review))]
+    (log/warn logger :reviewer :reviewer/backend-timeout-only
+              {:data {:llm-decision (:review/decision llm-review)
+                      :gate-decision (:decision gate-result)
+                      :blocking-issues blocking-issues
+                      :duration-ms duration}})
+    (leave-review logger {:review/decision (:decision gate-result)
+                          :duration-ms duration
+                          :gates-passed (:passed counts)
+                          :gates-failed (:failed counts)
+                          :llm? true
+                          :status :error
+                          :error-code :reviewer/backend-timeout})
+    (assoc
+     (result-boundary/error-response
+      normalized
+      timeout-failure-message
+      {:data (merge (or (some-> normalized :llm-error :data) {})
+                    {:code :reviewer/backend-timeout
+                     :blocking-issues blocking-issues})})
+     :metrics
+     (cond-> {:decision (:decision gate-result)
+              :gates-passed (:passed counts)
+              :gates-failed (:failed counts)
+              :gates-total (:total counts)
+              :duration-ms duration
+              :tokens tokens}
+       cost-usd (assoc :cost-usd cost-usd)))))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Public-API accessors

--- a/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
+++ b/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
@@ -68,6 +68,89 @@
              (:code/files payload)))
       (is (= "clojure" (:code/language payload))))))
 
+;------------------------------------------------------------------------------ LLM-timeout classification
+
+(deftest llm-timeout-type-extracts-canonical-keyword
+  (testing "reads [:llm-error :timeout :type] from the normalized boundary"
+    (is (= :stream-idle
+           (sut/llm-timeout-type
+             {:llm-error {:type "adaptive_timeout"
+                          :message "Adaptive timeout: No stream output for 360000ms (type: stream-idle, ...)"
+                          :timeout {:type :stream-idle
+                                    :elapsed-ms 360087
+                                    :message "No stream output for 360000ms"
+                                    :stats {:lines-read 0}}}})))
+
+    (is (= :network-drop
+           (sut/llm-timeout-type
+             {:llm-error {:type "adaptive_timeout"
+                          :timeout {:type :network-drop
+                                    :backend-key :claude
+                                    :elapsed-ms 30000}}})))
+
+    (is (= :stagnation
+           (sut/llm-timeout-type
+             {:llm-error {:timeout {:type :stagnation :elapsed-ms 180000}}})))
+
+    (is (= :hard-limit
+           (sut/llm-timeout-type
+             {:llm-error {:timeout {:type :hard-limit :elapsed-ms 600000}}}))))
+
+  (testing "returns nil for non-error / no-timeout normalized maps"
+    (is (nil? (sut/llm-timeout-type {:llm-error nil})))
+    (is (nil? (sut/llm-timeout-type {:llm-error {:type "cli_error" :message "Stderr"}}))
+        "an LLM error without a :timeout envelope has no timeout-type")
+    (is (nil? (sut/llm-timeout-type {}))
+        "boundary with no :llm-error at all returns nil"))
+
+  (testing "missing :type inside :timeout returns nil — does not crash on partial maps"
+    (is (nil? (sut/llm-timeout-type
+                {:llm-error {:timeout {:elapsed-ms 1000}}})))))
+
+(deftest stream-idle-error?-identifies-stream-idle-timeouts
+  ;; The 2026-06-05 dogfood (`adhoc-944448986`) reviewer-LLM stream-idle'd
+  ;; at 360s; the framework synthesized a false `:rejected` because the
+  ;; reviewer's parsed-review-based `timeout-only-review?` couldn't see
+  ;; the boundary-level error. This boundary-level predicate is the
+  ;; missing piece — fires on the production shape.
+  (testing "production stream-idle shape"
+    (is (true? (sut/stream-idle-error?
+                 {:llm-error {:type "adaptive_timeout"
+                              :message "Adaptive timeout: No stream output for 360000ms (type: stream-idle, elapsed: 360087ms)"
+                              :timeout {:type :stream-idle
+                                        :elapsed-ms 360087}}}))))
+
+  (testing "other timeout types do NOT match — symmetry with network-drop / stagnation / hard-limit"
+    (is (false? (sut/stream-idle-error?
+                  {:llm-error {:timeout {:type :network-drop :elapsed-ms 30000}}})))
+    (is (false? (sut/stream-idle-error?
+                  {:llm-error {:timeout {:type :stagnation :elapsed-ms 180000}}})))
+    (is (false? (sut/stream-idle-error?
+                  {:llm-error {:timeout {:type :hard-limit :elapsed-ms 600000}}}))))
+
+  (testing "non-timeout errors and missing-error normalized maps do NOT match"
+    (is (false? (sut/stream-idle-error? {:llm-error nil})))
+    (is (false? (sut/stream-idle-error? {:llm-error {:type "cli_error"}})))
+    (is (false? (sut/stream-idle-error? {})))))
+
+(deftest network-drop-error?-identifies-network-drop-timeouts
+  ;; Symmetry-only coverage — the network-drop verdict is produced by
+  ;; PR-B of the network-resilience stack (#1053); this boundary helper
+  ;; exists so future cross-phase consumers can branch on the canonical
+  ;; timeout taxonomy without each phase rolling its own get-in.
+  (testing "production network-drop shape"
+    (is (true? (sut/network-drop-error?
+                 {:llm-error {:type "adaptive_timeout"
+                              :timeout {:type :network-drop
+                                        :backend-key :claude
+                                        :elapsed-ms 30000}}}))))
+
+  (testing "other timeout types do NOT match"
+    (is (false? (sut/network-drop-error?
+                  {:llm-error {:timeout {:type :stream-idle :elapsed-ms 360000}}})))
+    (is (false? (sut/network-drop-error?
+                  {:llm-error {:timeout {:type :stagnation :elapsed-ms 180000}}})))))
+
 (deftest error-response-preserves-backend-error-shape
   (testing "error-response carries raw backend data and response metadata through"
     (let [normalized {:llm-error {:message "Adaptive timeout"

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -177,6 +177,21 @@
             :message message}
      data (assoc :data data))))
 
+(defn- stream-idle-llm-error
+  "Build the LLM-error shape `streaming-error-response` produces when the
+   stream-idle adaptive timeout fires — the same shape `llm/get-error`
+   surfaces. The 2026-06-05 dogfood (`adhoc-944448986`) hit exactly
+   this path on the reviewer LLM call."
+  [elapsed-ms]
+  (let [message (str "Adaptive timeout: No stream output for " elapsed-ms
+                     "ms (type: stream-idle, elapsed: " elapsed-ms "ms)")]
+    {:type backend-timeout-type
+     :message message
+     :timeout {:type :stream-idle
+               :message (str "No stream output for " elapsed-ms "ms")
+               :elapsed-ms elapsed-ms
+               :stats {:lines-read 0}}}))
+
 ;------------------------------------------------------------------------------ Core functionality tests
 
 (deftest test-create-reviewer
@@ -389,6 +404,46 @@
                (get-in result [:error :data :code])))
         (is (= timeout-success-wrapper-token-count
                (get-in result [:metrics :tokens])))))))
+
+(deftest test-reviewer-boundary-stream-idle-is-agent-error
+  ;; The 2026-06-05 dogfood (`adhoc-944448986`) shape: the reviewer LLM
+  ;; stream-idle'd at 360s and returned NO parsed review (parse-failed),
+  ;; only the LLM-error's `:timeout {:type :stream-idle}`. The OLD
+  ;; `timeout-only-review?` predicate read from the parsed review map
+  ;; and so could not fire — the framework then promoted the timeout
+  ;; text into `:review/blocking-issues` via the parse-failed branch
+  ;; and synthesized a false `:rejected`, which the `:review-approved`
+  ;; gate (correctly given the verdict it received) failed.
+  ;;
+  ;; With the boundary-level `result-boundary/stream-idle-error?`
+  ;; check wired in, the reviewer must take the `:reviewer/backend-
+  ;; timeout` exit — the same path the parseable variants already
+  ;; take — instead of producing a false rejection.
+  (testing "stream-idle on the LLM-call boundary (no parsed review) → :reviewer/backend-timeout"
+    (let [stream-idle-elapsed-ms 360087
+          err (stream-idle-llm-error stream-idle-elapsed-ms)]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                    llm/chat (fn [_client _prompt _opts]
+                               (mock-llm-response ""
+                                                  :success? false
+                                                  :tokens timeout-review-token-count
+                                                  :error err))
+                    llm/success? :success?
+                    llm/get-content :content
+                    llm/get-error :error]
+        (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                  :gates []})
+              result (core/invoke reviewer {} sample-artifact)]
+          (is (= :error (:status result))
+              "Stream-idle must surface as an agent-level error, not a synthetic :rejected review")
+          (is (= :reviewer/backend-timeout
+                 (get-in result [:error :data :code]))
+              "Error code must be :reviewer/backend-timeout — distinguishes infra timeout from real defect")
+          (is (= (:message err)
+                 (get-in result [:error :message]))
+              "Error message preserves the adaptive-timeout text verbatim for operator post-mortem")
+          (is (= timeout-review-token-count
+                 (get-in result [:metrics :tokens]))))))))
 
 (deftest test-reviewer-timeout-only-shape-does-not-hide-real-gate-failures
   (testing "timeout-only classification requires the deterministic gates to approve"

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -443,7 +443,16 @@
                  (get-in result [:error :message]))
               "Error message preserves the adaptive-timeout text verbatim for operator post-mortem")
           (is (= timeout-review-token-count
-                 (get-in result [:metrics :tokens]))))))))
+                 (get-in result [:metrics :tokens])))
+          (is (= []
+                 (get-in result [:error :data :blocking-issues]))
+              "blocking-issues defaults to an empty vector — never nil — when the
+               boundary-stream-idle path fires with no parsed review. Downstream
+               consumers that pattern-match on sequential data (count, seq, into)
+               must not see a surprise nil from the new path.")
+          (is (vector? (get-in result [:error :data :blocking-issues]))
+              "vector shape preserved end-to-end — pinned because PR #1058 review
+               flagged the original implementation returning nil here."))))))
 
 (deftest test-reviewer-timeout-only-shape-does-not-hide-real-gate-failures
   (testing "timeout-only classification requires the deterministic gates to approve"

--- a/components/phase-software-factory/resources/config/phase/messages/en-US.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/en-US.edn
@@ -20,6 +20,9 @@
   :review/needs-decomposition
   "Review-repair loop is not converging: {iterations} consecutive review→implement cycles each surfaced different legitimate blockers without reaching approval. The task is likely too coarse for one implement turn to satisfy in full — emitting :needs-decomposition so a meta-agent can split it instead of burning the remaining redirect budget."
 
+  :review/backend-timeout
+  "Reviewer LLM hit its adaptive timeout (stream-idle, stagnation, hard-limit, or generic) with no verdict produced — the call errored before any review artifact could be parsed. Routed to the :review/backend-timeout terminal verdict instead of synthesizing a false :rejected from the timeout text. Operator should retry from the last persisted checkpoint once provider is responsive."
+
   ;; Verify phase
   :verify/no-environment      "Verify phase has no execution environment"
   :verify/no-environment-hint "Workflow runner must acquire an execution environment before verify phase"

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -252,6 +252,23 @@
                :review/cycle-count review-cycle-count
                :review/fingerprint-history (vec fingerprint-history)})))
 
+(defn- attach-backend-timeout-anomaly
+  "PR-B of phase-timeout stack: attach the backend-timeout anomaly to the
+   phase result so the workflow runner / evidence bundle can surface that
+   the reviewer LLM hit its adaptive timeout — the same pattern
+   `attach-stagnated-anomaly` and `attach-needs-decomposition-anomaly`
+   use for their terminal verdicts. Pulls the timeout message verbatim
+   from the agent's error result so operators see the actual
+   `stream-idle` / `stagnation` / etc. detail in post-mortem."
+  [ctx]
+  (let [agent-error-message (get-in ctx [:phase :result :error :message])
+        msg (or agent-error-message
+                (messages/t :review/backend-timeout))]
+    (assoc-in ctx [:phase :error]
+              {:message msg
+               :anomaly/category :anomalies.review/backend-timeout
+               :anomaly/message  msg})))
+
 (defn- attach-repair-handoff
   "Phase 2b: attach repair feedback + a typed handoff so the implementer
    can pick up the work. Does NOT call `phase/request-redirect` anymore
@@ -326,27 +343,47 @@
    `:phase/fail` array reads it via `:verdict/terminal?` to decide
    between on-fail redirect and terminal `:failed`.
 
-     :approved            — reviewer green-lit; `:phase/succeed` event
-     :repair-requested    — actionable feedback + within budget;
-                            FSM may redirect via on-fail
-     :stagnated           — same blocking fingerprint as prior cycle;
-                            FSM terminates
-     :needs-decomposition — N non-stagnated rejections; FSM terminates
-                            with the decomposition signal
-     :exhausted           — reviewer blocked but no actionable
-                            feedback or over phase-level budget;
-                            FSM terminates"
-  #{:approved :repair-requested :stagnated :needs-decomposition :exhausted})
+     :approved              — reviewer green-lit; `:phase/succeed` event
+     :repair-requested      — actionable feedback + within budget;
+                              FSM may redirect via on-fail
+     :stagnated             — same blocking fingerprint as prior cycle;
+                              FSM terminates
+     :needs-decomposition   — N non-stagnated rejections; FSM terminates
+                              with the decomposition signal
+     :exhausted             — reviewer blocked but no actionable
+                              feedback or over phase-level budget;
+                              FSM terminates
+     :review/backend-timeout — the reviewer LLM call hit its adaptive
+                              timeout (stream-idle / stagnation / etc.)
+                              with no real verdict produced. PR-A
+                              (#1058) wired the agent to take the
+                              `:reviewer/backend-timeout` error exit
+                              instead of synthesizing a false
+                              `:rejected`; this verdict surfaces that
+                              infra failure to the FSM. Terminal —
+                              auto-resume composition (with the
+                              network-resilience PR-C, #1054) lives in
+                              a follow-up PR."
+  #{:approved :repair-requested :stagnated :needs-decomposition :exhausted
+    :review/backend-timeout})
 
 (defn- compute-verdict
   "Pick the verdict that should flow on the phase result. Mirrors the
    former `compute-decision` semantics one-for-one — `:stagnated` and
    `:needs-decomposition` keep their priority over `:repair-requested`;
    a reviewer-blocked failure with no actionable feedback collapses to
-   `:exhausted`."
-  [{:keys [reviewer-blocked? stagnated? needs-decomposition? within-budget?
-           actionable-feedback?]}]
+   `:exhausted`.
+
+   `:review/backend-timeout` takes priority over every code-review
+   verdict: when the reviewer LLM never produced a real verdict (PR-A
+   wiring), there is no `:rejected` to interpret as repair-requested
+   or exhausted. The infra failure must be reported as itself."
+  [{:keys [backend-timeout? reviewer-blocked? stagnated? needs-decomposition?
+           within-budget? actionable-feedback?]}]
   (cond
+    backend-timeout?
+    :review/backend-timeout
+
     stagnated?
     :stagnated
 
@@ -391,6 +428,9 @@
 
     :exhausted
     updated-ctx
+
+    :review/backend-timeout
+    (attach-backend-timeout-anomaly updated-ctx)
 
     :approved
     (mark-completed updated-ctx)))
@@ -451,6 +491,17 @@
         max-iterations    (get-in ctx [:phase :budget :iterations]
                                   (get-in default-config [:budget :iterations]))
         gate-failed?      (= :failed (:phase/status (get-in ctx [:phase])))
+        ;; PR-A (#1058) makes the reviewer agent take the
+        ;; `:reviewer/backend-timeout` error exit on an LLM-call
+        ;; stream-idle (or stagnation / hard-limit / generic timeout)
+        ;; instead of synthesizing a false `:rejected`. Detect that
+        ;; error code here and route to the `:review/backend-timeout`
+        ;; verdict — terminal, distinct from `:exhausted` — so the FSM
+        ;; can treat an infra timeout differently from a real
+        ;; non-actionable rejection (the auto-resume composition with
+        ;; the network-resilience PR-C lives in a follow-up PR).
+        backend-timeout?  (= :reviewer/backend-timeout
+                             (get-in result [:error :data :code]))
         reviewer-blocked? (contains? blocking-decisions review-decision)
         prior-history     (get-in ctx [:execution :review-fingerprints] [])
         current-fp        (agent/review-fingerprint review-artifact)
@@ -472,7 +523,8 @@
         needs-decomposition? (compute-needs-decomposition?
                               reviewer-blocked? stagnated?
                               review-cycle-count max-no-progress-attempts)
-        verdict           (compute-verdict {:reviewer-blocked?    reviewer-blocked?
+        verdict           (compute-verdict {:backend-timeout?     backend-timeout?
+                                            :reviewer-blocked?    reviewer-blocked?
                                             :stagnated?           stagnated?
                                             :needs-decomposition? needs-decomposition?
                                             :within-budget?       within-budget?

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -26,7 +26,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
-   [ai.miniforge.phase-software-factory.review]
+   [ai.miniforge.phase-software-factory.review :as review]
    [ai.miniforge.phase-software-factory.implement]))
 
 (def phase-test-config-resource
@@ -468,3 +468,111 @@
           "below cap, no decomposition verdict")
       (is (= :repair-requested (:verdict phase))
           "below cap with progress + actionable feedback = :repair-requested"))))
+
+;; ============================================================================
+;; Backend-timeout verdict — companion to PR-A (#1058)
+;;
+;; PR-A wires the reviewer agent to take a `:reviewer/backend-timeout`
+;; error exit when the LLM call itself stream-idle'd (or stagnation /
+;; hard-limit / generic timeout). PR-B's `compute-verdict` arm here
+;; translates that error code into a `:review/backend-timeout` verdict
+;; — terminal in the FSM's `terminal-verdicts` set — so an infra
+;; timeout no longer cascade-fails the workflow through the
+;; `:exhausted` / on-fail-implement path that would just hit the same
+;; dead provider on the next pass.
+;; ============================================================================
+
+(defn- simulate-leave-review-backend-timeout-context
+  "Simulate the leave-review logic when the reviewer agent returned a
+   `:reviewer/backend-timeout` error result (the PR-A exit shape).
+
+   The result mirrors what `artifact/timeout-only-error-result` wires
+   through `result-boundary/error-response`: `:status :error` at the
+   top of the result, the error data carries `:code :reviewer/backend-
+   timeout`, no `:output` artifact."
+  [iterations max-iterations]
+  (let [result {:status :error
+                :error {:message "Adaptive timeout: No stream output for 360000ms (type: stream-idle, elapsed: 360087ms)"
+                        :data {:code :reviewer/backend-timeout
+                               :blocking-issues ["Adaptive timeout: No stream output for 360000ms (type: stream-idle, elapsed: 360087ms)"]}}
+                :metrics {:tokens 9 :duration-ms 360087}}
+        ctx {:phase {:started-at (- (System/currentTimeMillis) 360087)
+                     :iterations iterations
+                     :budget {:iterations max-iterations}
+                     :result result}
+             :phase-config {:phase :review}
+             :execution/phase-results {}
+             :execution/input {:description "test task"}
+             :execution/metrics {}}
+        interceptor (phase/get-phase-interceptor {:phase :review})
+        leave-fn (:leave interceptor)]
+    (leave-fn ctx)))
+
+(deftest backend-timeout-result-emits-review-backend-timeout-verdict
+  ;; 2026-06-05 dogfood (workflow adhoc-944448986) repro: reviewer LLM
+  ;; stream-idle'd at 360s; PR-A makes the reviewer return the
+  ;; backend-timeout error code instead of synthesizing a false
+  ;; `:rejected`. PR-B converts that error code into the verdict the
+  ;; FSM reads to take the terminal branch.
+  (testing "reviewer-agent :reviewer/backend-timeout error → :review/backend-timeout verdict"
+    (let [final-ctx (simulate-leave-review-backend-timeout-context 1 2)
+          phase (:phase final-ctx)]
+      (is (= :review/backend-timeout (:verdict phase))
+          ":verdict slot exposes the canonical backend-timeout signal")
+      (is (= :review/backend-timeout
+             (get-in phase [:result :output :phase/verdict]))
+          "FSM-readable :phase/verdict carries the same verdict
+           — `determine-phase-event` plumbs this into the
+           `:verdict/terminal?` guard")))
+
+  (testing "backend-timeout verdict takes priority over the within-budget repair branch
+            — the LLM call NEVER produced a real verdict, so there's
+            nothing to repair; redirecting to implement would just hit
+            the same dead provider on the next review pass"
+    (let [final-ctx (simulate-leave-review-backend-timeout-context 1 4)
+          phase (:phase final-ctx)]
+      (is (= :review/backend-timeout (:verdict phase))
+          "even with iterations < max, backend-timeout pre-empts :repair-requested")
+      (is (not= :repair-requested (:verdict phase))))))
+
+(deftest backend-timeout-verdict-is-in-the-canonical-verdict-set
+  (testing "compute-verdict's verdict tag set declares :review/backend-timeout
+            — the FSM's terminal-verdicts wiring + `:verdict/terminal?`
+            guard look up the verdict by exact keyword match, so the
+            tag-set must enumerate it. Coverage here pins the public
+            surface so a rename can't silently slip past."
+    ;; Read the private var via the var; the resolved value is the set.
+    (let [verdicts @#'review/verdicts]
+      (is (contains? verdicts :review/backend-timeout))
+      (is (contains? verdicts :approved))
+      (is (contains? verdicts :exhausted))
+      (is (contains? verdicts :stagnated))
+      (is (contains? verdicts :needs-decomposition))
+      (is (contains? verdicts :repair-requested)))))
+
+(deftest backend-timeout-apply-verdict-attaches-anomaly-without-throwing
+  ;; PR #1059 review (Copilot): `apply-verdict` is a `case` with no
+  ;; default arm. Adding `:review/backend-timeout` to the verdicts set
+  ;; without a matching clause would raise IllegalArgumentException at
+  ;; the first production stream-idle. This test pins both the no-
+  ;; throw contract AND the anomaly-attached side-effect that mirrors
+  ;; the stagnated / needs-decomposition pattern.
+  (testing "leave-review on backend-timeout produces a context (no IllegalArgumentException)
+            and attaches the :anomalies.review/backend-timeout sub-anomaly
+            to [:phase :error] for the evidence bundle"
+    (let [final-ctx (simulate-leave-review-backend-timeout-context 1 2)
+          phase-error (get-in final-ctx [:phase :error])]
+      (is (some? phase-error)
+          ":phase :error is set — case clause fired the anomaly-attach side effect")
+      (is (= :anomalies.review/backend-timeout
+             (:anomaly/category phase-error))
+          "anomaly category matches the verdict — parallels :anomalies.review/stagnation
+           and :anomalies.review/needs-decomposition")
+      (is (string? (:anomaly/message phase-error))
+          "anomaly message is a string — pulled from the agent error message
+           or the catalog fallback")
+      (is (= (get-in final-ctx [:phase :result :error :message])
+             (:message phase-error))
+          "anomaly :message preserves the actual adaptive-timeout text the
+           operator needs (stream-idle / stagnation / etc.) — not just a
+           generic catalog string"))))

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -84,7 +84,19 @@
     ;; outages. Retrying again would just hit the same dead network on
     ;; the next probe cycle. Terminal — operator surfaces the workflow
     ;; for manual resume once connectivity is restored.
-    :implement/network-dropped})
+    :implement/network-dropped
+    ;; PR-B of phase-timeout stack (companion to network-resilience):
+    ;; the reviewer LLM call hit its adaptive timeout (stream-idle /
+    ;; stagnation / hard-limit / generic) with no real verdict
+    ;; produced. PR-A (#1058) made the reviewer agent take the
+    ;; `:reviewer/backend-timeout` error exit instead of synthesizing
+    ;; a false `:rejected`; this verdict surfaces that to the FSM.
+    ;; Distinct from `:exhausted` — `:exhausted` means the reviewer
+    ;; HAD a verdict the gate couldn't approve, this means the
+    ;; reviewer never produced one. Currently terminal; the cross-
+    ;; phase auto-resume composition (single retry from the persisted
+    ;; checkpoint, then terminate) lives in a follow-up PR.
+    :review/backend-timeout})
 
 (defn verdict-terminal?
   "Guard: true when the failing-phase event carries a terminal verdict.

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -295,6 +295,19 @@
         (let [evt {:type :phase/fail :phase/verdict :exhausted}
               after (fsm/transition-execution machine at-review evt)]
           (is (= :failed (fsm/execution-status machine after)))))
+      (testing ":review/backend-timeout terminates straight to :failed
+                — companion to :implement/network-dropped, fires when the
+                reviewer LLM hit its adaptive timeout (stream-idle /
+                stagnation / hard-limit) with no real verdict produced.
+                Distinct from :exhausted (LLM HAD a verdict the gate
+                couldn't approve) and from :rejected (real defect)."
+        (let [evt {:type :phase/fail :phase/verdict :review/backend-timeout}
+              after (fsm/transition-execution machine at-review evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "terminal verdict bypasses :on-fail :implement
+               — an infra timeout must not redirect into another
+               implement cycle that would just hit the same dead
+               provider on the next review pass")))
       (testing ":phase/verdict :repair-requested follows on-fail to :implement"
         (let [evt {:type :phase/fail :phase/verdict :repair-requested}
               after (fsm/transition-execution machine at-review evt)]


### PR DESCRIPTION
## Summary

PR-A of the phase-timeout stack (per `work/phase-stream-idle-as-terminal-timeout.spec.edn`). Detection primitive only — PR-B adds the `:phase/timeout` FSM terminal verdict, PR-C composes with the network-resilience auto-resume (#1054).

The 2026-06-05 dogfood (`adhoc-944448986`) walked explore → plan → implement → verify clean on a sharp 2-task DAG, then died when the reviewer LLM stream-idle'd at 360s. The framework promoted the adaptive-timeout text into `:review/blocking-issues`, synthesized a false `:rejected`, and the `:review-approved` gate (correctly given the verdict it received) failed. Task 2 cascade-failed by dependency. $2.95 / 40.9m lost on a transient infra timeout.

Root cause: the reviewer's existing `timeout-only-review?` predicate reads from the parsed review map and so cannot fire when the LLM call itself errored (`llm-review` is nil on parse-failed-from-stream-idle).

This PR adds the missing boundary-level detection.

### Changes

- **`result_boundary.clj`** — three new helpers operating on the normalized boundary map (mirror of the path-priority pattern in `network-drop-in-result?`):
  - `llm-timeout-type` — pulls the canonical `:type` keyword from `[:llm-error :timeout :type]`. The cross-phase primitive PR-B will build verdicts on.
  - `stream-idle-error?` / `network-drop-error?` — convenience predicates for the two recovery-eligible timeout types.
- **`reviewer.clj`** — wires `result-boundary/stream-idle-error?` next to the existing `timeout-only-review?` call. New `backend-timeout?` binding fires on either condition; takes the existing `timeout-only-error-result` exit when set. `all-blocking` no longer carries the parse-failure-message when `backend-timeout?` is true, so an infra timeout cannot leak into the artifact's blocking-issues channel. Telemetry preserves both flavors so post-mortems can attribute which path fired.
- **Tests** — direct coverage of all four timeout types in `result_boundary_test`, plus `test-reviewer-boundary-stream-idle-is-agent-error` pinning the exact 2026-06-05 dogfood shape end-to-end through the reviewer.

### Test plan

- [x] `bb pre-commit` green (303 tests / 1118 assertions, +1/+4)
- [x] `clojure -M:test -m cognitect.test-runner -n ai.miniforge.agent.result-boundary-test` green (7 tests / 36 assertions)
- [x] Reviewer dogfood-shape test exercises end-to-end: LLM call with empty content + stream-idle error in `:error :timeout` → `:reviewer/backend-timeout` agent error, NOT a `:rejected` artifact with timeout text in blocking-issues
- [ ] CI: full suite + Windows + Lint
- [ ] Follow-up PR-B: `:phase/timeout` terminal verdict in FSM `terminal-verdicts` set + per-phase compute-verdict wiring
- [ ] Follow-up PR-C: auto-resume budget + composition with PR-C of network-resilience stack

Relates to: 06-05 dogfood findings (`project_dogfood_findings_2026_06_05.md`); the network-resilience stack #1051/#1053/#1054 (same recovery shape, different trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)