### PR TITLE
feat(workflow,review): :review/backend-timeout terminal verdict (PR-B of phase-timeout stack)

### DIFF
--- a/components/phase-software-factory/resources/config/phase/messages/en-US.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/en-US.edn
@@ -20,6 +20,9 @@
   :review/needs-decomposition
   "Review-repair loop is not converging: {iterations} consecutive review→implement cycles each surfaced different legitimate blockers without reaching approval. The task is likely too coarse for one implement turn to satisfy in full — emitting :needs-decomposition so a meta-agent can split it instead of burning the remaining redirect budget."
 
+  :review/backend-timeout
+  "Reviewer LLM hit its adaptive timeout (stream-idle, stagnation, hard-limit, or generic) with no verdict produced — the call errored before any review artifact could be parsed. Routed to the :review/backend-timeout terminal verdict instead of synthesizing a false :rejected from the timeout text. Operator should retry from the last persisted checkpoint once provider is responsive."
+
   ;; Verify phase
   :verify/no-environment      "Verify phase has no execution environment"
   :verify/no-environment-hint "Workflow runner must acquire an execution environment before verify phase"

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -326,27 +326,47 @@
    `:phase/fail` array reads it via `:verdict/terminal?` to decide
    between on-fail redirect and terminal `:failed`.
 
-     :approved            — reviewer green-lit; `:phase/succeed` event
-     :repair-requested    — actionable feedback + within budget;
-                            FSM may redirect via on-fail
-     :stagnated           — same blocking fingerprint as prior cycle;
-                            FSM terminates
-     :needs-decomposition — N non-stagnated rejections; FSM terminates
-                            with the decomposition signal
-     :exhausted           — reviewer blocked but no actionable
-                            feedback or over phase-level budget;
-                            FSM terminates"
-  #{:approved :repair-requested :stagnated :needs-decomposition :exhausted})
+     :approved              — reviewer green-lit; `:phase/succeed` event
+     :repair-requested      — actionable feedback + within budget;
+                              FSM may redirect via on-fail
+     :stagnated             — same blocking fingerprint as prior cycle;
+                              FSM terminates
+     :needs-decomposition   — N non-stagnated rejections; FSM terminates
+                              with the decomposition signal
+     :exhausted             — reviewer blocked but no actionable
+                              feedback or over phase-level budget;
+                              FSM terminates
+     :review/backend-timeout — the reviewer LLM call hit its adaptive
+                              timeout (stream-idle / stagnation / etc.)
+                              with no real verdict produced. PR-A
+                              (#1058) wired the agent to take the
+                              `:reviewer/backend-timeout` error exit
+                              instead of synthesizing a false
+                              `:rejected`; this verdict surfaces that
+                              infra failure to the FSM. Terminal —
+                              auto-resume composition (with the
+                              network-resilience PR-C, #1054) lives in
+                              a follow-up PR."
+  #{:approved :repair-requested :stagnated :needs-decomposition :exhausted
+    :review/backend-timeout})
 
 (defn- compute-verdict
   "Pick the verdict that should flow on the phase result. Mirrors the
    former `compute-decision` semantics one-for-one — `:stagnated` and
    `:needs-decomposition` keep their priority over `:repair-requested`;
    a reviewer-blocked failure with no actionable feedback collapses to
-   `:exhausted`."
-  [{:keys [reviewer-blocked? stagnated? needs-decomposition? within-budget?
-           actionable-feedback?]}]
+   `:exhausted`.
+
+   `:review/backend-timeout` takes priority over every code-review
+   verdict: when the reviewer LLM never produced a real verdict (PR-A
+   wiring), there is no `:rejected` to interpret as repair-requested
+   or exhausted. The infra failure must be reported as itself."
+  [{:keys [backend-timeout? reviewer-blocked? stagnated? needs-decomposition?
+           within-budget? actionable-feedback?]}]
   (cond
+    backend-timeout?
+    :review/backend-timeout
+
     stagnated?
     :stagnated
 
@@ -451,6 +471,17 @@
         max-iterations    (get-in ctx [:phase :budget :iterations]
                                   (get-in default-config [:budget :iterations]))
         gate-failed?      (= :failed (:phase/status (get-in ctx [:phase])))
+        ;; PR-A (#1058) makes the reviewer agent take the
+        ;; `:reviewer/backend-timeout` error exit on an LLM-call
+        ;; stream-idle (or stagnation / hard-limit / generic timeout)
+        ;; instead of synthesizing a false `:rejected`. Detect that
+        ;; error code here and route to the `:review/backend-timeout`
+        ;; verdict — terminal, distinct from `:exhausted` — so the FSM
+        ;; can treat an infra timeout differently from a real
+        ;; non-actionable rejection (the auto-resume composition with
+        ;; the network-resilience PR-C lives in a follow-up PR).
+        backend-timeout?  (= :reviewer/backend-timeout
+                             (get-in result [:error :data :code]))
         reviewer-blocked? (contains? blocking-decisions review-decision)
         prior-history     (get-in ctx [:execution :review-fingerprints] [])
         current-fp        (agent/review-fingerprint review-artifact)
@@ -472,7 +503,8 @@
         needs-decomposition? (compute-needs-decomposition?
                               reviewer-blocked? stagnated?
                               review-cycle-count max-no-progress-attempts)
-        verdict           (compute-verdict {:reviewer-blocked?    reviewer-blocked?
+        verdict           (compute-verdict {:backend-timeout?     backend-timeout?
+                                            :reviewer-blocked?    reviewer-blocked?
                                             :stagnated?           stagnated?
                                             :needs-decomposition? needs-decomposition?
                                             :within-budget?       within-budget?

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -252,6 +252,23 @@
                :review/cycle-count review-cycle-count
                :review/fingerprint-history (vec fingerprint-history)})))
 
+(defn- attach-backend-timeout-anomaly
+  "PR-B of phase-timeout stack: attach the backend-timeout anomaly to the
+   phase result so the workflow runner / evidence bundle can surface that
+   the reviewer LLM hit its adaptive timeout — the same pattern
+   `attach-stagnated-anomaly` and `attach-needs-decomposition-anomaly`
+   use for their terminal verdicts. Pulls the timeout message verbatim
+   from the agent's error result so operators see the actual
+   `stream-idle` / `stagnation` / etc. detail in post-mortem."
+  [ctx]
+  (let [agent-error-message (get-in ctx [:phase :result :error :message])
+        msg (or agent-error-message
+                (messages/t :review/backend-timeout))]
+    (assoc-in ctx [:phase :error]
+              {:message msg
+               :anomaly/category :anomalies.review/backend-timeout
+               :anomaly/message  msg})))
+
 (defn- attach-repair-handoff
   "Phase 2b: attach repair feedback + a typed handoff so the implementer
    can pick up the work. Does NOT call `phase/request-redirect` anymore
@@ -411,6 +428,9 @@
 
     :exhausted
     updated-ctx
+
+    :review/backend-timeout
+    (attach-backend-timeout-anomaly updated-ctx)
 
     :approved
     (mark-completed updated-ctx)))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -549,3 +549,30 @@
       (is (contains? verdicts :stagnated))
       (is (contains? verdicts :needs-decomposition))
       (is (contains? verdicts :repair-requested)))))
+
+(deftest backend-timeout-apply-verdict-attaches-anomaly-without-throwing
+  ;; PR #1059 review (Copilot): `apply-verdict` is a `case` with no
+  ;; default arm. Adding `:review/backend-timeout` to the verdicts set
+  ;; without a matching clause would raise IllegalArgumentException at
+  ;; the first production stream-idle. This test pins both the no-
+  ;; throw contract AND the anomaly-attached side-effect that mirrors
+  ;; the stagnated / needs-decomposition pattern.
+  (testing "leave-review on backend-timeout produces a context (no IllegalArgumentException)
+            and attaches the :anomalies.review/backend-timeout sub-anomaly
+            to [:phase :error] for the evidence bundle"
+    (let [final-ctx (simulate-leave-review-backend-timeout-context 1 2)
+          phase-error (get-in final-ctx [:phase :error])]
+      (is (some? phase-error)
+          ":phase :error is set — case clause fired the anomaly-attach side effect")
+      (is (= :anomalies.review/backend-timeout
+             (:anomaly/category phase-error))
+          "anomaly category matches the verdict — parallels :anomalies.review/stagnation
+           and :anomalies.review/needs-decomposition")
+      (is (string? (:anomaly/message phase-error))
+          "anomaly message is a string — pulled from the agent error message
+           or the catalog fallback")
+      (is (= (get-in final-ctx [:phase :result :error :message])
+             (:message phase-error))
+          "anomaly :message preserves the actual adaptive-timeout text the
+           operator needs (stream-idle / stagnation / etc.) — not just a
+           generic catalog string"))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -26,7 +26,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
-   [ai.miniforge.phase-software-factory.review]
+   [ai.miniforge.phase-software-factory.review :as review]
    [ai.miniforge.phase-software-factory.implement]))
 
 (def phase-test-config-resource
@@ -468,3 +468,84 @@
           "below cap, no decomposition verdict")
       (is (= :repair-requested (:verdict phase))
           "below cap with progress + actionable feedback = :repair-requested"))))
+
+;; ============================================================================
+;; Backend-timeout verdict — companion to PR-A (#1058)
+;;
+;; PR-A wires the reviewer agent to take a `:reviewer/backend-timeout`
+;; error exit when the LLM call itself stream-idle'd (or stagnation /
+;; hard-limit / generic timeout). PR-B's `compute-verdict` arm here
+;; translates that error code into a `:review/backend-timeout` verdict
+;; — terminal in the FSM's `terminal-verdicts` set — so an infra
+;; timeout no longer cascade-fails the workflow through the
+;; `:exhausted` / on-fail-implement path that would just hit the same
+;; dead provider on the next pass.
+;; ============================================================================
+
+(defn- simulate-leave-review-backend-timeout-context
+  "Simulate the leave-review logic when the reviewer agent returned a
+   `:reviewer/backend-timeout` error result (the PR-A exit shape).
+
+   The result mirrors what `artifact/timeout-only-error-result` wires
+   through `result-boundary/error-response`: `:status :error` at the
+   top of the result, the error data carries `:code :reviewer/backend-
+   timeout`, no `:output` artifact."
+  [iterations max-iterations]
+  (let [result {:status :error
+                :error {:message "Adaptive timeout: No stream output for 360000ms (type: stream-idle, elapsed: 360087ms)"
+                        :data {:code :reviewer/backend-timeout
+                               :blocking-issues ["Adaptive timeout: No stream output for 360000ms (type: stream-idle, elapsed: 360087ms)"]}}
+                :metrics {:tokens 9 :duration-ms 360087}}
+        ctx {:phase {:started-at (- (System/currentTimeMillis) 360087)
+                     :iterations iterations
+                     :budget {:iterations max-iterations}
+                     :result result}
+             :phase-config {:phase :review}
+             :execution/phase-results {}
+             :execution/input {:description "test task"}
+             :execution/metrics {}}
+        interceptor (phase/get-phase-interceptor {:phase :review})
+        leave-fn (:leave interceptor)]
+    (leave-fn ctx)))
+
+(deftest backend-timeout-result-emits-review-backend-timeout-verdict
+  ;; 2026-06-05 dogfood (workflow adhoc-944448986) repro: reviewer LLM
+  ;; stream-idle'd at 360s; PR-A makes the reviewer return the
+  ;; backend-timeout error code instead of synthesizing a false
+  ;; `:rejected`. PR-B converts that error code into the verdict the
+  ;; FSM reads to take the terminal branch.
+  (testing "reviewer-agent :reviewer/backend-timeout error → :review/backend-timeout verdict"
+    (let [final-ctx (simulate-leave-review-backend-timeout-context 1 2)
+          phase (:phase final-ctx)]
+      (is (= :review/backend-timeout (:verdict phase))
+          ":verdict slot exposes the canonical backend-timeout signal")
+      (is (= :review/backend-timeout
+             (get-in phase [:result :output :phase/verdict]))
+          "FSM-readable :phase/verdict carries the same verdict
+           — `determine-phase-event` plumbs this into the
+           `:verdict/terminal?` guard")))
+
+  (testing "backend-timeout verdict takes priority over the within-budget repair branch
+            — the LLM call NEVER produced a real verdict, so there's
+            nothing to repair; redirecting to implement would just hit
+            the same dead provider on the next review pass"
+    (let [final-ctx (simulate-leave-review-backend-timeout-context 1 4)
+          phase (:phase final-ctx)]
+      (is (= :review/backend-timeout (:verdict phase))
+          "even with iterations < max, backend-timeout pre-empts :repair-requested")
+      (is (not= :repair-requested (:verdict phase))))))
+
+(deftest backend-timeout-verdict-is-in-the-canonical-verdict-set
+  (testing "compute-verdict's verdict tag set declares :review/backend-timeout
+            — the FSM's terminal-verdicts wiring + `:verdict/terminal?`
+            guard look up the verdict by exact keyword match, so the
+            tag-set must enumerate it. Coverage here pins the public
+            surface so a rename can't silently slip past."
+    ;; Read the private var via the var; the resolved value is the set.
+    (let [verdicts @#'review/verdicts]
+      (is (contains? verdicts :review/backend-timeout))
+      (is (contains? verdicts :approved))
+      (is (contains? verdicts :exhausted))
+      (is (contains? verdicts :stagnated))
+      (is (contains? verdicts :needs-decomposition))
+      (is (contains? verdicts :repair-requested)))))

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -84,7 +84,19 @@
     ;; outages. Retrying again would just hit the same dead network on
     ;; the next probe cycle. Terminal — operator surfaces the workflow
     ;; for manual resume once connectivity is restored.
-    :implement/network-dropped})
+    :implement/network-dropped
+    ;; PR-B of phase-timeout stack (companion to network-resilience):
+    ;; the reviewer LLM call hit its adaptive timeout (stream-idle /
+    ;; stagnation / hard-limit / generic) with no real verdict
+    ;; produced. PR-A (#1058) made the reviewer agent take the
+    ;; `:reviewer/backend-timeout` error exit instead of synthesizing
+    ;; a false `:rejected`; this verdict surfaces that to the FSM.
+    ;; Distinct from `:exhausted` — `:exhausted` means the reviewer
+    ;; HAD a verdict the gate couldn't approve, this means the
+    ;; reviewer never produced one. Currently terminal; the cross-
+    ;; phase auto-resume composition (single retry from the persisted
+    ;; checkpoint, then terminate) lives in a follow-up PR.
+    :review/backend-timeout})
 
 (defn verdict-terminal?
   "Guard: true when the failing-phase event carries a terminal verdict.

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -295,6 +295,19 @@
         (let [evt {:type :phase/fail :phase/verdict :exhausted}
               after (fsm/transition-execution machine at-review evt)]
           (is (= :failed (fsm/execution-status machine after)))))
+      (testing ":review/backend-timeout terminates straight to :failed
+                — companion to :implement/network-dropped, fires when the
+                reviewer LLM hit its adaptive timeout (stream-idle /
+                stagnation / hard-limit) with no real verdict produced.
+                Distinct from :exhausted (LLM HAD a verdict the gate
+                couldn't approve) and from :rejected (real defect)."
+        (let [evt {:type :phase/fail :phase/verdict :review/backend-timeout}
+              after (fsm/transition-execution machine at-review evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "terminal verdict bypasses :on-fail :implement
+               — an infra timeout must not redirect into another
+               implement cycle that would just hit the same dead
+               provider on the next review pass")))
       (testing ":phase/verdict :repair-requested follows on-fail to :implement"
         (let [evt {:type :phase/fail :phase/verdict :repair-requested}
               after (fsm/transition-execution machine at-review evt)]


### PR DESCRIPTION
## Summary

Stacked on **#1058** (PR-A). PR-A wired the reviewer to take a `:reviewer/backend-timeout` error exit on a boundary-level LLM-call stream-idle (or stagnation / hard-limit / generic timeout). This PR converts that error code into the FSM-readable terminal verdict so the workflow takes the right branch — `:failed` directly, not a redirect into another `:implement` cycle that would just hit the same dead provider on the next review pass.

Distinct from `:exhausted`: `:exhausted` means the reviewer HAD a verdict the gate couldn't approve; `:review/backend-timeout` means the reviewer never produced one. Distinct from `:implement/network-dropped`: that fires when the network is gone; this fires when the provider connected but stopped producing tokens.

### Changes

- **`phase-software-factory/review.clj`** — `leave-review` reads `[:error :data :code]` for `:reviewer/backend-timeout`; `compute-verdict` gains a top-priority `backend-timeout? → :review/backend-timeout` arm. Verdict tag set extended.
- **`workflow/standard_guards_and_actions.clj`** — `:review/backend-timeout` joins `:implement/network-dropped` in the `terminal-verdicts` set the FSM's `:verdict/terminal?` guard consumes.
- **Tests** — `review_repair_loop_test` pins the verdict assignment + priority-over-`:repair-requested` contract against the production result shape. `fsm_test` pins the FSM transition: `:phase/fail` + `:review/backend-timeout` → `:failed` (bypasses on-fail redirect).

### FSM integration

Per the user feedback during PR-A: these predicates move the workflow into a different terminal state, so they must integrate properly with the FSM, not bolt on. This PR follows the `:implement/network-dropped` precedent exactly:

1. Phase code attaches `:phase/verdict <kw>` on the failing phase result
2. `determine-phase-event` plumbs the verdict into the FSM event
3. `:verdict/terminal?` guard checks against `terminal-verdicts` set
4. Guarded `:phase/fail` transition routes terminal verdicts to `:failed` directly

No new event keyword, no parallel signaling channel — just the canonical verdict-driven path.

### Test plan

- [x] `bb pre-commit` green (303 tests / 1118 assertions)
- [x] Workflow FSM tests pass standalone (22 tests / 141 assertions)
- [ ] CI: full suite + Windows + Lint
- [ ] Stack base PR-A (#1058) needs to merge first

### Stack

- **PR-A #1058** — boundary detection primitives + reviewer wiring
- **PR-B (this)** — review-phase FSM verdict + terminal-verdicts set
- **PR-C (follow-up)** — cross-phase parity (implement/verify/release) + auto-resume composition with the network-resilience PR-C (#1054)

Relates to: `work/phase-stream-idle-as-terminal-timeout.spec.edn`; 2026-06-05 dogfood (`adhoc-944448986`) post-mortem in `project_dogfood_findings_2026_06_05.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)