### PR TITLE
feat(workflow,implement): :implement/backend-timeout terminal verdict (PR-C of phase-timeout stack)

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -536,6 +536,38 @@
         (and (string? msg)
              (re-find #"(?i)type:\s*network-drop" msg)))))
 
+(defn- backend-timeout-in-result?
+  "True when the agent result carries an adaptive-timeout signal that
+   is NOT `:network-drop` — i.e. the LLM call hit a stream-idle,
+   stagnation, or hard-limit timeout. Mirrors
+   `network-drop-in-result?`'s three-location path priority so the
+   two timeout families stay symmetrically shaped (matching the
+   2026-06-06 phase-timeout PR-A primitives in result-boundary).
+
+   The 2026-06-05 dogfood (`adhoc-944448986`) revealed the gap: the
+   reviewer LLM stream-idle'd at 360s and the workflow had no
+   per-phase verdict to distinguish that infra timeout from a real
+   defect. PR-A/B fixed the review-phase side; this is the implement-
+   phase parity.
+
+   Distinct from `network-drop-in-result?` — the network monitor
+   detects TCP/TLS reachability loss; this catches the cases where
+   the provider stayed connected but stopped producing output (or
+   ran past a hard wall-clock cutoff). The two arms never both fire
+   on the same result because the `:type` is mutually exclusive.
+
+   Distinct from `rate-limit-in-result?` — that keys off provider-
+   emitted 429/quota messages; this keys off the LLM client's own
+   adaptive-timeout taxonomy."
+  [result]
+  (let [timeout-types #{:stream-idle :stagnation :hard-limit}
+        boundary-type (or (get-in result [:error :data :timeout :type])
+                          (get-in result [:timeout :type]))]
+    (or (contains? timeout-types boundary-type)
+        (let [msg (get-in result [:error :message])]
+          (and (string? msg)
+               (re-find #"(?i)type:\s*(stream-idle|stagnation|hard-limit)" msg))))))
+
 (defn- extract-error-message
   "Extract the most relevant error message from an agent result."
   [result default-msg]
@@ -617,6 +649,16 @@
         ;; mid-stream when the drop hit.
         network-dropped? (and (= :error agent-status)
                               (network-drop-in-result? result))
+        ;; PR-C of phase-timeout stack: companion to network-dropped?.
+        ;; Stream-idle / stagnation / hard-limit timeouts from the
+        ;; implementer LLM call. Retriable from the persisted
+        ;; checkpoint up to the iteration budget (same recovery shape
+        ;; as network-dropped); after budget exhaustion the verdict
+        ;; below escalates to `:implement/backend-timeout` terminal.
+        ;; Two arms never both fire on the same result — the
+        ;; underlying `:timeout :type` is mutually exclusive.
+        backend-timeout? (and (= :error agent-status)
+                              (backend-timeout-in-result? result))
         gate-failed? (= :failed (:phase/status (get-in ctx [:phase])))
         ;; Curator's empty-diff verdict: the implementer wrote no files to the
         ;; environment. Retrying with the same prompt won't change that — the
@@ -658,6 +700,15 @@
                        ;; :implement/network-dropped (terminal).
                        network-dropped? (phase/determine-phase-status
                                           effective-status iterations max-iterations)
+                       ;; Backend timeout (stream-idle / stagnation /
+                       ;; hard-limit): retriable within the iteration
+                       ;; budget — same shape as network-dropped.
+                       ;; Provider may be transiently slow; retry from
+                       ;; the persisted checkpoint. After
+                       ;; max-iterations the verdict below escalates
+                       ;; to `:implement/backend-timeout` terminal.
+                       backend-timeout? (phase/determine-phase-status
+                                          effective-status iterations max-iterations)
                        ;; Curator said no files — terminal, no retry.
                        curator-empty-diff? :failed
                        :else (phase/determine-phase-status
@@ -697,6 +748,18 @@
                   ;; above and the FSM keeps cycling implement.
                   network-dropped?
                   :implement/network-dropped
+
+                  ;; Backend timeout (PR-C of phase-timeout stack):
+                  ;; companion to network-dropped — same iteration-
+                  ;; budget retry shape, fires when the implementer's
+                  ;; LLM call hit stream-idle / stagnation / hard-limit
+                  ;; for max-iterations consecutive cycles. Terminal:
+                  ;; retrying would just hit the same slow provider
+                  ;; on the next pass. The FSM's `:verdict/terminal?`
+                  ;; guard routes this straight to `:failed` without
+                  ;; the on-fail :implement loop re-firing.
+                  backend-timeout?
+                  :implement/backend-timeout
 
                   curator-empty-diff?
                   :implement/empty-diff

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -754,6 +754,109 @@
     (is (not (network-drop? rate-limit-result))
         "rate-limit must NOT trip the network-drop classifier")))
 
+;------------------------------------------------------------------------------ Backend-timeout classifier (PR-C of phase-timeout stack)
+;; Companion to the network-drop classifier — same three-location path
+;; priority but matches the implementer's `:stream-idle` / `:stagnation`
+;; / `:hard-limit` adaptive-timeout types. The two arms are mutually
+;; exclusive on `:timeout :type` so they never both fire on the same
+;; result.
+
+(defn- backend-timeout? [result]
+  (#'implement/backend-timeout-in-result? result))
+
+(deftest backend-timeout-classifier-matches-stream-idle-canonical-shape-test
+  ;; The 2026-06-05 dogfood (`adhoc-944448986`) revealed this exact
+  ;; production shape on the reviewer side; PR-C wires the implement-
+  ;; phase equivalent.
+  (testing "[:error :data :timeout :type] = :stream-idle → true"
+    (is (backend-timeout?
+          {:status :error
+           :error {:message "Adaptive timeout: No stream output for 360000ms (type: stream-idle, elapsed: 360087ms)"
+                   :data {:type "adaptive_timeout"
+                          :timeout {:type :stream-idle
+                                    :elapsed-ms 360087}}}}))))
+
+(deftest backend-timeout-classifier-matches-stagnation-canonical-shape-test
+  (testing "[:error :data :timeout :type] = :stagnation → true"
+    (is (backend-timeout?
+          {:status :error
+           :error {:data {:timeout {:type :stagnation
+                                    :elapsed-ms 180000}}}}))))
+
+(deftest backend-timeout-classifier-matches-hard-limit-canonical-shape-test
+  (testing "[:error :data :timeout :type] = :hard-limit → true"
+    (is (backend-timeout?
+          {:status :error
+           :error {:data {:timeout {:type :hard-limit
+                                    :elapsed-ms 600000}}}}))))
+
+(deftest backend-timeout-classifier-matches-raw-timeout-shape-test
+  (testing "raw top-level [:timeout :type] for back-compat / test harnesses"
+    (is (backend-timeout? {:timeout {:type :stream-idle :elapsed-ms 360000}}))
+    (is (backend-timeout? {:timeout {:type :stagnation  :elapsed-ms 180000}}))
+    (is (backend-timeout? {:timeout {:type :hard-limit  :elapsed-ms 600000}}))))
+
+(deftest backend-timeout-classifier-matches-formatted-error-message-test
+  (testing "[:error :message] carrying the explicit `type:` marker"
+    (is (backend-timeout?
+          {:error {:message "Adaptive timeout: No stream output for 360000ms (type: stream-idle, elapsed: 360087ms)"}}))
+    (is (backend-timeout?
+          {:error {:message "Adaptive timeout: stagnation timeout (type: stagnation, elapsed: 180000ms)"}}))
+    (is (backend-timeout?
+          {:error {:message "Adaptive timeout: hard-limit hit (type: hard-limit, elapsed: 600000ms)"}})))
+
+  (testing "case-insensitive match on the type marker"
+    (is (backend-timeout? {:error {:message "TYPE: STREAM-IDLE at provider"}}))
+    (is (backend-timeout? {:error {:message "...type:Hard-Limit..."}}))))
+
+(deftest backend-timeout-classifier-ignores-unrelated-results-test
+  (testing "successful or non-timeout errors must NOT classify"
+    (is (not (backend-timeout? {:status :success :output "ok"})))
+    (is (not (backend-timeout? {:status :error :error {:message "Rate limit exceeded"}})))
+    (is (not (backend-timeout? {:status :error :error {:message "Syntax error at line 5"}})))
+    (is (not (backend-timeout? {})))
+    (is (not (backend-timeout? {:error {:message nil}}))))
+
+  (testing "network-drop is a DISTINCT envelope — must NOT classify as backend-timeout"
+    ;; The two arms are mutually exclusive on `:timeout :type`; this
+    ;; is the contract `leave-implement` relies on so the cond chain
+    ;; can't accidentally route a network-drop through the backend-
+    ;; timeout branch (or vice versa).
+    (is (not (backend-timeout? {:timeout {:type :network-drop :elapsed-ms 30000}})))
+    (is (not (backend-timeout?
+               {:error {:data {:timeout {:type :network-drop :elapsed-ms 30000}}}})))
+    (is (not (backend-timeout?
+               {:error {:message "Adaptive timeout: (type: network-drop, elapsed: 30000ms)"}}))))
+
+  (testing "prose mentions without the type marker do NOT match"
+    (is (not (backend-timeout? {:error {:message "Stream idle on UI subscription"}})))
+    (is (not (backend-timeout? {:error {:message "Provider stagnation across regions"}})))))
+
+(deftest backend-timeout-classifier-distinct-from-network-drop-and-rate-limit-test
+  ;; Three classifiers feed three distinct verdicts:
+  ;; - backend-timeout      → :implement/backend-timeout (retriable + terminal)
+  ;; - network-drop         → :implement/network-dropped (retriable + terminal)
+  ;; - rate-limit           → :implement/rate-limited    (immediate terminal)
+  ;; The leave-implement cond chain depends on no two firing on the
+  ;; same result.
+  (let [stream-idle-result {:status :error
+                            :error {:data {:timeout {:type :stream-idle :elapsed-ms 360000}}}}
+        network-drop-result {:status :error
+                             :error {:data {:timeout {:type :network-drop :elapsed-ms 30000}}}}
+        rate-limit-result {:error {:message "HTTP 429 rate limit exceeded"}}]
+    (testing "stream-idle classifies as backend-timeout only"
+      (is (backend-timeout? stream-idle-result))
+      (is (not (network-drop? stream-idle-result)))
+      (is (not (rate-limit? stream-idle-result))))
+    (testing "network-drop classifies as network-drop only"
+      (is (network-drop? network-drop-result))
+      (is (not (backend-timeout? network-drop-result)))
+      (is (not (rate-limit? network-drop-result))))
+    (testing "rate-limit classifies as rate-limit only"
+      (is (rate-limit? rate-limit-result))
+      (is (not (backend-timeout? rate-limit-result)))
+      (is (not (network-drop? rate-limit-result))))))
+
 (deftest rate-limit-classifier-does-not-flag-legitimate-curator-failures-test
   (testing "curator no-files after a full-length attempt is a real task failure"
     ;; If the implementer ran for the full ~11 min and still wrote nothing,

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -93,10 +93,16 @@
     ;; a false `:rejected`; this verdict surfaces that to the FSM.
     ;; Distinct from `:exhausted` — `:exhausted` means the reviewer
     ;; HAD a verdict the gate couldn't approve, this means the
-    ;; reviewer never produced one. Currently terminal; the cross-
-    ;; phase auto-resume composition (single retry from the persisted
-    ;; checkpoint, then terminate) lives in a follow-up PR.
-    :review/backend-timeout})
+    ;; reviewer never produced one.
+    :review/backend-timeout
+    ;; PR-C of phase-timeout stack (companion to PR-B + network-
+    ;; resilience PR-C): the implementer LLM call exhausted its
+    ;; iteration budget retrying from the persisted checkpoint after
+    ;; consecutive stream-idle / stagnation / hard-limit timeouts.
+    ;; Same recovery shape as `:implement/network-dropped` — retriable
+    ;; up to the budget, then terminal. Retrying again would just hit
+    ;; the same slow provider on the next pass.
+    :implement/backend-timeout})
 
 (defn verdict-terminal?
   "Guard: true when the failing-phase event carries a terminal verdict.

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -439,6 +439,18 @@
               "implement network-drop after retry exhaustion MUST NOT
                redirect — operator surfaces for manual resume once
                connectivity is restored")))
+      (testing ":implement/backend-timeout terminates straight to :failed
+                (PR-C of phase-timeout stack: implementer LLM call
+                exhausted iteration budget retrying after consecutive
+                stream-idle / stagnation / hard-limit timeouts.
+                Companion to :review/backend-timeout — same shape,
+                applied to the implement phase)"
+        (let [evt {:type :phase/fail :phase/verdict :implement/backend-timeout}
+              after (fsm/transition-execution machine at-implement evt)]
+          (is (= :failed (fsm/execution-status machine after))
+              "implement backend-timeout after retry exhaustion MUST
+               NOT redirect — retrying would just hit the same slow
+               provider on the next pass")))
       (testing ":repair-requested follows on-fail (here :plan) + counter"
         (let [evt {:type :phase/fail :phase/verdict :repair-requested}
               after (fsm/transition-execution machine at-implement evt)]


### PR DESCRIPTION
## Summary

PR-C of the phase-timeout stack — implement-phase parity with the reviewer-side wiring landed in PR-A/B (#1058). Closes out the cross-phase shape per `work/phase-stream-idle-as-terminal-timeout.spec.edn`.

The 2026-06-05 dogfood revealed the gap: a phase-LLM call that stream-idles cascade-fails the DAG task with no terminal verdict distinct from a real defect. PR-A/B fixed the reviewer; this PR adds the implementer companion using the existing `:implement/network-dropped` recovery shape as the precedent.

### Changes

- **`implement.clj`** — new `backend-timeout-in-result?` predicate (mirror of `network-drop-in-result?`'s three-location path priority, matching `:stream-idle` / `:stagnation` / `:hard-limit` and mutually exclusive with the network-drop arm). `leave-implement` wires the detection at both the `phase-status` cond (retriable within iteration budget) and the `verdict` cond (escalates to `:implement/backend-timeout` on budget exhaustion).
- **`standard_guards_and_actions.clj`** — `:implement/backend-timeout` joins the FSM `terminal-verdicts` set so `:verdict/terminal?` routes the verdict straight to `:failed` (no on-fail redirect into another implement cycle that would just hit the same slow provider).
- **Tests** — six predicate-level deftests cover each timeout type, both canonical and raw shapes, the message-channel marker, the negative cases, and the three-way mutual exclusion contract with `network-drop?` and `rate-limit?`. New FSM sub-test pins the terminal-transition behavior alongside the existing `:implement/network-dropped` case.

### FSM integration

Mirrors `:implement/network-dropped` precedent exactly — phase code attaches `:phase/verdict` on the failing phase result, the FSM's `:verdict/terminal?` guard reads `terminal-verdicts`, the guarded `:phase/fail` transition routes terminals to `:failed`. No new event keyword, no parallel signaling channel.

### Test plan

- [x] `bb pre-commit` green (303 tests / 1118 assertions)
- [x] Workflow FSM tests pass standalone (22 tests / 142 assertions, +1 for the new transition)
- [ ] CI: full suite + Windows + Lint
- [ ] Dogfood re-run to validate the new verdict in a live event stream

### Stack

- **PR-A/B #1058 (merged)** — boundary detection primitives + reviewer wiring + `:review/backend-timeout` FSM verdict
- **PR-C (this)** — implement-phase parity + `:implement/backend-timeout` FSM verdict

Relates to: 2026-06-05 dogfood findings (`project_dogfood_findings_2026_06_05.md`); network-resilience stack #1051/#1053/#1054 (same recovery shape, different trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)