### PR TITLE
chore(headers): add Apache-2.0 headers to reliability component

### DIFF
--- a/components/reliability/resources/config/reliability/defaults.edn
+++ b/components/reliability/resources/config/reliability/defaults.edn
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Reliability engine configuration defaults per N1 §5.5
 {:budget-critical-threshold 0.25
  :inverted-slis #{:SLI-6}

--- a/components/reliability/resources/config/reliability/messages/en-US.edn
+++ b/components/reliability/resources/config/reliability/messages/en-US.edn
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 {:reliability/messages
  {:sli/computed         "SLI computed: {name} = {value} over {window}"
   :slo/breach           "SLO breach: {name} target={target} actual={actual} tier={tier}"

--- a/components/reliability/resources/config/reliability/slo-targets.edn
+++ b/components/reliability/resources/config/reliability/slo-targets.edn
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; SLO targets by workflow tier per N1 §5.5.3
 ;; nil means advisory-only (no enforcement for that tier).
 ;; For SLI-6 (unknown failure rate), the target is a maximum (lower is better).

--- a/components/reliability/src/ai/miniforge/reliability/budget.clj
+++ b/components/reliability/src/ai/miniforge/reliability/budget.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.budget

--- a/components/reliability/src/ai/miniforge/reliability/budget.clj
+++ b/components/reliability/src/ai/miniforge/reliability/budget.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.budget
   "Error budget computation per N1 §5.5.4.
 

--- a/components/reliability/src/ai/miniforge/reliability/degradation.clj
+++ b/components/reliability/src/ai/miniforge/reliability/degradation.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.degradation

--- a/components/reliability/src/ai/miniforge/reliability/degradation.clj
+++ b/components/reliability/src/ai/miniforge/reliability/degradation.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.degradation
   "Degradation mode FSM per N1 §5.5.5 and N8 §3.4.
 

--- a/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
+++ b/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.dependency-health
   "Pure dependency-health projection from classified dependency incidents.
 

--- a/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
+++ b/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.dependency-health

--- a/components/reliability/src/ai/miniforge/reliability/engine.clj
+++ b/components/reliability/src/ai/miniforge/reliability/engine.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.engine

--- a/components/reliability/src/ai/miniforge/reliability/engine.clj
+++ b/components/reliability/src/ai/miniforge/reliability/engine.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.engine
   "ReliabilityEngine — periodic SLI computation, SLO checking, and budget tracking.
 

--- a/components/reliability/src/ai/miniforge/reliability/interface.clj
+++ b/components/reliability/src/ai/miniforge/reliability/interface.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.interface
   "Public API for the reliability component per N1 §5.5.
 

--- a/components/reliability/src/ai/miniforge/reliability/interface.clj
+++ b/components/reliability/src/ai/miniforge/reliability/interface.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.interface

--- a/components/reliability/src/ai/miniforge/reliability/messages.clj
+++ b/components/reliability/src/ai/miniforge/reliability/messages.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.messages
   "Component-level message catalog for reliability.
    Delegates to the shared messages component."

--- a/components/reliability/src/ai/miniforge/reliability/messages.clj
+++ b/components/reliability/src/ai/miniforge/reliability/messages.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.messages

--- a/components/reliability/src/ai/miniforge/reliability/schema.clj
+++ b/components/reliability/src/ai/miniforge/reliability/schema.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.schema

--- a/components/reliability/src/ai/miniforge/reliability/schema.clj
+++ b/components/reliability/src/ai/miniforge/reliability/schema.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.schema
   "Malli schemas for reliability data structures per N1 §5.5.")
 

--- a/components/reliability/src/ai/miniforge/reliability/sli.clj
+++ b/components/reliability/src/ai/miniforge/reliability/sli.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.sli

--- a/components/reliability/src/ai/miniforge/reliability/sli.clj
+++ b/components/reliability/src/ai/miniforge/reliability/sli.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.sli
   "Pure SLI computation functions per N1 §5.5.2.
 

--- a/components/reliability/src/ai/miniforge/reliability/slo.clj
+++ b/components/reliability/src/ai/miniforge/reliability/slo.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.slo
   "SLO target checking per workflow tier per N1 §5.5.3.
 

--- a/components/reliability/src/ai/miniforge/reliability/slo.clj
+++ b/components/reliability/src/ai/miniforge/reliability/slo.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.slo

--- a/components/reliability/test/ai/miniforge/reliability/engine_test.clj
+++ b/components/reliability/test/ai/miniforge/reliability/engine_test.clj
@@ -16,8 +16,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.engine-test
   (:require
    [ai.miniforge.event-stream.interface.stream :as stream]

--- a/components/reliability/test/ai/miniforge/reliability/engine_test.clj
+++ b/components/reliability/test/ai/miniforge/reliability/engine_test.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.reliability.engine-test


### PR DESCRIPTION
## Summary

- 13 files in the `reliability` component were missing the canonical Apache-2.0 header required by `.standards/project/header-copyright.mdc`
- **10 src `.clj` files**: `budget`, `degradation`, `dependency_health`, `engine`, `interface`, `messages`, `schema`, `sli`, `slo` — plus `engine_test.clj`
- **3 resource `.edn` files**: `defaults.edn`, `messages/en-US.edn`, `slo-targets.edn`
- No behaviour change — header-only prepend

Found via drift scan against `header-copyright.mdc`.

## Test plan

- [ ] `bb poly:check` — OK
- [ ] `git grep -rL "Apache License" -- 'components/reliability/**/*.clj' 'components/reliability/**/*.edn'` returns 0 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)