### PR TITLE
Add warning-only rejection classifier to reviewer artifact (agent...

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/specialized.clj
@@ -91,6 +91,7 @@
 (def get-review-issues reviewer-artifact/get-issues)
 (def get-review-strengths reviewer-artifact/get-strengths)
 (def validate-review-artifact reviewer-artifact/validate-review-artifact)
+(def rejection-warnings-only? reviewer-artifact/rejection-warnings-only?)
 ;; Repair-loop fingerprint helpers — moved to
 ;; components/progress-detector/.../detectors/repair-loop in Stage 2.
 ;; These re-exports stay for backward compatibility; phase-software-factory

--- a/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
@@ -289,3 +289,24 @@
   "Extract strengths noted by the LLM from review artifact."
   [artifact]
   (:review/strengths artifact []))
+
+(defn rejection-warnings-only?
+  "True when the review is a rejection driven exclusively by warnings (no
+   real blocking defects).
+
+   Returns true iff ALL three conditions hold:
+   1. `:review/decision` is a rejection-class decision
+      (`issues/rejection-decisions` — `:rejected` or `:changes-requested`).
+   2. `:review/blocking-issues` is empty (no hard blockers).
+   3. `:review/warnings` is non-empty (there are warning-level nits).
+
+   This is the cause-classification primitive that `leave-review` (and
+   downstream phase logic) needs to distinguish a genuine-defect rejection
+   from nit-churn: a rejection where every complaint is advisory-only
+   warrants a different response (e.g. skip-redirect) versus one where at
+   least one true blocker exists."
+  [artifact]
+  (boolean
+   (and (contains? issues/rejection-decisions (:review/decision artifact))
+        (empty? (get artifact :review/blocking-issues []))
+        (seq (get artifact :review/warnings [])))))

--- a/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
@@ -294,11 +294,10 @@
   "True when the review is a rejection driven exclusively by warnings (no
    real blocking defects).
 
-   Returns true iff ALL three conditions hold:
-   1. `:review/decision` is a rejection-class decision
-      (`issues/rejection-decisions` — `:rejected` or `:changes-requested`).
+   Returns true iff all three conditions hold:
+   1. `:review/decision` is a rejection-class decision (`issues/rejection-decisions`).
    2. `:review/blocking-issues` is empty (no hard blockers).
-   3. `:review/warnings` is non-empty (there are warning-level nits).
+   3. `:review/warnings` is non-empty (there are advisory warnings).
 
    This is the cause-classification primitive that `leave-review` (and
    downstream phase logic) needs to distinguish a genuine-defect rejection

--- a/components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj
@@ -224,7 +224,7 @@
     (is (artifact/rejection-warnings-only?
          (canonical-review :decision :rejected
                            :blocking-issues []
-                           :warnings ["style nit"])))
+                           :warnings ["style warning"])))
     (is (artifact/rejection-warnings-only?
          (canonical-review :decision :changes-requested
                            :blocking-issues []

--- a/components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj
@@ -216,3 +216,49 @@
       (is (= ["fix a"]   (artifact/get-recommendations r)))
       (is (= [{:severity :nit :description "x"}] (artifact/get-issues r)))
       (is (= ["good API"] (artifact/get-strengths r))))))
+
+;------------------------------------------------------------------------------ rejection-warnings-only?
+
+(deftest rejection-warnings-only-test
+  (testing "true when rejection-class + no blockers + warnings present"
+    (is (artifact/rejection-warnings-only?
+         (canonical-review :decision :rejected
+                           :blocking-issues []
+                           :warnings ["style nit"])))
+    (is (artifact/rejection-warnings-only?
+         (canonical-review :decision :changes-requested
+                           :blocking-issues []
+                           :warnings ["trailing whitespace"]))))
+
+  (testing "false when the decision is approval-class"
+    (is (not (artifact/rejection-warnings-only?
+              (canonical-review :decision :approved
+                                :blocking-issues []
+                                :warnings ["advisory nit"]))))
+    (is (not (artifact/rejection-warnings-only?
+              (canonical-review :decision :conditionally-approved
+                                :blocking-issues []
+                                :warnings ["advisory nit"])))))
+
+  (testing "false when blocking issues are present alongside warnings"
+    (is (not (artifact/rejection-warnings-only?
+              (canonical-review :decision :rejected
+                                :blocking-issues ["real defect"]
+                                :warnings ["advisory nit"])))))
+
+  (testing "false when warnings are absent (empty)"
+    (is (not (artifact/rejection-warnings-only?
+              (canonical-review :decision :rejected
+                                :blocking-issues []
+                                :warnings [])))))
+
+  (testing "false when warnings key is missing entirely"
+    (let [r (dissoc (canonical-review :decision :rejected :blocking-issues [])
+                    :review/warnings)]
+      (is (not (artifact/rejection-warnings-only? r)))))
+
+  (testing "false when both blockers and warnings are absent"
+    (is (not (artifact/rejection-warnings-only?
+              (canonical-review :decision :rejected
+                                :blocking-issues []
+                                :warnings []))))))

--- a/docs/pull-requests/2026-06-06-add-warning-only-rejection-classifier-to-reviewer-artifact-agent.md
+++ b/docs/pull-requests/2026-06-06-add-warning-only-rejection-classifier-to-reviewer-artifact-agent.md
@@ -1,0 +1,28 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Add warning-only rejection classifier to reviewer artifact (agent...
+
+**PR:** [#1064](https://github.com/miniforge-ai/miniforge/pull/1064)
+**Branch:** `mf/add-warning-only-rejection-classifier-to-827ab28c`
+
+## Summary
+
+Add warning-only rejection classifier to reviewer artifact (agent component).
+
+## Files Changed
+
+- `components/agent/src/ai/miniforge/agent/interface/specialized.clj` (modify)
+- `components/agent/src/ai/miniforge/agent/reviewer/artifact.clj` (modify)
+- `components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+_No review artifacts available._


### PR DESCRIPTION
## Summary

Add warning-only rejection classifier to reviewer artifact (agent component).

## Changes

- `components/agent/src/ai/miniforge/agent/interface/specialized.clj` (modify)
- `components/agent/src/ai/miniforge/agent/reviewer/artifact.clj` (modify)
- `components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj` (modify)

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (3 files)