### PR TITLE
feat(llm,agent,dogfood): bump LLM stream-idle 360→420s + tee dogfood streams to disk

### DIFF
--- a/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
+++ b/components/agent/src/ai/miniforge/agent/stream_watchdog.clj
@@ -46,22 +46,25 @@
   (log/create-logger {:min-level :info :output :edn}))
 
 (def ^:const default-gap-threshold-ms
-  "Default stream-gap threshold in milliseconds (420 seconds).
+  "Default stream-gap threshold in milliseconds (480 seconds).
 
    INVARIANT: this MUST stay >= the LLM client's stream-line-timeout-ms
-   (currently 360 000 ms; see components/llm/resources/llm/client-defaults.edn).
+   (currently 420 000 ms; see components/llm/resources/llm/client-defaults.edn).
    The watchdog and that idle timeout watch the SAME signal — agent stdout
    activity — so the watchdog is a BACKSTOP for a wedged consumer thread, not a
    primary stall detector. When it is shorter than the idle timeout it FALSE-
    FIRES on legitimate model silence: Opus on a large first-turn prompt goes
-   silent on stdout for 180-300s by design, which the 360 000 ms idle timeout
-   deliberately tolerates. The old 90 000 ms default killed those legitimate
-   turns every iteration, and (pre-#988) the workflow retried forever — a 17h
-   overnight token burn. 420 000 = 360 000 idle + 60 000 margin, so the clean
-   in-stream idle timeout (which yields a resumable :stream-idle terminal)
-   fires first and the watchdog only catches the case the idle timeout cannot:
-   the stream consumer loop itself wedged."
-  420000)
+   silent on stdout for 180-300s by design, which the idle timeout deliberately
+   tolerates. The old 90 000 ms default killed those legitimate turns every
+   iteration, and (pre-#988) the workflow retried forever — a 17h overnight
+   token burn. 480 000 = 420 000 idle + 60 000 margin, so the clean in-stream
+   idle timeout (which yields a resumable :stream-idle terminal) fires first
+   and the watchdog only catches the case the idle timeout cannot: the stream
+   consumer loop itself wedged. The idle timeout was raised from 360s to 420s
+   2026-06-06 (review-redirect-convergence dogfood, `adhoc-2073513324`) to
+   give the reviewer's longer first-turn prompt the same margin the
+   implementer enjoys; this constant floats up alongside it."
+  480000)
 
 (def ^:const default-check-interval-ms
   "Default watchdog check interval in milliseconds (5 seconds)."
@@ -73,18 +76,18 @@
    Precedence (highest wins):
      1. Backend-specific entry in :agent/per-backend-gap-thresholds
      2. Global :agent/stream-gap-threshold-ms in config
-     3. `default-gap-threshold-ms` (420 000 ms)
+     3. `default-gap-threshold-ms` (480 000 ms)
 
    In production/real runs an override MUST honor the same invariant as
    `default-gap-threshold-ms`: keep it >= the LLM client's
-   stream-line-timeout-ms (360 000 ms) so the watchdog stays a backstop and
+   stream-line-timeout-ms (420 000 ms) so the watchdog stays a backstop and
    does not false-fire on legitimate model silence. (Tests deliberately set
    tiny sub-threshold values — e.g. 1 ms — to force a fast stall; that is an
    intentional exception, not a real-run configuration.)
 
    Example config:
-     {:agent/stream-gap-threshold-ms 420000
-      :agent/per-backend-gap-thresholds {:claude-code 480000}}"
+     {:agent/stream-gap-threshold-ms 480000
+      :agent/per-backend-gap-thresholds {:claude-code 540000}}"
   [config backend]
   (let [base      (get config :agent/stream-gap-threshold-ms default-gap-threshold-ms)
         overrides (get config :agent/per-backend-gap-thresholds {})]
@@ -208,7 +211,7 @@
   "Create and start a stream-gap watchdog.
 
    Options map:
-     :threshold-ms      — gap in ms before the kill fires (default 420 000)
+     :threshold-ms      — gap in ms before the kill fires (default 480 000)
      :check-interval-ms — how often to check for a stall (default 5 000)
      :phase-id          — keyword or string identifying the current phase
      :backend           — keyword identifying the agent backend (e.g. :claude-code)

--- a/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
+++ b/components/agent/test/ai/miniforge/agent/stream_watchdog_test.clj
@@ -133,9 +133,14 @@
                   :agent/per-backend-gap-thresholds  {:claude-code 120000}}]
       (is (= 60000 (sut/resolve-gap-threshold config :other-backend))))))
 
-(deftest resolve-gap-threshold-default-constant-is-420s
-  (testing "default constant is 420 000 ms — a backstop above the 360 000 ms LLM idle timeout"
-    (is (= 420000 sut/default-gap-threshold-ms))))
+(deftest resolve-gap-threshold-default-constant-is-480s
+  (testing "default constant is 480 000 ms — a backstop above the 420 000 ms LLM
+            idle timeout (LLM idle bumped 360→420 2026-06-06 per the
+            review-redirect-convergence dogfood, `adhoc-2073513324`).
+            INVARIANT: gap >= idle, with the 60s margin preserving the
+            ordering — idle terminal fires first, watchdog catches only
+            wedged consumer threads."
+    (is (= 480000 sut/default-gap-threshold-ms))))
 
 ;; ---------------------------------------------------------------------------
 ;; create-watchdog structure

--- a/components/llm/resources/llm/client-defaults.edn
+++ b/components/llm/resources/llm/client-defaults.edn
@@ -19,7 +19,8 @@
   ;; killed the call before any verdict landed. Raised to 420s to give
   ;; the reviewer's longer first turn the same margin the implementer
   ;; relies on; the watchdog backstop floats up alongside it (see
-  ;; `default-gap-threshold-ms` in agent/stream_watchdog.clj).
+  ;; `default-gap-threshold-ms` in components/agent/src/ai/miniforge/agent/stream_watchdog.clj).
+
   :line-timeout-ms 420000
   :process-join-timeout-ms 600000
   :post-kill-join-timeout-ms 5000

--- a/components/llm/resources/llm/client-defaults.edn
+++ b/components/llm/resources/llm/client-defaults.edn
@@ -13,8 +13,14 @@
   ;; silent on stdout for 180-300s after the initial system+rate_limit
   ;; pair (next line is the first assistant chunk). 180s used to fire
   ;; before the model could emit anything (event-log-tool-visibility
-  ;; dogfood, 2026-05-04). 360s gives long planner first turns room.
-  :line-timeout-ms 360000
+  ;; dogfood, 2026-05-04). The 2026-06-06 review-redirect-convergence
+  ;; dogfood (`adhoc-2073513324`) hit 360s on the reviewer's larger
+  ;; prompt — full review.clj + tests + spec + standards pack — and
+  ;; killed the call before any verdict landed. Raised to 420s to give
+  ;; the reviewer's longer first turn the same margin the implementer
+  ;; relies on; the watchdog backstop floats up alongside it (see
+  ;; `default-gap-threshold-ms` in agent/stream_watchdog.clj).
+  :line-timeout-ms 420000
   :process-join-timeout-ms 600000
   :post-kill-join-timeout-ms 5000
   :poll-interval-ms 250}}

--- a/tasks/dogfood.clj
+++ b/tasks/dogfood.clj
@@ -98,7 +98,7 @@
    Path printed before the run so the operator can tail it live."
   []
   (let [ts (.format (java.time.format.DateTimeFormatter/ofPattern
-                     "yyyyMMdd-HHmmss")
+                     "yyyyMMdd-HHmmss-SSS")
                     (java.time.LocalDateTime/now))]
     (str (miniforge-home) "/stream-dumps/dogfood-" ts ".log")))
 

--- a/tasks/dogfood.clj
+++ b/tasks/dogfood.clj
@@ -169,6 +169,14 @@
       (do (println "\n⚠️  Fix issues above before dogfooding")
           (System/exit 1)))))
 
+(defn- shell-single-quote
+  "Single-quote a path for shell use: any literal `'` becomes `'\\''`
+   and the whole value is wrapped. Round-trips spaces, parens, and the
+   characters bash treats as metacharacters without surprising the
+   operator when they copy/paste the dry-run command."
+  [s]
+  (str "'" (str/replace s "'" "'\\''") "'"))
+
 (defn dry-run
   "Show the exact command that dogfood would execute.
    Usage: bb dogfood:dry-run [spec-path]"
@@ -176,12 +184,25 @@
   (let [{:keys [spec-path github-auth checks backend]}
         (prerequisite-status args)
         dump-path (stream-dump-path)
+        ;; The LLM client opens the dump path in append mode but does
+        ;; not create the parent dir; the printed command must match
+        ;; the `run` fn's behavior (which calls `fs/create-dirs`
+        ;; before launching) or a copy/paste would throw on the first
+        ;; `open-stream-dump-writer` call.
+        mkdir-prefix (str "mkdir -p "
+                          (shell-single-quote (str (fs/parent dump-path)))
+                          " && ")
         env-prefix (cond-> ""
                      (= :gh-auth (:source github-auth))
                      (str "env GITHUB_TOKEN=$(gh auth token) ")
                      :always
-                     (str "MF_STREAM_DUMP=" dump-path " "))
-        command (str env-prefix "bb miniforge run " spec-path)]
+                     (str "MF_STREAM_DUMP="
+                          (shell-single-quote dump-path)
+                          " "))
+        command (str mkdir-prefix
+                     env-prefix
+                     "bb miniforge run "
+                     (shell-single-quote spec-path))]
     (println "🤖 Dogfood dry run")
     (println "  spec:" spec-path)
     (println "  backend:" (if backend (name backend) "none"))

--- a/tasks/dogfood.clj
+++ b/tasks/dogfood.clj
@@ -77,6 +77,31 @@
            (str (fs/home) "/.miniforge"))
        "/config.edn"))
 
+(defn- miniforge-home []
+  (or (System/getenv "MINIFORGE_HOME")
+      (str (fs/home) "/.miniforge")))
+
+(defn- stream-dump-path
+  "Per-run timestamped path the LLM client tees every stream line to.
+
+   The 2026-06-06 review-redirect-convergence dogfood (`adhoc-
+   2073513324`) hit reviewer-LLM stream-idles whose root cause was
+   ambiguous between (a) the provider going genuinely silent on the
+   wire and (b) the Claude CLI stream parser dropping tokens during
+   long output. Capturing every line the LLM client sees on stdin lets
+   the next post-mortem distinguish the two — if the dump grows during
+   the silent gap it's parser drift; if it doesn't it's provider
+   silence.
+
+   Single append-mode file per run; all phase agents share it (the
+   reviewer's section is the one of interest after a stream-idle).
+   Path printed before the run so the operator can tail it live."
+  []
+  (let [ts (.format (java.time.format.DateTimeFormatter/ofPattern
+                     "yyyyMMdd-HHmmss")
+                    (java.time.LocalDateTime/now))]
+    (str (miniforge-home) "/stream-dumps/dogfood-" ts ".log")))
+
 (defn- read-edn-file [path]
   (when (fs/exists? path)
     (try
@@ -150,14 +175,18 @@
   [& args]
   (let [{:keys [spec-path github-auth checks backend]}
         (prerequisite-status args)
-        command (if (= :gh-auth (:source github-auth))
-                  (str "env GITHUB_TOKEN=$(gh auth token) bb miniforge run "
-                       spec-path)
-                  (str "bb miniforge run " spec-path))]
+        dump-path (stream-dump-path)
+        env-prefix (cond-> ""
+                     (= :gh-auth (:source github-auth))
+                     (str "env GITHUB_TOKEN=$(gh auth token) ")
+                     :always
+                     (str "MF_STREAM_DUMP=" dump-path " "))
+        command (str env-prefix "bb miniforge run " spec-path)]
     (println "🤖 Dogfood dry run")
     (println "  spec:" spec-path)
     (println "  backend:" (if backend (name backend) "none"))
     (println "  github-auth:" (or (some-> github-auth :source name) "none"))
+    (println "  stream-dump:" dump-path)
     (println)
     (println "Command:")
     (println command)
@@ -183,10 +212,17 @@
   (let [{:keys [spec-path github-auth checks]}
         (prerequisite-status args)]
     (if (every? val checks)
-      (let [proc (p/process (cond-> {:out :inherit
-                                     :err :inherit}
-                              (:token github-auth)
-                              (assoc :extra-env {"GITHUB_TOKEN" (:token github-auth)}))
+      (let [dump-path (stream-dump-path)
+            ;; LLM client (`open-stream-dump-writer`) opens the path
+            ;; in append mode but does NOT create parent dirs.
+            _ (fs/create-dirs (fs/parent dump-path))
+            _ (println "📼 stream dump:" dump-path)
+            extra-env (cond-> {"MF_STREAM_DUMP" dump-path}
+                        (:token github-auth)
+                        (assoc "GITHUB_TOKEN" (:token github-auth)))
+            proc (p/process {:out :inherit
+                             :err :inherit
+                             :extra-env extra-env}
                             "bb" "miniforge" "run" spec-path)
             {:keys [exit]} @proc]
         (System/exit exit))


### PR DESCRIPTION
## Summary

Two coupled changes motivated by the 2026-06-06 review-redirect-convergence dogfood (`adhoc-2073513324`): give the next dogfood (a) more time to land the reviewer's longer prompts and (b) the captured stream data needed to root-cause the silent stretches.

The 06-06 run shipped 2 PRs (#1064, #1065) — first ever from this dogfood thread — but lost task 2 to a reviewer-LLM stream-idle at 360s. The phase-timeout stack (#1058 + #1060) handled it cleanly (`:review/backend-timeout` terminal verdict, no false rejection), but the underlying provider/prompt-size issue keeps killing the bigger reviewer turns.

### Changes

- **LLM stream-line-timeout 360 000 → 420 000 ms** (`client-defaults.edn`). The implementer's watchdog precedent was set at 420s for the same reason post-#988; the reviewer's larger first-turn prompt — review.clj + tests + spec + standards pack — needs the same margin. Empirical Opus 180–300s silence stretch was at the edge of 360s; 420s gives 120s headroom over the upper-end case.
- **Stream-watchdog default-gap-threshold 420 000 → 480 000 ms** (`agent/stream_watchdog.clj`). INVARIANT requires watchdog stay ≥ LLM idle + margin so the resumable in-stream idle terminal fires first. 480 = 420 + 60 preserves the existing 60s margin.
- **`bb dogfood` tees every LLM stream line to a per-run file** (`tasks/dogfood.clj`). New `MF_STREAM_DUMP=~/.miniforge/stream-dumps/dogfood-<timestamp>.log` env var passed through to the subprocess; the LLM client's existing `open-stream-dump-writer` picks it up unchanged. Path printed before the run so the operator can tail live. Discriminates (a) provider silent on the wire (dump doesn't grow during gap) from (b) Claude CLI parser dropping tokens during long output (dump grows but `last-line-at` doesn't refresh).

### Test plan

- [x] `bb pre-commit` green (303 tests / 1118 assertions)
- [x] `bb dogfood:dry-run` shows the dump path + env var prefix correctly
- [x] `resolve-gap-threshold-default-constant-is-480s` test renamed + updated to pin the new default + invariant
- [ ] CI: full suite + Windows + Lint
- [ ] Next dogfood run captures a stream dump for forensic review

### Followup

After this lands the next dogfood will (a) hopefully cross the 360s boundary on the larger reviewer turns and (b) leave behind a stream-dump file we can grep for the silent gap.

Relates to: 2026-06-06 dogfood findings (`project_dogfood_findings_2026_06_06.md`); the phase-timeout stack #1058 + #1060 that closes the framework side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)