### PR TITLE
docs(metric-registry,pr-train): lift contract docstrings to interface boundary (rule 009)

### DIFF
--- a/components/metric-registry/src/ai/miniforge/metric_registry/interface.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/interface.clj
@@ -51,7 +51,7 @@
   "Vector of the refresh-cadence keywords, ordered fastest to slowest."
   reg-schema/refresh-cadences)
 (def redistribution-risks
-  "Vector of the redistribution-risk keywords, ordered low to high."
+  "Vector of the redistribution-risk keywords ([:none :low :medium :high]), in ascending order of risk."
   reg-schema/redistribution-risks)
 (def metric-directions
   "Vector of the metric-direction keywords."

--- a/components/metric-registry/src/ai/miniforge/metric_registry/interface.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/interface.clj
@@ -12,29 +12,67 @@
    [clojure.java.io :as io]))
 
 ;; -- Schema re-exports --
-(def AcquisitionClass reg-schema/AcquisitionClass)
-(def ImplementationMode reg-schema/ImplementationMode)
-(def RefreshCadence reg-schema/RefreshCadence)
-(def RedistributionRisk reg-schema/RedistributionRisk)
-(def MetricDirection reg-schema/MetricDirection)
-(def MetricUnit reg-schema/MetricUnit)
-(def MetricEntry reg-schema/MetricEntry)
-(def MetricFamily reg-schema/MetricFamily)
-(def MetricRegistry reg-schema/MetricRegistry)
+(def AcquisitionClass
+  "Malli `[:enum ...]` schema for a metric's acquisition class (sourcing tier)."
+  reg-schema/AcquisitionClass)
+(def ImplementationMode
+  "Malli `[:enum ...]` schema for how a metric is implemented (pull/derive/vendor/deprecated)."
+  reg-schema/ImplementationMode)
+(def RefreshCadence
+  "Malli `[:enum ...]` schema for a metric's refresh cadence (realtime through annual)."
+  reg-schema/RefreshCadence)
+(def RedistributionRisk
+  "Malli `[:enum ...]` schema for a metric's redistribution-risk level (none/low/medium/high)."
+  reg-schema/RedistributionRisk)
+(def MetricDirection
+  "Malli `[:enum ...]` schema for a metric's directional polarity (normal/inverse)."
+  reg-schema/MetricDirection)
+(def MetricUnit
+  "Malli `[:enum ...]` schema for a metric's unit (percent/ratio/index/basis-points/count/usd/level)."
+  reg-schema/MetricUnit)
+(def MetricEntry
+  "Malli `[:map ...]` schema for one metric definition (id, name, sourcing, cadence, unit, etc.)."
+  reg-schema/MetricEntry)
+(def MetricFamily
+  "Malli `[:map ...]` schema for a named group of related metrics."
+  reg-schema/MetricFamily)
+(def MetricRegistry
+  "Malli `[:map ...]` schema for the complete registry (id, version, families, pipeline map)."
+  reg-schema/MetricRegistry)
 
 ;; -- Enum value sets --
-(def acquisition-classes reg-schema/acquisition-classes)
-(def implementation-modes reg-schema/implementation-modes)
-(def refresh-cadences reg-schema/refresh-cadences)
-(def redistribution-risks reg-schema/redistribution-risks)
-(def metric-directions reg-schema/metric-directions)
-(def metric-units reg-schema/metric-units)
+(def acquisition-classes
+  "Vector of the four acquisition-class keywords, in taxonomy order."
+  reg-schema/acquisition-classes)
+(def implementation-modes
+  "Vector of the implementation-mode keywords."
+  reg-schema/implementation-modes)
+(def refresh-cadences
+  "Vector of the refresh-cadence keywords, ordered fastest to slowest."
+  reg-schema/refresh-cadences)
+(def redistribution-risks
+  "Vector of the redistribution-risk keywords, ordered low to high."
+  reg-schema/redistribution-risks)
+(def metric-directions
+  "Vector of the metric-direction keywords."
+  reg-schema/metric-directions)
+(def metric-units
+  "Vector of the metric-unit keywords."
+  reg-schema/metric-units)
 
 ;; -- Validation --
-(def valid-metric? reg-schema/valid-metric?)
-(def valid-family? reg-schema/valid-family?)
-(def valid-registry? reg-schema/valid-registry?)
-(def validate-registry reg-schema/validate-registry)
+(def valid-metric?
+  "Predicate: true if value conforms to the MetricEntry schema, false otherwise. Takes one metric value."
+  reg-schema/valid-metric?)
+(def valid-family?
+  "Predicate: true if value conforms to the MetricFamily schema, false otherwise. Takes one family value."
+  reg-schema/valid-family?)
+(def valid-registry?
+  "Predicate: true if value conforms to the MetricRegistry schema, false otherwise. Takes one registry value."
+  reg-schema/valid-registry?)
+(def validate-registry
+  "Validate a registry value against MetricRegistry. Returns {:valid? bool :errors map-or-nil}; never throws on invalid input."
+  reg-schema/validate-registry)
 
 ;; -- Loading --
 (defn load-registry

--- a/components/metric-registry/src/ai/miniforge/metric_registry/lookup.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/lookup.clj
@@ -2,39 +2,32 @@
   "Pure query functions over metric registry data.")
 
 (defn all-metrics
-  "Return flat sequence of all metrics across all families."
   [registry]
   (mapcat :family/metrics (:registry/families registry)))
 
 (defn find-metric
-  "Find a single metric by id. Returns nil if not found."
   [registry metric-id]
   (some (fn [m] (when (= metric-id (:metric/id m)) m))
         (all-metrics registry)))
 
 (defn find-metrics-by-family
-  "Return all metrics in a given family."
   [registry family-id]
   (some (fn [f] (when (= family-id (:family/id f)) (:family/metrics f)))
         (:registry/families registry)))
 
 (defn find-metrics-by-source-type
-  "Return all metrics with a given acquisition class."
   [registry source-type]
   (filter #(= source-type (:metric/source-type %))
           (all-metrics registry)))
 
 (defn find-metrics-by-pipeline
-  "Return metric ids mapped to a given pipeline name."
   [registry pipeline-name]
   (get-in registry [:registry/pipeline-metric-map pipeline-name]))
 
 (defn family-ids
-  "Return all family ids in the registry."
   [registry]
   (mapv :family/id (:registry/families registry)))
 
 (defn metric-count
-  "Return total number of metrics across all families."
   [registry]
   (count (all-metrics registry)))

--- a/components/metric-registry/src/ai/miniforge/metric_registry/schema.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/schema.clj
@@ -52,7 +52,6 @@
 ;; Metric entry and family schemas
 
 (def MetricEntry
-  "Schema for an individual metric definition."
   [:map
    [:metric/id string?]
    [:metric/name string?]
@@ -68,7 +67,6 @@
    [:metric/series-id {:optional true} string?]])
 
 (def MetricFamily
-  "Schema for a group of related metrics."
   [:map
    [:family/id keyword?]
    [:family/name string?]
@@ -78,7 +76,6 @@
 ;; Registry schema
 
 (def MetricRegistry
-  "Schema for the complete metric registry."
   [:map
    [:registry/id string?]
    [:registry/version string?]

--- a/components/pr-train/src/ai/miniforge/pr_train/interface.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/interface.clj
@@ -30,27 +30,72 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol and schema re-exports
 
-(def PRTrainManager core/PRTrainManager)
+(def PRTrainManager
+  "Protocol governing PR train management: lifecycle, state sync, queries,
+   merge actions, rollback, and evidence generation. Implemented by the
+   in-memory manager returned from create-manager."
+  core/PRTrainManager)
 
 ;; Schema re-exports
-(def TrainPR schema/TrainPR)
-(def PRTrain schema/PRTrain)
-(def EvidenceBundle schema/EvidenceBundle)
-(def GateResult schema/GateResult)
-(def TaskIntent schema/TaskIntent)
-(def Progress schema/Progress)
-(def RollbackPlan schema/RollbackPlan)
+(def TrainPR
+  "Malli :map schema for an individual PR within a train (repo, number, url,
+   branch, title, status, merge-order, depends-on/blocks vectors, ci-status,
+   optional gate-results, intent, and Tier 2 governance fields)."
+  schema/TrainPR)
+(def PRTrain
+  "Malli :map schema for a complete PR train: identity, status, the :train/prs
+   vector, computed aggregate state (blocking-prs, ready-to-merge, progress),
+   optional rollback plan and evidence reference, and timestamps."
+  schema/PRTrain)
+(def EvidenceBundle
+  "Malli :map schema for a train's complete evidence bundle: id, train-id,
+   created-at, per-PR evidence vector, summary, and miniforge-version."
+  schema/EvidenceBundle)
+(def GateResult
+  "Malli :map schema for a single gate check result: gate id, type, passed?
+   boolean, and optional message, details, and timestamp."
+  schema/GateResult)
+(def TaskIntent
+  "Malli :map schema for semantic intent attached to a PR: intent type plus
+   optional invariants, forbidden-actions, and required-evidence vectors."
+  schema/TaskIntent)
+(def Progress
+  "Malli :map schema for a train progress summary: :total, :merged, :approved,
+   :pending, and :failed counts."
+  schema/Progress)
+(def RollbackPlan
+  "Malli :map schema for a train rollback plan: trigger, action, optional
+   checkpoint PR number, and the prs-to-revert vector."
+  schema/RollbackPlan)
 
 ;; Enum value sets
-(def pr-statuses schema/pr-statuses)
-(def train-statuses schema/train-statuses)
-(def ci-statuses schema/ci-statuses)
-(def rollback-triggers schema/rollback-triggers)
-(def evidence-types schema/evidence-types)
+(def pr-statuses
+  "Vector of the possible PR status keywords, ordered :draft through :failed."
+  schema/pr-statuses)
+(def train-statuses
+  "Vector of the possible train status keywords, ordered :drafting through
+   :abandoned."
+  schema/train-statuses)
+(def ci-statuses
+  "Vector of the possible CI status keywords: :pending :running :passed
+   :failed :skipped."
+  schema/ci-statuses)
+(def rollback-triggers
+  "Vector of the keywords that can trigger a rollback: :ci-failure
+   :gate-failure :manual :timeout."
+  schema/rollback-triggers)
+(def evidence-types
+  "Vector of the evidence artifact type keywords (e.g. :terraform-plan,
+   :ci-log, :gate-results, :approval-record)."
+  schema/evidence-types)
 
 ;; State machine re-exports
-(def train-transitions state/train-transitions)
-(def pr-transitions state/pr-transitions)
+(def train-transitions
+  "Map of train status keyword to the set of statuses it may transition to."
+  state/train-transitions)
+(def pr-transitions
+  "Map of PR status keyword to the set of statuses it may transition to."
+  state/pr-transitions)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Manager creation

--- a/components/pr-train/src/ai/miniforge/pr_train/schema.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/schema.clj
@@ -26,21 +26,17 @@
 ;; Enums and base types
 
 (def pr-statuses
-  "Possible states for a PR in a train."
   [:draft :open :reviewing :changes-requested
    :approved :merging :merged :closed :failed])
 
 (def train-statuses
-  "Possible states for a PR train."
   [:drafting :open :reviewing :merging
    :merged :failed :rolled-back :abandoned])
 
 (def ci-statuses
-  "CI status values."
   [:pending :running :passed :failed :skipped])
 
 (def rollback-triggers
-  "What can trigger a rollback."
   [:ci-failure :gate-failure :manual :timeout])
 
 (def rollback-actions
@@ -48,7 +44,6 @@
   [:revert-all :revert-to-checkpoint :pause])
 
 (def evidence-types
-  "Types of evidence artifacts."
   [:terraform-plan :atlantis-log :ci-log
    :gate-results :intent-validation :approval-record])
 
@@ -94,7 +89,6 @@
 ;; Gate result schema
 
 (def GateResult
-  "Schema for a gate check result."
   [:map {:registry registry}
    [:gate/id keyword?]
    [:gate/type keyword?]
@@ -117,7 +111,6 @@
      [:condition any?]]]])
 
 (def TaskIntent
-  "Schema for semantic intent attached to a PR."
   [:map {:registry registry}
    [:intent/type (into [:enum] intent-types)]
    [:intent/invariants {:optional true} [:vector Invariant]]
@@ -128,7 +121,6 @@
 ;; TrainPR schema
 
 (def TrainPR
-  "Schema for an individual PR in a train."
   [:map {:registry registry}
    [:pr/repo :pr/repo]
    [:pr/number :pr/number]
@@ -164,7 +156,6 @@
 ;; Progress schema
 
 (def Progress
-  "Schema for train progress summary."
   [:map {:registry registry}
    [:total pos-int?]
    [:merged :common/non-neg-int]
@@ -176,7 +167,6 @@
 ;; Rollback plan schema
 
 (def RollbackPlan
-  "Schema for train rollback configuration."
   [:map {:registry registry}
    [:trigger (into [:enum] rollback-triggers)]
    [:action (into [:enum] rollback-actions)]
@@ -187,7 +177,6 @@
 ;; PRTrain schema
 
 (def PRTrain
-  "Schema for a complete PR train."
   [:map {:registry registry}
    [:train/id :train/id]
    [:train/name :train/name]
@@ -240,7 +229,6 @@
    [:semantic-violations :common/non-neg-int]])
 
 (def EvidenceBundle
-  "Schema for the complete evidence bundle of a train."
   [:map {:registry registry}
    [:evidence/id :evidence/id]
    [:evidence/train-id :train/id]

--- a/components/pr-train/src/ai/miniforge/pr_train/state.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/state.clj
@@ -40,7 +40,6 @@
    :abandoned   #{}})
 
 (def pr-transitions
-  "Valid PR status transitions."
   {:draft             #{:open :closed}
    :open              #{:reviewing :closed}
    :reviewing         #{:changes-requested :approved :closed}


### PR DESCRIPTION
Wave-A boundary-documentation rollout (rule 009). Contract docstrings lifted to interface passthroughs (real types verified from impl); duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change; full pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)