### PR TITLE
docs(repo-dag,loop): lift contract docstrings to interface boundary (rule 009)

### DIFF
--- a/components/loop/src/ai/miniforge/loop/interface.clj
+++ b/components/loop/src/ai/miniforge/loop/interface.clj
@@ -33,27 +33,84 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
 
-(def InnerLoopState schema/InnerLoopState)
-(def InnerLoopResult schema/InnerLoopResult)
-(def GateResult schema/GateResult)
-(def GateConfig schema/GateConfig)
-(def RepairAttempt schema/RepairAttempt)
-(def LoopMetrics schema/LoopMetrics)
-(def LoopBudget schema/LoopBudget)
-(def OuterLoopState schema/OuterLoopState)
+(def InnerLoopState
+  "Malli schema (a `[:map ...]` vector) for the inner loop state machine,
+   tracking the generate -> validate -> repair cycle. Use with malli.core
+   (m/validate, m/explain)."
+  schema/InnerLoopState)
+(def InnerLoopResult
+  "Malli schema (a `[:map ...]` vector) for the result of running an inner
+   loop to completion: :success, optional :artifact, :iterations, :metrics,
+   :termination. Use with malli.core."
+  schema/InnerLoopResult)
+(def GateResult
+  "Malli schema (a `[:map ...]` vector) for the result of running a
+   validation gate: :gate/id, :gate/type, :gate/passed?, optional
+   :gate/errors, :gate/warnings, :gate/duration-ms. Use with malli.core."
+  schema/GateResult)
+(def GateConfig
+  "Malli schema (a `[:map ...]` vector) for gate configuration: :gate/id,
+   :gate/type, optional :gate/enabled?, :gate/config, :gate/applies-to.
+   Use with malli.core."
+  schema/GateConfig)
+(def RepairAttempt
+  "Malli schema (a `[:map ...]` vector) for a single repair attempt:
+   :repair/id, :repair/strategy, :repair/iteration, :repair/errors,
+   :repair/success?, optional duration and tokens. Use with malli.core."
+  schema/RepairAttempt)
+(def LoopMetrics
+  "Malli schema (a `[:map ...]` vector) for loop execution metrics: optional
+   :tokens, :cost-usd, :duration-ms, :generate-calls, :repair-calls.
+   Use with malli.core."
+  schema/LoopMetrics)
+(def LoopBudget
+  "Malli schema (a `[:map ...]` vector) for loop execution budget
+   constraints: optional :max-tokens, :max-cost-usd, :max-duration-ms,
+   :max-iterations. Use with malli.core."
+  schema/LoopBudget)
+(def OuterLoopState
+  "Malli schema (a `[:map ...]` vector) for the outer loop state machine,
+   tracking the SDLC phases. Use with malli.core."
+  schema/OuterLoopState)
 
 ;; Enum values
-(def inner-loop-states schema/inner-loop-states)
-(def outer-loop-phases schema/outer-loop-phases)
-(def gate-types schema/gate-types)
-(def repair-strategies schema/repair-strategies)
-(def termination-reasons schema/termination-reasons)
+(def inner-loop-states
+  "Vector of the possible inner-loop state-machine state keywords, in order:
+   [:pending :generating :validating :repairing :complete :failed :escalated]."
+  schema/inner-loop-states)
+(def outer-loop-phases
+  "Vector of the outer-loop SDLC phase keywords, in order:
+   [:spec :plan :design :implement :verify :review :release :observe]."
+  schema/outer-loop-phases)
+(def gate-types
+  "Vector of the supported validation-gate type keywords:
+   [:syntax :lint :test :policy :custom]."
+  schema/gate-types)
+(def repair-strategies
+  "Vector of the available repair-strategy keywords:
+   [:llm-fix :retry :escalate]."
+  schema/repair-strategies)
+(def termination-reasons
+  "Vector of the loop-termination reason keywords:
+   [:gates-passed :max-iterations :budget-exhausted :timeout
+    :unrecoverable-error :manual-stop]."
+  schema/termination-reasons)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol re-exports
 
-(def Gate gate-proto/Gate)
-(def RepairStrategy repair-proto/RepairStrategy)
+(def Gate
+  "Protocol for validation gates. Implement to provide a custom gate;
+   methods: (check this artifact context), (gate-id this), (gate-type this),
+   (repair this artifact violations context). check returns a gate-result map
+   with :gate/passed? and :gate/errors."
+  gate-proto/Gate)
+(def RepairStrategy
+  "Protocol for artifact repair strategies. Implement to provide a custom
+   strategy; methods: (can-repair? this errors context) -> boolean, and
+   (repair this artifact errors context) -> map with :success?, :artifact or
+   :errors, :strategy, optional :tokens-used/:duration-ms."
+  repair-proto/RepairStrategy)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Inner Loop API
@@ -416,8 +473,15 @@
 
 ;; Phase definitions
 
-(def phases outer/phases)
-(def phase-definitions outer/phase-definitions)
+(def phases
+  "Vector of the ordered outer-loop phase keywords:
+   [:spec :plan :design :implement :verify :review :release :observe]."
+  outer/phases)
+(def phase-definitions
+  "Map keyed by phase keyword to its metadata map (:phase/id,
+   :phase/description, :phase/agent, :phase/artifacts, :phase/requires).
+   Look up a single phase with get-phase-definition."
+  outer/phase-definitions)
 
 (defn get-phase-definition
   "Get the definition for a phase."

--- a/components/loop/src/ai/miniforge/loop/outer.clj
+++ b/components/loop/src/ai/miniforge/loop/outer.clj
@@ -35,7 +35,6 @@
 ;; Phase definitions
 
 (def phases
-  "Ordered sequence of outer loop phases."
   [:spec :plan :design :implement :verify :review :release :observe])
 
 (def ^:private initial-phase
@@ -47,7 +46,6 @@
   :observe)
 
 (def phase-definitions
-  "Phase metadata definitions."
   {:spec     {:phase/id :spec
               :phase/description (loop-messages/t :outer/spec-description)
               :phase/agent nil  ; No agent, external input

--- a/components/loop/src/ai/miniforge/loop/schema.clj
+++ b/components/loop/src/ai/miniforge/loop/schema.clj
@@ -27,23 +27,18 @@
 ;; Base types and enums
 
 (def inner-loop-states
-  "Possible states for the inner loop state machine."
   [:pending :generating :validating :repairing :complete :failed :escalated])
 
 (def outer-loop-phases
-  "Phases in the outer loop SDLC cycle."
   [:spec :plan :design :implement :verify :review :release :observe])
 
 (def gate-types
-  "Types of validation gates."
   [:syntax :lint :test :policy :custom])
 
 (def repair-strategies
-  "Available repair strategies."
   [:llm-fix :retry :escalate])
 
 (def termination-reasons
-  "Reasons for loop termination."
   [:gates-passed :max-iterations :budget-exhausted :timeout :unrecoverable-error :manual-stop])
 
 (def registry
@@ -88,7 +83,6 @@
      [:column {:optional true} :common/non-neg-int]]]])
 
 (def GateResult
-  "Schema for the result of running a validation gate."
   [:map {:registry registry}
    [:gate/id :gate/id]
    [:gate/type :gate/type]
@@ -98,7 +92,6 @@
    [:gate/duration-ms {:optional true} :common/non-neg-int]])
 
 (def GateConfig
-  "Schema for gate configuration."
   [:map {:registry registry}
    [:gate/id :gate/id]
    [:gate/type :gate/type]
@@ -110,7 +103,6 @@
 ;; Repair schemas
 
 (def RepairAttempt
-  "Schema for a single repair attempt."
   [:map {:registry registry}
    [:repair/id :id/uuid]
    [:repair/strategy :repair/strategy]
@@ -124,7 +116,6 @@
 ;; Loop metrics
 
 (def LoopMetrics
-  "Schema for loop execution metrics."
   [:map {:registry registry}
    [:tokens {:optional true} :common/non-neg-int]
    [:cost-usd {:optional true} :common/pos-number]
@@ -133,7 +124,6 @@
    [:repair-calls {:optional true} :common/non-neg-int]])
 
 (def LoopBudget
-  "Schema for loop execution budget constraints."
   [:map {:registry registry}
    [:max-tokens {:optional true} :common/non-neg-int]
    [:max-cost-usd {:optional true} :common/pos-number]
@@ -144,8 +134,6 @@
 ;; Inner loop state schema
 
 (def InnerLoopState
-  "Schema for the inner loop state machine.
-   Tracks the generate -> validate -> repair cycle."
   [:map {:registry registry}
    ;; Required fields
    [:loop/id :loop/id]
@@ -202,7 +190,6 @@
 ;; Inner loop result
 
 (def InnerLoopResult
-  "Schema for the result of running an inner loop to completion."
   [:map {:registry registry}
    [:success boolean?]
    [:artifact {:optional true}

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -26,24 +26,67 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
 
-(def RepoNode schema/RepoNode)
-(def RepoEdge schema/RepoEdge)
-(def RepoDag schema/RepoDag)
-(def WatchConfig schema/WatchConfig)
-(def EdgeValidation schema/EdgeValidation)
+(def RepoNode
+  "Malli `[:map ...]` schema for a repository node: its URL, name, type,
+   layer, default branch, and optional org and watch-config."
+  schema/RepoNode)
+(def RepoEdge
+  "Malli `[:map ...]` schema for a directed dependency edge between two repos
+   (`:edge/from` -> `:edge/to`) carrying a constraint, merge-ordering, and
+   optional validation config."
+  schema/RepoEdge)
+(def RepoDag
+  "Malli `[:map ...]` schema for a complete repository dependency graph:
+   id, name, optional description, vectors of repos and edges, and optional
+   computed topo-order and layers."
+  schema/RepoDag)
+(def WatchConfig
+  "Malli `[:map ...]` schema for change-watch configuration: optional
+   label and path include/exclude vectors of strings."
+  schema/WatchConfig)
+(def EdgeValidation
+  "Malli `[:map ...]` schema for per-edge validation gates: require-ci-pass?,
+   require-plan-clean?, and an optional custom-gate keyword."
+  schema/EdgeValidation)
 
 ;; Enum value sets for programmatic access
-(def repo-types schema/repo-types)
-(def repo-layers schema/repo-layers)
-(def edge-constraints schema/edge-constraints)
-(def merge-orderings schema/merge-orderings)
-(def type->layer schema/type->layer)
+(def repo-types
+  "Vector of the repository type keywords valid in the DAG
+   (e.g. :terraform-module, :kubernetes, :library)."
+  schema/repo-types)
+(def repo-layers
+  "Vector of the logical layer keywords for repositories
+   (:foundations :infrastructure :platform :application :adapters)."
+  schema/repo-layers)
+(def edge-constraints
+  "Vector of the dependency-edge constraint keywords
+   (e.g. :module-before-live, :schema-before-impl)."
+  schema/edge-constraints)
+(def merge-orderings
+  "Vector of the merge-ordering strategy keywords
+   (:sequential :parallel-ok :same-pr-train)."
+  schema/merge-orderings)
+(def type->layer
+  "Map of repository type keyword to its default layer keyword."
+  schema/type->layer)
 
 ;; Validation helpers
-(def valid-repo-node? schema/valid-repo-node?)
-(def valid-repo-edge? schema/valid-repo-edge?)
-(def valid-repo-dag? schema/valid-repo-dag?)
-(def infer-layer schema/infer-layer)
+(def valid-repo-node?
+  "Predicate: returns true if the value conforms to the RepoNode schema,
+   false otherwise."
+  schema/valid-repo-node?)
+(def valid-repo-edge?
+  "Predicate: returns true if the value conforms to the RepoEdge schema,
+   false otherwise."
+  schema/valid-repo-edge?)
+(def valid-repo-dag?
+  "Predicate: returns true if the value conforms to the RepoDag schema,
+   false otherwise."
+  schema/valid-repo-dag?)
+(def infer-layer
+  "Given a repository type keyword, returns its default layer keyword,
+   falling back to :application for unknown types."
+  schema/infer-layer)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Manager lifecycle

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -42,7 +42,8 @@
   schema/RepoDag)
 (def WatchConfig
   "Malli `[:map ...]` schema for change-watch configuration: optional
-   label and path include/exclude vectors of strings."
+   `:labels-include`/`:labels-exclude` and `:paths-include`/`:paths-exclude`
+   vectors of strings."
   schema/WatchConfig)
 (def EdgeValidation
   "Malli `[:map ...]` schema for per-edge validation gates: require-ci-pass?,

--- a/components/repo-dag/src/ai/miniforge/repo_dag/schema.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/schema.clj
@@ -28,16 +28,13 @@
 ;; Enums and base types
 
 (def repo-types
-  "Types of repositories that can be modeled in the DAG."
   [:terraform-module :terraform-live :kubernetes
    :argocd :application :library :documentation])
 
 (def repo-layers
-  "Logical layers for repository categorization."
   [:foundations :infrastructure :platform :application :adapters])
 
 (def edge-constraints
-  "Constraint types for dependency edges."
   [:module-before-live      ; TF modules before live infra
    :infra-before-k8s        ; Infrastructure before K8s manifests
    :k8s-before-argocd       ; Manifests before ArgoCD apps
@@ -45,13 +42,11 @@
    :schema-before-impl])    ; Schema changes before implementations
 
 (def merge-orderings
-  "Merge ordering strategies for edges."
   [:sequential    ; Must merge in order
    :parallel-ok   ; Can merge in parallel if both ready
    :same-pr-train]) ; Must be in same PR train
 
 (def type->layer
-  "Default layer inference from repository type."
   {:terraform-module :foundations
    :terraform-live   :infrastructure
    :kubernetes       :platform
@@ -79,7 +74,6 @@
 ;; RepoNode and RepoEdge schemas
 
 (def WatchConfig
-  "Configuration for watching repository changes."
   [:map
    [:labels-include {:optional true} [:vector string?]]
    [:labels-exclude {:optional true} [:vector string?]]
@@ -99,7 +93,6 @@
    [:repo/watch-config {:optional true} WatchConfig]])
 
 (def EdgeValidation
-  "Validation configuration for an edge."
   [:map
    [:require-ci-pass? {:default true} boolean?]
    [:require-plan-clean? {:default false} boolean?]
@@ -153,22 +146,18 @@
 ;; Validation helpers
 
 (defn valid-repo-node?
-  "Check if a value is a valid RepoNode."
   [value]
   (m/validate RepoNode value))
 
 (defn valid-repo-edge?
-  "Check if a value is a valid RepoEdge."
   [value]
   (m/validate RepoEdge value))
 
 (defn valid-repo-dag?
-  "Check if a value is a valid RepoDag."
   [value]
   (m/validate RepoDag value))
 
 (defn infer-layer
-  "Infer the layer from repository type if not explicitly specified."
   [repo-type]
   (get type->layer repo-type :application))
 


### PR DESCRIPTION
Wave-A boundary-documentation rollout (rule 009). Contract docstrings lifted to interface passthroughs (real types verified from impl); duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change; full pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)