### PR TITLE
docs(reliability): remove impl docstrings duplicated by the boundary (rule 009)

### DIFF
--- a/components/reliability/src/ai/miniforge/reliability/budget.clj
+++ b/components/reliability/src/ai/miniforge/reliability/budget.clj
@@ -42,7 +42,6 @@
 ;; Factory
 
 (defn error-budget
-  "Factory: create an error budget map."
   ([remaining burn-rate]
    {:error-budget/remaining remaining
     :error-budget/burn-rate burn-rate})
@@ -58,19 +57,6 @@
 ;; Budget computation
 
 (defn compute-error-budget
-  "Compute error budget for an SLI over a window.
-
-   Arguments:
-     sli-value   - current SLI value (0.0-1.0)
-     slo-target  - SLO target for the tier
-     inverted?   - true if lower-is-better (e.g., SLI-6 unknown failure rate)
-
-   Returns:
-     {:error-budget/remaining double  ; 0.0-1.0 fraction of budget remaining
-      :error-budget/burn-rate double} ; current burn rate (1.0 = nominal)
-
-   When remaining is 0.0, the budget is exhausted.
-   Burn-rate > 1.0 means the budget is being consumed faster than it should."
   [sli-value slo-target inverted?]
   (let [[remaining burn-rate]
         (if inverted?
@@ -98,13 +84,10 @@
 ;; Predicates
 
 (defn budget-exhausted?
-  "Returns true if the error budget remaining is at or below zero."
   [budget]
   (<= (:error-budget/remaining budget) 0.0))
 
 (defn budget-critical?
-  "Returns true if the error budget remaining is below the threshold.
-   Default threshold: 0.25 (25% remaining)."
   ([budget] (budget-critical? budget default-critical-threshold))
   ([budget threshold]
    (< (:error-budget/remaining budget) threshold)))

--- a/components/reliability/src/ai/miniforge/reliability/degradation.clj
+++ b/components/reliability/src/ai/miniforge/reliability/degradation.clj
@@ -99,11 +99,6 @@
   (merge default-config config))
 
 (defn create-manager
-  "Create a DegradationManager.
-
-   Arguments:
-     event-stream - event stream atom
-     config       - optional degradation policy overrides"
   [event-stream & [config]]
   (->DegradationManager
    (atom (fsm/initialize degradation-machine))
@@ -111,7 +106,6 @@
    (merge-manager-config config)))
 
 (defn current-mode
-  "Get the current degradation mode (:nominal, :degraded, or :safe-mode)."
   [manager]
   (fsm/current-state @(:fsm-state manager)))
 
@@ -318,12 +312,6 @@
       current))))
 
 (defn enter-safe-mode!
-  "Force entry to safe-mode. Works from any state.
-
-   Arguments:
-     manager - DegradationManager
-     trigger - keyword (:error-budget | :emergency-stop | :unknown-failures | :manual)
-     details - string with additional context"
   [manager trigger details]
   (let [current (current-mode manager)]
     (when (not= current :safe-mode)

--- a/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
+++ b/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
@@ -121,8 +121,6 @@
   (merge (base-entry incident) entry))
 
 (defn dependency-incident?
-  "Returns true when the classified incident belongs in dependency-health
-   projection."
   [incident]
   (failure-classifier/dependency-failure? incident))
 
@@ -228,7 +226,6 @@
              recoveries))))
 
 (defn project-health
-  "Project rolling dependency state into canonical dependency-health entities."
   ([dependency-state]
    (project-health dependency-state default-config))
   ([dependency-state config]

--- a/components/reliability/src/ai/miniforge/reliability/engine.clj
+++ b/components/reliability/src/ai/miniforge/reliability/engine.clj
@@ -226,12 +226,10 @@
      :recommendation recommendation}))
 
 (defn current-state
-  "Get the current reliability state."
   [engine]
   @(:state engine))
 
 (defn current-mode
-  "Get the current degradation mode recommendation."
   [engine]
   (:mode @(:state engine)))
 

--- a/components/reliability/src/ai/miniforge/reliability/schema.clj
+++ b/components/reliability/src/ai/miniforge/reliability/schema.clj
@@ -23,7 +23,6 @@
 ;; Enums
 
 (def WorkflowTier
-  "Workflow tier determines SLO targets and degradation behavior."
   [:enum :best-effort :standard :critical])
 
 (def SliName

--- a/components/reliability/src/ai/miniforge/reliability/sli.clj
+++ b/components/reliability/src/ai/miniforge/reliability/sli.clj
@@ -76,8 +76,6 @@
 ;; SLI-1: Workflow Success Rate
 
 (defn compute-workflow-success-rate
-  "Fraction of workflows completing successfully or with explicit escalation.
-   Computation: count(completed + escalated) / count(terminal)"
   [workflow-metrics window]
   (let [windowed (filter-by-window workflow-metrics window)
         terminal (filter terminal-workflow? windowed)
@@ -94,7 +92,6 @@
   (get-in metric [:metrics :duration-ms]))
 
 (defn compute-phase-latency
-  "Wall-clock duration per phase type. Returns {:p50 :p95 :p99} in ms."
   [phase-metrics window]
   (let [windowed (filter-by-window phase-metrics window)
         durations (->> windowed
@@ -110,8 +107,6 @@
 ;; SLI-3: Inner Loop Convergence Rate
 
 (defn compute-inner-loop-convergence
-  "Fraction of inner loops that converge within retry budget.
-   Takes phase metrics where :iterations and :success? are tracked."
   [phase-metrics window]
   (let [windowed (filter-by-window phase-metrics window)
         with-loops (filter :iterations windowed)
@@ -123,8 +118,6 @@
 ;; SLI-4: Gate Pass Rate
 
 (defn compute-gate-pass-rate
-  "Fraction of gate evaluations that pass on first attempt.
-   Takes gate events with :passed? field."
   [gate-metrics window]
   (let [windowed (filter-by-window gate-metrics window)
         total (count windowed)
@@ -135,7 +128,6 @@
 ;; SLI-5: Tool Invocation Success Rate
 
 (defn compute-tool-success-rate
-  "Fraction of tool invocations that return success."
   [tool-metrics window]
   (let [windowed (filter-by-window tool-metrics window)
         total (count windowed)
@@ -146,9 +138,6 @@
 ;; SLI-6: Failure Class Distribution
 
 (defn compute-failure-distribution
-  "Percentage of failures per :failure/class.
-   Returns map of {failure-class -> fraction}.
-   The :failure.class/unknown rate is the key meta-reliability indicator."
   [failure-events window]
   (let [windowed (filter-by-window failure-events window)
         total (count windowed)]
@@ -162,8 +151,6 @@
              (into {}))))))
 
 (defn compute-unknown-failure-rate
-  "Convenience: extract the :failure.class/unknown rate from distribution.
-   A high unknown rate signals insufficient failure instrumentation."
   [failure-events window]
   (get (compute-failure-distribution failure-events window)
        :failure.class/unknown
@@ -173,7 +160,6 @@
 ;; SLI-7: Context Staleness Rate
 
 (defn compute-context-staleness-rate
-  "Fraction of Context Packs that trigger staleness detection."
   [context-metrics window]
   (let [windowed (filter-by-window context-metrics window)
         total (count windowed)
@@ -184,19 +170,6 @@
 ;; Aggregate SLI computation
 
 (defn compute-all-slis
-  "Compute all SLIs from collected metrics.
-
-   Arguments:
-     metrics - map with keys:
-       :workflow-metrics  - vector of workflow metric records
-       :phase-metrics     - vector of phase metric records
-       :gate-metrics      - vector of gate evaluation records
-       :tool-metrics      - vector of tool invocation records
-       :failure-events    - vector of failure events with :failure/class
-       :context-metrics   - vector of context pack records
-     window - :1h | :7d | :30d
-
-   Returns: vector of SLI result maps."
   [metrics window]
   (let [{:keys [workflow-metrics phase-metrics gate-metrics
                 tool-metrics failure-events context-metrics]} metrics]

--- a/components/reliability/src/ai/miniforge/reliability/slo.clj
+++ b/components/reliability/src/ai/miniforge/reliability/slo.clj
@@ -29,8 +29,6 @@
 ;; Configuration
 
 (def default-targets
-  "SLO targets loaded from config/reliability/slo-targets.edn.
-   nil means advisory-only (no enforcement for that tier)."
   (-> (io/resource "config/reliability/slo-targets.edn")
       slurp
       edn/read-string))
@@ -54,10 +52,6 @@
    (get-in targets [sli-name tier])))
 
 (defn check-slo
-  "Check whether an SLI result meets its SLO target.
-
-   Returns: {:breached? bool :sli/name :slo/target :slo/actual :slo/tier :slo/window}
-   Returns nil if the SLI has no target for this tier (advisory-only)."
   ([sli-result tier] (check-slo sli-result tier default-targets))
   ([sli-result tier targets]
    (let [{:keys [sli/name sli/value sli/window]} sli-result
@@ -74,8 +68,6 @@
           :slo/window window})))))
 
 (defn check-all-slos
-  "Check all SLI results against SLO targets for a given tier.
-   Returns only the results that have targets (excludes advisory-only)."
   ([sli-results tier] (check-all-slos sli-results tier default-targets))
   ([sli-results tier targets]
    (->> sli-results
@@ -89,7 +81,6 @@
   (:breached? slo-check))
 
 (defn breached-slos
-  "Filter to only the SLOs that are breached."
   [slo-checks]
   (filter breached? slo-checks))
 


### PR DESCRIPTION
Wave-A boundary-documentation rollout (rule 009), impl-dedup half. Removes impl docstrings now duplicated by the interface boundary (kept those carrying extra info). **Stacked on the interface PR — merge that first.** Docstring-only; full pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)