### PR TITLE
docs(task-executor): remove impl docstrings duplicated by the boundary (rule 009)

### DIFF
--- a/components/task-executor/src/ai/miniforge/task_executor/bridge.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/bridge.clj
@@ -24,12 +24,6 @@
   DAG scheduler without coupling the two components.")
 
 (def pr-event->scheduler-action
-  "Map of PR lifecycle event types to DAG scheduler action keywords.
-
-  Events without mappings (e.g., :pr/comment-actionable) are handled internally
-  by the PR controller and don't require scheduler notification.
-
-  Conflict and rebase events map to :ci-failed to reuse existing retry logic."
   {:pr/opened                    :pr-opened
    :pr/ci-passed                 :ci-passed
    :pr/ci-failed                 :ci-failed
@@ -42,14 +36,6 @@
    :pr/rebase-needed             :ci-failed})   ; reuse retry logic
 
 (defn translate-event
-  "Translate a PR lifecycle event to a scheduler event.
-
-  Input: PR event map with :event/type and :task-id
-  Output: Scheduler event map with :event/action and :event/task-id, or nil if unmapped
-
-  Example:
-    (translate-event {:event/type :pr/ci-passed :task-id \"task-123\"})
-    => {:event/action :ci-passed :event/task-id \"task-123\"}"
   [{:keys [event/type task-id] :as pr-event}]
   (when-let [action (get pr-event->scheduler-action type)]
     {:event/action action
@@ -58,14 +44,6 @@
      :metadata (dissoc pr-event :event/type :task-id :timestamp)}))
 
 (defn create-scheduler-event
-  "Create a scheduler event map from components.
-
-  Args:
-    task-id: Task identifier string
-    action: Scheduler action keyword (e.g., :ci-passed)
-    opts: Optional map of additional fields (timestamp, metadata)
-
-  Returns: Event map suitable for scheduler/handle-task-event"
   [task-id action & [opts]]
   (merge
     {:event/action action
@@ -75,6 +53,5 @@
       {:metadata metadata})))
 
 (defn unmapped-event?
-  "Return true if the PR event type has no scheduler mapping."
   [event-type]
   (nil? (get pr-event->scheduler-action event-type)))

--- a/components/task-executor/src/ai/miniforge/task_executor/generate.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/generate.clj
@@ -29,13 +29,6 @@
             [clojure.string :as str]))
 
 (defn format-task-prompt
-  "Format a task description and context into a prompt for the agent.
-
-  Args:
-    task: Task map with :description, :files, :dependencies, etc.
-    context: Context map with :worktree-path, :base-commit, etc.
-
-  Returns: String prompt for the LLM"
   [task context]
   (let [{:keys [description files dependencies acceptance-criteria]} task
         {:keys [worktree-path base-commit]} context]
@@ -55,33 +48,6 @@
          "- Base commit: " base-commit "\n")))
 
 (defn create-generate-fn
-  "Create a generate-fn closure for use with the inner loop and PR lifecycle.
-
-  Args:
-    llm-backend: Agent backend instance (e.g., from agent/create-backend)
-    opts: Options map with:
-      :logger - Logger instance
-      :event-stream - Event stream for observability
-      :workflow-id - Workflow identifier for event correlation
-      :max-iterations - Max inner loop iterations (default 10)
-
-  Returns: Function (fn [task context] -> {:artifact map :tokens int})
-
-  The returned function wraps loop/run-simple and can be used for:
-  - Initial code generation (runner/execute-task)
-  - Fix loops (PR controller's :generate-fn option)
-
-  Example:
-    (def gen-fn (create-generate-fn my-backend
-                  {:logger logger
-                   :max-iterations 15
-                   :workflow-id \"dag-run-123\"}))
-
-    (gen-fn {:task/id \"task-1\"
-             :task/type :implement
-             :description \"Add feature X\"}
-            {:worktree-path \"/tmp/wt-1\"
-             :base-commit \"abc123\"})"
   [llm-backend & {:keys [logger event-stream workflow-id max-iterations]}]
   (fn [task context]
     (let [task-map (if (map? task)

--- a/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
@@ -29,23 +29,6 @@
             [ai.miniforge.logging.interface :as log]))
 
 (defn create-run-context
-  "Create shared context for a DAG run.
-
-  Args:
-    run-atom: Atom containing DAG run state
-    config: Configuration map with:
-      :workflow-id - Workflow identifier
-      :executor - IEnvironmentExecutor instance
-      :llm-backend - LLM backend for code generation
-      :logger - Logger instance
-      :event-stream - Event stream for observability
-      :max-iterations - Max inner loop iterations
-      :max-parallel - Max parallel tasks
-      :github-token - GitHub API token
-      :budget - Budget constraints
-      :lock-pool - Optional lock pool (created if not provided)
-
-  Returns: Run context map for task execution"
   [run-atom config]
   (let [lock-pool (or (:lock-pool config)
                       (dag/create-lock-pool
@@ -88,19 +71,6 @@
                                 {:dependency-id task-id})))))
 
 (defn make-execute-task-fn
-  "Create execute-task-fn callback for DAG scheduler.
-
-  The returned function:
-  - Looks up full task definition from run-atom
-  - Launches runner/execute-task in a future
-  - Tracks futures for graceful shutdown
-  - Catches exceptions and marks task as failed
-  - Cascades failures to dependent tasks
-
-  Args:
-    run-context: Shared run context (from create-run-context)
-
-  Returns: Function (fn [task-id context] -> future)"
   [run-context]
   (let [{:keys [run-atom logger]} run-context
         ;; Atom to track active futures
@@ -154,18 +124,6 @@
             task-future))))))
 
 (defn create-orchestrated-scheduler-context
-  "Create scheduler context with execute-task-fn wired in.
-
-  Convenience function that combines:
-  - create-run-context
-  - make-execute-task-fn
-  - Scheduler context assembly
-
-  Args:
-    run-atom: Atom containing DAG run state
-    config: Configuration map
-
-  Returns: Scheduler context map with :execute-task-fn"
   [run-atom config]
   (let [run-context (create-run-context run-atom config)
         execute-task-fn (make-execute-task-fn run-context)]
@@ -175,30 +133,6 @@
      :config config}))
 
 (defn execute-dag!
-  "Top-level convenience function to execute a DAG with task execution integrated.
-
-  Steps:
-  1. Initialize DAG run-atom
-  2. Create orchestrated scheduler context
-  3. Run scheduler loop until completion
-  4. Return final run state
-
-  Args:
-    dag-id: DAG identifier
-    task-defs: Sequence of maps with :task/id and :task/deps
-    config: Configuration map (see create-run-context)
-
-  Returns: Final run-atom state
-
-  Example:
-    (execute-dag! \"dag-123\"
-                  [{:task/id \"task-1\" :task/deps #{}}
-                   {:task/id \"task-2\" :task/deps #{\"task-1\"}}]
-                  {:workflow-id \"wf-123\"
-                   :executor my-executor
-                   :llm-backend my-backend
-                   :logger my-logger
-                   :max-parallel 4})"
   [dag-id task-defs config]
   (let [{:keys [logger budget state-profile state-profile-provider]} config
         ;; Initialize DAG using dag-executor's function

--- a/components/task-executor/src/ai/miniforge/task_executor/runner.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/runner.clj
@@ -34,14 +34,6 @@
             [ai.miniforge.spec-parser.interface :as spec-parser]))
 
 (defn create-task-context
-  "Assemble context for a task execution.
-
-  Args:
-    task-id: Task identifier
-    task: Task definition map
-    run-context: Shared run context with executor, config, etc.
-
-  Returns: Context map for task execution"
   [task-id task run-context]
   (let [{:keys [workflow-id executor config logger event-stream]} run-context
         {:keys [max-iterations llm-backend github-token]} config]
@@ -264,25 +256,6 @@
     (dag/update-metrics! run-atom task-id metrics)))
 
 (defn execute-task
-  "Execute a single task through its full lifecycle.
-
-  Steps:
-  0. Validate spec (fail fast — no resources acquired on bad spec)
-  1. Acquire resources (worktree + environment)
-  2. Generate code artifact (inner loop)
-  3. Create PR lifecycle controller
-  4. Run blocking PR lifecycle (open → CI → review → merge)
-  5. Update metrics
-  6. Clean up resources (in finally)
-
-  Args:
-    task-id: Task identifier string
-    task: Task definition map
-    run-context: Shared context with executor, config, logger, etc.
-
-  Returns: Result map with :ok? and :value or :error
-
-  Throws: None - catches all exceptions and marks task as failed"
   [task-id task run-context]
   (let [{:keys [run-atom executor logger lock-pool config]} run-context
         task-context (create-task-context task-id task run-context)


### PR DESCRIPTION
Wave-A boundary-documentation rollout (rule 009), impl-dedup half. Removes impl docstrings now duplicated by the interface boundary (kept those carrying extra info). **Stacked on the interface PR — merge that first.** Docstring-only; full pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)