### PR TITLE
docs(knowledge): remove impl docstrings duplicated by the boundary (rule 009)

### DIFF
--- a/components/knowledge/src/ai/miniforge/knowledge/learning.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/learning.clj
@@ -259,15 +259,6 @@
     patterns))
 
 (defn synthesize-recurring-patterns!
-  "Detect recurring patterns and capture them as meta-loop learnings.
-
-   Scans learnings for recurring tags, creates a meta-loop learning for each
-   new pattern found. Skips patterns that already have a corresponding learning.
-
-   Arguments:
-   - knowledge-store - KnowledgeStore instance
-
-   Returns count of new patterns synthesized."
   [knowledge-store]
   (let [patterns (detect-recurring-patterns knowledge-store)
         new-count (atom 0)]
@@ -293,12 +284,6 @@
     @new-count))
 
 (defn list-learnings
-  "List all learnings, optionally filtered.
-
-   Options:
-   - :min-confidence - Minimum confidence threshold
-   - :agent          - Filter by agent role
-   - :promotable?    - If true, only return high-confidence learnings"
   [knowledge-store & [{:keys [min-confidence agent promotable?]}]]
   (let [all-learnings (store/query knowledge-store {:include-types [:learning]})
         filtered (cond->> all-learnings

--- a/components/knowledge/src/ai/miniforge/knowledge/loader.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/loader.clj
@@ -168,17 +168,6 @@
    files))
 
 (defn load-rules-from-directory
-  "Load all .mdc rule files from a directory into the knowledge store.
-
-   Arguments:
-   - knowledge-store - KnowledgeStore instance
-   - rules-dir       - Path to .cursor/rules directory (string or File)
-
-   Returns:
-   - {:loaded int :failed int :zettels [zettel...]}
-
-   Example:
-     (load-rules-from-directory store \".cursor/rules\")"
   [knowledge-store rules-dir]
   (let [rules-root (io/file rules-dir)
         mdc-files (find-mdc-files rules-root)
@@ -189,17 +178,6 @@
         (assoc :zettels (:items result)))))
 
 (defn load-project-docs
-  "Load project documentation files (agents.md, claude.md, etc.) into knowledge store.
-
-   Arguments:
-   - knowledge-store - KnowledgeStore instance
-   - project-root    - Path to project root directory (string or File)
-
-   Returns:
-   - {:loaded int :failed int :files [string...]}
-
-   Example:
-     (load-project-docs store \".\")"
   [knowledge-store project-root]
   (let [root (io/file project-root)
         doc-files ["agents.md" "claude.md" ".clauderc" "claude_instructions.md"]

--- a/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
@@ -68,21 +68,6 @@
 ;; Lookup orchestration
 
 (defn lookup-policy-rules
-  "Search loaded policy-pack rules by keyword, dewey code, or tag.
-
-   Only :rule-type zettels are searched — those loaded from .mdc rule files
-   or compiled policy packs. The search is case-insensitive; all criteria
-   are ANDed; any criterion may be omitted.
-
-   Arguments:
-   - knowledge-store  KnowledgeStore instance with rules loaded
-   - policy-query     Map satisfying ai.miniforge.knowledge.schema/PolicyQuery
-                      {:query        string  — substring match on title + body
-                       :tags         [kw]    — zettel must carry at least one
-                       :dewey-prefix string  — e.g. \"210\" or \"21\"}
-
-   Returns a vector of {:rule/title string :rule/content string} maps.
-   Returns an empty vector when no rules match or store is nil."
   [knowledge-store policy-query]
   (if (nil? knowledge-store)
     []

--- a/components/knowledge/src/ai/miniforge/knowledge/store.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/store.clj
@@ -123,14 +123,6 @@
       (vec limited))))
 
 (defn create-store
-  "Create an in-memory knowledge store.
-
-   Options:
-   - :logger - Logger instance for structured logging
-
-   Example:
-     (create-store)
-     (create-store {:logger my-logger})"
   [& [{:keys [logger]}]]
   (->InMemoryStore
    (atom {})
@@ -243,18 +235,6 @@
       (vec limited))))
 
 (defn create-file-backed-store
-  "Create a file-backed persistent knowledge store.
-
-   On startup, scans the directory and loads all .edn files into
-   in-memory indices for fast querying. Writes are atomic (temp + rename).
-
-   Options:
-   - :path   - Base directory (default: ~/.miniforge/knowledge)
-   - :logger - Logger instance
-
-   Example:
-     (create-file-backed-store)
-     (create-file-backed-store {:path \"/repo/.miniforge/knowledge\"})"
   [& [{:keys [path logger]}]]
   (let [base-path (expand-path (or path (str (config/miniforge-home) "/knowledge")))
         _ (ensure-directory base-path)
@@ -273,13 +253,6 @@
 ;; Query operations
 
 (defn find-related
-  "Find zettels related to a given zettel through links.
-
-   Options:
-   - :max-hops - Maximum link traversal depth (default 1)
-   - :direction - :outgoing, :incoming, or :both (default :both)
-
-   Returns vector of related zettels sorted by hop distance."
   [store zettel-or-id & {:keys [max-hops direction] :or {max-hops 1 direction :both}}]
   (let [start-zettel (if (map? zettel-or-id)
                        zettel-or-id
@@ -307,8 +280,6 @@
                    (into results new-zettels))))))))
 
 (defn search
-  "Full-text search across zettel titles and content.
-   Returns matching zettels with basic relevance scoring."
   [store text]
   (let [terms (str/split (str/lower-case text) #"\s+")
         score-fn (fn [zettel]
@@ -361,7 +332,6 @@
     :max-zettels 15}})
 
 (defn get-agent-manifest
-  "Get the knowledge injection manifest for an agent role."
   [role]
   (get default-agent-manifests role
        {:agent-role role :types [:rule] :max-zettels 10}))
@@ -465,16 +435,6 @@
      :manifest manifest-entries}))
 
 (defn inject-knowledge
-  "Retrieve relevant knowledge for an agent based on role and context.
-
-   Arguments:
-   - store      - Knowledge store
-   - agent-role - Agent role keyword
-   - context    - Optional map with :task-type, :tags, etc.
-
-   Returns vector of zettels relevant to the agent.
-
-   See also: inject-knowledge-with-manifest for zettels + selection manifest."
   [store agent-role & [context]]
   (:zettels (inject-knowledge-with-manifest store agent-role context)))
 
@@ -494,13 +454,6 @@
        "\n"))
 
 (defn format-for-prompt
-  "Format a collection of zettels as a markdown knowledge block for LLM context.
-
-   Arguments:
-   - zettels - Collection of zettels to format
-   - role    - Agent role keyword (for header)
-
-   Returns markdown string, or nil if no zettels."
   [zettels role]
   (when (seq zettels)
     (str (messages/t :prompt/header {:role (name role)})

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -68,17 +68,6 @@
 ;; Pack trust schema
 
 (defn make-pack-ref
-  "Create a pack reference with trust information.
-
-   Arguments:
-   - pack-id       - Unique identifier for the pack
-   - trust-level   - :trusted, :untrusted, or :tainted
-   - authority     - :authority/instruction or :authority/data
-
-   Options:
-   - :dependencies - Vector of pack-ids this pack depends on
-
-   Returns pack reference map."
   [pack-id trust-level authority & {:keys [dependencies]}]
   {:pack-id pack-id
    :trust-level trust-level
@@ -123,15 +112,6 @@
       (schema/valid))))
 
 (defn compute-inherited-trust-level
-  "Rule 2: Trust level inheritance.
-
-   When pack A includes content from pack B, the combined content
-   MUST be assigned the lower trust level.
-
-   Arguments:
-   - pack-refs - Collection of pack references being combined
-
-   Returns the lowest trust level from all packs."
   [pack-refs]
   (let [levels (map :trust-level pack-refs)]
     (lowest-trust-level levels)))
@@ -259,20 +239,6 @@
     error))
 
 (defn validate-transitive-trust
-  "Validate all transitive trust rules for a pack graph.
-
-   Checks:
-   1. Instruction authority is not transitive
-   2. Trust level inheritance is correct
-   3. Cross-trust references are valid (no cycles, missing deps)
-   4. Tainted content is isolated from instruction authority
-
-   Arguments:
-   - pack-graph - Map of pack-id -> pack-ref
-
-   Returns:
-   - {:valid? true :packs [...]} if all rules pass
-   - {:valid? false :errors [...]} if any rule fails"
   [pack-graph]
   ;; Rule 3: Validate cross-trust references first (graph structure)
   (let [graph-validation (validate-cross-trust-references pack-graph)]

--- a/components/knowledge/src/ai/miniforge/knowledge/zettel.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/zettel.clj
@@ -241,13 +241,11 @@
     (assoc stamped :zettel/trust-level next-trust)))
 
 (defn zettel-summary
-  "Extract a lightweight summary from a zettel."
   [zettel]
   (select-keys zettel [:zettel/id :zettel/uid :zettel/title
                        :zettel/type :zettel/dewey :zettel/tags]))
 
 (defn validate-zettel
-  "Validate a zettel against the schema."
   [zettel]
   (if (m/validate schema/Zettel zettel)
     {:valid? true :errors nil}
@@ -257,20 +255,6 @@
 ;; Link management
 
 (defn create-link
-  "Create a link to another zettel.
-
-   Arguments:
-   - target-id  - UUID of the target zettel
-   - type       - Link type keyword
-   - rationale  - Explanation of why this connection exists (required!)
-
-   Options:
-   - :strength        - Relevance weight 0.0-1.0
-   - :bidirectional?  - Whether to create backlink
-
-   Example:
-     (create-link target-uuid :extends
-                  'Adds namespace details to the base Clojure rule')"
   [target-id type rationale & {:keys [strength bidirectional?]}]
   (cond-> {:link/target-id target-id
            :link/type type
@@ -279,7 +263,6 @@
     (some? bidirectional?) (assoc :link/bidirectional? bidirectional?)))
 
 (defn add-link
-  "Add a link to a zettel."
   [zettel link]
   (let [links (get zettel :zettel/links [])]
     (-> zettel
@@ -287,7 +270,6 @@
         (assoc :zettel/modified (java.util.Date.)))))
 
 (defn remove-link
-  "Remove a link by target ID."
   [zettel target-id]
   (let [links (get zettel :zettel/links [])]
     (-> zettel
@@ -310,8 +292,6 @@
                   (get-links zettel :incoming))))
 
 (defn compute-backlinks
-  "Given a collection of zettels, compute backlinks for each.
-   Returns map of zettel-id -> [source-ids...]"
   [zettels]
   (reduce
    (fn [acc zettel]
@@ -348,7 +328,6 @@
     (yaml/generate-string meta :dumper-options {:flow-style :block})))
 
 (defn zettel->markdown
-  "Serialize a zettel to Markdown with YAML frontmatter."
   [zettel]
   (str "---\n"
        (format-frontmatter zettel)
@@ -390,8 +369,6 @@
         (catch Exception _e2 nil)))))
 
 (defn markdown->zettel
-  "Parse a Markdown file with YAML frontmatter into a zettel.
-   Returns nil if parsing fails."
   [markdown-str]
   (when-let [matches (re-find #"(?s)^---\n(.+?)\n---\n\n?(.*)$" markdown-str)]
     (let [[_ frontmatter-str content] matches


### PR DESCRIPTION
Wave-A boundary-documentation rollout (rule 009), impl-dedup half. Removes impl docstrings now duplicated by the interface boundary (kept those carrying extra info). **Stacked on the interface PR — merge that first.** Docstring-only; full pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)