### PR TITLE
docs(agent): document both interface tiers (rule 009)

### DIFF
--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -77,7 +77,6 @@
 ;; literals with these keys outside of build-curated-artifact.
 
 (def FileEntry
-  "A single file entry in the code artifact."
   [:map
    [:path [:string {:min 1}]]
    [:content :string]
@@ -99,7 +98,6 @@
    [:code/curator-source [:enum :deterministic :hybrid]]])
 
 (defn validate-curated-artifact
-  "Validate a CuratedArtifact, returning schema/valid or schema/invalid."
   [artifact]
   (if (m/validate CuratedArtifact artifact)
     (schema/valid)

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -44,14 +44,12 @@
 ;; Implementer-specific schemas
 
 (def CodeFile
-  "Schema for a code file in the output."
   [:map
    [:path [:string {:min 1}]]
    [:content [:string {:min 0}]]
    [:action [:enum :create :modify :delete]]])
 
 (def CodeArtifact
-  "Schema for the implementer's output."
   [:map
    [:code/id uuid?]
    [:code/files [:vector CodeFile]]
@@ -102,7 +100,6 @@
        (filter #(> (val %) 1))))
 
 (defn validate-code-artifact
-  "Validate a code artifact against the schema and check for issues."
   [artifact]
   (if-not (m/validate CodeArtifact artifact)
     (schema/invalid (schema/explain CodeArtifact artifact)
@@ -891,7 +888,6 @@
       :repair-fn repair-code-artifact})))
 
 (defn code-summary
-  "Get a summary of a code artifact for logging/display."
   [artifact]
   {:id (:code/id artifact)
    :file-count (count (:code/files artifact))
@@ -901,12 +897,10 @@
    :dependencies-added (count (:code/dependencies-added artifact []))})
 
 (defn files-by-action
-  "Group files by their action type."
   [artifact]
   (group-by :action (:code/files artifact)))
 
 (defn total-lines
-  "Count total lines of code in the artifact."
   [artifact]
   (->> (:code/files artifact)
        (remove #(= :delete (:action %)))

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -110,13 +110,18 @@
   runtime/create-executor)
 (def execute
   "Run an agent on a task through the full lifecycle. Args: executor, agent,
-   task, context. Returns {:success bool :outputs [...] :metrics {...}}
-   and :error on failure."
+   task, context. Thin delegate to the AgentExecutor protocol: returns the
+   executor's result map, which is the agent's invoke result (commonly the
+   canonical {:status :success|:error :output ...}) merged with executor
+   metadata (:metrics :tool/invocations :agent-id :task-id :executed-at).
+   Exact keys depend on the agent and executor implementations."
   runtime/execute)
 (def invoke
   "Invoke an agent's main logic on a task, with supervisory projection
-   wrapping. Args: agent, task, context. Returns
-   {:success bool :outputs [...] :decisions [...] :signals [...] :metrics {...}}."
+   wrapping. Args: agent, task, context. Thin delegate to the Agent protocol's
+   invoke: returns the agent's result map (commonly the canonical
+   {:status :success|:error :output ...}, optionally augmented by the
+   supervisory projection). Exact keys depend on the agent implementation."
   runtime/invoke)
 (def validate
   "Check whether agent output meets requirements. Args: agent, output,
@@ -124,7 +129,9 @@
   runtime/validate)
 (def repair
   "Attempt to fix validation failures. Args: agent, output, errors, context.
-   Returns {:repaired output :changes [...] :success bool}."
+   Thin delegate to the Agent protocol's repair: returns the agent's repair
+   result map (commonly the canonical {:status :success|:error :output ...}).
+   Exact keys depend on the agent implementation."
   runtime/repair)
 (def init
   "Initialize an agent with configuration. Args: agent, config. Returns the

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -37,145 +37,589 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocols and configuration
 
-(def Agent protocols/Agent)
-(def AgentLifecycle protocols/AgentLifecycle)
-(def AgentExecutor protocols/AgentExecutor)
-(def LLMBackend protocols/LLMBackend)
-(def Memory protocols/Memory)
-(def MemoryStore protocols/MemoryStore)
-(def InterAgentMessaging protocols/InterAgentMessaging)
-(def MessageRouter protocols/MessageRouter)
-(def MessageValidator protocols/MessageValidator)
-(def default-role-configs protocols/default-role-configs)
-(def role-capabilities protocols/role-capabilities)
-(def role-system-prompts protocols/role-system-prompts)
+(def Agent
+  "Protocol: agent behavior and lifecycle. Methods invoke/validate/repair.
+   Implement to define a custom agent that processes tasks into
+   artifacts/decisions/signals."
+  protocols/Agent)
+(def AgentLifecycle
+  "Protocol: agent lifecycle management (init/status/shutdown/abort).
+   Implement to control how an agent is initialized and torn down."
+  protocols/AgentLifecycle)
+(def AgentExecutor
+  "Protocol: runs an agent on a task through the full
+   init->invoke->validate->repair->complete lifecycle. Implement to
+   customize execution orchestration."
+  protocols/AgentExecutor)
+(def LLMBackend
+  "Protocol: LLM interaction (single method complete). Implement to swap
+   or mock the language-model backend."
+  protocols/LLMBackend)
+(def Memory
+  "Protocol: agent memory storage and retrieval (add-message, get-messages,
+   get-window, clear-messages, get-metadata). Implement for a custom store."
+  protocols/Memory)
+(def MemoryStore
+  "Protocol: managing multiple agent memories (get/save/delete/list).
+   Implement to back memory persistence with a custom store."
+  protocols/MemoryStore)
+(def InterAgentMessaging
+  "Protocol: send/receive/respond messages between agents during execution.
+   Implement to customize how an agent exchanges messages."
+  protocols/InterAgentMessaging)
+(def MessageRouter
+  "Protocol: routes and queues messages between agents
+   (route-message, get-messages-for-agent, get-messages-by-workflow,
+   clear-messages). Implement for a custom delivery mechanism."
+  protocols/MessageRouter)
+(def MessageValidator
+  "Protocol: validates message structure against schema (validate-message).
+   Implement to plug in custom message validation."
+  protocols/MessageValidator)
+(def default-role-configs
+  "Map of agent role keyword -> default config map. Each config carries
+   static fields (temperature, max-tokens, budget) from
+   role-defaults.edn plus a dynamically selected :model."
+  protocols/default-role-configs)
+(def role-capabilities
+  "Map of agent role keyword -> set of capability keywords
+   (e.g. :planner -> #{:plan :decompose :estimate})."
+  protocols/role-capabilities)
+(def role-system-prompts
+  "Map of agent role keyword -> system-prompt string for that role."
+  protocols/role-system-prompts)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Runtime and memory API
 
-(def create-agent runtime/create-agent)
-(def create-agent-map runtime/create-agent-map)
-(def create-executor runtime/create-executor)
-(def execute runtime/execute)
-(def invoke runtime/invoke)
-(def validate runtime/validate)
-(def repair runtime/repair)
-(def init runtime/init)
-(def agent-status runtime/agent-status)
-(def shutdown runtime/shutdown)
+(def create-agent
+  "Create an agent by role with optional config overrides. Args: role
+   (keyword e.g. :planner :implementer), optional opts map (:model
+   :temperature :max-tokens :budget :phase :privacy-required etc.).
+   Returns a BaseAgent record satisfying the Agent protocol."
+  runtime/create-agent)
+(def create-agent-map
+  "Create an agent and return it as a plain map conforming to the Agent
+   schema (useful for serialization/storage). Args: role, optional opts.
+   Returns a map with :agent/* keys."
+  runtime/create-agent-map)
+(def create-executor
+  "Create an agent executor. Arg (optional): config map (e.g.
+   {:memory-store ...}). Returns a value satisfying the AgentExecutor
+   protocol."
+  runtime/create-executor)
+(def execute
+  "Run an agent on a task through the full lifecycle. Args: executor, agent,
+   task, context. Returns {:success bool :outputs [...] :metrics {...}}
+   and :error on failure."
+  runtime/execute)
+(def invoke
+  "Invoke an agent's main logic on a task, with supervisory projection
+   wrapping. Args: agent, task, context. Returns
+   {:success bool :outputs [...] :decisions [...] :signals [...] :metrics {...}}."
+  runtime/invoke)
+(def validate
+  "Check whether agent output meets requirements. Args: agent, output,
+   context. Returns {:valid? bool :errors [...] :warnings [...]}."
+  runtime/validate)
+(def repair
+  "Attempt to fix validation failures. Args: agent, output, errors, context.
+   Returns {:repaired output :changes [...] :success bool}."
+  runtime/repair)
+(def init
+  "Initialize an agent with configuration. Args: agent, config. Returns the
+   initialized agent instance."
+  runtime/init)
+(def agent-status
+  "Return an agent's current status. Arg: agent. Returns
+   {:state keyword :metrics {...} :last-activity inst}."
+  runtime/agent-status)
+(def shutdown
+  "Clean up agent resources. Arg: agent. Returns {:success bool}."
+  runtime/shutdown)
 
-(def create-memory memory/create-memory)
-(def add-to-memory memory/add-to-memory)
-(def add-system-message memory/add-system-message)
-(def add-user-message memory/add-user-message)
-(def add-assistant-message memory/add-assistant-message)
-(def get-messages memory/get-messages)
-(def get-memory-window memory/get-memory-window)
-(def clear-memory memory/clear-memory)
-(def memory-metadata memory/memory-metadata)
-(def create-memory-store memory/create-memory-store)
-(def get-memory memory/get-memory)
-(def save-memory memory/save-memory)
-(def delete-memory memory/delete-memory)
-(def list-memories memory/list-memories)
+(def create-memory
+  "Create a new agent memory. Arg (optional): {:scope :scope-id :metadata};
+   :scope defaults to :task. Returns an AgentMemory (a Memory) with an
+   empty message list."
+  memory/create-memory)
+(def add-to-memory
+  "Append a message to memory under the given role. Args: memory, role
+   (keyword), content. Returns the updated memory."
+  memory/add-to-memory)
+(def add-system-message
+  "Append a :system message to memory. Args: memory, content (string).
+   Returns the updated memory."
+  memory/add-system-message)
+(def add-user-message
+  "Append a :user message to memory. Args: memory, content (string).
+   Returns the updated memory."
+  memory/add-user-message)
+(def add-assistant-message
+  "Append an :assistant message to memory. Args: memory, content (string),
+   optional :tokens. Returns the updated memory."
+  memory/add-assistant-message)
+(def get-messages
+  "Return all messages in memory in chronological order (a sequence of
+   message maps). Arg: memory."
+  memory/get-messages)
+(def get-memory-window
+  "Return the most recent messages fitting within token-limit. Args: memory,
+   token-limit (int). Returns {:messages [...] :total-tokens int
+   :trimmed-count int}; system messages are always preserved."
+  memory/get-memory-window)
+(def clear-memory
+  "Remove all messages from memory. Arg: memory. Returns the emptied memory."
+  memory/clear-memory)
+(def memory-metadata
+  "Return memory metadata. Arg: memory. Returns a map merging stored
+   metadata with :memory/id :memory/scope :memory/message-count
+   :memory/total-tokens."
+  memory/memory-metadata)
+(def create-memory-store
+  "Create an in-memory MemoryStore backed by an atom. No args.
+   Returns an InMemoryStore (a MemoryStore)."
+  memory/create-memory-store)
+(def get-memory
+  "Retrieve a memory from a store by id. Args: store, memory-id.
+   Returns the memory, or nil if absent."
+  memory/get-memory)
+(def save-memory
+  "Save/update a memory in a store. Args: store, memory. Returns the memory."
+  memory/save-memory)
+(def delete-memory
+  "Delete a memory from a store by id. Args: store, memory-id. Returns nil."
+  memory/delete-memory)
+(def list-memories
+  "List memories in a store matching a scope. Args: store, scope, scope-id.
+   Returns a sequence of memories."
+  memory/list-memories)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Messaging, utilities, specialized agents, and meta-operations
 
-(def create-message-router messaging/create-message-router)
-(def create-agent-messaging messaging/create-agent-messaging)
-(def send-message messaging/send-message)
-(def receive-messages messaging/receive-messages)
-(def respond-to-message messaging/respond-to-message)
-(def send-clarification-request messaging/send-clarification-request)
-(def send-concern messaging/send-concern)
-(def send-suggestion messaging/send-suggestion)
-(def get-clarification-requests messaging/get-clarification-requests)
-(def get-concerns messaging/get-concerns)
-(def get-suggestions messaging/get-suggestions)
-(def route-message messaging/route-message)
-(def get-messages-for-agent messaging/get-messages-for-agent)
-(def get-messages-by-workflow messaging/get-messages-by-workflow)
-(def clear-workflow-messages messaging/clear-workflow-messages)
-(def validate-message messaging/validate-message)
-(def Message messaging/Message)
-(def MessageType messaging/MessageType)
+(def create-message-router
+  "Create a message router. No args. Returns a MessageRouter record backed by
+   atoms for per-workflow messages and per-agent inboxes."
+  messaging/create-message-router)
+(def create-agent-messaging
+  "Create messaging capability for an agent. Args: agent-id (keyword),
+   instance-id (uuid), workflow-id (uuid), router, optional event-stream.
+   Returns an AgentMessaging record (an InterAgentMessaging)."
+  messaging/create-agent-messaging)
+(def send-message
+  "Send a message from agent-messaging to the target specified in message-data.
+   Event emission is handled by the impl layer."
+  messaging/send-message)
+(def receive-messages
+  "Return all messages received by this agent. Arg: agent-messaging.
+   Returns a sequence of message maps."
+  messaging/receive-messages)
+(def respond-to-message
+  "Respond to a message. Event emission is handled by the impl layer."
+  messaging/respond-to-message)
+(def send-clarification-request
+  "Send a :clarification-request to another agent. Args: agent-messaging,
+   to-agent (keyword), content (string). Returns {:message map :event map}."
+  messaging/send-clarification-request)
+(def send-concern
+  "Send a :concern to another agent. Args: agent-messaging, to-agent
+   (keyword), content (string). Returns {:message map :event map}."
+  messaging/send-concern)
+(def send-suggestion
+  "Send a :suggestion to another agent. Args: agent-messaging, to-agent
+   (keyword), content (string). Returns {:message map :event map}."
+  messaging/send-suggestion)
+(def get-clarification-requests
+  "Return received messages of type :clarification-request. Arg:
+   agent-messaging. Returns a sequence of message maps."
+  messaging/get-clarification-requests)
+(def get-concerns
+  "Return received messages of type :concern. Arg: agent-messaging.
+   Returns a sequence of message maps."
+  messaging/get-concerns)
+(def get-suggestions
+  "Return received messages of type :suggestion. Arg: agent-messaging.
+   Returns a sequence of message maps."
+  messaging/get-suggestions)
+(def route-message
+  "Route a message to its recipient."
+  messaging/route-message)
+(def get-messages-for-agent
+  "Return messages for a specific agent in a workflow. Args: router, agent-id,
+   workflow-id. Returns a sequence of message maps (the agent's inbox)."
+  messaging/get-messages-for-agent)
+(def get-messages-by-workflow
+  "Return all messages in a workflow, ordered by timestamp. Args: router,
+   workflow-id. Returns a sequence of message maps."
+  messaging/get-messages-by-workflow)
+(def clear-workflow-messages
+  "Clear all messages for a workflow. Args: router, workflow-id. Returns nil."
+  messaging/clear-workflow-messages)
+(def validate-message
+  "Validate a message map against the Message schema. Arg: message.
+   Returns {:valid? boolean :errors [...]}."
+  messaging/validate-message)
+(def Message
+  "Malli schema (a [:map ...] vector) for an inter-agent message, per N1
+   §6.2.2. Required keys include :message/id :message/type :message/from-agent
+   :message/to-agent :message/workflow-id :message/content :message/timestamp."
+  messaging/Message)
+(def MessageType
+  "Malli schema (a [:enum ...] vector) of valid message types:
+   :clarification-request :clarification-response :concern :suggestion."
+  messaging/MessageType)
 
-(def estimate-tokens llm/estimate-tokens)
-(def estimate-cost llm/estimate-cost)
-(def create-mock-llm llm/create-mock-llm)
+(def estimate-tokens
+  "Estimate token count for message content. Arg: content (any). Returns an
+   int: for strings, max(1, chars/4); 100 for non-string content."
+  llm/estimate-tokens)
+(def estimate-cost
+  "Estimate cost in USD for token usage. Args: input-tokens, output-tokens,
+   model (string). Returns a double; unknown/unpriced models return 0.0."
+  llm/estimate-cost)
+(def create-mock-llm
+  "Create a mock LLMBackend record for testing. Arg (optional): a single
+   response map or a sequence of them; defaults to a canned response.
+   Returns a value satisfying the LLMBackend protocol."
+  llm/create-mock-llm)
 
-(def create-base-agent specialized/create-base-agent)
-(def make-validator specialized/make-validator)
-(def cycle-agent specialized/cycle-agent)
-(def create-planner specialized/create-planner)
-(def create-implementer specialized/create-implementer)
-(def create-tester specialized/create-tester)
-(def create-reviewer specialized/create-reviewer)
-(def create-releaser specialized/create-releaser)
-(def curate specialized/curate)
-(def curate-implement-output specialized/curate-implement-output)
-(def CuratedArtifact specialized/CuratedArtifact)
-(def CuratedFileEntry specialized/CuratedFileEntry)
-(def validate-curated-artifact specialized/validate-curated-artifact)
-(def substantive-file? specialized/substantive-file?)
-(def non-substantive-paths specialized/non-substantive-paths)
-(def Plan specialized/Plan)
-(def PlanTask specialized/PlanTask)
-(def CodeArtifact specialized/CodeArtifact)
-(def CodeFile specialized/CodeFile)
-(def TestArtifact specialized/TestArtifact)
-(def TestFile specialized/TestFile)
-(def Coverage specialized/Coverage)
-(def ReviewArtifact specialized/ReviewArtifact)
-(def ReviewIssue specialized/ReviewIssue)
-(def GateFeedback specialized/GateFeedback)
-(def ReleaseArtifact specialized/ReleaseArtifact)
-(def plan-summary specialized/plan-summary)
-(def task-dependency-order specialized/task-dependency-order)
-(def validate-plan specialized/validate-plan)
-(def code-summary specialized/code-summary)
-(def files-by-action specialized/files-by-action)
-(def total-lines specialized/total-lines)
-(def validate-code-artifact specialized/validate-code-artifact)
-(def test-summary specialized/test-summary)
-(def coverage-meets-threshold? specialized/coverage-meets-threshold?)
-(def tests-by-path specialized/tests-by-path)
-(def validate-test-artifact specialized/validate-test-artifact)
-(def review-summary specialized/review-summary)
-(def approved? specialized/approved?)
-(def rejected? specialized/rejected?)
-(def conditionally-approved? specialized/conditionally-approved?)
-(def get-blocking-issues specialized/get-blocking-issues)
-(def get-review-warnings specialized/get-review-warnings)
-(def get-recommendations specialized/get-recommendations)
-(def changes-requested? specialized/changes-requested?)
-(def get-review-issues specialized/get-review-issues)
-(def get-review-strengths specialized/get-review-strengths)
-(def validate-review-artifact specialized/validate-review-artifact)
-(def review-fingerprint specialized/review-fingerprint)
-(def review-stagnated? specialized/review-stagnated?)
-(def release-summary specialized/release-summary)
-(def validate-release-artifact specialized/validate-release-artifact)
+(def create-base-agent
+  "Create a base (functional) agent from callbacks. Arg: options map requiring
+   :role :system-prompt :invoke-fn :validate-fn :repair-fn, with optional
+   :config :logger. Returns a FunctionalAgent record (an Agent)."
+  specialized/create-base-agent)
+(def make-validator
+  "Build a validate-fn from a Malli schema. Arg: malli-schema. Returns a fn of
+   output -> {:valid? bool :errors nil-or-explanation}."
+  specialized/make-validator)
+(def cycle-agent
+  "Run an invoke->validate->repair cycle on a specialized agent. Args: agent,
+   context, input, optional :max-iterations (default 3). Returns the final
+   result map after repair attempts."
+  specialized/cycle-agent)
+(def create-planner
+  "Create a Planner agent. Arg (optional): options map (:config :logger
+   :llm-backend). Returns a FunctionalAgent record (an Agent)."
+  specialized/create-planner)
+(def create-implementer
+  "Create an Implementer agent. Arg (optional): options map. Returns a
+   FunctionalAgent record (an Agent)."
+  specialized/create-implementer)
+(def create-tester
+  "Create a Tester agent. Arg (optional): options map. Returns a
+   FunctionalAgent record (an Agent)."
+  specialized/create-tester)
+(def create-reviewer
+  "Create a Reviewer agent (LLM-backed review + deterministic gates, falling
+   back to gate-only without an LLM). Arg (optional): options map
+   (:gates :strict :logger :llm-backend :config). Returns a FunctionalAgent
+   record (an Agent)."
+  specialized/create-reviewer)
+(def create-releaser
+  "Create a Releaser agent. Arg (optional): options map. Returns a
+   FunctionalAgent record (an Agent)."
+  specialized/create-releaser)
+(def curate
+  "Curator entry point (a multimethod dispatching on :curator/kind). Arg:
+   input map. Returns a response map whose :output is a CuratedArtifact on
+   success, or an error response. Dispatch: :implement (default) and
+   :merge-resolution."
+  specialized/curate)
+(def curate-implement-output
+  "Curate an implementer's result + environment state into a CuratedArtifact.
+   Arg: input map (requires :implementer-result, :worktree-path; see impl for
+   capsule-mode keys). Returns a success response with :output a
+   CuratedArtifact, or an error response when no files were written. Thin
+   wrapper over (curate (assoc input :curator/kind :implement))."
+  specialized/curate-implement-output)
+(def CuratedArtifact
+  "Malli schema (a [:map ...] vector) for the curator's structured output,
+   consumed by verify/review/release/PR-doc phases. Keys include :code/id
+   :code/files :code/summary :code/tests-added? :code/scope-deviations
+   :code/breaking-change? :code/curated-at :code/curator-source."
+  specialized/CuratedArtifact)
+(def CuratedFileEntry
+  "Malli schema (a [:map ...] vector) for one file in a CuratedArtifact:
+   :path (string) :content (string) :action (:create|:modify|:delete)."
+  specialized/CuratedFileEntry)
+(def validate-curated-artifact
+  "Validate a CuratedArtifact against its schema. Arg: artifact. Returns a
+   validation result (schema/valid or schema/invalid map)."
+  specialized/validate-curated-artifact)
+(def substantive-file?
+  "True when a file entry represents real implementer work, not a
+   runtime/session side-effect. Arg: file-entry map. Returns boolean."
+  specialized/substantive-file?)
+(def non-substantive-paths
+  "Set of file paths the curator drops before assessing 'files written'
+   (runtime/session markers). A set of strings (currently
+   #{\".miniforge-session-id\"}), not a vector."
+  specialized/non-substantive-paths)
+(def Plan
+  "Malli schema (a [:map ...] vector) for a planner's output: :plan/id
+   :plan/name :plan/tasks (vector of PlanTask) plus optional complexity,
+   risks, assumptions."
+  specialized/Plan)
+(def PlanTask
+  "Malli schema (a [:map ...] vector) for one task in a Plan: :task/id
+   :task/description :task/type plus optional dependencies, acceptance
+   criteria, effort, component, stratum, merge-strategy."
+  specialized/PlanTask)
+(def CodeArtifact
+  "Malli schema (a [:map ...] vector) for the implementer's output: :code/id
+   :code/files (vector of CodeFile) plus optional dependencies-added,
+   tests-needed?, language, summary."
+  specialized/CodeArtifact)
+(def CodeFile
+  "Malli schema (a [:map ...] vector) for one code file: :path :content
+   :action (:create|:modify|:delete)."
+  specialized/CodeFile)
+(def TestArtifact
+  "Malli schema (a [:map ...] vector) for the tester's output: :test/id
+   :test/files (vector of TestFile) :test/type plus optional coverage,
+   framework, assertions/cases counts, summary."
+  specialized/TestArtifact)
+(def TestFile
+  "Malli schema (a [:map ...] vector) for one test file: :path :content."
+  specialized/TestFile)
+(def Coverage
+  "Malli schema (a [:map ...] vector) for test coverage: optional :lines
+   :branches :functions, each a double 0.0-100.0."
+  specialized/Coverage)
+(def ReviewArtifact
+  "Malli schema (a [:map ...] vector) for the reviewer's output: :review/id
+   :review/decision (enum) :review/gate-results :review/summary plus gate
+   counts and optional blocking-issues, warnings, recommendations, issues,
+   strengths."
+  specialized/ReviewArtifact)
+(def ReviewIssue
+  "Malli schema (a [:map ...] vector) for a single review issue: :severity
+   (:blocking|:warning|:nit) :description plus optional :file :line
+   :suggestion (each nil-tolerant)."
+  specialized/ReviewIssue)
+(def GateFeedback
+  "Malli schema (a [:map ...] vector) for feedback from one gate: :gate-id
+   :gate-type :passed? plus optional errors, warnings, duration-ms."
+  specialized/GateFeedback)
+(def ReleaseArtifact
+  "Malli schema (a [:map ...] vector) for the releaser's output:
+   :release/id :release/branch-name :release/commit-message :release/pr-title
+   :release/pr-description plus optional files-summary."
+  specialized/ReleaseArtifact)
+(def plan-summary
+  "Summarize a plan for logging/display. Arg: plan. Returns a map
+   {:id :name :task-count :complexity :risk-count}."
+  specialized/plan-summary)
+(def task-dependency-order
+  "Topologically sort a plan's tasks (dependency-free first). Arg: plan.
+   Returns a vector of task maps; on a cycle, remaining tasks are appended."
+  specialized/task-dependency-order)
+(def validate-plan
+  "Validate a plan against the Plan schema and check structural issues
+   (invalid/circular deps). Arg: plan. Returns {:valid? bool :errors ...}."
+  specialized/validate-plan)
+(def code-summary
+  "Summarize a code artifact for logging/display. Arg: artifact. Returns a
+   map {:id :file-count :actions :language :tests-needed? :dependencies-added}."
+  specialized/code-summary)
+(def files-by-action
+  "Group a code artifact's files by :action. Arg: artifact. Returns a map of
+   action keyword -> vector of file maps."
+  specialized/files-by-action)
+(def total-lines
+  "Count total lines of code in an artifact (excluding :delete files). Arg:
+   artifact. Returns an int."
+  specialized/total-lines)
+(def validate-code-artifact
+  "Validate a code artifact against the schema and check for issues (empty
+   creates, duplicate paths). Arg: artifact. Returns a validation result
+   (schema/valid or schema/invalid map)."
+  specialized/validate-code-artifact)
+(def test-summary
+  "Summarize a test artifact for logging/display. Arg: artifact. Returns a
+   map {:id :file-count :type :framework :assertions :cases :coverage}."
+  specialized/test-summary)
+(def coverage-meets-threshold?
+  "Check whether an artifact's coverage meets thresholds. Args: artifact,
+   optional :lines :branches :functions (defaults 80/70/80). Returns boolean."
+  specialized/coverage-meets-threshold?)
+(def tests-by-path
+  "Map a test artifact's file paths to their content. Arg: artifact. Returns
+   a map of path string -> content string."
+  specialized/tests-by-path)
+(def validate-test-artifact
+  "Validate a test artifact against the schema and check for issues (naming
+   convention, missing assertions). Arg: artifact. Returns
+   {:valid? bool :errors ...}."
+  specialized/validate-test-artifact)
+(def review-summary
+  "Summarize a review artifact for logging/display. Arg: artifact. Returns a
+   map {:id :decision :gates-passed :gates-failed :gates-total
+   :blocking-issues-count :warnings-count :llm-issues-count}."
+  specialized/review-summary)
+(def approved?
+  "True when a review artifact's :review/decision is :approved. Arg: artifact.
+   Returns boolean."
+  specialized/approved?)
+(def rejected?
+  "True when a review artifact's :review/decision is :rejected. Arg: artifact.
+   Returns boolean."
+  specialized/rejected?)
+(def conditionally-approved?
+  "True when a review artifact's :review/decision is :conditionally-approved.
+   Arg: artifact. Returns boolean."
+  specialized/conditionally-approved?)
+(def get-blocking-issues
+  "Extract blocking issues from a review artifact. Arg: artifact. Returns a
+   vector of strings (empty if none)."
+  specialized/get-blocking-issues)
+(def get-review-warnings
+  "Extract warnings from a review artifact. Arg: artifact. Returns a vector of
+   strings (empty if none)."
+  specialized/get-review-warnings)
+(def get-recommendations
+  "Extract recommendations from a review artifact. Arg: artifact. Returns a
+   vector of strings (empty if none)."
+  specialized/get-recommendations)
+(def changes-requested?
+  "True when a review artifact's :review/decision is :changes-requested. Arg:
+   artifact. Returns boolean."
+  specialized/changes-requested?)
+(def get-review-issues
+  "Extract LLM review issues from a review artifact. Arg: artifact. Returns a
+   vector of ReviewIssue maps (empty if none)."
+  specialized/get-review-issues)
+(def get-review-strengths
+  "Extract strengths noted by the LLM from a review artifact. Arg: artifact.
+   Returns a vector of strings (empty if none)."
+  specialized/get-review-strengths)
+(def validate-review-artifact
+  "Validate a review artifact against the schema and check gate-count
+   consistency. Arg: artifact. Returns {:valid? bool :errors ...}."
+  specialized/validate-review-artifact)
+(def review-fingerprint
+  "Reduce a review artifact to a stable, comparable fingerprint of its
+   actionable items. Arg: review. Returns a sorted vector of
+   [severity file line description] tuples (empty when nothing is actionable)."
+  specialized/review-fingerprint)
+(def review-stagnated?
+  "True when a review's fingerprint exactly matches the prior one (repair
+   loop made no actionable change). Args: prior (may be nil), current.
+   Returns boolean; false on first iteration or empty current fingerprint."
+  specialized/review-stagnated?)
+(def release-summary
+  "Summarize a release artifact for logging/display. Arg: artifact. Returns a
+   map {:id :branch :pr-title :files-summary}."
+  specialized/release-summary)
+(def validate-release-artifact
+  "Validate a release artifact against the schema and check for issues (branch
+   name spaces, PR-title length, empty commit first line). Arg: artifact.
+   Returns {:valid? bool :errors ...}."
+  specialized/validate-release-artifact)
 
-(def create-progress-monitor-agent meta/create-progress-monitor-agent)
-(def create-meta-coordinator meta/create-meta-coordinator)
-(def check-all-meta-agents meta/check-all-meta-agents)
-(def reset-all-meta-agents! meta/reset-all-meta-agents!)
-(def get-meta-check-history meta/get-meta-check-history)
-(def get-meta-agent-stats meta/get-meta-agent-stats)
-(def create-supervision-coordinator supervision/create-supervision-coordinator)
-(def check-all-supervisors supervision/check-all-supervisors)
-(def reset-all-supervisors! supervision/reset-all-supervisors!)
-(def get-supervision-check-history supervision/get-supervision-check-history)
-(def get-supervisor-stats supervision/get-supervisor-stats)
-(def run-meta-loop-cycle! meta/run-meta-loop-cycle!)
-(def create-meta-loop-context meta/create-meta-loop-context)
-(def record-workflow-outcome! meta/record-workflow-outcome!)
-(def run-cycle-from-context! meta/run-cycle-from-context!)
+(def create-progress-monitor-agent
+  "Create a Progress Monitor meta-agent. Arg (optional): options map
+   (:check-interval-ms :priority :stagnation-threshold-ms :max-total-ms).
+   Returns a meta-agent suitable for a meta coordinator."
+  meta/create-progress-monitor-agent)
+(def create-meta-coordinator
+  "Create a meta-agent coordinator over a set of meta-agents. Arg: vector of
+   meta-agent instances. Returns a MetaCoordinator record."
+  meta/create-meta-coordinator)
+(def check-all-meta-agents
+  "Run due health checks across all enabled meta-agents. Args: coordinator,
+   workflow-state. Returns {:status :healthy|:warning|:halt :checks [...]}
+   with :halt-reason/:halting-agent when status is :halt."
+  meta/check-all-meta-agents)
+(def reset-all-meta-agents!
+  "Reset all meta-agent state (on workflow restart). Arg: coordinator.
+   Returns the coordinator."
+  meta/reset-all-meta-agents!)
+(def get-meta-check-history
+  "Return recent meta-agent health-check history. Args: coordinator, optional
+   {:limit :agent-id :status}. Returns a sequence of check-record maps."
+  meta/get-meta-check-history)
+(def get-meta-agent-stats
+  "Return per-meta-agent statistics. Arg: coordinator. Returns
+   {:agents [{:id :name :checks-run :last-check :last-status
+              :halt-count :warning-count ...}]}."
+  meta/get-meta-agent-stats)
+(def create-supervision-coordinator
+  "Create a supervision coordinator over a set of supervisor agents. Arg:
+   vector of meta-agent instances. Returns a MetaCoordinator record."
+  supervision/create-supervision-coordinator)
+(def check-all-supervisors
+  "Run due health checks across all enabled supervisors. Args: coordinator,
+   workflow-state. Returns {:status :healthy|:warning|:halt :checks [...]}
+   with :halt-reason/:halting-agent when status is :halt."
+  supervision/check-all-supervisors)
+(def reset-all-supervisors!
+  "Reset all supervisor agent state (on workflow restart). Arg: coordinator.
+   Returns the coordinator."
+  supervision/reset-all-supervisors!)
+(def get-supervision-check-history
+  "Return recent supervisor health-check history. Args: coordinator, optional
+   {:limit :agent-id :status}. Returns a sequence of check-record maps."
+  supervision/get-supervision-check-history)
+(def get-supervisor-stats
+  "Return per-supervisor statistics. Arg: coordinator. Returns
+   {:agents [{:id :name :checks-run :last-check :last-status
+              :halt-count :warning-count ...}]}."
+  supervision/get-supervisor-stats)
+(def run-meta-loop-cycle!
+  "Execute one meta-loop learning cycle.
 
-(def classify-task classification/classify-task)
-(def get-task-characteristics classification/get-task-characteristics)
+   Orchestrates: reliability compute → degradation eval → diagnosis → improvement proposals.
+
+   Arguments:
+     ctx - {:event-stream :reliability-engine :degradation-manager
+            :improvement-pipeline :metrics :training-examples}
+
+   Returns: {:cycle/sli-count :cycle/breach-count :cycle/signal-count
+             :cycle/diagnosis-count :cycle/proposal-count :cycle/degradation-mode ...}"
+  meta/run-meta-loop-cycle!)
+(def create-meta-loop-context
+  "Create a MetaLoopContext bundling reliability engine, degradation manager,
+   improvement pipeline, and metrics store.
+
+   Arguments:
+     event-stream - event stream atom
+     config       - optional {:reliability {} :degradation {}}"
+  meta/create-meta-loop-context)
+(def record-workflow-outcome!
+  "Record a workflow completion for use in the next meta-loop cycle.
+
+   Arguments:
+     ctx           - MetaLoopContext
+     workflow-id   - uuid
+     status        - :completed | :failed | :escalated
+     failure-class - optional :failure.class/* keyword"
+  meta/record-workflow-outcome!)
+(def run-cycle-from-context!
+  "Run one meta-loop cycle using the accumulated metrics in ctx.
+
+   Arguments:
+     ctx               - MetaLoopContext
+     training-examples - optional vector of training records
+
+   Returns: cycle result map."
+  meta/run-cycle-from-context!)
+
+(def classify-task
+  "Classify a task to pick an optimal model type.
+   Arg: task map with optional :phase :agent-type :description :title and
+   sizing/privacy/cost hints. Returns a map
+   {:type keyword :confidence double :reason string
+    :alternative-types [keyword] :all-reasons [string]}; never nil
+   (defaults to :execution-focused at 0.5 confidence)."
+  classification/classify-task)
+(def get-task-characteristics
+  "Extract the features used during classification, for debugging/transparency.
+   Arg: task map. Returns a map
+   {:phase :agent-type :keywords #{kw} :context-size int
+    :privacy-required truthy-or-nil :cost-constrained truthy-or-nil}."
+  classification/get-task-characteristics)
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; File artifacts — working tree snapshot and fallback artifact collection
@@ -223,13 +667,43 @@
 ;; need only watchdog functionality should depend on
 ;; ai.miniforge.agent.interface.watchdog directly to avoid the prefix.
 
-(def resolve-gap-threshold watchdog/resolve-gap-threshold)
-(def default-gap-threshold-ms watchdog/default-gap-threshold-ms)
-(def default-check-interval-ms watchdog/default-check-interval-ms)
-(def create-watchdog watchdog/create-watchdog)
-(def ping-watchdog! watchdog/ping!)
-(def stop-watchdog! watchdog/stop!)
-(def watchdog-stalled? watchdog/stalled?)
-(def watchdog-stall-gap-ms watchdog/stall-gap-ms)
-(def capture-watchdog-session-id! watchdog/capture-session-id!)
-(def get-watchdog-session-id watchdog/get-session-id)
+(def resolve-gap-threshold
+  "Resolve the stream-gap threshold (ms) for a backend.
+   See `ai.miniforge.agent.stream-watchdog/resolve-gap-threshold`."
+  watchdog/resolve-gap-threshold)
+(def default-gap-threshold-ms
+  "Default stream-gap threshold in ms (90 000)."
+  watchdog/default-gap-threshold-ms)
+(def default-check-interval-ms
+  "Default watchdog check interval in ms (5 000)."
+  watchdog/default-check-interval-ms)
+(def create-watchdog
+  "Create and start a stream-gap watchdog.
+   See `ai.miniforge.agent.stream-watchdog/create-watchdog`."
+  watchdog/create-watchdog)
+(def ping-watchdog!
+  "Record a new agent event, resetting the gap timer.
+   Named ping! (not reset!) to avoid shadowing clojure.core/reset!.
+   See `ai.miniforge.agent.stream-watchdog/ping!`."
+  watchdog/ping!)
+(def stop-watchdog!
+  "Gracefully shut down the watchdog scheduler.
+   See `ai.miniforge.agent.stream-watchdog/stop!`."
+  watchdog/stop!)
+(def watchdog-stalled?
+  "Return true if the watchdog fired and killed the agent subprocess.
+   See `ai.miniforge.agent.stream-watchdog/stalled?`."
+  watchdog/stalled?)
+(def watchdog-stall-gap-ms
+  "Return the measured stream gap (ms) at the moment the watchdog fired, or nil.
+   See `ai.miniforge.agent.stream-watchdog/stall-gap-ms`."
+  watchdog/stall-gap-ms)
+(def capture-watchdog-session-id!
+  "Parse and persist the session ID from the initial agent handshake event.
+   Emits :agent/session-captured via event-stream.
+   See `ai.miniforge.agent.stream-watchdog/capture-session-id!`."
+  watchdog/capture-session-id!)
+(def get-watchdog-session-id
+  "Return the captured session ID string, or nil if not yet captured.
+   See `ai.miniforge.agent.stream-watchdog/get-session-id`."
+  watchdog/get-session-id)

--- a/components/agent/src/ai/miniforge/agent/interface/classification.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/classification.clj
@@ -24,5 +24,18 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Task classification
 
-(def classify-task classifier/classify-task)
-(def get-task-characteristics classifier/get-task-characteristics)
+(def classify-task
+  "Classify a task to pick an optimal model type.
+   Arg: task map with optional :phase :agent-type :description :title and
+   sizing/privacy/cost hints. Returns a map
+   {:type keyword :confidence double :reason string
+    :alternative-types [keyword] :all-reasons [string]}; never nil
+   (defaults to :execution-focused at 0.5 confidence)."
+  classifier/classify-task)
+
+(def get-task-characteristics
+  "Extract the features used during classification, for debugging/transparency.
+   Arg: task map. Returns a map
+   {:phase :agent-type :keywords #{kw} :context-size int
+    :privacy-required truthy-or-nil :cost-constrained truthy-or-nil}."
+  classifier/get-task-characteristics)

--- a/components/agent/src/ai/miniforge/agent/interface/llm.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/llm.clj
@@ -25,6 +25,18 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Utility helpers
 
-(def estimate-tokens mem-impl/estimate-tokens)
-(def estimate-cost core/estimate-cost)
-(def create-mock-llm core/create-mock-llm)
+(def estimate-tokens
+  "Estimate token count for message content. Arg: content (any). Returns an
+   int: for strings, max(1, chars/4); 100 for non-string content."
+  mem-impl/estimate-tokens)
+
+(def estimate-cost
+  "Estimate cost in USD for token usage. Args: input-tokens, output-tokens,
+   model (string). Returns a double; unknown/unpriced models return 0.0."
+  core/estimate-cost)
+
+(def create-mock-llm
+  "Create a mock LLMBackend record for testing. Arg (optional): a single
+   response map or a sequence of them; defaults to a canned response.
+   Returns a value satisfying the LLMBackend protocol."
+  core/create-mock-llm)

--- a/components/agent/src/ai/miniforge/agent/interface/memory.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/memory.clj
@@ -25,44 +25,81 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Memory operations
 
-(def create-memory mem-records/create-memory)
-(def add-system-message mem-records/add-system-message)
-(def add-user-message mem-records/add-user-message)
-(def add-assistant-message mem-records/add-assistant-message)
-(def create-memory-store mem-records/create-memory-store)
+(def create-memory
+  "Create a new agent memory. Arg (optional): {:scope :scope-id :metadata};
+   :scope defaults to :task. Returns an AgentMemory (a Memory) with an
+   empty message list."
+  mem-records/create-memory)
+
+(def add-system-message
+  "Append a :system message to memory. Args: memory, content (string).
+   Returns the updated memory."
+  mem-records/add-system-message)
+
+(def add-user-message
+  "Append a :user message to memory. Args: memory, content (string).
+   Returns the updated memory."
+  mem-records/add-user-message)
+
+(def add-assistant-message
+  "Append an :assistant message to memory. Args: memory, content (string),
+   optional :tokens. Returns the updated memory."
+  mem-records/add-assistant-message)
+
+(def create-memory-store
+  "Create an in-memory MemoryStore backed by an atom. No args.
+   Returns an InMemoryStore (a MemoryStore)."
+  mem-records/create-memory-store)
 
 (defn add-to-memory
+  "Append a message to memory under the given role. Args: memory, role
+   (keyword), content. Returns the updated memory."
   [memory role content]
   (mem-proto/add-message memory role content {}))
 
 (defn get-messages
+  "Return all messages in memory in chronological order (a sequence of
+   message maps). Arg: memory."
   [memory]
   (mem-proto/get-messages memory))
 
 (defn get-memory-window
+  "Return the most recent messages fitting within token-limit. Args: memory,
+   token-limit (int). Returns {:messages [...] :total-tokens int
+   :trimmed-count int}; system messages are always preserved."
   [memory token-limit]
   (mem-proto/get-window memory token-limit))
 
 (defn clear-memory
+  "Remove all messages from memory. Arg: memory. Returns the emptied memory."
   [memory]
   (mem-proto/clear-messages memory))
 
 (defn memory-metadata
+  "Return memory metadata. Arg: memory. Returns a map merging stored
+   metadata with :memory/id :memory/scope :memory/message-count
+   :memory/total-tokens."
   [memory]
   (mem-proto/get-metadata memory))
 
 (defn get-memory
+  "Retrieve a memory from a store by id. Args: store, memory-id.
+   Returns the memory, or nil if absent."
   [store memory-id]
   (mem-proto/get-memory store memory-id))
 
 (defn save-memory
+  "Save/update a memory in a store. Args: store, memory. Returns the memory."
   [store memory]
   (mem-proto/save-memory store memory))
 
 (defn delete-memory
+  "Delete a memory from a store by id. Args: store, memory-id. Returns nil."
   [store memory-id]
   (mem-proto/delete-memory store memory-id))
 
 (defn list-memories
+  "List memories in a store matching a scope. Args: store, scope, scope-id.
+   Returns a sequence of memories."
   [store scope scope-id]
   (mem-proto/list-memories store scope scope-id))

--- a/components/agent/src/ai/miniforge/agent/interface/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/messaging.clj
@@ -29,16 +29,57 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Messaging operations
 
-(def create-message-router msg-records/create-message-router)
-(def create-agent-messaging msg-records/create-agent-messaging)
-(def send-clarification-request msg-records/send-clarification-request)
-(def send-concern msg-records/send-concern)
-(def send-suggestion msg-records/send-suggestion)
-(def get-clarification-requests msg-records/get-clarification-requests)
-(def get-concerns msg-records/get-concerns)
-(def get-suggestions msg-records/get-suggestions)
-(def Message msg-impl/Message)
-(def MessageType msg-impl/MessageType)
+(def create-message-router
+  "Create a message router. No args. Returns a MessageRouter record backed by
+   atoms for per-workflow messages and per-agent inboxes."
+  msg-records/create-message-router)
+
+(def create-agent-messaging
+  "Create messaging capability for an agent. Args: agent-id (keyword),
+   instance-id (uuid), workflow-id (uuid), router, optional event-stream.
+   Returns an AgentMessaging record (an InterAgentMessaging)."
+  msg-records/create-agent-messaging)
+
+(def send-clarification-request
+  "Send a :clarification-request to another agent. Args: agent-messaging,
+   to-agent (keyword), content (string). Returns {:message map :event map}."
+  msg-records/send-clarification-request)
+
+(def send-concern
+  "Send a :concern to another agent. Args: agent-messaging, to-agent
+   (keyword), content (string). Returns {:message map :event map}."
+  msg-records/send-concern)
+
+(def send-suggestion
+  "Send a :suggestion to another agent. Args: agent-messaging, to-agent
+   (keyword), content (string). Returns {:message map :event map}."
+  msg-records/send-suggestion)
+
+(def get-clarification-requests
+  "Return received messages of type :clarification-request. Arg:
+   agent-messaging. Returns a sequence of message maps."
+  msg-records/get-clarification-requests)
+
+(def get-concerns
+  "Return received messages of type :concern. Arg: agent-messaging.
+   Returns a sequence of message maps."
+  msg-records/get-concerns)
+
+(def get-suggestions
+  "Return received messages of type :suggestion. Arg: agent-messaging.
+   Returns a sequence of message maps."
+  msg-records/get-suggestions)
+
+(def Message
+  "Malli schema (a [:map ...] vector) for an inter-agent message, per N1
+   §6.2.2. Required keys include :message/id :message/type :message/from-agent
+   :message/to-agent :message/workflow-id :message/content :message/timestamp."
+  msg-impl/Message)
+
+(def MessageType
+  "Malli schema (a [:enum ...] vector) of valid message types:
+   :clarification-request :clarification-response :concern :suggestion."
+  msg-impl/MessageType)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Messaging operations (thin pass-throughs)
@@ -50,6 +91,8 @@
   (msg-proto/send-message agent-messaging message-data))
 
 (defn receive-messages
+  "Return all messages received by this agent. Arg: agent-messaging.
+   Returns a sequence of message maps."
   [agent-messaging]
   (msg-proto/receive-messages agent-messaging))
 
@@ -64,17 +107,24 @@
   (msg-proto/route-message router message))
 
 (defn get-messages-for-agent
+  "Return messages for a specific agent in a workflow. Args: router, agent-id,
+   workflow-id. Returns a sequence of message maps (the agent's inbox)."
   [router agent-id workflow-id]
   (msg-proto/get-messages-for-agent router agent-id workflow-id))
 
 (defn get-messages-by-workflow
+  "Return all messages in a workflow, ordered by timestamp. Args: router,
+   workflow-id. Returns a sequence of message maps."
   [router workflow-id]
   (msg-proto/get-messages-by-workflow router workflow-id))
 
 (defn clear-workflow-messages
+  "Clear all messages for a workflow. Args: router, workflow-id. Returns nil."
   [router workflow-id]
   (msg-proto/clear-messages router workflow-id))
 
 (defn validate-message
+  "Validate a message map against the Message schema. Arg: message.
+   Returns {:valid? boolean :errors [...]}."
   [message]
   (msg-impl/validate-message-impl message))

--- a/components/agent/src/ai/miniforge/agent/interface/meta.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/meta.clj
@@ -26,12 +26,38 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Meta-agent operations
 
-(def create-progress-monitor-agent progress-monitor/create-progress-monitor-agent)
-(def create-meta-coordinator meta-coord/create-coordinator)
-(def check-all-meta-agents meta-coord/check-all-agents)
-(def reset-all-meta-agents! meta-coord/reset-all-agents!)
-(def get-meta-check-history meta-coord/get-check-history)
-(def get-meta-agent-stats meta-coord/get-agent-stats)
+(def create-progress-monitor-agent
+  "Create a Progress Monitor meta-agent. Arg (optional): options map
+   (:check-interval-ms :priority :stagnation-threshold-ms :max-total-ms).
+   Returns a meta-agent suitable for a meta coordinator."
+  progress-monitor/create-progress-monitor-agent)
+
+(def create-meta-coordinator
+  "Create a meta-agent coordinator over a set of meta-agents. Arg: vector of
+   meta-agent instances. Returns a MetaCoordinator record."
+  meta-coord/create-coordinator)
+
+(def check-all-meta-agents
+  "Run due health checks across all enabled meta-agents. Args: coordinator,
+   workflow-state. Returns {:status :healthy|:warning|:halt :checks [...]}
+   with :halt-reason/:halting-agent when status is :halt."
+  meta-coord/check-all-agents)
+
+(def reset-all-meta-agents!
+  "Reset all meta-agent state (on workflow restart). Arg: coordinator.
+   Returns the coordinator."
+  meta-coord/reset-all-agents!)
+
+(def get-meta-check-history
+  "Return recent meta-agent health-check history. Args: coordinator, optional
+   {:limit :agent-id :status}. Returns a sequence of check-record maps."
+  meta-coord/get-check-history)
+
+(def get-meta-agent-stats
+  "Return per-meta-agent statistics. Arg: coordinator. Returns
+   {:agents [{:id :name :checks-run :last-check :last-status
+              :halt-count :warning-count ...}]}."
+  meta-coord/get-agent-stats)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Learning layer — meta-loop cycle (N1 §3.3)

--- a/components/agent/src/ai/miniforge/agent/interface/protocols.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/protocols.clj
@@ -27,16 +27,65 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol and configuration re-exports
 
-(def Agent agent-proto/Agent)
-(def AgentLifecycle agent-proto/AgentLifecycle)
-(def AgentExecutor agent-proto/AgentExecutor)
-(def LLMBackend agent-proto/LLMBackend)
-(def Memory mem-proto/Memory)
-(def MemoryStore mem-proto/MemoryStore)
-(def InterAgentMessaging msg-proto/InterAgentMessaging)
-(def MessageRouter msg-proto/MessageRouter)
-(def MessageValidator msg-proto/MessageValidator)
+(def Agent
+  "Protocol: agent behavior and lifecycle. Methods invoke/validate/repair.
+   Implement to define a custom agent that processes tasks into
+   artifacts/decisions/signals."
+  agent-proto/Agent)
 
-(def default-role-configs core/default-role-configs)
-(def role-capabilities core/role-capabilities)
-(def role-system-prompts core/role-system-prompts)
+(def AgentLifecycle
+  "Protocol: agent lifecycle management (init/status/shutdown/abort).
+   Implement to control how an agent is initialized and torn down."
+  agent-proto/AgentLifecycle)
+
+(def AgentExecutor
+  "Protocol: runs an agent on a task through the full
+   init->invoke->validate->repair->complete lifecycle. Implement to
+   customize execution orchestration."
+  agent-proto/AgentExecutor)
+
+(def LLMBackend
+  "Protocol: LLM interaction (single method complete). Implement to swap
+   or mock the language-model backend."
+  agent-proto/LLMBackend)
+
+(def Memory
+  "Protocol: agent memory storage and retrieval (add-message, get-messages,
+   get-window, clear-messages, get-metadata). Implement for a custom store."
+  mem-proto/Memory)
+
+(def MemoryStore
+  "Protocol: managing multiple agent memories (get/save/delete/list).
+   Implement to back memory persistence with a custom store."
+  mem-proto/MemoryStore)
+
+(def InterAgentMessaging
+  "Protocol: send/receive/respond messages between agents during execution.
+   Implement to customize how an agent exchanges messages."
+  msg-proto/InterAgentMessaging)
+
+(def MessageRouter
+  "Protocol: routes and queues messages between agents
+   (route-message, get-messages-for-agent, get-messages-by-workflow,
+   clear-messages). Implement for a custom delivery mechanism."
+  msg-proto/MessageRouter)
+
+(def MessageValidator
+  "Protocol: validates message structure against schema (validate-message).
+   Implement to plug in custom message validation."
+  msg-proto/MessageValidator)
+
+(def default-role-configs
+  "Map of agent role keyword -> default config map. Each config carries
+   static fields (temperature, max-tokens, budget) from
+   role-defaults.edn plus a dynamically selected :model."
+  core/default-role-configs)
+
+(def role-capabilities
+  "Map of agent role keyword -> set of capability keywords
+   (e.g. :planner -> #{:plan :decompose :estimate})."
+  core/role-capabilities)
+
+(def role-system-prompts
+  "Map of agent role keyword -> system-prompt string for that role."
+  core/role-system-prompts)

--- a/components/agent/src/ai/miniforge/agent/interface/runtime.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/runtime.clj
@@ -26,15 +26,36 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Agent creation and execution
 
-(def create-agent core/create-agent)
-(def create-agent-map core/create-agent-map)
-(def create-executor core/create-executor)
+(def create-agent
+  "Create an agent by role with optional config overrides. Args: role
+   (keyword e.g. :planner :implementer), optional opts map (:model
+   :temperature :max-tokens :budget :phase :privacy-required etc.).
+   Returns a BaseAgent record satisfying the Agent protocol."
+  core/create-agent)
+
+(def create-agent-map
+  "Create an agent and return it as a plain map conforming to the Agent
+   schema (useful for serialization/storage). Args: role, optional opts.
+   Returns a map with :agent/* keys."
+  core/create-agent-map)
+
+(def create-executor
+  "Create an agent executor. Arg (optional): config map (e.g.
+   {:memory-store ...}). Returns a value satisfying the AgentExecutor
+   protocol."
+  core/create-executor)
 
 (defn execute
+  "Run an agent on a task through the full lifecycle. Args: executor, agent,
+   task, context. Returns {:success bool :outputs [...] :metrics {...}}
+   and :error on failure."
   [executor agent task context]
   (agent-proto/execute executor agent task context))
 
 (defn invoke
+  "Invoke an agent's main logic on a task, with supervisory projection
+   wrapping. Args: agent, task, context. Returns
+   {:success bool :outputs [...] :decisions [...] :signals [...] :metrics {...}}."
   [agent task context]
   (supervisory-bridge/invoke-with-projection
    agent
@@ -43,21 +64,30 @@
    #(agent-proto/invoke agent task context)))
 
 (defn validate
+  "Check whether agent output meets requirements. Args: agent, output,
+   context. Returns {:valid? bool :errors [...] :warnings [...]}."
   [agent output context]
   (agent-proto/validate agent output context))
 
 (defn repair
+  "Attempt to fix validation failures. Args: agent, output, errors, context.
+   Returns {:repaired output :changes [...] :success bool}."
   [agent output errors context]
   (agent-proto/repair agent output errors context))
 
 (defn init
+  "Initialize an agent with configuration. Args: agent, config. Returns the
+   initialized agent instance."
   [agent config]
   (agent-proto/init agent config))
 
 (defn agent-status
+  "Return an agent's current status. Arg: agent. Returns
+   {:state keyword :metrics {...} :last-activity inst}."
   [agent]
   (agent-proto/status agent))
 
 (defn shutdown
+  "Clean up agent resources. Arg: agent. Returns {:success bool}."
   [agent]
   (agent-proto/shutdown agent))

--- a/components/agent/src/ai/miniforge/agent/interface/runtime.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/runtime.clj
@@ -47,15 +47,20 @@
 
 (defn execute
   "Run an agent on a task through the full lifecycle. Args: executor, agent,
-   task, context. Returns {:success bool :outputs [...] :metrics {...}}
-   and :error on failure."
+   task, context. Thin delegate to the AgentExecutor protocol: returns the
+   executor's result map, which is the agent's invoke result (commonly the
+   canonical {:status :success|:error :output ...}) merged with executor
+   metadata (:metrics :tool/invocations :agent-id :task-id :executed-at).
+   Exact keys depend on the agent and executor implementations."
   [executor agent task context]
   (agent-proto/execute executor agent task context))
 
 (defn invoke
   "Invoke an agent's main logic on a task, with supervisory projection
-   wrapping. Args: agent, task, context. Returns
-   {:success bool :outputs [...] :decisions [...] :signals [...] :metrics {...}}."
+   wrapping. Args: agent, task, context. Thin delegate to the Agent protocol's
+   invoke: returns the agent's result map (commonly the canonical
+   {:status :success|:error :output ...}, optionally augmented by the
+   supervisory projection). Exact keys depend on the agent implementation."
   [agent task context]
   (supervisory-bridge/invoke-with-projection
    agent
@@ -71,7 +76,9 @@
 
 (defn repair
   "Attempt to fix validation failures. Args: agent, output, errors, context.
-   Returns {:repaired output :changes [...] :success bool}."
+   Thin delegate to the Agent protocol's repair: returns the agent's repair
+   result map (commonly the canonical {:status :success|:error :output ...}).
+   Exact keys depend on the agent implementation."
   [agent output errors context]
   (agent-proto/repair agent output errors context))
 

--- a/components/agent/src/ai/miniforge/agent/interface/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/specialized.clj
@@ -33,15 +33,49 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Specialized agent support
 
-(def create-base-agent specialized-records/create-base-agent)
-(def make-validator specialized-records/make-validator)
-(def cycle-agent specialized-records/cycle-agent)
+(def create-base-agent
+  "Create a base (functional) agent from callbacks. Arg: options map requiring
+   :role :system-prompt :invoke-fn :validate-fn :repair-fn, with optional
+   :config :logger. Returns a FunctionalAgent record (an Agent)."
+  specialized-records/create-base-agent)
 
-(def create-planner planner/create-planner)
-(def create-implementer implementer/create-implementer)
-(def create-tester tester/create-tester)
-(def create-reviewer reviewer/create-reviewer)
-(def create-releaser releaser/create-releaser)
+(def make-validator
+  "Build a validate-fn from a Malli schema. Arg: malli-schema. Returns a fn of
+   output -> {:valid? bool :errors nil-or-explanation}."
+  specialized-records/make-validator)
+
+(def cycle-agent
+  "Run an invoke->validate->repair cycle on a specialized agent. Args: agent,
+   context, input, optional :max-iterations (default 3). Returns the final
+   result map after repair attempts."
+  specialized-records/cycle-agent)
+
+(def create-planner
+  "Create a Planner agent. Arg (optional): options map (:config :logger
+   :llm-backend). Returns a FunctionalAgent record (an Agent)."
+  planner/create-planner)
+
+(def create-implementer
+  "Create an Implementer agent. Arg (optional): options map. Returns a
+   FunctionalAgent record (an Agent)."
+  implementer/create-implementer)
+
+(def create-tester
+  "Create a Tester agent. Arg (optional): options map. Returns a
+   FunctionalAgent record (an Agent)."
+  tester/create-tester)
+
+(def create-reviewer
+  "Create a Reviewer agent (LLM-backed review + deterministic gates, falling
+   back to gate-only without an LLM). Arg (optional): options map
+   (:gates :strict :logger :llm-backend :config). Returns a FunctionalAgent
+   record (an Agent)."
+  reviewer/create-reviewer)
+
+(def create-releaser
+  "Create a Releaser agent. Arg (optional): options map. Returns a
+   FunctionalAgent record (an Agent)."
+  releaser/create-releaser)
 
 ;; Curator is a multimethod (not an Agent record) — it post-processes the
 ;; environment state an agent left behind. Dispatches on `:curator/kind`:
@@ -49,54 +83,251 @@
 ;; - `:merge-resolution` (v2 §6.1.2) — validates the resolution agent's
 ;;                       iteration; surfaces :curator/markers-not-resolved
 ;;                       and :curator/recurring-conflict terminals.
-(def curate curator/curate)
-(def curate-implement-output curator/curate-implement-output)
-(def CuratedArtifact curator/CuratedArtifact)
-(def CuratedFileEntry curator/FileEntry)
-(def validate-curated-artifact curator/validate-curated-artifact)
-(def substantive-file? curator/substantive-file?)
-(def non-substantive-paths curator/non-substantive-paths)
+(def curate
+  "Curator entry point (a multimethod dispatching on :curator/kind). Arg:
+   input map. Returns a response map whose :output is a CuratedArtifact on
+   success, or an error response. Dispatch: :implement (default) and
+   :merge-resolution."
+  curator/curate)
 
-(def Plan planner/Plan)
-(def PlanTask planner/PlanTask)
-(def CodeArtifact implementer/CodeArtifact)
-(def CodeFile implementer/CodeFile)
-(def TestArtifact tester/TestArtifact)
-(def TestFile tester/TestFile)
-(def Coverage tester/Coverage)
-(def ReviewArtifact reviewer-issues/ReviewArtifact)
-(def ReviewIssue reviewer-issues/ReviewIssue)
-(def GateFeedback reviewer-issues/GateFeedback)
-(def ReleaseArtifact releaser/ReleaseArtifact)
+(def curate-implement-output
+  "Curate an implementer's result + environment state into a CuratedArtifact.
+   Arg: input map (requires :implementer-result, :worktree-path; see impl for
+   capsule-mode keys). Returns a success response with :output a
+   CuratedArtifact, or an error response when no files were written. Thin
+   wrapper over (curate (assoc input :curator/kind :implement))."
+  curator/curate-implement-output)
 
-(def plan-summary planner/plan-summary)
-(def task-dependency-order planner/task-dependency-order)
-(def validate-plan planner/validate-plan)
-(def code-summary implementer/code-summary)
-(def files-by-action implementer/files-by-action)
-(def total-lines implementer/total-lines)
-(def validate-code-artifact implementer/validate-code-artifact)
-(def test-summary tester/test-summary)
-(def coverage-meets-threshold? tester/coverage-meets-threshold?)
-(def tests-by-path tester/tests-by-path)
-(def validate-test-artifact tester/validate-test-artifact)
-(def review-summary reviewer-artifact/review-summary)
-(def approved? reviewer-artifact/approved?)
-(def rejected? reviewer-artifact/rejected?)
-(def conditionally-approved? reviewer-artifact/conditionally-approved?)
-(def get-blocking-issues reviewer-artifact/get-blocking-issues)
-(def get-review-warnings reviewer-artifact/get-warnings)
-(def get-recommendations reviewer-artifact/get-recommendations)
-(def changes-requested? reviewer-artifact/changes-requested?)
-(def get-review-issues reviewer-artifact/get-issues)
-(def get-review-strengths reviewer-artifact/get-strengths)
-(def validate-review-artifact reviewer-artifact/validate-review-artifact)
-(def rejection-warnings-only? reviewer-artifact/rejection-warnings-only?)
+(def CuratedArtifact
+  "Malli schema (a [:map ...] vector) for the curator's structured output,
+   consumed by verify/review/release/PR-doc phases. Keys include :code/id
+   :code/files :code/summary :code/tests-added? :code/scope-deviations
+   :code/breaking-change? :code/curated-at :code/curator-source."
+  curator/CuratedArtifact)
+
+(def CuratedFileEntry
+  "Malli schema (a [:map ...] vector) for one file in a CuratedArtifact:
+   :path (string) :content (string) :action (:create|:modify|:delete)."
+  curator/FileEntry)
+
+(def validate-curated-artifact
+  "Validate a CuratedArtifact against its schema. Arg: artifact. Returns a
+   validation result (schema/valid or schema/invalid map)."
+  curator/validate-curated-artifact)
+
+(def substantive-file?
+  "True when a file entry represents real implementer work, not a
+   runtime/session side-effect. Arg: file-entry map. Returns boolean."
+  curator/substantive-file?)
+
+(def non-substantive-paths
+  "Set of file paths the curator drops before assessing 'files written'
+   (runtime/session markers). A set of strings (currently
+   #{\".miniforge-session-id\"}), not a vector."
+  curator/non-substantive-paths)
+
+(def Plan
+  "Malli schema (a [:map ...] vector) for a planner's output: :plan/id
+   :plan/name :plan/tasks (vector of PlanTask) plus optional complexity,
+   risks, assumptions."
+  planner/Plan)
+
+(def PlanTask
+  "Malli schema (a [:map ...] vector) for one task in a Plan: :task/id
+   :task/description :task/type plus optional dependencies, acceptance
+   criteria, effort, component, stratum, merge-strategy."
+  planner/PlanTask)
+
+(def CodeArtifact
+  "Malli schema (a [:map ...] vector) for the implementer's output: :code/id
+   :code/files (vector of CodeFile) plus optional dependencies-added,
+   tests-needed?, language, summary."
+  implementer/CodeArtifact)
+
+(def CodeFile
+  "Malli schema (a [:map ...] vector) for one code file: :path :content
+   :action (:create|:modify|:delete)."
+  implementer/CodeFile)
+
+(def TestArtifact
+  "Malli schema (a [:map ...] vector) for the tester's output: :test/id
+   :test/files (vector of TestFile) :test/type plus optional coverage,
+   framework, assertions/cases counts, summary."
+  tester/TestArtifact)
+
+(def TestFile
+  "Malli schema (a [:map ...] vector) for one test file: :path :content."
+  tester/TestFile)
+
+(def Coverage
+  "Malli schema (a [:map ...] vector) for test coverage: optional :lines
+   :branches :functions, each a double 0.0-100.0."
+  tester/Coverage)
+
+(def ReviewArtifact
+  "Malli schema (a [:map ...] vector) for the reviewer's output: :review/id
+   :review/decision (enum) :review/gate-results :review/summary plus gate
+   counts and optional blocking-issues, warnings, recommendations, issues,
+   strengths."
+  reviewer-issues/ReviewArtifact)
+
+(def ReviewIssue
+  "Malli schema (a [:map ...] vector) for a single review issue: :severity
+   (:blocking|:warning|:nit) :description plus optional :file :line
+   :suggestion (each nil-tolerant)."
+  reviewer-issues/ReviewIssue)
+
+(def GateFeedback
+  "Malli schema (a [:map ...] vector) for feedback from one gate: :gate-id
+   :gate-type :passed? plus optional errors, warnings, duration-ms."
+  reviewer-issues/GateFeedback)
+
+(def ReleaseArtifact
+  "Malli schema (a [:map ...] vector) for the releaser's output:
+   :release/id :release/branch-name :release/commit-message :release/pr-title
+   :release/pr-description plus optional files-summary."
+  releaser/ReleaseArtifact)
+
+(def plan-summary
+  "Summarize a plan for logging/display. Arg: plan. Returns a map
+   {:id :name :task-count :complexity :risk-count}."
+  planner/plan-summary)
+
+(def task-dependency-order
+  "Topologically sort a plan's tasks (dependency-free first). Arg: plan.
+   Returns a vector of task maps; on a cycle, remaining tasks are appended."
+  planner/task-dependency-order)
+
+(def validate-plan
+  "Validate a plan against the Plan schema and check structural issues
+   (invalid/circular deps). Arg: plan. Returns {:valid? bool :errors ...}."
+  planner/validate-plan)
+
+(def code-summary
+  "Summarize a code artifact for logging/display. Arg: artifact. Returns a
+   map {:id :file-count :actions :language :tests-needed? :dependencies-added}."
+  implementer/code-summary)
+
+(def files-by-action
+  "Group a code artifact's files by :action. Arg: artifact. Returns a map of
+   action keyword -> vector of file maps."
+  implementer/files-by-action)
+
+(def total-lines
+  "Count total lines of code in an artifact (excluding :delete files). Arg:
+   artifact. Returns an int."
+  implementer/total-lines)
+
+(def validate-code-artifact
+  "Validate a code artifact against the schema and check for issues (empty
+   creates, duplicate paths). Arg: artifact. Returns a validation result
+   (schema/valid or schema/invalid map)."
+  implementer/validate-code-artifact)
+
+(def test-summary
+  "Summarize a test artifact for logging/display. Arg: artifact. Returns a
+   map {:id :file-count :type :framework :assertions :cases :coverage}."
+  tester/test-summary)
+
+(def coverage-meets-threshold?
+  "Check whether an artifact's coverage meets thresholds. Args: artifact,
+   optional :lines :branches :functions (defaults 80/70/80). Returns boolean."
+  tester/coverage-meets-threshold?)
+
+(def tests-by-path
+  "Map a test artifact's file paths to their content. Arg: artifact. Returns
+   a map of path string -> content string."
+  tester/tests-by-path)
+
+(def validate-test-artifact
+  "Validate a test artifact against the schema and check for issues (naming
+   convention, missing assertions). Arg: artifact. Returns
+   {:valid? bool :errors ...}."
+  tester/validate-test-artifact)
+
+(def review-summary
+  "Summarize a review artifact for logging/display. Arg: artifact. Returns a
+   map {:id :decision :gates-passed :gates-failed :gates-total
+   :blocking-issues-count :warnings-count :llm-issues-count}."
+  reviewer-artifact/review-summary)
+
+(def approved?
+  "True when a review artifact's :review/decision is :approved. Arg: artifact.
+   Returns boolean."
+  reviewer-artifact/approved?)
+
+(def rejected?
+  "True when a review artifact's :review/decision is :rejected. Arg: artifact.
+   Returns boolean."
+  reviewer-artifact/rejected?)
+
+(def conditionally-approved?
+  "True when a review artifact's :review/decision is :conditionally-approved.
+   Arg: artifact. Returns boolean."
+  reviewer-artifact/conditionally-approved?)
+
+(def get-blocking-issues
+  "Extract blocking issues from a review artifact. Arg: artifact. Returns a
+   vector of strings (empty if none)."
+  reviewer-artifact/get-blocking-issues)
+
+(def get-review-warnings
+  "Extract warnings from a review artifact. Arg: artifact. Returns a vector of
+   strings (empty if none)."
+  reviewer-artifact/get-warnings)
+
+(def get-recommendations
+  "Extract recommendations from a review artifact. Arg: artifact. Returns a
+   vector of strings (empty if none)."
+  reviewer-artifact/get-recommendations)
+
+(def changes-requested?
+  "True when a review artifact's :review/decision is :changes-requested. Arg:
+   artifact. Returns boolean."
+  reviewer-artifact/changes-requested?)
+
+(def get-review-issues
+  "Extract LLM review issues from a review artifact. Arg: artifact. Returns a
+   vector of ReviewIssue maps (empty if none)."
+  reviewer-artifact/get-issues)
+
+(def get-review-strengths
+  "Extract strengths noted by the LLM from a review artifact. Arg: artifact.
+   Returns a vector of strings (empty if none)."
+  reviewer-artifact/get-strengths)
+
+(def validate-review-artifact
+  "Validate a review artifact against the schema and check gate-count
+   consistency. Arg: artifact. Returns {:valid? bool :errors ...}."
+  reviewer-artifact/validate-review-artifact)
+
+(def rejection-warnings-only?
+  "True when a review is a rejection driven solely by warnings (no blocking
+   issues). Arg: artifact. Returns boolean."
+  reviewer-artifact/rejection-warnings-only?)
 ;; Repair-loop fingerprint helpers — moved to
 ;; components/progress-detector/.../detectors/repair-loop in Stage 2.
 ;; These re-exports stay for backward compatibility; phase-software-factory
 ;; reads them through this interface.
-(def review-fingerprint progress-detector/review-fingerprint)
-(def review-stagnated?  progress-detector/stagnated?)
-(def release-summary releaser/release-summary)
-(def validate-release-artifact releaser/validate-release-artifact)
+(def review-fingerprint
+  "Reduce a review artifact to a stable, comparable fingerprint of its
+   actionable items. Arg: review. Returns a sorted vector of
+   [severity file line description] tuples (empty when nothing is actionable)."
+  progress-detector/review-fingerprint)
+
+(def review-stagnated?
+  "True when a review's fingerprint exactly matches the prior one (repair
+   loop made no actionable change). Args: prior (may be nil), current.
+   Returns boolean; false on first iteration or empty current fingerprint."
+  progress-detector/stagnated?)
+
+(def release-summary
+  "Summarize a release artifact for logging/display. Arg: artifact. Returns a
+   map {:id :branch :pr-title :files-summary}."
+  releaser/release-summary)
+
+(def validate-release-artifact
+  "Validate a release artifact against the schema and check for issues (branch
+   name spaces, PR-title length, empty commit first line). Arg: artifact.
+   Returns {:valid? bool :errors ...}."
+  releaser/validate-release-artifact)

--- a/components/agent/src/ai/miniforge/agent/interface/supervision.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/supervision.clj
@@ -29,9 +29,35 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Supervision runtime operations
 
-(def create-progress-monitor-agent progress-monitor/create-progress-monitor-agent)
-(def create-supervision-coordinator meta-coord/create-coordinator)
-(def check-all-supervisors meta-coord/check-all-agents)
-(def reset-all-supervisors! meta-coord/reset-all-agents!)
-(def get-supervision-check-history meta-coord/get-check-history)
-(def get-supervisor-stats meta-coord/get-agent-stats)
+(def create-progress-monitor-agent
+  "Create a Progress Monitor supervisor agent. Arg (optional): options map
+   (:check-interval-ms :priority :stagnation-threshold-ms :max-total-ms).
+   Returns a meta-agent suitable for a supervision coordinator."
+  progress-monitor/create-progress-monitor-agent)
+
+(def create-supervision-coordinator
+  "Create a supervision coordinator over a set of supervisor agents. Arg:
+   vector of meta-agent instances. Returns a MetaCoordinator record."
+  meta-coord/create-coordinator)
+
+(def check-all-supervisors
+  "Run due health checks across all enabled supervisors. Args: coordinator,
+   workflow-state. Returns {:status :healthy|:warning|:halt :checks [...]}
+   with :halt-reason/:halting-agent when status is :halt."
+  meta-coord/check-all-agents)
+
+(def reset-all-supervisors!
+  "Reset all supervisor agent state (on workflow restart). Arg: coordinator.
+   Returns the coordinator."
+  meta-coord/reset-all-agents!)
+
+(def get-supervision-check-history
+  "Return recent supervisor health-check history. Args: coordinator, optional
+   {:limit :agent-id :status}. Returns a sequence of check-record maps."
+  meta-coord/get-check-history)
+
+(def get-supervisor-stats
+  "Return per-supervisor statistics. Arg: coordinator. Returns
+   {:agents [{:id :name :checks-run :last-check :last-status
+              :halt-count :warning-count ...}]}."
+  meta-coord/get-agent-stats)

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -41,7 +41,6 @@
 ;; Planner-specific schemas
 
 (def PlanTask
-  "Schema for a task in the plan."
   [:map
    [:task/id uuid?]
    [:task/description [:string {:min 1}]]
@@ -62,7 +61,6 @@
     [:enum :git-merge :sequential-merge]]])
 
 (def Plan
-  "Schema for the planner's output."
   [:map
    [:plan/id uuid?]
    [:plan/name [:string {:min 1}]]
@@ -88,7 +86,6 @@
 ;; Planner functions
 
 (defn validate-plan
-  "Validate a plan against the Plan schema and check for structural issues."
   [plan]
   (let [schema-valid? (m/validate Plan plan)]
     (if-not schema-valid?
@@ -738,7 +735,6 @@
       :repair-fn repair-plan})))
 
 (defn plan-summary
-  "Get a summary of a plan for logging/display."
   [plan]
   {:id (:plan/id plan)
    :name (:plan/name plan)
@@ -747,8 +743,6 @@
    :risk-count (count (:plan/risks plan))})
 
 (defn task-dependency-order
-  "Return tasks in dependency order (topological sort).
-   Tasks with no dependencies come first."
   [plan]
   (let [tasks (:plan/tasks plan)
         task-map (into {} (map (juxt :task/id identity) tasks))

--- a/components/agent/src/ai/miniforge/agent/protocols/impl/memory.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/memory.clj
@@ -36,8 +36,6 @@
     metadata (assoc :memory/metadata metadata)))
 
 (defn estimate-tokens
-  "Estimate token count for a message.
-   Uses rough heuristic: ~4 chars per token for English text."
   [content]
   (if (string? content)
     (max 1 (int (/ (count content) 4)))

--- a/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
@@ -128,8 +128,6 @@
   (m/explainer Message))
 
 (defn validate-message-impl
-  "Validate message against schema.
-   Returns {:valid? boolean :errors [...]}"
   [message]
   (if (message-validator message)
     {:valid? true :errors []}

--- a/components/agent/src/ai/miniforge/agent/protocols/records/memory.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/records/memory.clj
@@ -80,21 +80,17 @@
            metadata))))
 
 (defn add-system-message
-  "Add a system message to memory. Convenience function."
   [memory content]
   (p/add-message memory :system content {}))
 
 (defn add-user-message
-  "Add a user message to memory. Convenience function."
   [memory content]
   (p/add-message memory :user content {}))
 
 (defn add-assistant-message
-  "Add an assistant message to memory. Convenience function."
   [memory content & {:keys [tokens]}]
   (p/add-message memory :assistant content {:tokens tokens}))
 
 (defn create-memory-store
-  "Create an in-memory store for agent memories."
   []
   (->InMemoryStore (atom {})))

--- a/components/agent/src/ai/miniforge/agent/protocols/records/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/records/messaging.clj
@@ -110,9 +110,6 @@
 ;; Helper Functions
 
 (defn send-clarification-request
-  "Send a clarification request to another agent.
-
-   Convenience function for common message type."
   [agent-messaging to-agent content]
   (p/send-message agent-messaging
                   {:type :clarification-request
@@ -120,9 +117,6 @@
                    :content content}))
 
 (defn send-concern
-  "Send a concern to another agent.
-
-   Convenience function for common message type."
   [agent-messaging to-agent content]
   (p/send-message agent-messaging
                   {:type :concern
@@ -130,9 +124,6 @@
                    :content content}))
 
 (defn send-suggestion
-  "Send a suggestion to another agent.
-
-   Convenience function for common message type."
   [agent-messaging to-agent content]
   (p/send-message agent-messaging
                   {:type :suggestion
@@ -153,21 +144,18 @@
   (filter #(= (:message/type %) message-type) messages))
 
 (defn get-clarification-requests
-  "Get all clarification requests received."
   [agent-messaging]
   (filter-messages-by-type
    (p/receive-messages agent-messaging)
    :clarification-request))
 
 (defn get-concerns
-  "Get all concerns received."
   [agent-messaging]
   (filter-messages-by-type
    (p/receive-messages agent-messaging)
    :concern))
 
 (defn get-suggestions
-  "Get all suggestions received."
   [agent-messaging]
   (filter-messages-by-type
    (p/receive-messages agent-messaging)

--- a/components/agent/src/ai/miniforge/agent/protocols/records/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/records/specialized.clj
@@ -69,7 +69,6 @@
   (->FunctionalAgent role config system-prompt invoke-fn validate-fn repair-fn logger))
 
 (defn make-validator
-  "Create a validation function from a Malli schema."
   [malli-schema]
   (fn [output]
     (if (schema/valid? malli-schema output)

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -40,7 +40,6 @@
 ;; Releaser-specific schemas
 
 (def ReleaseArtifact
-  "Schema for the releaser's output."
   [:map
    [:release/id uuid?]
    [:release/branch-name [:string {:min 1 :max 100}]]
@@ -61,7 +60,6 @@
 ;; Releaser functions
 
 (defn validate-release-artifact
-  "Validate a release artifact against the schema and check for issues."
   [artifact]
   (let [schema-valid? (m/validate ReleaseArtifact artifact)]
     (if-not schema-valid?
@@ -283,7 +281,6 @@
       :repair-fn repair-release-artifact})))
 
 (defn release-summary
-  "Get a summary of a release artifact for logging/display."
   [artifact]
   {:id (:release/id artifact)
    :branch (:release/branch-name artifact)

--- a/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
@@ -74,7 +74,6 @@
 ;; Validation + repair
 
 (defn validate-review-artifact
-  "Validate a review artifact against the schema."
   [artifact]
   (let [schema-valid? (m/validate issues/ReviewArtifact artifact)]
     (if-not schema-valid?
@@ -234,7 +233,6 @@
 ;; renames here don't ripple silently through the SDLC pipeline.
 
 (defn review-summary
-  "Get a summary of a review artifact for logging/display."
   [artifact]
   {:id (:review/id artifact)
    :decision (:review/decision artifact)
@@ -246,47 +244,38 @@
    :llm-issues-count (count (:review/issues artifact))})
 
 (defn approved?
-  "Check if a review artifact represents approval."
   [artifact]
   (= :approved (:review/decision artifact)))
 
 (defn rejected?
-  "Check if a review artifact represents rejection."
   [artifact]
   (= :rejected (:review/decision artifact)))
 
 (defn conditionally-approved?
-  "Check if a review artifact is conditionally approved."
   [artifact]
   (= :conditionally-approved (:review/decision artifact)))
 
 (defn changes-requested?
-  "Check if a review artifact has changes requested."
   [artifact]
   (= :changes-requested (:review/decision artifact)))
 
 (defn get-blocking-issues
-  "Extract blocking issues from review artifact."
   [artifact]
   (:review/blocking-issues artifact []))
 
 (defn get-warnings
-  "Extract warnings from review artifact."
   [artifact]
   (:review/warnings artifact []))
 
 (defn get-recommendations
-  "Extract recommendations from review artifact."
   [artifact]
   (:review/recommendations artifact []))
 
 (defn get-issues
-  "Extract LLM review issues from review artifact."
   [artifact]
   (:review/issues artifact []))
 
 (defn get-strengths
-  "Extract strengths noted by the LLM from review artifact."
   [artifact]
   (:review/strengths artifact []))
 

--- a/components/agent/src/ai/miniforge/agent/reviewer/issues.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/issues.clj
@@ -35,7 +35,6 @@
 ;; Schemas
 
 (def GateFeedback
-  "Schema for feedback from a single gate."
   [:map
    [:gate-id keyword?]
    [:gate-type keyword?]
@@ -66,7 +65,6 @@
    [:suggestion {:optional true} [:maybe [:string {:min 1}]]]])
 
 (def ReviewArtifact
-  "Schema for the reviewer's output."
   [:map
    [:review/id uuid?]
    [:review/decision [:enum :approved :rejected :conditionally-approved :changes-requested]]

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -39,20 +39,17 @@
 ;; Tester-specific schemas
 
 (def TestFile
-  "Schema for a test file."
   [:map
    [:path [:string {:min 1}]]
    [:content [:string {:min 1}]]])
 
 (def Coverage
-  "Schema for test coverage information."
   [:map
    [:lines {:optional true} [:double {:min 0.0 :max 100.0}]]
    [:branches {:optional true} [:double {:min 0.0 :max 100.0}]]
    [:functions {:optional true} [:double {:min 0.0 :max 100.0}]]])
 
 (def TestArtifact
-  "Schema for the tester's output."
   [:map
    [:test/id uuid?]
    [:test/files [:vector TestFile]]
@@ -84,7 +81,6 @@
 ;; Tester functions
 
 (defn validate-test-artifact
-  "Validate a test artifact against the schema and check for issues."
   [artifact]
   (let [schema-valid? (m/validate TestArtifact artifact)]
     (if-not schema-valid?
@@ -435,7 +431,6 @@
       :repair-fn repair-test-artifact})))
 
 (defn test-summary
-  "Get a summary of a test artifact for logging/display."
   [artifact]
   {:id (:test/id artifact)
    :file-count (count (:test/files artifact))
@@ -446,7 +441,6 @@
    :coverage (:test/coverage artifact)})
 
 (defn coverage-meets-threshold?
-  "Check if coverage meets the specified thresholds."
   [artifact & {:keys [lines branches functions]
                :or {lines 80.0 branches 70.0 functions 80.0}}]
   (let [coverage (:test/coverage artifact {})]
@@ -455,7 +449,6 @@
          (>= (get coverage :functions 0) functions))))
 
 (defn tests-by-path
-  "Get a map of test file paths to their content."
   [artifact]
   (into {} (map (juxt :path :content) (:test/files artifact))))
 


### PR DESCRIPTION
Boundary-documentation rollout (rule 009). Both interface tiers (`component.interface` + `component.interface.*`) now carry contract docstrings — both are consumed; types verified from impl. Duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change. Commit-budget override used (mechanical doc-only lift); poly:check + smoke + GraalVM all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)