### PR TITLE
docs(policy-pack): document both interface tiers (rule 009)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/capability.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/capability.clj
@@ -67,12 +67,6 @@
 ;; Public API — all return data, never throw
 
 (defn register-capability!
-  "Register (or replace) capability `k` with `entry`. Returns the stored
-   entry on success, or an `:invalid-input` anomaly map on bad input.
-
-   - `k`     must be a keyword.
-   - `entry` must be `{:meta map :check fn}` where `:check` is
-     `(fn [artifact context] -> violation-or-nil)`."
   [k entry]
   (cond
     (not (keyword? k))
@@ -90,17 +84,14 @@
         entry)))
 
 (defn get-capability
-  "Return the registered capability entry for `k`, or nil when unregistered."
   [k]
   (get @registry k))
 
 (defn list-capabilities
-  "Return the set of registered capability keywords."
   []
   (set (keys @registry)))
 
 (defn capability-available?
-  "True when capability `k` is registered."
   [k]
   (contains? @registry k))
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -546,19 +546,16 @@
 ;; Violation classification helpers
 
 (defn blocking-violations
-  "Filter violations that should block progress (:hard-halt enforcement)."
   [violations]
   (filter #(= :hard-halt (get-in % [:rule :rule/enforcement :action]))
           violations))
 
 (defn approval-required-violations
-  "Filter violations that require approval."
   [violations]
   (filter #(= :require-approval (get-in % [:rule :rule/enforcement :action]))
           violations))
 
 (defn warning-violations
-  "Filter violations that are warnings only."
   [violations]
   (filter #(= :warn (get-in % [:rule :rule/enforcement :action]))
           violations))
@@ -570,7 +567,6 @@
           violations))
 
 (defn violation->error
-  "Convert a violation to a gate error map."
   [{:keys [rule violation]}]
   {:code (:rule/id rule)
    :message (:message violation)
@@ -580,7 +576,6 @@
    :remediation (get-in rule [:rule/enforcement :remediation])})
 
 (defn violation->warning
-  "Convert a violation to a gate warning map."
   [{:keys [rule violation]}]
   {:code (:rule/id rule)
    :message (:message violation)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -369,7 +369,7 @@
 (def halt-enforcement
   "Build a hard-halt enforcement config map. (halt-enforcement message) or
    (halt-enforcement message {:remediation s}) returns
-   {:action :hard-halt :message ... :remediation?}."
+   {:action :hard-halt :message ... :remediation} (:remediation present only when supplied)."
   builders/halt-enforcement)
 
 (def approval-enforcement

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -36,106 +36,473 @@
 
 ;------------------------------------------------------------------------------ Schema and registry API
 
-(def Rule schema/Rule)
-(def PackManifest schema/PackManifest)
-(def RuleSeverity schema/RuleSeverity)
-(def RuleEnforcement schema/RuleEnforcement)
-(def RuleApplicability schema/RuleApplicability)
-(def RuleDetection schema/RuleDetection)
-(def rule-severities schema/rule-severities)
-(def enforcement-actions schema/enforcement-actions)
-(def detection-types schema/detection-types)
-(def valid-rule? schema/valid-rule?)
-(def validate-rule schema/validate-rule)
-(def valid-pack? schema/valid-pack?)
-(def validate-pack schema/validate-pack)
+(def Rule
+  "Malli schema (a `[:map ...]` vector) for an individual policy rule —
+   identity, applicability, detection, enforcement, and optional knowledge,
+   remediation, and example fields."
+  schema/Rule)
 
-(def PolicyPackRegistry registry/PolicyPackRegistry)
-(def create-registry registry/create-registry)
-(def register-pack registry/register-pack)
-(def get-pack registry/get-pack)
-(def get-pack-version registry/get-pack-version)
-(def list-packs registry/list-packs)
-(def delete-pack registry/delete-pack)
-(def resolve-pack registry/resolve-pack)
-(def get-rules-for-context registry/get-rules-for-context)
-(def glob-matches? registry/glob-matches?)
-(def compare-versions registry/compare-versions)
+(def PackManifest
+  "Malli schema (a `[:map ...]` vector) for a policy pack manifest — a
+   versioned collection of rules with identity, trust/authority, taxonomy
+   reference, dependencies, overrides, categories, and timestamps."
+  schema/PackManifest)
+
+(def RuleSeverity
+  "Malli enum schema (`[:enum :critical :major :minor :info]`) for a rule's
+   severity level."
+  schema/RuleSeverity)
+
+(def RuleEnforcement
+  "Malli enum schema (`[:enum :hard-halt :require-approval :warn :audit]`) for
+   a rule's enforcement action."
+  schema/RuleEnforcement)
+
+(def RuleApplicability
+  "Malli schema (a `[:map ...]` vector) for when a rule applies — optional
+   task-types, file-globs, resource-patterns, repo-types, and phases."
+  schema/RuleApplicability)
+
+(def RuleDetection
+  "Malli schema (a `[:map ...]` vector) for how to detect violations —
+   required :type plus optional pattern(s), context-lines, custom-fn,
+   capability, mode, and email-pattern."
+  schema/RuleDetection)
+
+(def rule-severities
+  "Vector of severity keywords `[:critical :major :minor :info]`, ordered most
+   to least severe."
+  schema/rule-severities)
+
+(def enforcement-actions
+  "Vector of enforcement keywords `[:hard-halt :require-approval :warn :audit]`,
+   ordered strictest to most lenient."
+  schema/enforcement-actions)
+
+(def detection-types
+  "Vector of detection-type keywords
+   `[:plan-output :diff-analysis :state-comparison :content-scan :ast-analysis
+   :custom :capability]`."
+  schema/detection-types)
+
+(def valid-rule?
+  "Predicate. Returns true when the value validates against the Rule schema,
+   false otherwise."
+  schema/valid-rule?)
+
+(def validate-rule
+  "Validate a rule against the Rule schema. Returns {:valid? bool :errors
+   map-or-nil} (humanized Malli errors when invalid)."
+  schema/validate-rule)
+
+(def valid-pack?
+  "Predicate. Returns true when the value validates against the PackManifest
+   schema, false otherwise."
+  schema/valid-pack?)
+
+(def validate-pack
+  "Validate a pack manifest against the PackManifest schema. Returns
+   {:valid? bool :errors map-or-nil} (humanized Malli errors when invalid)."
+  schema/validate-pack)
+
+(def PolicyPackRegistry
+  "Protocol for managing policy packs: CRUD, import/export, validation, and
+   composition. Implemented by the in-memory registry from create-registry."
+  registry/PolicyPackRegistry)
+
+(def create-registry
+  "Create an in-memory PolicyPackRegistry. Arity [] or [opts] (opts may carry
+   :logger). Returns a registry value backed by an atom."
+  registry/create-registry)
+
+(def register-pack
+  "Protocol fn. (register-pack registry pack) registers a pack (or new
+   version), keyed by :pack/id and :pack/version. Returns the registered pack;
+   throws an :anomalies/incorrect anomaly when the pack fails schema validation."
+  registry/register-pack)
+
+(def get-pack
+  "Protocol fn. (get-pack registry pack-id) returns the latest-version pack for
+   pack-id, or nil if none is registered."
+  registry/get-pack)
+
+(def get-pack-version
+  "Protocol fn. (get-pack-version registry pack-id version) returns the pack at
+   the exact version, or nil if not found."
+  registry/get-pack-version)
+
+(def list-packs
+  "Protocol fn. (list-packs registry criteria) returns a vector of pack-summary
+   maps (:pack/id :pack/name :pack/version :pack/author :pack/description
+   :rule-count). Criteria may filter by :category, :author, :search."
+  registry/list-packs)
+
+(def delete-pack
+  "Protocol fn. (delete-pack registry pack-id version) removes the pack version.
+   Returns true if deleted, false if it was not present."
+  registry/delete-pack)
+
+(def resolve-pack
+  "Protocol fn. (resolve-pack registry pack-id) returns the pack with all
+   :pack/extends parents recursively merged (child rules override parents by
+   :rule/id), or nil if the pack is not found."
+  registry/resolve-pack)
+
+(def get-rules-for-context
+  "Protocol fn. (get-rules-for-context registry pack-ids context) resolves the
+   named packs, filters their rules by the context (:task, :artifact, :repo,
+   :phase), deduplicates by :rule/id, and returns a vector of applicable rules."
+  registry/get-rules-for-context)
+
+(def glob-matches?
+  "Predicate. (glob-matches? pattern path) returns true when path matches the
+   glob pattern (supports * within a segment and ** across segments); false on
+   no match or a bad pattern."
+  registry/glob-matches?)
+
+(def compare-versions
+  "Compare two DateVer (YYYY.MM.DD) version strings. Returns a negative int if
+   a < b, 0 if equal, positive if a > b; unparseable versions compare as
+   [0 0 0]."
+  registry/compare-versions)
 
 ;------------------------------------------------------------------------------ Loading and checking API
 
-(def load-pack loading/load-pack)
-(def load-pack-from-file loading/load-pack-from-file)
-(def load-pack-from-directory loading/load-pack-from-directory)
-(def resolve-overlay loading/resolve-overlay)
-(def discover-packs loading/discover-packs)
-(def load-all-packs loading/load-all-packs)
-(def write-pack-to-file loading/write-pack-to-file)
+(def load-pack
+  "Load a policy pack from a path, auto-detecting single-EDN-file vs directory
+   layout. Returns {:success? bool :pack PackManifest :errors [...]}."
+  loading/load-pack)
 
-(def detect-violation checking/detect-violation)
-(def detect-semantic checking/detect-semantic)
-(def check-rules checking/check-rules)
-(def check-artifact checking/check-artifact)
-(def check-artifacts checking/check-artifacts)
-(def blocking-violations checking/blocking-violations)
-(def approval-required-violations checking/approval-required-violations)
-(def warning-violations checking/warning-violations)
-(def violation->error checking/violation->error)
-(def violation->warning checking/violation->warning)
+(def load-pack-from-file
+  "Load a policy pack from a single EDN manifest file (pack.edn or
+   *.pack.edn). Returns {:success? bool :pack PackManifest :errors [...]}."
+  loading/load-pack-from-file)
 
-(def resolve-detector checking/resolve-detector)
-(def rule-enabled? checking/rule-enabled?)
-(def compile-pack checking/compile-pack)
+(def load-pack-from-directory
+  "Load a policy pack from a directory (pack.edn manifest plus optional rules/
+   subtree; directory rules override inline rules by :rule/id). Returns
+   {:success? bool :pack PackManifest :errors [...]}."
+  loading/load-pack-from-directory)
+
+(def resolve-overlay
+  "Resolve an overlay pack by merging inherited rules from its :pack/extends
+   base packs (looked up in pack-store), appending overlay rules, applying
+   :pack/overrides, and inheriting the taxonomy ref. Returns
+   {:success? true :pack <resolved PackManifest>} or
+   {:success? false :errors [...]} on missing base, taxonomy conflict, or
+   rule-id collision."
+  loading/resolve-overlay)
+
+(def discover-packs
+  "Discover packs in a directory: top-level *.pack.edn files and subdirectories
+   containing pack.edn. Returns a vector of {:path string :type :file|:directory}
+   (nil when the directory does not exist)."
+  loading/discover-packs)
+
+(def load-all-packs
+  "Load every pack discovered in a directory. Arity [packs-dir] or
+   [packs-dir opts] (opts: :validate-dependencies? default true,
+   :max-dependency-depth default 5). Returns {:loaded [PackManifest...]
+   :failed [{:path :errors}...] :dependency-validation {...}?}."
+  loading/load-all-packs)
+
+(def write-pack-to-file
+  "Serialize a PackManifest to an EDN file via pprint. (write-pack-to-file pack
+   file-path) returns {:success? bool :error string-or-nil}."
+  loading/write-pack-to-file)
+
+(def detect-violation
+  "Detect a violation for one rule against an artifact, dispatching on
+   :rule/detection :type. (detect-violation rule artifact context) returns a
+   violation map (keys include :type :rule-id :matches :message) or nil when
+   clean."
+  checking/detect-violation)
+
+(def detect-semantic
+  "Run the LLM-as-judge detector for a heuristic :custom rule.
+   (detect-semantic rule artifact context) returns a :type :semantic violation
+   map when the judge reports violations, a :type :semantic-error map when the
+   judge throws, or nil when clean or when the semantic wiring is absent from
+   context."
+  checking/detect-semantic)
+
+(def check-rules
+  "Check multiple rules against one artifact.
+   (check-rules rules artifact context) returns a vector of
+   {:rule rule :violation violation-map :timestamp Instant} for each rule that
+   fired."
+  checking/check-rules)
+
+(def check-artifact
+  "Check one artifact against all applicable rules from a pack (or vector of
+   packs). (check-artifact pack artifact context) returns
+   {:passed? bool :violations [...] :blocking [...] :require-approval [...]
+   :warnings [...] :audits [...] :read-only? bool} where :passed? is true when
+   there are no hard-halt blocking violations."
+  checking/check-artifact)
+
+(def check-artifacts
+  "Check several artifacts against pack rules.
+   (check-artifacts pack artifacts context) returns a vector of check-artifact
+   result maps, one per artifact."
+  checking/check-artifacts)
+
+(def blocking-violations
+  "Filter check-rules violations to those whose rule enforces :hard-halt.
+   Returns a lazy seq of the matching violation entries."
+  checking/blocking-violations)
+
+(def approval-required-violations
+  "Filter check-rules violations to those whose rule enforces
+   :require-approval. Returns a lazy seq of the matching violation entries."
+  checking/approval-required-violations)
+
+(def warning-violations
+  "Filter check-rules violations to those whose rule enforces :warn. Returns a
+   lazy seq of the matching violation entries."
+  checking/warning-violations)
+
+(def violation->error
+  "Convert a check-rules violation entry into a gate error map
+   {:code :message :severity :location {:matches :path} :remediation}."
+  checking/violation->error)
+
+(def violation->warning
+  "Convert a check-rules violation entry into a gate warning map
+   {:code :message :severity}."
+  checking/violation->warning)
+
+(def resolve-detector
+  "Return the detection-mechanism keyword a rule binds to: one of
+   :content-scan/:diff-analysis/:plan-output/:state-comparison/:ast-analysis,
+   or :capability/:custom/:semantic, or :none when it binds to no available
+   mechanism. (resolve-detector rule)"
+  checking/resolve-detector)
+
+(def rule-enabled?
+  "Predicate. (rule-enabled? rule) returns true unless the rule explicitly sets
+   :rule/enabled? to false; a missing flag means enabled."
+  checking/rule-enabled?)
+
+(def compile-pack
+  "Validate that every enabled rule in a pack binds to a detection mechanism.
+   (compile-pack pack) returns {:ok true :rule-count int :detector-counts {...}}
+   on success, or an :invalid-input anomaly map (data, not a throw) naming
+   :unbindable-rule-ids when any enabled rule resolves to :none."
+  checking/compile-pack)
 
 ;------------------------------------------------------------------------------ Capability registry API
 
-(def register-capability! capability/register-capability!)
-(def get-capability capability/get-capability)
-(def list-capabilities capability/list-capabilities)
-(def capability-available? capability/capability-available?)
+(def register-capability!
+  "Register (or replace) a mechanical-check capability in the registry.
+   (register-capability! k entry), where k is a keyword and entry is
+   {:meta map :check (fn [artifact context] -> violation-or-nil)}, returns the
+   stored entry on success, or an :invalid-input anomaly map (data, not a throw)
+   on bad input."
+  capability/register-capability!)
+
+(def get-capability
+  "Return the registered capability entry for keyword k, or nil when
+   unregistered."
+  capability/get-capability)
+
+(def list-capabilities
+  "Return the set of registered capability keywords."
+  capability/list-capabilities)
+
+(def capability-available?
+  "Predicate. Returns true when capability keyword k is registered, false
+   otherwise."
+  capability/capability-available?)
 
 ;------------------------------------------------------------------------------ Builders and rule resolution
 
-(def create-pack builders/create-pack)
-(def create-rule builders/create-rule)
-(def add-rule-to-pack builders/add-rule-to-pack)
-(def remove-rule-from-pack builders/remove-rule-from-pack)
-(def update-pack-categories builders/update-pack-categories)
-(def content-scan-detection builders/content-scan-detection)
-(def diff-analysis-detection builders/diff-analysis-detection)
-(def plan-output-detection builders/plan-output-detection)
-(def warn-enforcement builders/warn-enforcement)
-(def halt-enforcement builders/halt-enforcement)
-(def approval-enforcement builders/approval-enforcement)
-(def resolve-rules builders/resolve-rules)
-(def merge-rules builders/merge-rules)
-(def filter-applicable-rules checking/filter-applicable-rules)
-(def rule-applies-to-phase? checking/rule-applies-to-phase?)
+(def create-pack
+  "Build a new PackManifest map with defaults.
+   (create-pack id name description author & {:keys [version license rules]}).
+   :version defaults to today's DateVer, :rules to []. Returns the pack map."
+  builders/create-pack)
+
+(def create-rule
+  "Build a new rule map from required fields plus options.
+   (create-rule id title description severity category detection enforcement
+   & {:keys [applies-to agent-behavior examples]}). Returns the rule map."
+  builders/create-rule)
+
+(def add-rule-to-pack
+  "Append a rule to a pack and bump :pack/updated-at. (add-rule-to-pack pack
+   rule) returns the updated pack map."
+  builders/add-rule-to-pack)
+
+(def remove-rule-from-pack
+  "Remove a rule by :rule/id from a pack and bump :pack/updated-at.
+   (remove-rule-from-pack pack rule-id) returns the updated pack map."
+  builders/remove-rule-from-pack)
+
+(def update-pack-categories
+  "Regenerate :pack/categories from the pack's rules, grouped by
+   :rule/category. (update-pack-categories pack) returns the updated pack map."
+  builders/update-pack-categories)
+
+(def content-scan-detection
+  "Build a content-scan detection config map. (content-scan-detection pattern)
+   or (content-scan-detection pattern {:context-lines n}) (default 2). Returns
+   {:type :content-scan :pattern ... :context-lines ...}."
+  builders/content-scan-detection)
+
+(def diff-analysis-detection
+  "Build a diff-analysis detection config map. (diff-analysis-detection pattern)
+   or (diff-analysis-detection pattern {:context-lines n}) (default 3). Returns
+   {:type :diff-analysis :pattern ... :context-lines ...}."
+  builders/diff-analysis-detection)
+
+(def plan-output-detection
+  "Build a plan-output detection config map. (plan-output-detection patterns)
+   returns {:type :plan-output :patterns patterns}."
+  builders/plan-output-detection)
+
+(def warn-enforcement
+  "Build a warn-only enforcement config map. (warn-enforcement message) returns
+   {:action :warn :message message}."
+  builders/warn-enforcement)
+
+(def halt-enforcement
+  "Build a hard-halt enforcement config map. (halt-enforcement message) or
+   (halt-enforcement message {:remediation s}) returns
+   {:action :hard-halt :message ... :remediation?}."
+  builders/halt-enforcement)
+
+(def approval-enforcement
+  "Build a require-approval enforcement config map. (approval-enforcement
+   message approvers) returns {:action :require-approval :message ...
+   :approvers ...}."
+  builders/approval-enforcement)
+
+(def resolve-rules
+  "Resolve a sequence of rules from multiple packs: group by :rule/id and merge
+   each group (severity escalates higher, enforcement escalates stricter).
+   (resolve-rules rules) returns a vector of resolved rules."
+  builders/resolve-rules)
+
+(def merge-rules
+  "Merge two same-id rules. (merge-rules base override) returns a rule map where
+   override wins for most fields but :rule/severity keeps the more severe and
+   :rule/enforcement :action keeps the stricter."
+  builders/merge-rules)
+
+(def filter-applicable-rules
+  "Filter rules to those enabled and applicable to a context (by file globs,
+   task type, and phase). (filter-applicable-rules rules context) returns a
+   vector of applicable rules."
+  checking/filter-applicable-rules)
+
+(def rule-applies-to-phase?
+  "Predicate. (rule-applies-to-phase? rule phase) returns true when the rule
+   has no :phases constraint or its constraint contains phase."
+  checking/rule-applies-to-phase?)
 
 ;------------------------------------------------------------------------------ Intent validation API
 
-(def infer-intent intent/infer-intent)
-(def intent-matches? intent/intent-matches?)
-(def semantic-intent-check intent/semantic-intent-check)
-(def parse-terraform-plan-counts intent/parse-terraform-plan-counts)
-(def parse-k8s-diff-counts intent/parse-k8s-diff-counts)
+(def infer-intent
+  "Infer the intent keyword from resource change counts.
+   (infer-intent {:creates :updates :destroys}) returns one of
+   :refactor/:create/:update/:destroy/:migrate, or :mixed when no clear pattern."
+  intent/infer-intent)
+
+(def intent-matches?
+  "Validate that a declared intent matches actual resource change counts.
+   (intent-matches? declared counts) returns {:passed? true} when consistent,
+   else {:passed? false :violations [...]}. Unknown intents pass by default."
+  intent/intent-matches?)
+
+(def semantic-intent-check
+  "Full semantic intent check (N4 §4).
+   (semantic-intent-check declared-intent counts) returns
+   {:passed? bool :violations [...] :inferred-intent keyword :metadata {...}}."
+  intent/semantic-intent-check)
+
+(def parse-terraform-plan-counts
+  "Parse terraform plan output into resource change counts.
+   (parse-terraform-plan-counts plan-output) returns
+   {:creates int :updates int :destroys int}."
+  intent/parse-terraform-plan-counts)
+
+(def parse-k8s-diff-counts
+  "Parse kubectl diff output into resource change counts.
+   (parse-k8s-diff-counts diff-output) returns
+   {:creates int :updates int :destroys int}."
+  intent/parse-k8s-diff-counts)
 
 ;------------------------------------------------------------------------------ Mapping API
 
-(def MappingArtifact mapping/MappingArtifact)
-(def MappingEntry mapping/MappingEntry)
-(def valid-mapping? mapping/valid-mapping?)
-(def validate-mapping mapping/validate-mapping)
-(def load-mapping mapping/load-mapping)
-(def resolve-mapping mapping/resolve-mapping)
-(def project-report mapping/project-report)
+(def MappingArtifact
+  "Malli schema (a `[:map ...]` vector) for a mapping artifact — an independent,
+   versioned bridge between a source and target policy system, carrying entries
+   and optional authorship."
+  mapping/MappingArtifact)
+
+(def MappingEntry
+  "Malli schema (a `[:map ...]` vector) for one mapping entry — an optional
+   source rule/category, an optional target control, a :mapping/type, and
+   optional notes."
+  mapping/MappingEntry)
+
+(def valid-mapping?
+  "Predicate. Returns true when the value conforms to the MappingArtifact
+   schema, false otherwise."
+  mapping/valid-mapping?)
+
+(def validate-mapping
+  "Validate a mapping artifact against the MappingArtifact schema. Returns
+   {:valid? bool :errors map-or-nil}."
+  mapping/validate-mapping)
+
+(def load-mapping
+  "Load a mapping artifact from an EDN file. (load-mapping path) returns
+   {:success? true :mapping <MappingArtifact>} or
+   {:success? false :error <message>} on read or validation failure."
+  mapping/load-mapping)
+
+(def resolve-mapping
+  "Resolve a mapping against a pack, enriching each entry with match status.
+   (resolve-mapping mapping pack) returns a vector of entry maps each carrying
+   :matched? (and :rule-title when a source rule matched)."
+  mapping/resolve-mapping)
+
+(def project-report
+  "Project a mapping onto a pack to produce a coverage report.
+   (project-report mapping pack) returns
+   {:target-controls [{:control :type :matched? :source :notes} ...]
+   :summary {:exact :broad :partial :none :unmatched}}."
+  mapping/project-report)
 
 ;------------------------------------------------------------------------------ Prompt templates
 
-(def interpolate prompt-template/interpolate)
-(def render-repair-prompt prompt-template/render-repair-prompt)
-(def render-behavior-section prompt-template/render-behavior-section)
-(def render-knowledge-section prompt-template/render-knowledge-section)
+(def interpolate
+  "Replace {{variable}} placeholders in a template with values from a bindings
+   map (keys may be strings or keywords; unknown variables become \"\").
+   (interpolate template bindings) returns the interpolated string."
+  prompt-template/interpolate)
+
+(def render-repair-prompt
+  "Render a complete repair prompt for a violation.
+   (render-repair-prompt violation rule pack) resolves the repair template
+   (rule → pack → default), interpolates it, and returns
+   {:role :user :content <string>}."
+  prompt-template/render-repair-prompt)
+
+(def render-behavior-section
+  "Render the numbered behavior-rules section for prompt injection.
+   (render-behavior-section behaviors pack) returns the formatted string, or
+   nil when behaviors is empty."
+  prompt-template/render-behavior-section)
+
+(def render-knowledge-section
+  "Render the reference-material section for prompt injection.
+   (render-knowledge-section knowledge pack), where knowledge is a seq of
+   {:rule/title :content} maps, returns the formatted string, or nil when
+   empty."
+  prompt-template/render-knowledge-section)
 
 ;------------------------------------------------------------------------------ MDC compilation
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/builders.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/builders.clj
@@ -25,18 +25,89 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Builders and resolution helpers
 
-(def create-pack core/create-pack)
-(def create-rule core/create-rule)
-(def add-rule-to-pack core/add-rule-to-pack)
-(def remove-rule-from-pack core/remove-rule-from-pack)
-(def update-pack-categories core/update-pack-categories)
-(def content-scan-detection core/content-scan-detection)
-(def diff-analysis-detection core/diff-analysis-detection)
-(def plan-output-detection core/plan-output-detection)
-(def warn-enforcement core/warn-enforcement)
-(def halt-enforcement core/halt-enforcement)
-(def approval-enforcement core/approval-enforcement)
-(def resolve-rules core/resolve-rules)
-(def merge-rules core/merge-rules)
-(def evaluate-external-pr external/evaluate-external-pr)
-(def parse-pr-diff external/parse-pr-diff)
+(def create-pack
+  "Build a new PackManifest map with defaults.
+   (create-pack id name description author & {:keys [version license rules]}).
+   :version defaults to today's DateVer, :rules to []. Returns the pack map."
+  core/create-pack)
+
+(def create-rule
+  "Build a new rule map from required fields plus options.
+   (create-rule id title description severity category detection enforcement
+   & {:keys [applies-to agent-behavior examples]}). Returns the rule map."
+  core/create-rule)
+
+(def add-rule-to-pack
+  "Append a rule to a pack and bump :pack/updated-at. (add-rule-to-pack pack
+   rule) returns the updated pack map."
+  core/add-rule-to-pack)
+
+(def remove-rule-from-pack
+  "Remove a rule by :rule/id from a pack and bump :pack/updated-at.
+   (remove-rule-from-pack pack rule-id) returns the updated pack map."
+  core/remove-rule-from-pack)
+
+(def update-pack-categories
+  "Regenerate :pack/categories from the pack's rules, grouped by
+   :rule/category. (update-pack-categories pack) returns the updated pack map."
+  core/update-pack-categories)
+
+(def content-scan-detection
+  "Build a content-scan detection config map. (content-scan-detection pattern)
+   or (content-scan-detection pattern {:context-lines n}) (default 2). Returns
+   {:type :content-scan :pattern ... :context-lines ...}."
+  core/content-scan-detection)
+
+(def diff-analysis-detection
+  "Build a diff-analysis detection config map. (diff-analysis-detection pattern)
+   or (diff-analysis-detection pattern {:context-lines n}) (default 3). Returns
+   {:type :diff-analysis :pattern ... :context-lines ...}."
+  core/diff-analysis-detection)
+
+(def plan-output-detection
+  "Build a plan-output detection config map. (plan-output-detection patterns)
+   returns {:type :plan-output :patterns patterns}."
+  core/plan-output-detection)
+
+(def warn-enforcement
+  "Build a warn-only enforcement config map. (warn-enforcement message) returns
+   {:action :warn :message message}."
+  core/warn-enforcement)
+
+(def halt-enforcement
+  "Build a hard-halt enforcement config map. (halt-enforcement message) or
+   (halt-enforcement message {:remediation s}) returns
+   {:action :hard-halt :message ... :remediation?}."
+  core/halt-enforcement)
+
+(def approval-enforcement
+  "Build a require-approval enforcement config map. (approval-enforcement
+   message approvers) returns {:action :require-approval :message ...
+   :approvers ...}."
+  core/approval-enforcement)
+
+(def resolve-rules
+  "Resolve a sequence of rules from multiple packs: group by :rule/id and merge
+   each group (severity escalates higher, enforcement escalates stricter).
+   (resolve-rules rules) returns a vector of resolved rules."
+  core/resolve-rules)
+
+(def merge-rules
+  "Merge two same-id rules. (merge-rules base override) returns a rule map where
+   override wins for most fields but :rule/severity keeps the more severe and
+   :rule/enforcement :action keeps the stricter."
+  core/merge-rules)
+
+(def evaluate-external-pr
+  "Evaluate an external PR against policy packs in read-only mode.
+   (evaluate-external-pr packs pr-data) returns
+   {:evaluation/passed? bool :evaluation/violations [...]
+   :evaluation/summary {:critical :major :minor :info :total}
+   :evaluation/artifacts-checked int :evaluation/packs-applied [string]}."
+  external/evaluate-external-pr)
+
+(def parse-pr-diff
+  "Parse a unified diff string into artifact maps. (parse-pr-diff diff-content)
+   returns a vector of {:artifact/path :artifact/content (added lines)
+   :artifact/diff (raw hunk)}, or nil for blank input."
+  external/parse-pr-diff)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/builders.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/builders.clj
@@ -77,7 +77,7 @@
 (def halt-enforcement
   "Build a hard-halt enforcement config map. (halt-enforcement message) or
    (halt-enforcement message {:remediation s}) returns
-   {:action :hard-halt :message ... :remediation?}."
+   {:action :hard-halt :message ... :remediation} (:remediation present only when supplied)."
   core/halt-enforcement)
 
 (def approval-enforcement

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/checking.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/checking.clj
@@ -26,22 +26,96 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Detection and checking
 
-(def detect-violation detection/detect-violation)
-(def detect-semantic detection/detect-semantic)
-(def check-rules detection/check-rules)
-(def check-artifact core/check-artifact)
-(def check-artifacts core/check-artifacts)
-(def filter-applicable-rules core/filter-applicable-rules)
-(def rule-applies-to-phase? core/rule-applies-to-phase?)
-(def blocking-violations detection/blocking-violations)
-(def approval-required-violations detection/approval-required-violations)
-(def warning-violations detection/warning-violations)
-(def violation->error detection/violation->error)
-(def violation->warning detection/violation->warning)
+(def detect-violation
+  "Detect a violation for one rule against an artifact, dispatching on
+   :rule/detection :type. (detect-violation rule artifact context) returns a
+   violation map (keys include :type :rule-id :matches :message) or nil when
+   clean."
+  detection/detect-violation)
+
+(def detect-semantic
+  "Run the LLM-as-judge detector for a heuristic :custom rule.
+   (detect-semantic rule artifact context) returns a :type :semantic violation
+   map when the judge reports violations, a :type :semantic-error map when the
+   judge throws, or nil when clean or when the semantic wiring is absent from
+   context."
+  detection/detect-semantic)
+
+(def check-rules
+  "Check multiple rules against one artifact.
+   (check-rules rules artifact context) returns a vector of
+   {:rule rule :violation violation-map :timestamp Instant} for each rule that
+   fired."
+  detection/check-rules)
+
+(def check-artifact
+  "Check one artifact against all applicable rules from a pack (or vector of
+   packs). (check-artifact pack artifact context) returns
+   {:passed? bool :violations [...] :blocking [...] :require-approval [...]
+   :warnings [...] :audits [...] :read-only? bool} where :passed? is true when
+   there are no hard-halt blocking violations."
+  core/check-artifact)
+
+(def check-artifacts
+  "Check several artifacts against pack rules.
+   (check-artifacts pack artifacts context) returns a vector of check-artifact
+   result maps, one per artifact."
+  core/check-artifacts)
+
+(def filter-applicable-rules
+  "Filter rules to those enabled and applicable to a context (by file globs,
+   task type, and phase). (filter-applicable-rules rules context) returns a
+   vector of applicable rules."
+  core/filter-applicable-rules)
+
+(def rule-applies-to-phase?
+  "Predicate. (rule-applies-to-phase? rule phase) returns true when the rule
+   has no :phases constraint or its constraint contains phase."
+  core/rule-applies-to-phase?)
+
+(def blocking-violations
+  "Filter check-rules violations to those whose rule enforces :hard-halt.
+   Returns a lazy seq of the matching violation entries."
+  detection/blocking-violations)
+
+(def approval-required-violations
+  "Filter check-rules violations to those whose rule enforces
+   :require-approval. Returns a lazy seq of the matching violation entries."
+  detection/approval-required-violations)
+
+(def warning-violations
+  "Filter check-rules violations to those whose rule enforces :warn. Returns a
+   lazy seq of the matching violation entries."
+  detection/warning-violations)
+
+(def violation->error
+  "Convert a check-rules violation entry into a gate error map
+   {:code :message :severity :location {:matches :path} :remediation}."
+  detection/violation->error)
+
+(def violation->warning
+  "Convert a check-rules violation entry into a gate warning map
+   {:code :message :severity}."
+  detection/violation->warning)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Detection binding compiler / validator
 
-(def resolve-detector compiler/resolve-detector)
-(def rule-enabled? compiler/rule-enabled?)
-(def compile-pack compiler/compile-pack)
+(def resolve-detector
+  "Return the detection-mechanism keyword a rule binds to: one of
+   :content-scan/:diff-analysis/:plan-output/:state-comparison/:ast-analysis,
+   or :capability/:custom/:semantic, or :none when it binds to no available
+   mechanism. (resolve-detector rule)"
+  compiler/resolve-detector)
+
+(def rule-enabled?
+  "Predicate. (rule-enabled? rule) returns true unless the rule explicitly sets
+   :rule/enabled? to false; a missing flag means enabled."
+  compiler/rule-enabled?)
+
+(def compile-pack
+  "Validate that every enabled rule in a pack binds to a detection mechanism.
+   (compile-pack pack) returns {:ok true :rule-count int :detector-counts {...}}
+   on success, or an :invalid-input anomaly map (data, not a throw) naming
+   :unbindable-rule-ids when any enabled rule resolves to :none."
+  compiler/compile-pack)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/intent.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/intent.clj
@@ -21,9 +21,37 @@
   (:require
    [ai.miniforge.policy-pack.intent :as intent]))
 
-(def intent-types intent/intent-types)
-(def infer-intent intent/infer-intent)
-(def intent-matches? intent/intent-matches?)
-(def semantic-intent-check intent/semantic-intent-check)
-(def parse-terraform-plan-counts intent/parse-terraform-plan-counts)
-(def parse-k8s-diff-counts intent/parse-k8s-diff-counts)
+(def intent-types
+  "Set of valid intent keywords
+   `#{:import :create :update :destroy :refactor :migrate}`."
+  intent/intent-types)
+
+(def infer-intent
+  "Infer the intent keyword from resource change counts.
+   (infer-intent {:creates :updates :destroys}) returns one of
+   :refactor/:create/:update/:destroy/:migrate, or :mixed when no clear pattern."
+  intent/infer-intent)
+
+(def intent-matches?
+  "Validate that a declared intent matches actual resource change counts.
+   (intent-matches? declared counts) returns {:passed? true} when consistent,
+   else {:passed? false :violations [...]}. Unknown intents pass by default."
+  intent/intent-matches?)
+
+(def semantic-intent-check
+  "Full semantic intent check (N4 §4).
+   (semantic-intent-check declared-intent counts) returns
+   {:passed? bool :violations [...] :inferred-intent keyword :metadata {...}}."
+  intent/semantic-intent-check)
+
+(def parse-terraform-plan-counts
+  "Parse terraform plan output into resource change counts.
+   (parse-terraform-plan-counts plan-output) returns
+   {:creates int :updates int :destroys int}."
+  intent/parse-terraform-plan-counts)
+
+(def parse-k8s-diff-counts
+  "Parse kubectl diff output into resource change counts.
+   (parse-k8s-diff-counts diff-output) returns
+   {:creates int :updates int :destroys int}."
+  intent/parse-k8s-diff-counts)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/loading.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/loading.clj
@@ -24,10 +24,45 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Loading operations
 
-(def load-pack loader/load-pack)
-(def load-pack-from-file loader/load-pack-from-file)
-(def load-pack-from-directory loader/load-pack-from-directory)
-(def resolve-overlay loader/resolve-overlay)
-(def discover-packs loader/discover-packs)
-(def load-all-packs loader/load-all-packs)
-(def write-pack-to-file loader/write-pack-to-file)
+(def load-pack
+  "Load a policy pack from a path, auto-detecting single-EDN-file vs directory
+   layout. Returns {:success? bool :pack PackManifest :errors [...]}."
+  loader/load-pack)
+
+(def load-pack-from-file
+  "Load a policy pack from a single EDN manifest file (pack.edn or
+   *.pack.edn). Returns {:success? bool :pack PackManifest :errors [...]}."
+  loader/load-pack-from-file)
+
+(def load-pack-from-directory
+  "Load a policy pack from a directory (pack.edn manifest plus optional rules/
+   subtree; directory rules override inline rules by :rule/id). Returns
+   {:success? bool :pack PackManifest :errors [...]}."
+  loader/load-pack-from-directory)
+
+(def resolve-overlay
+  "Resolve an overlay pack by merging inherited rules from its :pack/extends
+   base packs (looked up in pack-store), appending overlay rules, applying
+   :pack/overrides, and inheriting the taxonomy ref. Returns
+   {:success? true :pack <resolved PackManifest>} or
+   {:success? false :errors [...]} on missing base, taxonomy conflict, or
+   rule-id collision."
+  loader/resolve-overlay)
+
+(def discover-packs
+  "Discover packs in a directory: top-level *.pack.edn files and subdirectories
+   containing pack.edn. Returns a vector of {:path string :type :file|:directory}
+   (nil when the directory does not exist)."
+  loader/discover-packs)
+
+(def load-all-packs
+  "Load every pack discovered in a directory. Arity [packs-dir] or
+   [packs-dir opts] (opts: :validate-dependencies? default true,
+   :max-dependency-depth default 5). Returns {:loaded [PackManifest...]
+   :failed [{:path :errors}...] :dependency-validation {...}?}."
+  loader/load-all-packs)
+
+(def write-pack-to-file
+  "Serialize a PackManifest to an EDN file via pprint. (write-pack-to-file pack
+   file-path) returns {:success? bool :error string-or-nil}."
+  loader/write-pack-to-file)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/mapping.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/mapping.clj
@@ -24,24 +24,62 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schemas
 
-(def MappingArtifact mapping/MappingArtifact)
-(def MappingEntry mapping/MappingEntry)
-(def MappingAuthorship mapping/MappingAuthorship)
-(def MappingType mapping/MappingType)
+(def MappingArtifact
+  "Malli schema (a `[:map ...]` vector) for a mapping artifact — an independent,
+   versioned bridge between a source and target policy system, carrying entries
+   and optional authorship."
+  mapping/MappingArtifact)
+
+(def MappingEntry
+  "Malli schema (a `[:map ...]` vector) for one mapping entry — an optional
+   source rule/category, an optional target control, a :mapping/type, and
+   optional notes."
+  mapping/MappingEntry)
+
+(def MappingAuthorship
+  "Malli schema (a `[:map ...]` vector) for mapping provenance — :publisher,
+   :confidence, and an optional :validated-at."
+  mapping/MappingAuthorship)
+
+(def MappingType
+  "Malli enum schema (`[:enum :exact :broad :partial :none]`) for how closely a
+   source satisfies a target."
+  mapping/MappingType)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Validation
 
-(def valid-mapping? mapping/valid-mapping?)
-(def validate-mapping mapping/validate-mapping)
+(def valid-mapping?
+  "Predicate. Returns true when the value conforms to the MappingArtifact
+   schema, false otherwise."
+  mapping/valid-mapping?)
+
+(def validate-mapping
+  "Validate a mapping artifact against the MappingArtifact schema. Returns
+   {:valid? bool :errors map-or-nil}."
+  mapping/validate-mapping)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Loading
 
-(def load-mapping mapping/load-mapping)
+(def load-mapping
+  "Load a mapping artifact from an EDN file. (load-mapping path) returns
+   {:success? true :mapping <MappingArtifact>} or
+   {:success? false :error <message>} on read or validation failure."
+  mapping/load-mapping)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Resolution
 
-(def resolve-mapping mapping/resolve-mapping)
-(def project-report mapping/project-report)
+(def resolve-mapping
+  "Resolve a mapping against a pack, enriching each entry with match status.
+   (resolve-mapping mapping pack) returns a vector of entry maps each carrying
+   :matched? (and :rule-title when a source rule matched)."
+  mapping/resolve-mapping)
+
+(def project-report
+  "Project a mapping onto a pack to produce a coverage report.
+   (project-report mapping pack) returns
+   {:target-controls [{:control :type :matched? :source :notes} ...]
+   :summary {:exact :broad :partial :none :unmatched}}."
+  mapping/project-report)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/prompt_template.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/prompt_template.clj
@@ -21,10 +21,47 @@
   (:require
    [ai.miniforge.policy-pack.prompt-template :as pt]))
 
-(def interpolate pt/interpolate)
-(def render-repair-prompt pt/render-repair-prompt)
-(def render-behavior-section pt/render-behavior-section)
-(def render-knowledge-section pt/render-knowledge-section)
-(def resolve-repair-template pt/resolve-repair-template)
-(def resolve-behavior-template pt/resolve-behavior-template)
-(def resolve-knowledge-template pt/resolve-knowledge-template)
+(def interpolate
+  "Replace {{variable}} placeholders in a template with values from a bindings
+   map (keys may be strings or keywords; unknown variables become \"\").
+   (interpolate template bindings) returns the interpolated string."
+  pt/interpolate)
+
+(def render-repair-prompt
+  "Render a complete repair prompt for a violation.
+   (render-repair-prompt violation rule pack) resolves the repair template
+   (rule → pack → default), interpolates it, and returns
+   {:role :user :content <string>}."
+  pt/render-repair-prompt)
+
+(def render-behavior-section
+  "Render the numbered behavior-rules section for prompt injection.
+   (render-behavior-section behaviors pack) returns the formatted string, or
+   nil when behaviors is empty."
+  pt/render-behavior-section)
+
+(def render-knowledge-section
+  "Render the reference-material section for prompt injection.
+   (render-knowledge-section knowledge pack), where knowledge is a seq of
+   {:rule/title :content} maps, returns the formatted string, or nil when
+   empty."
+  pt/render-knowledge-section)
+
+(def resolve-repair-template
+  "Resolve the repair prompt template string for a violation, preferring the
+   rule's :rule/repair-prompt-template, then the pack's :repair-prompt, then the
+   built-in default. (resolve-repair-template rule pack) returns the template
+   string."
+  pt/resolve-repair-template)
+
+(def resolve-behavior-template
+  "Resolve the behavior-section template string, preferring the pack's
+   :behavior-section, else the built-in default. (resolve-behavior-template
+   pack) returns the template string."
+  pt/resolve-behavior-template)
+
+(def resolve-knowledge-template
+  "Resolve the knowledge-section template string, preferring the pack's
+   :knowledge-section, else the built-in default. (resolve-knowledge-template
+   pack) returns the template string."
+  pt/resolve-knowledge-template)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/registry.clj
@@ -24,14 +24,63 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Registry protocol and helpers
 
-(def PolicyPackRegistry registry/PolicyPackRegistry)
-(def create-registry registry/create-registry)
-(def register-pack registry/register-pack)
-(def get-pack registry/get-pack)
-(def get-pack-version registry/get-pack-version)
-(def list-packs registry/list-packs)
-(def delete-pack registry/delete-pack)
-(def resolve-pack registry/resolve-pack)
-(def get-rules-for-context registry/get-rules-for-context)
-(def glob-matches? registry/glob-matches?)
-(def compare-versions registry/compare-versions)
+(def PolicyPackRegistry
+  "Protocol for managing policy packs: CRUD, import/export, validation, and
+   composition. Implemented by the in-memory registry from create-registry."
+  registry/PolicyPackRegistry)
+
+(def create-registry
+  "Create an in-memory PolicyPackRegistry. Arity [] or [opts] (opts may carry
+   :logger). Returns a registry value backed by an atom."
+  registry/create-registry)
+
+(def register-pack
+  "Protocol fn. (register-pack registry pack) registers a pack (or new
+   version), keyed by :pack/id and :pack/version. Returns the registered pack;
+   throws an :anomalies/incorrect anomaly when the pack fails schema validation."
+  registry/register-pack)
+
+(def get-pack
+  "Protocol fn. (get-pack registry pack-id) returns the latest-version pack for
+   pack-id, or nil if none is registered."
+  registry/get-pack)
+
+(def get-pack-version
+  "Protocol fn. (get-pack-version registry pack-id version) returns the pack at
+   the exact version, or nil if not found."
+  registry/get-pack-version)
+
+(def list-packs
+  "Protocol fn. (list-packs registry criteria) returns a vector of pack-summary
+   maps (:pack/id :pack/name :pack/version :pack/author :pack/description
+   :rule-count). Criteria may filter by :category, :author, :search."
+  registry/list-packs)
+
+(def delete-pack
+  "Protocol fn. (delete-pack registry pack-id version) removes the pack version.
+   Returns true if deleted, false if it was not present."
+  registry/delete-pack)
+
+(def resolve-pack
+  "Protocol fn. (resolve-pack registry pack-id) returns the pack with all
+   :pack/extends parents recursively merged (child rules override parents by
+   :rule/id), or nil if the pack is not found."
+  registry/resolve-pack)
+
+(def get-rules-for-context
+  "Protocol fn. (get-rules-for-context registry pack-ids context) resolves the
+   named packs, filters their rules by the context (:task, :artifact, :repo,
+   :phase), deduplicates by :rule/id, and returns a vector of applicable rules."
+  registry/get-rules-for-context)
+
+(def glob-matches?
+  "Predicate. (glob-matches? pattern path) returns true when path matches the
+   glob pattern (supports * within a segment and ** across segments); false on
+   no match or a bad pattern."
+  registry/glob-matches?)
+
+(def compare-versions
+  "Compare two DateVer (YYYY.MM.DD) version strings. Returns a negative int if
+   a < b, 0 if equal, positive if a > b; unparseable versions compare as
+   [0 0 0]."
+  registry/compare-versions)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/schema.clj
@@ -24,16 +24,71 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema and validation re-exports
 
-(def Rule schema/Rule)
-(def PackManifest schema/PackManifest)
-(def RuleSeverity schema/RuleSeverity)
-(def RuleEnforcement schema/RuleEnforcement)
-(def RuleApplicability schema/RuleApplicability)
-(def RuleDetection schema/RuleDetection)
-(def rule-severities schema/rule-severities)
-(def enforcement-actions schema/enforcement-actions)
-(def detection-types schema/detection-types)
-(def valid-rule? schema/valid-rule?)
-(def validate-rule schema/validate-rule)
-(def valid-pack? schema/valid-pack?)
-(def validate-pack schema/validate-pack)
+(def Rule
+  "Malli schema (a `[:map ...]` vector) for an individual policy rule —
+   identity, applicability, detection, enforcement, and optional knowledge,
+   remediation, and example fields."
+  schema/Rule)
+
+(def PackManifest
+  "Malli schema (a `[:map ...]` vector) for a policy pack manifest — a
+   versioned collection of rules with identity, trust/authority, taxonomy
+   reference, dependencies, overrides, categories, and timestamps."
+  schema/PackManifest)
+
+(def RuleSeverity
+  "Malli enum schema (`[:enum :critical :major :minor :info]`) for a rule's
+   severity level."
+  schema/RuleSeverity)
+
+(def RuleEnforcement
+  "Malli enum schema (`[:enum :hard-halt :require-approval :warn :audit]`) for
+   a rule's enforcement action."
+  schema/RuleEnforcement)
+
+(def RuleApplicability
+  "Malli schema (a `[:map ...]` vector) for when a rule applies — optional
+   task-types, file-globs, resource-patterns, repo-types, and phases."
+  schema/RuleApplicability)
+
+(def RuleDetection
+  "Malli schema (a `[:map ...]` vector) for how to detect violations —
+   required :type plus optional pattern(s), context-lines, custom-fn,
+   capability, mode, and email-pattern."
+  schema/RuleDetection)
+
+(def rule-severities
+  "Vector of severity keywords `[:critical :major :minor :info]`, ordered most
+   to least severe."
+  schema/rule-severities)
+
+(def enforcement-actions
+  "Vector of enforcement keywords `[:hard-halt :require-approval :warn :audit]`,
+   ordered strictest to most lenient."
+  schema/enforcement-actions)
+
+(def detection-types
+  "Vector of detection-type keywords
+   `[:plan-output :diff-analysis :state-comparison :content-scan :ast-analysis
+   :custom :capability]`."
+  schema/detection-types)
+
+(def valid-rule?
+  "Predicate. Returns true when the value validates against the Rule schema,
+   false otherwise."
+  schema/valid-rule?)
+
+(def validate-rule
+  "Validate a rule against the Rule schema. Returns {:valid? bool :errors
+   map-or-nil} (humanized Malli errors when invalid)."
+  schema/validate-rule)
+
+(def valid-pack?
+  "Predicate. Returns true when the value validates against the PackManifest
+   schema, false otherwise."
+  schema/valid-pack?)
+
+(def validate-pack
+  "Validate a pack manifest against the PackManifest schema. Returns
+   {:valid? bool :errors map-or-nil} (humanized Malli errors when invalid)."
+  schema/validate-pack)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/taxonomy.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/taxonomy.clj
@@ -32,7 +32,7 @@
 
 (def TaxonomyCategory
   "Malli schema (a `[:map ...]` vector) for a single taxonomy category —
-   :category/id, :code, :title, optional :parent, and an integer :order."
+   :category/id, :category/code, :category/title, optional :category/parent, and an integer :category/order."
   taxonomy/TaxonomyCategory)
 
 (def TaxonomyAlias

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/taxonomy.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/taxonomy.clj
@@ -24,27 +24,79 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schemas
 
-(def Taxonomy taxonomy/Taxonomy)
-(def TaxonomyCategory taxonomy/TaxonomyCategory)
-(def TaxonomyAlias taxonomy/TaxonomyAlias)
-(def TaxonomyRef taxonomy/TaxonomyRef)
+(def Taxonomy
+  "Malli schema (a `[:map ...]` vector) for a taxonomy artifact — an
+   independently versioned category tree with id, version, title, categories,
+   and optional aliases."
+  taxonomy/Taxonomy)
+
+(def TaxonomyCategory
+  "Malli schema (a `[:map ...]` vector) for a single taxonomy category —
+   :category/id, :code, :title, optional :parent, and an integer :order."
+  taxonomy/TaxonomyCategory)
+
+(def TaxonomyAlias
+  "Malli schema (a `[:map ...]` vector) for a taxonomy alias — a stable
+   :alias/name keyword pointing at an :alias/target category ID."
+  taxonomy/TaxonomyAlias)
+
+(def TaxonomyRef
+  "Malli schema (a `[:map ...]` vector) for a pack's taxonomy reference —
+   :taxonomy/id and :taxonomy/min-version."
+  taxonomy/TaxonomyRef)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Validation
 
-(def valid-taxonomy? taxonomy/valid-taxonomy?)
-(def validate-taxonomy taxonomy/validate-taxonomy)
+(def valid-taxonomy?
+  "Predicate. Returns true when the value conforms to the Taxonomy schema,
+   false otherwise."
+  taxonomy/valid-taxonomy?)
+
+(def validate-taxonomy
+  "Validate a taxonomy artifact against the Taxonomy schema. Returns
+   {:valid? bool :errors map-or-nil}."
+  taxonomy/validate-taxonomy)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Loading
 
-(def load-taxonomy taxonomy/load-taxonomy)
-(def load-taxonomy-from-classpath taxonomy/load-taxonomy-from-classpath)
+(def load-taxonomy
+  "Load a taxonomy artifact from an EDN file or classpath resource.
+   (load-taxonomy path) returns {:success? true :taxonomy <Taxonomy>} or
+   {:success? false :error <message>}."
+  taxonomy/load-taxonomy)
+
+(def load-taxonomy-from-classpath
+  "Load a taxonomy artifact from a classpath resource path.
+   (load-taxonomy-from-classpath resource-path) returns
+   {:success? true :taxonomy <Taxonomy>} or {:success? false :error <message>}
+   (including when the resource is not found)."
+  taxonomy/load-taxonomy-from-classpath)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Lookups
 
-(def category-by-id taxonomy/category-by-id)
-(def resolve-alias taxonomy/resolve-alias)
-(def category-title taxonomy/category-title)
-(def category-order taxonomy/category-order)
+(def category-by-id
+  "Look up a category by its keyword ID in a loaded taxonomy.
+   (category-by-id taxonomy category-id) returns the TaxonomyCategory map, or
+   nil if not present."
+  taxonomy/category-by-id)
+
+(def resolve-alias
+  "Resolve an alias keyword to its target category ID.
+   (resolve-alias taxonomy alias-kw) returns the target keyword, or the input
+   keyword unchanged when no alias matches."
+  taxonomy/resolve-alias)
+
+(def category-title
+  "Get the display title for a category ID, resolving aliases first.
+   (category-title taxonomy category-id) returns the title string, or nil if
+   not found."
+  taxonomy/category-title)
+
+(def category-order
+  "Get the integer sort order for a category ID, resolving aliases first.
+   (category-order taxonomy category-id) returns the order int, or
+   Integer/MAX_VALUE if not found."
+  taxonomy/category-order)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mapping.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mapping.clj
@@ -84,12 +84,10 @@
 ;; Validation
 
 (defn valid-mapping?
-  "Check if value conforms to the MappingArtifact schema."
   [value]
   (m/validate MappingArtifact value))
 
 (defn validate-mapping
-  "Validate a mapping artifact. Returns {:valid? bool :errors map-or-nil}."
   [value]
   (if (m/validate MappingArtifact value)
     {:valid? true :errors nil}

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -359,22 +359,18 @@
     (me/humanize explanation)))
 
 (defn valid-rule?
-  "Check if value is a valid Rule."
   [value]
   (valid? Rule value))
 
 (defn validate-rule
-  "Validate a rule. Returns {:valid? bool :errors ...}."
   [value]
   (validate Rule value))
 
 (defn valid-pack?
-  "Check if value is a valid PackManifest."
   [value]
   (valid? PackManifest value))
 
 (defn validate-pack
-  "Validate a pack manifest. Returns {:valid? bool :errors ...}."
   [value]
   (validate PackManifest value))
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/software_factory.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/software_factory.clj
@@ -21,10 +21,6 @@
   (:require
    [ai.miniforge.policy-pack.external :as external]))
 
-(def evaluate-external-pr
-  "Evaluate an external PR diff against policy packs in read-only mode."
-  external/evaluate-external-pr)
+(def evaluate-external-pr external/evaluate-external-pr)
 
-(def parse-pr-diff
-  "Parse a unified diff into artifact-like inputs for external evaluation."
-  external/parse-pr-diff)
+(def parse-pr-diff external/parse-pr-diff)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/software_factory.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/software_factory.clj
@@ -21,6 +21,10 @@
   (:require
    [ai.miniforge.policy-pack.external :as external]))
 
-(def evaluate-external-pr external/evaluate-external-pr)
+(def evaluate-external-pr
+  "Evaluate an external PR diff against policy packs in read-only mode."
+  external/evaluate-external-pr)
 
-(def parse-pr-diff external/parse-pr-diff)
+(def parse-pr-diff
+  "Parse a unified diff into artifact-like inputs for external evaluation."
+  external/parse-pr-diff)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/taxonomy.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/taxonomy.clj
@@ -86,12 +86,10 @@
 ;; Validation
 
 (defn valid-taxonomy?
-  "Check if value conforms to the Taxonomy schema."
   [value]
   (m/validate Taxonomy value))
 
 (defn validate-taxonomy
-  "Validate a taxonomy artifact. Returns {:valid? bool :errors map-or-nil}."
   [value]
   (if (m/validate Taxonomy value)
     {:valid? true :errors nil}
@@ -150,8 +148,6 @@
 ;; Lookup helpers
 
 (defn category-by-id
-  "Look up a category by its keyword ID in a loaded taxonomy.
-   Returns the TaxonomyCategory map, or nil."
   [taxonomy category-id]
   (some (fn [cat]
           (when (= category-id (:category/id cat))
@@ -159,8 +155,6 @@
         (:taxonomy/categories taxonomy)))
 
 (defn resolve-alias
-  "Resolve an alias keyword to a category ID.
-   Returns the target keyword, or the input if no alias matches."
   [taxonomy alias-kw]
   (or (some (fn [a]
               (when (= alias-kw (:alias/name a))
@@ -169,15 +163,11 @@
       alias-kw))
 
 (defn category-title
-  "Get the display title for a category ID, resolving aliases.
-   Returns the title string, or nil if not found."
   [taxonomy category-id]
   (let [resolved (resolve-alias taxonomy category-id)]
     (:category/title (category-by-id taxonomy resolved))))
 
 (defn category-order
-  "Get the sort order for a category ID, resolving aliases.
-   Returns the order integer, or Integer/MAX_VALUE if not found."
   [taxonomy category-id]
   (let [resolved (resolve-alias taxonomy category-id)]
     (or (:category/order (category-by-id taxonomy resolved))


### PR DESCRIPTION
Boundary-documentation rollout (rule 009). Both interface tiers now carry contract docstrings (both consumed; types verified from impl). Duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change. Commit-budget override (mechanical doc-only); poly:check + smoke + GraalVM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)