### PR TITLE
docs(workflow): document both interface tiers (rule 009)

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -35,89 +35,392 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocols and workflow topology
 
-(def Workflow protocols/Workflow)
-(def PhaseExecutor protocols/PhaseExecutor)
-(def WorkflowObserver protocols/WorkflowObserver)
-(def phases protocols/phases)
-(def phase-transitions protocols/phase-transitions)
+(def Workflow
+  "Protocol governing workflow execution: start/get-state/advance/rollback/
+   complete/fail. Main extensibility point for custom workflow
+   implementations."
+  protocols/Workflow)
+
+(def PhaseExecutor
+  "Protocol for executing an individual SDLC phase: execute-phase/
+   can-execute?/get-phase-requirements. Extensibility point for custom
+   phase executors."
+  protocols/PhaseExecutor)
+
+(def WorkflowObserver
+  "Protocol for observing workflow events (phase start/complete/error,
+   workflow complete, rollback). Extensibility point for operator/
+   meta-loop integration."
+  protocols/WorkflowObserver)
+
+(def phases
+  "Ordered vector of SDLC phase keywords:
+   [:spec :plan :design :implement :verify :review :release :observe :done]."
+  protocols/phases)
+
+(def phase-transitions
+  "Map of phase keyword -> set of allowed next-phase keywords. The empty
+   set for :done marks the terminal phase."
+  protocols/phase-transitions)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Workflow lifecycle and execution
 
-(def create-workflow runtime/create-workflow)
-(def add-observer runtime/add-observer)
-(def remove-observer runtime/remove-observer)
-(def start runtime/start)
-(def get-state runtime/get-state)
-(def advance runtime/advance)
-(def rollback runtime/rollback)
-(def complete runtime/complete)
-(def fail runtime/fail)
-(def create-phase-executor runtime/create-phase-executor)
-(def execute-phase runtime/execute-phase)
-(def can-execute? runtime/can-execute?)
-(def get-phase-requirements runtime/get-phase-requirements)
-(def run-workflow runtime/run-workflow)
+(def create-workflow
+  "Construct a new in-memory SimpleWorkflow instance (Workflow protocol).
+   No args. Returns the workflow object used as `this` in the lifecycle fns."
+  runtime/create-workflow)
+
+(def add-observer
+  "Register a WorkflowObserver on a workflow. Args: [workflow observer].
+   Returns the workflow with the observer attached."
+  runtime/add-observer)
+
+(def remove-observer
+  "Detach a previously-registered WorkflowObserver. Args: [workflow observer].
+   Returns the workflow without that observer."
+  runtime/remove-observer)
+
+(def start
+  "Start a new run from a spec. Args: [workflow spec context]; spec is
+   {:title :description}, context is {:llm-backend :budget :tags}. Returns
+   the workflow-id (UUID)."
+  runtime/start)
+
+(def get-state
+  "Read current run state. Args: [workflow workflow-id]. Returns the state
+   map {:workflow/phase :workflow/status :workflow/artifacts ...}, or nil
+   when the id is unknown."
+  runtime/get-state)
+
+(def advance
+  "Advance a run to its next phase from a phase result. Args:
+   [workflow workflow-id phase-result] where phase-result is
+   {:success? :artifacts :errors :metrics}. Returns the updated state map."
+  runtime/advance)
+
+(def rollback
+  "Roll a run back to an earlier phase. Args:
+   [workflow workflow-id target-phase reason]. Returns the updated state
+   map; transitions to :failed status once max-rollbacks is exceeded."
+  runtime/rollback)
+
+(def complete
+  "Mark a run complete (phase :done, status :completed). Args:
+   [workflow workflow-id]. Returns the final state map."
+  runtime/complete)
+
+(def fail
+  "Mark a run failed and append the error. Args: [workflow workflow-id error].
+   Returns the final state map with status :failed."
+  runtime/fail)
+
+(def create-phase-executor
+  "Build a PhaseExecutor for a phase keyword. Args: [phase llm-backend].
+   Returns an executor for :plan/:implement/:verify/:release, or nil for
+   phases with no dedicated executor."
+  runtime/create-phase-executor)
+
+(def execute-phase
+  "Run the current phase via a PhaseExecutor. Args:
+   [executor workflow-state context]. Returns
+   {:success? :artifacts :errors :metrics}."
+  runtime/execute-phase)
+
+(def can-execute?
+  "Test whether a PhaseExecutor handles a phase. Args: [executor phase].
+   Returns boolean."
+  runtime/can-execute?)
+
+(def get-phase-requirements
+  "Required/optional inputs for a phase from a PhaseExecutor. Args:
+   [executor phase]. Returns
+   {:required-artifacts [...] :optional-artifacts [...]}."
+  runtime/get-phase-requirements)
+
+(def run-workflow
+  "Drive a run end-to-end from spec to a terminal state. Args:
+   [workflow spec context]. Loops execute-phase/advance until the run is
+   :completed or :failed. Returns the final state map."
+  runtime/run-workflow)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Supervision machine
 
-(def supervision-states supervision/supervision-states)
-(def supervision-terminal-states supervision/terminal-states)
-(def supervision-transitions supervision/supervision-transitions)
-(def valid-supervision-state? supervision/valid-state?)
-(def supervision-terminal-state? supervision/terminal-state?)
-(def valid-supervision-transition? supervision/valid-transition?)
-(def next-supervision-state supervision/next-state)
-(def transition-supervision supervision/transition)
-(def get-supervision-events supervision/get-available-events)
-(def supervision-machine-graph supervision/machine-graph)
-(def initialize-supervision supervision/initialize)
-(def transition-supervision-fsm supervision/transition-fsm)
-(def current-supervision-state supervision/current-state)
-(def final-supervision-state? supervision/is-final?)
+(def supervision-states
+  "Set of all per-run supervision state keywords (keys of the machine config)."
+  supervision/supervision-states)
+
+(def supervision-terminal-states
+  "Set of supervision state keywords whose config type is :final."
+  supervision/terminal-states)
+
+(def supervision-transitions
+  "Map of [from-state event] -> to-state for the supervision machine."
+  supervision/supervision-transitions)
+
+(def valid-supervision-state?
+  "Predicate: is the keyword a known supervision state? Args: [state].
+   Returns boolean."
+  supervision/valid-state?)
+
+(def supervision-terminal-state?
+  "Predicate: is the supervision state terminal? Args: [state]. Returns
+   boolean."
+  supervision/terminal-state?)
+
+(def valid-supervision-transition?
+  "Predicate: is [current-state event] a defined transition? Args:
+   [current-state event]. Returns boolean."
+  supervision/valid-transition?)
+
+(def next-supervision-state
+  "Resolve the target state for a transition. Args: [current-state event].
+   Returns the to-state keyword, or nil when no such transition exists."
+  supervision/next-state)
+
+(def transition-supervision
+  "Attempt a pure supervision transition (optionally guarded). Args:
+   [current-state event] or [current-state event guard-fn]. Returns
+   {:success? true :state new-state} on success, or
+   {:success? false :error keyword :message string} on rejection."
+  supervision/transition)
+
+(def get-supervision-events
+  "List events available from a state. Args: [current-state]. Returns a
+   vector of event keywords."
+  supervision/get-available-events)
+
+(def supervision-machine-graph
+  "Graph-style view of the supervision machine. No args. Returns
+   {:states set :transitions [{:from :event :to} ...] :terminal-states set}."
+  supervision/machine-graph)
+
+(def initialize-supervision
+  "Initialize a compiled-FSM supervision state. No args. Returns the
+   shared-FSM state map at the machine's initial state."
+  supervision/initialize)
+
+(def transition-supervision-fsm
+  "Transition the compiled-FSM supervision state. Args: [state event].
+   Returns the new shared-FSM state map."
+  supervision/transition-fsm)
+
+(def current-supervision-state
+  "Read the current state keyword from a compiled-FSM state map. Args:
+   [state]. Returns the state keyword."
+  supervision/current-state)
+
+(def final-supervision-state?
+  "Predicate: is the compiled-FSM state map in a final state? Args:
+   [state]. Returns boolean."
+  supervision/is-final?)
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Pipeline, configurable workflows, persistence, and registry helpers
 
-(def run-pipeline pipeline/run-pipeline)
-(def build-pipeline pipeline/build-pipeline)
-(def validate-pipeline pipeline/validate-pipeline)
-(def load-checkpoint-data checkpoints/load-checkpoint-data)
-(def run-chain pipeline/run-chain)
-(def load-chain pipeline/load-chain)
-(def list-chains pipeline/list-chains)
+(def run-pipeline
+  "Execute a workflow's interceptor pipeline end-to-end. Args:
+   [workflow input] or [workflow input opts]. Acquires the execution
+   environment, runs phases, validates, publishes, and always cleans up.
+   Returns the final execution context map; throws a slingshot anomaly on
+   governed-mode misconfiguration."
+  pipeline/run-pipeline)
 
-(def load-workflow configurable/load-workflow)
-(def execute-workflow configurable/execute-workflow)
-(def get-active-workflow configurable/get-active-workflow)
-(def set-active-workflow configurable/set-active-workflow)
-(def append-event configurable/append-event)
-(def load-event-log configurable/load-event-log)
-(def replay-workflow configurable/replay-workflow)
-(def verify-determinism configurable/verify-determinism)
-(def save-workflow configurable/save-workflow)
-(def list-workflows configurable/list-workflows)
-(def compare-workflows configurable/compare-workflows)
-(def create-directory-publisher configurable/create-directory-publisher)
-(def publish-output! configurable/publish-output!)
-(def create-event-trigger configurable/create-event-trigger)
-(def create-merge-trigger configurable/create-merge-trigger)
-(def stop-trigger! configurable/stop-trigger!)
+(def build-pipeline
+  "Build the interceptor pipeline from a workflow config. Args: [workflow].
+   Returns a vector of phase interceptors."
+  pipeline/build-pipeline)
 
-(def load-state-profile-provider profiles/load-state-profile-provider)
-(def available-state-profile-ids profiles/available-state-profile-ids)
-(def default-state-profile-id profiles/default-state-profile-id)
-(def resolve-state-profile profiles/resolve-state-profile)
+(def validate-pipeline
+  "Validate a workflow's pipeline (phase + execution-machine checks). Args:
+   [workflow]. Returns {:valid? boolean :errors [...] :warnings [...]}."
+  pipeline/validate-pipeline)
 
-(def register-workflow! registry/register-workflow!)
-(def get-workflow registry/get-workflow)
-(def list-workflow-ids registry/list-workflow-ids)
-(def workflow-exists? registry/workflow-exists?)
-(def workflow-characteristics registry/workflow-characteristics)
-(def ensure-initialized! registry/ensure-initialized!)
-(def valid-recommendation? registry/valid-recommendation?)
-(def explain-recommendation registry/explain-recommendation)
+(def load-checkpoint-data
+  "Load durable checkpoint data for a run and validate it at the boundary.
+   Args: [workflow-run-id] or [workflow-run-id opts]. Returns the validated
+   checkpoint-data map, or nil when no checkpoint exists; throws ex-info
+   when a found checkpoint fails schema validation."
+  checkpoints/load-checkpoint-data)
+
+(def run-chain
+  "Run a sequence of workflows, feeding each step's output into the next.
+   Args: [chain-def chain-input opts]. Returns
+   {:chain/id :chain/status (:completed|:failed) :chain/step-results
+   :chain/step-count :chain/duration-ms}."
+  pipeline/run-chain)
+
+(def load-chain
+  "Load a chain definition from classpath resources. Args: [chain-id version].
+   Returns the chain-def result map; throws a :not-found anomaly when no
+   matching chain resource exists."
+  pipeline/load-chain)
+
+(def list-chains
+  "List all chain definitions on the classpath. No args. Returns a vector of
+   summary maps {:id :version :description :steps}."
+  pipeline/list-chains)
+
+(def load-workflow
+  "Load a configurable workflow config (cache -> resource -> heuristic store),
+   validating unless skipped. Args: [workflow-id version] or
+   [workflow-id version opts]. Returns
+   {:workflow :source (:resource|:store|:cache) :validation}; throws an
+   anomaly on parse failure, validation failure, or not-found."
+  configurable/load-workflow)
+
+(def execute-workflow
+  "Execute a loaded configurable workflow against an input. Args:
+   [workflow input] or [workflow input opts]. Returns the final execution
+   context map."
+  configurable/execute-workflow)
+
+(def get-active-workflow
+  "Read the active workflow selection for a task type. Args: [task-type].
+   Returns {:workflow-id :version}, or nil when none is set."
+  configurable/get-active-workflow)
+
+(def set-active-workflow
+  "Persist the active workflow selection for a task type. Args:
+   [task-type workflow-id version]. Returns true on success, false on I/O
+   error."
+  configurable/set-active-workflow)
+
+(def append-event
+  "Append a log event to a run's event log file. Args: [workflow-id event].
+   Returns true on success, false on I/O error."
+  configurable/append-event)
+
+(def load-event-log
+  "Load all events for a run from its event log. Args: [workflow-id].
+   Returns a vector of event maps, empty when the log is absent."
+  configurable/load-event-log)
+
+(def replay-workflow
+  "Reconstruct run state by replaying an event stream. Args:
+   [events & {:keys [workflow-id until]}]. Returns
+   {:state :events-applied :final-status}."
+  configurable/replay-workflow)
+
+(def verify-determinism
+  "Replay events and compare to an expected state. Args:
+   [events expected-state & {:keys [workflow-id until]}]. Returns
+   {:deterministic? boolean :differences [...] :replayed-state :events-applied}."
+  configurable/verify-determinism)
+
+(def save-workflow
+  "Persist a workflow config to the heuristic store. Args: [workflow] or
+   [workflow opts]. Returns the saved workflow's UUID."
+  configurable/save-workflow)
+
+(def list-workflows
+  "List workflow metadata discovered on the classpath. No args. Returns a
+   vector of maps {:workflow/id :workflow/version :workflow/type
+   :workflow/description ...}."
+  configurable/list-workflows)
+
+(def compare-workflows
+  "Compare multiple execution states side by side. Args: [execution-states].
+   Returns {:executions [summary ...] :comparison {:total-executions
+   :completed-count :failed-count :avg-tokens :avg-cost :avg-duration}}."
+  configurable/compare-workflows)
+
+(def create-directory-publisher
+  "Build a directory publisher descriptor for workflow outputs. Args:
+   [output-dir] or [output-dir opts]. Returns a publisher map
+   {:publisher/type :directory :publisher/output-dir :publisher/default-format}."
+  configurable/create-directory-publisher)
+
+(def publish-output!
+  "Write a publication via a publisher. Args: [publisher publication] or
+   [publisher publication logger]. Returns
+   {:success? true :publication/path ...} on success, or
+   {:success? false :error string} for an unknown publisher type."
+  configurable/publish-output!)
+
+(def create-event-trigger
+  "Subscribe to an event stream and fire workflows on matching events. Args:
+   [event-stream trigger-config opts]. Returns
+   {:subscriber-id keyword :stop-fn (fn [])}."
+  configurable/create-event-trigger)
+
+(def create-merge-trigger
+  "Compatibility alias for PR-merge triggered workflows; same contract as
+   create-event-trigger. Args: [event-stream trigger-config opts]. Returns
+   {:subscriber-id keyword :stop-fn (fn [])}."
+  configurable/create-merge-trigger)
+
+(def stop-trigger!
+  "Stop a trigger: unsubscribe and cancel pending work. Args:
+   [trigger-handle] (the map returned by create-event-trigger). Returns nil."
+  configurable/stop-trigger!)
+
+(def load-state-profile-provider
+  "Build the state-profile provider by merging app-owned registry.edn
+   resources on the classpath. No args. Returns a provider object, or nil
+   when no profiles are contributed."
+  profiles/load-state-profile-provider)
+
+(def available-state-profile-ids
+  "List the profile ids the active provider exposes. No args. Returns a
+   vector of profile ids (empty when no provider is present)."
+  profiles/available-state-profile-ids)
+
+(def default-state-profile-id
+  "Read the provider's default profile id. No args. Returns the id keyword,
+   or nil when no provider/default is configured."
+  profiles/default-state-profile-id)
+
+(def resolve-state-profile
+  "Resolve a profile to its concrete config. Args: [profile] (nil for the
+   default, a keyword id, or an inline profile). Returns the resolved
+   profile map, or nil when no provider is present."
+  profiles/resolve-state-profile)
+
+(def register-workflow!
+  "Validate and register a workflow definition. Args: [workflow]. Returns
+   the registered workflow; throws an anomaly when :workflow/id is missing
+   or validation fails."
+  registry/register-workflow!)
+
+(def get-workflow
+  "Fetch a registered workflow by id. Args: [workflow-id]. Returns the
+   workflow definition map, or nil when absent."
+  registry/get-workflow)
+
+(def list-workflow-ids
+  "List ids of all registered workflows. No args. Returns a seq of workflow
+   id keywords."
+  registry/list-workflow-ids)
+
+(def workflow-exists?
+  "Predicate: is a workflow id registered? Args: [workflow-id]. Returns
+   boolean."
+  registry/workflow-exists?)
+
+(def workflow-characteristics
+  "Derive selection characteristics from a workflow, validated against the
+   WorkflowCharacteristics schema. Args: [workflow]. Returns
+   {:id :version :name :description :phases :max-iterations :task-types
+   :complexity (:simple|:medium|:complex) :has-review :has-testing}; throws
+   an anomaly when the computed characteristics fail validation."
+  registry/workflow-characteristics)
+
+(def ensure-initialized!
+  "Idempotently load workflows from resources into the registry. No args.
+   Returns the count of workflows in the registry."
+  registry/ensure-initialized!)
+
+(def valid-recommendation?
+  "Predicate: does a value satisfy the WorkflowRecommendation schema? Args:
+   [value]. Returns boolean."
+  registry/valid-recommendation?)
+
+(def explain-recommendation
+  "Humanize WorkflowRecommendation schema errors for a value. Args: [value].
+   Returns the humanized malli explanation, or nil when the value is valid."
+  registry/explain-recommendation)
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; FSM compile + visualization (Phase 6 of the FSM RFC)

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -68,7 +68,10 @@
 
 (def create-workflow
   "Construct a new in-memory SimpleWorkflow instance (Workflow protocol).
-   No args. Returns the workflow object used as `this` in the lifecycle fns."
+   Args: [] or [config]. The optional config map is merged over the defaults
+   {:max-iterations-per-phase 5, :max-rollbacks 3, :timeout-per-phase-ms 600000};
+   omit it to use the defaults. Returns the workflow object used as `this` in
+   the lifecycle fns."
   runtime/create-workflow)
 
 (def add-observer

--- a/components/workflow/src/ai/miniforge/workflow/interface/configurable.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/configurable.clj
@@ -42,10 +42,26 @@
   ([workflow input opts]
    (configurable/run-configurable-workflow workflow input opts)))
 
-(def get-active-workflow persist/get-active-workflow-id)
-(def set-active-workflow persist/set-active-workflow)
-(def append-event persist/append-event)
-(def load-event-log persist/load-event-log)
+(def get-active-workflow
+  "Read the active workflow selection for a task type. Args: [task-type].
+   Returns {:workflow-id :version}, or nil when none is set."
+  persist/get-active-workflow-id)
+
+(def set-active-workflow
+  "Persist the active workflow selection for a task type. Args:
+   [task-type workflow-id version]. Returns true on success, false on I/O
+   error."
+  persist/set-active-workflow)
+
+(def append-event
+  "Append a log event to a run's event log file. Args: [workflow-id event].
+   Returns true on success, false on I/O error."
+  persist/append-event)
+
+(def load-event-log
+  "Load all events for a run from its event log. Args: [workflow-id].
+   Returns a vector of event maps, empty when the log is absent."
+  persist/load-event-log)
 
 (defn replay-workflow
   [events & {:keys [workflow-id until] :as _opts}]

--- a/components/workflow/src/ai/miniforge/workflow/interface/pipeline.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/pipeline.clj
@@ -26,9 +26,23 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pipeline API
 
-(def run-pipeline runner/run-pipeline)
-(def build-pipeline runner/build-pipeline)
-(def validate-pipeline runner/validate-pipeline)
+(def run-pipeline
+  "Execute a workflow's interceptor pipeline end-to-end. Args:
+   [workflow input] or [workflow input opts]. Acquires the execution
+   environment, runs phases, validates, publishes, and always cleans up.
+   Returns the final execution context map; throws a slingshot anomaly on
+   governed-mode misconfiguration."
+  runner/run-pipeline)
+
+(def build-pipeline
+  "Build the interceptor pipeline from a workflow config. Args: [workflow].
+   Returns a vector of phase interceptors."
+  runner/build-pipeline)
+
+(def validate-pipeline
+  "Validate a workflow's pipeline (phase + execution-machine checks). Args:
+   [workflow]. Returns {:valid? boolean :errors [...] :warnings [...]}."
+  runner/validate-pipeline)
 
 (defn run-chain
   [chain-def chain-input opts]

--- a/components/workflow/src/ai/miniforge/workflow/interface/protocols.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/protocols.clj
@@ -27,8 +27,30 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol re-exports
 
-(def Workflow workflow-proto/Workflow)
-(def PhaseExecutor executor-proto/PhaseExecutor)
-(def WorkflowObserver observer-proto/WorkflowObserver)
-(def phases workflow-impl/phases)
-(def phase-transitions workflow-impl/phase-transitions)
+(def Workflow
+  "Protocol governing workflow execution: start/get-state/advance/rollback/
+   complete/fail. Main extensibility point for custom workflow
+   implementations."
+  workflow-proto/Workflow)
+
+(def PhaseExecutor
+  "Protocol for executing an individual SDLC phase: execute-phase/
+   can-execute?/get-phase-requirements. Extensibility point for custom
+   phase executors."
+  executor-proto/PhaseExecutor)
+
+(def WorkflowObserver
+  "Protocol for observing workflow events (phase start/complete/error,
+   workflow complete, rollback). Extensibility point for operator/
+   meta-loop integration."
+  observer-proto/WorkflowObserver)
+
+(def phases
+  "Ordered vector of SDLC phase keywords:
+   [:spec :plan :design :implement :verify :review :release :observe :done]."
+  workflow-impl/phases)
+
+(def phase-transitions
+  "Map of phase keyword -> set of allowed next-phase keywords. The empty
+   set for :done marks the terminal phase."
+  workflow-impl/phase-transitions)

--- a/components/workflow/src/ai/miniforge/workflow/interface/registry.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/registry.clj
@@ -25,11 +25,46 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Registry and schema helpers
 
-(def register-workflow! registry/register-workflow!)
-(def get-workflow registry/get-workflow)
-(def list-workflow-ids registry/list-workflow-ids)
-(def workflow-exists? registry/workflow-exists?)
-(def workflow-characteristics registry/workflow-characteristics)
-(def ensure-initialized! registry/ensure-initialized!)
-(def valid-recommendation? schemas/valid-recommendation?)
-(def explain-recommendation schemas/explain-recommendation)
+(def register-workflow!
+  "Validate and register a workflow definition. Args: [workflow]. Returns
+   the registered workflow; throws an anomaly when :workflow/id is missing
+   or validation fails."
+  registry/register-workflow!)
+
+(def get-workflow
+  "Fetch a registered workflow by id. Args: [workflow-id]. Returns the
+   workflow definition map, or nil when absent."
+  registry/get-workflow)
+
+(def list-workflow-ids
+  "List ids of all registered workflows. No args. Returns a seq of workflow
+   id keywords."
+  registry/list-workflow-ids)
+
+(def workflow-exists?
+  "Predicate: is a workflow id registered? Args: [workflow-id]. Returns
+   boolean."
+  registry/workflow-exists?)
+
+(def workflow-characteristics
+  "Derive selection characteristics from a workflow, validated against the
+   WorkflowCharacteristics schema. Args: [workflow]. Returns
+   {:id :version :name :description :phases :max-iterations :task-types
+   :complexity (:simple|:medium|:complex) :has-review :has-testing}; throws
+   an anomaly when the computed characteristics fail validation."
+  registry/workflow-characteristics)
+
+(def ensure-initialized!
+  "Idempotently load workflows from resources into the registry. No args.
+   Returns the count of workflows in the registry."
+  registry/ensure-initialized!)
+
+(def valid-recommendation?
+  "Predicate: does a value satisfy the WorkflowRecommendation schema? Args:
+   [value]. Returns boolean."
+  schemas/valid-recommendation?)
+
+(def explain-recommendation
+  "Humanize WorkflowRecommendation schema errors for a value. Args: [value].
+   Returns the humanized malli explanation, or nil when the value is valid."
+  schemas/explain-recommendation)

--- a/components/workflow/src/ai/miniforge/workflow/interface/runtime.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/runtime.clj
@@ -26,11 +26,32 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Workflow lifecycle
 
-(def create-workflow core/create-workflow)
-(def add-observer core/add-observer)
-(def remove-observer core/remove-observer)
-(def create-phase-executor core/create-phase-executor)
-(def run-workflow core/run-workflow)
+(def create-workflow
+  "Construct a new in-memory SimpleWorkflow instance (Workflow protocol).
+   No args. Returns the workflow object used as `this` in the lifecycle fns."
+  core/create-workflow)
+
+(def add-observer
+  "Register a WorkflowObserver on a workflow. Args: [workflow observer].
+   Returns the workflow with the observer attached."
+  core/add-observer)
+
+(def remove-observer
+  "Detach a previously-registered WorkflowObserver. Args: [workflow observer].
+   Returns the workflow without that observer."
+  core/remove-observer)
+
+(def create-phase-executor
+  "Build a PhaseExecutor for a phase keyword. Args: [phase llm-backend].
+   Returns an executor for :plan/:implement/:verify/:release, or nil for
+   phases with no dedicated executor."
+  core/create-phase-executor)
+
+(def run-workflow
+  "Drive a run end-to-end from spec to a terminal state. Args:
+   [workflow spec context]. Loops execute-phase/advance until the run is
+   :completed or :failed. Returns the final state map."
+  core/run-workflow)
 
 (defn start
   [workflow spec context]

--- a/components/workflow/src/ai/miniforge/workflow/interface/runtime.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/runtime.clj
@@ -28,7 +28,10 @@
 
 (def create-workflow
   "Construct a new in-memory SimpleWorkflow instance (Workflow protocol).
-   No args. Returns the workflow object used as `this` in the lifecycle fns."
+   Args: [] or [config]. The optional config map is merged over the defaults
+   {:max-iterations-per-phase 5, :max-rollbacks 3, :timeout-per-phase-ms 600000};
+   omit it to use the defaults. Returns the workflow object used as `this` in
+   the lifecycle fns."
   core/create-workflow)
 
 (def add-observer

--- a/components/workflow/src/ai/miniforge/workflow/interface/supervision.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/supervision.clj
@@ -24,25 +24,77 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; State and transition definitions
 
-(def supervision-states supervision/supervision-states)
-(def terminal-states supervision/terminal-states)
-(def supervision-transitions supervision/supervision-transitions)
+(def supervision-states
+  "Set of all per-run supervision state keywords (keys of the machine config)."
+  supervision/supervision-states)
+
+(def terminal-states
+  "Set of supervision state keywords whose config type is :final."
+  supervision/terminal-states)
+
+(def supervision-transitions
+  "Map of [from-state event] -> to-state for the supervision machine."
+  supervision/supervision-transitions)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; State helpers
 
-(def valid-state? supervision/valid-state?)
-(def terminal-state? supervision/terminal-state?)
-(def valid-transition? supervision/valid-transition?)
-(def next-state supervision/next-state)
-(def transition supervision/transition)
-(def get-available-events supervision/get-available-events)
-(def machine-graph supervision/machine-graph)
+(def valid-state?
+  "Predicate: is the keyword a known supervision state? Args: [state].
+   Returns boolean."
+  supervision/valid-state?)
+
+(def terminal-state?
+  "Predicate: is the supervision state terminal? Args: [state]. Returns
+   boolean."
+  supervision/terminal-state?)
+
+(def valid-transition?
+  "Predicate: is [current-state event] a defined transition? Args:
+   [current-state event]. Returns boolean."
+  supervision/valid-transition?)
+
+(def next-state
+  "Resolve the target state for a transition. Args: [current-state event].
+   Returns the to-state keyword, or nil when no such transition exists."
+  supervision/next-state)
+
+(def transition
+  "Attempt a pure supervision transition (optionally guarded). Args:
+   [current-state event] or [current-state event guard-fn]. Returns
+   {:success? true :state new-state} on success, or
+   {:success? false :error keyword :message string} on rejection."
+  supervision/transition)
+
+(def get-available-events
+  "List events available from a state. Args: [current-state]. Returns a
+   vector of event keywords."
+  supervision/get-available-events)
+
+(def machine-graph
+  "Graph-style view of the supervision machine. No args. Returns
+   {:states set :transitions [{:from :event :to} ...] :terminal-states set}."
+  supervision/machine-graph)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Shared FSM surface
 
-(def initialize supervision/initialize)
-(def transition-fsm supervision/transition-fsm)
-(def current-state supervision/current-state)
-(def is-final? supervision/is-final?)
+(def initialize
+  "Initialize a compiled-FSM supervision state. No args. Returns the
+   shared-FSM state map at the machine's initial state."
+  supervision/initialize)
+
+(def transition-fsm
+  "Transition the compiled-FSM supervision state. Args: [state event].
+   Returns the new shared-FSM state map."
+  supervision/transition-fsm)
+
+(def current-state
+  "Read the current state keyword from a compiled-FSM state map. Args:
+   [state]. Returns the state keyword."
+  supervision/current-state)
+
+(def is-final?
+  "Predicate: is the compiled-FSM state map in a final state? Args:
+   [state]. Returns boolean."
+  supervision/is-final?)

--- a/components/workflow/src/ai/miniforge/workflow/publish.clj
+++ b/components/workflow/src/ai/miniforge/workflow/publish.clj
@@ -80,7 +80,6 @@
      :publication/output-dir (str output-dir)}))
 
 (defn publish!
-  "Publish a workflow output using the configured publisher."
   ([publisher publication]
    (publish! publisher publication nil))
   ([publisher publication logger]

--- a/components/workflow/src/ai/miniforge/workflow/supervision.clj
+++ b/components/workflow/src/ai/miniforge/workflow/supervision.clj
@@ -86,22 +86,18 @@
 ;; Legacy-style helper API
 
 (defn valid-state?
-  "Check if a supervision state keyword is valid."
   [state]
   (contains? supervision-states state))
 
 (defn terminal-state?
-  "Check if a supervision state is terminal."
   [state]
   (contains? terminal-states state))
 
 (defn valid-transition?
-  "Check if a supervision transition is valid."
   [current-state event]
   (contains? supervision-transitions [current-state event]))
 
 (defn next-state
-  "Get the next state for a supervision transition."
   [current-state event]
   (get supervision-transitions [current-state event]))
 
@@ -145,22 +141,18 @@
         :state (fsm/current-state new-state-map)}))))
 
 (defn initialize
-  "Initialize supervision state."
   []
   (fsm/initialize supervision-machine))
 
 (defn transition-fsm
-  "Transition supervision state using the compiled shared FSM."
   [state event]
   (fsm/transition supervision-machine state event))
 
 (defn current-state
-  "Read the current supervision state keyword."
   [state]
   (fsm/current-state state))
 
 (defn is-final?
-  "Check if the compiled machine state is final."
   [state]
   (fsm/final? supervision-machine state))
 


### PR DESCRIPTION
Boundary-documentation rollout (rule 009). Both interface tiers now carry contract docstrings (both consumed; types verified from impl). Duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change. Commit-budget override (mechanical doc-only); poly:check + smoke + GraalVM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)