### PR TITLE
fix(llm): pass --strict-mcp-config so host MCP config can't leak into agents

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -526,7 +526,20 @@
       streaming?                   (conj "--verbose")
       stdin?                       (conj claude-input-format-flag
                                          claude-input-format-stdin)
-      mcp-config                   (into ["--mcp-config" mcp-config])
+      ;; --strict-mcp-config: only load the MCP servers from our
+      ;; --mcp-config, ignoring the host's user/project MCP config. On
+      ;; the local worktree executor the agent CLI otherwise inherits the
+      ;; operator's personal ~/.claude MCP servers (e.g. Gmail / Calendar
+      ;; / Drive), whose tool schemas bloat the agent's fixed context
+      ;; overhead. On 2026-06-07 that leakage pushed the planner's
+      ;; first-turn prompt past the 200k window — a single ToolSearch
+      ;; result tipped it over and the CLI returned "Prompt is too long"
+      ;; (plan phase, review-redirect-convergence dogfood adhoc-2135293220).
+      ;; The container executor is already isolated from host config; this
+      ;; brings the local runner to parity for the MCP vector. Mirrors the
+      ;; codex builder's --ignore-user-config.
+      mcp-config                   (into ["--mcp-config" mcp-config
+                                          "--strict-mcp-config"])
       (seq mcp-allowed-tools)      (into ["--allowedTools" (claude-mcp-allowlist-string mcp-allowed-tools)])
       (seq disallowed-tools)       (into ["--disallowedTools" (str/join "," disallowed-tools)])
       (:settings-path supervision) (into ["--settings" (:settings-path supervision)])

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -50,7 +50,20 @@
   (testing "mcp-config adds --mcp-config flag"
     (let [args ((private-fn 'claude-args) {:prompt "p" :mcp-config "/tmp/mcp.json"})]
       (is (some #(= "--mcp-config" %) args))
-      (is (some #(= "/tmp/mcp.json" %) args)))))
+      (is (some #(= "/tmp/mcp.json" %) args))))
+
+  (testing "mcp-config also adds --strict-mcp-config so host MCP config does not leak"
+    (let [args ((private-fn 'claude-args) {:prompt "p" :mcp-config "/tmp/mcp.json"})]
+      (is (some #(= "--strict-mcp-config" %) args))
+      (is (= ["--mcp-config" "/tmp/mcp.json" "--strict-mcp-config"]
+             (->> args
+                  (drop-while #(not= "--mcp-config" %))
+                  (take 3)))
+          "--strict-mcp-config immediately follows the --mcp-config path")))
+
+  (testing "no mcp-config means no --strict-mcp-config"
+    (let [args ((private-fn 'claude-args) {:prompt "p"})]
+      (is (not (some #(= "--strict-mcp-config" %) args))))))
 
 (deftest claude-args-allowed-tools-test
   (testing "mcp maps format as mcp__<server>__<tool>, joined with commas"


### PR DESCRIPTION
## Summary

The Claude backend arg-builder (`claude-args` in `llm_client.clj`) passed `--mcp-config` but **not** `--strict-mcp-config`. Without that flag the agent CLI *merges* miniforge's `context` MCP server with the operator's personal `~/.claude` MCP servers. On the local worktree executor that meant the planner/implementer/reviewer subprocesses inherited the operator's Gmail / Calendar / Drive servers, whose tool schemas inflate the agent's fixed (non-conversational) context overhead.

### Why it matters — 2026-06-07 dogfood regression

`review-redirect-convergence` (dogfood `adhoc-2135293220`) **failed at the plan phase** and never reached the DAG. The planner (`claude-opus-4-6`, 200k window) emitted one turn, called `ToolSearch`, and the tool result tipped the prompt past 200k → the CLI's auto-compaction reported `too_few_groups` (one-turn conversation, nothing to compact — the bloat is all fixed system-prompt/tool overhead) → **"Prompt is too long"**. The same spec planned fine ~24h earlier; the regression vector is operator-environment growth leaking into the local executor's agent.

The **container executor is already isolated** from host config, so this is a local-runner-only artifact. This change brings the local runner to parity for the MCP vector, and mirrors the codex builder's existing `--ignore-user-config`.

### Scope

- MCP vector only (surgical). The plugin/skill slash-command leak is **not** addressed here — that requires `--bare`, which switches agent auth from OAuth/subscription to `ANTHROPIC_API_KEY` (pay-per-token) and is deferred pending input-token data (see follow-up PR that records planner input-prompt size).

## Test plan

- `args-fn-test`: asserts `--strict-mcp-config` is emitted immediately after the `--mcp-config <path>` pair when `:mcp-config` is set, and is absent otherwise.
- `bb pre-commit` green (poly check + lint + smoke + GraalVM/bb compat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)