### PR TITLE
docs(connectors): document interface boundaries — linter/http/sarif (rule 009)

### DIFF
--- a/components/connector-http/src/ai/miniforge/connector_http/cursors.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/cursors.clj
@@ -29,7 +29,6 @@
 ;; Timestamp parsing
 
 (defn parse-timestamp
-  "Parse an ISO-8601 timestamp string to Instant, or nil if blank/nil."
   [value]
   (when (and (string? value) (not (str/blank? value)))
     (Instant/parse value)))
@@ -38,9 +37,6 @@
 ;; Per-record cursor predicates and builders
 
 (defn after-cursor?
-  "True if record's timestamp is strictly after the cursor timestamp.
-   timestamp-fn: (fn [record] iso-string-or-nil)
-   Always returns true when cursor is nil (no prior watermark)."
   [timestamp-fn cursor record]
   (if-let [cursor-ts (some-> cursor :cursor/value parse-timestamp)]
     (some-> (timestamp-fn record)
@@ -49,8 +45,6 @@
     true))
 
 (defn last-record-cursor
-  "Compute a :timestamp-watermark cursor from the last record's :updated_at or :created_at.
-   Returns nil if records is empty or resource-def :cursor-type is not :timestamp-watermark."
   [resource-def records]
   (when-let [last-record (last records)]
     (when (= :timestamp-watermark (:cursor-type resource-def))
@@ -62,15 +56,10 @@
 ;; Collection-level cursor operations
 
 (defn sort-by-timestamp
-  "Sort records ascending by timestamp. Records with nil timestamps sort first.
-   timestamp-fn: (fn [record] iso-string-or-nil)"
   [timestamp-fn records]
   (sort-by #(or (timestamp-fn %) "") records))
 
 (defn max-timestamp-cursor
-  "Compute a :timestamp-watermark cursor from the maximum timestamp across records.
-   Returns nil if records is empty or none have a timestamp.
-   timestamp-fn: (fn [record] iso-string-or-nil)"
   [timestamp-fn records]
   (when-let [latest-ts (some->> records (keep timestamp-fn) sort last)]
     {:cursor/type  :timestamp-watermark

--- a/components/connector-http/src/ai/miniforge/connector_http/interface.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/interface.clj
@@ -40,21 +40,84 @@
    :connector/maintainer   "data-foundry"})
 
 ;; -- Cursor utilities (shared by HTTP-based source connectors) --
-(def after-cursor?        cursors/after-cursor?)
-(def last-record-cursor   cursors/last-record-cursor)
-(def max-timestamp-cursor cursors/max-timestamp-cursor)
-(def sort-by-timestamp    cursors/sort-by-timestamp)
-(def parse-timestamp      cursors/parse-timestamp)
+(def after-cursor?
+  "Predicate (fn [timestamp-fn cursor record] boolean): true if the record's
+   timestamp is strictly after the cursor's :cursor/value watermark. timestamp-fn
+   extracts an ISO-8601 string (or nil) from a record. Returns true when cursor is
+   nil (no prior watermark)."
+  cursors/after-cursor?)
+(def last-record-cursor
+  "(fn [resource-def records] cursor-map-or-nil): build a :timestamp-watermark
+   cursor map {:cursor/type :timestamp-watermark :cursor/value iso-string} from the
+   last record's :updated_at or :created_at. Returns nil when records is empty or
+   the resource-def :cursor-type is not :timestamp-watermark."
+  cursors/last-record-cursor)
+(def max-timestamp-cursor
+  "(fn [timestamp-fn records] cursor-map-or-nil): build a :timestamp-watermark
+   cursor map {:cursor/type :timestamp-watermark :cursor/value iso-string} from the
+   maximum timestamp across records. timestamp-fn extracts an ISO-8601 string (or
+   nil) per record. Returns nil when records is empty or none carry a timestamp."
+  cursors/max-timestamp-cursor)
+(def sort-by-timestamp
+  "(fn [timestamp-fn records] sorted-seq): sort records ascending by timestamp.
+   timestamp-fn extracts an ISO-8601 string (or nil) per record; records with nil
+   timestamps sort first."
+  cursors/sort-by-timestamp)
+(def parse-timestamp
+  "(fn [value] Instant-or-nil): parse an ISO-8601 timestamp string to a
+   java.time.Instant. Returns nil when value is nil, non-string, or blank; throws
+   on a malformed non-blank string."
+  cursors/parse-timestamp)
 
 ;; -- Request utilities (shared by HTTP-based source connectors) --
-(def coerce-records    request/coerce-records)
-(def do-request        request/do-request)
-(def error-response    request/error-response)
-(def next-url          request/next-url)
-(def throw-on-failure! request/throw-on-failure!)
+(def coerce-records
+  "(fn [body] vector): coerce a parsed response body to a vector of records. A
+   sequential body is returned as a vector; any other value is wrapped in a
+   single-element vector."
+  request/coerce-records)
+(def do-request
+  "(fn [url headers query-params error-fn] result): execute an HTTP GET, applying
+   ETag conditional-request handling (If-None-Match). Returns a schema/success
+   (2xx or 304 Not Modified) or schema/failure. error-fn (fn [status resp] failure)
+   supplies connector-specific error messages for non-success, non-304 responses."
+  request/do-request)
+(def error-response
+  "(fn [status resp msgs] failure): build a schema/failure from a non-success,
+   non-304 response. msgs map: {:rate-limited string :request-failed (fn [status
+   err-str] string)}. The :error-type in failure metadata is :rate-limited (429),
+   :transient (5xx), or :permanent (other 4xx)."
+  request/error-response)
+(def next-url
+  "(fn [resp] string-or-nil): extract the 'next' page URL from the response's Link
+   header. Returns nil when no Link header or no next relation is present."
+  request/next-url)
+(def throw-on-failure!
+  "(fn [result] result): return result unchanged on success; on failure throw an
+   ExceptionInfo carrying :anomaly/category :anomalies/unavailable and the legacy
+   :error-type key in ex-data."
+  request/throw-on-failure!)
 
 ;; -- Rate-limit utilities --
-(def acquire-permit!     rate-limit/acquire-permit!)
-(def parse-rate-headers  rate-limit/parse-rate-headers)
-(def time-based-acquire! rate-limit/time-based-acquire!)
-(def update-rate-state!  rate-limit/update-rate-state!)
+(def acquire-permit!
+  "(fn [handles-atom handle opts] nil): side-effecting. Inspect the handle's stored
+   rate-limit state and block (via a non-blocking scheduled delay, capped at 60s)
+   when remaining requests fall below the threshold. opts: {:threshold long}
+   overrides the default (10). Returns nil."
+  rate-limit/acquire-permit!)
+(def parse-rate-headers
+  "(fn [headers mapping] info-map-or-nil): extract rate-limit info from response
+   headers. mapping: {:remaining header :reset header :limit header}. Returns
+   {:remaining long :reset-epoch long :limit long-or-nil}, or nil when the
+   remaining/reset headers are absent or unparseable."
+  rate-limit/parse-rate-headers)
+(def time-based-acquire!
+  "(fn [rps last-request-ms] epoch-ms): side-effecting. Sleep if needed to honor an
+   rps (requests-per-second) limit given the prior request's epoch-millis (0 or nil
+   means no prior request). Returns the current epoch-millis for use as the next
+   last-request-at."
+  rate-limit/time-based-acquire!)
+(def update-rate-state!
+  "(fn [handles-atom handle rate-info] state-or-nil): side-effecting. Store
+   rate-info under [handle :rate-limit] in the handles atom via swap!. No-op
+   returning nil when rate-info is nil."
+  rate-limit/update-rate-state!)

--- a/components/connector-http/src/ai/miniforge/connector_http/interface.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/interface.clj
@@ -43,14 +43,16 @@
 (def after-cursor?
   "Predicate (fn [timestamp-fn cursor record] boolean): true if the record's
    timestamp is strictly after the cursor's :cursor/value watermark. timestamp-fn
-   extracts an ISO-8601 string (or nil) from a record. Returns true when cursor is
-   nil (no prior watermark)."
+   extracts an ISO-8601 string (or nil) from a record. Returns true whenever the
+   cursor carries no parseable :cursor/value timestamp — i.e. a nil cursor, a
+   missing :cursor/value, or a blank/malformed one (no prior watermark)."
   cursors/after-cursor?)
 (def last-record-cursor
   "(fn [resource-def records] cursor-map-or-nil): build a :timestamp-watermark
    cursor map {:cursor/type :timestamp-watermark :cursor/value iso-string} from the
-   last record's :updated_at or :created_at. Returns nil when records is empty or
-   the resource-def :cursor-type is not :timestamp-watermark."
+   last record's :updated_at or :created_at. :cursor/value may be nil when the last
+   record carries neither :updated_at nor :created_at. Returns nil when records is
+   empty or the resource-def :cursor-type is not :timestamp-watermark."
   cursors/last-record-cursor)
 (def max-timestamp-cursor
   "(fn [timestamp-fn records] cursor-map-or-nil): build a :timestamp-watermark
@@ -100,9 +102,10 @@
 ;; -- Rate-limit utilities --
 (def acquire-permit!
   "(fn [handles-atom handle opts] nil): side-effecting. Inspect the handle's stored
-   rate-limit state and block (via a non-blocking scheduled delay, capped at 60s)
-   when remaining requests fall below the threshold. opts: {:threshold long}
-   overrides the default (10). Returns nil."
+   rate-limit state and, when remaining requests fall below the threshold, block the
+   calling thread until the rate limit resets (capped at 60s) by deref-ing a promise
+   that a task scheduled on a ScheduledExecutorService delivers. opts: {:threshold
+   long} overrides the default (10). Returns nil."
   rate-limit/acquire-permit!)
 (def parse-rate-headers
   "(fn [headers mapping] info-map-or-nil): extract rate-limit info from response

--- a/components/connector-http/src/ai/miniforge/connector_http/rate_limit.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/rate_limit.clj
@@ -33,9 +33,6 @@
     (try (Long/parseLong (str v)) (catch NumberFormatException _ nil))))
 
 (defn parse-rate-headers
-  "Extract rate limit info from response headers using a provider mapping.
-   mapping: {:remaining \"x-ratelimit-remaining\" :reset \"x-ratelimit-reset\" :limit \"x-ratelimit-limit\"}
-   Returns: {:remaining long :reset-epoch long :limit long} or nil if headers absent."
   [headers mapping]
   (let [remaining (parse-long-header headers (:remaining mapping))
         reset-at  (parse-long-header headers (:reset mapping))
@@ -49,7 +46,6 @@
 ;; State management
 
 (defn update-rate-state!
-  "Store rate limit info in a handle's atom state."
   [handles-atom handle rate-info]
   (when rate-info
     (swap! handles-atom assoc-in [handle :rate-limit] rate-info)))
@@ -70,9 +66,6 @@
   10)
 
 (defn acquire-permit!
-  "Check rate limit state and wait if remaining is below threshold.
-   Uses a ScheduledExecutorService for non-blocking delay.
-   opts: {:threshold long} — override the default remaining threshold."
   [handles-atom handle opts]
   (when-let [rate-info (get-in @handles-atom [handle :rate-limit])]
     (let [remaining (:remaining rate-info)
@@ -91,9 +84,6 @@
 ;; Time-based (interval) rate limiting
 
 (defn time-based-acquire!
-  "Sleep if needed to enforce a requests-per-second limit.
-   Takes rps (number) and last-request-ms (epoch millis; 0 or nil means no prior request).
-   Returns current epoch-ms for use as the new last-request-at timestamp."
   [rps last-request-ms]
   (let [min-interval-ms (/ 1000.0 rps)
         elapsed         (- (System/currentTimeMillis) (or last-request-ms 0))]

--- a/components/connector-http/src/ai/miniforge/connector_http/request.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/request.clj
@@ -64,8 +64,6 @@
   (schema/success :body nil {:headers (:headers resp) :not-modified true}))
 
 (defn error-response
-  "Build a schema/failure from a non-success, non-304 response.
-   msgs map: {:rate-limited string :request-failed (fn [status err-str] string)}"
   [status resp msgs]
   (let [request-failed (:request-failed msgs)]
     (case (classify-error status)
@@ -77,9 +75,6 @@
 ;; Request execution and post-request helpers
 
 (defn do-request
-  "Execute an HTTP GET. Returns schema/success or schema/failure.
-   Supports ETag conditional requests via If-None-Match header.
-   error-fn: (fn [status resp] schema/failure) — supplies connector-specific messages."
   [url headers query-params error-fn]
   (let [resp   (http/get url {:headers      (etag/add-etag-header headers url)
                               :query-params query-params
@@ -106,7 +101,6 @@
   result)
 
 (defn next-url
-  "Extract the 'next' page URL from a response's Link header, or nil."
   [resp]
   (some-> (:headers resp)
           (get "link")
@@ -114,6 +108,5 @@
           page/link-header-next-url))
 
 (defn coerce-records
-  "Coerce a response body to a vector of records."
   [body]
   (if (sequential? body) (vec body) [body]))

--- a/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
@@ -139,14 +139,6 @@
 ;; Apply mapping
 
 (defn apply-mapping
-  "Apply a mapping spec to raw linter output, producing canonical violations.
-
-   Arguments:
-   - mapping — Mapping spec from linter-mappings.edn
-   - output  — Raw linter output string
-
-   Returns:
-   - Vector of violation maps"
   [mapping output]
   (let [linter-id    (get mapping :mapping/id)
         fields       (get mapping :mapping/fields)
@@ -166,7 +158,6 @@
 (def ^:private mappings-resource "connector_linter/linter-mappings.edn")
 
 (def mappings
-  "All linter mappings loaded from classpath EDN."
   (delay
     (if-let [url (io/resource mappings-resource)]
       (let [raw (edn/read-string (slurp url))]
@@ -174,6 +165,5 @@
       {})))
 
 (defn get-mapping
-  "Look up a mapping by linter ID. Returns nil if not found."
   [linter-id]
   (get @mappings linter-id))

--- a/components/connector-linter/src/ai/miniforge/connector_linter/interface.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/interface.clj
@@ -9,12 +9,39 @@
    [ai.miniforge.connector-linter.runner :as runner]))
 
 ;; ETL
-(def apply-mapping etl/apply-mapping)
-(def get-mapping etl/get-mapping)
-(def mappings etl/mappings)
+(def apply-mapping
+  "Apply a mapping spec to raw linter output, producing canonical violations.
+   Args: mapping (spec map from linter-mappings.edn), output (raw linter output
+   string). Returns a vector of violation maps (empty when nothing matches);
+   never nil."
+  etl/apply-mapping)
+(def get-mapping
+  "Look up a mapping spec by linter ID. Args: linter-id (keyword). Returns the
+   mapping map, or nil if no mapping is registered for that ID."
+  etl/get-mapping)
+(def mappings
+  "All linter mappings loaded from classpath EDN, as a `delay`. Deref to obtain
+   a map of {linter-id mapping-spec}; yields {} when the resource is absent."
+  etl/mappings)
 
 ;; Runner
-(def linter-available? runner/linter-available?)
-(def run-linter runner/run-linter)
-(def run-all runner/run-all)
-(def run-fixes runner/run-fixes)
+(def linter-available?
+  "Check whether a linter CLI is available on PATH. Args: check-cmd (command
+   vector). Returns boolean; false on any subprocess failure."
+  runner/linter-available?)
+(def run-linter
+  "Run a single linter and parse its output via the ETL mapping. Args:
+   repo-path, tech-id (keyword), linter-config (map). Returns a map
+   {:tech keyword :violations vector :available? boolean :duration-ms int}."
+  runner/run-linter)
+(def run-all
+  "Run linters for all detected technologies. Args: repo-path, fingerprints
+   (seq of tech fingerprint maps), detected-techs (set of tech-id keywords).
+   Returns a map {:linter-results vector :violations vector
+   :total-violations int :total-duration-ms int}."
+  runner/run-all)
+(def run-fixes
+  "Run linter fix commands for detected technologies. Args: repo-path,
+   fingerprints (seq of tech fingerprint maps), detected-techs (set of tech-id
+   keywords). Returns a map {:fixed vector} of per-tech {:tech :exit} results."
+  runner/run-fixes)

--- a/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
@@ -20,7 +20,6 @@
 ;; No in-namespace dependencies.
 
 (defn linter-available?
-  "Check if a linter CLI is available on PATH."
   [check-cmd]
   (try
     (zero? (:exit (process/sh {:cmd check-cmd :continue true
@@ -49,8 +48,6 @@
 ;; Composes Layer 0.
 
 (defn run-linter
-  "Run a single linter and parse output via ETL mapping.
-   Returns {:tech keyword :violations [...] :available? bool :duration-ms int}."
   [repo-path tech-id linter-config]
   (let [{:keys [command args parser check-cmd]} linter-config
         available? (linter-available? (or check-cmd [command "--version"]))
@@ -73,8 +70,6 @@
 ;; helpers (`lintable-tech`, `linter-available?`, `run-subprocess`).
 
 (defn run-all
-  "Run linters for all detected technologies.
-   Returns {:linter-results [...] :violations [...] :total-violations int :total-duration-ms int}."
   [repo-path fingerprints detected-techs]
   (let [lintable (filter #(lintable-tech detected-techs %) fingerprints)
         results  (mapv (fn [fp]
@@ -87,8 +82,6 @@
      :total-duration-ms (reduce + 0 (map :duration-ms results))}))
 
 (defn run-fixes
-  "Run linter fix commands for detected technologies.
-   Returns {:fixed [...]}."
   [repo-path fingerprints detected-techs]
   (let [fixable (->> fingerprints
                      (filter #(lintable-tech detected-techs %))

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/interface.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/interface.clj
@@ -40,10 +40,37 @@
    :connector/maintainer   "data-foundry"})
 
 ;; Schema exports
-(def SarifViolation schema/SarifViolation)
-(def SarifConfig schema/SarifConfig)
+(def SarifViolation
+  "Malli schema (a `[:map ...]` vector) for a unified violation record,
+   normalized from both SARIF and CSV sources. Required keys:
+   :violation/id, :violation/rule-id, :violation/message (strings),
+   :violation/severity (one of :error/:warning/:note/:none),
+   :violation/location (a map of optional :file/:line/:column),
+   :violation/source-tool (string), :violation/raw (map)."
+  schema/SarifViolation)
 
-(defn validate-config [config] (schema/validate-config config))
-(defn validate-violation [v] (schema/validate-violation v))
-(defn violation-json-schema [] (schema/violation-json-schema))
-(defn config-json-schema [] (schema/config-json-schema))
+(def SarifConfig
+  "Malli schema (a `[:map ...]` vector) for the SARIF connector config.
+   Required key :sarif/source-path (string); optional :sarif/format
+   (:sarif/:csv/:auto) and :sarif/csv-columns (keyword->string map)."
+  schema/SarifConfig)
+
+(defn validate-config
+  "Validate a SARIF connector config map against SarifConfig.
+   Returns a map {:valid? boolean :errors map-or-nil}; :errors holds the
+   humanized Malli error map when invalid, nil when valid."
+  [config] (schema/validate-config config))
+
+(defn validate-violation
+  "Validate a single violation record against SarifViolation.
+   Returns a map {:valid? boolean :errors map-or-nil}; :errors holds the
+   humanized Malli error map when invalid, nil when valid."
+  [v] (schema/validate-violation v))
+
+(defn violation-json-schema
+  "Return the SarifViolation schema transformed to a JSON Schema map."
+  [] (schema/violation-json-schema))
+
+(defn config-json-schema
+  "Return the SarifConfig schema transformed to a JSON Schema map."
+  [] (schema/config-json-schema))

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/schema.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/schema.clj
@@ -49,7 +49,6 @@
    [:column {:optional true} [:maybe :int]]])
 
 (def SarifViolation
-  "Unified violation record — normalized from both SARIF and CSV sources."
   [:map
    [:violation/id :string]
    [:violation/rule-id :string]
@@ -60,7 +59,6 @@
    [:violation/raw :map]])
 
 (def SarifConfig
-  "Configuration for the SARIF connector."
   [:map
    [:sarif/source-path :string]
    [:sarif/format {:optional true} SourceFormat]
@@ -78,12 +76,10 @@
      :errors (me/humanize (m/explain schema value))}))
 
 (defn validate-config
-  "Validate a SARIF connector config map."
   [value]
   (validate SarifConfig value))
 
 (defn validate-violation
-  "Validate a single violation record."
   [value]
   (validate SarifViolation value))
 
@@ -91,11 +87,9 @@
 ;; JSON Schema export
 
 (defn violation-json-schema
-  "Return the SarifViolation schema as JSON Schema."
   []
   (json-schema/transform SarifViolation))
 
 (defn config-json-schema
-  "Return the SarifConfig schema as JSON Schema."
   []
   (json-schema/transform SarifConfig))


### PR DESCRIPTION
Wave-B boundary-documentation rollout (rule 009). Contract docstrings lifted to interface boundary (both tiers where consumed; types verified from impl); duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change. Commit-budget override (mechanical doc-only); poly:check + smoke + GraalVM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)