### PR TITLE
docs(schema,data): document interface boundaries (rule 009)

### DIFF
--- a/components/config/src/ai/miniforge/config/interface.clj
+++ b/components/config/src/ai/miniforge/config/interface.clj
@@ -25,10 +25,23 @@
    [ai.miniforge.config.profile :as profile]))
 
 ;; Re-export public functions
-(def default-user-config-path user/default-user-config-path)
-(def default-config user/default-config)
-(def miniforge-home user/miniforge-home)
-(def repo-config-dir-name user/repo-config-dir-name)
+(def default-user-config-path
+  "Default filesystem path string for the user config file
+   (`<miniforge-home>/config.edn`). Computed once at load time."
+  user/default-user-config-path)
+(def default-config
+  "Default configuration value: a map loaded at load time from the shipped
+   classpath resource config/default-user-config.edn (with a fallback
+   resource). Empty map {} if neither resource can be read."
+  user/default-config)
+(def miniforge-home
+  "Function returning the miniforge home directory as a string.
+   Args: none. Returns: MINIFORGE_HOME env var if set, else
+   `<user.home>/.miniforge`. Never nil."
+  user/miniforge-home)
+(def repo-config-dir-name
+  "String naming the repo-level config directory: \".miniforge\"."
+  user/repo-config-dir-name)
 
 (defn repo-config-path
   "Return the path to .miniforge/config.edn in the given working directory."
@@ -110,7 +123,10 @@
   (digest/verify-governance-file config-key content))
 
 ;; Profile functions
-(def profile-path profile/profile-path)
+(def profile-path
+  "Default filesystem path string for the user profile file
+   (`<miniforge-home>/profile.edn`). Computed once at load time."
+  profile/profile-path)
 
 (defn load-profile
   "Load user profile from ~/.miniforge/profile.edn."

--- a/components/config/src/ai/miniforge/config/profile.clj
+++ b/components/config/src/ai/miniforge/config/profile.clj
@@ -43,7 +43,6 @@
 ;; Schema and path
 
 (def profile-path
-  "Default location for user profile."
   (str (user/miniforge-home) "/profile.edn"))
 
 

--- a/components/config/src/ai/miniforge/config/user.clj
+++ b/components/config/src/ai/miniforge/config/user.clj
@@ -34,14 +34,11 @@
 ;; Constants and utilities
 
 (defn miniforge-home
-  "Return the miniforge home directory.
-   Resolution: MINIFORGE_HOME env > ~/.miniforge"
   []
   (or (System/getenv "MINIFORGE_HOME")
       (str (System/getProperty "user.home") "/.miniforge")))
 
 (def default-user-config-path
-  "Default location for user config file."
   (str (miniforge-home) "/config.edn"))
 
 (def ^:private default-config-resource-path
@@ -78,7 +75,6 @@
       {}))
 
 (def default-config
-  "Default configuration values loaded from resources/config/default-user-config.edn"
   (load-default-config))
 
 (defn read-edn-file
@@ -100,7 +96,6 @@
 ;; Repo-level configuration
 
 (def repo-config-dir-name
-  "Directory name for repo-level miniforge configuration."
   ".miniforge")
 
 (defn repo-config-path
@@ -300,7 +295,6 @@
 ;; Config saving and initialization
 
 (defn save-user-config
-  "Save user configuration to file."
   ([config] (save-user-config config default-user-config-path))
   ([config path]
    (write-edn-file path config)
@@ -329,7 +323,6 @@
      (save-user-config updated-config path))))
 
 (defn reset-user-config
-  "Reset user config to defaults."
   ([] (reset-user-config default-user-config-path))
   ([path]
    (save-user-config default-config path)))

--- a/components/context-pack/src/ai/miniforge/context_pack/factory.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/factory.clj
@@ -11,7 +11,6 @@
 ;; ContextPack
 
 (defn ->context-pack
-  "Create a ContextPack map."
   [phase budget repo-map-text files search-results]
   {:phase phase
    :budget budget
@@ -26,7 +25,6 @@
 ;; Budget audit
 
 (defn ->budget-audit
-  "Create a budget audit snapshot."
   [phase budget tokens-used exhausted? source-count]
   {:phase phase
    :budget budget
@@ -42,7 +40,6 @@
 ;; Source tracking
 
 (defn ->source
-  "Create a source-tracking entry for audit trail."
   [kind path tokens]
   {:kind kind
    :path path
@@ -52,7 +49,6 @@
 ;; Pack context (used by implement phase to cache context-pack results)
 
 (defn ->pack-context
-  "Create a pack-context map for caching in execution context."
   [repo-index context-pack]
   {:repo-index repo-index
    :context-pack context-pack

--- a/components/context-pack/src/ai/miniforge/context_pack/interface.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/interface.clj
@@ -60,10 +60,12 @@
   "Construct a BudgetAudit snapshot map.
 
    Args: phase (keyword), budget (int), tokens-used (int),
-   exhausted? (boolean), source-count (int).
+   exhausted? (boolean), source-count (int). `budget` and `tokens-used`
+   must be numeric — they feed arithmetic (`(- budget tokens-used)` and
+   `(/ tokens-used budget)`) that throws on nil or non-numeric input.
    Returns a BudgetAudit map; :tokens-remaining clamped at >= 0,
    :utilization is tokens-used/budget as a double (0.0 when budget
-   is non-positive). Total function, never throws."
+   is non-positive)."
   factory/->budget-audit)
 
 (def ->source

--- a/components/context-pack/src/ai/miniforge/context_pack/interface.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/interface.clj
@@ -20,17 +20,69 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
 
-(def ContextPack schema/ContextPack)
-(def BudgetAudit schema/BudgetAudit)
-(def Source schema/Source)
+(def ContextPack
+  "Malli schema (a [:map ...] vector) for a bounded context pack.
+
+   Keys: :phase (keyword), :budget (int), :tokens-used (int),
+   :repo-map (string or nil), :files (vector of maps),
+   :search-results (vector of maps), :exhausted? (boolean),
+   :sources (vector of Source)."
+  schema/ContextPack)
+
+(def BudgetAudit
+  "Malli schema (a [:map ...] vector) for a budget audit snapshot.
+
+   Keys: :phase (keyword), :budget (int), :tokens-used (int),
+   :tokens-remaining (int), :exhausted? (boolean), :source-count (int),
+   :utilization (double)."
+  schema/BudgetAudit)
+
+(def Source
+  "Malli schema (a [:map ...] vector) for a single source-tracking entry.
+
+   Keys: :kind (enum :repo-map | :file | :search), :path (non-empty
+   string or nil), :tokens (int)."
+  schema/Source)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Factory re-exports
 
-(def ->context-pack factory/->context-pack)
-(def ->budget-audit factory/->budget-audit)
-(def ->source factory/->source)
-(def ->pack-context factory/->pack-context)
+(def ->context-pack
+  "Construct a ContextPack map with an empty audit trail.
+
+   Args: phase (keyword), budget (int), repo-map-text (string or nil),
+   files (vector of maps), search-results (vector of maps).
+   Returns a ContextPack map; :tokens-used 0, :exhausted? false,
+   :sources []. Total function, never throws."
+  factory/->context-pack)
+
+(def ->budget-audit
+  "Construct a BudgetAudit snapshot map.
+
+   Args: phase (keyword), budget (int), tokens-used (int),
+   exhausted? (boolean), source-count (int).
+   Returns a BudgetAudit map; :tokens-remaining clamped at >= 0,
+   :utilization is tokens-used/budget as a double (0.0 when budget
+   is non-positive). Total function, never throws."
+  factory/->budget-audit)
+
+(def ->source
+  "Construct a Source-tracking entry for a pack's audit trail.
+
+   Args: kind (keyword :repo-map | :file | :search), path (string or
+   nil), tokens (int). Returns a Source map. Total function, never
+   throws."
+  factory/->source)
+
+(def ->pack-context
+  "Construct a pack-context map for caching context-pack results in an
+   execution context.
+
+   Args: repo-index (RepoIndex map), context-pack (ContextPack map).
+   Returns a map with :repo-index, :context-pack, :repo-map-text (the
+   pack's :repo-map) and :existing-files (the pack's :files). Total
+   function, never throws."
+  factory/->pack-context)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Budget queries

--- a/components/context-pack/src/ai/miniforge/context_pack/schema.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/schema.clj
@@ -10,14 +10,12 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 (def Source
-  "Schema for a source-tracking entry."
   [:map
    [:kind [:enum :repo-map :file :search]]
    [:path [:maybe [:string {:min 1}]]]
    [:tokens :int]])
 
 (def ContextPack
-  "Schema for a bounded context pack."
   [:map
    [:phase :keyword]
    [:budget :int]
@@ -29,7 +27,6 @@
    [:sources [:vector Source]]])
 
 (def BudgetAudit
-  "Schema for a budget audit snapshot."
   [:map
    [:phase :keyword]
    [:budget :int]

--- a/components/dataset-schema/src/ai/miniforge/dataset_schema/interface.clj
+++ b/components/dataset-schema/src/ai/miniforge/dataset_schema/interface.clj
@@ -4,12 +4,25 @@
             [ai.miniforge.dataset-schema.field-types :as field-types]))
 
 ;; -- Dataset Types --
-(def dataset-types core/dataset-types)
+(def dataset-types
+  "Set of enumerated dataset-type keywords per N1 §2.2.
+   Value: #{:table :time-series :document-collection :graph :feature-set :report}."
+  core/dataset-types)
 
 ;; -- Field Types --
-(def field-types field-types/field-types)
-(def valid-field-type? field-types/valid-field-type?)
-(def type-widening-compatible? field-types/type-widening-compatible?)
+(def field-types
+  "Set of enumerated field-type keywords per N1 §4.2.
+   Value: #{:string :int :long :decimal :double :boolean :date :instant :uuid :json :bytes}."
+  field-types/field-types)
+
+(def valid-field-type?
+  "Predicate. Given a candidate type, returns true if it is a member of `field-types`, else false."
+  field-types/valid-field-type?)
+
+(def type-widening-compatible?
+  "Predicate. Given `from-type` and `to-type` keywords, returns true if widening from-type to
+   to-type is lossless/backward-compatible (e.g. :int -> :long), else false. Unknown types return false."
+  field-types/type-widening-compatible?)
 
 ;; -- Schema CRUD --
 (defn create-schema

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -45,8 +45,6 @@
 ;; Intent Collection
 
 (defn extract-intent
-  "Extract intent from workflow specification.
-   Returns intent evidence map."
   [workflow-spec]
   {:intent/type (get workflow-spec :intent/type :update)
    :intent/description (or (:description workflow-spec)
@@ -533,8 +531,6 @@
   (contains? #{:completed :failed} (:workflow/status workflow-state)))
 
 (defn auto-collect-evidence
-  "Automatically collect evidence when workflow reaches terminal state.
-   Returns evidence bundle or nil if not ready."
   [workflow-id workflow-state artifact-store]
   (when (should-create-bundle? workflow-state)
     (assemble-evidence-bundle workflow-id workflow-state artifact-store)))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
@@ -31,9 +31,24 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol re-exports
 
-(def EvidenceBundle p/EvidenceBundle)
-(def ProvenanceTracer p/ProvenanceTracer)
-(def SemanticValidator p/SemanticValidator)
+(def EvidenceBundle
+  "Protocol for creating, storing, and querying evidence bundles.
+   Methods: create-bundle, get-bundle, get-bundle-by-workflow,
+   query-bundles, validate-bundle, export-bundle.
+   Implemented by the manager returned from create-evidence-manager."
+  p/EvidenceBundle)
+
+(def ProvenanceTracer
+  "Protocol for tracing artifact provenance chains.
+   Methods: query-provenance, trace-artifact-chain, query-intent-mismatches.
+   Implemented by the manager returned from create-evidence-manager."
+  p/ProvenanceTracer)
+
+(def SemanticValidator
+  "Protocol for semantic intent validation.
+   Methods: validate-intent, analyze-terraform-plan, analyze-kubernetes-manifest.
+   Implemented by the manager returned from create-evidence-manager."
+  p/SemanticValidator)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Evidence Bundle Manager Creation

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/interface.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/interface.clj
@@ -55,17 +55,98 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports.
 
-(def ZettelRef     schema-impl/ZettelRef)
-(def KnowledgePack schema-impl/KnowledgePack)
+(def ZettelRef
+  "Malli schema (`[:map {:closed false}]`) for the canonical
+   Decision-6 content-addressed reference to a zettel revision: the
+   `(:zettel/id, :zettel/revision-id, :zettel/digest)` triple. `id`
+   and `revision-id` are `uuid?`; `digest` is a 64-char lowercase
+   hex string. Pack manifests reference zettels only via this triple
+   so trust attaches to an immutable revision, never the mutable
+   logical id."
+  schema-impl/ZettelRef)
+
+(def KnowledgePack
+  "Malli schema (`[:map {:closed false}]`) for a knowledge-pack
+   manifest: a curated, content-addressed collection of zettel
+   revisions. Required keys: `:pack/id` (uuid), `:pack/uid`,
+   `:pack/title`, `:pack/version` (non-empty strings),
+   `:pack/zettels` (vector of `ZettelRef`, may be empty),
+   `:pack/created` (inst), `:pack/author` (string). Revision-keyed
+   identity (`:pack/revision-id` uuid, `:pack/digest` hex) and
+   Fleet-share fields (`:pack/description`, `:pack/dependencies`,
+   `:fleet/shareable`, `:fleet/share-scope`,
+   `:privacy/classification`, `:fleet/oss-version`, `:pack/modified`)
+   are optional; the constructors stamp the derived identity fields."
+  schema-impl/KnowledgePack)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Operation re-exports.
 
-(def build-pack             pack-impl/build-pack)
-(def update-pack            pack-impl/update-pack)
-(def add-zettel             pack-impl/add-zettel)
-(def remove-zettel          pack-impl/remove-zettel)
-(def zettel->ref            pack-impl/zettel->ref)
-(def compute-digest         pack-impl/compute-digest)
-(def revision-id-from-digest pack-impl/revision-id-from-digest)
-(def verify-pack            verify-impl/verify-pack)
+(def build-pack
+  "Construct a fresh content-addressed pack manifest.
+   `(build-pack uid title version zettels & opts)`. `uid` / `title` /
+   `version` are strings; `zettels` is a sequence of zettel MAPS (not
+   triples) — each is projected via `zettel->ref`. Optional kwargs:
+   `:description`, `:author` (default \"user\"), `:dependencies`,
+   `:fleet/shareable`, `:fleet/share-scope`, `:privacy/classification`,
+   `:fleet/oss-version`. Returns a pack map with `:pack/digest` +
+   `:pack/revision-id` stamped automatically. Throws (via
+   `zettel->ref`) if any zettel lacks the required reference fields."
+  pack-impl/build-pack)
+
+(def update-pack
+  "Apply `changes` to a pack and re-stamp its revision identity.
+   `(update-pack pack changes)` -> updated pack map. Caller-supplied
+   `:pack/digest` / `:pack/revision-id` in `changes` are dropped;
+   `:pack/modified` is set; the result is re-stamped. Idempotent on
+   unchanged content (same content -> same digest -> same
+   revision-id); rotates the revision only when a content-bearing
+   field changes (`:pack/uid` / `:pack/title` / `:pack/version` /
+   `:pack/description` / `:pack/zettels` / `:pack/dependencies`)."
+  pack-impl/update-pack)
+
+(def add-zettel
+  "Append a zettel reference to a pack's manifest.
+   `(add-zettel pack zettel)` -> updated pack map. `zettel` is a
+   zettel MAP (projected via `zettel->ref`); the pack revision
+   rotates via `update-pack`. Throws if `zettel` lacks the required
+   reference fields."
+  pack-impl/add-zettel)
+
+(def remove-zettel
+  "Remove every reference to `zettel-id` from a pack's manifest.
+   `(remove-zettel pack zettel-id)` -> updated pack map. The revision
+   rotates only if a reference was actually removed."
+  pack-impl/remove-zettel)
+
+(def zettel->ref
+  "Pure projection from a zettel map to its content-addressed
+   reference triple. `(zettel->ref zettel)` -> `{:zettel/id
+   :zettel/revision-id :zettel/digest}`. Throws `ex-info` if any of
+   the three fields is missing (legacy zettels must be backfilled via
+   `knowledge.zettel/update-zettel` first)."
+  pack-impl/zettel->ref)
+
+(def compute-digest
+  "Pure: SHA-256 hex string of the pack's canonical-EDN content
+   projection. `(compute-digest pack)` -> 64-char hex string. Stable
+   across map-key reorderings and non-content metadata changes;
+   rotates when a content-bearing field changes."
+  pack-impl/compute-digest)
+
+(def revision-id-from-digest
+  "Pure: derive a stable UUID from a digest hex string.
+   `(revision-id-from-digest digest)` -> `java.util.UUID`. Two packs
+   with identical content projections land on the same revision-id."
+  pack-impl/revision-id-from-digest)
+
+(def verify-pack
+  "Verify a pack against a zettel store.
+   `(verify-pack pack lookup-fn)` where `lookup-fn` is
+   `(fn [zettel-id revision-id] -> zettel-map | nil)`. Returns a map
+   `{:valid? boolean, :pack/discrepancy (map | nil),
+   :ref/discrepancies vector}`. `:valid?` is true iff the
+   manifest-level discrepancy is nil AND the per-ref discrepancy
+   vector is empty; per-ref problems are accumulated, not
+   short-circuited."
+  verify-impl/verify-pack)

--- a/components/schema/src/ai/miniforge/schema/core.clj
+++ b/components/schema/src/ai/miniforge/schema/core.clj
@@ -27,7 +27,6 @@
 ;; Base types and registries
 
 (def agent-roles
-  "Canonical agent roles ordered by implementation priority."
   [:planner :architect :implementer :tester :reviewer :sre :security :release :historian :operator])
 
 (def meta-agent-roles
@@ -35,23 +34,18 @@
   [:progress-monitor :test-quality :conflict-detector :resource-manager :evidence-collector])
 
 (def task-types
-  "Types of tasks that can be assigned to agents."
   [:plan :design :implement :test :review :deploy])
 
 (def task-statuses
-  "Possible states for a task."
   [:pending :running :completed :failed :blocked])
 
 (def artifact-types
-  "Types of artifacts produced by the system."
   [:spec :plan :adr :code :test :review :manifest :image :telemetry :incident])
 
 (def workflow-phases
-  "Phases in the outer loop SDLC cycle."
   [:plan :design :implement :verify :review :release :observe])
 
 (def workflow-statuses
-  "Possible states for a workflow."
   [:pending :running :paused :completed :failed :cancelled])
 
 (def registry

--- a/components/schema/src/ai/miniforge/schema/interface.clj
+++ b/components/schema/src/ai/miniforge/schema/interface.clj
@@ -30,43 +30,173 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports (allow other components to reference schemas)
 
-(def Agent core/Agent)
-(def Task core/Task)
-(def Artifact core/Artifact)
-(def Workflow core/Workflow)
-(def TaskConstraints core/TaskConstraints)
-(def TaskResult core/TaskResult)
-(def ArtifactOrigin core/ArtifactOrigin)
-(def WorkflowBudget core/WorkflowBudget)
+(def Agent
+  "Malli schema (closed-ish `:map`) for an AI agent: `:agent/id` (uuid) and
+   `:agent/role` (enum) required; optional capabilities, memory, config.
+   Pass to [[valid?]]/[[validate]]/[[validate-anomaly]] to check agent maps."
+  core/Agent)
 
-(def LogEntry logging/LogEntry)
-(def Scenario logging/Scenario)
+(def Task
+  "Malli `:map` schema for a unit of work: `:task/id`, `:task/type`,
+   `:task/status` required; optional agent, io artifacts, parent/children,
+   constraints, result. Use with the validation fns."
+  core/Task)
+
+(def Artifact
+  "Malli `:map` schema for a versioned work product with provenance:
+   `:artifact/id`, `:artifact/type`, `:artifact/version` required; optional
+   content, origin, lineage, metadata, created-at."
+  core/Artifact)
+
+(def Workflow
+  "Malli `:map` schema for an outer-loop SDLC delivery instance:
+   `:workflow/id` and `:workflow/status` required; optional name, phase,
+   priority, checkpoint, budget/consumed, spec-id, meta-agents."
+  core/Workflow)
+
+(def TaskConstraints
+  "Malli `:map` schema for task execution constraints: optional budget
+   (tokens/cost-usd/duration-ms), deadline, policies, max-iterations.
+   Embedded under `:task/constraints` in [[Task]]."
+  core/TaskConstraints)
+
+(def TaskResult
+  "Malli `:map` schema for task execution result: required `:outcome`
+   (`:success`/`:failure`/`:escalated`); optional error, signals, metrics.
+   Embedded under `:task/result` in [[Task]]."
+  core/TaskResult)
+
+(def ArtifactOrigin
+  "Malli `:map` schema for artifact provenance: optional `:intent-id`,
+   `:agent-id`, `:task-id`. Embedded under `:artifact/origin` in [[Artifact]]."
+  core/ArtifactOrigin)
+
+(def WorkflowBudget
+  "Malli `:map` schema for a workflow budget allocation: optional `:tokens`,
+   `:cost-usd`, `:duration-ms`. Used for both `:workflow/budget` and
+   `:workflow/consumed` in [[Workflow]]."
+  core/WorkflowBudget)
+
+(def LogEntry
+  "Malli `:map` schema for a structured EDN log entry. Required: `:log/id`,
+   `:log/timestamp`, `:log/level`, `:log/category`, `:log/event`. Optional:
+   message, context (`:ctx/*`), scenario, data, tracing, perf metrics."
+  logging/LogEntry)
+
+(def Scenario
+  "Malli `:map` schema for a test scenario definition: `:scenario/id`,
+   `:scenario/name`, `:scenario/created-at`, `:scenario/status` required;
+   optional tags, created-by, config, expected."
+  logging/Scenario)
 
 ;; Supervisory entity schemas
-(def WorkflowRun supervisory/WorkflowRun)
-(def PolicyEvaluation supervisory/PolicyEvaluation)
-(def PolicyViolation supervisory/PolicyViolation)
-(def AttentionItem supervisory/AttentionItem)
-(def Waiver supervisory/Waiver)
-(def EvidenceBundle supervisory/EvidenceBundle)
+(def WorkflowRun
+  "Malli open `:map` schema for a supervisory workflow run: `:workflow/id`,
+   `:workflow/key`, `:workflow/status`, `:workflow/phase`,
+   `:workflow/started-at` required. Extra keys pass through."
+  supervisory/WorkflowRun)
+
+(def PolicyEvaluation
+  "Malli open `:map` schema for a policy evaluation result: `:eval/id`,
+   `:eval/pr-id`, `:eval/result`, `:eval/rules-applied`, `:eval/evaluated-at`
+   required. Extra keys pass through."
+  supervisory/PolicyEvaluation)
+
+(def PolicyViolation
+  "Malli open `:map` schema for a single policy violation: `:violation/id`,
+   `:violation/eval-id`, `:violation/rule`, `:violation/category`,
+   `:violation/severity` required. Extra keys pass through."
+  supervisory/PolicyViolation)
+
+(def AttentionItem
+  "Malli open `:map` schema for an item needing human oversight:
+   `:attention/id`, `:attention/severity`, `:attention/summary`,
+   `:attention/source-type`, `:attention/source-id` required. Extra keys pass."
+  supervisory/AttentionItem)
+
+(def Waiver
+  "Malli open `:map` schema for a human waiver of a violation: `:waiver/id`,
+   `:waiver/eval-id`, `:waiver/actor`, `:waiver/reason`, `:waiver/created-at`
+   required. Extra keys pass through."
+  supervisory/Waiver)
+
+(def EvidenceBundle
+  "Malli open `:map` schema for evidence collected during a workflow:
+   `:evidence/id`, `:evidence/workflow-id`, `:evidence/entries` required.
+   Extra keys pass through."
+  supervisory/EvidenceBundle)
 
 ;; Enum value sets for programmatic access
-(def agent-roles core/agent-roles)
-(def task-types core/task-types)
-(def task-statuses core/task-statuses)
-(def artifact-types core/artifact-types)
-(def workflow-phases core/workflow-phases)
-(def workflow-statuses core/workflow-statuses)
-(def log-levels logging/log-levels)
-(def log-categories logging/log-categories)
-(def all-events logging/all-events)
-(def scenario-tags logging/scenario-tags)
+(def agent-roles
+  "Vector of canonical agent role keywords, ordered by implementation priority
+   (`:planner`, `:architect`, `:implementer`, ...)."
+  core/agent-roles)
+
+(def task-types
+  "Vector of task-type keywords (`:plan`, `:design`, `:implement`, `:test`,
+   `:review`, `:deploy`)."
+  core/task-types)
+
+(def task-statuses
+  "Vector of task-status keywords (`:pending`, `:running`, `:completed`,
+   `:failed`, `:blocked`)."
+  core/task-statuses)
+
+(def artifact-types
+  "Vector of artifact-type keywords (`:spec`, `:plan`, `:adr`, `:code`,
+   `:test`, `:review`, `:manifest`, `:image`, `:telemetry`, `:incident`)."
+  core/artifact-types)
+
+(def workflow-phases
+  "Vector of outer-loop SDLC phase keywords (`:plan`, `:design`, `:implement`,
+   `:verify`, `:review`, `:release`, `:observe`)."
+  core/workflow-phases)
+
+(def workflow-statuses
+  "Vector of workflow-status keywords (`:pending`, `:running`, `:paused`,
+   `:completed`, `:failed`, `:cancelled`)."
+  core/workflow-statuses)
+
+(def log-levels
+  "Vector of log severity keywords, most to least verbose (`:trace`, `:debug`,
+   `:info`, `:warn`, `:error`, `:fatal`)."
+  logging/log-levels)
+
+(def log-categories
+  "Vector of log category keywords (`:agent`, `:loop`, `:policy`, `:artifact`,
+   `:system`)."
+  logging/log-categories)
+
+(def all-events
+  "Vector of all known log-event keywords across the agent, loop, policy,
+   artifact, and system taxonomies."
+  logging/all-events)
+
+(def scenario-tags
+  "Vector of standard scenario-test tag keywords (`:canary`, `:shadow`,
+   `:regression`, ...)."
+  logging/scenario-tags)
 
 ;; Supervisory enum value sets
-(def eval-results supervisory/eval-results)
-(def violation-categories supervisory/violation-categories)
-(def violation-severities supervisory/violation-severities)
-(def attention-source-types supervisory/attention-source-types)
+(def eval-results
+  "Vector of policy-evaluation outcome keywords (`:pass`, `:fail`, `:warn`,
+   `:skip`)."
+  supervisory/eval-results)
+
+(def violation-categories
+  "Vector of policy-violation category keywords (`:style`, `:security`,
+   `:testing`, `:documentation`, `:architecture`, `:process`, `:budget`)."
+  supervisory/violation-categories)
+
+(def violation-severities
+  "Vector of severity keywords for violations and attention items (`:info`,
+   `:low`, `:medium`, `:high`, `:critical`)."
+  supervisory/violation-severities)
+
+(def attention-source-types
+  "Vector of source-type keywords that can raise attention items (`:workflow`,
+   `:policy`, `:agent`, `:system`, `:human`)."
+  supervisory/attention-source-types)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Validation functions

--- a/components/schema/src/ai/miniforge/schema/interface.clj
+++ b/components/schema/src/ai/miniforge/schema/interface.clj
@@ -31,8 +31,9 @@
 ;; Schema re-exports (allow other components to reference schemas)
 
 (def Agent
-  "Malli schema (closed-ish `:map`) for an AI agent: `:agent/id` (uuid) and
-   `:agent/role` (enum) required; optional capabilities, memory, config.
+  "Malli schema (open `:map` — no `{:closed true}`, so extra keys are accepted)
+   for an AI agent: `:agent/id` (uuid) and `:agent/role` (enum) required;
+   optional capabilities, memory, config.
    Pass to [[valid?]]/[[validate]]/[[validate-anomaly]] to check agent maps."
   core/Agent)
 

--- a/components/schema/src/ai/miniforge/schema/logging.clj
+++ b/components/schema/src/ai/miniforge/schema/logging.clj
@@ -28,11 +28,9 @@
 ;; Base types and event taxonomy
 
 (def log-levels
-  "Log severity levels ordered from most to least verbose."
   [:trace :debug :info :warn :error :fatal])
 
 (def log-categories
-  "High-level categorization of log events."
   [:agent :loop :policy :artifact :system])
 
 (def loop-types
@@ -88,11 +86,9 @@
    :system/health-check])
 
 (def all-events
-  "All known log events."
   (vec (concat agent-events loop-events policy-events artifact-events system-events)))
 
 (def scenario-tags
-  "Standard tags for scenario-based testing."
   [:canary :shadow :regression :smoke :stress :chaos :golden-path :error-recovery :rollback])
 
 (def logging-registry

--- a/components/schema/src/ai/miniforge/schema/supervisory.clj
+++ b/components/schema/src/ai/miniforge/schema/supervisory.clj
@@ -19,19 +19,15 @@
 ;; Enums for supervisory entities
 
 (def eval-results
-  "Possible outcomes of a policy evaluation."
   [:pass :fail :warn :skip])
 
 (def violation-categories
-  "Categories of policy violations."
   [:style :security :testing :documentation :architecture :process :budget])
 
 (def violation-severities
-  "Severity levels for violations and attention items."
   [:info :low :medium :high :critical])
 
 (def attention-source-types
-  "Source types that can generate attention items."
   [:workflow :policy :agent :system :human])
 
 ;------------------------------------------------------------------------------ Layer 0a

--- a/components/spec-parser/src/ai/miniforge/spec_parser/interface.clj
+++ b/components/spec-parser/src/ai/miniforge/spec_parser/interface.clj
@@ -30,9 +30,12 @@
 
 (def SpecPayload
   "Malli `[:map ...]` schema for a normalized spec payload — the canonical
-   :spec/* format the workflow engine consumes. Required keys :spec/title and
-   :spec/description; the rest carry normalize-spec defaults. Pass to
-   malli.core fns or `valid-spec-payload?`."
+   :spec/* format the workflow engine consumes. Required (non-optional) keys:
+   :spec/title, :spec/description, :spec/intent, :spec/constraints, :spec/tags,
+   :spec/workflow-version, :spec/raw-data — normalize-spec supplies defaults for
+   the ones the user omits. Remaining :spec/* keys (e.g. :spec/workflow-type,
+   :spec/acceptance-criteria, :spec/provenance) are optional. Pass to malli.core
+   fns or `valid-spec-payload?`."
   schema/SpecPayload)
 
 (def SpecInput

--- a/components/spec-parser/src/ai/miniforge/spec_parser/interface.clj
+++ b/components/spec-parser/src/ai/miniforge/spec_parser/interface.clj
@@ -28,16 +28,52 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
 
-(def SpecPayload schema/SpecPayload)
-(def SpecInput schema/SpecInput)
-(def SpecIntent schema/SpecIntent)
-(def SpecProvenance schema/SpecProvenance)
-(def PlanTask schema/PlanTask)
-(def CodeArtifact schema/CodeArtifact)
+(def SpecPayload
+  "Malli `[:map ...]` schema for a normalized spec payload — the canonical
+   :spec/* format the workflow engine consumes. Required keys :spec/title and
+   :spec/description; the rest carry normalize-spec defaults. Pass to
+   malli.core fns or `valid-spec-payload?`."
+  schema/SpecPayload)
+
+(def SpecInput
+  "Malli `[:map ...]` schema for raw user spec input in :spec/* format,
+   before normalization. Required keys :spec/title and :spec/description;
+   all other :spec/* keys plus :workflow/type and :workflow/version are
+   optional. Pass to malli.core fns or `valid-spec-input?`."
+  schema/SpecInput)
+
+(def SpecIntent
+  "Malli `[:map ...]` schema for :spec/intent — the kind of work. Requires
+   :type (one of `intent-types`); optional :scope is a vector of strings."
+  schema/SpecIntent)
+
+(def SpecProvenance
+  "Malli `[:map ...]` schema for :spec/provenance source metadata: requires
+   :source-file (string), :source-format (one of `source-formats`),
+   :loaded-at (inst), :file-size (int). Attached by `parse-spec-file`."
+  schema/SpecProvenance)
+
+(def PlanTask
+  "Malli `[:map ...]` schema for one task within :spec/plan-tasks. Requires
+   :task/id (keyword or uuid) and :task/description (string); optional
+   :task/type (keyword) and :task/dependencies (vector of keyword/uuid)."
+  schema/PlanTask)
+
+(def CodeArtifact
+  "Malli `[:map ...]` schema for a code artifact reference. Requires
+   :code/id (string or uuid); optional :code/files is a vector of strings."
+  schema/CodeArtifact)
 
 ;; Enum values
-(def intent-types schema/intent-types)
-(def source-formats schema/source-formats)
+(def intent-types
+  "Vector of valid :spec/intent :type keywords:
+   [:refactor :feature :bugfix :general :chore :docs :test :performance]."
+  schema/intent-types)
+
+(def source-formats
+  "Vector of supported spec file format keywords:
+   [:yaml :edn :json :markdown]."
+  schema/source-formats)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Parsing

--- a/components/spec-parser/src/ai/miniforge/spec_parser/schema.clj
+++ b/components/spec-parser/src/ai/miniforge/spec_parser/schema.clj
@@ -29,24 +29,20 @@
 ;; Enums and base types
 
 (def intent-types
-  "Valid spec intent types."
   [:refactor :feature :bugfix :general :chore :docs :test :performance])
 
 (def source-formats
-  "Supported spec file formats."
   [:yaml :edn :json :markdown])
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Composite schemas
 
 (def SpecIntent
-  "Schema for spec intent — what kind of work this is."
   [:map
    [:type (into [:enum] intent-types)]
    [:scope {:optional true} [:vector :string]]])
 
 (def PlanTask
-  "Schema for an individual task within :spec/plan-tasks."
   [:map
    [:task/id [:or :keyword :uuid]]
    [:task/description :string]
@@ -54,13 +50,11 @@
    [:task/dependencies {:optional true} [:vector [:or :keyword :uuid]]]])
 
 (def CodeArtifact
-  "Schema for a code artifact reference."
   [:map
    [:code/id [:or :string :uuid]]
    [:code/files {:optional true} [:vector :string]]])
 
 (def SpecProvenance
-  "Schema for spec source provenance metadata."
   [:map
    [:source-file :string]
    [:source-format (into [:enum] source-formats)]


### PR DESCRIPTION
Wave-B boundary-documentation rollout (rule 009). Contract docstrings lifted to interface boundary (both tiers where consumed; types verified from impl); duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change. Commit-budget override (mechanical doc-only); poly:check + smoke + GraalVM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)