### PR TITLE
docs(workflow,pr): document interface boundaries (rule 009)

### DIFF
--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -116,7 +116,6 @@
     #{:repeated-phase-failure :frequent-rollback :recurring-repair}))
 
 (defn create-pattern-detector
-  "Create a pattern detector."
   ([] (create-pattern-detector default-config))
   ([config] (->SimplePatternDetector config)))
 
@@ -190,7 +189,6 @@
     #{:repeated-phase-failure :frequent-rollback :recurring-repair}))
 
 (defn create-improvement-generator
-  "Create an improvement generator."
   []
   (->SimpleImprovementGenerator))
 
@@ -236,7 +234,6 @@
        :shadow-period-ms (* 24 60 60 1000)})))
 
 (defn create-governance
-  "Create a governance manager."
   ([] (create-governance default-config))
   ([config] (->SimpleGovernance config)))
 

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -27,18 +27,56 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol re-exports
 
-(def Operator proto/Operator)
-(def PatternDetector proto/PatternDetector)
-(def ImprovementGenerator proto/ImprovementGenerator)
-(def Governance proto/Governance)
+(def Operator
+  "Protocol satisfied by the meta-agent: observe signals, analyze patterns,
+   propose/apply/reject improvements. Implement to provide an operator backend."
+  proto/Operator)
+
+(def PatternDetector
+  "Protocol satisfied by pattern detectors: turn a sequence of signals into a
+   sequence of detected patterns. Implement to provide custom detection."
+  proto/PatternDetector)
+
+(def ImprovementGenerator
+  "Protocol satisfied by improvement generators: turn detected patterns plus
+   context into a sequence of improvement proposals."
+  proto/ImprovementGenerator)
+
+(def Governance
+  "Protocol satisfied by governance backends: decide whether an improvement
+   needs human approval, may auto-apply, and resolve per-type approval policy."
+  proto/Governance)
 
 ;; Type definitions
-(def signal-types proto/signal-types)
-(def improvement-types proto/improvement-types)
-(def intervention-types intervention/intervention-types)
-(def intervention-target-types intervention/target-types)
-(def intervention-lifecycle-states intervention/lifecycle-states)
-(def intervention-terminal-states intervention/terminal-states)
+(def signal-types
+  "Set of keywords naming the signal types the operator can observe
+   (e.g. :workflow-complete, :workflow-failed, :phase-rollback)."
+  proto/signal-types)
+
+(def improvement-types
+  "Set of keywords naming the improvement types the operator can propose
+   (e.g. :prompt-change, :gate-adjustment, :policy-update)."
+  proto/improvement-types)
+
+(def intervention-types
+  "Set of keywords naming the bounded v1 supervisory intervention vocabulary
+   (e.g. :acknowledge, :retry, :cancel, :force-safe-mode)."
+  intervention/intervention-types)
+
+(def intervention-target-types
+  "Set of keywords naming the recognized intervention target categories
+   (e.g. :attention, :workflow, :policy-eval, :pr, :degradation, :supervision)."
+  intervention/target-types)
+
+(def intervention-lifecycle-states
+  "Set of keywords naming all valid intervention lifecycle states, including
+   the initial state, every transition endpoint, and the terminal states."
+  intervention/lifecycle-states)
+
+(def intervention-terminal-states
+  "Set of keywords naming the terminal intervention lifecycle states:
+   :rejected, :verified, :failed."
+  intervention/terminal-states)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Operator creation

--- a/components/operator/src/ai/miniforge/operator/intervention.clj
+++ b/components/operator/src/ai/miniforge/operator/intervention.clj
@@ -54,7 +54,6 @@
   (:approval-required-types @intervention-config))
 
 (def terminal-states
-  "Terminal intervention lifecycle states."
   (:terminal-states @intervention-config))
 
 (def default-target-type-by-intervention
@@ -71,7 +70,6 @@
   (set (keys default-target-type-by-intervention)))
 
 (def target-types
-  "Known target categories for v1 interventions."
   (set (vals default-target-type-by-intervention)))
 
 (def lifecycle-states
@@ -86,32 +84,26 @@
 ;; Construction and validation
 
 (defn approval-required?
-  "Return true when `intervention-type` defaults to a pending-human step."
   [intervention-type]
   (contains? approval-required-types intervention-type))
 
 (defn valid-type?
-  "Check if an intervention type is part of the bounded vocabulary."
   [intervention-type]
   (contains? intervention-types intervention-type))
 
 (defn valid-target-type?
-  "Check if a target type is recognized."
   [target-type]
   (contains? target-types target-type))
 
 (defn valid-state?
-  "Check if an intervention lifecycle state is valid."
   [state]
   (contains? lifecycle-states state))
 
 (defn terminal-state?
-  "Check if an intervention lifecycle state is terminal."
   [state]
   (contains? terminal-states state))
 
 (defn intervention-target-type
-  "Resolve the default target type for an intervention."
   [intervention-type]
   (get default-target-type-by-intervention intervention-type))
 
@@ -266,12 +258,10 @@
 ;; Lifecycle helpers
 
 (defn valid-transition?
-  "Check if an intervention lifecycle transition is valid."
   [current-state event]
   (contains? lifecycle-transitions [current-state event]))
 
 (defn next-state
-  "Resolve the next intervention lifecycle state."
   [current-state event]
   (get lifecycle-transitions [current-state event]))
 
@@ -316,17 +306,14 @@
                           (with-optional-intervention-attrs opts))}))))
 
 (defn start-approval
-  "Move an intervention into `:pending-human`."
   [intervention]
   (transition intervention :require-human))
 
 (defn approve
-  "Approve an intervention."
   [intervention]
   (transition intervention :approve))
 
 (defn reject
-  "Reject an intervention."
   ([intervention]
    (reject intervention nil))
   ([intervention reason]
@@ -338,28 +325,24 @@
   (transition intervention :dispatch))
 
 (defn apply-result
-  "Mark an intervention as applied."
   ([intervention]
    (apply-result intervention nil))
   ([intervention outcome]
    (transition intervention :apply (transition-opts :outcome outcome))))
 
 (defn verify
-  "Mark an intervention as verified."
   ([intervention]
    (verify intervention nil))
   ([intervention outcome]
    (transition intervention :verify (transition-opts :outcome outcome))))
 
 (defn fail
-  "Mark an intervention as failed."
   ([intervention]
    (fail intervention nil))
   ([intervention reason]
    (transition intervention :fail (transition-opts :reason reason))))
 
 (defn supported-target-types
-  "Return the configured target types for a given intervention type."
   [intervention-type]
   (let [target-type (intervention-target-type intervention-type)]
     (if target-type
@@ -367,6 +350,5 @@
       #{})))
 
 (defn bounded-vocabulary?
-  "Check if every requested intervention type is part of the bounded vocabulary."
   [types]
   (empty? (set/difference (set types) intervention-types)))

--- a/components/operator/src/ai/miniforge/operator/protocol.clj
+++ b/components/operator/src/ai/miniforge/operator/protocol.clj
@@ -29,7 +29,6 @@
 ;; Signal types
 
 (def signal-types
-  "Types of signals the operator can observe."
   #{:workflow-complete
     :workflow-failed
     :phase-rollback
@@ -40,7 +39,6 @@
     :quality-regression})
 
 (def improvement-types
-  "Types of improvements the operator can propose."
   #{:prompt-change
     :gate-adjustment
     :policy-update

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -287,16 +287,7 @@
 
 (defn create-control-plane
   "Create a control plane (orchestrator) with all components.
-
-   Arguments:
-   - llm-backend      - LLM backend for agent execution
-   - knowledge-store  - Knowledge store for injection/learning
-   - artifact-store   - Artifact store for results
-
-   Options:
-   - :config   - Override default configuration
-   - :logger   - Logger instance
-   - :operator - Operator instance for meta-loop integration"
+   See orchestrator.interface for the full argument/option contract."
   [llm-backend knowledge-store artifact-store & [{:keys [config logger operator]}]]
   (let [merged-config (merge default-config config)
         router (create-router merged-config)

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -287,7 +287,7 @@
 
 (defn create-control-plane
   "Create a control plane (orchestrator) with all components.
-   See orchestrator.interface for the full argument/option contract."
+   See ai.miniforge.orchestrator.interface for the full argument/option contract."
   [llm-backend knowledge-store artifact-store & [{:keys [config logger operator]}]]
   (let [merged-config (merge default-config config)
         router (create-router merged-config)

--- a/components/orchestrator/src/ai/miniforge/orchestrator/interface.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/interface.clj
@@ -26,10 +26,37 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol re-exports
 
-(def Orchestrator proto/Orchestrator)
-(def TaskRouter proto/TaskRouter)
-(def BudgetManager proto/BudgetManager)
-(def KnowledgeCoordinator proto/KnowledgeCoordinator)
+(def Orchestrator
+  "Protocol satisfied by control-plane instances.
+
+   Defines the workflow lifecycle contract: execute-workflow,
+   get-workflow-status, cancel-workflow, get-workflow-results,
+   pause-workflow, resume-workflow. Re-exported so callers can
+   extend or check satisfies? against the published contract."
+  proto/Orchestrator)
+
+(def TaskRouter
+  "Protocol satisfied by task-router instances.
+
+   Defines route-task and can-handle?, mapping task types to agent
+   roles. Re-exported for extension and satisfies? checks."
+  proto/TaskRouter)
+
+(def BudgetManager
+  "Protocol satisfied by budget-manager instances.
+
+   Defines track-usage, check-budget, and set-budget for tracking
+   and enforcing per-workflow resource budgets. Re-exported for
+   extension and satisfies? checks."
+  proto/BudgetManager)
+
+(def KnowledgeCoordinator
+  "Protocol satisfied by knowledge-coordinator instances.
+
+   Defines inject-for-agent, capture-execution-learning, and
+   should-promote-learning? for knowledge injection and learning
+   capture. Re-exported for extension and satisfies? checks."
+  proto/KnowledgeCoordinator)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Orchestrator creation

--- a/components/pipeline-pack/src/ai/miniforge/pipeline_pack/interface.clj
+++ b/components/pipeline-pack/src/ai/miniforge/pipeline_pack/interface.clj
@@ -8,15 +8,41 @@
    [ai.miniforge.pipeline-pack.registry :as registry]))
 
 ;; -- Schema re-exports --
-(def TrustLevel pack-schema/TrustLevel)
-(def AuthorityChannel pack-schema/AuthorityChannel)
-(def PipelinePackManifest pack-schema/PipelinePackManifest)
-(def trust-levels pack-schema/trust-levels)
-(def authority-channels pack-schema/authority-channels)
+(def TrustLevel
+  "Malli enum schema for a pack's trust level: [:enum :tainted :untrusted :trusted].
+   Use to validate or coerce :pack/trust-level."
+  pack-schema/TrustLevel)
+(def AuthorityChannel
+  "Malli enum schema for a pack's authority channel: [:enum :authority/data :authority/instruction].
+   :authority/data = data-only; :authority/instruction = code-bearing (requires :trusted)."
+  pack-schema/AuthorityChannel)
+(def PipelinePackManifest
+  "Malli :map schema for a pipeline pack manifest (pack.edn contents).
+   Required keys: :pack/id, :pack/name, :pack/version, :pack/description,
+   :pack/author, :pack/trust-level, :pack/authority, :pack/pipelines (vector),
+   :pack/envs (vector), :pack/created-at, :pack/updated-at. Optional:
+   :pack/metric-registry (string), :pack/connector-types (set of keywords),
+   :pack/extends (vector of {:pack-id string})."
+  pack-schema/PipelinePackManifest)
+(def trust-levels
+  "Vector of the legal trust-level keywords, in ascending trust order:
+   [:tainted :untrusted :trusted]."
+  pack-schema/trust-levels)
+(def authority-channels
+  "Vector of the legal authority-channel keywords:
+   [:authority/data :authority/instruction]."
+  pack-schema/authority-channels)
 
 ;; -- Validation --
-(def valid-manifest? pack-schema/valid-manifest?)
-(def validate-manifest pack-schema/validate-manifest)
+(def valid-manifest?
+  "Predicate. Returns true if the given value conforms to PipelinePackManifest,
+   else false. Takes a manifest map."
+  pack-schema/valid-manifest?)
+(def validate-manifest
+  "Validate a manifest map against PipelinePackManifest.
+   Returns {:valid? true :errors nil} on success, or
+   {:valid? false :errors <humanized-error-map>} on failure."
+  pack-schema/validate-manifest)
 
 ;; -- Loading --
 (defn load-pack

--- a/components/pipeline-pack/src/ai/miniforge/pipeline_pack/loader.clj
+++ b/components/pipeline-pack/src/ai/miniforge/pipeline_pack/loader.clj
@@ -181,9 +181,6 @@
   (select-keys result [:pack-id :path :error]))
 
 (defn load-all-packs
-  "Load all packs from a packs directory.
-
-   Returns {:loaded [...] :failed [...]}."
   [packs-dir]
   (let [discovered (discover-packs packs-dir)
         results (mapv load-discovered-pack discovered)

--- a/components/pipeline-pack/src/ai/miniforge/pipeline_pack/registry.clj
+++ b/components/pipeline-pack/src/ai/miniforge/pipeline_pack/registry.clj
@@ -9,7 +9,6 @@
 ;; Registry creation
 
 (defn create-registry
-  "Create a new empty pack registry."
   []
   (atom {}))
 
@@ -25,7 +24,6 @@
     registry))
 
 (defn unregister-pack!
-  "Remove a pack from the registry by id."
   [registry pack-id]
   (swap! registry dissoc pack-id)
   registry)
@@ -44,12 +42,10 @@
   (vec (vals @registry)))
 
 (defn list-pack-ids
-  "List all registered pack ids."
   [registry]
   (vec (keys @registry)))
 
 (defn pack-count
-  "Return number of registered packs."
   [registry]
   (count @registry))
 

--- a/components/pipeline/src/ai/miniforge/pipeline/interface.clj
+++ b/components/pipeline/src/ai/miniforge/pipeline/interface.clj
@@ -4,10 +4,17 @@
             [ai.miniforge.pipeline.dag :as dag]))
 
 ;; -- Stage Families --
-(def stage-families stage/stage-families)
+(def stage-families
+  "Set of valid stage-family keywords (N3 §2.2): #{:ingest :extract :normalize
+   :transform :aggregate :validate :enrich :publish}. Used to validate
+   :stage/family on stage definitions."
+  stage/stage-families)
 
 ;; -- Execution Modes --
-(def execution-modes core/execution-modes)
+(def execution-modes
+  "Set of valid pipeline execution-mode keywords (N3 §3): #{:full-refresh
+   :incremental :backfill :reprocess}. Used to validate :pipeline/mode."
+  core/execution-modes)
 
 ;; -- Pipeline CRUD --
 (defn create-pipeline

--- a/components/pipeline/src/ai/miniforge/pipeline/stage.clj
+++ b/components/pipeline/src/ai/miniforge/pipeline/stage.clj
@@ -15,7 +15,6 @@
   #{:extract :normalize :transform :aggregate :validate :enrich})
 
 (defn validate-stage
-  "Validate a stage definition against N3 §2.2."
   [{:stage/keys [id name family connector-ref input-datasets output-datasets dependencies]}]
   (let [errors
         (cond-> []

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/events.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/events.clj
@@ -72,7 +72,6 @@
    data))
 
 (defn pr-opened
-  "Create a PR opened event."
   [dag-id run-id task-id pr-id pr-url branch sha]
   (create-event :pr/opened
                 {:dag/id dag-id
@@ -84,7 +83,6 @@
                  :pr/sha sha}))
 
 (defn ci-passed
-  "Create a CI passed event."
   [dag-id run-id task-id pr-id sha]
   (create-event :pr/ci-passed
                 {:dag/id dag-id
@@ -94,7 +92,6 @@
                  :pr/sha sha}))
 
 (defn ci-failed
-  "Create a CI failed event."
   [dag-id run-id task-id pr-id sha logs]
   (create-event :pr/ci-failed
                 {:dag/id dag-id
@@ -105,7 +102,6 @@
                  :ci/logs logs}))
 
 (defn review-approved
-  "Create a review approved event."
   [dag-id run-id task-id pr-id approvers]
   (create-event :pr/review-approved
                 {:dag/id dag-id
@@ -115,7 +111,6 @@
                  :review/approvers approvers}))
 
 (defn review-changes-requested
-  "Create a changes requested event."
   [dag-id run-id task-id pr-id comments]
   (create-event :pr/review-changes-requested
                 {:dag/id dag-id
@@ -125,7 +120,6 @@
                  :review/comments comments}))
 
 (defn comment-actionable
-  "Create an actionable comment event."
   [dag-id run-id task-id pr-id comment-data]
   (create-event :pr/comment-actionable
                 {:dag/id dag-id
@@ -165,7 +159,6 @@
                  :close/reason reason}))
 
 (defn rebase-needed
-  "Create a rebase needed event."
   [dag-id run-id task-id pr-id base-sha]
   (create-event :pr/rebase-needed
                 {:dag/id dag-id
@@ -185,7 +178,6 @@
                  :conflict/files conflicting-files}))
 
 (defn fix-pushed
-  "Create a fix pushed event."
   [dag-id run-id task-id pr-id sha fix-type]
   (create-event :pr/fix-pushed
                 {:dag/id dag-id

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -98,15 +98,72 @@
   events/events-for-pr)
 
 ;; Event constructors
-(def pr-opened events/pr-opened)
-(def ci-passed events/ci-passed)
-(def ci-failed events/ci-failed)
-(def review-approved events/review-approved)
-(def review-changes-requested events/review-changes-requested)
-(def comment-actionable events/comment-actionable)
-(def merged events/merged)
-(def rebase-needed events/rebase-needed)
-(def fix-pushed events/fix-pushed)
+(def pr-opened
+  "Build a `:pr/opened` event map.
+   Args: [dag-id run-id task-id pr-id pr-url branch sha].
+   Returns an event map with `:event/id` `:event/type :pr/opened`
+   `:event/timestamp` plus `:dag/id :run/id :task/id :pr/id :pr/url
+   :pr/branch :pr/sha`. Pure constructor — never throws."
+  events/pr-opened)
+
+(def ci-passed
+  "Build a `:pr/ci-passed` event map.
+   Args: [dag-id run-id task-id pr-id sha]. Returns an event map with
+   `:event/type :pr/ci-passed` plus `:dag/id :run/id :task/id :pr/id
+   :pr/sha`. Pure constructor."
+  events/ci-passed)
+
+(def ci-failed
+  "Build a `:pr/ci-failed` event map.
+   Args: [dag-id run-id task-id pr-id sha logs]. Returns an event map
+   with `:event/type :pr/ci-failed` plus `:dag/id :run/id :task/id
+   :pr/id :pr/sha :ci/logs`. Pure constructor."
+  events/ci-failed)
+
+(def review-approved
+  "Build a `:pr/review-approved` event map.
+   Args: [dag-id run-id task-id pr-id approvers]. Returns an event map
+   with `:event/type :pr/review-approved` plus `:dag/id :run/id
+   :task/id :pr/id :review/approvers`. Pure constructor."
+  events/review-approved)
+
+(def review-changes-requested
+  "Build a `:pr/review-changes-requested` event map.
+   Args: [dag-id run-id task-id pr-id comments]. Returns an event map
+   with `:event/type :pr/review-changes-requested` plus `:dag/id
+   :run/id :task/id :pr/id :review/comments`. Pure constructor."
+  events/review-changes-requested)
+
+(def comment-actionable
+  "Build a `:pr/comment-actionable` event map.
+   Args: [dag-id run-id task-id pr-id comment-data]. Returns an event
+   map with `:event/type :pr/comment-actionable` plus `:dag/id :run/id
+   :task/id :pr/id :comment`. Pure constructor."
+  events/comment-actionable)
+
+(def merged
+  "Build a `:pr/merged` event map.
+   Arities: [dag-id run-id task-id pr-id merge-sha] (labels default to
+   an empty set) and [... merge-sha labels] where `labels` is a
+   coll of GitHub label-name strings, coerced to a set. Returns an
+   event map with `:event/type :pr/merged` plus `:dag/id :run/id
+   :task/id :pr/id :pr/merge-sha :pr/labels`. Pure constructor."
+  events/merged)
+
+(def rebase-needed
+  "Build a `:pr/rebase-needed` event map.
+   Args: [dag-id run-id task-id pr-id base-sha]. Returns an event map
+   with `:event/type :pr/rebase-needed` plus `:dag/id :run/id :task/id
+   :pr/id :pr/base-sha`. Pure constructor."
+  events/rebase-needed)
+
+(def fix-pushed
+  "Build a `:pr/fix-pushed` event map.
+   Args: [dag-id run-id task-id pr-id sha fix-type] where `fix-type`
+   is one of `:ci-fix` `:review-fix` `:conflict-fix`. Returns an event
+   map with `:event/type :pr/fix-pushed` plus `:dag/id :run/id
+   :task/id :pr/id :pr/sha :fix/type`. Pure constructor."
+  events/fix-pushed)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Comment triage

--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
@@ -68,7 +68,6 @@
 ;; Trigger events — loaded from data
 
 (def trigger-config-resource
-  "Classpath location of the default trigger-event-types EDN set."
   "config/pr-scoring/triggers.edn")
 
 (defn load-default-triggers
@@ -83,8 +82,6 @@
                     {:resource trigger-config-resource}))))
 
 (def default-trigger-event-types
-  "Memoized default trigger set loaded from [[trigger-config-resource]].
-   Delayed so classpath scan happens on first use, not namespace load."
   (delay (load-default-triggers)))
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/interface.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/interface.clj
@@ -39,15 +39,59 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Lifecycle
 
-(def create  core/create)
-(def start!  core/start!)
-(def stop!   core/stop!)
-(def attach! core/attach!)
+(def create
+  "Build a fresh pr-scoring component instance bound to event stream `stream`.
+   Does not subscribe yet — call [[start!]] to begin consuming events.
+
+   Args: `stream`, and an optional opts map:
+     :scorer-fn           — 1-ary fn (pr-event → score-map or nil); defaults
+                            to [[default-scorer-fn]] (emits nothing)
+     :trigger-event-types — set of event-type keywords that trigger scoring;
+                            defaults to the EDN set at [[trigger-config-resource]]
+
+   Returns an atom holding the component state map
+   {:stream :scorer-fn :triggers :subscribed?}."
+  core/create)
+
+(def start!
+  "Subscribe the component to its stream so events begin flowing to the
+   scorer-fn. Idempotent — repeat calls are no-ops.
+   Args: `component` (the atom from [[create]]). Returns that same atom."
+  core/start!)
+
+(def stop!
+  "Unsubscribe the component from its stream. Idempotent — no-op if not
+   currently subscribed.
+   Args: `component` (the atom). Returns that same atom."
+  core/stop!)
+
+(def attach!
+  "Create + start in one step.
+   Args: `stream`, and an optional opts map (see [[create]]).
+   Returns the started component atom."
+  core/attach!)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Extension points
 
-(def default-scorer-fn           core/default-scorer-fn)
-(def load-default-triggers       core/load-default-triggers)
-(def default-trigger-event-types core/default-trigger-event-types)
-(def trigger-config-resource     core/trigger-config-resource)
+(def default-scorer-fn
+  "Placeholder scorer used when no `:scorer-fn` is supplied to [[create]].
+   1-ary fn (pr-event → nil); always returns nil, so no `:pr/scored`
+   events are emitted. Replace with a real scorer at create time."
+  core/default-scorer-fn)
+
+(def load-default-triggers
+  "Read the default trigger-event-types set from the classpath resource at
+   [[trigger-config-resource]]. Takes no args. Returns a set of event-type
+   keywords. Throws ex-info if the resource is missing from the classpath."
+  core/load-default-triggers)
+
+(def default-trigger-event-types
+  "A delay wrapping the default trigger set (see [[load-default-triggers]]);
+   deref to obtain the set of event-type keywords. Delayed so the classpath
+   scan runs on first use rather than at namespace load."
+  core/default-trigger-event-types)
+
+(def trigger-config-resource
+  "String: classpath location of the default trigger-event-types EDN set."
+  core/trigger-config-resource)

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -72,8 +72,6 @@
 ;; Lifecycle
 
 (defn create
-  "Build a fresh supervisory-state component instance bound to `stream`.
-   Does not subscribe yet — call `start!` to begin consuming events."
   [stream]
   (atom {:table  schema/empty-table
          :stream stream
@@ -109,8 +107,6 @@
     component))
 
 (defn stop!
-  "Unsubscribe from the stream. The entity table is retained so it can be
-   queried post-shutdown."
   [component]
   (let [{:keys [stream subscribed?]} @component]
     (when subscribed?
@@ -128,7 +124,6 @@
   (start! (create stream)))
 
 (defn attached?
-  "True when supervisory-state is already subscribed to `stream`."
   [stream]
   (contains? (:subscribers @stream) subscriber-id))
 
@@ -148,7 +143,6 @@
 ;; Query API
 
 (defn table
-  "Current entity table snapshot (pure read)."
   [component]
   (:table @component))
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
@@ -31,39 +31,139 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schemas (re-exports)
 
-(def Spec             schema/Spec)
-(def WorkflowRun      schema/WorkflowRun)
-(def AgentSession     schema/AgentSession)
-(def PrFleetEntry     schema/PrFleetEntry)
-(def PolicyEvaluation schema/PolicyEvaluation)
-(def PolicyViolation  schema/PolicyViolation)
-(def AttentionItem    schema/AttentionItem)
-(def InterventionRequest schema/InterventionRequest)
+(def Spec
+  "Malli `[:map ...]` schema (open) for a long-lived Spec — the operator's
+   top-level unit of work that owns N WorkflowRuns over its lifetime
+   (N5-delta-3 §3.1, §5.1)."
+  schema/Spec)
+
+(def WorkflowRun
+  "Malli `[:map ...]` schema (open) for a WorkflowRun — one concrete
+   execution instance of a workflow (N5-delta-1 §3.1)."
+  schema/WorkflowRun)
+
+(def AgentSession
+  "Malli `[:map ...]` schema (open) for an AgentSession — an external or
+   internal agent observable to the supervisory plane (N5-delta-1 §3.3)."
+  schema/AgentSession)
+
+(def PrFleetEntry
+  "Malli `[:map ...]` schema (open) for a PrFleetEntry — a pull request in
+   the supervisory PR fleet view, with optional pre-computed readiness/risk/
+   policy/recommendation scores (N5-delta-2)."
+  schema/PrFleetEntry)
+
+(def PolicyEvaluation
+  "Malli `[:map ...]` schema (open) for a PolicyEvaluation — an immutable
+   record of a completed policy evaluation (N5-delta-1 §3.1)."
+  schema/PolicyEvaluation)
+
+(def PolicyViolation
+  "Malli `[:map ...]` schema (open) for a PolicyViolation — a single rule
+   failure within a PolicyEvaluation (N5-delta-1 §3.1)."
+  schema/PolicyViolation)
+
+(def AttentionItem
+  "Malli `[:map ...]` schema (open) for an AttentionItem — a derived
+   supervisory signal (N5-delta-1 §3.1 + §5)."
+  schema/AttentionItem)
+
+(def InterventionRequest
+  "Malli `[:map ...]` schema (open) for an InterventionRequest — a bounded
+   supervisory control request (N5 supervisory delta §3.1)."
+  schema/InterventionRequest)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Lifecycle
 
-(def create  core/create)
-(def start!  core/start!)
-(def stop!   core/stop!)
-(def attach! core/attach!)
-(def attached? core/attached?)
-(def ensure-attached! core/ensure-attached!)
+(def create
+  "Build a fresh supervisory-state component instance bound to `stream`.
+   Returns an atom holding the component state; does not subscribe yet —
+   call `start!` to begin consuming events."
+  core/create)
+
+(def start!
+  "Subscribe the component to its stream so it begins materializing the
+   entity table from live events. Idempotent — repeat calls are no-ops.
+   Returns the component. No startup replay of the event log."
+  core/start!)
+
+(def stop!
+  "Unsubscribe the component from its stream. The entity table is retained
+   so it stays queryable post-shutdown. Returns the component."
+  core/stop!)
+
+(def attach!
+  "Create a component bound to `stream` and start it in one step
+   (create + start!). Returns the started component."
+  core/attach!)
+
+(def attached?
+  "True when supervisory-state is already subscribed to `stream`; false
+   otherwise. Returns boolean."
+  core/attached?)
+
+(def ensure-attached!
+  "Attach supervisory-state to `stream` exactly once, synchronized per
+   stream so concurrent callers cannot double-attach. Returns a new
+   component when an attachment is created; otherwise nil."
+  core/ensure-attached!)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Query API (reads only; consumers should prefer subscribing to
 ;; `:supervisory/*-upserted` events on the event stream)
 
-(def table         core/table)
-(def specs         core/specs)
-(def workflows     core/workflows)
-(def agents        core/agents)
-(def prs           core/prs)
-(def policy-evals  core/policy-evals)
-(def attention     core/attention)
-(def tasks         core/tasks)
-(def decisions     core/decisions)
-(def interventions core/interventions)
+(def table
+  "Current entity table snapshot for `component` (pure read). Returns the
+   EntityTable map: keys `:specs :workflows :agents :prs :policy-evals
+   :attention :tasks :decisions :interventions :dependencies`, each a map
+   of id -> entity."
+  core/table)
+
+(def specs
+  "All Spec entities in `component`. Returns a seq of Spec maps (empty when
+   none)."
+  core/specs)
+
+(def workflows
+  "All WorkflowRun entities in `component`. Returns a seq of WorkflowRun
+   maps (empty when none)."
+  core/workflows)
+
+(def agents
+  "All AgentSession entities in `component`. Returns a seq of AgentSession
+   maps (empty when none)."
+  core/agents)
+
+(def prs
+  "All PrFleetEntry entities in `component`. Returns a seq of PrFleetEntry
+   maps (empty when none)."
+  core/prs)
+
+(def policy-evals
+  "All PolicyEvaluation entities in `component`. Returns a seq of
+   PolicyEvaluation maps (empty when none)."
+  core/policy-evals)
+
+(def attention
+  "All derived AttentionItem entities in `component`. Returns a seq of
+   AttentionItem maps (empty when none)."
+  core/attention)
+
+(def tasks
+  "All TaskNode entities in `component`. Returns a seq of TaskNode maps
+   (empty when none)."
+  core/tasks)
+
+(def decisions
+  "All DecisionCard entities in `component`. Returns a seq of DecisionCard
+   maps (empty when none)."
+  core/decisions)
+
+(def interventions
+  "All InterventionRequest entities in `component`. Returns a seq of
+   InterventionRequest maps (empty when none)."
+  core/interventions)
 
 (comment
   (require '[ai.miniforge.event-stream.interface :as es])

--- a/components/workflow-financial-etl/src/ai/miniforge/workflow_financial_etl/interface.clj
+++ b/components/workflow-financial-etl/src/ai/miniforge/workflow_financial_etl/interface.clj
@@ -22,14 +22,97 @@
    [ai.miniforge.workflow-financial-etl.core :as core]
    [ai.miniforge.workflow-financial-etl.events :as events]))
 
-(def create-etl-state core/create-etl-state)
-(def classify-sources core/classify-sources)
-(def scan-sources core/scan-sources)
-(def extract-knowledge core/extract-knowledge)
-(def validate-packs core/validate-packs)
-(def run-etl-workflow core/run-etl-workflow)
+(def create-etl-state
+  "Build the initial in-memory state map for an ETL workflow run.
 
-(def etl-completed-event events/etl-completed-event)
-(def etl-failed-event events/etl-failed-event)
-(def emit-etl-completed events/emit-etl-completed)
-(def emit-etl-failed events/emit-etl-failed)
+   Args: workflow-id (any id value), sources (collection of source descriptors).
+   Returns a map with keys :workflow/id, :workflow/type (:etl),
+   :workflow/status (:running), :workflow/started-at (java.util.Date),
+   :etl/sources (the passed sources), and :etl/stats (a map of zeroed counters
+   :packs-generated, :packs-promoted, :high-risk-findings, :sources-processed).
+   Pure; does not throw."
+  core/create-etl-state)
+
+(def classify-sources
+  "Classify ETL sources (first pipeline stage).
+
+   Args: logger, sources (collection). Returns a schema success/failure map.
+   On success: {:success? true :classified <sources> ...}. On error: an
+   exception-failure map {:success? false :classified nil :error {...}
+   :anomaly {...} :stage :classification}. Catches exceptions internally and
+   returns a failure map rather than throwing."
+  core/classify-sources)
+
+(def scan-sources
+  "Scan classified sources for findings (second pipeline stage).
+
+   Args: logger, classified-sources (collection). Returns a schema
+   success/failure map. On success: {:success? true :scanned <sources>
+   :findings <vector>}. On error: exception-failure map {:success? false
+   :scanned nil :error {...} :anomaly {...} :stage :scanning}. Catches
+   exceptions internally; does not throw."
+  core/scan-sources)
+
+(def extract-knowledge
+  "Extract knowledge packs from scanned sources (third pipeline stage).
+
+   Args: logger, scanned-sources (collection). Returns a schema success/failure
+   map. On success: {:success? true :packs <vector>}. On error:
+   exception-failure map {:success? false :packs nil :error {...} :anomaly {...}
+   :stage :extraction}. Catches exceptions internally; does not throw."
+  core/extract-knowledge)
+
+(def validate-packs
+  "Validate extracted packs (fourth pipeline stage).
+
+   Args: logger, packs (collection). Returns a schema success/failure map.
+   On success: {:success? true :validated <packs>}. On error:
+   exception-failure map {:success? false :validated nil :error {...}
+   :anomaly {...} :stage :validation}. Catches exceptions internally;
+   does not throw."
+  core/validate-packs)
+
+(def run-etl-workflow
+  "Run the full ETL pipeline (classify -> scan -> extract -> validate).
+
+   Args: logger, workflow-id, sources (collection). Returns a schema
+   success/failure map. On success: {:success? true :packs <validated-packs>
+   :stats <stats-map> :duration-ms <long>} and emits an etl-completed event.
+   On the first failing stage: a failure map {:success? false :packs nil
+   :error <stage-error> :duration-ms <long> :stats <merged-stats>} and emits an
+   etl-failed event. Does not throw (stage failures are returned as maps)."
+  core/run-etl-workflow)
+
+(def etl-completed-event
+  "Construct an ETL-completed event map (no side effects).
+
+   Args: workflow-id, duration-ms, summary (stats map). Returns a map with the
+   common event-base keys (:event/type :etl/completed, :event/id (uuid),
+   :event/timestamp (java.util.Date), :event/version, :event/sequence-number,
+   :workflow/id) plus :etl/duration-ms, :etl/summary, and a :message string."
+  events/etl-completed-event)
+
+(def etl-failed-event
+  "Construct an ETL-failed event map (no side effects).
+
+   Args: workflow-id, failure-stage, failure-reason, and optional error-details.
+   Returns a map with the common event-base keys plus :etl/failure-stage,
+   :etl/failure-reason, and a :message string; when error-details is supplied it
+   is attached under :etl/error-details."
+  events/etl-failed-event)
+
+(def emit-etl-completed
+  "Log an ETL-completed event at info level via the logger.
+
+   Args: logger, workflow-id, duration-ms, summary (stats map). Builds the
+   completed-event map and writes it through the logger. Returns the logger
+   call's value; called for its logging side effect."
+  events/emit-etl-completed)
+
+(def emit-etl-failed
+  "Log an ETL-failed event at error level via the logger.
+
+   Args: logger, workflow-id, failure-stage, failure-reason, and optional
+   error-details. Builds the failed-event map and writes it through the logger.
+   Returns the logger call's value; called for its logging side effect."
+  events/emit-etl-failed)

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -47,22 +47,18 @@
 ;; Pure extractors over an event sequence
 
 (defn completed?
-  "True when a reconstructed workflow context has completed successfully."
   [reconstructed]
   (true? (:completed? reconstructed)))
 
 (defn failed?
-  "True when a reconstructed workflow context has failed."
   [reconstructed]
   (true? (:failed? reconstructed)))
 
 (defn paused?
-  "True when a reconstructed workflow context reflects a paused DAG."
   [reconstructed]
   (true? (:dag-paused? reconstructed)))
 
 (defn extract-completed-dag-tasks
-  "Task IDs that finished successfully as `:dag/task-completed` events."
   [events]
   (->> events
        (filter #(= :dag/task-completed (:event/type %)))
@@ -70,7 +66,6 @@
        set))
 
 (defn extract-completed-dag-artifacts
-  "Artifacts recorded on successful `:dag/task-completed` events."
   [events]
   (->> events
        (filter #(= :dag/task-completed (:event/type %)))
@@ -103,7 +98,6 @@
        vec))
 
 (defn extract-dag-pause-info
-  "Find the last `:dag/paused` event and extract completed task IDs + reason."
   [events]
   (when-let [pause-event (->> events
                               (filter #(= :dag/paused (:event/type %)))
@@ -112,7 +106,6 @@
      :pause-reason (:dag/pause-reason pause-event)}))
 
 (defn extract-completed-phases
-  "Phase names (keywords) that completed with `:success` outcome."
   [events]
   (->> events
        (filter #(= :workflow/phase-completed (:event/type %)))
@@ -120,8 +113,6 @@
        (mapv :workflow/phase)))
 
 (defn extract-phase-results
-  "Map from phase keyword to outcome/duration/timestamp, built from
-   `:workflow/phase-completed` events."
   [events]
   (->> events
        (filter #(= :workflow/phase-completed (:event/type %)))
@@ -133,8 +124,6 @@
                {})))
 
 (defn find-workflow-spec
-  "The workflow spec recorded on the first `:workflow/started` event,
-   or nil if the run never emitted one."
   [events]
   (->> events
        (filter #(= :workflow/started (:event/type %)))

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
@@ -41,20 +41,105 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure extractors
 
-(def completed?                  core/completed?)
-(def failed?                     core/failed?)
-(def paused?                     core/paused?)
-(def extract-completed-dag-tasks core/extract-completed-dag-tasks)
-(def extract-completed-dag-artifacts core/extract-completed-dag-artifacts)
-(def extract-workspace-checkpoints core/extract-workspace-checkpoints)
-(def extract-dag-pause-info      core/extract-dag-pause-info)
-(def extract-completed-phases    core/extract-completed-phases)
-(def extract-phase-results       core/extract-phase-results)
-(def find-workflow-spec          core/find-workflow-spec)
+(def completed?
+  "True when a reconstructed workflow context completed successfully.
+   Arg: the context map from `reconstruct-context`. Returns boolean."
+  core/completed?)
+
+(def failed?
+  "True when a reconstructed workflow context has failed.
+   Arg: the context map from `reconstruct-context`. Returns boolean."
+  core/failed?)
+
+(def paused?
+  "True when a reconstructed workflow context reflects a paused DAG.
+   Arg: the context map from `reconstruct-context`. Returns boolean."
+  core/paused?)
+
+(def extract-completed-dag-tasks
+  "Task IDs that finished successfully as `:dag/task-completed` events.
+   Arg: a sequence of events. Returns a set of task-id values."
+  core/extract-completed-dag-tasks)
+
+(def extract-completed-dag-artifacts
+  "Artifacts recorded on successful `:dag/task-completed` events.
+   Arg: a sequence of events. Returns a vector of artifact maps
+   (empty when none)."
+  core/extract-completed-dag-artifacts)
+
+(def extract-workspace-checkpoints
+  "Workspace persistence records emitted at phase boundaries, used so a
+   failed repair loop can resume from the last persisted branch/bundle
+   rather than the spec base. Arg: a sequence of events. Returns a vector
+   of checkpoint maps {:branch :bundle-path :commit-sha :persist-tier
+   :env-id :phase :timestamp}; only records with a :branch and at least
+   one of :bundle-path/:commit-sha are kept (empty when none)."
+  core/extract-workspace-checkpoints)
+
+(def extract-dag-pause-info
+  "Completed task IDs + pause reason from the last `:dag/paused` event.
+   Arg: a sequence of events. Returns {:completed-task-ids set
+   :pause-reason keyword-or-nil}, or nil when no pause event exists."
+  core/extract-dag-pause-info)
+
+(def extract-completed-phases
+  "Phase names (keywords) that completed with `:success` outcome.
+   Arg: a sequence of events. Returns a vector of phase keywords in
+   event order."
+  core/extract-completed-phases)
+
+(def extract-phase-results
+  "Per-phase outcome/duration/timestamp from `:workflow/phase-completed`
+   events. Arg: a sequence of events. Returns a map from phase keyword to
+   {:outcome :duration-ms :timestamp} (empty when none)."
+  core/extract-phase-results)
+
+(def find-workflow-spec
+  "The workflow spec recorded on the first `:workflow/started` event.
+   Arg: a sequence of events. Returns the spec value, or nil if the run
+   never emitted one."
+  core/find-workflow-spec)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; High-level APIs
 
-(def reconstruct-context       core/reconstruct-context)
-(def trim-pipeline             core/trim-pipeline)
-(def resolve-workflow-identity core/resolve-workflow-identity)
+(def reconstruct-context
+  "Build a complete resume-context map from a workflow id's events.
+
+   Args:
+   - `events-dir`  — base directory (e.g. `~/.miniforge/events`)
+   - `workflow-id` — UUID string of the original run
+
+   Returns a map: {:phase-results map :completed-phases vector-of-keywords
+   :workflow-spec :workflow-id :completed? bool :failed? bool
+   :event-count int :completed-dag-tasks set :completed-dag-artifacts vector
+   :workspace-checkpoint :dag-paused? bool :dag-pause-reason keyword-or-nil
+   :machine-snapshot :checkpoint-manifest}.
+
+   Throws `:anomalies/not-found` when no valid events exist for the
+   workflow. Throws on invalid input args. Events failing shape
+   validation (missing/non-keyword `:event/type`) are dropped silently."
+  core/reconstruct-context)
+
+(def trim-pipeline
+  "Drop the already-completed leading phases from a workflow's pipeline.
+
+   Args: a workflow map with `:workflow/pipeline` and a collection of
+   completed phase keywords. Returns the workflow with only the leading
+   completed-phase prefix removed (completed phases after the first
+   incomplete phase are preserved). Throws on invalid input args."
+  core/trim-pipeline)
+
+(def resolve-workflow-identity
+  "Resolve `{:workflow-type keyword :workflow-version string}` for a
+   resume run.
+
+   Args:
+   - `reconstructed` — context map from `reconstruct-context`
+   - `fallback-fn`   — 0-arity returning a type keyword or nil
+
+   Preference for type: keyword-valid id from the recorded spec, then the
+   machine-snapshot `:execution/workflow-id` (unless a synthetic DAG-task
+   key), then `fallback-fn`. Throws `:anomalies/not-found` if no source
+   yields a loadable type; throws on invalid input args."
+  core/resolve-workflow-identity)


### PR DESCRIPTION
Wave-B boundary-documentation rollout (rule 009). Contract docstrings lifted to interface boundary (both tiers where consumed; types verified from impl); duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change. Commit-budget override (mechanical doc-only); poly:check + smoke + GraalVM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)