### PR TITLE
docs(analysis,repo): document interface boundaries (rule 009)

### DIFF
--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/core.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/core.clj
@@ -455,9 +455,6 @@
     handle))
 
 (defn stop!
-  "Unsubscribe from the stream and cancel the expire ticker. Idempotent.
-   Retains the in-memory pure state so post-shutdown queries can still
-   read the edge indices."
   [handle]
   (let [{:keys [stream subscribed? ^ScheduledExecutorService scheduler]} @handle]
     (when subscribed?

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/interface.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/interface.clj
@@ -38,18 +38,61 @@
 ;; would invite downstream callers to depend on its exact key set, turning
 ;; later consolidation into a breaking change.
 
-(def AutomationEdge          schema/AutomationEdge)
-(def routing-trigger-kinds   schema/routing-trigger-kinds)
-(def automation-edge-statuses schema/automation-edge-statuses)
+(def AutomationEdge
+  "Malli schema (vector `[:map ...]` form) for the AutomationEdge wire shape
+   emitted as `:supervisory/automation-edge-upserted`. Open map: additional
+   keys pass validation. Mirrors the Rust `AutomationEdge` struct one-to-one;
+   `:edge/id` is a deterministic UUIDv5 idempotency key derived from
+   `:edge/trigger-event-id`. Use with `malli.core` to validate or explain
+   edge envelopes at the boundary."
+  schema/AutomationEdge)
+
+(def routing-trigger-kinds
+  "Vector of keywords — every recognised RoutingTriggerKind value
+   (`:pr-merged`, `:review-comments-arrived`, `:ci-failed`,
+   `:standards-review-arrived`, `:workflow-completed`, `:gate-fired`).
+   Ordered for deterministic malli error messages; matches the Rust enum."
+  schema/routing-trigger-kinds)
+
+(def automation-edge-statuses
+  "Vector of keywords — every recognised AutomationEdge status value
+   (`:observed`, `:handled`, `:failed`, `:needs-operator`, `:suppressed`).
+   Ordered for determinism; matches the Rust enum."
+  schema/automation-edge-statuses)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Trigger classification
 
-(def classify-trigger triggers/classify-trigger)
+(def classify-trigger
+  "Classify an event-stream event into a RoutingTriggerKind keyword.
+
+   Args: a map carrying a `:type` key (standard event-stream envelope shape).
+   Returns the matching RoutingTriggerKind keyword (one of
+   `routing-trigger-kinds`), or `nil` when the event type is not a routing
+   trigger. Pure — no side effects, no state."
+  triggers/classify-trigger)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Lifecycle — the only surface the rest of the workspace should touch.
 
-(def start!  core/start!)
-(def stop!   core/stop!)
-(def attach! core/attach!)
+(def start!
+  "Start a correlator handle: subscribe to its stream, replay the published
+   prefix, drain events that arrived during replay, then start the periodic
+   expire ticker. Args: the handle returned by `create`/`attach!`. Returns
+   the same handle. Idempotent — a second call on a started handle is a no-op.
+   Side effects: stream subscription, edge emission on replay, scheduler
+   thread."
+  core/start!)
+
+(def stop!
+  "Stop a correlator handle: unsubscribe from the stream and cancel the
+   expire ticker. Args: a handle. Returns the same handle. Idempotent.
+   Retains the in-memory pure state so post-shutdown queries still read the
+   edge indices."
+  core/stop!)
+
+(def attach!
+  "Convenience constructor: `create` + `start!` in one step. Args: a `stream`,
+   and an optional `deps` map (`:clock`, `:config`). Returns a started handle
+   subscribed to `stream`. The test/wiring injection point."
+  core/attach!)

--- a/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/triggers.clj
+++ b/components/automation-edge-correlator/src/ai/miniforge/automation_edge_correlator/triggers.clj
@@ -51,12 +51,5 @@
    :gate/failed                            :gate-fired})
 
 (defn classify-trigger
-  "Classify an event-stream event into a RoutingTriggerKind keyword.
-
-   Accepts any map with a `:type` key (the standard event-stream envelope
-   shape). Returns the matching RoutingTriggerKind keyword, or `nil` if the
-   event type is not a routing trigger.
-
-   Pure function. No side effects. No state."
   [event]
   (get trigger-table (:type event)))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -45,7 +45,6 @@
 ;; Rule identity
 
 (def rule-id
-  "Stable ID for the exceptions-as-data linter rule."
   :std/exceptions-as-data)
 
 (def rule-category

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/factory.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/factory.clj
@@ -28,7 +28,6 @@
 ;; Violation
 
 (defn ->violation
-  "Create a Violation map."
   [rule-id rule-category title file line current suggested auto-fixable? rationale]
   {:rule/id       rule-id
    :rule/category rule-category
@@ -44,7 +43,6 @@
 ;; ScanResult
 
 (defn ->scan-result
-  "Create a ScanResult map."
   [violations rules-scanned files-scanned scan-duration-ms]
   {:violations       violations
    :rules-scanned    rules-scanned
@@ -55,7 +53,6 @@
 ;; PlanSummary
 
 (defn ->plan-summary
-  "Create a PlanSummary map from a collection of violations."
   [violations]
   (let [auto-fixable (filter :auto-fixable? violations)
         needs-review (remove :auto-fixable? violations)
@@ -71,7 +68,6 @@
 ;; PlanTask
 
 (defn ->plan-task
-  "Create a PlanTask map."
   [id deps file rule-id violations]
   {:task/id         id
    :task/deps       deps
@@ -83,7 +79,6 @@
 ;; Plan
 
 (defn ->plan
-  "Create a Plan map."
   [dag-tasks work-spec summary]
   {:dag-tasks dag-tasks
    :work-spec work-spec
@@ -93,7 +88,6 @@
 ;; DeltaReport
 
 (defn ->delta-report
-  "Create a DeltaReport map."
   [repo-path standards-path scan-timestamp summary violations]
   {:repo-path      repo-path
    :standards-path standards-path

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -37,22 +37,70 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
 
-(def Violation   schema/Violation)
-(def ScanResult  schema/ScanResult)
-(def PlanTask    schema/PlanTask)
-(def Plan        schema/Plan)
-(def PlanSummary schema/PlanSummary)
+(def Violation
+  "Malli schema (a `[:map ...]` vector) for a single detected rule breach.
+   Keys: :rule/id (keyword), :rule/category (non-empty string),
+   :rule/title (string), :file (string), :line (int), :current (string),
+   :suggested (string or nil), :auto-fixable? (boolean), :rationale (string)."
+  schema/Violation)
+(def ScanResult
+  "Malli schema (a `[:map ...]` vector) for the output of the scan phase.
+   Keys: :violations (vector of Violation), :rules-scanned (vector of
+   keywords), :files-scanned (int), :scan-duration-ms (int)."
+  schema/ScanResult)
+(def PlanTask
+  "Malli schema (a `[:map ...]` vector) for one DAG task node in a Plan.
+   Keys: :task/id (uuid), :task/deps (set of uuids), :task/file (string),
+   :task/rule-id (keyword), :task/violations (vector of Violation)."
+  schema/PlanTask)
+(def Plan
+  "Malli schema (a `[:map ...]` vector) for the full remediation plan.
+   Keys: :dag-tasks (vector of PlanTask), :work-spec (string),
+   :summary (PlanSummary)."
+  schema/Plan)
+(def PlanSummary
+  "Malli schema (a `[:map ...]` vector) of aggregate plan counts.
+   Keys: :total-violations, :auto-fixable, :needs-review, :files-affected,
+   :rules-violated (all ints)."
+  schema/PlanSummary)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Factory re-exports
 
-(def ->violation factory/->violation)
-(def ->scan-result factory/->scan-result)
-(def ->plan-summary factory/->plan-summary)
-(def ->plan-task factory/->plan-task)
-(def ->plan factory/->plan)
-(def ->delta-report factory/->delta-report)
-(def DeltaReport schema/DeltaReport)
+(def ->violation
+  "Construct a Violation map from positional args:
+   [rule-id rule-category title file line current suggested auto-fixable?
+   rationale]. Pure; returns the map."
+  factory/->violation)
+(def ->scan-result
+  "Construct a ScanResult map from positional args:
+   [violations rules-scanned files-scanned scan-duration-ms]. Pure;
+   returns the map."
+  factory/->scan-result)
+(def ->plan-summary
+  "Derive a PlanSummary map from a collection of violations by counting
+   totals, auto-fixable, needs-review, distinct files, and distinct rules.
+   Pure; returns the map."
+  factory/->plan-summary)
+(def ->plan-task
+  "Construct a PlanTask map from positional args:
+   [id deps file rule-id violations]. Pure; returns the map."
+  factory/->plan-task)
+(def ->plan
+  "Construct a Plan map from positional args:
+   [dag-tasks work-spec summary]. Pure; returns the map."
+  factory/->plan)
+(def ->delta-report
+  "Construct a DeltaReport map from positional args:
+   [repo-path standards-path scan-timestamp summary violations]. Pure;
+   returns the map."
+  factory/->delta-report)
+(def DeltaReport
+  "Malli schema (a `[:map ...]` vector) for the delta report written to
+   disk. Keys: :repo-path (string), :standards-path (string),
+   :scan-timestamp (string), :summary (PlanSummary), :violations (vector
+   of Violation)."
+  schema/DeltaReport)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Built-in linter re-exports

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/schema.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/schema.clj
@@ -25,7 +25,6 @@
 ;; Violation — one detected instance of a rule breach
 
 (def Violation
-  "Schema for a single detected violation."
   [:map
    [:rule/id       :keyword]
    [:rule/category [:string {:min 1}]]
@@ -41,7 +40,6 @@
 ;; ScanResult — output of the scan phase
 
 (def ScanResult
-  "Schema for the result of scanning a repository."
   [:map
    [:violations       [:vector Violation]]
    [:rules-scanned    [:vector :keyword]]
@@ -52,7 +50,6 @@
 ;; PlanTask — one DAG task node
 
 (def PlanTask
-  "Schema for a single task in the remediation plan DAG."
   [:map
    [:task/id         uuid?]
    [:task/deps       [:set uuid?]]
@@ -64,7 +61,6 @@
 ;; PlanSummary — aggregate counts
 
 (def PlanSummary
-  "Schema for plan summary statistics."
   [:map
    [:total-violations :int]
    [:auto-fixable     :int]
@@ -76,7 +72,6 @@
 ;; Plan — output of the plan phase
 
 (def Plan
-  "Schema for the full remediation plan."
   [:map
    [:dag-tasks [:vector PlanTask]]
    [:work-spec :string]
@@ -86,7 +81,6 @@
 ;; DeltaReport — final serialisable output
 
 (def DeltaReport
-  "Schema for the delta report written to disk."
   [:map
    [:repo-path       :string]
    [:standards-path  :string]

--- a/components/patterns/src/ai/miniforge/patterns/core.clj
+++ b/components/patterns/src/ai/miniforge/patterns/core.clj
@@ -26,42 +26,34 @@
 ;; Markdown / file-path extraction patterns
 
 (def md-heading-file-path
-  "Match a file path in a markdown heading: ### path/to/file.clj"
   #"#{1,4}\s+[`*]*([^\s`*]+\.\w{1,6})[`*]*")
 
 (def md-delimited-file-path
-  "Match a file path in backticks or bold: **path/to/file.clj** or `path/to/file.clj`"
   #"[`*]+([^\s`*]+\.\w{1,6})[`*]+")
 
 (def md-label-file-path
-  "Match 'File: path/to/file.clj' or 'Path: path/to/file.clj'"
   #"(?i)(?:file|path):\s*`?([^\s`]+\.\w{1,6})`?")
 
 (def md-code-block
-  "Match a fenced code block: ```lang\\ncontent```"
   #"```(?:(\w+)\n)?([^`]+)```")
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; File extension patterns
 
 (def file-extension
-  "Extract file extension: .clj, .js, etc."
   #"\.(\w+)$")
 
 ;;------------------------------------------------------------------------------ Layer 2
 ;; EDN / structured content patterns
 
 (def edn-code-block
-  "Match a clojure/edn fenced code block."
   #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```")
 
 (def inline-already-implemented
-  "Match an inline {:status :already-implemented ...} EDN map."
   #"\{:status\s+:already-implemented[^}]*\}")
 
 ;;------------------------------------------------------------------------------ Layer 3
 ;; Rate-limit detection (canonical pattern — use this everywhere)
 
 (def rate-limit
-  "Detect rate-limit / quota messages in LLM or API responses."
   #"(?i)you've hit your limit|rate.?limit|429|quota.?exceeded|resets \d+[ap]m")

--- a/components/patterns/src/ai/miniforge/patterns/interface.clj
+++ b/components/patterns/src/ai/miniforge/patterns/interface.clj
@@ -27,17 +27,57 @@
   (:require [ai.miniforge.patterns.core :as core]))
 
 ;; Markdown / file-path extraction
-(def md-heading-file-path    core/md-heading-file-path)
-(def md-delimited-file-path  core/md-delimited-file-path)
-(def md-label-file-path      core/md-label-file-path)
-(def md-code-block           core/md-code-block)
+(def md-heading-file-path
+  "java.util.regex.Pattern matching a file path inside a markdown heading,
+   e.g. `### path/to/file.clj` (1-4 leading #, optional ` or * wrapping).
+   Capture group 1 holds the bare path. Use with re-find: returns
+   [whole-match path] vector on a hit, nil on no match."
+  core/md-heading-file-path)
+(def md-delimited-file-path
+  "java.util.regex.Pattern matching a file path wrapped in backticks or
+   bold/italic asterisks, e.g. `` `path/to/file.clj` `` or `**path/to/file.clj**`.
+   Capture group 1 holds the bare path. Use with re-find: returns
+   [whole-match path] vector on a hit, nil on no match."
+  core/md-delimited-file-path)
+(def md-label-file-path
+  "java.util.regex.Pattern (case-insensitive) matching a labelled file path,
+   e.g. `File: path/to/file.clj` or `Path: path/to/file.clj` (optional
+   backticks). Capture group 1 holds the bare path. Use with re-find:
+   returns [whole-match path] vector on a hit, nil on no match."
+  core/md-label-file-path)
+(def md-code-block
+  "java.util.regex.Pattern matching a fenced markdown code block:
+   ```lang\\ncontent```. Capture group 1 holds the optional language tag
+   (nil if absent), group 2 the block body. Use with re-find/re-seq:
+   returns [whole-match lang body] vectors, nil/empty on no match."
+  core/md-code-block)
 
 ;; File extensions
-(def file-extension          core/file-extension)
+(def file-extension
+  "java.util.regex.Pattern matching a trailing file extension, e.g. `.clj`.
+   Capture group 1 holds the extension without the dot. Use with re-find:
+   returns [whole-match ext] vector on a hit, nil on no match."
+  core/file-extension)
 
 ;; EDN / structured content
-(def edn-code-block          core/edn-code-block)
-(def inline-already-implemented core/inline-already-implemented)
+(def edn-code-block
+  "java.util.regex.Pattern matching a clojure/edn fenced code block
+   (lang tag clojure, edn, or absent). Capture group 1 holds the block
+   body. Use with re-find/re-seq: returns [whole-match body] vectors,
+   nil/empty on no match."
+  core/edn-code-block)
+(def inline-already-implemented
+  "java.util.regex.Pattern matching an inline
+   `{:status :already-implemented ...}` EDN map within free text. No capture
+   groups. Use with re-find: returns the matched substring on a hit, nil on
+   no match."
+  core/inline-already-implemented)
 
 ;; Rate-limit detection
-(def rate-limit              core/rate-limit)
+(def rate-limit
+  "Canonical java.util.regex.Pattern (case-insensitive) detecting
+   rate-limit / quota messages in LLM or API responses (e.g. \"rate limit\",
+   \"429\", \"quota exceeded\", \"resets 3pm\"). Use everywhere instead of
+   ad-hoc regexes. Use with re-find: returns the matched substring on a hit,
+   nil on no match."
+  core/rate-limit)

--- a/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
@@ -122,10 +122,33 @@
   anomaly/anomaly?)
 
 ;; Progress-detector-local schemas (not duplicates of anomaly/*).
-(def Observation         schema/Observation)
-(def DetectorConfig      schema/DetectorConfig)
-(def ToolProfile         schema/ToolProfile)
-(def DetectorAnomalyData schema/DetectorAnomalyData)
+(def Observation
+  "Malli schema (a [:map …] vector) for a single tool-invocation event
+   fed into the detector reduce loop. Required keys: :tool/id (keyword),
+   :seq (int), :timestamp (inst). Optional: :tool/duration-ms,
+   :tool/input, :tool/output, :tool/error?, :resource/version-hash."
+  schema/Observation)
+
+(def DetectorConfig
+  "Malli schema (a [:map …] vector) for one per-detector configuration
+   overlay layer. Optional keys: :config/directive (one of :inherit
+   :disable :enable :tune) and :config/params (map of keyword→any)."
+  schema/DetectorConfig)
+
+(def ToolProfile
+  "Malli schema (a [:map …] vector) for a tool-profile registry entry.
+   Required: :tool/id (keyword), :determinism (one of schema/determinisms).
+   Optional: :anomaly/categories (set of keywords), :timeout-ms (int or
+   nil), :config (map of keyword→any)."
+  schema/ToolProfile)
+
+(def DetectorAnomalyData
+  "Malli schema (a [:map …] vector) for the map carried under an
+   anomaly's :anomaly/data. Required keys: :detector/kind (keyword),
+   :detector/version (string), :anomaly/class (:mechanical | :heuristic),
+   :anomaly/severity (:info | :warn | :error | :fatal), :anomaly/category
+   (keyword), :anomaly/evidence (bounded evidence map)."
+  schema/DetectorAnomalyData)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Event-envelope normalizer
@@ -149,14 +172,39 @@
    the field."
   envelope/make-normalizer)
 
-(def valid-observation?            schema/valid-observation?)
-(def explain-observation           schema/explain-observation)
-(def valid-tool-profile?           schema/valid-tool-profile?)
-(def explain-tool-profile          schema/explain-tool-profile)
-(def valid-detector-config?        schema/valid-detector-config?)
-(def explain-detector-config       schema/explain-detector-config)
-(def valid-detector-anomaly-data?  schema/valid-detector-anomaly-data?)
-(def explain-detector-anomaly-data schema/explain-detector-anomaly-data)
+(def valid-observation?
+  "Predicate: return true if m satisfies the Observation schema, else false."
+  schema/valid-observation?)
+
+(def explain-observation
+  "Return a humanized error map if m fails Observation validation, else nil."
+  schema/explain-observation)
+
+(def valid-tool-profile?
+  "Predicate: return true if m satisfies the ToolProfile schema, else false."
+  schema/valid-tool-profile?)
+
+(def explain-tool-profile
+  "Return a humanized error map if m fails ToolProfile validation, else nil."
+  schema/explain-tool-profile)
+
+(def valid-detector-config?
+  "Predicate: return true if m satisfies the DetectorConfig schema, else false."
+  schema/valid-detector-config?)
+
+(def explain-detector-config
+  "Return a humanized error map if m fails DetectorConfig validation, else nil."
+  schema/explain-detector-config)
+
+(def valid-detector-anomaly-data?
+  "Predicate: return true if m satisfies the DetectorAnomalyData schema
+   (the shape carried under an anomaly's :anomaly/data), else false."
+  schema/valid-detector-anomaly-data?)
+
+(def explain-detector-anomaly-data
+  "Return a humanized error map if m fails DetectorAnomalyData validation,
+   else nil."
+  schema/explain-detector-anomaly-data)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Tool-profile registration (no built-in profiles — components contribute)

--- a/components/progress-detector/src/ai/miniforge/progress_detector/protocol.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/protocol.clj
@@ -100,8 +100,6 @@
         (update :window-size inc))))
 
 (defn null-detector
-  "Return a NullDetector that never flags any anomaly.
-   Useful as a no-op placeholder and for composing detector pipelines."
   []
   (->NullDetector))
 

--- a/components/progress-detector/src/ai/miniforge/progress_detector/supervisor.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/supervisor.clj
@@ -206,7 +206,6 @@
          (assoc :reason reason))))))
 
 (defn terminate?
-  "Convenience predicate over a `handle` decision map."
   [decision]
   (= :terminate (:action decision)))
 

--- a/components/progress-detector/src/ai/miniforge/progress_detector/tool_profile.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/tool_profile.clj
@@ -91,8 +91,6 @@
   (swap! registry-atom assoc (:tool/id profile) profile))
 
 (defn unregister!
-  "Remove the profile for `tool-id` from `registry-atom`.
-   Returns the new registry map."
   [registry-atom tool-id]
   (swap! registry-atom dissoc tool-id))
 
@@ -118,24 +116,18 @@
    (get (registry-value registry) tool-id)))
 
 (defn determinism-of
-  "Return the :determinism level for `tool-id`, or :unstable if unknown.
-
-   :unstable is the safe default — unknown tools are treated as heuristic
-   signals only, never as mechanical-eligible loops."
   ([tool-id]
    (determinism-of tool-id default-registry))
   ([tool-id registry]
    (get (lookup tool-id registry) :determinism :unstable)))
 
 (defn categories-of
-  "Return the set of anomaly categories for `tool-id`, or #{} if unknown."
   ([tool-id]
    (categories-of tool-id default-registry))
   ([tool-id registry]
    (get (lookup tool-id registry) :anomaly/categories #{})))
 
 (defn all-tool-ids
-  "Return sorted vector of all registered tool-id keywords."
   ([]
    (all-tool-ids default-registry))
   ([registry]

--- a/components/repo-index/src/ai/miniforge/repo_index/interface.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/interface.clj
@@ -44,12 +44,41 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
 
-(def FileRecord schema/FileRecord)
-(def RepoIndex schema/RepoIndex)
-(def RepoMapEntry schema/RepoMapEntry)
-(def RepoMapSlice schema/RepoMapSlice)
-(def SearchHit schema/SearchHit)
-(def Snippet schema/Snippet)
+(def FileRecord
+  "Malli schema (a [:map ...] vector) for a single file entry in the repo index.
+   Keys: :path (non-empty string), :blob-sha (string, min 7), :size (int),
+   :lines (int), :language (string or nil), :generated? (boolean)."
+  schema/FileRecord)
+
+(def RepoIndex
+  "Malli schema (a [:map ...] vector) for a complete repo index.
+   Keys: :tree-sha (string, min 7), :repo-root (non-empty string),
+   :files (vector of FileRecord), :file-count (int), :total-lines (int),
+   :languages (map of string->int), :indexed-at (inst)."
+  schema/RepoIndex)
+
+(def RepoMapEntry
+  "Malli schema (a [:map ...] vector) for a single entry in the repo map.
+   Keys: :path (non-empty string), :lang (string or nil), :lines (int),
+   :size (int)."
+  schema/RepoMapEntry)
+
+(def RepoMapSlice
+  "Malli schema (a [:map ...] vector) for a token-budgeted repo map slice.
+   Keys: :tree-sha (string, min 7), :entries (vector of RepoMapEntry),
+   :total-files (int), :shown-files (int), :truncated? (boolean),
+   :token-estimate (int)."
+  schema/RepoMapSlice)
+
+(def SearchHit
+  "Malli schema (a [:map ...] vector) for a single search result.
+   Keys: :path (non-empty string), :score (double), :snippets (vector of Snippet)."
+  schema/SearchHit)
+
+(def Snippet
+  "Malli schema (a [:map ...] vector) for a search result snippet.
+   Keys: :start-line (int), :end-line (int), :text (string)."
+  schema/Snippet)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Index building

--- a/components/repo-index/src/ai/miniforge/repo_index/messages.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/messages.clj
@@ -22,6 +22,5 @@
   (:require [ai.miniforge.messages.interface :as messages]))
 
 (def t
-  "Look up a repo-index message by key, with optional param substitution."
   (messages/create-translator "config/repo-index/messages/en-US.edn"
                               :repo-index/messages))

--- a/components/repo-index/src/ai/miniforge/repo_index/schema.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/schema.clj
@@ -25,7 +25,6 @@
 ;; File Record
 
 (def FileRecord
-  "Schema for a single file entry in the repo index."
   [:map
    [:path [:string {:min 1}]]
    [:blob-sha [:string {:min 7}]]
@@ -38,7 +37,6 @@
 ;; Repo Index
 
 (def RepoIndex
-  "Schema for the complete repo index."
   [:map
    [:tree-sha [:string {:min 7}]]
    [:repo-root [:string {:min 1}]]
@@ -52,7 +50,6 @@
 ;; Repo Map Slice
 
 (def RepoMapEntry
-  "Schema for a single entry in the repo map."
   [:map
    [:path [:string {:min 1}]]
    [:lang [:maybe :string]]
@@ -60,7 +57,6 @@
    [:size :int]])
 
 (def RepoMapSlice
-  "Schema for a token-budgeted repo map slice."
   [:map
    [:tree-sha [:string {:min 7}]]
    [:entries [:vector RepoMapEntry]]
@@ -73,14 +69,12 @@
 ;; Search Hit
 
 (def Snippet
-  "Schema for a search result snippet."
   [:map
    [:start-line :int]
    [:end-line :int]
    [:text [:string {:min 0}]]])
 
 (def SearchHit
-  "Schema for a single search result."
   [:map
    [:path [:string {:min 1}]]
    [:score :double]

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -41,8 +41,6 @@
    :file-content      file-content})
 
 (defn build-judge-prompt
-  "Build system + user prompts for LLM-as-judge analysis.
-   Returns {:system string :user string}."
   [rule file-path file-content]
   (let [templates @judge-templates
         bindings  (rule->prompt-bindings rule file-path file-content)]
@@ -91,17 +89,6 @@
   (mapv #(raw->violation rule file-path %) raw-violations))
 
 (defn analyze-file
-  "Analyze a single file against a behavioral rule using the LLM.
-
-   Arguments:
-   - llm-client — LLM client from ai.miniforge.llm.interface
-   - complete-fn — Function to call LLM: (fn [client request]) -> response
-   - rule — Policy pack rule with :rule/knowledge-content
-   - file-path — Path to the file
-   - file-content — File content string
-
-   Returns:
-   - Vector of canonical violation maps"
   [llm-client complete-fn rule file-path file-content]
   (let [{:keys [system user]} (build-judge-prompt rule file-path file-content)
         response (complete-fn llm-client
@@ -170,16 +157,6 @@
   300000)
 
 (defn analyze-rule
-  "Analyze all matching files against a single behavioral rule.
-
-   Arguments:
-   - llm-client — LLM client
-   - complete-fn — LLM completion function
-   - repo-path — Repository root path
-   - rule — Behavioral rule with :rule/knowledge-content
-
-   Returns:
-   - {:rule/id keyword :violations [...] :files-analyzed int :duration-ms int :status keyword}"
   [llm-client complete-fn repo-path rule]
   (let [start-ms (System/currentTimeMillis)
         files    (select-files-for-rule repo-path rule)
@@ -215,19 +192,6 @@
          :error        (.getMessage e)}))))
 
 (defn analyze-rules-parallel
-  "Analyze all behavioral rules in parallel with per-rule timeouts.
-
-   Arguments:
-   - llm-client — LLM client
-   - complete-fn — LLM completion function
-   - repo-path — Repository root path
-   - rules — Vector of behavioral rules
-   - opts — Options map:
-     :timeout-ms — Per-rule timeout (default 120000)
-     :max-parallel — Max concurrent rules (default 4)
-
-   Returns:
-   - Vector of per-rule result maps"
   [llm-client complete-fn repo-path rules opts]
   (let [timeout-ms   (get opts :timeout-ms default-rule-timeout-ms)
         max-parallel (get opts :max-parallel 4)

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
@@ -7,9 +7,46 @@
   (:require
    [ai.miniforge.semantic-analyzer.core :as core]))
 
-(def build-judge-prompt core/build-judge-prompt)
-(def analyze-file core/analyze-file)
-(def analyze-rule core/analyze-rule)
-(def analyze-rules-parallel core/analyze-rules-parallel)
-(def select-files-for-rule core/select-files-for-rule)
-(def behavioral-rules core/behavioral-rules)
+(def build-judge-prompt
+  "Build the LLM-as-judge system + user prompts for one rule/file pair.
+   Args: rule (policy-pack rule map), file-path (string), file-content (string).
+   Returns a map {:system string :user string}."
+  core/build-judge-prompt)
+
+(def analyze-file
+  "Analyze a single file against one behavioral rule via the LLM.
+   Args: llm-client (LLM client from ai.miniforge.llm.interface), complete-fn
+   (fn [client request] -> response map), rule (policy-pack rule with
+   :rule/knowledge-content), file-path (string), file-content (string).
+   Returns a vector of canonical violation maps (empty on no violations or
+   unparseable LLM output)."
+  core/analyze-file)
+
+(def analyze-rule
+  "Analyze all matching files in a repo against one behavioral rule.
+   Args: llm-client, complete-fn, repo-path (string repo root), rule.
+   Returns a map {:rule/id keyword :violations vector :files-analyzed int
+   :duration-ms int :status keyword}. Selects files via select-files-for-rule."
+  core/analyze-rule)
+
+(def analyze-rules-parallel
+  "Analyze many behavioral rules in parallel batches with per-rule timeouts.
+   Args: llm-client, complete-fn, repo-path (string), rules (vector of rule
+   maps), opts (map with optional :timeout-ms per-rule timeout default 300000
+   and :max-parallel max concurrent rules default 4).
+   Returns a vector of per-rule result maps (same shape as analyze-rule, with
+   :status :timeout or :error and an :error message on failures)."
+  core/analyze-rules-parallel)
+
+(def select-files-for-rule
+  "Select repo files matching a rule's :rule/applies-to file globs.
+   Args: repo-path (string repo root), rule (policy-pack rule map).
+   Returns a lazy/clojure sequence of java.io.File, capped at the per-rule file
+   limit, excluding files over the max size limit."
+  core/select-files-for-rule)
+
+(def behavioral-rules
+  "Filter rules to those carrying :rule/knowledge-content (need LLM analysis).
+   Args: pack-rules (sequence of policy-pack rule maps).
+   Returns a vector of the matching rule maps."
+  core/behavioral-rules)

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
@@ -34,8 +34,9 @@
    Args: llm-client, complete-fn, repo-path (string), rules (vector of rule
    maps), opts (map with optional :timeout-ms per-rule timeout default 300000
    and :max-parallel max concurrent rules default 4).
-   Returns a vector of per-rule result maps (same shape as analyze-rule, with
-   :status :timeout or :error and an :error message on failures)."
+   Returns a vector of per-rule result maps (same shape as analyze-rule). On a
+   per-rule timeout the result carries :status :timeout (no :error key); on an
+   exception it carries :status :error plus an :error message string."
   core/analyze-rules-parallel)
 
 (def select-files-for-rule


### PR DESCRIPTION
Wave-B boundary-documentation rollout (rule 009). Contract docstrings lifted to interface boundary (both tiers where consumed; types verified from impl); duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change. Commit-budget override (mechanical doc-only); poly:check + smoke + GraalVM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)