### PR TITLE
docs(control-plane-adapter,reporting,llm,artifact): document interface boundaries (rule 009)

### DIFF
--- a/components/artifact/src/ai/miniforge/artifact/interface.clj
+++ b/components/artifact/src/ai/miniforge/artifact/interface.clj
@@ -23,7 +23,17 @@
    [ai.miniforge.artifact.interface.protocols.artifact-store :as p]))
 
 ;; Re-export protocol for public API
-(def ArtifactStore p/ArtifactStore)
+(def ArtifactStore
+  "Protocol contract for pluggable artifact stores (extensibility point).
+
+   Re-exported from ai.miniforge.artifact.interface.protocols.artifact-store.
+   Implement this protocol to back artifacts with a custom store; the bundled
+   implementations are the Datalevin store (JVM, via create-store) and the
+   Transit store (Babashka compatible, via create-transit-store).
+
+   Methods: save, load-artifact, query, link, close. See the sub-namespace
+   docstrings for each method's args, return shape, and failure mode."
+  p/ArtifactStore)
 
 (defn create-store
   "Create a Datalevin-based artifact store (JVM only).

--- a/components/artifact/src/ai/miniforge/artifact/interface.clj
+++ b/components/artifact/src/ai/miniforge/artifact/interface.clj
@@ -32,7 +32,8 @@
    Transit store (Babashka compatible, via create-transit-store).
 
    Methods: save, load-artifact, query, link, close. See the sub-namespace
-   docstrings for each method's args, return shape, and failure mode."
+   protocol docstrings for each method's purpose and return shape (they do not
+   currently document argument contracts or failure modes)."
   p/ArtifactStore)
 
 (defn create-store

--- a/components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
@@ -61,18 +61,6 @@
     (impl/close-store this)))
 
 (defn create-transit-store
-  "Create a new Transit-based artifact store.
-
-   Options:
-   - :dir      - Base directory for storage (defaults to ~/.miniforge)
-   - :logger   - Optional logger
-
-   The artifacts will be stored in {dir}/artifacts/
-
-   Examples:
-     (create-transit-store)                              ; Uses ~/.miniforge/artifacts
-     (create-transit-store {:dir \"/tmp/test\"})          ; Uses /tmp/test/artifacts
-     (create-transit-store {:logger my-logger})"
   ([] (create-transit-store {}))
   ([{:keys [dir logger]}]
    (let [artifacts-dir (impl/artifacts-dir dir)]

--- a/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj
+++ b/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj
@@ -31,15 +31,69 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol re-exports + pure data + helpers with no in-namespace deps.
 
-(def ControlPlaneAdapter proto/ControlPlaneAdapter)
-(def ControlPlaneAdapterLogs proto/ControlPlaneAdapterLogs)
+(def ControlPlaneAdapter
+  "Protocol vendor-specific adapters must implement to bridge a
+   vendor-native agent API to the control plane's normalized model.
 
-(def adapter-id proto/adapter-id)
-(def discover-agents proto/discover-agents)
-(def poll-agent-status proto/poll-agent-status)
-(def deliver-decision proto/deliver-decision)
-(def send-command proto/send-command)
-(def agent-logs proto/agent-logs)
+   Members: `adapter-id`, `discover-agents`, `poll-agent-status`,
+   `deliver-decision`, `send-command`. Implement via defrecord/reify."
+  proto/ControlPlaneAdapter)
+
+(def ControlPlaneAdapterLogs
+  "Optional protocol for adapters that can retrieve agent logs.
+
+   Single member `agent-logs`; adapters without log support omit it."
+  proto/ControlPlaneAdapterLogs)
+
+(def adapter-id
+  "Protocol fn. Return the keyword identifying an adapter (e.g.
+   :claude-code, :openai). Unique across all registered adapters.
+
+   Args: [this]. Returns: keyword."
+  proto/adapter-id)
+
+(def discover-agents
+  "Protocol fn. Discover running agents for the adapter's vendor.
+
+   Args: [this config]. Returns: seq of agent-registration maps
+   ({:agent/vendor kw :agent/external-id str :agent/name str
+   :agent/capabilities set-of-kw :agent/metadata map}); empty seq
+   when none found or discovery unsupported (push-only adapters)."
+  proto/discover-agents)
+
+(def poll-agent-status
+  "Protocol fn. Poll the current status of a single agent.
+
+   Args: [this agent-record]. Returns: map
+   {:status kw :task str-optional :metrics map-optional}, or nil
+   when the agent is no longer reachable."
+  proto/poll-agent-status)
+
+(def deliver-decision
+  "Protocol fn. Deliver a resolved decision to an agent.
+
+   Args: [this agent-record decision-resolution], where
+   decision-resolution is {:decision/id uuid
+   :decision/resolution str-or-kw :decision/comment str-or-nil}.
+   Returns: map {:delivered? boolean :error str-or-nil}."
+  proto/deliver-decision)
+
+(def send-command
+  "Protocol fn. Send a control command to an agent.
+
+   Args: [this agent-record command] where command is one of
+   :pause :resume :terminate :restart.
+   Returns: map {:success? boolean :error str-or-nil}."
+  proto/send-command)
+
+(def agent-logs
+  "Protocol fn (ControlPlaneAdapterLogs). Retrieve recent agent logs.
+
+   Args: [this agent-record opts] where opts is
+   {:limit max-entries :since java.util.Date}. Returns: seq of
+   log-entry maps ([{:timestamp inst :level kw :message str}]),
+   or nil when log retrieval is unsupported."
+  proto/agent-logs)
 
 (def ^:private vendor-heartbeat-ms
   "Recommended heartbeat intervals per vendor (ms)."

--- a/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj
+++ b/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj
@@ -90,8 +90,8 @@
   "Protocol fn (ControlPlaneAdapterLogs). Retrieve recent agent logs.
 
    Args: [this agent-record opts] where opts is
-   {:limit max-entries :since java.util.Date}. Returns: seq of
-   log-entry maps ([{:timestamp inst :level kw :message str}]),
+   {:limit max-entries :since java.util.Date}. Returns: a seq of
+   log-entry maps, each {:timestamp inst :level kw :message str},
    or nil when log retrieval is unsupported."
   proto/agent-logs)
 

--- a/components/llm/src/ai/miniforge/llm/interface.clj
+++ b/components/llm/src/ai/miniforge/llm/interface.clj
@@ -36,7 +36,13 @@
   impl/backends)
 
 ;; Re-export protocol for public API
-(def LLMClient p/LLMClient)
+(def LLMClient
+  "Protocol clients implement for LLM interaction; the public extensibility
+   point for custom backends. Methods: complete* [this request] -> result
+   map ({:success true :content :usage} or {:success false :error :anomaly});
+   complete-stream* [this request on-chunk] -> same result map, invoking
+   on-chunk per token; get-config [this] -> the client's config map."
+  p/LLMClient)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Client creation

--- a/components/llm/src/ai/miniforge/llm/interface.clj
+++ b/components/llm/src/ai/miniforge/llm/interface.clj
@@ -41,7 +41,9 @@
    point for custom backends. Methods: complete* [this request] -> result
    map ({:success true :content :usage} or {:success false :error :anomaly});
    complete-stream* [this request on-chunk] -> same result map, invoking
-   on-chunk per token; get-config [this] -> the client's config map."
+   on-chunk per parsed stream chunk/event (text deltas, which may span
+   multiple tokens, plus tool-use and heartbeat events); get-config [this]
+   -> the client's config map."
   p/LLMClient)
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/reporting/src/ai/miniforge/reporting/core.clj
+++ b/components/reporting/src/ai/miniforge/reporting/core.clj
@@ -266,19 +266,6 @@
 ;; Constructor
 
 (defn create-reporting-service
-  "Create a reporting service.
-
-   Options:
-   - :workflow-component - Workflow component instance
-   - :orchestrator-component - Orchestrator component instance
-   - :operator-component - Operator component instance
-   - :artifact-store - Artifact store instance
-   - :logger - Logger instance
-
-   Example:
-     (create-reporting-service {:workflow-component wf
-                                :operator-component op
-                                :logger logger})"
   ([] (create-reporting-service {}))
   ([{:keys [workflow-component
             orchestrator-component

--- a/components/reporting/src/ai/miniforge/reporting/interface.clj
+++ b/components/reporting/src/ai/miniforge/reporting/interface.clj
@@ -30,7 +30,15 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol re-exports
 
-(def ReportingService proto/ReportingService)
+(def ReportingService
+  "Protocol satisfied by reporting service instances.
+
+   Defines the monitoring/aggregation contract: get-system-status,
+   get-workflow-list, get-workflow-detail, get-meta-loop-status,
+   subscribe, unsubscribe, poll-events. Use with satisfies?/extend
+   or as the dispatch target for the interface fns below. Instances
+   are produced by create-reporting-service."
+  proto/ReportingService)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Service creation


### PR DESCRIPTION
Wave-B boundary-documentation rollout (rule 009). Contract docstrings lifted to interface boundary (both tiers where consumed; types verified from impl); duplicate impl docstrings removed, extras kept. Docstring-only — no behavior change. Commit-budget override (mechanical doc-only); poly:check + smoke + GraalVM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)