### PR TITLE
fix(llm,agent): classify context-overflow as terminal so no doomed retry fires

### DIFF
--- a/components/agent/src/ai/miniforge/agent/submission_recovery.clj
+++ b/components/agent/src/ai/miniforge/agent/submission_recovery.clj
@@ -41,7 +41,12 @@
 
 (def ^:private recoverable-error-types
   "Backend error classes whose stdout still holds the agent's work, so a
-   submission-only retry can recover it."
+   submission-only retry can recover it.
+
+   Deliberately EXCLUDES `llm/context-overflow-error-type`
+   (\"context_overflow\"): a prompt that exceeded the model's context
+   window left no artifact to recover, and a retry re-sends an over-budget
+   prompt — so it must terminate, not retry (see that var's docstring)."
   #{"adaptive_timeout" "cli_error"})
 
 (defn submission-retry?

--- a/components/agent/test/ai/miniforge/agent/submission_recovery_test.clj
+++ b/components/agent/test/ai/miniforge/agent/submission_recovery_test.clj
@@ -50,3 +50,12 @@
                           {:success false :error {:stdout "" :type "cli_error"}} nil nil ""))))
     (is (false? (boolean (sut/submission-retry?
                           {:success false :error {:stdout "x" :type "other"}} nil nil ""))))))
+
+(deftest no-fire-on-context-overflow
+  (testing "a context_overflow error never retries even with stdout — its stdout
+            holds no artifact and a retry re-sends an over-budget prompt"
+    (is (false? (boolean (sut/submission-retry?
+                          {:success false
+                           :error {:stdout "Need to explore the components..."
+                                   :type "context_overflow"}}
+                          nil nil ""))))))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1579,6 +1579,33 @@
        (zero? tool-call-count)
        (nil? usage)))
 
+(def context-overflow-error-type
+  "Distinct error :type for a prompt that exceeded the model's context
+   window. Kept OUT of submission-recovery/recoverable-error-types: such a
+   turn produced no usable artifact (its stdout holds no plan) and a
+   submission-only retry cannot recover it — the retry re-sends an
+   over-budget prompt and, with nothing to convert, burns its whole budget
+   re-planning from scratch. Classifying it distinctly lets the phase fail
+   cleanly on the real overflow instead of firing a doomed retry.
+   (review-redirect-convergence dogfood adhoc-2135293220, 2026-06-07: the
+   planner's main turn overflowed, was misclassified as a recoverable
+   cli_error, and the submission-retry then died at its 120s hard cap.)"
+  "context_overflow")
+
+(def ^:private context-overflow-markers
+  "Lower-cased substrings the agent CLIs emit when the prompt exceeds the
+   model's context window. Matched case-insensitively against the error
+   message."
+  ["prompt is too long"])
+
+(defn context-overflow-error?
+  "True when `message` indicates the prompt exceeded the model's context
+   window — an unrecoverable terminal condition (see
+   `context-overflow-error-type`)."
+  [message]
+  (let [m (str/lower-case (or message ""))]
+    (boolean (some #(str/includes? m %) context-overflow-markers))))
+
 (defn streaming-error-response
   "Build a streaming error response with diagnostic metadata.
 
@@ -1593,7 +1620,10 @@
                           (not-empty (str/trim (or raw-stdout "")))
                           (msg/t :streaming-error.system/no-output))
         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
-        error-type (if timeout-info "adaptive_timeout" "cli_error")]
+        error-type (cond
+                     timeout-info "adaptive_timeout"
+                     (context-overflow-error? error-message) context-overflow-error-type
+                     :else "cli_error")]
     (cond-> (llm-error category error-type (str/trim error-message)
                        {:exit-code exit-code
                         :stderr err-result

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -526,7 +526,20 @@
       streaming?                   (conj "--verbose")
       stdin?                       (conj claude-input-format-flag
                                          claude-input-format-stdin)
-      mcp-config                   (into ["--mcp-config" mcp-config])
+      ;; --strict-mcp-config: only load the MCP servers from our
+      ;; --mcp-config, ignoring the host's user/project MCP config. On
+      ;; the local worktree executor the agent CLI otherwise inherits the
+      ;; operator's personal ~/.claude MCP servers (e.g. Gmail / Calendar
+      ;; / Drive), whose tool schemas bloat the agent's fixed context
+      ;; overhead. On 2026-06-07 that leakage pushed the planner's
+      ;; first-turn prompt past the 200k window — a single ToolSearch
+      ;; result tipped it over and the CLI returned "Prompt is too long"
+      ;; (plan phase, review-redirect-convergence dogfood adhoc-2135293220).
+      ;; The container executor is already isolated from host config; this
+      ;; brings the local runner to parity for the MCP vector. Mirrors the
+      ;; codex builder's --ignore-user-config.
+      mcp-config                   (into ["--mcp-config" mcp-config
+                                          "--strict-mcp-config"])
       (seq mcp-allowed-tools)      (into ["--allowedTools" (claude-mcp-allowlist-string mcp-allowed-tools)])
       (seq disallowed-tools)       (into ["--disallowedTools" (str/join "," disallowed-tools)])
       (:settings-path supervision) (into ["--settings" (:settings-path supervision)])

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -50,7 +50,20 @@
   (testing "mcp-config adds --mcp-config flag"
     (let [args ((private-fn 'claude-args) {:prompt "p" :mcp-config "/tmp/mcp.json"})]
       (is (some #(= "--mcp-config" %) args))
-      (is (some #(= "/tmp/mcp.json" %) args)))))
+      (is (some #(= "/tmp/mcp.json" %) args))))
+
+  (testing "mcp-config also adds --strict-mcp-config so host MCP config does not leak"
+    (let [args ((private-fn 'claude-args) {:prompt "p" :mcp-config "/tmp/mcp.json"})]
+      (is (some #(= "--strict-mcp-config" %) args))
+      (is (= ["--mcp-config" "/tmp/mcp.json" "--strict-mcp-config"]
+             (->> args
+                  (drop-while #(not= "--mcp-config" %))
+                  (take 3)))
+          "--strict-mcp-config immediately follows the --mcp-config path")))
+
+  (testing "no mcp-config means no --strict-mcp-config"
+    (let [args ((private-fn 'claude-args) {:prompt "p"})]
+      (is (not (some #(= "--strict-mcp-config" %) args))))))
 
 (deftest claude-args-allowed-tools-test
   (testing "mcp maps format as mcp__<server>__<tool>, joined with commas"

--- a/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
+++ b/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
@@ -1,0 +1,54 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.llm.context-overflow-test
+  "Context-overflow ('Prompt is too long') is classified as a distinct
+   terminal error type so the submission-only retry can't fire on it."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
+
+(deftest context-overflow-error?-test
+  (testing "matches the CLI's overflow message case-insensitively"
+    (is (impl/context-overflow-error? "Prompt is too long"))
+    (is (impl/context-overflow-error? "prompt is too long"))
+    (is (impl/context-overflow-error? "Error: PROMPT IS TOO LONG")))
+
+  (testing "does not match ordinary errors or nil"
+    (is (not (impl/context-overflow-error? "Stagnation timeout: no progress")))
+    (is (not (impl/context-overflow-error? "")))
+    (is (not (impl/context-overflow-error? nil)))))
+
+(deftest streaming-error-response-classifies-overflow-test
+  (testing "an overflow message gets the terminal context_overflow type, not cli_error"
+    (let [resp (impl/streaming-error-response
+                "Prompt is too long" 0 nil "Prompt is too long"
+                nil nil nil 0 nil)]
+      (is (= impl/context-overflow-error-type (get-in resp [:error :type])))
+      (is (not= "cli_error" (get-in resp [:error :type])))))
+
+  (testing "an ordinary CLI error stays cli_error"
+    (let [resp (impl/streaming-error-response
+                "boom" 1 "boom" "boom" nil nil nil 0 nil)]
+      (is (= "cli_error" (get-in resp [:error :type])))))
+
+  (testing "a timeout still wins as adaptive_timeout"
+    (let [resp (impl/streaming-error-response
+                "Prompt is too long" 0 nil "Prompt is too long"
+                {:type :stream-idle :elapsed-ms 1} nil nil 0 nil)]
+      (is (= "adaptive_timeout" (get-in resp [:error :type]))))))


### PR DESCRIPTION
## Summary

Stacked on #1081. `"Prompt is too long"` (the agent CLI's context-window-exceeded error) was classified by `streaming-error-response` as a generic `cli_error`, and `submission-recovery/recoverable-error-types` treats `cli_error` as retryable. But a context-overflow turn produces **no artifact to recover**: its stdout holds no plan, and a submission-only retry merely re-sends an over-budget prompt. With nothing to convert, the retry re-plans from scratch and burns its whole (deliberately tight, Write-only) budget.

### Why it matters — 2026-06-07 dogfood

In `review-redirect-convergence` (`adhoc-2135293220`) the plan phase failed in **two** steps: the planner's main turn overflowed (`"Prompt is too long"`), and because that was misclassified as a recoverable `cli_error`, the **submission-retry fired** — then died at its 120s hard cap (`:prompt/submission-retry-monitor`) after pure extended-thinking with no plan to submit. (The keepalive already neutralizes *stagnation* on every stream; only the hard cap could fire, and it only fired because the retry should never have run.)

### Fix

- New terminal error type `context_overflow` (`llm-client/context-overflow-error-type`) + a `context-overflow-error?` message predicate.
- `streaming-error-response` classifies overflow messages as `context_overflow` instead of `cli_error` (timeouts still win as `adaptive_timeout`).
- `context_overflow` is deliberately **excluded** from `recoverable-error-types`, so the doomed submission-retry can't fire — the phase terminates cleanly on the real overflow.

Complements #1081's `--strict-mcp-config`, which prevents the overflow in the first place; this is the defense-in-depth that keeps a genuine overflow (e.g. an oversized spec) from spending a doomed retry budget.

## Test plan

- `context-overflow-test`: `context-overflow-error?` matches the CLI message case-insensitively and rejects ordinary errors/nil; `streaming-error-response` yields `context_overflow` for overflow, `cli_error` for ordinary errors, `adaptive_timeout` when a timeout is present.
- `submission-recovery-test`: a `context_overflow` error with stdout does **not** trigger `submission-retry?`.
- `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)