### PR TITLE
feat(llm): record pre-flight agent prompt size so context overflow is visible

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1642,19 +1642,11 @@
   4)
 
 (defn prompt-size-telemetry
-  "Pre-flight size gauge for the assembled agent prompt, computed from the
-   system + user prompt BEFORE the request is sent — so it is captured even
-   when the call is rejected with a context-overflow (where `:usage` never
-   arrives). `:estimated-input-tokens` is a coarse chars/4 estimate to
-   gauge headroom against the model's context window. It rounds UP (ceil):
-   as a headroom gauge, truncating would under-report a near-boundary
-   prompt and make an imminent overflow look further off than it is.
-
-   Motivated by the 2026-06-07 review-redirect-convergence dogfood, where
-   the planner's first turn silently ran up against the 200k window and
-   only surfaced as 'Prompt is too long' after the fact — miniforge
-   recorded completion tokens but never the input size, so the overflow
-   was a surprise."
+  "Pre-flight size gauge over the assembled system + user prompt, computed
+   BEFORE dispatch so it survives a context-overflow rejection (where
+   `:usage` never arrives). `:estimated-input-tokens` is a coarse chars/4
+   estimate, rounded UP so a near-boundary prompt isn't under-reported.
+   See N12 §3."
   [system prompt]
   (let [system-chars (count (or system ""))
         user-chars   (count (or prompt ""))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1635,6 +1635,33 @@
       (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
       (seq final-message-preview) (assoc :final-message-preview final-message-preview))))
 
+(def ^:private chars-per-token-estimate
+  "Rough characters-per-token divisor for a pre-flight input-size estimate.
+   ~4 chars/token is the usual English heuristic; this is a coarse gauge of
+   headroom against the model's context window, not a billing figure."
+  4)
+
+(defn prompt-size-telemetry
+  "Pre-flight size gauge for the assembled agent prompt, computed from the
+   system + user prompt BEFORE the request is sent — so it is captured even
+   when the call is rejected with a context-overflow (where `:usage` never
+   arrives). `:estimated-input-tokens` is a coarse chars/4 estimate to
+   gauge headroom against the model's context window.
+
+   Motivated by the 2026-06-07 review-redirect-convergence dogfood, where
+   the planner's first turn silently ran up against the 200k window and
+   only surfaced as 'Prompt is too long' after the fact — miniforge
+   recorded completion tokens but never the input size, so the overflow
+   was a surprise."
+  [system prompt]
+  (let [system-chars (count (or system ""))
+        user-chars   (count (or prompt ""))
+        total-chars  (+ system-chars user-chars)]
+    {:system-chars system-chars
+     :user-chars user-chars
+     :total-chars total-chars
+     :estimated-input-tokens (quot total-chars chars-per-token-estimate)}))
+
 (defn handle-streaming [client request on-chunk backend-config progress-monitor]
   (let [{:keys [logger config]} client
         stream-fn (or (:stream-exec-fn client) stream-exec-fn)
@@ -1656,9 +1683,10 @@
         accumulated-stop-reason (atom nil)
         accumulated-turns (atom nil)]
     (when logger
-      (log/debug logger :system :agent/streaming-prompt-sent
-                 {:data {:backend backend
-                         :prompt-length (count prompt)}}))
+      (log/info logger :system :agent/streaming-prompt-sent
+                {:data (assoc (prompt-size-telemetry (:system request) prompt)
+                              :backend backend
+                              :model model)}))
     (let [base-opts {:progress-monitor progress-monitor
                      :workdir (:workdir request)}
           stream-opts (merge base-opts

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1646,7 +1646,9 @@
    system + user prompt BEFORE the request is sent — so it is captured even
    when the call is rejected with a context-overflow (where `:usage` never
    arrives). `:estimated-input-tokens` is a coarse chars/4 estimate to
-   gauge headroom against the model's context window.
+   gauge headroom against the model's context window. It rounds UP (ceil):
+   as a headroom gauge, truncating would under-report a near-boundary
+   prompt and make an imminent overflow look further off than it is.
 
    Motivated by the 2026-06-07 review-redirect-convergence dogfood, where
    the planner's first turn silently ran up against the 200k window and
@@ -1660,7 +1662,9 @@
     {:system-chars system-chars
      :user-chars user-chars
      :total-chars total-chars
-     :estimated-input-tokens (quot total-chars chars-per-token-estimate)}))
+     ;; ceil division (stay conservative for a headroom gauge)
+     :estimated-input-tokens (quot (+ total-chars (dec chars-per-token-estimate))
+                                   chars-per-token-estimate)}))
 
 (defn handle-streaming [client request on-chunk backend-config progress-monitor]
   (let [{:keys [logger config]} client

--- a/components/llm/test/ai/miniforge/llm/prompt_size_telemetry_test.clj
+++ b/components/llm/test/ai/miniforge/llm/prompt_size_telemetry_test.clj
@@ -30,6 +30,14 @@
             :estimated-input-tokens 5}
            (impl/prompt-size-telemetry "sysprmpt" "user-prompt!"))))
 
+  (testing "estimate rounds UP (ceil) so a near-boundary prompt isn't under-reported"
+    ;; 21 chars / 4 = 5.25 → 6, not 5 (truncation would hide imminent overflow)
+    (is (= 6 (:estimated-input-tokens (impl/prompt-size-telemetry "" (apply str (repeat 21 \x))))))
+    ;; exact multiples don't over-count
+    (is (= 5 (:estimated-input-tokens (impl/prompt-size-telemetry "" (apply str (repeat 20 \x))))))
+    ;; a single char is at least 1 token, never 0
+    (is (= 1 (:estimated-input-tokens (impl/prompt-size-telemetry "" "x")))))
+
   (testing "nil system or prompt is treated as empty, never throws"
     (is (= {:system-chars 0 :user-chars 4 :total-chars 4 :estimated-input-tokens 1}
            (impl/prompt-size-telemetry nil "abcd")))

--- a/components/llm/test/ai/miniforge/llm/prompt_size_telemetry_test.clj
+++ b/components/llm/test/ai/miniforge/llm/prompt_size_telemetry_test.clj
@@ -1,0 +1,42 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.llm.prompt-size-telemetry-test
+  "Pre-flight input-size gauge for the assembled agent prompt."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
+
+(deftest prompt-size-telemetry-test
+  (testing "counts system + user chars and estimates input tokens (chars/4)"
+    (is (= {:system-chars 8
+            :user-chars 12
+            :total-chars 20
+            :estimated-input-tokens 5}
+           (impl/prompt-size-telemetry "sysprmpt" "user-prompt!"))))
+
+  (testing "nil system or prompt is treated as empty, never throws"
+    (is (= {:system-chars 0 :user-chars 4 :total-chars 4 :estimated-input-tokens 1}
+           (impl/prompt-size-telemetry nil "abcd")))
+    (is (= {:system-chars 0 :user-chars 0 :total-chars 0 :estimated-input-tokens 0}
+           (impl/prompt-size-telemetry nil nil))))
+
+  (testing "scales toward the context window — a ~200k-token prompt reads as such"
+    (let [big (apply str (repeat 800000 \x))
+          {:keys [estimated-input-tokens]} (impl/prompt-size-telemetry "" big)]
+      (is (= 200000 estimated-input-tokens)))))


### PR DESCRIPTION
## Summary

Stacked on #1087. miniforge recorded completion tokens (`:phase/tokens`) but never the **input** prompt size, so the planner running up against the 200k context window was invisible until it failed with `"Prompt is too long"` after the fact (review-redirect-convergence dogfood `adhoc-2135293220`, 2026-06-07). This is the observability gap behind that surprise.

### Change

- New `prompt-size-telemetry` computes `{:system-chars :user-chars :total-chars :estimated-input-tokens}` from the **system + user** prompt **before** the request is sent — so the gauge is captured even on a context-overflow rejection, where `:usage` never arrives.
- The existing DEBUG `:agent/streaming-prompt-sent` log (user-prompt chars only) becomes an **INFO** structured event carrying the full telemetry plus `:backend` and `:model`.
- `:estimated-input-tokens` is a coarse chars/4 gauge of headroom against the window — not a billing figure.

This is the **instrument** that closes the A→C loop: on the next dogfood we'll see how close each phase's prompt runs to 200k, so we can confirm whether #1081's `--strict-mcp-config` reclaimed enough headroom — and catch a near-overflow *before* it fails.

## Test plan

- `prompt-size-telemetry-test`: char counts + chars/4 estimate; nil system/prompt treated as empty (never throws); an ~800k-char prompt reads as ~200k estimated tokens.
- `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)