### PR TITLE
refactor(llm): detect context-overflow from token counts, not localized text

### DIFF
--- a/components/agent/src/ai/miniforge/agent/submission_recovery.clj
+++ b/components/agent/src/ai/miniforge/agent/submission_recovery.clj
@@ -43,10 +43,9 @@
   "Backend error classes whose stdout still holds the agent's work, so a
    submission-only retry can recover it.
 
-   Deliberately EXCLUDES `llm/context-overflow-error-type`
-   (\"context_overflow\"): a prompt that exceeded the model's context
-   window left no artifact to recover, and a retry re-sends an over-budget
-   prompt — so it must terminate, not retry (see that var's docstring)."
+   Deliberately EXCLUDES the \"context_overflow\" error type: a prompt that
+   exceeded the model's context window left no artifact to recover, and a
+   retry re-sends an over-budget prompt — so it must terminate, not retry."
   #{"adaptive_timeout" "cli_error"})
 
 (defn submission-retry?

--- a/components/llm/src/ai/miniforge/llm/model_registry.clj
+++ b/components/llm/src/ai/miniforge/llm/model_registry.clj
@@ -61,6 +61,18 @@
   [model-key]
   (get model-registry model-key))
 
+(defn context-window-for-model-id
+  "Context window (max input tokens) for a backend model-id string
+   (e.g. \"claude-opus-4-6\"), or nil when the model-id is not in the
+   catalog. Looks up by the entry's :model-id rather than the catalog key,
+   because the runtime threads the provider model-id string, not the
+   catalog keyword."
+  [model-id]
+  (some (fn [[_k v]]
+          (when (= model-id (:model-id v))
+            (get-in v [:capabilities :context-window])))
+        model-registry))
+
 (defn get-models-by-capability
   "Get models meeting or exceeding a capability level.
    Example: (get-models-by-capability :reasoning :excellent)

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.cost :as cost]
    [ai.miniforge.llm.messages :as msg]
+   [ai.miniforge.llm.model-registry :as model-registry]
    [ai.miniforge.llm.network-monitor :as nnm]
    [ai.miniforge.llm.progress-monitor :as pm]
    [ai.miniforge.response.interface :as response]
@@ -190,11 +191,18 @@
 (defn- parsed-usage
   [usage]
   (let [input-tokens (:input_tokens usage)
-        output-tokens (:output_tokens usage)]
-    (when (or (number? input-tokens)
-              (number? output-tokens))
-      {:input-tokens input-tokens
-       :output-tokens output-tokens})))
+        output-tokens (:output_tokens usage)
+        ;; A large prompt lands mostly under cache_creation_input_tokens
+        ;; (input_tokens itself can be tiny), so capture the cache fields
+        ;; too — they're what `total-input-tokens` needs to measure the
+        ;; real input size against the context window.
+        cache-creation (:cache_creation_input_tokens usage)
+        cache-read (:cache_read_input_tokens usage)]
+    (when (some number? [input-tokens output-tokens cache-creation cache-read])
+      (cond-> {:input-tokens input-tokens
+               :output-tokens output-tokens}
+        (number? cache-creation) (assoc :cache-creation-input-tokens cache-creation)
+        (number? cache-read)     (assoc :cache-read-input-tokens cache-read)))))
 
 (defn parse-claude-stream-line
   "Parse a line from Claude CLI streaming output.
@@ -1592,19 +1600,30 @@
    cli_error, and the submission-retry then died at its 120s hard cap.)"
   "context_overflow")
 
-(def ^:private context-overflow-markers
-  "Lower-cased substrings the agent CLIs emit when the prompt exceeds the
-   model's context window. Matched case-insensitively against the error
-   message."
-  ["prompt is too long"])
+(defn total-input-tokens
+  "Total input tokens the model actually consumed for a turn:
+   prompt + cache-creation + cache-read. The CLI reports the bulk of a
+   large prompt under cache_creation_input_tokens (`:input-tokens` itself
+   can be a handful), so summing all three is the only faithful measure of
+   input size to compare against the context window."
+  [usage]
+  (+ (or (:input-tokens usage) 0)
+     (or (:cache-creation-input-tokens usage) 0)
+     (or (:cache-read-input-tokens usage) 0)))
 
-(defn context-overflow-error?
-  "True when `message` indicates the prompt exceeded the model's context
-   window — an unrecoverable terminal condition (see
-   `context-overflow-error-type`)."
-  [message]
-  (let [m (str/lower-case (or message ""))]
-    (boolean (some #(str/includes? m %) context-overflow-markers))))
+(defn context-overflow-by-usage?
+  "True when a turn's total input tokens met or exceeded the model's
+   context window — the structured, locale- and backend-independent signal
+   that the prompt overflowed (see `context-overflow-error-type`). Replaces
+   matching the backend's human-readable 'prompt is too long' text, which
+   is localized product output and phrased differently per backend.
+
+   `context-window` is the model's max input tokens (nil when the model is
+   not in the catalog, in which case overflow can't be asserted here)."
+  [usage context-window]
+  (boolean (and context-window
+                (pos? (total-input-tokens usage))
+                (>= (total-input-tokens usage) context-window))))
 
 (defn streaming-error-response
   "Build a streaming error response with diagnostic metadata.
@@ -1613,8 +1632,14 @@
    - :stop-reason          — last observed stop reason before failure
    - :num-turns            — number of conversation turns consumed
    - :tool-call-count      — total number of tool invocations during the run
-   - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)"
-  [content exit-code err-result raw-stdout timeout-info stop-reason num-turns tool-call-count final-message-preview]
+   - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)
+
+   `usage` and `context-window` drive structured context-overflow
+   classification: when the turn's total input tokens reached the model's
+   window, the error is typed `context_overflow` (terminal, non-retryable)
+   instead of a generic recoverable `cli_error`."
+  [content exit-code err-result raw-stdout timeout-info stop-reason num-turns
+   tool-call-count final-message-preview usage context-window]
   (let [error-message (or (not-empty (str/trim (or err-result "")))
                           (when-not (str/blank? content) content)
                           (not-empty (str/trim (or raw-stdout "")))
@@ -1622,7 +1647,7 @@
         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
         error-type (cond
                      timeout-info "adaptive_timeout"
-                     (context-overflow-error? error-message) context-overflow-error-type
+                     (context-overflow-by-usage? usage context-window) context-overflow-error-type
                      :else "cli_error")]
     (cond-> (llm-error category error-type (str/trim error-message)
                        {:exit-code exit-code
@@ -1739,7 +1764,9 @@
             (cond-> (streaming-error-response final-content exit-code (:err result)
                                               diagnostic-content
                                               timeout-info stop-reason num-turns
-                                              tool-call-count final-message-preview)
+                                              tool-call-count final-message-preview
+                                              usage
+                                              (model-registry/context-window-for-model-id model))
               session-id (assoc :session-id session-id))))))))
 
 (defn complete-stream-impl [client request on-chunk]

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -198,9 +198,15 @@
         ;; real input size against the context window.
         cache-creation (:cache_creation_input_tokens usage)
         cache-read (:cache_read_input_tokens usage)]
+    ;; Associate ONLY numeric fields so missing values stay absent. A
+    ;; present-but-nil key breaks downstream `(get usage :input-tokens 0)`
+    ;; defaulting (the default applies only when the key is ABSENT) — e.g.
+    ;; llm-success's `:tokens (+ (get usage :input-tokens 0) ...)` would NPE
+    ;; on a cache-only usage frame.
     (when (some number? [input-tokens output-tokens cache-creation cache-read])
-      (cond-> {:input-tokens input-tokens
-               :output-tokens output-tokens}
+      (cond-> {}
+        (number? input-tokens)   (assoc :input-tokens input-tokens)
+        (number? output-tokens)  (assoc :output-tokens output-tokens)
         (number? cache-creation) (assoc :cache-creation-input-tokens cache-creation)
         (number? cache-read)     (assoc :cache-read-input-tokens cache-read)))))
 
@@ -1637,28 +1643,35 @@
    `usage` and `context-window` drive structured context-overflow
    classification: when the turn's total input tokens reached the model's
    window, the error is typed `context_overflow` (terminal, non-retryable)
-   instead of a generic recoverable `cli_error`."
-  [content exit-code err-result raw-stdout timeout-info stop-reason num-turns
-   tool-call-count final-message-preview usage context-window]
-  (let [error-message (or (not-empty (str/trim (or err-result "")))
-                          (when-not (str/blank? content) content)
-                          (not-empty (str/trim (or raw-stdout "")))
-                          (msg/t :streaming-error.system/no-output))
-        category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
-        error-type (cond
-                     timeout-info "adaptive_timeout"
-                     (context-overflow-by-usage? usage context-window) context-overflow-error-type
-                     :else "cli_error")]
-    (cond-> (llm-error category error-type (str/trim error-message)
-                       {:exit-code exit-code
-                        :stderr err-result
-                        :stdout content
-                        :raw-stdout raw-stdout
-                        :timeout timeout-info})
-      stop-reason                 (assoc :stop-reason stop-reason)
-      num-turns                   (assoc :num-turns num-turns)
-      (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
-      (seq final-message-preview) (assoc :final-message-preview final-message-preview))))
+   instead of a generic recoverable `cli_error`. They are optional — the
+   9-arity form (used by diagnostic callers that don't have usage/window in
+   hand) simply skips overflow classification."
+  ([content exit-code err-result raw-stdout timeout-info stop-reason num-turns
+    tool-call-count final-message-preview]
+   (streaming-error-response content exit-code err-result raw-stdout timeout-info
+                             stop-reason num-turns tool-call-count
+                             final-message-preview nil nil))
+  ([content exit-code err-result raw-stdout timeout-info stop-reason num-turns
+    tool-call-count final-message-preview usage context-window]
+   (let [error-message (or (not-empty (str/trim (or err-result "")))
+                           (when-not (str/blank? content) content)
+                           (not-empty (str/trim (or raw-stdout "")))
+                           (msg/t :streaming-error.system/no-output))
+         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
+         error-type (cond
+                      timeout-info "adaptive_timeout"
+                      (context-overflow-by-usage? usage context-window) context-overflow-error-type
+                      :else "cli_error")]
+     (cond-> (llm-error category error-type (str/trim error-message)
+                        {:exit-code exit-code
+                         :stderr err-result
+                         :stdout content
+                         :raw-stdout raw-stdout
+                         :timeout timeout-info})
+       stop-reason                 (assoc :stop-reason stop-reason)
+       num-turns                   (assoc :num-turns num-turns)
+       (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
+       (seq final-message-preview) (assoc :final-message-preview final-message-preview)))))
 
 (defn handle-streaming [client request on-chunk backend-config progress-monitor]
   (let [{:keys [logger config]} client
@@ -1766,7 +1779,12 @@
                                               timeout-info stop-reason num-turns
                                               tool-call-count final-message-preview
                                               usage
-                                              (model-registry/context-window-for-model-id model))
+                                              ;; effective model = the one actually invoked
+                                              ;; (request-with-model), which honors a per-request
+                                              ;; :model when config carries none — keeps overflow
+                                              ;; classification consistent with the real call.
+                                              (model-registry/context-window-for-model-id
+                                               (:model request-with-model)))
               session-id (assoc :session-id session-id))))))))
 
 (defn complete-stream-impl [client request on-chunk]

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -190,19 +190,13 @@
 
 (defn- parsed-usage
   [usage]
+  ;; Capture cache fields: a large prompt lands mostly under cache-creation.
+  ;; Assoc only numeric fields — a present-but-nil key defeats downstream
+  ;; `(get usage :input-tokens 0)` defaulting (NPEs llm-success's :tokens sum).
   (let [input-tokens (:input_tokens usage)
         output-tokens (:output_tokens usage)
-        ;; A large prompt lands mostly under cache_creation_input_tokens
-        ;; (input_tokens itself can be tiny), so capture the cache fields
-        ;; too — they're what `total-input-tokens` needs to measure the
-        ;; real input size against the context window.
         cache-creation (:cache_creation_input_tokens usage)
         cache-read (:cache_read_input_tokens usage)]
-    ;; Associate ONLY numeric fields so missing values stay absent. A
-    ;; present-but-nil key breaks downstream `(get usage :input-tokens 0)`
-    ;; defaulting (the default applies only when the key is ABSENT) — e.g.
-    ;; llm-success's `:tokens (+ (get usage :input-tokens 0) ...)` would NPE
-    ;; on a cache-only usage frame.
     (when (some number? [input-tokens output-tokens cache-creation cache-read])
       (cond-> {}
         (number? input-tokens)   (assoc :input-tokens input-tokens)
@@ -1594,38 +1588,23 @@
        (nil? usage)))
 
 (def context-overflow-error-type
-  "Distinct error :type for a prompt that exceeded the model's context
-   window. Kept OUT of submission-recovery/recoverable-error-types: such a
-   turn produced no usable artifact (its stdout holds no plan) and a
-   submission-only retry cannot recover it — the retry re-sends an
-   over-budget prompt and, with nothing to convert, burns its whole budget
-   re-planning from scratch. Classifying it distinctly lets the phase fail
-   cleanly on the real overflow instead of firing a doomed retry.
-   (review-redirect-convergence dogfood adhoc-2135293220, 2026-06-07: the
-   planner's main turn overflowed, was misclassified as a recoverable
-   cli_error, and the submission-retry then died at its 120s hard cap.)"
+  "Error :type for a prompt that exceeded the model's context window.
+   Terminal: excluded from submission-recovery (the turn has no artifact to
+   recover and a retry just re-sends the over-budget prompt). See N12 §4."
   "context_overflow")
 
 (defn total-input-tokens
-  "Total input tokens the model actually consumed for a turn:
-   prompt + cache-creation + cache-read. The CLI reports the bulk of a
-   large prompt under cache_creation_input_tokens (`:input-tokens` itself
-   can be a handful), so summing all three is the only faithful measure of
-   input size to compare against the context window."
+  "prompt + cache-creation + cache-read tokens. Summed because a large
+   prompt lands mostly under cache-creation, not :input-tokens. See N12 §2."
   [usage]
   (+ (or (:input-tokens usage) 0)
      (or (:cache-creation-input-tokens usage) 0)
      (or (:cache-read-input-tokens usage) 0)))
 
 (defn context-overflow-by-usage?
-  "True when a turn's total input tokens met or exceeded the model's
-   context window — the structured, locale- and backend-independent signal
-   that the prompt overflowed (see `context-overflow-error-type`). Replaces
-   matching the backend's human-readable 'prompt is too long' text, which
-   is localized product output and phrased differently per backend.
-
-   `context-window` is the model's max input tokens (nil when the model is
-   not in the catalog, in which case overflow can't be asserted here)."
+  "True when total input tokens >= the model's context window — the
+   structured, locale/backend-independent overflow signal (N12 §4).
+   `context-window` is nil for uncatalogued models → no assertion."
   [usage context-window]
   (boolean (and context-window
                 (pos? (total-input-tokens usage))
@@ -1640,12 +1619,8 @@
    - :tool-call-count      — total number of tool invocations during the run
    - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)
 
-   `usage` and `context-window` drive structured context-overflow
-   classification: when the turn's total input tokens reached the model's
-   window, the error is typed `context_overflow` (terminal, non-retryable)
-   instead of a generic recoverable `cli_error`. They are optional — the
-   9-arity form (used by diagnostic callers that don't have usage/window in
-   hand) simply skips overflow classification."
+   `usage` + `context-window` drive context-overflow classification (N12 §4);
+   optional — the 9-arity form skips it (for callers without them)."
   ([content exit-code err-result raw-stdout timeout-info stop-reason num-turns
     tool-call-count final-message-preview]
    (streaming-error-response content exit-code err-result raw-stdout timeout-info
@@ -1779,10 +1754,7 @@
                                               timeout-info stop-reason num-turns
                                               tool-call-count final-message-preview
                                               usage
-                                              ;; effective model = the one actually invoked
-                                              ;; (request-with-model), which honors a per-request
-                                              ;; :model when config carries none — keeps overflow
-                                              ;; classification consistent with the real call.
+                                              ;; effective model actually invoked (honors per-request :model)
                                               (model-registry/context-window-for-model-id
                                                (:model request-with-model)))
               session-id (assoc :session-id session-id))))))))

--- a/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
+++ b/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
@@ -17,38 +17,56 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.llm.context-overflow-test
-  "Context-overflow ('Prompt is too long') is classified as a distinct
-   terminal error type so the submission-only retry can't fire on it."
+  "Context-overflow is classified as a distinct terminal error type from the
+   structured usage token counts (locale- and backend-independent), NOT from
+   the backend's localized 'prompt is too long' text — so the submission-only
+   retry can't fire on it."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
 
-(deftest context-overflow-error?-test
-  (testing "matches the CLI's overflow message case-insensitively"
-    (is (impl/context-overflow-error? "Prompt is too long"))
-    (is (impl/context-overflow-error? "prompt is too long"))
-    (is (impl/context-overflow-error? "Error: PROMPT IS TOO LONG")))
+(deftest total-input-tokens-test
+  (testing "sums prompt + cache-creation + cache-read; the real prompt size
+            lives mostly in cache-creation, not :input-tokens"
+    (is (= 204282 (impl/total-input-tokens
+                   {:input-tokens 3
+                    :cache-creation-input-tokens 204279
+                    :cache-read-input-tokens 0})))
+    (is (= 0 (impl/total-input-tokens nil)))
+    (is (= 5 (impl/total-input-tokens {:input-tokens 5})))))
 
-  (testing "does not match ordinary errors or nil"
-    (is (not (impl/context-overflow-error? "Stagnation timeout: no progress")))
-    (is (not (impl/context-overflow-error? "")))
-    (is (not (impl/context-overflow-error? nil)))))
+(deftest context-overflow-by-usage?-test
+  (testing "true once total input tokens reach the model's context window"
+    ;; the actual adhoc-2135293220 shape: 204,282 input vs a 200k window
+    (is (impl/context-overflow-by-usage?
+         {:input-tokens 3 :cache-creation-input-tokens 204279} 200000))
+    (is (impl/context-overflow-by-usage? {:input-tokens 200000} 200000)))
+
+  (testing "false below the window, with no window, or with no usage"
+    (is (not (impl/context-overflow-by-usage? {:input-tokens 199999} 200000)))
+    (is (not (impl/context-overflow-by-usage? {:input-tokens 204282} nil)))
+    (is (not (impl/context-overflow-by-usage? {} 200000)))
+    (is (not (impl/context-overflow-by-usage? nil 200000)))))
 
 (deftest streaming-error-response-classifies-overflow-test
-  (testing "an overflow message gets the terminal context_overflow type, not cli_error"
+  (testing "input tokens >= window => terminal context_overflow type, not cli_error"
     (let [resp (impl/streaming-error-response
                 "Prompt is too long" 0 nil "Prompt is too long"
-                nil nil nil 0 nil)]
+                nil nil nil 0 nil
+                {:input-tokens 3 :cache-creation-input-tokens 204279} 200000)]
       (is (= impl/context-overflow-error-type (get-in resp [:error :type])))
       (is (not= "cli_error" (get-in resp [:error :type])))))
 
-  (testing "an ordinary CLI error stays cli_error"
+  (testing "an ordinary error under the window stays cli_error — even if its
+            text happens to mention being long (no string matching anymore)"
     (let [resp (impl/streaming-error-response
-                "boom" 1 "boom" "boom" nil nil nil 0 nil)]
+                "boom" 1 "boom" "boom" nil nil nil 0 nil
+                {:input-tokens 100} 200000)]
       (is (= "cli_error" (get-in resp [:error :type])))))
 
-  (testing "a timeout still wins as adaptive_timeout"
+  (testing "a timeout still wins as adaptive_timeout regardless of usage"
     (let [resp (impl/streaming-error-response
-                "Prompt is too long" 0 nil "Prompt is too long"
-                {:type :stream-idle :elapsed-ms 1} nil nil 0 nil)]
+                "x" 0 nil "x"
+                {:type :stream-idle :elapsed-ms 1} nil nil 0 nil
+                {:input-tokens 3 :cache-creation-input-tokens 204279} 200000)]
       (is (= "adaptive_timeout" (get-in resp [:error :type]))))))

--- a/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
+++ b/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
@@ -25,6 +25,9 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
 
+(defn- private-fn [sym]
+  (var-get (ns-resolve 'ai.miniforge.llm.protocols.impl.llm-client sym)))
+
 (deftest total-input-tokens-test
   (testing "sums prompt + cache-creation + cache-read; the real prompt size
             lives mostly in cache-creation, not :input-tokens"
@@ -69,4 +72,25 @@
                 "x" 0 nil "x"
                 {:type :stream-idle :elapsed-ms 1} nil nil 0 nil
                 {:input-tokens 3 :cache-creation-input-tokens 204279} 200000)]
-      (is (= "adaptive_timeout" (get-in resp [:error :type]))))))
+      (is (= "adaptive_timeout" (get-in resp [:error :type])))))
+
+  (testing "the 9-arg form (no usage/window) stays backward-compatible and
+            skips overflow classification"
+    (let [resp (impl/streaming-error-response
+                "" -1 "process died" "" nil nil nil 5 nil)]
+      (is (= "cli_error" (get-in resp [:error :type]))))))
+
+(deftest parsed-usage-omits-absent-fields-test
+  (testing "a cache-only usage frame produces NO nil :input-tokens key, so
+            downstream `(get usage :input-tokens 0)` defaulting still works
+            (would otherwise NPE in llm-success's :tokens sum)"
+    (let [parsed ((private-fn 'parsed-usage)
+                  {:cache_creation_input_tokens 204279})]
+      (is (= {:cache-creation-input-tokens 204279} parsed))
+      (is (not (contains? parsed :input-tokens)))
+      (is (= 0 (get parsed :input-tokens 0)))
+      (is (= 204279 (impl/total-input-tokens parsed)))))
+
+  (testing "nil when no numeric token field is present"
+    (is (nil? ((private-fn 'parsed-usage) {})))
+    (is (nil? ((private-fn 'parsed-usage) {:input_tokens nil})))))

--- a/components/llm/test/ai/miniforge/llm/model_registry_test.clj
+++ b/components/llm/test/ai/miniforge/llm/model_registry_test.clj
@@ -111,6 +111,15 @@
       (is (some #{:gpt-5.3-codex} models))
       (is (some #{:gpt-5.2-codex} models)))))
 
+(deftest test-context-window-for-model-id
+  (testing "resolves the context window by provider model-id string"
+    (is (= 200000 (registry/context-window-for-model-id "claude-opus-4-6")))
+    (is (= 1000000 (registry/context-window-for-model-id "claude-opus-4-7"))))
+
+  (testing "unknown or nil model-id returns nil (overflow can't be asserted)"
+    (is (nil? (registry/context-window-for-model-id "no-such-model")))
+    (is (nil? (registry/context-window-for-model-id nil)))))
+
 (deftest test-get-local-models
   (testing "Get all local models"
     (let [models (registry/get-local-models)]


### PR DESCRIPTION
## Summary

Follow-up hardening of #1087. That PR classified context-overflow by matching the backend's human-readable `"prompt is too long"` string. As surfaced reviewing #1088: that text is **localized product output** and is phrased differently per backend (claude vs codex vs cursor) — so the match is fragile on **both** the locale and multi-backend axes. In a non-English locale or on a non-Claude backend it silently fails to detect overflow, and the doomed submission-retry fires again (the exact bug #1087 set out to kill).

Detect from the **structured usage token counts** instead — locale- and backend-independent:

- `parsed-usage` now captures `cache_creation`/`cache_read` input tokens. A large prompt lands mostly under `cache_creation_input_tokens` (`input_tokens` itself can be a handful — **3** in the `adhoc-2135293220` dogfood, vs **204,279** cached), so these are required to measure real input size.
- `total-input-tokens` sums prompt + cache-creation + cache-read.
- `model-registry/context-window-for-model-id` resolves the window from the shipped `model-catalog.edn` by provider model-id.
- `streaming-error-response` types the error `context_overflow` when total input tokens ≥ the window. Timeouts still win as `adaptive_timeout`. The string markers/predicate are **removed**.

Net: for the real `adhoc-2135293220` shape (204,282 input vs a 200k window) the overflow is detected with **zero English in the path**, and the same detection holds in any locale and on any backend that reports usage.

## Test plan

- `context-overflow-test`: `total-input-tokens` sums the cache fields; `context-overflow-by-usage?` true at/over the window, false below / with no window / no usage; `streaming-error-response` yields `context_overflow` for 204k≥200k, `cli_error` below the window (even when the text mentions being long — no string matching), `adaptive_timeout` when a timeout is present.
- `model-registry-test`: `context-window-for-model-id` resolves known model-ids, nil for unknown/nil.
- `submission-recovery-test`: `context_overflow` still excluded from retry (unchanged from #1087).
- `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)