### PR TITLE
feat(agent,llm): planner sheds eager files before bailing on context overflow

### DIFF
--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -176,6 +176,34 @@
                    {:spec-text              spec-text
                     :existing-files-section (existing-files-section existing-files)}))
 
+(defn- assemble-within-budget
+  "Assemble the planner user-prompt within the model's context window
+   (N12 §5). If the prompt would overflow, shed the eagerly-inlined
+   existing-files section — the files stay reachable via the context MCP
+   cache (seeded separately in invoke-planner-session), so the agent keeps
+   a query surface. Returns
+   {:user-prompt :shed? :over-after-shed? :window :est-full :est-final
+    :file-count}; :over-after-shed? marks an irreducible overflow."
+  [spec-text existing-files effective-system model]
+  (let [window   (llm/context-window-for-model-id model)
+        est      (fn [user] (:estimated-input-tokens
+                             (llm/prompt-size-telemetry effective-system user)))
+        full     (build-user-prompt spec-text existing-files)
+        est-full (est full)
+        base     {:window window :est-full est-full :file-count (count existing-files)}]
+    (cond
+      (or (nil? window) (< est-full window))
+      (merge base {:user-prompt full :shed? false :over-after-shed? false :est-final est-full})
+
+      (empty? existing-files)            ; nothing left to shed — irreducibly over
+      (merge base {:user-prompt full :shed? false :over-after-shed? true :est-final est-full})
+
+      :else
+      (let [shed (build-user-prompt spec-text nil)
+            est-shed (est shed)]
+        (merge base {:user-prompt shed :shed? true
+                     :over-after-shed? (>= est-shed window) :est-final est-shed})))))
+
 (defn spec->text
   "Convert a spec to text for the LLM."
   [spec]
@@ -618,9 +646,27 @@
               on-chunk (:on-chunk context)
               spec-text (spec->text input)
               existing-files (:task/existing-files input)
-              user-prompt    (build-user-prompt spec-text existing-files)
               effective-system (str @planner-system-prompt
-                                    (get input :task/behavior-addendum ""))]
+                                    (get input :task/behavior-addendum ""))
+              budget (assemble-within-budget spec-text existing-files
+                                             effective-system (:model config))
+              user-prompt (:user-prompt budget)]
+          (when (:shed? budget)
+            (log/info logger :planner :planner/context-shed
+                      {:data {:file-count (:file-count budget)
+                              :window (:window budget)
+                              :estimated-tokens-before (:est-full budget)
+                              :estimated-tokens-after (:est-final budget)}}))
+          ;; Irreducible overflow: bail pre-flight (no LLM call) rather than
+          ;; pay for a request the model will reject. N12 §5.4-5.5.
+          (when (:over-after-shed? budget)
+            (response/throw-anomaly!
+             :anomalies.agent/invoke-failed
+             "Planner prompt exceeds the model's context window even after shedding inlined files"
+             {:context-overflow true
+              :estimated-tokens (:est-final budget)
+              :context-window (:window budget)
+              :tokens 0}))
           ;; Past this point `llm-client` is non-nil — the
           ;; require-llm-client-or-anomaly boundary above already
           ;; escalated when the backend was missing.

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -158,30 +158,50 @@
   "Shared `{{key}}` template renderer (single source in the prompts ns)."
   prompts/render-template)
 
+(defn format-existing-files-manifest
+  "Compact manifest of in-scope files for the shed path (N12 §6): paths and
+   size only, not bodies. Keeps the planner aware the files exist and tells
+   it to fetch them on demand via context_read."
+  [files]
+  (when (seq files)
+    (str "_Bodies omitted to fit the context window — fetch any on demand "
+         "with `context_read`:_\n"
+         (->> files
+              (map (fn [{:keys [path lines content]}]
+                     (str "- " path
+                          (cond lines   (str " (" lines " lines)")
+                                content (str " (" (count content) " chars)")
+                                :else   ""))))
+              (str/join "\n")))))
+
 (defn- existing-files-section
-  "Build the planner-prompt section that previews existing in-scope
-   files. Returns the empty string when no files are present."
-  [existing-files]
-  (if (seq existing-files)
-    (render-template (get @planner-prompt-data :prompt/existing-files-template)
-                     {:files-list (format-existing-files existing-files)})
-    ""))
+  "Build the planner-prompt section that previews existing in-scope files.
+   `files-list-fn` renders the file list — full bodies by default, a
+   manifest on the shed path. Empty string when no files are present."
+  ([existing-files] (existing-files-section existing-files format-existing-files))
+  ([existing-files files-list-fn]
+   (if (seq existing-files)
+     (render-template (get @planner-prompt-data :prompt/existing-files-template)
+                      {:files-list (files-list-fn existing-files)})
+     "")))
 
 (defn- build-user-prompt
-  "Render the planner user-turn prompt from the spec text and any
-   existing in-scope files. Template lives in
-   resources/prompts/planner.edn (:prompt/user-template)."
-  [spec-text existing-files]
-  (render-template (get @planner-prompt-data :prompt/user-template)
-                   {:spec-text              spec-text
-                    :existing-files-section (existing-files-section existing-files)}))
+  "Render the planner user-turn prompt from the spec text and any existing
+   in-scope files. `files-list-fn` selects body inlining (default) vs a
+   manifest. Template lives in planner.edn (:prompt/user-template)."
+  ([spec-text existing-files] (build-user-prompt spec-text existing-files format-existing-files))
+  ([spec-text existing-files files-list-fn]
+   (render-template (get @planner-prompt-data :prompt/user-template)
+                    {:spec-text              spec-text
+                     :existing-files-section (existing-files-section existing-files files-list-fn)})))
 
 (defn- assemble-within-budget
   "Assemble the planner user-prompt within the model's context window
-   (N12 §5). If the prompt would overflow, shed the eagerly-inlined
-   existing-files section — the files stay reachable via the context MCP
-   cache (seeded separately in invoke-planner-session), so the agent keeps
-   a query surface. Returns
+   (N12 §5). If the prompt would overflow, shed the eagerly-inlined file
+   bodies down to a manifest (paths only) — the bodies stay reachable via
+   the context MCP cache (seeded separately in invoke-planner-session), so
+   the agent keeps a query surface, and the section's already-satisfied
+   evidence-bundle instructions are preserved. Returns
    {:user-prompt :shed? :over-after-shed? :window :est-full :est-final
     :file-count}; :over-after-shed? marks an irreducible overflow."
   [spec-text existing-files effective-system model]
@@ -199,7 +219,7 @@
       (merge base {:user-prompt full :shed? false :over-after-shed? true :est-final est-full})
 
       :else
-      (let [shed (build-user-prompt spec-text nil)
+      (let [shed (build-user-prompt spec-text existing-files format-existing-files-manifest)
             est-shed (est shed)]
         (merge base {:user-prompt shed :shed? true
                      :over-after-shed? (>= est-shed window) :est-final est-shed})))))
@@ -662,7 +682,9 @@
           (when (:over-after-shed? budget)
             (response/throw-anomaly!
              :anomalies.agent/invoke-failed
-             "Planner prompt exceeds the model's context window even after shedding inlined files"
+             (if (:shed? budget)
+               "Planner prompt exceeds the model's context window even after shedding inlined file bodies to a manifest"
+               "Planner prompt (spec + system) exceeds the model's context window; no inlined files to shed")
              {:context-overflow true
               :estimated-tokens (:est-final budget)
               :context-window (:window budget)

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -688,6 +688,48 @@
     (is (false? (boolean (submission-retry?
                           {:success false :error {:stdout "x" :type "other"}} nil nil ""))))))
 
+;------------------------------------------------------------------------------ Layer 6
+;; Context-budget shedding (N12 §5)
+
+(def ^:private assemble-within-budget
+  (var-get (ns-resolve 'ai.miniforge.agent.planner 'assemble-within-budget)))
+
+(defn- big-file [chars]
+  {:path "components/agent/src/ai/miniforge/agent/big.clj"
+   :content (apply str (repeat chars \x))})
+
+(deftest assemble-within-budget-test
+  (testing "uncatalogued model (nil window) → never sheds, files stay inlined"
+    (let [r (assemble-within-budget "do the thing" [(big-file 100)]
+                                    "system" "no-such-model")]
+      (is (false? (:shed? r)))
+      (is (false? (:over-after-shed? r)))
+      (is (str/includes? (:user-prompt r) "big.clj"))))
+
+  (testing "a small prompt under the window is not shed"
+    ;; codellama-34b → 16384-token window; a tiny prompt fits
+    (let [r (assemble-within-budget "do the thing" [(big-file 100)]
+                                    "system" "codellama-34b")]
+      (is (false? (:shed? r)))
+      (is (str/includes? (:user-prompt r) "big.clj"))))
+
+  (testing "files that blow the window are shed; the inlined section drops but
+            the prompt now fits (files stay reachable via the context cache)"
+    ;; ~300k chars of file content >> 16384 tokens; spec+system alone fits
+    (let [r (assemble-within-budget "do the thing" [(big-file 300000)]
+                                    "system" "codellama-34b")]
+      (is (true? (:shed? r)))
+      (is (false? (:over-after-shed? r)))
+      (is (= 1 (:file-count r)))
+      (is (< (:est-final r) (:est-full r)))
+      (is (not (str/includes? (:user-prompt r) "big.clj")))))
+
+  (testing "irreducible overflow (huge spec, no files) → over-after-shed?, no shed"
+    (let [r (assemble-within-budget (apply str (repeat 300000 \y)) []
+                                    "system" "codellama-34b")]
+      (is (false? (:shed? r)))
+      (is (true? (:over-after-shed? r))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.agent.planner-test)

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -691,8 +691,7 @@
 ;------------------------------------------------------------------------------ Layer 6
 ;; Context-budget shedding (N12 §5)
 
-(def ^:private assemble-within-budget
-  (var-get (ns-resolve 'ai.miniforge.agent.planner 'assemble-within-budget)))
+(def ^:private assemble-within-budget #'planner/assemble-within-budget)
 
 (defn- big-file [chars]
   {:path "components/agent/src/ai/miniforge/agent/big.clj"
@@ -713,8 +712,8 @@
       (is (false? (:shed? r)))
       (is (str/includes? (:user-prompt r) "big.clj"))))
 
-  (testing "files that blow the window are shed; the inlined section drops but
-            the prompt now fits (files stay reachable via the context cache)"
+  (testing "files that blow the window shed to a manifest: bodies drop, the
+            path + context_read hint stay, and the prompt now fits"
     ;; ~300k chars of file content >> 16384 tokens; spec+system alone fits
     (let [r (assemble-within-budget "do the thing" [(big-file 300000)]
                                     "system" "codellama-34b")]
@@ -722,7 +721,13 @@
       (is (false? (:over-after-shed? r)))
       (is (= 1 (:file-count r)))
       (is (< (:est-final r) (:est-full r)))
-      (is (not (str/includes? (:user-prompt r) "big.clj")))))
+      ;; manifest keeps the path + the query-surface hint...
+      (is (str/includes? (:user-prompt r) "big.clj"))
+      (is (str/includes? (:user-prompt r) "context_read"))
+      ;; ...but not the inlined body
+      (is (not (str/includes? (:user-prompt r) (apply str (repeat 5000 \x)))))
+      ;; ...and keeps the already-satisfied evidence-bundle instructions
+      (is (str/includes? (:user-prompt r) ":already-satisfied"))))
 
   (testing "irreducible overflow (huge spec, no files) → over-after-shed?, no shed"
     (let [r (assemble-within-budget (apply str (repeat 300000 \y)) []

--- a/components/llm/src/ai/miniforge/llm/interface.clj
+++ b/components/llm/src/ai/miniforge/llm/interface.clj
@@ -310,6 +310,19 @@
   [model-key]
   (registry/get-model model-key))
 
+(defn context-window-for-model-id
+  "Context window (max input tokens) for a backend model-id string
+   (e.g. \"claude-opus-4-6\"), or nil when uncatalogued. See N12 §2."
+  [model-id]
+  (registry/context-window-for-model-id model-id))
+
+(defn prompt-size-telemetry
+  "Pre-flight size gauge over the assembled system + user prompt:
+   {:system-chars :user-chars :total-chars :estimated-input-tokens}.
+   See N12 §3."
+  [system prompt]
+  (impl/prompt-size-telemetry system prompt))
+
 (defn get-models-by-capability
   "Get models meeting or exceeding a capability level.
 


### PR DESCRIPTION
## Summary

The action half of the context-economy stack (N12 §5). Instead of overflowing the context window, the planner now **sheds the eagerly-inlined "Existing Files in Scope" section** and relies on the context MCP query surface — the files are still cache-seeded in `invoke-planner-session`, so the agent can `context_read` them on demand. Bail is the last rung, not the first.

This is what would have prevented the `adhoc-2135293220` plan-phase failure: the inlined file bodies were the bulk of the 204,282-token prompt.

### Changes

- **llm interface:** expose `context-window-for-model-id` and `prompt-size-telemetry` (both already existed internally from #1088/#1089).
- **`planner/assemble-within-budget`:** estimate the assembled system+user prompt; if it exceeds the model's window, rebuild without the inlined files and re-measure. Emits a `:planner/context-shed` event. If the irreducible prompt (system + spec) *still* overflows, bail **pre-flight** (no LLM call) rather than pay for a request the model will reject.

### How it fits the stack

| PR | Role (N12) |
|----|-----------|
| #1081 | isolate the prompt (`--strict-mcp-config`) |
| #1088 | measure it (pre-flight telemetry, §3) |
| #1089 | classify a *realized* overflow as terminal (§4) |
| **this** | **shed to avoid the overflow in the first place (§5)** |

## Test plan

- `assemble-within-budget-test`: nil window → no shed (files inlined); small prompt → no shed; files that blow a 16384-token-window model → shed (inlined section dropped, prompt now fits, `:est-final < :est-full`); huge spec with no files → `:over-after-shed?` (irreducible).
- `bb pre-commit` green (poly + lint clean + smoke + GraalVM/bb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)