### PR TITLE
fix(demo): validate portfolio_id to prevent path traversal in example api.py

### DIFF
--- a/examples/demo-polyglot-repo/src/api.py
+++ b/examples/demo-polyglot-repo/src/api.py
@@ -3,12 +3,38 @@
 import os
 import json
 import sys  # unused import (ruff F401)
+import re
+from pathlib import Path
+
+# Intentionally defensive: this example demonstrates safe file-path handling.
+_DATA_DIR = Path(__file__).parent.parent / "data"
+_SAFE_ID = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def get_portfolio(portfolio_id: str) -> dict:
-    """Fetch portfolio by ID."""
-    data = json.loads(open(f"data/{portfolio_id}.json").read())  # noqa
-    return data
+    """Fetch portfolio by ID.
+
+    Validates portfolio_id before constructing the file path to prevent
+    path traversal attacks (e.g. '../../../etc/passwd').
+    """
+    # Guard 1: allowlist — reject anything that isn't alphanumeric / _ / -
+    if not _SAFE_ID.match(portfolio_id):
+        raise ValueError(
+            f"Invalid portfolio_id {portfolio_id!r}: "
+            "must match ^[a-zA-Z0-9_-]+$"
+        )
+
+    # Guard 2: resolve and assert the resolved path stays inside _DATA_DIR
+    target = (_DATA_DIR / f"{portfolio_id}.json").resolve()
+    if not str(target).startswith(str(_DATA_DIR.resolve())):
+        raise ValueError(
+            f"portfolio_id {portfolio_id!r} resolves outside data directory"
+        )
+
+    try:
+        return json.loads(target.read_text())
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Portfolio not found: {portfolio_id!r}")
 
 
 # VIOLATION: hardcoded API key pattern

--- a/examples/demo-polyglot-repo/src/api.py
+++ b/examples/demo-polyglot-repo/src/api.py
@@ -26,15 +26,15 @@ def get_portfolio(portfolio_id: str) -> dict:
 
     # Guard 2: resolve and assert the resolved path stays inside _DATA_DIR
     target = (_DATA_DIR / f"{portfolio_id}.json").resolve()
-    if not str(target).startswith(str(_DATA_DIR.resolve())):
+    if not target.is_relative_to(_DATA_DIR.resolve()):
         raise ValueError(
             f"portfolio_id {portfolio_id!r} resolves outside data directory"
         )
 
     try:
-        return json.loads(target.read_text())
+        return json.loads(target.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        raise FileNotFoundError(f"Portfolio not found: {portfolio_id!r}")
+        raise FileNotFoundError(f"Portfolio not found: {portfolio_id!r}") from None
 
 
 # VIOLATION: hardcoded API key pattern


### PR DESCRIPTION
## Summary

- `get_portfolio` previously constructed a file path directly from user-supplied `portfolio_id` with no validation, allowing `../../../etc/passwd`-style traversal out of `data/`.
- Added regex allowlist guard (`^[a-zA-Z0-9_-]+$`) — rejects any id containing dots, slashes, or other traversal characters before the path is formed.
- Added `pathlib.Path.resolve()` containment check as a second line of defence — even if the regex were somehow bypassed, the resolved path must remain inside `_DATA_DIR`.
- Wrapped file read in `try/except FileNotFoundError` for clean error handling.
- Added explanatory comment marking the function as intentionally defensive example code.

All other intentional violations in the file (unused import, hardcoded key, unused variable) are left intact — they exist to exercise the linter/scanner demo pipeline.

## Test plan

- [ ] Confirm `get_portfolio("../../../etc/passwd")` raises `ValueError` (regex guard fires)
- [ ] Confirm `get_portfolio("valid-id")` reads `data/valid-id.json` normally when the file exists
- [ ] Confirm `get_portfolio("missing")` raises `FileNotFoundError` (not a raw OS error)
- [ ] Pre-commit: `poly:check` + smoke tests pass (verified locally before push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)