### PR TITLE
fix(compliance-scanner): reject relative-path values that escape repo-root

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -479,17 +479,43 @@
                ;; the linter is a human-review gate, not a mechanical fix.
                :auto-fixable-default false))))
 
+(defn- within-root?
+  "Return true iff the canonical path of `candidate` starts with the
+   canonical path of `root` followed by the system file separator.
+   Uses canonical paths to resolve symlinks and `..` segments before
+   the comparison, preventing path-traversal via relative-path inputs."
+  [^java.io.File root ^java.io.File candidate]
+  (let [canonical-root      (.getCanonicalPath root)
+        canonical-candidate (.getCanonicalPath candidate)
+        prefix              (str canonical-root java.io.File/separator)]
+    (str/starts-with? canonical-candidate prefix)))
+
 (defn analyze-file
   "Analyze a single file by absolute or relative path. Returns a vector
-   of public Violation maps."
+   of public Violation maps.
+
+   Returns an empty vector without reading the file when `relative-path`
+   escapes `repo-root` — this prevents path-traversal attacks via inputs
+   such as \"../../../etc/passwd\" or absolute paths like \"/etc/passwd\".
+   Canonical paths resolve symlinks and `..` segments before comparison."
   [repo-root relative-path]
-  (let [abs (io/file repo-root relative-path)]
-    (if (.isFile abs)
-      (let [content (try (slurp abs) (catch Exception _ nil))]
-        (if content
-          (mapv format-violation (:violations (analyze-content relative-path content)))
-          []))
-      [])))
+  (let [root (io/file repo-root)
+        abs  (try (io/file root relative-path)
+                  (catch IllegalArgumentException _
+                    ;; clojure.java.io/file rejects absolute second arguments;
+                    ;; treat as traversal attempt.
+                    nil))]
+    (if (or (nil? abs) (not (within-root? root abs)))
+      (do (.println System/err
+                    (str "[compliance-scanner] WARN path-traversal rejected: "
+                         relative-path " escapes repo-root " repo-root))
+          [])
+      (if (.isFile abs)
+        (let [content (try (slurp abs) (catch Exception _ nil))]
+          (if content
+            (mapv format-violation (:violations (analyze-content relative-path content)))
+            []))
+        []))))
 
 (defn scan-repo
   "Scan a repository for exceptions-as-data violations.

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -483,12 +483,22 @@
   "Return true iff the canonical path of `candidate` starts with the
    canonical path of `root` followed by the system file separator.
    Uses canonical paths to resolve symlinks and `..` segments before
-   the comparison, preventing path-traversal via relative-path inputs."
+   the comparison, preventing path-traversal via relative-path inputs.
+
+   Returns false (safe default) when .getCanonicalPath throws
+   IOException or SecurityException so the caller's exceptions-as-data
+   contract is preserved."
   [^java.io.File root ^java.io.File candidate]
-  (let [canonical-root      (.getCanonicalPath root)
-        canonical-candidate (.getCanonicalPath candidate)
-        prefix              (str canonical-root java.io.File/separator)]
-    (str/starts-with? canonical-candidate prefix)))
+  (try
+    (let [canonical-root      (.getCanonicalPath root)
+          canonical-candidate (.getCanonicalPath candidate)
+          sep                 java.io.File/separator
+          prefix              (if (str/ends-with? canonical-root sep)
+                                canonical-root
+                                (str canonical-root sep))]
+      (str/starts-with? canonical-candidate prefix))
+    (catch Exception _
+      false)))
 
 (defn analyze-file
   "Analyze a single file by absolute or relative path. Returns a vector
@@ -506,9 +516,9 @@
                     ;; treat as traversal attempt.
                     nil))]
     (if (or (nil? abs) (not (within-root? root abs)))
-      (do (.println System/err
-                    (str "[compliance-scanner] WARN path-traversal rejected: "
-                         relative-path " escapes repo-root " repo-root))
+      (do (binding [*out* *err*]
+            (println (str "[compliance-scanner] WARN path-traversal rejected: "
+                          relative-path " escapes repo-root " repo-root)))
           [])
       (if (.isFile abs)
         (let [content (try (slurp abs) (catch Exception _ nil))]

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/path_traversal_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/path_traversal_test.clj
@@ -51,7 +51,12 @@
        ;; Supply an absolute path outside root directly as relative-path.
        ;; io/file ignores root when the second arg is absolute on most JVMs,
        ;; so canonical resolution must still catch this.
-       (let [result (exc/analyze-file root "/etc/passwd")]
+       ;; Use java.io.tmpdir so the path exists on all platforms (including
+       ;; Windows and minimal containers that lack /etc/passwd).
+       (let [outside-path (str (System/getProperty "java.io.tmpdir")
+                               java.io.File/separator
+                               "outside-the-repo-root-sentinel")
+             result       (exc/analyze-file root outside-path)]
          (is (= [] result)
              "analyze-file must return [] when path resolves outside repo-root"))))))
 

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/path_traversal_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/path_traversal_test.clj
@@ -1,0 +1,69 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.exceptions-as-data.path-traversal-test
+  "Security: analyze-file must reject relative-path values that escape repo-root.
+   A caller supplying \"../../../etc/passwd\" must receive [] — not file contents."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
+
+(defn- with-temp-root
+  "Create a temp directory, call (f root-path), then delete the tree."
+  [f]
+  (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
+                            (str "exc-traversal-" (random-uuid)))
+               .mkdirs)]
+    (try (f (.getAbsolutePath root))
+         (finally (doseq [^java.io.File ff (reverse (file-seq root))]
+                    (.delete ff))))))
+
+(deftest path-traversal-via-dotdot-is-rejected
+  (testing "relative-path with .. segments that escape repo-root returns []"
+    (with-temp-root
+     (fn [root]
+       ;; Construct a traversal path that would resolve outside root.
+       ;; e.g. root = /tmp/exc-traversal-<uuid>, escape = ../../../etc/passwd
+       (let [result (exc/analyze-file root "../../../etc/passwd")]
+         (is (= [] result)
+             "analyze-file must return [] when relative-path escapes repo-root"))))))
+
+(deftest path-traversal-via-absolute-path-is-rejected
+  (testing "absolute path that is outside repo-root returns []"
+    (with-temp-root
+     (fn [root]
+       ;; Supply an absolute path outside root directly as relative-path.
+       ;; io/file ignores root when the second arg is absolute on most JVMs,
+       ;; so canonical resolution must still catch this.
+       (let [result (exc/analyze-file root "/etc/passwd")]
+         (is (= [] result)
+             "analyze-file must return [] when path resolves outside repo-root"))))))
+
+(deftest legitimate-path-inside-root-is-allowed
+  (testing "a path that stays inside repo-root is analyzed normally"
+    (with-temp-root
+     (fn [root]
+       (let [rel "components/foo/src/ai/miniforge/foo/core.clj"
+             f   (io/file root rel)]
+         (io/make-parents f)
+         (spit f "(ns ai.miniforge.foo.core)\n(defn safe [] :ok)")
+         ;; No throws → no violations expected
+         (let [result (exc/analyze-file root rel)]
+           (is (vector? result))
+           (is (empty? result))))))))


### PR DESCRIPTION
## Summary

- **Vulnerability fixed:** Path traversal in `analyze-file` — `(io/file repo-root relative-path)` previously composed paths without verifying the resolved path stayed inside `repo-root`, allowing a caller to supply `../../../etc/passwd` and read arbitrary files via `slurp`.
- **Guard added:** New private `within-root?` predicate resolves canonical paths (resolving symlinks and `..` segments) for both root and candidate before comparison. `analyze-file` also catches `IllegalArgumentException` from `io/file` when an absolute path is supplied as `relative-path`.
- **Failure mode:** Returns `[]` and emits a stderr warning — no exception thrown, consistent with the existing anomaly-as-data patterns in this namespace.
- **Test coverage:** New `path_traversal_test.clj` covers `..`-based traversal, absolute-path injection, and a legitimate-path smoke check.

## Test plan

- [x] `bb poly:check` — OK
- [x] All `exceptions-as-data.*` tests pass (23 tests / 70 assertions)
- [x] Pre-commit smoke (303 tests / 1120 assertions) — 0 failures, 0 errors
- [x] GraalVM/Babashka compatibility — 0 failures

## Security notes

- Attack vector: caller-supplied `relative-path` with `../` sequences or absolute path string
- Fixed by: canonical path prefix check before `slurp`; absolute paths rejected at `io/file` construction
- Severity: HIGH — arbitrary file read on the host running the scanner

🤖 Generated with [Claude Code](https://claude.com/claude-code)