### PR TITLE
fix(release-executor): validate and safely pass file paths in sandbox write-file!

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -51,11 +51,16 @@
    on violation."
   [path]
   (let [s (str path)]
+    (when (or (str/starts-with? s "/")
+              (re-find #"^[A-Za-z]:" s))
+      (throw (ex-info "Path traversal rejected: sandbox path must be relative"
+                      {:type :path-traversal
+                       :path s})))
     (when (re-find #"(^|[/\\])\.\.([/\\]|$)" s)
       (throw (ex-info "Path traversal rejected: sandbox path contains .. segment"
                       {:type :path-traversal
                        :path s})))
-    (when (re-find #"['\\`$! \t\n\r;|&><(){}*?\[\]#~]" s)
+    (when (re-find #"['\\`$! \t\n\r\x00;|&><(){}*?\[\]#~]" s)
       (throw (ex-info "Shell injection rejected: sandbox path contains unsafe character"
                       {:type :shell-injection
                        :path s})))))

--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -34,15 +34,31 @@
 ;; Helpers
 
 (defn assert-safe-container-path!
-  "Assert that `path` contains no `..` segments that could escape the container
-   working directory.  The check is lexical because `path` targets the container
-   filesystem — host-side normalization cannot be applied.
-   Throws ex-info with {:type :path-traversal :path path} on violation."
+  "Assert that `path` is safe to interpolate into a single-quoted shell argument
+   and cannot escape the container working directory.
+
+   Two classes of attack are blocked:
+
+   1. Path traversal -- any `..` segment (lexical check; host-side
+      normalization cannot be applied to a container path).
+
+   2. Shell injection -- any character that terminates a POSIX single-quoted
+      string or introduces a shell metacharacter that survives quoting:
+      single-quote, backslash, backtick, $, !, space, tab, newline, NUL,
+      and the glob/redirect set (; | & > < ( ) { } * ? [ ] # ~).
+
+   Throws ex-info with {:type :path-traversal} or {:type :shell-injection}
+   on violation."
   [path]
-  (when (re-find #"(^|[/\\])\.\.([/\\]|$)" (str path))
-    (throw (ex-info "Path traversal rejected: sandbox path contains .. segment"
-                    {:type :path-traversal
-                     :path (str path)}))))
+  (let [s (str path)]
+    (when (re-find #"(^|[/\\])\.\.([/\\]|$)" s)
+      (throw (ex-info "Path traversal rejected: sandbox path contains .. segment"
+                      {:type :path-traversal
+                       :path s})))
+    (when (re-find #"['\\`$! \t\n\r;|&><(){}*?\[\]#~]" s)
+      (throw (ex-info "Shell injection rejected: sandbox path contains unsafe character"
+                      {:type :shell-injection
+                       :path s})))))
 
 (defn exec!
   "Execute a command in the sandbox environment.

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -365,51 +365,58 @@
 (deftest write-file-rejects-path-traversal-test
   (testing "write-file! throws on path containing .. segment"
     (let [[exec _cmds] (create-mock-executor)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Path traversal rejected"
-                            (sandbox/write-file! exec "env-1" "../etc/passwd" "evil"))))))
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (sandbox/write-file! exec "env-1" "../etc/passwd" "evil")))]
+        (is (re-find #"Path traversal rejected" (ex-message e)))
+        (is (= :path-traversal (:type (ex-data e))))))))
 
 (deftest write-file-rejects-embedded-traversal-test
   (testing "write-file! throws on path with embedded .. segment"
     (let [[exec _cmds] (create-mock-executor)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Path traversal rejected"
-                            (sandbox/write-file! exec "env-1" "src/../../etc/passwd" "evil"))))))
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (sandbox/write-file! exec "env-1" "src/../../etc/passwd" "evil")))]
+        (is (re-find #"Path traversal rejected" (ex-message e)))
+        (is (= :path-traversal (:type (ex-data e))))))))
 
 (deftest write-file-rejects-single-quote-injection-test
   (testing "write-file! throws on path containing single-quote (shell injection)"
     (let [[exec _cmds] (create-mock-executor)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Shell injection rejected"
-                            (sandbox/write-file! exec "env-1" "src/a'.clj" "evil"))))))
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (sandbox/write-file! exec "env-1" "src/a'.clj" "evil")))]
+        (is (re-find #"Shell injection rejected" (ex-message e)))
+        (is (= :shell-injection (:type (ex-data e))))))))
 
 (deftest write-file-rejects-dollar-injection-test
   (testing "write-file! throws on path containing $ (shell injection)"
     (let [[exec _cmds] (create-mock-executor)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Shell injection rejected"
-                            (sandbox/write-file! exec "env-1" "src/$HOME/x.clj" "evil"))))))
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (sandbox/write-file! exec "env-1" "src/$HOME/x.clj" "evil")))]
+        (is (re-find #"Shell injection rejected" (ex-message e)))
+        (is (= :shell-injection (:type (ex-data e))))))))
 
 (deftest write-file-rejects-semicolon-injection-test
   (testing "write-file! throws on path containing ; (shell injection)"
     (let [[exec _cmds] (create-mock-executor)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Shell injection rejected"
-                            (sandbox/write-file! exec "env-1" "src/a;rm -rf /;b.clj" "evil"))))))
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (sandbox/write-file! exec "env-1" "src/a;rm -rf /;b.clj" "evil")))]
+        (is (re-find #"Shell injection rejected" (ex-message e)))
+        (is (= :shell-injection (:type (ex-data e))))))))
 
 (deftest delete-file-rejects-path-traversal-test
   (testing "delete-file! throws on path containing .. segment"
     (let [[exec _cmds] (create-mock-executor)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Path traversal rejected"
-                            (sandbox/delete-file! exec "env-1" "../etc/shadow"))))))
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (sandbox/delete-file! exec "env-1" "../etc/shadow")))]
+        (is (re-find #"Path traversal rejected" (ex-message e)))
+        (is (= :path-traversal (:type (ex-data e))))))))
 
 (deftest delete-file-rejects-single-quote-injection-test
   (testing "delete-file! throws on path containing single-quote (shell injection)"
     (let [[exec _cmds] (create-mock-executor)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Shell injection rejected"
-                            (sandbox/delete-file! exec "env-1" "src/a' || rm -rf /;b.clj"))))))
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (sandbox/delete-file! exec "env-1" "src/a' || rm -rf /;b.clj")))]
+        (is (re-find #"Shell injection rejected" (ex-message e)))
+        (is (= :shell-injection (:type (ex-data e))))))))
 
 (deftest write-file-accepts-normal-paths-test
   (testing "write-file! accepts well-formed relative source paths"
@@ -422,3 +429,11 @@
       (is (:success? (sandbox/write-file! exec "env-1"
                                           "components/my-comp/src/ai/company/my_comp/core.clj"
                                           "(ns ai.company.my-comp.core)"))))))
+
+(deftest write-file-rejects-absolute-path-test
+  (testing "write-file! throws on absolute path (cannot escape container workspace)"
+    (let [[exec _cmds] (create-mock-executor)]
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (sandbox/write-file! exec "env-1" "/etc/passwd" "evil")))]
+        (is (re-find #"Path traversal rejected" (ex-message e)))
+        (is (= :path-traversal (:type (ex-data e))))))))

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -357,3 +357,68 @@
               :error "signing failed"
               :output ""}
              result)))))
+
+;; ============================================================================
+;; assert-safe-container-path! / path-validation tests
+;; ============================================================================
+
+(deftest write-file-rejects-path-traversal-test
+  (testing "write-file! throws on path containing .. segment"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Path traversal rejected"
+                            (sandbox/write-file! exec "env-1" "../etc/passwd" "evil"))))))
+
+(deftest write-file-rejects-embedded-traversal-test
+  (testing "write-file! throws on path with embedded .. segment"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Path traversal rejected"
+                            (sandbox/write-file! exec "env-1" "src/../../etc/passwd" "evil"))))))
+
+(deftest write-file-rejects-single-quote-injection-test
+  (testing "write-file! throws on path containing single-quote (shell injection)"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Shell injection rejected"
+                            (sandbox/write-file! exec "env-1" "src/a'.clj" "evil"))))))
+
+(deftest write-file-rejects-dollar-injection-test
+  (testing "write-file! throws on path containing $ (shell injection)"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Shell injection rejected"
+                            (sandbox/write-file! exec "env-1" "src/$HOME/x.clj" "evil"))))))
+
+(deftest write-file-rejects-semicolon-injection-test
+  (testing "write-file! throws on path containing ; (shell injection)"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Shell injection rejected"
+                            (sandbox/write-file! exec "env-1" "src/a;rm -rf /;b.clj" "evil"))))))
+
+(deftest delete-file-rejects-path-traversal-test
+  (testing "delete-file! throws on path containing .. segment"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Path traversal rejected"
+                            (sandbox/delete-file! exec "env-1" "../etc/shadow"))))))
+
+(deftest delete-file-rejects-single-quote-injection-test
+  (testing "delete-file! throws on path containing single-quote (shell injection)"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Shell injection rejected"
+                            (sandbox/delete-file! exec "env-1" "src/a' || rm -rf /;b.clj"))))))
+
+(deftest write-file-accepts-normal-paths-test
+  (testing "write-file! accepts well-formed relative source paths"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (:success? (sandbox/write-file! exec "env-1" "src/foo/bar.clj" "(ns foo.bar)"))))))
+
+(deftest write-file-accepts-deep-paths-test
+  (testing "write-file! accepts deep nested paths without traversal"
+    (let [[exec _cmds] (create-mock-executor)]
+      (is (:success? (sandbox/write-file! exec "env-1"
+                                          "components/my-comp/src/ai/company/my_comp/core.clj"
+                                          "(ns ai.company.my-comp.core)"))))))


### PR DESCRIPTION
## Summary

- Extends `assert-safe-container-path!` (Layer 0 of `sandbox.clj`) to block **shell injection** in addition to the existing path-traversal guard. Any path containing a single-quote, backslash, backtick, `$`, `!`, whitespace, semicolon, pipe, redirect, or glob character now throws `ex-info {:type :shell-injection}` before the path is interpolated into the container shell command string.
- The prior guard only rejected `..` traversal segments; a path like `src/a'.clj` could terminate the single-quote wrapping and execute arbitrary shell commands inside the task capsule.
- Adds 10 targeted tests: traversal rejection (`..`, embedded `../..`), injection rejection (single-quote, `$`, `;`), and two happy-path cases confirming normal source paths are accepted.

## Security impact

Severity: HIGH. Affected functions: `write-file!`, `delete-file!` (both call `assert-safe-container-path!` before building the shell command). Paths originate from LLM-generated `code/files` entries — untrusted input.

## Test plan

- [x] `clojure -M:test` for `ai.miniforge.release-executor.sandbox-test` — 32 tests, 69 assertions, 0 failures
- [x] `bb pre-commit` — commit budget, poly:check, lint, smoke (303 tests), GraalVM compat — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)