### PR TITLE
fix(agent): reserve context headroom for the CLI baseline + emit prompt-size event

### DIFF
--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -31,6 +31,16 @@
   :max-total-ms                600000
   :min-activity-interval-ms    3000}
 
+ ;; Headroom reserved below the model's context window when deciding whether
+ ;; to shed the inlined existing-files section (N12 §5). The shed/bail
+ ;; estimate covers only miniforge's assembled prompt (system + user); the
+ ;; agent CLI adds its own baseline on top (system prompt, tool schemas,
+ ;; host plugins/skills) that we can't measure. This reserve fires the shed
+ ;; before that unmeasured baseline pushes the true total over the window.
+ ;; 2026-06-07 review-redirect-convergence dogfood: miniforge prompt was
+ ;; <200k so the shed didn't fire, but actual input hit 215k and overflowed.
+ :prompt/context-window-reserve-tokens 50000
+
  ;; Submission-retry runs after the main planner turn already produced
  ;; useful prose but failed to land the plan as `.miniforge/plan.edn`.
  ;; Caps and turn budget are tight on purpose: the only legitimate work

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -29,6 +29,7 @@
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.agent.submission-recovery :as submission-recovery]
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
@@ -202,17 +203,25 @@
    the context MCP cache (seeded separately in invoke-planner-session), so
    the agent keeps a query surface, and the section's already-satisfied
    evidence-bundle instructions are preserved. Returns
-   {:user-prompt :shed? :over-after-shed? :window :est-full :est-final
-    :file-count}; :over-after-shed? marks an irreducible overflow."
-  [spec-text existing-files effective-system model]
-  (let [window   (llm/context-window-for-model-id model)
-        est      (fn [user] (:estimated-input-tokens
-                             (llm/prompt-size-telemetry effective-system user)))
-        full     (build-user-prompt spec-text existing-files)
-        est-full (est full)
-        base     {:window window :est-full est-full :file-count (count existing-files)}]
+   {:user-prompt :shed? :over-after-shed? :window :reserve :effective-window
+    :est-full :est-final :file-count}; :over-after-shed? marks an
+    irreducible overflow.
+
+   `reserve` is headroom kept below the real window: the estimate covers
+   only miniforge's assembled prompt, while the agent CLI adds its own
+   unmeasured baseline (system prompt, tools, host plugins/skills) on top.
+   The shed/bail fire against `effective-window = window - reserve`."
+  [spec-text existing-files effective-system model reserve]
+  (let [window     (llm/context-window-for-model-id model)
+        effective  (when window (max 0 (- window reserve)))
+        est        (fn [user] (:estimated-input-tokens
+                               (llm/prompt-size-telemetry effective-system user)))
+        full       (build-user-prompt spec-text existing-files)
+        est-full   (est full)
+        base       {:window window :reserve reserve :effective-window effective
+                    :est-full est-full :file-count (count existing-files)}]
     (cond
-      (or (nil? window) (< est-full window))
+      (or (nil? effective) (< est-full effective))
       (merge base {:user-prompt full :shed? false :over-after-shed? false :est-final est-full})
 
       (empty? existing-files)            ; nothing left to shed — irreducibly over
@@ -222,7 +231,31 @@
       (let [shed (build-user-prompt spec-text existing-files format-existing-files-manifest)
             est-shed (est shed)]
         (merge base {:user-prompt shed :shed? true
-                     :over-after-shed? (>= est-shed window) :est-final est-shed})))))
+                     :over-after-shed? (>= est-shed effective) :est-final est-shed})))))
+
+(defn- emit-prompt-size!
+  "Emit an :agent/prompt-size workflow event recording the planner's
+   pre-flight budget (N12 §3) so estimate-vs-window is visible/queryable —
+   the logger isn't surfaced in headless runs. Safe no-op without a stream."
+  [context budget]
+  (when-let [stream (or (:event-stream context) (:execution/event-stream context))]
+    (when-let [wf-id (or (:execution/id context) (:workflow/id context))]
+      (try
+        (es/publish!
+         stream
+         (-> (es/create-envelope stream :agent/prompt-size wf-id
+                                 (str "planner prompt ~" (:est-full budget)
+                                      " est tokens / window " (:window budget)
+                                      (when (:shed? budget) " (shed to manifest)")))
+             (assoc :agent/id :planner
+                    :prompt/estimated-input-tokens (:est-full budget)
+                    :prompt/context-window (:window budget)
+                    :prompt/reserve (:reserve budget)
+                    :prompt/effective-window (:effective-window budget)
+                    :prompt/shed? (:shed? budget)
+                    :prompt/estimated-after-shed (:est-final budget)
+                    :prompt/file-count (:file-count budget))))
+        (catch Exception _ nil)))))
 
 (defn spec->text
   "Convert a spec to text for the LLM."
@@ -668,9 +701,11 @@
               existing-files (:task/existing-files input)
               effective-system (str @planner-system-prompt
                                     (get input :task/behavior-addendum ""))
-              budget (assemble-within-budget spec-text existing-files
-                                             effective-system (:model config))
+              budget (assemble-within-budget
+                      spec-text existing-files effective-system (:model config)
+                      (get @planner-prompt-data :prompt/context-window-reserve-tokens 50000))
               user-prompt (:user-prompt budget)]
+          (emit-prompt-size! context budget)
           (when (:shed? budget)
             (log/info logger :planner :planner/context-shed
                       {:data {:file-count (:file-count budget)

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -210,15 +210,21 @@
    `reserve` is headroom kept below the real window: the estimate covers
    only miniforge's assembled prompt, while the agent CLI adds its own
    unmeasured baseline (system prompt, tools, host plugins/skills) on top.
-   The shed/bail fire against `effective-window = window - reserve`."
+   The shed/bail fire against `effective-window = window - reserve`. The
+   reserve is clamped to at most half the window so a reserve >= window
+   (misconfig, or a tiny-window model) can't zero the effective window and
+   make every prompt look over-budget; `:reserve-clamped?` flags that."
   [spec-text existing-files effective-system model reserve]
   (let [window     (llm/context-window-for-model-id model)
-        effective  (when window (max 0 (- window reserve)))
+        eff-reserve (when window (min reserve (quot window 2)))
+        clamped?   (boolean (and window (> reserve eff-reserve)))
+        effective  (when window (- window eff-reserve))
         est        (fn [user] (:estimated-input-tokens
                                (llm/prompt-size-telemetry effective-system user)))
         full       (build-user-prompt spec-text existing-files)
         est-full   (est full)
         base       {:window window :reserve reserve :effective-window effective
+                    :reserve-clamped? clamped?
                     :est-full est-full :file-count (count existing-files)}]
     (cond
       (or (nil? effective) (< est-full effective))
@@ -251,6 +257,7 @@
                     :prompt/estimated-input-tokens (:est-full budget)
                     :prompt/context-window (:window budget)
                     :prompt/reserve (:reserve budget)
+                    :prompt/reserve-clamped? (:reserve-clamped? budget)
                     :prompt/effective-window (:effective-window budget)
                     :prompt/shed? (:shed? budget)
                     :prompt/estimated-after-shed (:est-final budget)

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -731,16 +731,30 @@
 
   (testing "the reserve fires the shed earlier: a prompt that fits the full
             window sheds once the reserve drops the effective window below it"
-    ;; ~20k chars (~5k tokens) fits the 16384 window with reserve 0, but a
-    ;; 13000-token reserve → effective ~3384 → shed fires. This is the
-    ;; 2026-06-07 fix: reserve headroom for the unmeasured CLI baseline.
-    (let [files [(big-file 20000)]
+    ;; This is the 2026-06-07 fix — reserve headroom for the unmeasured CLI
+    ;; baseline. Derive the reserve from the actual estimate so the test
+    ;; doesn't hard-code window/template sizes.
+    (let [files      [(big-file 50000)]
           no-reserve (assemble-within-budget "do it" files "system" "codellama-34b" 0)
-          reserved   (assemble-within-budget "do it" files "system" "codellama-34b" 13000)]
-      (is (false? (:shed? no-reserve)))
-      (is (true? (:shed? reserved)))
-      (is (= 13000 (:reserve reserved)))
-      (is (= (- 16384 13000) (:effective-window reserved)))))
+          window     (:window no-reserve)
+          est        (:est-full no-reserve)
+          ;; a reserve that drops the effective window just below the estimate
+          ;; (kept under window/2 so it isn't clamped)
+          reserve    (+ (- window est) 1000)
+          reserved   (assemble-within-budget "do it" files "system" "codellama-34b" reserve)]
+      (is (false? (:shed? no-reserve)) "fits the full window with no reserve")
+      (is (true? (:shed? reserved)) "reserve pushes it past the effective window")
+      (is (false? (:reserve-clamped? reserved)))
+      (is (= (- window reserve) (:effective-window reserved)))))
+
+  (testing "a reserve >= window is clamped so it can't make every prompt
+            over-budget (the misconfig footgun)"
+    (let [r (assemble-within-budget "do it" [(big-file 100)]
+                                    "system" "codellama-34b" 999999)]
+      (is (true? (:reserve-clamped? r)))
+      (is (pos? (:effective-window r)) "effective window is never zeroed")
+      (is (false? (:shed? r)) "a trivial prompt still fits")
+      (is (false? (:over-after-shed? r)) "not forced over-budget")))
 
   (testing "irreducible overflow (huge spec, no files) → over-after-shed?, no shed"
     (let [r (assemble-within-budget (apply str (repeat 300000 \y)) []

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -700,15 +700,15 @@
 (deftest assemble-within-budget-test
   (testing "uncatalogued model (nil window) → never sheds, files stay inlined"
     (let [r (assemble-within-budget "do the thing" [(big-file 100)]
-                                    "system" "no-such-model")]
+                                    "system" "no-such-model" 0)]
       (is (false? (:shed? r)))
       (is (false? (:over-after-shed? r)))
       (is (str/includes? (:user-prompt r) "big.clj"))))
 
-  (testing "a small prompt under the window is not shed"
+  (testing "a small prompt under the window is not shed (reserve 0)"
     ;; codellama-34b → 16384-token window; a tiny prompt fits
     (let [r (assemble-within-budget "do the thing" [(big-file 100)]
-                                    "system" "codellama-34b")]
+                                    "system" "codellama-34b" 0)]
       (is (false? (:shed? r)))
       (is (str/includes? (:user-prompt r) "big.clj"))))
 
@@ -716,7 +716,7 @@
             path + context_read hint stay, and the prompt now fits"
     ;; ~300k chars of file content >> 16384 tokens; spec+system alone fits
     (let [r (assemble-within-budget "do the thing" [(big-file 300000)]
-                                    "system" "codellama-34b")]
+                                    "system" "codellama-34b" 0)]
       (is (true? (:shed? r)))
       (is (false? (:over-after-shed? r)))
       (is (= 1 (:file-count r)))
@@ -729,9 +729,22 @@
       ;; ...and keeps the already-satisfied evidence-bundle instructions
       (is (str/includes? (:user-prompt r) ":already-satisfied"))))
 
+  (testing "the reserve fires the shed earlier: a prompt that fits the full
+            window sheds once the reserve drops the effective window below it"
+    ;; ~20k chars (~5k tokens) fits the 16384 window with reserve 0, but a
+    ;; 13000-token reserve → effective ~3384 → shed fires. This is the
+    ;; 2026-06-07 fix: reserve headroom for the unmeasured CLI baseline.
+    (let [files [(big-file 20000)]
+          no-reserve (assemble-within-budget "do it" files "system" "codellama-34b" 0)
+          reserved   (assemble-within-budget "do it" files "system" "codellama-34b" 13000)]
+      (is (false? (:shed? no-reserve)))
+      (is (true? (:shed? reserved)))
+      (is (= 13000 (:reserve reserved)))
+      (is (= (- 16384 13000) (:effective-window reserved)))))
+
   (testing "irreducible overflow (huge spec, no files) → over-after-shed?, no shed"
     (let [r (assemble-within-budget (apply str (repeat 300000 \y)) []
-                                    "system" "codellama-34b")]
+                                    "system" "codellama-34b" 0)]
       (is (false? (:shed? r)))
       (is (true? (:over-after-shed? r))))))
 


### PR DESCRIPTION
## Summary

The 2026-06-07 re-run (`adhoc-411026284`) showed the shed **didn't fire** and plan still overflowed — **215,446 tokens vs the 200k window** (though now terminal in 18.7s, no doomed retry, confirming #1089 works). Two fixes, both chosen after diagnosis:

### 1. Headroom reserve (the shed was gating on an undercount)

`assemble-within-budget` estimated only **miniforge's** assembled prompt (system + user). But the real input also includes the **agent CLI's own baseline** — its system prompt, tool schemas, and host plugins/skills (`--strict-mcp-config` drops MCP servers, *not* plugins/skills). miniforge's prompt was under 200k → no shed → the CLI baseline pushed actual to 215k → overflow.

Now the shed/bail fire against `effective-window = window − reserve`. `:prompt/context-window-reserve-tokens` (default **50000**) reserves headroom for that unmeasured baseline, so the shed triggers *before* it tips the true total over. `assemble-within-budget` takes `reserve` explicitly (testable across window sizes).

### 2. Surface the prompt-size telemetry (it was invisible)

The `prompt-size-telemetry` was a `logger.info`, and headless dogfood runs surface neither logger output nor `~/.miniforge/logs` (empty) — which is *why this run was hard to diagnose*. The planner now emits an **`:agent/prompt-size`** workflow event (estimate, window, reserve, `shed?`, post-shed estimate) via the event stream (`agent` already depends on `event-stream`; uses the exposed `create-envelope` + `publish!`, no event-stream changes). Next run, estimate-vs-window and whether the shed fired are greppable in the event stream.

## Test plan

- `assemble-within-budget-test`: reserve threaded through all cases; new case proves a prompt that fits the full window **sheds once the reserve drops the effective window below it** (`reserve 0` → no shed, `reserve 13000` → shed; asserts `:reserve` + `:effective-window`).
- `bb pre-commit` green, lint clean.

## Still open (deferred by choice)
Shrinking the CLI baseline at the source (`--bare`/`CLAUDE_CONFIG_DIR` to drop the plugin/skill leak) and trimming explore-phase file loading — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)