### PR TITLE
Add cause-classification helper and warning-only cycle tracking to...

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -505,6 +505,10 @@
   "Validate a review artifact against the schema and check gate-count
    consistency. Arg: artifact. Returns {:valid? bool :errors ...}."
   specialized/validate-review-artifact)
+(def rejection-warnings-only?
+  "True when a review is a rejection driven solely by warnings (no blocking
+   issues). Arg: artifact. Returns boolean."
+  specialized/rejection-warnings-only?)
 (def review-fingerprint
   "Reduce a review artifact to a stable, comparable fingerprint of its
    actionable items. Arg: review. Returns a sorted vector of

--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+ :deps {metosin/malli {:mvn/version "0.16.4"}
+        ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/phase {:local/root "../phase"}
         ai.miniforge/agent {:local/root "../agent"}

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -25,7 +25,17 @@
    :budget {:tokens 20000
             :iterations 2
             :time-seconds 180}
-   :model-hint :sonnet}
+   :model-hint :sonnet
+   ;; Convergence policy: what to do when the reviewer keeps emitting
+   ;; warnings but no blocking issues.  :accept-with-warnings lets the
+   ;; SDLC proceed (warnings recorded in the evidence bundle, not fatal).
+   ;; :needs-decomposition escalates to task-split instead.
+   :review/warning-churn-policy :accept-with-warnings
+   ;; Maximum consecutive warning-only rejection cycles before the churn
+   ;; policy fires.  2 allows one retry after the first warning round —
+   ;; enough to catch a transient LLM false-positive, short enough that
+   ;; a genuinely warning-heavy PR does not loop to max-redirects.
+   :review/max-warning-only-cycles 2}
 
   ;; Plan phase defaults.
   :plan

--- a/components/phase-software-factory/resources/config/phase/messages/system.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/system.edn
@@ -1,0 +1,4 @@
+{:phase/system
+ {;; Review phase — startup/config errors (system-locale; operator-facing only)
+  :review/invalid-convergence-config
+  "Invalid review convergence config in defaults.edn:"}}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/messages.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/messages.clj
@@ -25,3 +25,9 @@
   "Look up a phase message by key, with optional param substitution."
   (messages/create-translator "config/phase/messages/en-US.edn"
                               :phase/messages))
+
+(def ts
+  "Look up a system-locale phase message by key (operator-facing: logs, startup
+   errors, observability pipelines — never rendered directly to a user)."
+  (messages/create-translator "config/phase/messages/system.edn"
+                              :phase/system))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -46,9 +46,7 @@
    bundle but do not block the release gate.  This is the safe default: it
    avoids silent task-explosion while still making warnings visible.
    The active operational value lives in :review/warning-churn-policy
-   in resources/config/phase/defaults.edn.
-   NOTE: consumed by the compute-verdict warning-churn branch — wired in the
-   follow-up PR 'feat/review-convergence-policy-wiring' (rule 008 deferral)."
+   in resources/config/phase/defaults.edn."
   :accept-with-warnings)
 
 (def default-max-warning-only-cycles
@@ -58,9 +56,7 @@
    transient LLM false-positive, short enough that a genuinely warning-heavy
    PR does not loop all the way to max-redirects and exhaust its token budget.
    The active operational value lives in :review/max-warning-only-cycles
-   in resources/config/phase/defaults.edn.
-   NOTE: consumed by leave-review warning-cycle cap — wired in the follow-up
-   PR 'feat/review-convergence-policy-wiring' (rule 008 deferral)."
+   in resources/config/phase/defaults.edn."
   2)
 
 ;; Schema — validates review convergence config keys at config load time (rule 004).
@@ -102,6 +98,43 @@
 
 ;; Register defaults on load
 (phase/register-phase-defaults! :review default-config)
+
+;; Pure helper — cause classification
+
+(defn- classify-rejection-cause
+  "Pure function. Given a review artifact and the count of prior consecutive
+   warning-only cycles, classify the rejection cause and return an updated count.
+
+   Uses `agent/rejection-warnings-only?` to distinguish a warning-driven
+   rejection (no blocking issues, only advisory warnings) from one containing
+   genuine blocking defects.
+
+   Returns {:cause/type :blocking-defect | :warning-churn
+            :warning-only-count <updated int>}
+
+   :warning-churn increments the counter; :blocking-defect resets to 0."
+  [review-artifact prior-warning-only-count]
+  (if (agent/rejection-warnings-only? review-artifact)
+    {:cause/type         :warning-churn
+     :warning-only-count (inc prior-warning-only-count)}
+    {:cause/type         :blocking-defect
+     :warning-only-count 0}))
+
+(defn- compute-warning-churn?
+  "True when the cause is :warning-churn AND the warning-only-count has reached
+   or exceeded max-warning-only-cycles (the churn policy threshold).
+
+   With the default cap of 2, the first warning-only rejection (count=1) still
+   redirects to implement; the second (count=2) trips the policy."
+  [cause-type warning-only-count max-warning-only-cycles]
+  (and (= :warning-churn cause-type)
+       (>= warning-only-count max-warning-only-cycles)))
+
+(defn- record-warning-cycle-count
+  "Persist the warning-only cycle count at [:execution :review-warning-only-cycles].
+   Survives phase re-entries because it lives on :execution, not :phase."
+  [ctx count]
+  (assoc-in ctx [:execution :review-warning-only-cycles] count))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
@@ -402,6 +435,11 @@
    between on-fail redirect and terminal `:failed`.
 
      :approved              — reviewer green-lit; `:phase/succeed` event
+     :accept-with-warnings  — reviewer only raised warnings (no blocking
+                              issues) for max-warning-only-cycles consecutive
+                              cycles; phase succeeds with unresolved warnings
+                              attached at [:phase :unresolved-warnings] so
+                              release can surface them as PR comments
      :repair-requested      — actionable feedback + within budget;
                               FSM may redirect via on-fail
      :stagnated             — same blocking fingerprint as prior cycle;
@@ -422,22 +460,29 @@
                               auto-resume composition (with the
                               network-resilience PR-C, #1054) lives in
                               a follow-up PR."
-  #{:approved :repair-requested :stagnated :needs-decomposition :exhausted
-    :review/backend-timeout})
+  #{:approved :accept-with-warnings :repair-requested :stagnated :needs-decomposition
+    :exhausted :review/backend-timeout})
 
 (defn- compute-verdict
   "Pick the verdict that should flow on the phase result. Mirrors the
    former `compute-decision` semantics one-for-one — `:stagnated` and
-   `:needs-decomposition` keep their priority over `:repair-requested`;
-   a reviewer-blocked failure with no actionable feedback collapses to
-   `:exhausted`.
+   `:needs-decomposition` keep their priority over `:repair-requested`.
+
+   Priority order (highest to lowest):
+     backend-timeout → stagnated → needs-decomposition →
+     warning-churn (policy-resolved) → repair-requested → exhausted → approved
 
    `:review/backend-timeout` takes priority over every code-review
    verdict: when the reviewer LLM never produced a real verdict (PR-A
    wiring), there is no `:rejected` to interpret as repair-requested
-   or exhausted. The infra failure must be reported as itself."
+   or exhausted. The infra failure must be reported as itself.
+
+   `:warning-churn?` gates the warning-churn branch; when true the
+   verdict is resolved from `:warning-churn-policy`:
+     :accept-with-warnings → :accept-with-warnings (phase succeeds)
+     :needs-decomposition  → :needs-decomposition  (terminal)"
   [{:keys [backend-timeout? reviewer-blocked? stagnated? needs-decomposition?
-           within-budget? actionable-feedback?]}]
+           warning-churn? warning-churn-policy within-budget? actionable-feedback?]}]
   (cond
     backend-timeout?
     :review/backend-timeout
@@ -447,6 +492,11 @@
 
     needs-decomposition?
     :needs-decomposition
+
+    (and reviewer-blocked? warning-churn?)
+    (case warning-churn-policy
+      :accept-with-warnings :accept-with-warnings
+      :needs-decomposition  :needs-decomposition)
 
     (and reviewer-blocked? within-budget? actionable-feedback?)
     :repair-requested
@@ -470,9 +520,9 @@
 (defn- apply-verdict
   "Carry out the side-effects implied by a verdict — attach anomalies
    for terminal verdicts, attach handoff feedback for repair-requested,
-   mark completed for approved. The FSM drives the actual phase
-   transition; this fn only enriches the ctx with payload data that
-   evidence-bundle / downstream phases consume."
+   mark completed for approved and accept-with-warnings. The FSM drives
+   the actual phase transition; this fn only enriches the ctx with
+   payload data that evidence-bundle / downstream phases consume."
   [verdict updated-ctx feedback fingerprint-history review-cycle-count]
   (case verdict
     :stagnated
@@ -489,6 +539,16 @@
 
     :review/backend-timeout
     (attach-backend-timeout-anomaly updated-ctx)
+
+    :accept-with-warnings
+    (let [review-artifact (get-in updated-ctx [:phase :result :output])
+          warnings        (get review-artifact :review/warnings [])]
+      ;; Override :phase :status from :failed (set by accumulate-base-ctx because
+      ;; reviewer-blocked? was true) back to :completed — the phase succeeds despite
+      ;; the warning-only rejection; the PR proceeds with warnings surfaced.
+      (-> (mark-completed updated-ctx)
+          (assoc-in [:phase :status] :completed)
+          (assoc-in [:phase :unresolved-warnings] warnings)))
 
     :approved
     (mark-completed updated-ctx)))
@@ -535,7 +595,13 @@
    identical to the immediately prior iteration's, the repair loop has
    produced no movement on the blocking complaints. Terminate with
    :anomalies.review/stagnation instead of redirecting — better to
-   surface the loop than burn another budget cycle."
+   surface the loop than burn another budget cycle.
+
+   Warning-churn guard: if the reviewer only raises warnings (no blocking
+   issues) for max-warning-only-cycles consecutive cycles, apply the
+   configured :review/warning-churn-policy instead of looping indefinitely.
+   The cycle count persists at [:execution :review-warning-only-cycles]
+   across phase re-entries, like fingerprints."
   [ctx]
   (let [start-time        (get-in ctx [:phase :started-at])
         end-time          (System/currentTimeMillis)
@@ -581,16 +647,37 @@
         needs-decomposition? (compute-needs-decomposition?
                               reviewer-blocked? stagnated?
                               review-cycle-count max-no-progress-attempts)
+        ;; Warning-churn tracking: classify the rejection cause and check
+        ;; whether we have exceeded max-warning-only-cycles.
+        max-warning-only-cycles  (get default-config :review/max-warning-only-cycles
+                                       default-max-warning-only-cycles)
+        warning-churn-policy     (get default-config :review/warning-churn-policy
+                                       default-warning-churn-policy)
+        prior-warning-only-count (get-in ctx [:execution :review-warning-only-cycles] 0)
+        cause-map                (when reviewer-blocked?
+                                   (classify-rejection-cause review-artifact
+                                                             prior-warning-only-count))
+        warning-only-count       (get cause-map :warning-only-count prior-warning-only-count)
+        warning-churn?           (boolean
+                                  (when reviewer-blocked?
+                                    (compute-warning-churn?
+                                     (:cause/type cause-map)
+                                     warning-only-count
+                                     max-warning-only-cycles)))
         verdict           (compute-verdict {:backend-timeout?     backend-timeout?
                                             :reviewer-blocked?    reviewer-blocked?
                                             :stagnated?           stagnated?
                                             :needs-decomposition? needs-decomposition?
+                                            :warning-churn?       warning-churn?
+                                            :warning-churn-policy warning-churn-policy
                                             :within-budget?       within-budget?
                                             :actionable-feedback? (actionable-feedback? feedback)})
-        updated-ctx       (-> ctx
-                              (accumulate-base-ctx end-time duration-ms phase-status
-                                                   metrics iterations current-fp)
-                              (attach-verdict verdict))
+        updated-ctx       (cond-> (-> ctx
+                                      (accumulate-base-ctx end-time duration-ms phase-status
+                                                           metrics iterations current-fp)
+                                      (attach-verdict verdict))
+                            reviewer-blocked?
+                            (record-warning-cycle-count warning-only-count))
         next-ctx          (apply-verdict verdict updated-ctx feedback
                                          (conj prior-history current-fp)
                                          review-cycle-count)]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -496,7 +496,12 @@
     (and reviewer-blocked? warning-churn?)
     (case warning-churn-policy
       :accept-with-warnings :accept-with-warnings
-      :needs-decomposition  :needs-decomposition)
+      :needs-decomposition  :needs-decomposition
+      ;; Programmer-error guard — invalid policy should have been caught at config
+      ;; load by ReviewConvergenceConfigSchema; throw here makes the offending value
+      ;; visible rather than silently routing to an unrelated verdict branch (rule 005).
+      (throw (IllegalArgumentException.
+              (str "Unknown warning-churn-policy: " (pr-str warning-churn-policy)))))
 
     (and reviewer-blocked? within-budget? actionable-feedback?)
     :repair-requested
@@ -570,10 +575,14 @@
       (record-fingerprint current-fp)))
 
 (defn- review-feedback
-  "Extract feedback the implementer should consume on a repair redirect."
+  "Extract feedback the implementer should consume on a repair redirect.
+   Falls back to :review/warnings when no structured feedback or issues
+   are present — warnings ARE actionable feedback when there are no
+   blocking issues (the warning-churn repair path)."
   [result]
   (or (get-in result [:output :review/feedback])
-      (get-in result [:output :review/issues])))
+      (get-in result [:output :review/issues])
+      (not-empty (get-in result [:output :review/warnings]))))
 
 (defn- actionable-feedback?
   "True when review feedback gives implement something concrete to repair."

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -33,14 +33,66 @@
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.response.interface :as response]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Named constants — fallback defaults used when config/phase/defaults.edn is absent
+
+(def default-warning-churn-policy
+  "Fallback policy applied when the reviewer emits only warnings (no blocking
+   issues) for :review/max-warning-only-cycles consecutive cycles.
+   :accept-with-warnings lets the SDLC proceed — warnings land in the evidence
+   bundle but do not block the release gate.  This is the safe default: it
+   avoids silent task-explosion while still making warnings visible.
+   The active operational value lives in :review/warning-churn-policy
+   in resources/config/phase/defaults.edn."
+  :accept-with-warnings)
+
+(def default-max-warning-only-cycles
+  "Fallback cap on consecutive warning-only review cycles before the churn
+   policy fires, used when config/phase/defaults.edn is absent.
+   2 allows one retry after the first warning round — enough to survive a
+   transient LLM false-positive, short enough that a genuinely warning-heavy
+   PR does not loop all the way to max-redirects and exhaust its token budget.
+   The active operational value lives in :review/max-warning-only-cycles
+   in resources/config/phase/defaults.edn."
+  2)
+
+;; Schema — validates review convergence config keys at config load time (rule 004).
+;; Defined as a value; validation is a one-time side-effect below.
+(def ^:private ReviewConvergenceConfigSchema
+  "Malli schema for the :review/warning-churn-policy and
+   :review/max-warning-only-cycles keys.  Closed map with only the
+   convergence keys; the rest of the phase config is validated elsewhere."
+  [:map
+   [:review/warning-churn-policy
+    {:default     default-warning-churn-policy
+     :description "Policy when max warning-only cycles are exhausted."}
+    [:enum :accept-with-warnings :needs-decomposition]]
+   [:review/max-warning-only-cycles
+    {:default     default-max-warning-only-cycles
+     :description "Max consecutive warning-only cycles before the churn policy fires."}
+    [:int {:min 1}]]])
+
 ;; Defaults
 
 (def default-config
   "Phase defaults loaded from config/phase/defaults.edn."
   (phase-config/defaults-for :review))
+
+;; Validate convergence config once at load — fail fast on a bad defaults.edn
+;; rather than surfacing a ClassCastException deep inside the review phase.
+;; Only validates when the keys are present; absent keys fall back to constants.
+(let [convergence-config (select-keys default-config
+                                       [:review/warning-churn-policy
+                                        :review/max-warning-only-cycles])]
+  (when (seq convergence-config)
+    (when-not (m/validate ReviewConvergenceConfigSchema convergence-config)
+      (throw (IllegalArgumentException.
+              (str "Invalid review convergence config in defaults.edn: "
+                   (pr-str (m/explain ReviewConvergenceConfigSchema
+                                       convergence-config))))))))
 
 ;; Register defaults on load
 (phase/register-phase-defaults! :review default-config)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -46,7 +46,9 @@
    bundle but do not block the release gate.  This is the safe default: it
    avoids silent task-explosion while still making warnings visible.
    The active operational value lives in :review/warning-churn-policy
-   in resources/config/phase/defaults.edn."
+   in resources/config/phase/defaults.edn.
+   NOTE: consumed by the compute-verdict warning-churn branch — wired in the
+   follow-up PR 'feat/review-convergence-policy-wiring' (rule 008 deferral)."
   :accept-with-warnings)
 
 (def default-max-warning-only-cycles
@@ -56,15 +58,18 @@
    transient LLM false-positive, short enough that a genuinely warning-heavy
    PR does not loop all the way to max-redirects and exhaust its token budget.
    The active operational value lives in :review/max-warning-only-cycles
-   in resources/config/phase/defaults.edn."
+   in resources/config/phase/defaults.edn.
+   NOTE: consumed by leave-review warning-cycle cap — wired in the follow-up
+   PR 'feat/review-convergence-policy-wiring' (rule 008 deferral)."
   2)
 
 ;; Schema — validates review convergence config keys at config load time (rule 004).
 ;; Defined as a value; validation is a one-time side-effect below.
 (def ^:private ReviewConvergenceConfigSchema
   "Malli schema for the :review/warning-churn-policy and
-   :review/max-warning-only-cycles keys.  Closed map with only the
-   convergence keys; the rest of the phase config is validated elsewhere."
+   :review/max-warning-only-cycles keys.  Open map (no {:closed true}) —
+   callers must pass (select-keys cfg [...]) before validating to avoid
+   silently accepting extra keys from the full phase-config map."
   [:map
    [:review/warning-churn-policy
     {:default     default-warning-churn-policy
@@ -90,7 +95,8 @@
   (when (seq convergence-config)
     (when-not (m/validate ReviewConvergenceConfigSchema convergence-config)
       (throw (IllegalArgumentException.
-              (str "Invalid review convergence config in defaults.edn: "
+              (str (messages/ts :review/invalid-convergence-config)
+                   " "
                    (pr-str (m/explain ReviewConvergenceConfigSchema
                                        convergence-config))))))))
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
@@ -22,6 +22,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]
+   [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.review :as review]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]))
 
@@ -108,9 +109,24 @@
       (is (= review/default-max-warning-only-cycles
              (:review/max-warning-only-cycles cfg))))))
 
+;; System-locale message catalog tests
+
+(deftest test-system-catalog-has-invalid-convergence-config-key
+  (testing "system.edn exposes :review/invalid-convergence-config for startup errors"
+    (let [msg (messages/ts :review/invalid-convergence-config)]
+      (is (string? msg))
+      (is (pos? (count msg))))))
+
+(deftest test-system-message-is-not-raw-placeholder
+  (testing ":review/invalid-convergence-config is not the raw missing-key placeholder"
+    ;; If the key were absent, messages/t returns the keyword or a fallback sentinel.
+    ;; A real string value confirms the catalog is wired up correctly.
+    (is (not (keyword? (messages/ts :review/invalid-convergence-config))))))
+
 (comment
   ;; REPL smoke-test
   (valid? {:review/warning-churn-policy :accept-with-warnings
            :review/max-warning-only-cycles 2})   ;; => true
   (valid? {:review/warning-churn-policy :bad :review/max-warning-only-cycles 0}) ;; => false
-  (phase-config/defaults-for :review))
+  (phase-config/defaults-for :review)
+  (messages/ts :review/invalid-convergence-config))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
@@ -1,0 +1,116 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-software-factory.review-convergence-config-test
+  "Tests for review convergence policy config — named constants, Malli schema,
+   and defaults loaded from resources/config/phase/defaults.edn."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as m]
+   [ai.miniforge.phase-software-factory.review :as review]
+   [ai.miniforge.phase-software-factory.phase-config :as phase-config]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers and var-access
+
+(def ^:private schema
+  "Direct var access to the private schema for white-box validation tests."
+  #'ai.miniforge.phase-software-factory.review/ReviewConvergenceConfigSchema)
+
+(defn- valid?
+  "Returns true when the candidate map satisfies the convergence schema."
+  [candidate]
+  (m/validate @schema candidate))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Named-constant tests
+
+(deftest test-default-warning-churn-policy-value
+  (testing "default policy is :accept-with-warnings"
+    (is (= :accept-with-warnings review/default-warning-churn-policy))))
+
+(deftest test-default-max-warning-only-cycles-value
+  (testing "default max cycles is 2"
+    (is (= 2 review/default-max-warning-only-cycles))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Schema validation tests
+
+(deftest test-schema-accepts-valid-accept-with-warnings
+  (testing "given :accept-with-warnings policy and positive cycle count → valid"
+    (is (valid? {:review/warning-churn-policy  :accept-with-warnings
+                 :review/max-warning-only-cycles 2}))))
+
+(deftest test-schema-accepts-valid-needs-decomposition
+  (testing "given :needs-decomposition policy and positive cycle count → valid"
+    (is (valid? {:review/warning-churn-policy  :needs-decomposition
+                 :review/max-warning-only-cycles 1}))))
+
+(deftest test-schema-rejects-unknown-policy
+  (testing "given an unknown policy keyword → invalid"
+    (is (not (valid? {:review/warning-churn-policy  :unknown-policy
+                      :review/max-warning-only-cycles 2})))))
+
+(deftest test-schema-rejects-zero-cycle-count
+  (testing "given max-warning-only-cycles = 0 → invalid (min is 1)"
+    (is (not (valid? {:review/warning-churn-policy  :accept-with-warnings
+                      :review/max-warning-only-cycles 0})))))
+
+(deftest test-schema-rejects-negative-cycle-count
+  (testing "given max-warning-only-cycles < 0 → invalid"
+    (is (not (valid? {:review/warning-churn-policy  :accept-with-warnings
+                      :review/max-warning-only-cycles -1})))))
+
+(deftest test-schema-rejects-string-policy
+  (testing "given a string instead of a keyword for the policy → invalid"
+    (is (not (valid? {:review/warning-churn-policy  "accept-with-warnings"
+                      :review/max-warning-only-cycles 2})))))
+
+;; EDN config round-trip
+
+(deftest test-defaults-edn-provides-convergence-keys
+  (testing "defaults.edn :review map includes both convergence keys"
+    (let [cfg (phase-config/defaults-for :review)]
+      (is (contains? cfg :review/warning-churn-policy))
+      (is (contains? cfg :review/max-warning-only-cycles)))))
+
+(deftest test-defaults-edn-convergence-keys-are-valid
+  (testing "given convergence keys from defaults.edn → schema validates"
+    (let [cfg (phase-config/defaults-for :review)
+          candidate (select-keys cfg [:review/warning-churn-policy
+                                      :review/max-warning-only-cycles])]
+      (is (valid? candidate)))))
+
+(deftest test-defaults-edn-policy-matches-constant
+  (testing "defaults.edn :review/warning-churn-policy matches the fallback constant"
+    (let [cfg (phase-config/defaults-for :review)]
+      (is (= review/default-warning-churn-policy
+             (:review/warning-churn-policy cfg))))))
+
+(deftest test-defaults-edn-cycle-count-matches-constant
+  (testing "defaults.edn :review/max-warning-only-cycles matches the fallback constant"
+    (let [cfg (phase-config/defaults-for :review)]
+      (is (= review/default-max-warning-only-cycles
+             (:review/max-warning-only-cycles cfg))))))
+
+(comment
+  ;; REPL smoke-test
+  (valid? {:review/warning-churn-policy :accept-with-warnings
+           :review/max-warning-only-cycles 2})   ;; => true
+  (valid? {:review/warning-churn-policy :bad :review/max-warning-only-cycles 0}) ;; => false
+  (phase-config/defaults-for :review))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -545,6 +545,7 @@
     (let [verdicts @#'review/verdicts]
       (is (contains? verdicts :review/backend-timeout))
       (is (contains? verdicts :approved))
+      (is (contains? verdicts :accept-with-warnings))
       (is (contains? verdicts :exhausted))
       (is (contains? verdicts :stagnated))
       (is (contains? verdicts :needs-decomposition))
@@ -576,3 +577,193 @@
           "anomaly :message preserves the actual adaptive-timeout text the
            operator needs (stream-idle / stagnation / etc.) — not just a
            generic catalog string"))))
+
+;; ============================================================================
+;; Warning-churn tracking — classify-rejection-cause + compute-warning-churn?
+;;
+;; When the reviewer emits only warnings (no blocking issues) for
+;; max-warning-only-cycles consecutive cycles the churn policy fires.
+;; The default policy (:accept-with-warnings) lets the phase succeed with
+;; unresolved warnings attached; the :needs-decomposition policy terminates.
+;;
+;; With the default cap of 2:
+;;   cycle 1: warning-only → count=1, (>= 1 2) = false → :repair-requested
+;;   cycle 2: warning-only → count=2, (>= 2 2) = true  → policy verdict
+;; ============================================================================
+
+(def ^:private warning-only-issue
+  "Review issue that is only a warning (non-blocking)."
+  {:severity :warning :description "Style nit: prefer cond over nested if"})
+
+(def ^:private default-cap
+  "Matches `default-max-warning-only-cycles` in review.clj."
+  2)
+
+(def ^:private count-below-cap
+  "Warning-only-count for cycle 1 — one short of default cap."
+  1)
+
+(def ^:private count-at-cap
+  "Warning-only-count for cycle 2 — exactly at default cap."
+  2)
+
+(defn- run-leave-review-warning-only
+  "Run leave-review with a warning-only reviewer output.
+   `prior-warning-cycles` seeds [:execution :review-warning-only-cycles].
+   Returns the resulting full context."
+  [{:keys [prior-warning-cycles iterations max-iterations]
+    :or   {prior-warning-cycles 0
+           iterations           first-iteration
+           max-iterations       default-max-iterations}}]
+  (let [result {:output  {:review/decision :changes-requested
+                          :review/blocking-issues []
+                          :review/warnings [warning-only-issue]}
+                :metrics {:tokens mock-token-count :duration-ms mock-duration-ms}}
+        ctx {:phase     {:started-at (- (System/currentTimeMillis) mock-elapsed-ms)
+                         :iterations iterations
+                         :budget     {:iterations max-iterations}
+                         :result     result}
+             :phase-config {:phase :review}
+             :execution {:review-fingerprints    []
+                         :review-warning-only-cycles prior-warning-cycles}
+             :execution/phase-results {}
+             :execution/input {:description "test task"}
+             :execution/metrics {}}
+        interceptor (phase/get-phase-interceptor {:phase :review})]
+    ((:leave interceptor) ctx)))
+
+;;------------------------------------------------------------------------------ classify-rejection-cause
+
+(deftest classify-rejection-cause-warning-only-increments-count
+  (testing "warning-only rejection increments the prior count"
+    (let [classify #'review/classify-rejection-cause
+          artifact {:review/decision        :changes-requested
+                    :review/blocking-issues []
+                    :review/warnings        [warning-only-issue]}
+          result   (classify artifact 0)]
+      (is (= :warning-churn (:cause/type result)))
+      (is (= 1 (:warning-only-count result)))))
+  (testing "increments from a non-zero prior"
+    (let [classify #'review/classify-rejection-cause
+          artifact {:review/decision        :changes-requested
+                    :review/blocking-issues []
+                    :review/warnings        [warning-only-issue]}
+          result   (classify artifact 1)]
+      (is (= :warning-churn (:cause/type result)))
+      (is (= 2 (:warning-only-count result))))))
+
+(deftest classify-rejection-cause-blocking-resets-count
+  (testing "blocking defect resets the warning-only count to 0"
+    (let [classify #'review/classify-rejection-cause
+          artifact {:review/decision        :changes-requested
+                    :review/blocking-issues [{:severity :blocking
+                                              :description "Missing require"}]
+                    :review/warnings        []}
+          result   (classify artifact 3)]
+      (is (= :blocking-defect (:cause/type result)))
+      (is (= 0 (:warning-only-count result))))))
+
+;;------------------------------------------------------------------------------ compute-warning-churn?
+
+(deftest compute-warning-churn-below-cap-returns-false
+  (testing "warning-only-count below cap → not churn yet"
+    (let [pred #'review/compute-warning-churn?]
+      (is (not (pred :warning-churn count-below-cap default-cap))
+          "count 1 with cap 2 must not trip the policy"))))
+
+(deftest compute-warning-churn-at-cap-returns-true
+  (testing "warning-only-count at cap → churn fires"
+    (let [pred #'review/compute-warning-churn?]
+      (is (pred :warning-churn count-at-cap default-cap)
+          "count 2 with cap 2 must trip the policy"))))
+
+(deftest compute-warning-churn-blocking-cause-returns-false
+  (testing "blocking-defect cause never trips warning-churn even at or above cap"
+    (let [pred #'review/compute-warning-churn?]
+      (is (not (pred :blocking-defect count-at-cap default-cap))
+          "blocking-defect must not be churn regardless of count"))))
+
+;;------------------------------------------------------------------------------ first warning-only cycle → still repairs
+
+(deftest first-warning-only-rejection-still-redirects
+  (testing "first warning-only rejection (count=1 < cap=2) emits :repair-requested
+            — the policy should not fire until max-warning-only-cycles is reached"
+    (let [final-ctx (run-leave-review-warning-only {:prior-warning-cycles 0})
+          phase     (:phase final-ctx)]
+      (is (= :repair-requested (:verdict phase))
+          "first warning-only cycle must still redirect to implement")
+      (is (= 1 (get-in final-ctx [:execution :review-warning-only-cycles]))
+          "warning cycle count persisted as 1 after first warning-only review"))))
+
+;;------------------------------------------------------------------------------ second warning-only cycle → accept-with-warnings
+
+(deftest second-warning-only-rejection-emits-accept-with-warnings
+  (testing "second consecutive warning-only rejection (count=2 >= cap=2) trips the
+            default :accept-with-warnings policy — phase succeeds"
+    (let [final-ctx (run-leave-review-warning-only {:prior-warning-cycles 1})
+          phase     (:phase final-ctx)]
+      (is (= :accept-with-warnings (:verdict phase))
+          "second warning-only cycle must emit :accept-with-warnings verdict")
+      (is (= :accept-with-warnings
+             (get-in phase [:result :output :phase/verdict]))
+          ":phase/verdict on the result is what determine-phase-event reads")
+      (is (= 2 (get-in final-ctx [:execution :review-warning-only-cycles]))
+          "warning cycle count persisted as 2"))))
+
+(deftest accept-with-warnings-marks-phase-completed
+  (testing ":accept-with-warnings mark the phase as :completed
+            so the workflow can proceed to release"
+    (let [final-ctx (run-leave-review-warning-only {:prior-warning-cycles 1})
+          phase     (:phase final-ctx)]
+      (is (phase/succeeded? phase)
+          ":accept-with-warnings must succeed (not fail) — PR proceeds"))))
+
+(deftest accept-with-warnings-attaches-unresolved-warnings
+  (testing ":accept-with-warnings attaches the unresolved warnings at
+            [:phase :unresolved-warnings] so release can surface them"
+    (let [final-ctx (run-leave-review-warning-only {:prior-warning-cycles 1})
+          phase     (:phase final-ctx)]
+      (is (= [warning-only-issue] (:unresolved-warnings phase))
+          "unresolved warnings from the review artifact are attached to the phase"))))
+
+;;------------------------------------------------------------------------------ warning count persists correctly
+
+(deftest warning-cycle-count-persists-across-re-entries
+  (testing "each warning-only cycle increments the counter stored at
+            [:execution :review-warning-only-cycles]"
+    (let [ctx-after-1 (run-leave-review-warning-only {:prior-warning-cycles 0})
+          count-after-1 (get-in ctx-after-1 [:execution :review-warning-only-cycles])]
+      (is (= 1 count-after-1) "first warning-only cycle stores count=1"))
+    (let [ctx-after-2 (run-leave-review-warning-only {:prior-warning-cycles 1})
+          count-after-2 (get-in ctx-after-2 [:execution :review-warning-only-cycles])]
+      (is (= 2 count-after-2) "second warning-only cycle stores count=2"))))
+
+(deftest blocking-rejection-resets-warning-cycle-count
+  (testing "a blocking-defect rejection resets the warning-only count to 0"
+    (let [result {:output  {:review/decision        :changes-requested
+                            :review/blocking-issues [{:severity    :blocking
+                                                      :description "Missing require"}]
+                            :review/warnings        []}
+                  :metrics {:tokens mock-token-count :duration-ms mock-duration-ms}}
+          ctx {:phase     {:started-at (- (System/currentTimeMillis) mock-elapsed-ms)
+                           :iterations first-iteration
+                           :budget     {:iterations default-max-iterations}
+                           :result     result}
+               :phase-config {:phase :review}
+               :execution {:review-fingerprints        []
+                           :review-warning-only-cycles 1}
+               :execution/phase-results {}
+               :execution/input {:description "test task"}
+               :execution/metrics {}}
+          interceptor (phase/get-phase-interceptor {:phase :review})
+          final-ctx   ((:leave interceptor) ctx)]
+      (is (= 0 (get-in final-ctx [:execution :review-warning-only-cycles]))
+          "blocking defect resets the warning-only cycle counter"))))
+
+;;------------------------------------------------------------------------------ accept-with-warnings is in the verdict set
+
+(deftest accept-with-warnings-is-in-canonical-verdict-set
+  (testing ":accept-with-warnings is declared in the verdicts set so the FSM
+            can recognise it without an IllegalArgumentException from case"
+    (let [verdicts @#'review/verdicts]
+      (is (contains? verdicts :accept-with-warnings)))))


### PR DESCRIPTION
## Summary

Add cause-classification helper and warning-only cycle tracking to review.clj.

## Changes

- `components/agent/src/ai/miniforge/agent/interface.clj` (modify)
- `components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj` (modify)
- `components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj` (modify)

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (3 files)