### PR TITLE
feat(review): review-redirect convergence policy (config + cause-classification + terminal event)

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -505,6 +505,10 @@
   "Validate a review artifact against the schema and check gate-count
    consistency. Arg: artifact. Returns {:valid? bool :errors ...}."
   specialized/validate-review-artifact)
+(def rejection-warnings-only?
+  "True when a review is a rejection driven solely by warnings (no blocking
+   issues). Arg: artifact. Returns boolean."
+  specialized/rejection-warnings-only?)
 (def review-fingerprint
   "Reduce a review artifact to a stable, comparable fingerprint of its
    actionable items. Arg: review. Returns a sorted vector of

--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+ :deps {metosin/malli {:mvn/version "0.16.4"}
+        ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/phase {:local/root "../phase"}
         ai.miniforge/agent {:local/root "../agent"}

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -24,7 +24,14 @@
    :gates [:review-approved :quality-check :policy-review]
    :budget {:tokens 20000
             :iterations 2
-            :time-seconds 180}
+            :time-seconds 180
+            ;; Redirect-convergence caps (review-convergence ns). Decompose
+            ;; after this many CONSECUTIVE non-shrinking review→implement
+            ;; cycles...
+            :max-no-progress-attempts 3
+            ;; ...but never run past this hard ceiling, even while the
+            ;; blocking-issue count is still shrinking.
+            :absolute-max-redirect-attempts 6}
    :model-hint :sonnet
    ;; Convergence policy: what to do when the reviewer keeps emitting
    ;; warnings but no blocking issues.  :accept-with-warnings lets the

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -25,7 +25,17 @@
    :budget {:tokens 20000
             :iterations 2
             :time-seconds 180}
-   :model-hint :sonnet}
+   :model-hint :sonnet
+   ;; Convergence policy: what to do when the reviewer keeps emitting
+   ;; warnings but no blocking issues.  :accept-with-warnings lets the
+   ;; SDLC proceed (warnings recorded in the evidence bundle, not fatal).
+   ;; :needs-decomposition escalates to task-split instead.
+   :review/warning-churn-policy :accept-with-warnings
+   ;; Maximum consecutive warning-only rejection cycles before the churn
+   ;; policy fires.  2 allows one retry after the first warning round —
+   ;; enough to catch a transient LLM false-positive, short enough that
+   ;; a genuinely warning-heavy PR does not loop to max-redirects.
+   :review/max-warning-only-cycles 2}
 
   ;; Plan phase defaults.
   :plan

--- a/components/phase-software-factory/resources/config/phase/messages/system.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/system.edn
@@ -1,0 +1,4 @@
+{:phase/system
+ {;; Review phase — startup/config errors (system-locale; operator-facing only)
+  :review/invalid-convergence-config
+  "Invalid review convergence config in defaults.edn:"}}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/messages.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/messages.clj
@@ -25,3 +25,9 @@
   "Look up a phase message by key, with optional param substitution."
   (messages/create-translator "config/phase/messages/en-US.edn"
                               :phase/messages))
+
+(def ts
+  "Look up a system-locale phase message by key (operator-facing: logs, startup
+   errors, observability pipelines — never rendered directly to a user)."
+  (messages/create-translator "config/phase/messages/system.edn"
+                              :phase/system))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -84,17 +84,21 @@
 
 ;; Validate convergence config once at load — fail fast on a bad defaults.edn
 ;; rather than surfacing a ClassCastException deep inside the review phase.
-;; Only validates when the keys are present; absent keys fall back to constants.
-(let [convergence-config (select-keys default-config
-                                       [:review/warning-churn-policy
-                                        :review/max-warning-only-cycles])]
-  (when (seq convergence-config)
-    (when-not (m/validate ReviewConvergenceConfigSchema convergence-config)
-      (throw (IllegalArgumentException.
-              (str (messages/ts :review/invalid-convergence-config)
-                   " "
-                   (pr-str (m/explain ReviewConvergenceConfigSchema
-                                       convergence-config))))))))
+;; Merge the constant fallbacks UNDER whatever defaults.edn provides, then
+;; validate the complete map: a partial override (only one of the two keys)
+;; is filled in by the fallback instead of failing the schema's both-keys
+;; requirement, while an invalid VALUE for a provided key still throws.
+(let [convergence-config (merge {:review/warning-churn-policy    default-warning-churn-policy
+                                 :review/max-warning-only-cycles default-max-warning-only-cycles}
+                                (select-keys default-config
+                                             [:review/warning-churn-policy
+                                              :review/max-warning-only-cycles]))]
+  (when-not (m/validate ReviewConvergenceConfigSchema convergence-config)
+    (throw (IllegalArgumentException.
+            (str (messages/ts :review/invalid-convergence-config)
+                 " "
+                 (pr-str (m/explain ReviewConvergenceConfigSchema
+                                     convergence-config)))))))
 
 ;; Register defaults on load
 (phase/register-phase-defaults! :review default-config)
@@ -728,7 +732,11 @@
        (:knowledge-store ctx) :reviewer
        (get-in ctx [:execution/input :title]) feedback))
     (phase/emit-phase-completed! next-ctx :review
-      (merge {:outcome     (if (= :completed phase-status) :success :failure)
+      ;; Derive :outcome from the FINAL (verdict-corrected) status, not the
+      ;; pre-verdict `phase-status` local: apply-verdict promotes
+      ;; :accept-with-warnings to :completed, so reading the stale local would
+      ;; emit {:outcome :failure} for a success and mislead telemetry.
+      (merge {:outcome     (if (= :completed (get-in next-ctx [:phase :status])) :success :failure)
               :duration-ms duration-ms
               :tokens      (:tokens metrics 0)}
              (phase-terminal/derive-termination-reason result nil)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -30,146 +30,30 @@
    [ai.miniforge.phase-software-factory.phase-handoff :as phase-handoff]
    [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
    [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
+   [ai.miniforge.phase-software-factory.review-convergence :as conv]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.knowledge.interface :as knowledge]
-   [ai.miniforge.response.interface :as response]
-   [clojure.string :as str]
-   [malli.core :as m]))
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Named constants — fallback defaults used when config/phase/defaults.edn is absent
-
-(def default-warning-churn-policy
-  "Fallback policy applied when the reviewer emits only warnings (no blocking
-   issues) for :review/max-warning-only-cycles consecutive cycles.
-   :accept-with-warnings lets the SDLC proceed — warnings land in the evidence
-   bundle but do not block the release gate.  This is the safe default: it
-   avoids silent task-explosion while still making warnings visible.
-   The active operational value lives in :review/warning-churn-policy
-   in resources/config/phase/defaults.edn."
-  :accept-with-warnings)
-
-(def default-max-warning-only-cycles
-  "Fallback cap on consecutive warning-only review cycles before the churn
-   policy fires, used when config/phase/defaults.edn is absent.
-   2 allows one retry after the first warning round — enough to survive a
-   transient LLM false-positive, short enough that a genuinely warning-heavy
-   PR does not loop all the way to max-redirects and exhaust its token budget.
-   The active operational value lives in :review/max-warning-only-cycles
-   in resources/config/phase/defaults.edn."
-  2)
-
-;; Schema — validates review convergence config keys at config load time (rule 004).
-;; Defined as a value; validation is a one-time side-effect below.
-(def ^:private ReviewConvergenceConfigSchema
-  "Malli schema for the :review/warning-churn-policy and
-   :review/max-warning-only-cycles keys.  Open map (no {:closed true}) —
-   callers must pass (select-keys cfg [...]) before validating to avoid
-   silently accepting extra keys from the full phase-config map."
-  [:map
-   [:review/warning-churn-policy
-    {:default     default-warning-churn-policy
-     :description "Policy when max warning-only cycles are exhausted."}
-    [:enum :accept-with-warnings :needs-decomposition]]
-   [:review/max-warning-only-cycles
-    {:default     default-max-warning-only-cycles
-     :description "Max consecutive warning-only cycles before the churn policy fires."}
-    [:int {:min 1}]]])
-
-;; Defaults
+;; Phase config — convergence decision logic lives in the review-convergence ns
 
 (def default-config
   "Phase defaults loaded from config/phase/defaults.edn."
   (phase-config/defaults-for :review))
 
-;; Validate convergence config once at load — fail fast on a bad defaults.edn
-;; rather than surfacing a ClassCastException deep inside the review phase.
-;; Merge the constant fallbacks UNDER whatever defaults.edn provides, then
-;; validate the complete map: a partial override (only one of the two keys)
-;; is filled in by the fallback instead of failing the schema's both-keys
-;; requirement, while an invalid VALUE for a provided key still throws.
-(let [convergence-config (merge {:review/warning-churn-policy    default-warning-churn-policy
-                                 :review/max-warning-only-cycles default-max-warning-only-cycles}
-                                (select-keys default-config
-                                             [:review/warning-churn-policy
-                                              :review/max-warning-only-cycles]))]
-  (when-not (m/validate ReviewConvergenceConfigSchema convergence-config)
-    (throw (IllegalArgumentException.
-            (str (messages/ts :review/invalid-convergence-config)
-                 " "
-                 (pr-str (m/explain ReviewConvergenceConfigSchema
-                                     convergence-config)))))))
+;; Fail fast on a bad defaults.edn at load (rule 004) rather than surfacing a
+;; ClassCastException deep inside the review phase.
+(conv/validate-convergence-config! default-config)
 
 ;; Register defaults on load
 (phase/register-phase-defaults! :review default-config)
-
-;; Pure helper — cause classification
-
-(defn- classify-rejection-cause
-  "Pure function. Given a review artifact and the count of prior consecutive
-   warning-only cycles, classify the rejection cause and return an updated count.
-
-   Uses `agent/rejection-warnings-only?` to distinguish a warning-driven
-   rejection (no blocking issues, only advisory warnings) from one containing
-   genuine blocking defects.
-
-   Returns {:cause/type :blocking-defect | :warning-churn
-            :warning-only-count <updated int>}
-
-   :warning-churn increments the counter; :blocking-defect resets to 0."
-  [review-artifact prior-warning-only-count]
-  (if (agent/rejection-warnings-only? review-artifact)
-    {:cause/type         :warning-churn
-     :warning-only-count (inc prior-warning-only-count)}
-    {:cause/type         :blocking-defect
-     :warning-only-count 0}))
-
-(defn- compute-warning-churn?
-  "True when the cause is :warning-churn AND the warning-only-count has reached
-   or exceeded max-warning-only-cycles (the churn policy threshold).
-
-   With the default cap of 2, the first warning-only rejection (count=1) still
-   redirects to implement; the second (count=2) trips the policy."
-  [cause-type warning-only-count max-warning-only-cycles]
-  (and (= :warning-churn cause-type)
-       (>= warning-only-count max-warning-only-cycles)))
 
 (defn- record-warning-cycle-count
   "Persist the warning-only cycle count at [:execution :review-warning-only-cycles].
    Survives phase re-entries because it lives on :execution, not :phase."
   [ctx count]
   (assoc-in ctx [:execution :review-warning-only-cycles] count))
-
-(def ^:private terminal-review-verdicts
-  "Review verdicts that end the repair loop without redirecting to implement.
-   Only these four verdicts produce a :review/cause entry in the
-   phase-completed event payload so the evidence bundle and dashboard can
-   surface why the loop terminated rather than converging."
-  #{:accept-with-warnings :needs-decomposition :stagnated :exhausted})
-
-(defn- build-review-cause
-  "Build the :review/cause map for terminal review verdicts.
-   Returns nil for non-terminal verdicts (:repair-requested, :approved,
-   :review/backend-timeout).
-
-   Fields always present on a terminal verdict:
-     :cause/type                — :warning-churn or :blocking-defect
-     :review/warning-only-cycles — consecutive warning-only cycles completed
-     :review/total-cycles       — total review cycles in this task
-     :review/verdict            — the terminal verdict keyword
-
-   For :accept-with-warnings only:
-     :review/unresolved-warning-count — count of advisory warnings accepted
-                                        without resolution"
-  [verdict cause-map warning-only-count review-cycle-count review-artifact]
-  (when (contains? terminal-review-verdicts verdict)
-    (cond-> {:cause/type                (get cause-map :cause/type :blocking-defect)
-             :review/warning-only-cycles warning-only-count
-             :review/total-cycles       review-cycle-count
-             :review/verdict            verdict}
-      (= :accept-with-warnings verdict)
-      (assoc :review/unresolved-warning-count
-             (count (get review-artifact :review/warnings))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
@@ -332,34 +216,6 @@
     (-> (phase/enter-context ctx :review :reviewer gates budget start-time result)
         (assoc-in [:phase :rules-manifest] rules-manifest))))
 
-(def ^:private blocking-decisions
-  "Reviewer decisions that mean 'don't ship this — fix it.' Iter 23
-   regression: :rejected fell through to :completed, letting release
-   open a PR against a reviewer-rejected artifact. Both decisions
-   route through the :failed branch; the FSM's verdict-driven guarded
-   :phase/fail array (Phase 2b) decides between redirect and terminate."
-  #{:rejected :changes-requested})
-
-(def ^:private default-max-no-progress-attempts
-  "After this many CONSECUTIVE review→implement repair cycles where each
-   review still rejects (with non-identical fingerprints — stagnation hasn't
-   fired) the workflow emits :needs-decomposition rather than continuing to
-   burn the redirect budget. Catches the dogfood case where the implementer
-   keeps fixing the reviewer's prior blockers but the reviewer keeps surfacing
-   new legitimate ones — a strong signal the task is too coarse for one
-   implement turn to satisfy in full. Default 3; configurable via
-   `:phase :budget :max-no-progress-attempts` (and overridable by
-   `:phase-config`)."
-  3)
-
-(def ^:private default-absolute-max-redirect-attempts
-  "Hard ceiling on review→implement repair cycles, regardless of progress.
-   A loop whose blocking-issue count keeps shrinking (converging) is allowed
-   past `max-no-progress-attempts` — but never past this. Backstop against a
-   genuinely huge task that decrements one blocker per cycle indefinitely.
-   Default 6; configurable via `:phase :budget :absolute-max-redirect-attempts`."
-  6)
-
 (defn- attach-stagnated-anomaly
   "Phase 2b: attach the stagnation anomaly to the phase result so the
    workflow runner / evidence bundle can report what didn't move.
@@ -443,161 +299,11 @@
   [ctx blocking-count]
   (update-in ctx [:execution :review-blocking-counts] (fnil conj []) blocking-count))
 
-(defn- count-blocking-issues
-  "Blocking-issue count for a review artifact, tolerant of both shapes:
-   the enumerated `:review/blocking-issues` list (real reviewer output) and
-   `:review/issues` filtered by `:severity :blocking`."
-  [review-artifact]
-  (let [enumerated (count (agent/get-blocking-issues review-artifact))]
-    (if (pos? enumerated)
-      enumerated
-      (count (filter #(= :blocking (:severity %))
-                     (:review/issues review-artifact))))))
-
 (defn- mark-completed
   "Mark the review phase as completed in the execution-level
    phases-completed list. Only called on the :complete branch."
   [ctx]
   (update-in ctx [:execution :phases-completed] (fnil conj []) :review))
-
-(defn- compute-stagnated?
-  "True when the reviewer is blocked AND the new fingerprint matches
-   the immediately prior fingerprint — i.e., the repair loop has
-   produced no movement on the blocking complaints."
-  [reviewer-blocked? prior-history current-fp]
-  (and reviewer-blocked?
-       (agent/review-stagnated? (peek prior-history) current-fp)))
-
-(defn- no-progress-streak
-  "Consecutive trailing review cycles that did NOT strictly reduce the
-   blocking-issue count, given the full per-cycle count sequence (oldest
-   first, including the current cycle). A cycle counts as progress — and
-   resets the streak to 0 — only when its count is strictly less than the
-   immediately prior cycle's; the first cycle has no predecessor and counts
-   as no-progress.
-
-   Examples: [3 2 1] → 0 (each pass shrank); [3 2 2] → 1 (one stall after
-   progress); [1 1 1] → 3 (flat throughout)."
-  [counts]
-  (reduce (fn [streak [prev cur]]
-            (if (and prev (< cur prev)) 0 (inc streak)))
-          0
-          (map vector (cons nil counts) counts)))
-
-(defn- compute-needs-decomposition?
-  "True when the reviewer keeps rejecting with NEW blockers (not stagnated)
-   and the loop is NOT converging — either the blocking count has failed to
-   shrink for `max-no-progress-attempts` CONSECUTIVE cycles, OR the task has
-   hit the absolute redirect ceiling.
-
-   A loop whose blocking count is still shrinking is allowed to continue up
-   to `absolute-max-attempts`: it is converging, just not in one turn.
-   (Dogfood 2026-06-07b: a standards-dense task fixed a real blocker each
-   pass — strict progress — but the old flat cap killed it at 3 while it was
-   still converging.)
-
-   `no-progress-streak` is the consecutive trailing no-progress cycle count
-   (see `no-progress-streak`); `review-cycle-count` is the TASK-LEVEL attempt
-   count, used only for the absolute ceiling."
-  [reviewer-blocked? stagnated? no-progress-streak
-   review-cycle-count max-no-progress-attempts absolute-max-attempts]
-  (and reviewer-blocked?
-       (not stagnated?)
-       (or (>= review-cycle-count absolute-max-attempts)
-           (>= no-progress-streak max-no-progress-attempts))))
-
-(defn- compute-phase-status
-  [reviewer-blocked? gate-failed?]
-  (cond
-    reviewer-blocked? :failed
-    gate-failed?      :failed
-    :else             :completed))
-
-(def ^:private verdicts
-  "Phase 2b verdict tag set. Replaces the old flag bag
-   (`:stagnated?` / `:needs-decomposition?`) + `compute-decision` ladder
-   with a single keyword that flows through `[:phase :result :output
-   :phase/verdict]` to the FSM. The FSM's verdict-driven guarded
-   `:phase/fail` array reads it via `:verdict/terminal?` to decide
-   between on-fail redirect and terminal `:failed`.
-
-     :approved              — reviewer green-lit; `:phase/succeed` event
-     :accept-with-warnings  — reviewer only raised warnings (no blocking
-                              issues) for max-warning-only-cycles consecutive
-                              cycles; phase succeeds with unresolved warnings
-                              attached at [:phase :unresolved-warnings] so
-                              release can surface them as PR comments
-     :repair-requested      — actionable feedback + within budget;
-                              FSM may redirect via on-fail
-     :stagnated             — same blocking fingerprint as prior cycle;
-                              FSM terminates
-     :needs-decomposition   — N non-stagnated rejections; FSM terminates
-                              with the decomposition signal
-     :exhausted             — reviewer blocked but no actionable
-                              feedback or over phase-level budget;
-                              FSM terminates
-     :review/backend-timeout — the reviewer LLM call hit its adaptive
-                              timeout (stream-idle / stagnation / etc.)
-                              with no real verdict produced. PR-A
-                              (#1058) wired the agent to take the
-                              `:reviewer/backend-timeout` error exit
-                              instead of synthesizing a false
-                              `:rejected`; this verdict surfaces that
-                              infra failure to the FSM. Terminal —
-                              auto-resume composition (with the
-                              network-resilience PR-C, #1054) lives in
-                              a follow-up PR."
-  #{:approved :accept-with-warnings :repair-requested :stagnated :needs-decomposition
-    :exhausted :review/backend-timeout})
-
-(defn- compute-verdict
-  "Pick the verdict that should flow on the phase result. Mirrors the
-   former `compute-decision` semantics one-for-one — `:stagnated` and
-   `:needs-decomposition` keep their priority over `:repair-requested`.
-
-   Priority order (highest to lowest):
-     backend-timeout → stagnated → needs-decomposition →
-     warning-churn (policy-resolved) → repair-requested → exhausted → approved
-
-   `:review/backend-timeout` takes priority over every code-review
-   verdict: when the reviewer LLM never produced a real verdict (PR-A
-   wiring), there is no `:rejected` to interpret as repair-requested
-   or exhausted. The infra failure must be reported as itself.
-
-   `:warning-churn?` gates the warning-churn branch; when true the
-   verdict is resolved from `:warning-churn-policy`:
-     :accept-with-warnings → :accept-with-warnings (phase succeeds)
-     :needs-decomposition  → :needs-decomposition  (terminal)"
-  [{:keys [backend-timeout? reviewer-blocked? stagnated? needs-decomposition?
-           warning-churn? warning-churn-policy within-budget? actionable-feedback?]}]
-  (cond
-    backend-timeout?
-    :review/backend-timeout
-
-    stagnated?
-    :stagnated
-
-    needs-decomposition?
-    :needs-decomposition
-
-    (and reviewer-blocked? warning-churn?)
-    (case warning-churn-policy
-      :accept-with-warnings :accept-with-warnings
-      :needs-decomposition  :needs-decomposition
-      ;; Programmer-error guard — invalid policy should have been caught at config
-      ;; load by ReviewConvergenceConfigSchema; throw here makes the offending value
-      ;; visible rather than silently routing to an unrelated verdict branch (rule 005).
-      (throw (IllegalArgumentException.
-              (str "Unknown warning-churn-policy: " (pr-str warning-churn-policy)))))
-
-    (and reviewer-blocked? within-budget? actionable-feedback?)
-    :repair-requested
-
-    reviewer-blocked?
-    :exhausted
-
-    :else
-    :approved))
 
 (defn- attach-verdict
   "Phase 2b: attach the verdict to both the phase-internal `:phase
@@ -663,24 +369,6 @@
       (record-fingerprint current-fp)
       (record-blocking-count current-blocking-count)))
 
-(defn- review-feedback
-  "Extract feedback the implementer should consume on a repair redirect.
-   Falls back to :review/warnings when no structured feedback or issues
-   are present — warnings ARE actionable feedback when there are no
-   blocking issues (the warning-churn repair path)."
-  [result]
-  (or (get-in result [:output :review/feedback])
-      (get-in result [:output :review/issues])
-      (not-empty (get-in result [:output :review/warnings]))))
-
-(defn- actionable-feedback?
-  "True when review feedback gives implement something concrete to repair."
-  [feedback]
-  (cond
-    (string? feedback)     (not (str/blank? feedback))
-    (sequential? feedback) (seq feedback)
-    :else                  (some? feedback)))
-
 (defn leave-review
   "Post-processing for review phase.
 
@@ -701,105 +389,51 @@
    The cycle count persists at [:execution :review-warning-only-cycles]
    across phase re-entries, like fingerprints."
   [ctx]
-  (let [start-time        (get-in ctx [:phase :started-at])
-        end-time          (System/currentTimeMillis)
-        duration-ms       (- end-time start-time)
-        result            (get-in ctx [:phase :result])
-        review-artifact   (get result :output)
-        review-decision   (get-in result [:output :review/decision])
-        metrics           (-> (get result :metrics {:tokens 0 :duration-ms duration-ms})
-                              (assoc :duration-ms duration-ms))
-        iterations        (get-in ctx [:phase :iterations] 1)
-        max-iterations    (get-in ctx [:phase :budget :iterations]
-                                  (get-in default-config [:budget :iterations]))
-        gate-failed?      (= :failed (:phase/status (get-in ctx [:phase])))
-        ;; PR-A (#1058) makes the reviewer agent take the
-        ;; `:reviewer/backend-timeout` error exit on an LLM-call
-        ;; stream-idle (or stagnation / hard-limit / generic timeout)
-        ;; instead of synthesizing a false `:rejected`. Detect that
-        ;; error code here and route to the `:review/backend-timeout`
-        ;; verdict — terminal, distinct from `:exhausted` — so the FSM
-        ;; can treat an infra timeout differently from a real
-        ;; non-actionable rejection (the auto-resume composition with
-        ;; the network-resilience PR-C lives in a follow-up PR).
-        backend-timeout?  (= :reviewer/backend-timeout
-                             (get-in result [:error :data :code]))
-        reviewer-blocked? (contains? blocking-decisions review-decision)
-        prior-history     (get-in ctx [:execution :review-fingerprints] [])
-        current-fp        (agent/review-fingerprint review-artifact)
-        stagnated?        (compute-stagnated? reviewer-blocked? prior-history current-fp)
-        phase-status      (compute-phase-status reviewer-blocked? gate-failed?)
-        within-budget?    (< iterations max-iterations)
-        feedback          (review-feedback result)
-        ;; Convergence cap: terminate with :needs-decomposition when the
-        ;; loop keeps surfacing NEW legit blockers (non-stagnated) but is NOT
-        ;; converging — a sharper signal for the meta-agent to split the task
-        ;; than a generic "exhausted".
-        max-no-progress-attempts (get-in ctx [:phase :budget :max-no-progress-attempts]
-                                         default-max-no-progress-attempts)
-        absolute-max-attempts (get-in ctx [:phase :budget :absolute-max-redirect-attempts]
-                                      default-absolute-max-redirect-attempts)
-        ;; Task-level review count: prior fingerprints already recorded + this
-        ;; cycle. The phase-local :iterations counter resets per phase entry,
-        ;; so it can never reach the shipped review :budget :iterations of 2;
-        ;; the cap MUST key off the task-wide history or it stays dead code.
-        review-cycle-count (inc (count prior-history))
-        ;; Convergence trend: blocking-issue count per cycle. While the count
-        ;; keeps shrinking the repair loop is converging (just not in one
-        ;; turn); decompose only after it stalls for max-no-progress-attempts
-        ;; consecutive cycles, or at the absolute ceiling.
-        current-blocking-count (count-blocking-issues review-artifact)
-        prior-counts      (get-in ctx [:execution :review-blocking-counts] [])
-        np-streak         (no-progress-streak (conj (vec prior-counts) current-blocking-count))
-        needs-decomposition? (compute-needs-decomposition?
-                              reviewer-blocked? stagnated? np-streak
-                              review-cycle-count max-no-progress-attempts absolute-max-attempts)
-        ;; Warning-churn tracking: classify the rejection cause and check
-        ;; whether we have exceeded max-warning-only-cycles.
-        max-warning-only-cycles  (get default-config :review/max-warning-only-cycles
-                                      default-max-warning-only-cycles)
-        warning-churn-policy     (get default-config :review/warning-churn-policy
-                                      default-warning-churn-policy)
-        prior-warning-only-count (get-in ctx [:execution :review-warning-only-cycles] 0)
-        cause-map                (when reviewer-blocked?
-                                   (classify-rejection-cause review-artifact
-                                                             prior-warning-only-count))
-        warning-only-count       (get cause-map :warning-only-count prior-warning-only-count)
-        warning-churn?           (boolean
-                                  (when reviewer-blocked?
-                                    (compute-warning-churn?
-                                     (:cause/type cause-map)
-                                     warning-only-count
-                                     max-warning-only-cycles)))
-        verdict           (compute-verdict {:backend-timeout?     backend-timeout?
-                                            :reviewer-blocked?    reviewer-blocked?
-                                            :stagnated?           stagnated?
-                                            :needs-decomposition? needs-decomposition?
-                                            :warning-churn?       warning-churn?
-                                            :warning-churn-policy warning-churn-policy
-                                            :within-budget?       within-budget?
-                                            :actionable-feedback? (actionable-feedback? feedback)})
-        review-cause      (build-review-cause verdict cause-map warning-only-count
-                                              review-cycle-count review-artifact)
-        updated-ctx       (cond-> (-> ctx
-                                      (accumulate-base-ctx end-time duration-ms phase-status
-                                                           metrics iterations current-fp
-                                                           current-blocking-count)
-                                      (attach-verdict verdict))
-                            reviewer-blocked?
-                            (record-warning-cycle-count warning-only-count))
-        next-ctx          (apply-verdict verdict updated-ctx feedback
-                                         (conj prior-history current-fp)
-                                         review-cycle-count)]
+  (let [end-time    (System/currentTimeMillis)
+        duration-ms (- end-time (get-in ctx [:phase :started-at]))
+        result      (get-in ctx [:phase :result])
+        metrics     (-> (get result :metrics {:tokens 0 :duration-ms duration-ms})
+                        (assoc :duration-ms duration-ms))
+        iterations  (get-in ctx [:phase :iterations] 1)
+        ;; All convergence decision logic is pure in review-convergence; this
+        ;; interceptor gathers the ctx inputs, then applies the decision.
+        decision (conv/compute-review-decision
+                  {:review-artifact          (get result :output)
+                   :review-decision          (get-in result [:output :review/decision])
+                   :result                   result
+                   :prior-fingerprints       (get-in ctx [:execution :review-fingerprints] [])
+                   :prior-blocking-counts    (get-in ctx [:execution :review-blocking-counts] [])
+                   :prior-warning-only-count (get-in ctx [:execution :review-warning-only-cycles] 0)
+                   :gate-failed?             (= :failed (:phase/status (get-in ctx [:phase])))
+                   :within-budget?           (< iterations
+                                                (get-in ctx [:phase :budget :iterations]
+                                                        (get-in default-config [:budget :iterations])))
+                   :max-no-progress-attempts (get-in ctx [:phase :budget :max-no-progress-attempts]
+                                                     conv/default-max-no-progress-attempts)
+                   :absolute-max-attempts    (get-in ctx [:phase :budget :absolute-max-redirect-attempts]
+                                                     conv/default-absolute-max-redirect-attempts)
+                   :max-warning-only-cycles  (get default-config :review/max-warning-only-cycles
+                                                  conv/default-max-warning-only-cycles)
+                   :warning-churn-policy     (get default-config :review/warning-churn-policy
+                                                  conv/default-warning-churn-policy)})
+        {:keys [verdict review-cause phase-status reviewer-blocked? current-fp
+                current-blocking-count warning-only-count review-cycle-count feedback]} decision
+        prior-history (get-in ctx [:execution :review-fingerprints] [])
+        updated-ctx (cond-> (-> ctx
+                                (accumulate-base-ctx end-time duration-ms phase-status
+                                                     metrics iterations current-fp
+                                                     current-blocking-count)
+                                (attach-verdict verdict))
+                      reviewer-blocked? (record-warning-cycle-count warning-only-count))
+        next-ctx (apply-verdict verdict updated-ctx feedback
+                                (conj prior-history current-fp) review-cycle-count)]
     (when (= :repair-requested verdict)
       (knowledge/capture-feedback-learning!
        (:knowledge-store ctx) :reviewer
        (get-in ctx [:execution/input :title]) feedback))
     (phase/emit-phase-completed! next-ctx :review
-      ;; Derive :outcome from the FINAL (verdict-corrected) status, not the
-      ;; pre-verdict `phase-status` local: apply-verdict promotes
-      ;; :accept-with-warnings to :completed, so reading the stale local would
-      ;; emit {:outcome :failure} for a success and mislead telemetry.
+      ;; :outcome from the FINAL (verdict-corrected) status, not phase-status:
+      ;; apply-verdict promotes :accept-with-warnings to :completed.
       (merge {:outcome     (if (= :completed (get-in next-ctx [:phase :status])) :success :failure)
               :duration-ms duration-ms
               :tokens      (:tokens metrics 0)}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -46,9 +46,7 @@
    bundle but do not block the release gate.  This is the safe default: it
    avoids silent task-explosion while still making warnings visible.
    The active operational value lives in :review/warning-churn-policy
-   in resources/config/phase/defaults.edn.
-   NOTE: consumed by the compute-verdict warning-churn branch — wired in the
-   follow-up PR 'feat/review-convergence-policy-wiring' (rule 008 deferral)."
+   in resources/config/phase/defaults.edn."
   :accept-with-warnings)
 
 (def default-max-warning-only-cycles
@@ -58,9 +56,7 @@
    transient LLM false-positive, short enough that a genuinely warning-heavy
    PR does not loop all the way to max-redirects and exhaust its token budget.
    The active operational value lives in :review/max-warning-only-cycles
-   in resources/config/phase/defaults.edn.
-   NOTE: consumed by leave-review warning-cycle cap — wired in the follow-up
-   PR 'feat/review-convergence-policy-wiring' (rule 008 deferral)."
+   in resources/config/phase/defaults.edn."
   2)
 
 ;; Schema — validates review convergence config keys at config load time (rule 004).
@@ -102,6 +98,43 @@
 
 ;; Register defaults on load
 (phase/register-phase-defaults! :review default-config)
+
+;; Pure helper — cause classification
+
+(defn- classify-rejection-cause
+  "Pure function. Given a review artifact and the count of prior consecutive
+   warning-only cycles, classify the rejection cause and return an updated count.
+
+   Uses `agent/rejection-warnings-only?` to distinguish a warning-driven
+   rejection (no blocking issues, only advisory warnings) from one containing
+   genuine blocking defects.
+
+   Returns {:cause/type :blocking-defect | :warning-churn
+            :warning-only-count <updated int>}
+
+   :warning-churn increments the counter; :blocking-defect resets to 0."
+  [review-artifact prior-warning-only-count]
+  (if (agent/rejection-warnings-only? review-artifact)
+    {:cause/type         :warning-churn
+     :warning-only-count (inc prior-warning-only-count)}
+    {:cause/type         :blocking-defect
+     :warning-only-count 0}))
+
+(defn- compute-warning-churn?
+  "True when the cause is :warning-churn AND the warning-only-count has reached
+   or exceeded max-warning-only-cycles (the churn policy threshold).
+
+   With the default cap of 2, the first warning-only rejection (count=1) still
+   redirects to implement; the second (count=2) trips the policy."
+  [cause-type warning-only-count max-warning-only-cycles]
+  (and (= :warning-churn cause-type)
+       (>= warning-only-count max-warning-only-cycles)))
+
+(defn- record-warning-cycle-count
+  "Persist the warning-only cycle count at [:execution :review-warning-only-cycles].
+   Survives phase re-entries because it lives on :execution, not :phase."
+  [ctx count]
+  (assoc-in ctx [:execution :review-warning-only-cycles] count))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
@@ -402,6 +435,11 @@
    between on-fail redirect and terminal `:failed`.
 
      :approved              — reviewer green-lit; `:phase/succeed` event
+     :accept-with-warnings  — reviewer only raised warnings (no blocking
+                              issues) for max-warning-only-cycles consecutive
+                              cycles; phase succeeds with unresolved warnings
+                              attached at [:phase :unresolved-warnings] so
+                              release can surface them as PR comments
      :repair-requested      — actionable feedback + within budget;
                               FSM may redirect via on-fail
      :stagnated             — same blocking fingerprint as prior cycle;
@@ -422,22 +460,29 @@
                               auto-resume composition (with the
                               network-resilience PR-C, #1054) lives in
                               a follow-up PR."
-  #{:approved :repair-requested :stagnated :needs-decomposition :exhausted
-    :review/backend-timeout})
+  #{:approved :accept-with-warnings :repair-requested :stagnated :needs-decomposition
+    :exhausted :review/backend-timeout})
 
 (defn- compute-verdict
   "Pick the verdict that should flow on the phase result. Mirrors the
    former `compute-decision` semantics one-for-one — `:stagnated` and
-   `:needs-decomposition` keep their priority over `:repair-requested`;
-   a reviewer-blocked failure with no actionable feedback collapses to
-   `:exhausted`.
+   `:needs-decomposition` keep their priority over `:repair-requested`.
+
+   Priority order (highest to lowest):
+     backend-timeout → stagnated → needs-decomposition →
+     warning-churn (policy-resolved) → repair-requested → exhausted → approved
 
    `:review/backend-timeout` takes priority over every code-review
    verdict: when the reviewer LLM never produced a real verdict (PR-A
    wiring), there is no `:rejected` to interpret as repair-requested
-   or exhausted. The infra failure must be reported as itself."
+   or exhausted. The infra failure must be reported as itself.
+
+   `:warning-churn?` gates the warning-churn branch; when true the
+   verdict is resolved from `:warning-churn-policy`:
+     :accept-with-warnings → :accept-with-warnings (phase succeeds)
+     :needs-decomposition  → :needs-decomposition  (terminal)"
   [{:keys [backend-timeout? reviewer-blocked? stagnated? needs-decomposition?
-           within-budget? actionable-feedback?]}]
+           warning-churn? warning-churn-policy within-budget? actionable-feedback?]}]
   (cond
     backend-timeout?
     :review/backend-timeout
@@ -447,6 +492,11 @@
 
     needs-decomposition?
     :needs-decomposition
+
+    (and reviewer-blocked? warning-churn?)
+    (case warning-churn-policy
+      :accept-with-warnings :accept-with-warnings
+      :needs-decomposition  :needs-decomposition)
 
     (and reviewer-blocked? within-budget? actionable-feedback?)
     :repair-requested
@@ -470,9 +520,9 @@
 (defn- apply-verdict
   "Carry out the side-effects implied by a verdict — attach anomalies
    for terminal verdicts, attach handoff feedback for repair-requested,
-   mark completed for approved. The FSM drives the actual phase
-   transition; this fn only enriches the ctx with payload data that
-   evidence-bundle / downstream phases consume."
+   mark completed for approved and accept-with-warnings. The FSM drives
+   the actual phase transition; this fn only enriches the ctx with
+   payload data that evidence-bundle / downstream phases consume."
   [verdict updated-ctx feedback fingerprint-history review-cycle-count]
   (case verdict
     :stagnated
@@ -489,6 +539,16 @@
 
     :review/backend-timeout
     (attach-backend-timeout-anomaly updated-ctx)
+
+    :accept-with-warnings
+    (let [review-artifact (get-in updated-ctx [:phase :result :output])
+          warnings        (get review-artifact :review/warnings [])]
+      ;; Override :phase :status from :failed (set by accumulate-base-ctx because
+      ;; reviewer-blocked? was true) back to :completed — the phase succeeds despite
+      ;; the warning-only rejection; the PR proceeds with warnings surfaced.
+      (-> (mark-completed updated-ctx)
+          (assoc-in [:phase :status] :completed)
+          (assoc-in [:phase :unresolved-warnings] warnings)))
 
     :approved
     (mark-completed updated-ctx)))
@@ -535,7 +595,13 @@
    identical to the immediately prior iteration's, the repair loop has
    produced no movement on the blocking complaints. Terminate with
    :anomalies.review/stagnation instead of redirecting — better to
-   surface the loop than burn another budget cycle."
+   surface the loop than burn another budget cycle.
+
+   Warning-churn guard: if the reviewer only raises warnings (no blocking
+   issues) for max-warning-only-cycles consecutive cycles, apply the
+   configured :review/warning-churn-policy instead of looping indefinitely.
+   The cycle count persists at [:execution :review-warning-only-cycles]
+   across phase re-entries, like fingerprints."
   [ctx]
   (let [start-time        (get-in ctx [:phase :started-at])
         end-time          (System/currentTimeMillis)
@@ -581,16 +647,37 @@
         needs-decomposition? (compute-needs-decomposition?
                               reviewer-blocked? stagnated?
                               review-cycle-count max-no-progress-attempts)
+        ;; Warning-churn tracking: classify the rejection cause and check
+        ;; whether we have exceeded max-warning-only-cycles.
+        max-warning-only-cycles  (get default-config :review/max-warning-only-cycles
+                                       default-max-warning-only-cycles)
+        warning-churn-policy     (get default-config :review/warning-churn-policy
+                                       default-warning-churn-policy)
+        prior-warning-only-count (get-in ctx [:execution :review-warning-only-cycles] 0)
+        cause-map                (when reviewer-blocked?
+                                   (classify-rejection-cause review-artifact
+                                                             prior-warning-only-count))
+        warning-only-count       (get cause-map :warning-only-count prior-warning-only-count)
+        warning-churn?           (boolean
+                                  (when reviewer-blocked?
+                                    (compute-warning-churn?
+                                     (:cause/type cause-map)
+                                     warning-only-count
+                                     max-warning-only-cycles)))
         verdict           (compute-verdict {:backend-timeout?     backend-timeout?
                                             :reviewer-blocked?    reviewer-blocked?
                                             :stagnated?           stagnated?
                                             :needs-decomposition? needs-decomposition?
+                                            :warning-churn?       warning-churn?
+                                            :warning-churn-policy warning-churn-policy
                                             :within-budget?       within-budget?
                                             :actionable-feedback? (actionable-feedback? feedback)})
-        updated-ctx       (-> ctx
-                              (accumulate-base-ctx end-time duration-ms phase-status
-                                                   metrics iterations current-fp)
-                              (attach-verdict verdict))
+        updated-ctx       (cond-> (-> ctx
+                                      (accumulate-base-ctx end-time duration-ms phase-status
+                                                           metrics iterations current-fp)
+                                      (attach-verdict verdict))
+                            reviewer-blocked?
+                            (record-warning-cycle-count warning-only-count))
         next-ctx          (apply-verdict verdict updated-ctx feedback
                                          (conj prior-history current-fp)
                                          review-cycle-count)]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -496,7 +496,12 @@
     (and reviewer-blocked? warning-churn?)
     (case warning-churn-policy
       :accept-with-warnings :accept-with-warnings
-      :needs-decomposition  :needs-decomposition)
+      :needs-decomposition  :needs-decomposition
+      ;; Programmer-error guard — invalid policy should have been caught at config
+      ;; load by ReviewConvergenceConfigSchema; throw here makes the offending value
+      ;; visible rather than silently routing to an unrelated verdict branch (rule 005).
+      (throw (IllegalArgumentException.
+              (str "Unknown warning-churn-policy: " (pr-str warning-churn-policy)))))
 
     (and reviewer-blocked? within-budget? actionable-feedback?)
     :repair-requested
@@ -570,10 +575,14 @@
       (record-fingerprint current-fp)))
 
 (defn- review-feedback
-  "Extract feedback the implementer should consume on a repair redirect."
+  "Extract feedback the implementer should consume on a repair redirect.
+   Falls back to :review/warnings when no structured feedback or issues
+   are present — warnings ARE actionable feedback when there are no
+   blocking issues (the warning-churn repair path)."
   [result]
   (or (get-in result [:output :review/feedback])
-      (get-in result [:output :review/issues])))
+      (get-in result [:output :review/issues])
+      (not-empty (get-in result [:output :review/warnings]))))
 
 (defn- actionable-feedback?
   "True when review feedback gives implement something concrete to repair."

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -136,6 +136,37 @@
   [ctx count]
   (assoc-in ctx [:execution :review-warning-only-cycles] count))
 
+(def ^:private terminal-review-verdicts
+  "Review verdicts that end the repair loop without redirecting to implement.
+   Only these four verdicts produce a :review/cause entry in the
+   phase-completed event payload so the evidence bundle and dashboard can
+   surface why the loop terminated rather than converging."
+  #{:accept-with-warnings :needs-decomposition :stagnated :exhausted})
+
+(defn- build-review-cause
+  "Build the :review/cause map for terminal review verdicts.
+   Returns nil for non-terminal verdicts (:repair-requested, :approved,
+   :review/backend-timeout).
+
+   Fields always present on a terminal verdict:
+     :cause/type                — :warning-churn or :blocking-defect
+     :review/warning-only-cycles — consecutive warning-only cycles completed
+     :review/total-cycles       — total review cycles in this task
+     :review/verdict            — the terminal verdict keyword
+
+   For :accept-with-warnings only:
+     :review/unresolved-warning-count — count of advisory warnings accepted
+                                        without resolution"
+  [verdict cause-map warning-only-count review-cycle-count review-artifact]
+  (when (contains? terminal-review-verdicts verdict)
+    (cond-> {:cause/type                (get cause-map :cause/type :blocking-defect)
+             :review/warning-only-cycles warning-only-count
+             :review/total-cycles       review-cycle-count
+             :review/verdict            verdict}
+      (= :accept-with-warnings verdict)
+      (assoc :review/unresolved-warning-count
+             (count (get review-artifact :review/warnings))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
 
@@ -681,6 +712,8 @@
                                             :warning-churn-policy warning-churn-policy
                                             :within-budget?       within-budget?
                                             :actionable-feedback? (actionable-feedback? feedback)})
+        review-cause      (build-review-cause verdict cause-map warning-only-count
+                                              review-cycle-count review-artifact)
         updated-ctx       (cond-> (-> ctx
                                       (accumulate-base-ctx end-time duration-ms phase-status
                                                            metrics iterations current-fp)
@@ -698,7 +731,8 @@
       (merge {:outcome     (if (= :completed phase-status) :success :failure)
               :duration-ms duration-ms
               :tokens      (:tokens metrics 0)}
-             (phase-terminal/derive-termination-reason result nil)))
+             (phase-terminal/derive-termination-reason result nil)
+             (when review-cause {:review/cause review-cause})))
     next-ctx))
 
 (defn error-review

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -33,14 +33,66 @@
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.response.interface :as response]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Named constants — fallback defaults used when config/phase/defaults.edn is absent
+
+(def default-warning-churn-policy
+  "Fallback policy applied when the reviewer emits only warnings (no blocking
+   issues) for :review/max-warning-only-cycles consecutive cycles.
+   :accept-with-warnings lets the SDLC proceed — warnings land in the evidence
+   bundle but do not block the release gate.  This is the safe default: it
+   avoids silent task-explosion while still making warnings visible.
+   The active operational value lives in :review/warning-churn-policy
+   in resources/config/phase/defaults.edn."
+  :accept-with-warnings)
+
+(def default-max-warning-only-cycles
+  "Fallback cap on consecutive warning-only review cycles before the churn
+   policy fires, used when config/phase/defaults.edn is absent.
+   2 allows one retry after the first warning round — enough to survive a
+   transient LLM false-positive, short enough that a genuinely warning-heavy
+   PR does not loop all the way to max-redirects and exhaust its token budget.
+   The active operational value lives in :review/max-warning-only-cycles
+   in resources/config/phase/defaults.edn."
+  2)
+
+;; Schema — validates review convergence config keys at config load time (rule 004).
+;; Defined as a value; validation is a one-time side-effect below.
+(def ^:private ReviewConvergenceConfigSchema
+  "Malli schema for the :review/warning-churn-policy and
+   :review/max-warning-only-cycles keys.  Closed map with only the
+   convergence keys; the rest of the phase config is validated elsewhere."
+  [:map
+   [:review/warning-churn-policy
+    {:default     default-warning-churn-policy
+     :description "Policy when max warning-only cycles are exhausted."}
+    [:enum :accept-with-warnings :needs-decomposition]]
+   [:review/max-warning-only-cycles
+    {:default     default-max-warning-only-cycles
+     :description "Max consecutive warning-only cycles before the churn policy fires."}
+    [:int {:min 1}]]])
+
 ;; Defaults
 
 (def default-config
   "Phase defaults loaded from config/phase/defaults.edn."
   (phase-config/defaults-for :review))
+
+;; Validate convergence config once at load — fail fast on a bad defaults.edn
+;; rather than surfacing a ClassCastException deep inside the review phase.
+;; Only validates when the keys are present; absent keys fall back to constants.
+(let [convergence-config (select-keys default-config
+                                       [:review/warning-churn-policy
+                                        :review/max-warning-only-cycles])]
+  (when (seq convergence-config)
+    (when-not (m/validate ReviewConvergenceConfigSchema convergence-config)
+      (throw (IllegalArgumentException.
+              (str "Invalid review convergence config in defaults.edn: "
+                   (pr-str (m/explain ReviewConvergenceConfigSchema
+                                       convergence-config))))))))
 
 ;; Register defaults on load
 (phase/register-phase-defaults! :review default-config)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -46,7 +46,9 @@
    bundle but do not block the release gate.  This is the safe default: it
    avoids silent task-explosion while still making warnings visible.
    The active operational value lives in :review/warning-churn-policy
-   in resources/config/phase/defaults.edn."
+   in resources/config/phase/defaults.edn.
+   NOTE: consumed by the compute-verdict warning-churn branch — wired in the
+   follow-up PR 'feat/review-convergence-policy-wiring' (rule 008 deferral)."
   :accept-with-warnings)
 
 (def default-max-warning-only-cycles
@@ -56,15 +58,18 @@
    transient LLM false-positive, short enough that a genuinely warning-heavy
    PR does not loop all the way to max-redirects and exhaust its token budget.
    The active operational value lives in :review/max-warning-only-cycles
-   in resources/config/phase/defaults.edn."
+   in resources/config/phase/defaults.edn.
+   NOTE: consumed by leave-review warning-cycle cap — wired in the follow-up
+   PR 'feat/review-convergence-policy-wiring' (rule 008 deferral)."
   2)
 
 ;; Schema — validates review convergence config keys at config load time (rule 004).
 ;; Defined as a value; validation is a one-time side-effect below.
 (def ^:private ReviewConvergenceConfigSchema
   "Malli schema for the :review/warning-churn-policy and
-   :review/max-warning-only-cycles keys.  Closed map with only the
-   convergence keys; the rest of the phase config is validated elsewhere."
+   :review/max-warning-only-cycles keys.  Open map (no {:closed true}) —
+   callers must pass (select-keys cfg [...]) before validating to avoid
+   silently accepting extra keys from the full phase-config map."
   [:map
    [:review/warning-churn-policy
     {:default     default-warning-churn-policy
@@ -90,7 +95,8 @@
   (when (seq convergence-config)
     (when-not (m/validate ReviewConvergenceConfigSchema convergence-config)
       (throw (IllegalArgumentException.
-              (str "Invalid review convergence config in defaults.edn: "
+              (str (messages/ts :review/invalid-convergence-config)
+                   " "
                    (pr-str (m/explain ReviewConvergenceConfigSchema
                                        convergence-config))))))))
 

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review_convergence.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review_convergence.clj
@@ -1,0 +1,264 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-software-factory.review-convergence
+  "Review-phase convergence engine: the pure decision logic that turns a
+   completed review into a verdict. No ctx mutation, no IO — `review.clj`
+   owns the phase interceptor and applies the decision this namespace
+   returns. Operational config values live in
+   resources/config/phase/defaults.edn (`:review/warning-churn-policy`,
+   `:review/max-warning-only-cycles`); the defs here are fallbacks used only
+   when that file is absent."
+  (:require
+   [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.phase-software-factory.messages :as messages]
+   [clojure.string :as str]
+   [malli.core :as m]))
+
+;; ----------------------------------------------------------------------------
+;; Config fallbacks + schema (operational values + rationale: defaults.edn)
+
+(def default-warning-churn-policy
+  "Fallback :review/warning-churn-policy when defaults.edn is absent."
+  :accept-with-warnings)
+
+(def default-max-warning-only-cycles
+  "Fallback :review/max-warning-only-cycles when defaults.edn is absent."
+  2)
+
+(def default-max-no-progress-attempts
+  "Fallback :review/max-no-progress-attempts — consecutive non-shrinking
+   review cycles before :needs-decomposition fires."
+  3)
+
+(def default-absolute-max-redirect-attempts
+  "Fallback :review/absolute-max-redirect-attempts — hard ceiling on
+   review→implement cycles regardless of progress."
+  6)
+
+(def ^:private ReviewConvergenceConfigSchema
+  "Malli schema for the convergence config keys. Open map — callers pass a
+   select-keys subset before validating (see `validate-convergence-config!`)."
+  [:map
+   [:review/warning-churn-policy
+    {:default default-warning-churn-policy}
+    [:enum :accept-with-warnings :needs-decomposition]]
+   [:review/max-warning-only-cycles
+    {:default default-max-warning-only-cycles}
+    [:int {:min 1}]]])
+
+(defn validate-convergence-config!
+  "Throw IllegalArgumentException when `config`'s convergence keys are
+   invalid. Merges the fallbacks UNDER config first, so a partial override
+   (only one key) is accepted while an invalid VALUE still fails fast."
+  [config]
+  (let [merged (merge {:review/warning-churn-policy    default-warning-churn-policy
+                       :review/max-warning-only-cycles default-max-warning-only-cycles}
+                      (select-keys config [:review/warning-churn-policy
+                                           :review/max-warning-only-cycles]))]
+    (when-not (m/validate ReviewConvergenceConfigSchema merged)
+      (throw (IllegalArgumentException.
+              (str (messages/ts :review/invalid-convergence-config)
+                   " "
+                   (pr-str (m/explain ReviewConvergenceConfigSchema merged))))))))
+
+;; ----------------------------------------------------------------------------
+;; Decision primitives (pure)
+
+(def blocking-decisions
+  "Reviewer decisions meaning 'don't ship — fix it.' Both route through the
+   :failed branch; the verdict decides redirect vs terminate."
+  #{:rejected :changes-requested})
+
+(def terminal-review-verdicts
+  "Verdicts that end the repair loop without redirecting. Only these emit a
+   :review/cause in the phase-completed payload."
+  #{:accept-with-warnings :needs-decomposition :stagnated :exhausted})
+
+(def verdicts
+  "Phase 2b verdict tag set, flowing via [:phase :result :output
+   :phase/verdict] to the FSM (read by :verdict/terminal?)."
+  #{:approved :accept-with-warnings :repair-requested :stagnated :needs-decomposition
+    :exhausted :review/backend-timeout})
+
+(defn classify-rejection-cause
+  "Classify a blocked review: :warning-churn (warnings only, no blocking)
+   increments the warning-only count; :blocking-defect resets it to 0."
+  [review-artifact prior-warning-only-count]
+  (if (agent/rejection-warnings-only? review-artifact)
+    {:cause/type :warning-churn  :warning-only-count (inc prior-warning-only-count)}
+    {:cause/type :blocking-defect :warning-only-count 0}))
+
+(defn compute-warning-churn?
+  "True when the cause is :warning-churn and the count has reached the cap."
+  [cause-type warning-only-count max-warning-only-cycles]
+  (and (= :warning-churn cause-type)
+       (>= warning-only-count max-warning-only-cycles)))
+
+(defn count-blocking-issues
+  "Blocking-issue count, tolerant of both :review/blocking-issues (real
+   reviewer output) and :review/issues filtered by :severity :blocking."
+  [review-artifact]
+  (let [enumerated (count (agent/get-blocking-issues review-artifact))]
+    (if (pos? enumerated)
+      enumerated
+      (count (filter #(= :blocking (:severity %)) (:review/issues review-artifact))))))
+
+(defn compute-stagnated?
+  "True when blocked AND the new fingerprint matches the prior cycle's —
+   the repair loop produced no movement on the blocking complaints."
+  [reviewer-blocked? prior-history current-fp]
+  (and reviewer-blocked?
+       (agent/review-stagnated? (peek prior-history) current-fp)))
+
+(defn no-progress-streak
+  "Consecutive trailing cycles whose blocking count did NOT strictly shrink,
+   given the full per-cycle count sequence (oldest first, incl. current). A
+   shrink resets the streak; the first cycle counts as no-progress.
+   [3 2 1]→0, [3 2 2]→1, [1 1 1]→3."
+  [counts]
+  (reduce (fn [streak [prev cur]]
+            (if (and prev (< cur prev)) 0 (inc streak)))
+          0
+          (map vector (cons nil counts) counts)))
+
+(defn compute-needs-decomposition?
+  "True when blocked + not stagnated + the loop is NOT converging — the
+   blocking count failed to shrink for `max-no-progress-attempts` consecutive
+   cycles, OR the absolute ceiling is hit. A shrinking loop runs to the
+   ceiling (converging, just not in one turn)."
+  [reviewer-blocked? stagnated? no-progress-streak
+   review-cycle-count max-no-progress-attempts absolute-max-attempts]
+  (and reviewer-blocked?
+       (not stagnated?)
+       (or (>= review-cycle-count absolute-max-attempts)
+           (>= no-progress-streak max-no-progress-attempts))))
+
+(defn compute-phase-status
+  [reviewer-blocked? gate-failed?]
+  (cond
+    reviewer-blocked? :failed
+    gate-failed?      :failed
+    :else             :completed))
+
+(defn compute-verdict
+  "Pick the verdict. Priority: backend-timeout → stagnated →
+   needs-decomposition → warning-churn (policy-resolved) → repair-requested
+   → exhausted → approved."
+  [{:keys [backend-timeout? reviewer-blocked? stagnated? needs-decomposition?
+           warning-churn? warning-churn-policy within-budget? actionable-feedback?]}]
+  (cond
+    backend-timeout?     :review/backend-timeout
+    stagnated?           :stagnated
+    needs-decomposition? :needs-decomposition
+
+    (and reviewer-blocked? warning-churn?)
+    (case warning-churn-policy
+      :accept-with-warnings :accept-with-warnings
+      :needs-decomposition  :needs-decomposition
+      ;; Programmer-error guard — invalid policy should have failed at config
+      ;; load (ReviewConvergenceConfigSchema). Throw rather than mis-route (rule 005).
+      (throw (IllegalArgumentException.
+              (str "Unknown warning-churn-policy: " (pr-str warning-churn-policy)))))
+
+    (and reviewer-blocked? within-budget? actionable-feedback?) :repair-requested
+    reviewer-blocked?                                           :exhausted
+    :else                                                       :approved))
+
+(defn build-review-cause
+  "Build the :review/cause map for a terminal verdict, else nil."
+  [verdict cause-map warning-only-count review-cycle-count review-artifact]
+  (when (contains? terminal-review-verdicts verdict)
+    (cond-> {:cause/type                 (get cause-map :cause/type :blocking-defect)
+             :review/warning-only-cycles warning-only-count
+             :review/total-cycles        review-cycle-count
+             :review/verdict             verdict}
+      (= :accept-with-warnings verdict)
+      (assoc :review/unresolved-warning-count
+             (count (get review-artifact :review/warnings))))))
+
+(defn review-feedback
+  "Feedback the implementer consumes on a repair redirect. Falls back to
+   :review/warnings (warnings ARE actionable when there are no blocking issues)."
+  [result]
+  (or (get-in result [:output :review/feedback])
+      (get-in result [:output :review/issues])
+      (not-empty (get-in result [:output :review/warnings]))))
+
+(defn actionable-feedback?
+  "True when feedback gives implement something concrete to repair."
+  [feedback]
+  (cond
+    (string? feedback)     (not (str/blank? feedback))
+    (sequential? feedback) (seq feedback)
+    :else                  (some? feedback)))
+
+;; ----------------------------------------------------------------------------
+;; Orchestrator (pure): completed-review inputs → verdict + supporting data
+
+(defn compute-review-decision
+  "Resolve a completed review into a verdict and the data the caller applies
+   to ctx. Pure: takes ctx-derived values, returns a decision map. Keeps
+   leave-review a thin gather → decide → apply → emit orchestration.
+
+   Returns {:verdict :review-cause :phase-status :reviewer-blocked?
+            :current-fp :current-blocking-count :warning-only-count
+            :review-cycle-count :feedback}."
+  [{:keys [review-artifact review-decision result
+           prior-fingerprints prior-blocking-counts prior-warning-only-count
+           within-budget? gate-failed?
+           max-no-progress-attempts absolute-max-attempts
+           max-warning-only-cycles warning-churn-policy]}]
+  (let [backend-timeout?       (= :reviewer/backend-timeout (get-in result [:error :data :code]))
+        reviewer-blocked?      (contains? blocking-decisions review-decision)
+        current-fp             (agent/review-fingerprint review-artifact)
+        stagnated?             (compute-stagnated? reviewer-blocked? prior-fingerprints current-fp)
+        phase-status           (compute-phase-status reviewer-blocked? gate-failed?)
+        feedback               (review-feedback result)
+        review-cycle-count     (inc (count prior-fingerprints))
+        current-blocking-count (count-blocking-issues review-artifact)
+        np-streak              (no-progress-streak
+                                (conj (vec prior-blocking-counts) current-blocking-count))
+        needs-decomposition?   (compute-needs-decomposition?
+                                reviewer-blocked? stagnated? np-streak
+                                review-cycle-count max-no-progress-attempts absolute-max-attempts)
+        cause-map              (when reviewer-blocked?
+                                 (classify-rejection-cause review-artifact prior-warning-only-count))
+        warning-only-count     (get cause-map :warning-only-count prior-warning-only-count)
+        warning-churn?         (boolean (when reviewer-blocked?
+                                          (compute-warning-churn? (:cause/type cause-map)
+                                                                  warning-only-count
+                                                                  max-warning-only-cycles)))
+        verdict                (compute-verdict {:backend-timeout?     backend-timeout?
+                                                 :reviewer-blocked?    reviewer-blocked?
+                                                 :stagnated?           stagnated?
+                                                 :needs-decomposition? needs-decomposition?
+                                                 :warning-churn?       warning-churn?
+                                                 :warning-churn-policy warning-churn-policy
+                                                 :within-budget?       within-budget?
+                                                 :actionable-feedback? (actionable-feedback? feedback)})]
+    {:verdict                verdict
+     :review-cause           (build-review-cause verdict cause-map warning-only-count
+                                                 review-cycle-count review-artifact)
+     :phase-status           phase-status
+     :reviewer-blocked?      reviewer-blocked?
+     :current-fp             current-fp
+     :current-blocking-count current-blocking-count
+     :warning-only-count     warning-only-count
+     :review-cycle-count     review-cycle-count
+     :feedback               feedback}))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_cause_event_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_cause_event_test.clj
@@ -1,0 +1,192 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-software-factory.review-cause-event-test
+  "Tests for :review/cause enrichment on terminal review verdicts.
+
+   Covers two surfaces:
+     1. build-review-cause (pure helper, tested via #') — cause map shape per verdict
+     2. leave-review integration — :review/cause rides on emit-phase-completed! payload"
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.phase.loader :as loader]
+   [ai.miniforge.phase-software-factory.review]
+   [ai.miniforge.phase-software-factory.implement]))
+
+;; ---------------------------------------------------------------------------
+;; Layer 0 — factories and shared constants
+
+(def ^:private phase-test-config-resource
+  "config/phase/test-support-namespaces.edn")
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (try
+      (binding [loader/phase-loader-config-resource phase-test-config-resource]
+        (f))
+      (finally
+        (phase/reset-phase-loader!)))))
+
+;; Private helper accessed directly for pure-function unit tests.
+(def ^:private build-review-cause
+  #'ai.miniforge.phase-software-factory.review/build-review-cause)
+
+(def ^:private blocking-cause-map
+  {:cause/type :blocking-defect :warning-only-count 0})
+
+(def ^:private warning-cause-map
+  {:cause/type :warning-churn :warning-only-count 2})
+
+(defn- make-leave-review-ctx
+  "Minimal context for leave-review, matching the shape used in
+   review-repair-loop-test."
+  [decision iterations max-iterations review-output]
+  (let [result {:output  (merge {:review/decision decision} review-output)
+                :metrics {:tokens 100 :duration-ms 5000}}]
+    {:phase           {:started-at (- (System/currentTimeMillis) 1000)
+                       :iterations iterations
+                       :budget     {:iterations max-iterations}
+                       :result     result}
+     :phase-config    {:phase :review}
+     :execution/phase-results {}
+     :execution/input {:description "test task"}
+     :execution/metrics {}}))
+
+(defn- run-leave-review
+  "Invoke the leave-review interceptor function and return the updated context."
+  [ctx]
+  (let [interceptor (phase/get-phase-interceptor {:phase :review})
+        leave-fn    (:leave interceptor)]
+    (leave-fn ctx)))
+
+;; ---------------------------------------------------------------------------
+;; Layer 1 — build-review-cause unit tests (pure function, no event-stream)
+
+(deftest build-review-cause-returns-nil-for-non-terminal-verdicts
+  (testing "non-terminal verdicts produce no cause map"
+    (doseq [v [:repair-requested :approved :review/backend-timeout]]
+      (is (nil? (build-review-cause v blocking-cause-map 0 1 {}))
+          (str "verdict " v " should not produce a cause map")))))
+
+(deftest build-review-cause-stagnated
+  (testing "stagnated verdict — correct shape, no unresolved-warning-count"
+    (let [cause (build-review-cause :stagnated blocking-cause-map 0 3 {})]
+      (is (= :stagnated       (:review/verdict cause)))
+      (is (= :blocking-defect (:cause/type cause)))
+      (is (= 0 (:review/warning-only-cycles cause)))
+      (is (= 3 (:review/total-cycles cause)))
+      (is (not (contains? cause :review/unresolved-warning-count))
+          "stagnated should not carry unresolved-warning-count"))))
+
+(deftest build-review-cause-needs-decomposition
+  (testing "needs-decomposition verdict — correct shape, no unresolved-warning-count"
+    (let [cause (build-review-cause :needs-decomposition blocking-cause-map 1 4 {})]
+      (is (= :needs-decomposition (:review/verdict cause)))
+      (is (= :blocking-defect     (:cause/type cause)))
+      (is (= 1 (:review/warning-only-cycles cause)))
+      (is (= 4 (:review/total-cycles cause)))
+      (is (not (contains? cause :review/unresolved-warning-count))
+          "needs-decomposition should not carry unresolved-warning-count"))))
+
+(deftest build-review-cause-exhausted
+  (testing "exhausted verdict — correct shape, no unresolved-warning-count"
+    (let [cause (build-review-cause :exhausted blocking-cause-map 0 2 {})]
+      (is (= :exhausted       (:review/verdict cause)))
+      (is (= :blocking-defect (:cause/type cause)))
+      (is (= 0 (:review/warning-only-cycles cause)))
+      (is (= 2 (:review/total-cycles cause)))
+      (is (not (contains? cause :review/unresolved-warning-count))
+          "exhausted should not carry unresolved-warning-count"))))
+
+(deftest build-review-cause-accept-with-warnings-includes-count
+  (testing "accept-with-warnings — includes :review/unresolved-warning-count"
+    (let [warnings [{:text "nit: rename x to foo"}
+                    {:text "nit: add docstring"}]
+          artifact {:review/warnings warnings}
+          cause    (build-review-cause :accept-with-warnings warning-cause-map 2 3 artifact)]
+      (is (= :accept-with-warnings (:review/verdict cause)))
+      (is (= :warning-churn        (:cause/type cause)))
+      (is (= 2 (:review/warning-only-cycles cause)))
+      (is (= 3 (:review/total-cycles cause)))
+      (is (= 2 (:review/unresolved-warning-count cause))
+          "should count the warnings in the review artifact"))))
+
+(deftest build-review-cause-accept-with-warnings-no-warnings
+  (testing "accept-with-warnings with no warnings in artifact → count is 0"
+    (let [cause (build-review-cause :accept-with-warnings warning-cause-map 2 2 {})]
+      (is (= 0 (:review/unresolved-warning-count cause))
+          "absent :review/warnings → count 0, not nil or exception"))))
+
+(deftest build-review-cause-defaults-to-blocking-defect-when-cause-map-nil
+  (testing "nil cause-map falls back to :blocking-defect"
+    (let [cause (build-review-cause :exhausted nil 0 1 {})]
+      (is (= :blocking-defect (:cause/type cause))
+          "absent cause-map → :blocking-defect default"))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 2 — integration tests via emit-phase-completed! capture
+
+(deftest exhausted-verdict-emits-review-cause-in-phase-completed
+  (testing "exhausted: :review/cause appears in emit-phase-completed! payload"
+    (let [captured (atom nil)
+          ctx      (make-leave-review-ctx :rejected 4 4 {})]
+      (with-redefs [phase/emit-phase-completed!
+                    (fn [_ctx _phase-kw payload]
+                      (reset! captured payload))]
+        (run-leave-review ctx)
+        (is (some? (:review/cause @captured))
+            "exhausted verdict must include :review/cause")
+        (is (= :exhausted
+               (get-in @captured [:review/cause :review/verdict])))
+        (is (= :blocking-defect
+               (get-in @captured [:review/cause :cause/type])))
+        (is (= 1
+               (get-in @captured [:review/cause :review/total-cycles]))
+            "first review cycle → total-cycles = 1")))))
+
+(deftest approved-verdict-does-not-emit-review-cause
+  (testing "approved: :review/cause is absent from emit-phase-completed! payload"
+    (let [captured (atom nil)
+          ctx      (make-leave-review-ctx :approved 1 4 {})]
+      (with-redefs [phase/emit-phase-completed!
+                    (fn [_ctx _phase-kw payload]
+                      (reset! captured payload))]
+        (run-leave-review ctx)
+        (is (nil? (:review/cause @captured))
+            "approved verdict must not include :review/cause")))))
+
+(deftest repair-requested-does-not-emit-review-cause
+  (testing "repair-requested (within budget): :review/cause is absent from payload"
+    (let [captured (atom nil)
+          ctx      (make-leave-review-ctx
+                    :rejected 1 4
+                    {:review/issues [{:severity :blocking :description "Use defn not def"}]})]
+      (with-redefs [phase/emit-phase-completed!
+                    (fn [_ctx _phase-kw payload]
+                      (reset! captured payload))]
+        (run-leave-review ctx)
+        (is (nil? (:review/cause @captured))
+            "repair-requested is not a terminal verdict; no :review/cause")))))
+
+(comment
+  ;; REPL: run individual cause map assertions
+  (build-review-cause :stagnated blocking-cause-map 0 3 {})
+  (build-review-cause :accept-with-warnings warning-cause-map 2 3
+                      {:review/warnings [{:text "nit: foo"}]}))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_cause_event_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_cause_event_test.clj
@@ -46,7 +46,7 @@
 
 ;; Private helper accessed directly for pure-function unit tests.
 (def ^:private build-review-cause
-  #'ai.miniforge.phase-software-factory.review/build-review-cause)
+  #'ai.miniforge.phase-software-factory.review-convergence/build-review-cause)
 
 (def ^:private blocking-cause-map
   {:cause/type :blocking-defect :warning-only-count 0})

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_cause_event_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_cause_event_test.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
    [ai.miniforge.phase-software-factory.review]
+   [ai.miniforge.phase-software-factory.review-convergence]
    [ai.miniforge.phase-software-factory.implement]))
 
 ;; ---------------------------------------------------------------------------

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
@@ -22,6 +22,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]
+   [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.review :as review]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]))
 
@@ -108,9 +109,24 @@
       (is (= review/default-max-warning-only-cycles
              (:review/max-warning-only-cycles cfg))))))
 
+;; System-locale message catalog tests
+
+(deftest test-system-catalog-has-invalid-convergence-config-key
+  (testing "system.edn exposes :review/invalid-convergence-config for startup errors"
+    (let [msg (messages/ts :review/invalid-convergence-config)]
+      (is (string? msg))
+      (is (pos? (count msg))))))
+
+(deftest test-system-message-is-not-raw-placeholder
+  (testing ":review/invalid-convergence-config is not the raw missing-key placeholder"
+    ;; If the key were absent, messages/t returns the keyword or a fallback sentinel.
+    ;; A real string value confirms the catalog is wired up correctly.
+    (is (not (keyword? (messages/ts :review/invalid-convergence-config))))))
+
 (comment
   ;; REPL smoke-test
   (valid? {:review/warning-churn-policy :accept-with-warnings
            :review/max-warning-only-cycles 2})   ;; => true
   (valid? {:review/warning-churn-policy :bad :review/max-warning-only-cycles 0}) ;; => false
-  (phase-config/defaults-for :review))
+  (phase-config/defaults-for :review)
+  (messages/ts :review/invalid-convergence-config))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
@@ -23,7 +23,7 @@
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]
    [ai.miniforge.phase-software-factory.messages :as messages]
-   [ai.miniforge.phase-software-factory.review :as review]
+   [ai.miniforge.phase-software-factory.review-convergence :as rconv]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -31,7 +31,7 @@
 
 (def ^:private schema
   "Direct var access to the private schema for white-box validation tests."
-  #'ai.miniforge.phase-software-factory.review/ReviewConvergenceConfigSchema)
+  #'ai.miniforge.phase-software-factory.review-convergence/ReviewConvergenceConfigSchema)
 
 (defn- valid?
   "Returns true when the candidate map satisfies the convergence schema."
@@ -43,11 +43,11 @@
 
 (deftest test-default-warning-churn-policy-value
   (testing "default policy is :accept-with-warnings"
-    (is (= :accept-with-warnings review/default-warning-churn-policy))))
+    (is (= :accept-with-warnings rconv/default-warning-churn-policy))))
 
 (deftest test-default-max-warning-only-cycles-value
   (testing "default max cycles is 2"
-    (is (= 2 review/default-max-warning-only-cycles))))
+    (is (= 2 rconv/default-max-warning-only-cycles))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Schema validation tests
@@ -100,13 +100,13 @@
 (deftest test-defaults-edn-policy-matches-constant
   (testing "defaults.edn :review/warning-churn-policy matches the fallback constant"
     (let [cfg (phase-config/defaults-for :review)]
-      (is (= review/default-warning-churn-policy
+      (is (= rconv/default-warning-churn-policy
              (:review/warning-churn-policy cfg))))))
 
 (deftest test-defaults-edn-cycle-count-matches-constant
   (testing "defaults.edn :review/max-warning-only-cycles matches the fallback constant"
     (let [cfg (phase-config/defaults-for :review)]
-      (is (= review/default-max-warning-only-cycles
+      (is (= rconv/default-max-warning-only-cycles
              (:review/max-warning-only-cycles cfg))))))
 
 ;; System-locale message catalog tests

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
@@ -113,15 +113,16 @@
 
 (deftest test-system-catalog-has-invalid-convergence-config-key
   (testing "system.edn exposes :review/invalid-convergence-config for startup errors"
-    (let [msg (messages/ts :review/invalid-convergence-config)]
+    ;; create-translator falls back to `(name k)` for a missing key, so a
+    ;; bare string/pos? check passes even when the catalog entry is absent.
+    ;; Assert the resolved message DIFFERS from that fallback to actually
+    ;; prove the resource is wired.
+    (let [msg      (messages/ts :review/invalid-convergence-config)
+          fallback (name :review/invalid-convergence-config)]
       (is (string? msg))
-      (is (pos? (count msg))))))
-
-(deftest test-system-message-is-not-raw-placeholder
-  (testing ":review/invalid-convergence-config is not the raw missing-key placeholder"
-    ;; If the key were absent, messages/t returns the keyword or a fallback sentinel.
-    ;; A real string value confirms the catalog is wired up correctly.
-    (is (not (keyword? (messages/ts :review/invalid-convergence-config))))))
+      (is (pos? (count msg)))
+      (is (not= fallback msg)
+          "message equals the (name k) fallback — catalog entry is missing"))))
 
 (comment
   ;; REPL smoke-test

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
@@ -1,0 +1,116 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-software-factory.review-convergence-config-test
+  "Tests for review convergence policy config — named constants, Malli schema,
+   and defaults loaded from resources/config/phase/defaults.edn."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as m]
+   [ai.miniforge.phase-software-factory.review :as review]
+   [ai.miniforge.phase-software-factory.phase-config :as phase-config]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers and var-access
+
+(def ^:private schema
+  "Direct var access to the private schema for white-box validation tests."
+  #'ai.miniforge.phase-software-factory.review/ReviewConvergenceConfigSchema)
+
+(defn- valid?
+  "Returns true when the candidate map satisfies the convergence schema."
+  [candidate]
+  (m/validate @schema candidate))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Named-constant tests
+
+(deftest test-default-warning-churn-policy-value
+  (testing "default policy is :accept-with-warnings"
+    (is (= :accept-with-warnings review/default-warning-churn-policy))))
+
+(deftest test-default-max-warning-only-cycles-value
+  (testing "default max cycles is 2"
+    (is (= 2 review/default-max-warning-only-cycles))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Schema validation tests
+
+(deftest test-schema-accepts-valid-accept-with-warnings
+  (testing "given :accept-with-warnings policy and positive cycle count → valid"
+    (is (valid? {:review/warning-churn-policy  :accept-with-warnings
+                 :review/max-warning-only-cycles 2}))))
+
+(deftest test-schema-accepts-valid-needs-decomposition
+  (testing "given :needs-decomposition policy and positive cycle count → valid"
+    (is (valid? {:review/warning-churn-policy  :needs-decomposition
+                 :review/max-warning-only-cycles 1}))))
+
+(deftest test-schema-rejects-unknown-policy
+  (testing "given an unknown policy keyword → invalid"
+    (is (not (valid? {:review/warning-churn-policy  :unknown-policy
+                      :review/max-warning-only-cycles 2})))))
+
+(deftest test-schema-rejects-zero-cycle-count
+  (testing "given max-warning-only-cycles = 0 → invalid (min is 1)"
+    (is (not (valid? {:review/warning-churn-policy  :accept-with-warnings
+                      :review/max-warning-only-cycles 0})))))
+
+(deftest test-schema-rejects-negative-cycle-count
+  (testing "given max-warning-only-cycles < 0 → invalid"
+    (is (not (valid? {:review/warning-churn-policy  :accept-with-warnings
+                      :review/max-warning-only-cycles -1})))))
+
+(deftest test-schema-rejects-string-policy
+  (testing "given a string instead of a keyword for the policy → invalid"
+    (is (not (valid? {:review/warning-churn-policy  "accept-with-warnings"
+                      :review/max-warning-only-cycles 2})))))
+
+;; EDN config round-trip
+
+(deftest test-defaults-edn-provides-convergence-keys
+  (testing "defaults.edn :review map includes both convergence keys"
+    (let [cfg (phase-config/defaults-for :review)]
+      (is (contains? cfg :review/warning-churn-policy))
+      (is (contains? cfg :review/max-warning-only-cycles)))))
+
+(deftest test-defaults-edn-convergence-keys-are-valid
+  (testing "given convergence keys from defaults.edn → schema validates"
+    (let [cfg (phase-config/defaults-for :review)
+          candidate (select-keys cfg [:review/warning-churn-policy
+                                      :review/max-warning-only-cycles])]
+      (is (valid? candidate)))))
+
+(deftest test-defaults-edn-policy-matches-constant
+  (testing "defaults.edn :review/warning-churn-policy matches the fallback constant"
+    (let [cfg (phase-config/defaults-for :review)]
+      (is (= review/default-warning-churn-policy
+             (:review/warning-churn-policy cfg))))))
+
+(deftest test-defaults-edn-cycle-count-matches-constant
+  (testing "defaults.edn :review/max-warning-only-cycles matches the fallback constant"
+    (let [cfg (phase-config/defaults-for :review)]
+      (is (= review/default-max-warning-only-cycles
+             (:review/max-warning-only-cycles cfg))))))
+
+(comment
+  ;; REPL smoke-test
+  (valid? {:review/warning-churn-policy :accept-with-warnings
+           :review/max-warning-only-cycles 2})   ;; => true
+  (valid? {:review/warning-churn-policy :bad :review/max-warning-only-cycles 0}) ;; => false
+  (phase-config/defaults-for :review))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -26,7 +26,8 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
-   [ai.miniforge.phase-software-factory.review :as review]
+   [ai.miniforge.phase-software-factory.review]
+   [ai.miniforge.phase-software-factory.review-convergence :as rconv]
    [ai.miniforge.phase-software-factory.implement]))
 
 (def phase-test-config-resource
@@ -513,7 +514,7 @@
           "absolute ceiling overrides progress"))))
 
 (deftest no-progress-streak-unit-test
-  (let [streak @#'review/no-progress-streak]
+  (let [streak @#'rconv/no-progress-streak]
     (testing "shrinking every cycle = 0 streak"
       (is (= 0 (streak [3 2 1])))
       (is (= 0 (streak [5 4]))))
@@ -527,7 +528,7 @@
       (is (= 0 (streak []))))))
 
 (deftest compute-needs-decomposition?-progress-aware-unit-test
-  (let [nd @#'review/compute-needs-decomposition?]
+  (let [nd @#'rconv/compute-needs-decomposition?]
     ;; args: blocked? stagnated? no-progress-streak cycle-count max-no-progress absolute-max
     (testing "streak below the cap does not decompose (still converging)"
       (is (false? (nd true false 0 3 3 6)))
@@ -614,7 +615,7 @@
             tag-set must enumerate it. Coverage here pins the public
             surface so a rename can't silently slip past."
     ;; Read the private var via the var; the resolved value is the set.
-    (let [verdicts @#'review/verdicts]
+    (let [verdicts @#'rconv/verdicts]
       (is (contains? verdicts :review/backend-timeout))
       (is (contains? verdicts :approved))
       (is (contains? verdicts :accept-with-warnings))
@@ -708,7 +709,7 @@
 
 (deftest classify-rejection-cause-warning-only-increments-count
   (testing "warning-only rejection increments the prior count"
-    (let [classify #'review/classify-rejection-cause
+    (let [classify #'rconv/classify-rejection-cause
           artifact {:review/decision        :changes-requested
                     :review/blocking-issues []
                     :review/warnings        [warning-only-issue]}
@@ -716,7 +717,7 @@
       (is (= :warning-churn (:cause/type result)))
       (is (= 1 (:warning-only-count result)))))
   (testing "increments from a non-zero prior"
-    (let [classify #'review/classify-rejection-cause
+    (let [classify #'rconv/classify-rejection-cause
           artifact {:review/decision        :changes-requested
                     :review/blocking-issues []
                     :review/warnings        [warning-only-issue]}
@@ -726,7 +727,7 @@
 
 (deftest classify-rejection-cause-blocking-resets-count
   (testing "blocking defect resets the warning-only count to 0"
-    (let [classify #'review/classify-rejection-cause
+    (let [classify #'rconv/classify-rejection-cause
           artifact {:review/decision        :changes-requested
                     :review/blocking-issues [{:severity :blocking
                                               :description "Missing require"}]
@@ -739,19 +740,19 @@
 
 (deftest compute-warning-churn-below-cap-returns-false
   (testing "warning-only-count below cap → not churn yet"
-    (let [pred #'review/compute-warning-churn?]
+    (let [pred #'rconv/compute-warning-churn?]
       (is (not (pred :warning-churn count-below-cap default-cap))
           "count 1 with cap 2 must not trip the policy"))))
 
 (deftest compute-warning-churn-at-cap-returns-true
   (testing "warning-only-count at cap → churn fires"
-    (let [pred #'review/compute-warning-churn?]
+    (let [pred #'rconv/compute-warning-churn?]
       (is (pred :warning-churn count-at-cap default-cap)
           "count 2 with cap 2 must trip the policy"))))
 
 (deftest compute-warning-churn-blocking-cause-returns-false
   (testing "blocking-defect cause never trips warning-churn even at or above cap"
-    (let [pred #'review/compute-warning-churn?]
+    (let [pred #'rconv/compute-warning-churn?]
       (is (not (pred :blocking-defect count-at-cap default-cap))
           "blocking-defect must not be churn regardless of count"))))
 
@@ -837,5 +838,5 @@
 (deftest accept-with-warnings-is-in-canonical-verdict-set
   (testing ":accept-with-warnings is declared in the verdicts set so the FSM
             can recognise it without an IllegalArgumentException from case"
-    (let [verdicts @#'review/verdicts]
+    (let [verdicts @#'rconv/verdicts]
       (is (contains? verdicts :accept-with-warnings)))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -545,6 +545,7 @@
     (let [verdicts @#'review/verdicts]
       (is (contains? verdicts :review/backend-timeout))
       (is (contains? verdicts :approved))
+      (is (contains? verdicts :accept-with-warnings))
       (is (contains? verdicts :exhausted))
       (is (contains? verdicts :stagnated))
       (is (contains? verdicts :needs-decomposition))
@@ -576,3 +577,193 @@
           "anomaly :message preserves the actual adaptive-timeout text the
            operator needs (stream-idle / stagnation / etc.) — not just a
            generic catalog string"))))
+
+;; ============================================================================
+;; Warning-churn tracking — classify-rejection-cause + compute-warning-churn?
+;;
+;; When the reviewer emits only warnings (no blocking issues) for
+;; max-warning-only-cycles consecutive cycles the churn policy fires.
+;; The default policy (:accept-with-warnings) lets the phase succeed with
+;; unresolved warnings attached; the :needs-decomposition policy terminates.
+;;
+;; With the default cap of 2:
+;;   cycle 1: warning-only → count=1, (>= 1 2) = false → :repair-requested
+;;   cycle 2: warning-only → count=2, (>= 2 2) = true  → policy verdict
+;; ============================================================================
+
+(def ^:private warning-only-issue
+  "Review issue that is only a warning (non-blocking)."
+  {:severity :warning :description "Style nit: prefer cond over nested if"})
+
+(def ^:private default-cap
+  "Matches `default-max-warning-only-cycles` in review.clj."
+  2)
+
+(def ^:private count-below-cap
+  "Warning-only-count for cycle 1 — one short of default cap."
+  1)
+
+(def ^:private count-at-cap
+  "Warning-only-count for cycle 2 — exactly at default cap."
+  2)
+
+(defn- run-leave-review-warning-only
+  "Run leave-review with a warning-only reviewer output.
+   `prior-warning-cycles` seeds [:execution :review-warning-only-cycles].
+   Returns the resulting full context."
+  [{:keys [prior-warning-cycles iterations max-iterations]
+    :or   {prior-warning-cycles 0
+           iterations           first-iteration
+           max-iterations       default-max-iterations}}]
+  (let [result {:output  {:review/decision :changes-requested
+                          :review/blocking-issues []
+                          :review/warnings [warning-only-issue]}
+                :metrics {:tokens mock-token-count :duration-ms mock-duration-ms}}
+        ctx {:phase     {:started-at (- (System/currentTimeMillis) mock-elapsed-ms)
+                         :iterations iterations
+                         :budget     {:iterations max-iterations}
+                         :result     result}
+             :phase-config {:phase :review}
+             :execution {:review-fingerprints    []
+                         :review-warning-only-cycles prior-warning-cycles}
+             :execution/phase-results {}
+             :execution/input {:description "test task"}
+             :execution/metrics {}}
+        interceptor (phase/get-phase-interceptor {:phase :review})]
+    ((:leave interceptor) ctx)))
+
+;;------------------------------------------------------------------------------ classify-rejection-cause
+
+(deftest classify-rejection-cause-warning-only-increments-count
+  (testing "warning-only rejection increments the prior count"
+    (let [classify #'review/classify-rejection-cause
+          artifact {:review/decision        :changes-requested
+                    :review/blocking-issues []
+                    :review/warnings        [warning-only-issue]}
+          result   (classify artifact 0)]
+      (is (= :warning-churn (:cause/type result)))
+      (is (= 1 (:warning-only-count result)))))
+  (testing "increments from a non-zero prior"
+    (let [classify #'review/classify-rejection-cause
+          artifact {:review/decision        :changes-requested
+                    :review/blocking-issues []
+                    :review/warnings        [warning-only-issue]}
+          result   (classify artifact 1)]
+      (is (= :warning-churn (:cause/type result)))
+      (is (= 2 (:warning-only-count result))))))
+
+(deftest classify-rejection-cause-blocking-resets-count
+  (testing "blocking defect resets the warning-only count to 0"
+    (let [classify #'review/classify-rejection-cause
+          artifact {:review/decision        :changes-requested
+                    :review/blocking-issues [{:severity :blocking
+                                              :description "Missing require"}]
+                    :review/warnings        []}
+          result   (classify artifact 3)]
+      (is (= :blocking-defect (:cause/type result)))
+      (is (= 0 (:warning-only-count result))))))
+
+;;------------------------------------------------------------------------------ compute-warning-churn?
+
+(deftest compute-warning-churn-below-cap-returns-false
+  (testing "warning-only-count below cap → not churn yet"
+    (let [pred #'review/compute-warning-churn?]
+      (is (not (pred :warning-churn count-below-cap default-cap))
+          "count 1 with cap 2 must not trip the policy"))))
+
+(deftest compute-warning-churn-at-cap-returns-true
+  (testing "warning-only-count at cap → churn fires"
+    (let [pred #'review/compute-warning-churn?]
+      (is (pred :warning-churn count-at-cap default-cap)
+          "count 2 with cap 2 must trip the policy"))))
+
+(deftest compute-warning-churn-blocking-cause-returns-false
+  (testing "blocking-defect cause never trips warning-churn even at or above cap"
+    (let [pred #'review/compute-warning-churn?]
+      (is (not (pred :blocking-defect count-at-cap default-cap))
+          "blocking-defect must not be churn regardless of count"))))
+
+;;------------------------------------------------------------------------------ first warning-only cycle → still repairs
+
+(deftest first-warning-only-rejection-still-redirects
+  (testing "first warning-only rejection (count=1 < cap=2) emits :repair-requested
+            — the policy should not fire until max-warning-only-cycles is reached"
+    (let [final-ctx (run-leave-review-warning-only {:prior-warning-cycles 0})
+          phase     (:phase final-ctx)]
+      (is (= :repair-requested (:verdict phase))
+          "first warning-only cycle must still redirect to implement")
+      (is (= 1 (get-in final-ctx [:execution :review-warning-only-cycles]))
+          "warning cycle count persisted as 1 after first warning-only review"))))
+
+;;------------------------------------------------------------------------------ second warning-only cycle → accept-with-warnings
+
+(deftest second-warning-only-rejection-emits-accept-with-warnings
+  (testing "second consecutive warning-only rejection (count=2 >= cap=2) trips the
+            default :accept-with-warnings policy — phase succeeds"
+    (let [final-ctx (run-leave-review-warning-only {:prior-warning-cycles 1})
+          phase     (:phase final-ctx)]
+      (is (= :accept-with-warnings (:verdict phase))
+          "second warning-only cycle must emit :accept-with-warnings verdict")
+      (is (= :accept-with-warnings
+             (get-in phase [:result :output :phase/verdict]))
+          ":phase/verdict on the result is what determine-phase-event reads")
+      (is (= 2 (get-in final-ctx [:execution :review-warning-only-cycles]))
+          "warning cycle count persisted as 2"))))
+
+(deftest accept-with-warnings-marks-phase-completed
+  (testing ":accept-with-warnings mark the phase as :completed
+            so the workflow can proceed to release"
+    (let [final-ctx (run-leave-review-warning-only {:prior-warning-cycles 1})
+          phase     (:phase final-ctx)]
+      (is (phase/succeeded? phase)
+          ":accept-with-warnings must succeed (not fail) — PR proceeds"))))
+
+(deftest accept-with-warnings-attaches-unresolved-warnings
+  (testing ":accept-with-warnings attaches the unresolved warnings at
+            [:phase :unresolved-warnings] so release can surface them"
+    (let [final-ctx (run-leave-review-warning-only {:prior-warning-cycles 1})
+          phase     (:phase final-ctx)]
+      (is (= [warning-only-issue] (:unresolved-warnings phase))
+          "unresolved warnings from the review artifact are attached to the phase"))))
+
+;;------------------------------------------------------------------------------ warning count persists correctly
+
+(deftest warning-cycle-count-persists-across-re-entries
+  (testing "each warning-only cycle increments the counter stored at
+            [:execution :review-warning-only-cycles]"
+    (let [ctx-after-1 (run-leave-review-warning-only {:prior-warning-cycles 0})
+          count-after-1 (get-in ctx-after-1 [:execution :review-warning-only-cycles])]
+      (is (= 1 count-after-1) "first warning-only cycle stores count=1"))
+    (let [ctx-after-2 (run-leave-review-warning-only {:prior-warning-cycles 1})
+          count-after-2 (get-in ctx-after-2 [:execution :review-warning-only-cycles])]
+      (is (= 2 count-after-2) "second warning-only cycle stores count=2"))))
+
+(deftest blocking-rejection-resets-warning-cycle-count
+  (testing "a blocking-defect rejection resets the warning-only count to 0"
+    (let [result {:output  {:review/decision        :changes-requested
+                            :review/blocking-issues [{:severity    :blocking
+                                                      :description "Missing require"}]
+                            :review/warnings        []}
+                  :metrics {:tokens mock-token-count :duration-ms mock-duration-ms}}
+          ctx {:phase     {:started-at (- (System/currentTimeMillis) mock-elapsed-ms)
+                           :iterations first-iteration
+                           :budget     {:iterations default-max-iterations}
+                           :result     result}
+               :phase-config {:phase :review}
+               :execution {:review-fingerprints        []
+                           :review-warning-only-cycles 1}
+               :execution/phase-results {}
+               :execution/input {:description "test task"}
+               :execution/metrics {}}
+          interceptor (phase/get-phase-interceptor {:phase :review})
+          final-ctx   ((:leave interceptor) ctx)]
+      (is (= 0 (get-in final-ctx [:execution :review-warning-only-cycles]))
+          "blocking defect resets the warning-only cycle counter"))))
+
+;;------------------------------------------------------------------------------ accept-with-warnings is in the verdict set
+
+(deftest accept-with-warnings-is-in-canonical-verdict-set
+  (testing ":accept-with-warnings is declared in the verdicts set so the FSM
+            can recognise it without an IllegalArgumentException from case"
+    (let [verdicts @#'review/verdicts]
+      (is (contains? verdicts :accept-with-warnings)))))


### PR DESCRIPTION
## Summary

The complete **review-redirect convergence policy** the dogfood (`review-redirect-convergence`, workflow 91557e70) built across three stacked tasks. This branch **is** the consolidated stack — its commit chain contains #1096 (config + Malli schema) → #1097 (cause-classification + warning-only cycle tracking) → #1098 (terminal cause-classified event). One squash-merge lands the whole feature.

**Supersedes #1096 and #1097** (their commits are ancestors of this branch); both closed.

### What it adds
- `:review/warning-churn-policy` + `:review/max-warning-only-cycles` config with a Malli schema, validated once at load.
- `classify-rejection-cause` — distinguishes `:warning-churn` from `:blocking-defect`; warning-only cycle tracking that survives phase re-entries.
- `:accept-with-warnings` verdict so warning-only churn stops gating release; `:review/cause` emitted on terminal review decisions for evidence/telemetry.

### Review-comment fixes (all four, across the three PRs)
- **Load validation** merges the constant fallbacks *under* `defaults.edn` before validating — a partial override (one of two keys) no longer throws the schema's both-keys requirement; an invalid *value* still fails fast.
- **`:accept-with-warnings` outcome**: `emit-phase-completed` now derives `:outcome` from the final verdict-corrected status, not the stale pre-verdict local — no more `{:outcome :failure}` on a success.
- **Catalog test** asserts the message differs from the `(name k)` translator fallback, so it fails when the entry is missing; dropped the incorrect placeholder test.
- Description now reflects the full change set.

> Note on provenance: these arrived as three PRs-vs-`main` because the release phase opens chained tasks' PRs against `main` rather than their parent branch — a presentation bug, not duplicated work. Tracked separately for a prevention fix.

## Test plan
- `review-convergence-config-test`, `review-cause-event-test`, `review-repair-loop-test` green (60 tests); `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)