### PR TITLE
feat(ci): auto-bump standards submodule and recompile policy pack

### DIFF
--- a/.github/workflows/bump-standards.yml
+++ b/.github/workflows/bump-standards.yml
@@ -55,7 +55,9 @@ jobs:
 
       - name: Update standards submodule
         run: |
-          git submodule update --remote --merge standards/miniforge
+          git -C standards/miniforge fetch origin
+          git -C standards/miniforge checkout origin/main
+          git add standards/miniforge
           NEW_SHA=$(git -C standards/miniforge rev-parse HEAD)
           echo "NEW_SHA=$NEW_SHA" >> "$GITHUB_ENV"
           echo "standards/miniforge updated to $NEW_SHA"
@@ -70,7 +72,7 @@ jobs:
           bb -e "(clojure.edn/read-string (slurp \"$PACK\"))" && echo "Pack is valid EDN"
 
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: auto/bump-standards-${{ env.NEW_SHA }}

--- a/.github/workflows/bump-standards.yml
+++ b/.github/workflows/bump-standards.yml
@@ -1,0 +1,100 @@
+# Triggered by miniforge-ai/miniforge-standards push to main via repository_dispatch.
+# Updates the standards submodule and recompiles the policy pack.
+# Requires no extra secrets beyond GITHUB_TOKEN.
+
+name: Bump Standards
+
+on:
+  repository_dispatch:
+    types: [standards-updated]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Standards SHA to pin; leave blank for latest main"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump standards submodule and recompile policy pack
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install Clojure
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: clojure-${{ runner.os }}-${{ hashFiles('deps.edn', '**/deps.edn') }}
+          restore-keys: |
+            clojure-${{ runner.os }}-
+
+      - name: Update standards submodule
+        run: |
+          git submodule update --remote --merge standards/miniforge
+          NEW_SHA=$(git -C standards/miniforge rev-parse HEAD)
+          echo "NEW_SHA=$NEW_SHA" >> "$GITHUB_ENV"
+          echo "standards/miniforge updated to $NEW_SHA"
+
+      - name: Compile policy pack
+        run: bb standards:pack
+
+      - name: Verify compiled pack
+        run: |
+          PACK=components/phase/resources/packs/miniforge-standards.pack.edn
+          [ -f "$PACK" ] || { echo "ERROR: pack not found at $PACK"; exit 1; }
+          bb -e "(clojure.edn/read-string (slurp \"$PACK\"))" && echo "Pack is valid EDN"
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: auto/bump-standards-${{ env.NEW_SHA }}
+          commit-message: |
+            chore(standards): bump standards/miniforge to ${{ env.NEW_SHA }}
+
+            Recompiled components/phase/resources/packs/miniforge-standards.pack.edn
+          title: "chore(standards): bump + recompile policy pack (${{ env.NEW_SHA }})"
+          body: |
+            ## Standards submodule bump
+
+            Triggered automatically by a push to `main` on [miniforge-ai/miniforge-standards](https://github.com/miniforge-ai/miniforge-standards) via `repository_dispatch`.
+
+            ### Changes
+
+            | File | Description |
+            |------|-------------|
+            | `standards/miniforge` | Submodule pointer advanced to `${{ env.NEW_SHA }}` |
+            | `components/phase/resources/packs/miniforge-standards.pack.edn` | Recompiled policy pack from updated standards |
+
+            ### How to review
+
+            1. Check the submodule diff to confirm the standards changes are expected.
+            2. Inspect the recompiled pack for any rule additions, removals, or severity changes.
+            3. Merge when satisfied — the branch will be deleted automatically on merge.
+          labels: automated,standards
+          delete-branch: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/bump-standards.yml` triggered by `repository_dispatch` type `standards-updated` (fired by miniforge-ai/miniforge-standards on push to main) and optionally by `workflow_dispatch` with an optional `sha` input.
- On trigger: updates the `standards/miniforge` submodule to latest main, runs `bb standards:pack` to recompile `components/phase/resources/packs/miniforge-standards.pack.edn`, verifies the output is valid EDN, then opens an auto-PR via `peter-evans/create-pull-request@v6`.
- Java/Clojure/Babashka setup and dep-cache key copied exactly from `ci.yml` for consistent cache hits.

## Security notes

- No untrusted `client_payload.*` or `github.event.inputs.*` values are interpolated into `run:` shells. `NEW_SHA` is derived from `git rev-parse HEAD` in our own shell — hex-only, not attacker-controlled.
- `workflow_dispatch` `sha` input is declared for future use (pinning) but intentionally not wired to any `run:` step in this PR.

## Test plan

- [ ] Manually trigger via `workflow_dispatch` on a branch to confirm submodule update + pack compilation succeeds.
- [ ] Verify the auto-PR opens with correct branch name `auto/bump-standards-<sha>`, correct labels, and correct body.
- [ ] Confirm dep cache is hit on second run (cache key matches ci.yml jobs).
- [ ] After miniforge-standards sends a real `repository_dispatch`, confirm end-to-end flow works without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)