### PR TITLE
fix(dag,release): stack dependent task PRs on their parent branch

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -295,6 +295,12 @@
              ;; Allow disabling PR creation via config or execution opts
              :create-pr? (or (get-in ctx [:execution/opts :create-pr?])
                              (get config :create-pr? true))
+             ;; PR base override for a dependency-chained DAG task: the DAG
+             ;; orchestrator passes the parent task's branch so this task's PR
+             ;; STACKS on the parent (base = parent branch) instead of opening
+             ;; against the default branch with a cumulative diff. Absent (root
+             ;; tasks / non-DAG runs) → executor falls back to the default branch.
+             :base-branch (get-in ctx [:execution/opts :release/base-branch])
              ;; Resolve and inject GitHub token for capsule gh CLI auth
              :github-token (resolve-github-token ctx)}
       on-chunk (assoc :on-chunk on-chunk)

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -104,17 +104,24 @@
 (defn step-create-branch [state]
   (if (failed? state)
     state
-    (let [{:keys [release-meta executor environment-id]} state
+    (let [{:keys [release-meta executor environment-id base-branch-override]} state
           branch-name (:release/branch-name release-meta)
           result (sandbox/create-branch! executor environment-id branch-name)]
-      (if (result/succeeded? result)
-        (assoc state
-               :branch (:branch result)
-               ;; An explicit override (chained DAG task's parent branch) wins
-               ;; over the detected default, so the PR stacks on the parent.
-               :base-branch (or (:base-branch-override state)
-                                (:base-branch result)))
-        (fail state :branch-create-failed (:error result))))))
+      (if-not (result/succeeded? result)
+        (fail state :branch-create-failed (:error result))
+        (let [detected (:base-branch result)
+              ;; An explicit override (chained DAG task's parent branch) wins
+              ;; over the detected default, so the PR stacks on the parent.
+              base (or base-branch-override detected)
+              ;; create-branch! fetched only origin/<detected>. When the base
+              ;; is a different parent branch, fetch it too so later
+              ;; origin/<base> range diffs / commits-ahead and the PR
+              ;; merge-base resolve rather than failing on a missing ref.
+              fetch-r (when (and base-branch-override (not= base-branch-override detected))
+                        (sandbox/fetch-branch! executor environment-id base-branch-override))]
+          (if (and fetch-r (not (result/succeeded? fetch-r)))
+            (fail state :base-branch-fetch-failed (:error fetch-r))
+            (assoc state :branch (:branch result) :base-branch base)))))))
 
 (defn step-stage-dirty-files
   "Stage all dirty files in the executor environment.

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -110,7 +110,10 @@
       (if (result/succeeded? result)
         (assoc state
                :branch (:branch result)
-               :base-branch (:base-branch result))
+               ;; An explicit override (chained DAG task's parent branch) wins
+               ;; over the detected default, so the PR stacks on the parent.
+               :base-branch (or (:base-branch-override state)
+                                (:base-branch result)))
         (fail state :branch-create-failed (:error result))))))
 
 (defn step-stage-dirty-files
@@ -645,6 +648,12 @@
                                :artifact-store (:artifact-store context)
                                :context context
                                :create-pr? (get context :create-pr? true)
+                               ;; Explicit PR base override (a dependency-chained
+                               ;; DAG task's parent branch). When present it wins
+                               ;; over the branch-creation default so the PR
+                               ;; stacks on the parent; diff/commits-ahead ranges
+                               ;; key off it too, yielding this task's own layer.
+                               :base-branch-override (:base-branch context)
                                :releaser (:releaser opts)
                                :task-description (get-in workflow-state [:workflow/spec :spec/description])
                                :code-artifacts (extract-code-artifacts workflow-artifacts)

--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -142,6 +142,15 @@
       (result/shell-failure (str "Failed to fetch: " (:error fetch-r)) {:branch nil})
       (try-checkout-branch executor env-id branch-name default-branch))))
 
+(defn fetch-branch!
+  "Fetch origin/<branch> into the sandbox. `create-branch!` fetches only the
+   detected default; when a stacked-PR base is a parent task's branch, this
+   pulls it so later `origin/<base>` range diffs / commits-ahead and the PR
+   merge-base resolve instead of failing on a missing remote-tracking ref.
+   Returns a shell-result."
+  [executor env-id branch]
+  (exec! executor env-id (str "git fetch origin " branch)))
+
 (defn commits-ahead-of-base
   "Count commits HEAD has added since branching from `origin/<base>`.
    Counts against the merge-base (`origin/<base>...HEAD`, three-dot

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -292,3 +292,31 @@
                     :release-meta test-release-meta}
           result   (core/step-create-branch state)]
       (is (= "main" (:base-branch result))))))
+
+(deftest step-create-branch-fetches-override-branch
+  (testing "when stacking on a parent branch, the override branch is fetched
+            (create-branch! only fetched the default) so later origin/<base>
+            range diffs and the PR merge-base resolve"
+    (let [[exec commands] (create-mock-executor :responses detects-main-branch)
+          state    {:executor exec :environment-id "mock-env"
+                    :release-meta test-release-meta
+                    :base-branch-override "mf/parent-task"}
+          result   (core/step-create-branch state)]
+      (is (not (core/failed? result)))
+      (is (= "mf/parent-task" (:base-branch result)))
+      (is (some #(clojure.string/includes? (str %) "fetch origin mf/parent-task") @commands)
+          "the parent branch was fetched"))))
+
+(deftest step-create-branch-fails-when-override-fetch-fails
+  (testing "an unfetchable parent branch fails the step fast — the stacked PR
+            base would be unresolvable, so don't proceed silently"
+    (let [[exec _] (create-mock-executor
+                    :responses (merge detects-main-branch
+                                      {"fetch origin mf/parent-task"
+                                       {:exit-code 1 :stdout "" :stderr "no such ref"}}))
+          state    {:executor exec :environment-id "mock-env"
+                    :release-meta test-release-meta
+                    :base-branch-override "mf/parent-task"}
+          result   (core/step-create-branch state)]
+      (is (core/failed? result))
+      (is (= :base-branch-fetch-failed (:type (:failure result)))))))

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -265,3 +265,30 @@
                   {:release-meta test-release-meta})]
       ;; The pipeline should succeed and create a PR
       (is (:success? result)))))
+
+;; ============================================================================
+;; Stacked-PR base: a chained DAG task's parent-branch override wins
+;; ============================================================================
+
+(def ^:private detects-main-branch
+  "Mock executor responses so detect-default-branch resolves to 'main'."
+  {"symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}})
+
+(deftest step-create-branch-prefers-base-branch-override
+  (testing "an explicit base-branch-override (chained DAG task's parent branch)
+            wins over the executor-detected default, so the PR stacks on the
+            parent and diff/commits-ahead range off it"
+    (let [[exec _] (create-mock-executor :responses detects-main-branch)
+          state    {:executor exec :environment-id "mock-env"
+                    :release-meta test-release-meta
+                    :base-branch-override "mf/parent-task"}
+          result   (core/step-create-branch state)]
+      (is (= "mf/parent-task" (:base-branch result))
+          "override wins over the detected 'main'")))
+
+  (testing "absent override → executor-detected default branch (root task / non-DAG)"
+    (let [[exec _] (create-mock-executor :responses detects-main-branch)
+          state    {:executor exec :environment-id "mock-env"
+                    :release-meta test-release-meta}
+          result   (core/step-create-branch state)]
+      (is (= "main" (:base-branch result))))))

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -1166,6 +1166,11 @@
        (get-in context [:execution/opts :event-stream])
        (assoc :event-stream (get-in context [:execution/opts :event-stream]))
        resolved-branch (assoc :branch resolved-branch)
+       ;; Same resolved base drives the task's release PR base, so a
+       ;; dependency-chained task's PR STACKS on its parent's branch instead
+       ;; of opening against the default branch with a cumulative diff. Root
+       ;; tasks resolve to the spec branch → base unchanged.
+       resolved-branch (assoc :release/base-branch resolved-branch)
        merge-anomaly  (assoc :dag/merge-anomaly merge-anomaly)))))
 
 ;--- Layer 1: Mini-Workflow Execution

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -246,6 +246,23 @@
       (is (= "task-a" (:branch opts))
           "single-dep base resolves to the dep's branch, NOT the spec branch"))))
 
+(deftest task-sub-opts-release-base-branch-mirrors-resolved-branch-test
+  (testing "the release PR base equals the resolved fork base, so a chained
+            task's PR STACKS on its parent (base = parent branch) while a
+            root task bases on the spec branch. Prevents the
+            chained-task-PRs-vs-main duplication."
+    (let [root  (dag-orch/task-sub-opts (registry-context {} "feat/spec")
+                                        (make-task-def id-a "A"))
+          child (dag-orch/task-sub-opts (registry-context {id-a {:branch "task-a"}} "main")
+                                        (make-task-def id-b "B" #{id-a}))]
+      (is (= "feat/spec" (:release/base-branch root))
+          "root task's PR bases on the spec branch (unchanged)")
+      (is (= (:branch root) (:release/base-branch root))
+          "release base mirrors the worktree fork base")
+      (is (= "task-a" (:release/base-branch child))
+          "chained task's PR bases on the parent's branch (stacked, not main)")
+      (is (= (:branch child) (:release/base-branch child))))))
+
 (deftest task-sub-opts-single-dep-unregistered-falls-back-test
   (testing "single dep not yet registered: fall back to default branch.
             Defensive: scheduler shouldn't allow this in practice (deps


### PR DESCRIPTION
## Summary

Prevents the recurrence behind #1096/#1097/#1098. The DAG **did** chain those tasks correctly — worktrees forked from parent branches, so the commit branches were a clean additive stack (`#1096 ⊂ #1097 ⊂ #1098`). The bug was downstream: the release phase opened **every** task's PR against the default branch, so a linear chain surfaced as N PRs-vs-`main` with cumulative diffs that read as conflicting duplicates and couldn't be merged independently.

Fix: the release PR base now equals the **same branch the worktree forked from** (`resolve-task-base-branch`).
- **Root tasks** resolve to the spec branch → base unchanged (`main`).
- **Dependency-chained tasks** base their PR on the **parent's branch** — a true stacked PR whose diff shows only that task's own layer, and whose `diff`/`commits-ahead` ranges key off the parent too.

### Changes
- `dag-orchestrator/task-sub-opts` — pass the resolved base as `:release/base-branch` alongside the existing `:branch`.
- `release/build-executor-context` — read `:execution/opts :release/base-branch`.
- `release-executor` — carry it as `:base-branch-override`; `step-create-branch` prefers it over the executor-detected default.

Additive: when the resolved base is the spec branch (roots, non-DAG runs), behavior is unchanged.

## Test plan
- `dag-orchestrator-test`: `:release/base-branch` mirrors the resolved `:branch` — spec branch for a root, parent branch for a single-dep child.
- `release-executor` `core-sandbox-test`: `step-create-branch` prefers `:base-branch-override` over the detected default; absent → default.
- `bb pre-commit` green.

> Follow-up (smaller, separate): the dag-result `:pr-infos :deps` field is emitted empty — fix it to carry the real task deps (it's what first masked this diagnosis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)