### PR TITLE
feat(release): YAML provenance frontmatter on autonomous PRs

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -90,10 +90,7 @@
         execution-opts (cond-> {}
                          (:worktree opts) (assoc :worktree-path (:worktree opts)))
         parsed-spec (-> (spec-parser/parse-spec-file spec-path)
-                        (assoc :spec/source-dir source-dir)
-                        ;; Carry the spec path through to the PR provenance
-                        ;; frontmatter so a PR maps back to its source spec.
-                        (assoc :spec/path spec-path))
+                        (assoc :spec/source-dir source-dir))
         validation  (spec-parser/validate-spec parsed-spec)
         runner-opts (cond-> {:output :pretty :quiet false}
                       (:backend opts)         (assoc :backend (:backend opts))
@@ -107,7 +104,11 @@
         nil)
       (do
         (display/print-info (messages/t :run/running-workflow {:title (:spec/title parsed-spec)}))
-        (workflow-runner/run-workflow-from-spec! parsed-spec runner-opts)))))
+        ;; Attach the spec path AFTER validation (it's runtime provenance, not
+        ;; part of the validated spec contract) so it reaches the PR frontmatter
+        ;; without tripping the SpecPayload schema.
+        (workflow-runner/run-workflow-from-spec!
+         (assoc parsed-spec :spec/path spec-path) runner-opts)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Run command

--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -90,7 +90,10 @@
         execution-opts (cond-> {}
                          (:worktree opts) (assoc :worktree-path (:worktree opts)))
         parsed-spec (-> (spec-parser/parse-spec-file spec-path)
-                        (assoc :spec/source-dir source-dir))
+                        (assoc :spec/source-dir source-dir)
+                        ;; Carry the spec path through to the PR provenance
+                        ;; frontmatter so a PR maps back to its source spec.
+                        (assoc :spec/path spec-path))
         validation  (spec-parser/validate-spec parsed-spec)
         runner-opts (cond-> {:output :pretty :quiet false}
                       (:backend opts)         (assoc :backend (:backend opts))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -151,7 +151,10 @@
           :sandbox (:spec/sandbox enriched-spec)
           :context (:spec/context enriched-spec)
           :metadata (:spec/metadata enriched-spec)
-          :provenance (:spec/provenance enriched-spec)}))
+          :provenance (:spec/provenance enriched-spec)
+          ;; Spec source path → PR provenance frontmatter (deterministic
+          ;; PR → spec mapping).
+          :spec/path (:spec/path enriched-spec)}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Context decoration

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -301,6 +301,14 @@
              ;; against the default branch with a cumulative diff. Absent (root
              ;; tasks / non-DAG runs) → executor falls back to the default branch.
              :base-branch (get-in ctx [:execution/opts :release/base-branch])
+             ;; PR provenance → rendered as YAML frontmatter on the PR body so
+             ;; a PR maps deterministically back to its workflow run + spec.
+             ;; :workflow is the PARENT run id for a DAG sub-task (shared across
+             ;; the run's PRs) else this run's id; :task distinguishes DAG tasks.
+             :provenance {:workflow (or (get-in ctx [:execution/input :workflow/parent-id])
+                                        (get-in ctx [:execution/id]))
+                          :spec     (get-in ctx [:execution/input :spec/path])
+                          :task     (get-in ctx [:execution/input :task/id])}
              ;; Resolve and inject GitHub token for capsule gh CLI auth
              :github-token (resolve-github-token ctx)}
       on-chunk (assoc :on-chunk on-chunk)

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -254,6 +254,31 @@
         state
         (fail state :push-failed (:error result))))))
 
+(defn provenance-frontmatter
+  "YAML frontmatter mapping a PR back to its workflow run + spec. Built from
+   state's :provenance ({:workflow :spec :task}) + :commit-sha. Always emits
+   `generated-by: miniforge` (authorship) plus whatever provenance is present.
+   Visible in the rendered PR — human-readable AND deterministically parsable
+   (fixed position, explicit `---` delimiters, rigid key: value)."
+  [{:keys [provenance commit-sha]}]
+  (let [{:keys [workflow spec task]} provenance
+        rows (cond-> []
+               workflow   (conj (str "miniforge-workflow: " workflow))
+               spec       (conj (str "spec: " spec))
+               task       (conj (str "task: " task))
+               commit-sha (conj (str "commit: " commit-sha))
+               :always    (conj "generated-by: miniforge"))]
+    (str "---\n" (str/join "\n" rows) "\n---\n\n")))
+
+(defn with-provenance
+  "Prepend the provenance frontmatter to a PR body. Idempotent: a body that
+   already opens with a `---` frontmatter block is returned unchanged."
+  [body state]
+  (let [body (str body)]
+    (if (str/starts-with? body "---\n")
+      body
+      (str (provenance-frontmatter state) body))))
+
 (defn step-create-pr [state]
   (cond
     (failed? state) state
@@ -262,7 +287,7 @@
     (let [{:keys [release-meta base-branch executor environment-id]} state
           result (sandbox/create-pr! executor environment-id
                                      {:title (:release/pr-title release-meta)
-                                      :body (:release/pr-body release-meta)
+                                      :body (with-provenance (:release/pr-body release-meta) state)
                                       :base-branch base-branch}
                                      (gh-exec-opts state))]
       (if (result/succeeded? result)
@@ -494,7 +519,9 @@
     :else
     (let [{:keys [release-meta pr-number executor environment-id logger
                   code-artifacts workflow-data]} state
-          body (render-pr-body-fallback release-meta code-artifacts workflow-data)]
+          body (with-provenance
+                (render-pr-body-fallback release-meta code-artifacts workflow-data)
+                state)]
       (try
         (sandbox/edit-pr-body! executor environment-id
                                pr-number body
@@ -661,6 +688,9 @@
                                ;; stacks on the parent; diff/commits-ahead ranges
                                ;; key off it too, yielding this task's own layer.
                                :base-branch-override (:base-branch context)
+                               ;; PR provenance ({:workflow :spec :task}) →
+                               ;; rendered as YAML frontmatter on the PR body.
+                               :provenance (:provenance context)
                                :releaser (:releaser opts)
                                :task-description (get-in workflow-state [:workflow/spec :spec/description])
                                :code-artifacts (extract-code-artifacts workflow-artifacts)

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -267,7 +267,7 @@
                spec       (conj (str "spec: " spec))
                task       (conj (str "task: " task))
                commit-sha (conj (str "commit: " commit-sha))
-               :always    (conj "generated-by: miniforge"))]
+               true       (conj "generated-by: miniforge"))]
     (str "---\n" (str/join "\n" rows) "\n---\n\n")))
 
 (defn with-provenance

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -320,3 +320,38 @@
           result   (core/step-create-branch state)]
       (is (core/failed? result))
       (is (= :base-branch-fetch-failed (:type (:failure result)))))))
+
+;; ============================================================================
+;; PR provenance frontmatter — deterministic PR → workflow + spec mapping
+;; ============================================================================
+
+(deftest provenance-frontmatter-renders-yaml
+  (testing "frontmatter carries workflow + spec + task + commit + generated-by"
+    (let [fm (core/provenance-frontmatter
+              {:provenance {:workflow "adhoc--123" :spec "work/x.spec.edn" :task "t-1"}
+               :commit-sha "abc1234"})]
+      (is (clojure.string/starts-with? fm "---\n"))
+      (is (clojure.string/includes? fm "miniforge-workflow: adhoc--123"))
+      (is (clojure.string/includes? fm "spec: work/x.spec.edn"))
+      (is (clojure.string/includes? fm "task: t-1"))
+      (is (clojure.string/includes? fm "commit: abc1234"))
+      (is (clojure.string/includes? fm "generated-by: miniforge"))
+      (is (clojure.string/includes? fm "\n---\n\n")))))
+
+(deftest provenance-frontmatter-omits-absent-fields
+  (testing "absent spec/task/commit omitted; workflow + generated-by remain"
+    (let [fm (core/provenance-frontmatter {:provenance {:workflow "run-1"} :commit-sha nil})]
+      (is (clojure.string/includes? fm "miniforge-workflow: run-1"))
+      (is (not (clojure.string/includes? fm "spec:")))
+      (is (not (clojure.string/includes? fm "task:")))
+      (is (not (clojure.string/includes? fm "commit:")))
+      (is (clojure.string/includes? fm "generated-by: miniforge")))))
+
+(deftest with-provenance-prepends-and-is-idempotent
+  (testing "prepends frontmatter to a plain body"
+    (let [out (core/with-provenance "## Summary\nbody" {:provenance {:workflow "r1"} :commit-sha "c1"})]
+      (is (clojure.string/starts-with? out "---\n"))
+      (is (clojure.string/includes? out "## Summary"))))
+  (testing "does not double-prepend when the body already opens with frontmatter"
+    (let [already "---\nminiforge-workflow: x\n---\n\nbody"]
+      (is (= already (core/with-provenance already {:provenance {:workflow "r1"}}))))))

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -241,22 +241,33 @@
    The task description becomes the spec description, and the task itself
    is passed as the plan (single-task plan) so the implement phase can
    pick it up directly. Includes task title and acceptance criteria for
-   use by the release phase (PR title/body)."
-  [task-def]
-  (cond-> {:title (:task/description task-def "Implement task")
-           :description (:task/description task-def "Implement task")
-           :task/type (:task/type task-def :implement)
-           :task/acceptance-criteria (:task/acceptance-criteria task-def [])
-           :task/id (:task/id task-def)
-           ;; Provide the task as a single-task plan so the implement phase
-           ;; receives it without needing another plan phase
-           :plan/tasks [{:task/id (random-uuid)
-                         :task/description (:task/description task-def "Implement task")
-                         :task/type (:task/type task-def :implement)}]}
-    (:task/exclusive-files task-def)
-    (assoc :files-in-scope (:task/exclusive-files task-def))
-    (:task/component task-def)
-    (assoc :task/component (:task/component task-def))))
+   use by the release phase (PR title/body).
+
+   The 2-arity form threads PR-provenance from the orchestrator context: a
+   sub-task's PR frontmatter shares the parent RUN's id and spec path (so all
+   PRs from one workflow map back to it), distinguished by :task/id."
+  ([task-def] (task-sub-input task-def nil))
+  ([task-def context]
+   (cond-> {:title (:task/description task-def "Implement task")
+            :description (:task/description task-def "Implement task")
+            :task/type (:task/type task-def :implement)
+            :task/acceptance-criteria (:task/acceptance-criteria task-def [])
+            :task/id (:task/id task-def)
+            ;; Provide the task as a single-task plan so the implement phase
+            ;; receives it without needing another plan phase
+            :plan/tasks [{:task/id (random-uuid)
+                          :task/description (:task/description task-def "Implement task")
+                          :task/type (:task/type task-def :implement)}]}
+     (:task/exclusive-files task-def)
+     (assoc :files-in-scope (:task/exclusive-files task-def))
+     (:task/component task-def)
+     (assoc :task/component (:task/component task-def))
+     ;; PR provenance: parent run id + source spec, shared across the DAG's
+     ;; PRs; :task/id (above) distinguishes them.
+     (get-in context [:execution/input :spec/path])
+     (assoc :spec/path (get-in context [:execution/input :spec/path]))
+     (get context :execution/id)
+     (assoc :workflow/parent-id (get context :execution/id)))))
 
 (defn- default-spec-branch
   "Branch the orchestrator should treat as the spec's parent — the one root
@@ -1241,7 +1252,7 @@
    workflow result."
   [task-def context]
   (let [sub-workflow (task-sub-workflow task-def context)
-        sub-input    (task-sub-input task-def)
+        sub-input    (task-sub-input task-def context)
         sub-opts     (task-sub-opts context task-def)
         merge-anomaly (:dag/merge-anomaly sub-opts)]
     (if merge-anomaly

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -236,6 +236,20 @@
       (is (= "feat/spec" (:branch opts))
           "zero-dep tasks fork from the spec branch resolved off context"))))
 
+(deftest task-sub-input-threads-pr-provenance-test
+  (testing "2-arity threads the parent run id + spec path into the sub-input
+            so a DAG task's PR frontmatter maps back to its workflow + spec"
+    (let [ctx {:execution/id "parent-run-1"
+               :execution/input {:spec/path "work/x.spec.edn"}}
+          in  (dag-orch/task-sub-input (make-task-def id-a "A") ctx)]
+      (is (= "parent-run-1" (:workflow/parent-id in)))
+      (is (= "work/x.spec.edn" (:spec/path in)))
+      (is (= id-a (:task/id in)) "task id distinguishes PRs within the run")))
+  (testing "1-arity (no context) omits provenance — backward compatible"
+    (let [in (dag-orch/task-sub-input (make-task-def id-a "A"))]
+      (is (not (contains? in :workflow/parent-id)))
+      (is (not (contains? in :spec/path))))))
+
 (deftest task-sub-opts-single-dep-uses-deps-branch-test
   (testing "single dep registered: base = the dep's persisted branch.
             This is the whole point of the chaining feature — the


### PR DESCRIPTION
## Summary

Miniforge-authored PRs (e.g. #1103) carried only a "Generated by Miniforge" footer — no way to map a PR back to the **workflow run** and **spec** that produced it. This adds a visible, deterministically-parsable YAML frontmatter block at the top of every autonomous PR body:

```
---
miniforge-workflow: adhoc--445443771
spec: work/phase-transition-graph-validator.spec.edn
task: <task-uuid>
commit: <sha>
generated-by: miniforge
---
```

**Header, not footer**, chosen for parse-determinism: fixed position (offset 0), explicit `---` delimiters, rigid `key: value` — a parser reads the first block and stops, no scanning past variable body. Visible too (humans seeing it is a feature).

For a DAG sub-task, `miniforge-workflow` is the **parent run id** (shared across all the run's PRs) and `task` distinguishes them — so the 8 PRs of one dogfood all map to the same run + spec, each uniquely identified.

## Threading
- `run.clj` captures the spec path onto the parsed spec; `spec->workflow-input` carries `:spec/path` into the execution input.
- `dag-orchestrator/task-sub-input` (new 2-arity) threads the parent run id + spec path into each sub-task's input.
- `release/build-executor-context` assembles `:provenance` from ctx; the release-executor renders it via `provenance-frontmatter` / `with-provenance` (idempotent — won't double-prepend) onto both the create body and the fallback-update body.

Absent fields (non-spec or non-DAG runs) are omitted; `miniforge-workflow` + `generated-by` always emit. The existing footer is left as-is.

## Test plan
- `release-executor core-sandbox-test`: frontmatter renders all fields; omits absent ones; `with-provenance` prepends and is idempotent.
- `dag-orchestrator-test`: `task-sub-input` 2-arity threads parent run id + spec path + task id; 1-arity stays backward-compatible.
- `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)