### PR TITLE
feat(agent): observability for empty-implement diagnosis

### DIFF
--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -257,45 +257,54 @@
        (not (contains? non-substantive-paths path))
        (not (.startsWith ^String path ".miniforge/"))))
 
+(defn- source-file-count
+  "Raw vs substantive count for one collection source's result — so a diff of
+   only non-substantive files (e.g. .miniforge-session-id) reads as zero
+   substantive, not a misleading non-zero. nil-safe: count/filterv treat a
+   nil (didn't-run) source as empty."
+  [raw]
+  {:raw (count raw)
+   :substantive (count (filterv substantive-file? raw))})
+
+(defn collect-files+diagnostic
+  "Single-pass collection: resolve the substantive file diff AND a diagnostic
+   in ONE traversal of the sources, in priority order:
+   1. implementer-result :code/files (fast path)
+   2. executor collection (capsule mode)
+   3. local git-status collection (non-capsule)
+
+   Each source is probed at most once; later sources run only when earlier
+   ones return nil (preserving the short-circuit — no executor IO / git scan
+   when the result already carries files). Returns
+   `{:files <substantive vector> :diagnostic <map>}`. The diagnostic reports
+   raw vs substantive per-source counts plus the loss-mode signals
+   (pre-session-snapshot?, worktree-path, collection-mode) so an empty result
+   is debuggable without a second collection pass."
+  [input]
+  (let [from-result (files-from-result (:implementer-result input))
+        via-exec    (when (nil? from-result) (files-via-executor input))
+        via-local   (when (and (nil? from-result) (nil? via-exec))
+                      (files-via-local-snapshot input))
+        ;; nil when every source returned nil — filterv handles it, no (or … []).
+        raw         (or from-result via-exec via-local)]
+    {:files (filterv substantive-file? raw)
+     :diagnostic {:source-file-counts {:from-result  (source-file-count from-result)
+                                       :via-executor (source-file-count via-exec)
+                                       :via-local    (source-file-count via-local)}
+                  :pre-session-snapshot? (some? (:pre-session-snapshot input))
+                  :worktree-path         (:worktree-path input)
+                  :collection-mode       (if (and (:executor input) (:execute-fn input)
+                                                  (:env-id input) (:worktree-path input))
+                                           :capsule :local)
+                  :env-id                (:env-id input)}}))
+
 (defn collect-files
-  "Resolve the file diff from available sources, in priority order:
-   1. implementer-result has :code/files already (fast path)
-   2. fresh collection via executor (capsule mode)
-   3. fresh collection via local git status (non-capsule)
-
-   Filters non-substantive files (session markers, miniforge runtime
-   artifacts) — these shouldn't count as implementer output.
-
-   Returns a vector (possibly empty) of file entries."
+  "Substantive file diff from available sources (priority order). Filters
+   non-substantive files (session markers, miniforge runtime artifacts).
+   Returns a vector (possibly empty). For the diagnostic alongside it, use
+   `collect-files+diagnostic`."
   [input]
-  (filterv substantive-file?
-           (or (files-from-result (:implementer-result input))
-               (files-via-executor input)
-               (files-via-local-snapshot input)
-               [])))
-
-(defn collect-files-diagnostic
-  "Explain WHY file collection came up empty, so the terminal
-   :curator/no-files-written error is debuggable rather than opaque.
-   Distinguishes the documented loss modes — nil pre-session-snapshot,
-   missing worktree-path, wrong collection mode, or the implementer simply
-   capturing nothing — from a genuine no-write. Pure probes; no FS mutation.
-
-   Reports per-source file counts so the reader sees exactly which fallback
-   (result / executor / local-snapshot) produced what."
-  [input]
-  (let [from-result (count (or (files-from-result (:implementer-result input)) []))
-        via-exec    (count (or (files-via-executor input) []))
-        via-local   (count (or (files-via-local-snapshot input) []))]
-    {:source-file-counts {:from-result   from-result
-                          :via-executor  via-exec
-                          :via-local     via-local}
-     :pre-session-snapshot? (some? (:pre-session-snapshot input))
-     :worktree-path         (:worktree-path input)
-     :collection-mode       (if (and (:executor input) (:execute-fn input)
-                                     (:env-id input) (:worktree-path input))
-                              :capsule :local)
-     :env-id                (:env-id input)}))
+  (:files (collect-files+diagnostic input)))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Optional LLM enrichment
@@ -413,7 +422,7 @@
 (defn- empty-diff-error
   "Build the terminal 'no files written' error. The :code keyword is the
    stable contract the phase runner branches on to stop retrying."
-  [input]
+  [input diagnostic]
   (response/error
    (messages/t :error/curator-no-files-written)
    {:data {:code :curator/no-files-written
@@ -422,8 +431,9 @@
            :intent-scope (:intent-scope input)
            ;; Why each collection source came up empty — distinguishes a
            ;; genuine no-write from a capture loss (nil pre-snapshot / wrong
-           ;; dir / mode). See collect-files-diagnostic.
-           :diagnostic (collect-files-diagnostic input)}}))
+           ;; dir / mode). Computed in the SAME pass as collect-files (no
+           ;; second collection / executor IO on the error path).
+           :diagnostic diagnostic}}))
 
 (defmulti curate
   "Curator entry point. Dispatches on `:curator/kind` so each agent
@@ -433,9 +443,9 @@
 
 (defmethod curate :implement
   [{:keys [intent-scope spec-description llm-client] :as input}]
-  (let [files (collect-files input)]
+  (let [{:keys [files diagnostic]} (collect-files+diagnostic input)]
     (if (empty? files)
-      (empty-diff-error input)
+      (empty-diff-error input diagnostic)
       (let [tests-added? (detect-tests-added files)
             deviations (detect-scope-deviations files intent-scope)
             language (detect-language files)

--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -274,6 +274,29 @@
                (files-via-local-snapshot input)
                [])))
 
+(defn collect-files-diagnostic
+  "Explain WHY file collection came up empty, so the terminal
+   :curator/no-files-written error is debuggable rather than opaque.
+   Distinguishes the documented loss modes — nil pre-session-snapshot,
+   missing worktree-path, wrong collection mode, or the implementer simply
+   capturing nothing — from a genuine no-write. Pure probes; no FS mutation.
+
+   Reports per-source file counts so the reader sees exactly which fallback
+   (result / executor / local-snapshot) produced what."
+  [input]
+  (let [from-result (count (or (files-from-result (:implementer-result input)) []))
+        via-exec    (count (or (files-via-executor input) []))
+        via-local   (count (or (files-via-local-snapshot input) []))]
+    {:source-file-counts {:from-result   from-result
+                          :via-executor  via-exec
+                          :via-local     via-local}
+     :pre-session-snapshot? (some? (:pre-session-snapshot input))
+     :worktree-path         (:worktree-path input)
+     :collection-mode       (if (and (:executor input) (:execute-fn input)
+                                     (:env-id input) (:worktree-path input))
+                              :capsule :local)
+     :env-id                (:env-id input)}))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Optional LLM enrichment
 
@@ -396,7 +419,11 @@
    {:data {:code :curator/no-files-written
            :worktree-path (:worktree-path input)
            :env-id (:env-id input)
-           :intent-scope (:intent-scope input)}}))
+           :intent-scope (:intent-scope input)
+           ;; Why each collection source came up empty — distinguishes a
+           ;; genuine no-write from a capture loss (nil pre-snapshot / wrong
+           ;; dir / mode). See collect-files-diagnostic.
+           :diagnostic (collect-files-diagnostic input)}}))
 
 (defmulti curate
   "Curator entry point. Dispatches on `:curator/kind` so each agent

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -796,6 +796,10 @@
                               :tokens (:tokens normalized)
                               :streaming? (boolean on-chunk)
                               :artifact-source (or (:artifact-source normalized) :none)
+                              ;; Dir the agent wrote to / collection scanned —
+                              ;; surfaces the worktree-path-vs-CWD resolution so
+                              ;; a write/scan dir mismatch is diagnosable.
+                              :working-dir working-dir
                               :tools-called (:tools-called normalized)}
                        (:stop-reason response)
                        (assoc :stop-reason (:stop-reason response))

--- a/components/agent/test/ai/miniforge/agent/curator_test.clj
+++ b/components/agent/test/ai/miniforge/agent/curator_test.clj
@@ -184,6 +184,25 @@
            this is the terminal signal that makes the implement phase fail
            instead of retrying blindly"))))
 
+(deftest curate-no-files-error-carries-diagnostic
+  (testing "the terminal no-files error includes a diagnostic explaining why
+            each collection source was empty — so capture loss (nil
+            pre-snapshot / wrong dir / mode) is distinguishable from a genuine
+            no-write"
+    (let [result (sut/curate-implement-output
+                  {:implementer-result (impl-result-with-files [])
+                   :worktree-path "/tmp/nothing"
+                   :intent-scope ["a.clj"]})
+          diag   (get-in result [:error :data :diagnostic])]
+      (is (some? diag) "no-files error must carry a :diagnostic")
+      (is (= 0 (get-in diag [:source-file-counts :from-result]))
+          "reports per-source counts so the empty source is visible")
+      (is (false? (:pre-session-snapshot? diag))
+          "flags the missing pre-session-snapshot — a documented loss mode")
+      (is (= "/tmp/nothing" (:worktree-path diag)))
+      (is (= :local (:collection-mode diag))
+          "no executor/env-id → local collection mode"))))
+
 (deftest curate-errors-when-implementer-result-has-no-output
   (testing "missing :output map → empty diff → error"
     (let [result (sut/curate-implement-output

--- a/components/agent/test/ai/miniforge/agent/curator_test.clj
+++ b/components/agent/test/ai/miniforge/agent/curator_test.clj
@@ -195,13 +195,27 @@
                    :intent-scope ["a.clj"]})
           diag   (get-in result [:error :data :diagnostic])]
       (is (some? diag) "no-files error must carry a :diagnostic")
-      (is (= 0 (get-in diag [:source-file-counts :from-result]))
-          "reports per-source counts so the empty source is visible")
+      (is (= {:raw 0 :substantive 0} (get-in diag [:source-file-counts :from-result]))
+          "reports raw + substantive per-source counts so the empty source is visible")
       (is (false? (:pre-session-snapshot? diag))
           "flags the missing pre-session-snapshot — a documented loss mode")
       (is (= "/tmp/nothing" (:worktree-path diag)))
       (is (= :local (:collection-mode diag))
           "no executor/env-id → local collection mode"))))
+
+(deftest curate-diagnostic-distinguishes-raw-from-substantive
+  (testing "a diff of ONLY non-substantive files (e.g. .miniforge-session-id)
+            still errors, and the diagnostic reports raw>0 / substantive=0 —
+            not a misleading non-zero count"
+    (let [result (sut/curate-implement-output
+                  {:implementer-result
+                   (impl-result-with-files [{:path ".miniforge-session-id" :action :modify}])
+                   :worktree-path "/tmp/x"
+                   :intent-scope []})
+          diag   (get-in result [:error :data :diagnostic])]
+      (is (= :curator/no-files-written (get-in result [:error :data :code])))
+      (is (= {:raw 1 :substantive 0} (get-in diag [:source-file-counts :from-result]))
+          "raw counts the session marker; substantive correctly excludes it"))))
 
 (deftest curate-errors-when-implementer-result-has-no-output
   (testing "missing :output map → empty diff → error"


### PR DESCRIPTION
## Summary

Dogfood runs keep hitting "File entirely absent" at review with no way to tell **why** — did the implementer not write, or did capture lose the files? The clean-main run `adhoc--670062198` failed 0/4 and we couldn't attribute the one empty task. This adds the signals to distinguish the cases on the next run, *before* committing to a fix.

This is the "observability first" step: pure instrumentation, no behavior change.

## Changes
- **`curator/collect-files-diagnostic`** — when file collection comes up empty, the terminal `:curator/no-files-written` error now carries a `:diagnostic`:
  - `:source-file-counts` — per-source counts (`from-result` / `via-executor` / `via-local`), so the empty source is visible
  - `:pre-session-snapshot?` — whether a pre-session snapshot was present (a documented loss mode: nil snapshot + clean-committed worktree → empty diff)
  - `:worktree-path`, `:collection-mode` (`:capsule` vs `:local`), `:env-id`
- **`implementer` `:implementer/llm-called` log** — now includes `:working-dir` next to `:artifact-source`, surfacing the worktree-path-vs-CWD resolution so a write/scan dir mismatch is diagnosable.

## Why
The investigation showed file capture mostly works (the `file-artifact-fallback` path recovers written files; the curator prefers them). The documented loss points (nil pre-snapshot propagation, `worktree-path` → CWD, capsule `/workspace`) are all *conditional* and none was clearly the cause. Rather than guess, this makes the next failure self-explanatory — `:diagnostic` will say exactly which source was empty and whether the pre-snapshot/dir/mode were the culprit.

## Test plan
- `curator-test`: new test asserts the no-files error carries `:diagnostic` with per-source counts, the pre-snapshot flag, worktree-path, and collection-mode.
- `bb pre-commit` green (0 lint warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)