### PR TITLE
fix(compliance-scanner): validate git ref before use in ProcessBuilder

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
@@ -277,32 +277,44 @@
 ;------------------------------------------------------------------------------ Layer 0.6
 ;; Diff/plan detection and incremental mode helpers
 
+(defn- safe-git-ref?
+  "Return true iff ref contains only characters valid in a git ref argument.
+   Rejects empty strings, nil, and any value starting with '-' (which git
+   could interpret as an option flag)."
+  [ref]
+  (boolean (and (string? ref)
+                (seq ref)
+                (not (str/starts-with? ref "-"))
+                (re-matches #"[a-zA-Z0-9/_.\-~^@{}]+" ref))))
+
 (defn- git-diff
   "Run git diff and return the output string."
   [repo-path since-ref]
-  (try
-    (let [pb (ProcessBuilder. ^java.util.List
-              ["git" "diff" (str since-ref "..HEAD")])
-          _  (.directory pb (io/file repo-path))
-          proc (.start pb)
-          out  (slurp (.getInputStream proc))]
-      (.waitFor proc)
-      (when-not (str/blank? out) out))
-    (catch Exception _ nil)))
+  (when (safe-git-ref? since-ref)
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List
+                ["git" "diff" (str since-ref "..HEAD")])
+            _  (.directory pb (io/file repo-path))
+            proc (.start pb)
+            out  (slurp (.getInputStream proc))]
+        (.waitFor proc)
+        (when-not (str/blank? out) out))
+      (catch Exception _ nil))))
 
 (defn- git-diff-name-only
   "Run git diff --name-only and return set of changed file paths."
   [repo-path since-ref]
-  (try
-    (let [pb (ProcessBuilder. ^java.util.List
-              ["git" "diff" "--name-only" (str since-ref "..HEAD")])
-          _  (.directory pb (io/file repo-path))
-          proc (.start pb)
-          out  (slurp (.getInputStream proc))]
-      (.waitFor proc)
-      (when-not (str/blank? out)
-        (set (str/split-lines (str/trim out)))))
-    (catch Exception _ nil)))
+  (when (safe-git-ref? since-ref)
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List
+                ["git" "diff" "--name-only" (str since-ref "..HEAD")])
+            _  (.directory pb (io/file repo-path))
+            proc (.start pb)
+            out  (slurp (.getInputStream proc))]
+        (.waitFor proc)
+        (when-not (str/blank? out)
+          (set (str/split-lines (str/trim out)))))
+      (catch Exception _ nil))))
 
 (defn- scan-diff-rule
   "Scan a git diff for violations using a diff-analysis rule.

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
@@ -142,6 +142,26 @@
           (doseq [f (reverse (file-seq tmp-dir))]
             (.delete f)))))))
 
+;; ---------------------------------------------------------------------------
+;; safe-git-ref? validation
+
+(deftest safe-git-ref-allows-well-formed-refs
+  (testing "common git ref forms are accepted"
+    (is (#'scan/safe-git-ref? "origin/main"))
+    (is (#'scan/safe-git-ref? "HEAD~1"))
+    (is (#'scan/safe-git-ref? "abc123def456"))
+    (is (#'scan/safe-git-ref? "v1.0.0-rc1"))
+    (is (#'scan/safe-git-ref? "refs/heads/feature-branch"))))
+
+(deftest safe-git-ref-rejects-unsafe-values
+  (testing "values that could inject git options or shell constructs are rejected"
+    (is (not (#'scan/safe-git-ref? "; rm -rf /")))
+    (is (not (#'scan/safe-git-ref? "--exec=cmd")))
+    (is (not (#'scan/safe-git-ref? "-C /malicious/path")))
+    (is (not (#'scan/safe-git-ref? "ref with spaces")))
+    (is (not (#'scan/safe-git-ref? "")))
+    (is (not (#'scan/safe-git-ref? nil)))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (clojure.test/run-tests 'ai.miniforge.compliance-scanner.scan-test)


### PR DESCRIPTION
## What

Adds a `safe-git-ref?` predicate to `compliance_scanner/scan.clj` and gates both `git-diff` and `git-diff-name-only` on it.

## Why

Both functions accepted a `since-ref` value (from `:base-ref` in `pr-review` opts or the `--base` CLI flag) and string-interpolated it directly into a `ProcessBuilder` array argument:

```clojure
["git" "diff" (str since-ref "..HEAD")]
```

While array-based `ProcessBuilder` prevents shell injection, a value starting with `-` would be interpreted by git as an option flag (e.g. `-C /malicious/path`, `--work-tree=…`). In addition, both functions wrapped the subprocess call in a bare `(catch Exception _ nil)`, silently swallowing any git error and making malformed refs undetectable.

The interface layer only checked for non-empty string (`(seq base-ref)`); no character-level validation existed.

## Fix

`safe-git-ref?` allows only `[a-zA-Z0-9/_.\-~^@{}]+` and requires the value not start with `-`. Both git functions return `nil` immediately for unsafe refs, consistent with their existing nil-on-exception behaviour. The predicate is accessible via `#'` for unit testing.

**Two new tests** cover the allowlist (`origin/main`, `HEAD~1`, SHA hashes, semver tags) and the blocklist (semicolons, option-like values, spaces, empty string, nil).

## Test plan

- `safe-git-ref-allows-well-formed-refs` — all common ref forms accepted
- `safe-git-ref-rejects-unsafe-values` — all dangerous forms rejected
- Existing `scan-repo-detects-210-in-temp-dir` integration test unaffected

_Generated by [Claude Code](https://claude.ai/code/session_01XTKizZSmjJEFoyA5X9WB3y)_