### PR TITLE
fix(workflow-runner): list-workflows-from-resources swallows exception

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -1079,13 +1079,10 @@
       (println (display/colorize :cyan (apply str (repeat 60 "─")))))))
 
 (defn list-workflows-from-resources []
-  (try
-    (let [list-workflows workflow/list-workflows]
-      (->> (list-workflows)
-           (sort-by (juxt :workflow/id :workflow/version))
-           format-workflow-listing))
-    (catch Exception e
-      (println (display/colorize :red (messages/t :workflow-runner/list-failed {:error (ex-message e)}))))))
+  (let [list-workflows workflow/list-workflows]
+    (->> (list-workflows)
+         (sort-by (juxt :workflow/id :workflow/version))
+         format-workflow-listing)))
 
 (defn list-workflows! []
   (try


### PR DESCRIPTION
## What

Remove the `try/catch` from `list-workflows-from-resources` so exceptions propagate to `list-workflows!`, which is the correct single error boundary.

## Why

`list-workflows-from-resources` previously caught all exceptions, printed a red error message via `messages/t`, and **returned `nil` silently** — making `list-workflows!`'s outer `(catch Exception e ... (throw e))` dead code. The consequence:

- Callers of `list-workflows!` received `nil` on failure instead of a thrown exception, silently losing the error signal.
- Any downstream code that assumed a non-nil return (e.g. trying to render or iterate the workflow listing) would encounter a `NullPointerException` with no connection to the original failure.
- The duplicate `println` in `list-workflows!` could never fire, so error messages were printed only at the inner boundary without the correct stack context.

## Fix

Delete the `try/catch` from `list-workflows-from-resources` entirely. The function now contains only its business logic (list → sort → format). `list-workflows!` remains the single error boundary: it catches, prints the user-visible error, and rethrows so CLI dispatch can exit non-zero.

## Test plan

- `bb test` — full test suite; `list-workflows-from-resources` has no direct unit tests because it delegates to `workflow/list-workflows`, but the structural change is covered by existing integration-level workflow listing tests.
- No new tests required — the fix removes dead code and restores the contract that `list-workflows!` already documented.

https://claude.ai/code/session_01H8MtKFtSLYsAATdGhjTfEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8MtKFtSLYsAATdGhjTfEU)_