### PR TITLE
fix(fsm): unknown events fail loud — no silent return-state-unchanged

### DIFF
--- a/components/fsm/src/ai/miniforge/fsm/core.clj
+++ b/components/fsm/src/ai/miniforge/fsm/core.clj
@@ -149,8 +149,11 @@
       (sc/transition machine state event-map)
       (catch clojure.lang.ExceptionInfo e
         (if (re-find #"got unknown event" (ex-message e))
+          ;; Compact message — just the state NAME (:_state), not the whole
+          ;; state map (which can be large / carry sensitive context). The
+          ;; full state is in ex-data :fsm/state for diagnosis.
           (throw (ex-info (str "FSM unknown event " (pr-str (:type event-map))
-                               " at state " (pr-str state))
+                               " at state " (pr-str (get state :_state state)))
                           {:anomaly/category :anomalies/fsm-unknown-event
                            :fsm/state state
                            :fsm/event event-map}

--- a/components/fsm/src/ai/miniforge/fsm/core.clj
+++ b/components/fsm/src/ai/miniforge/fsm/core.clj
@@ -132,8 +132,15 @@
      state   - Current state
      event   - Event keyword or {:type :event-type :data ...}
 
-   Returns:
-     New state after transition (or same state if no valid transition)."
+   Returns the new state after transition.
+
+   An event the current state does not handle is NOT silently ignored: it
+   throws a typed `:anomalies/fsm-unknown-event` ex-info (carrying the state +
+   event) rather than returning the state unchanged. A silent no-op here was a
+   load-bearing source of 'machine seemed stuck' / 'workflow advanced wrongly'
+   mysteries (Fable review §2.2). An unknown event is either a programming
+   error or an ignore that MUST be declared in the machine — both should be
+   loud. Callers that legitimately tolerate it catch this category."
   [machine state event]
   (let [event-map (if (keyword? event)
                     {:type event}
@@ -141,9 +148,13 @@
     (try
       (sc/transition machine state event-map)
       (catch clojure.lang.ExceptionInfo e
-        ;; If it's an unknown event error, return current state unchanged
         (if (re-find #"got unknown event" (ex-message e))
-          state
+          (throw (ex-info (str "FSM unknown event " (pr-str (:type event-map))
+                               " at state " (pr-str state))
+                          {:anomaly/category :anomalies/fsm-unknown-event
+                           :fsm/state state
+                           :fsm/event event-map}
+                          e))
           (throw e))))))
 
 (defn current-state

--- a/components/fsm/test/ai/miniforge/fsm/interface_test.clj
+++ b/components/fsm/test/ai/miniforge/fsm/interface_test.clj
@@ -83,16 +83,22 @@
       (is (= :b (fsm/current-state s1)))
       (is (= :c (fsm/current-state s2))))))
 
-(deftest transition-no-match-test
-  (testing "transition stays in state when no matching event"
+(deftest transition-unknown-event-throws-test
+  (testing "an event the state doesn't handle throws a typed anomaly — never a
+            silent no-op (Fable review §2.2)"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
                     :fsm/initial :idle
                     :fsm/states {:idle {:on {:start :running}}
                                  :running {:type :final}}})
           s0 (fsm/initialize machine)
-          s1 (fsm/transition machine s0 :unknown-event)]
-      (is (= :idle (fsm/current-state s1))))))
+          ex (try (fsm/transition machine s0 :unknown-event) nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "unknown event must throw, not return state unchanged")
+      (is (= :anomalies/fsm-unknown-event (:anomaly/category (ex-data ex)))
+          "typed category so boundaries can catch + emit :fsm/unknown-event")
+      (is (= {:type :unknown-event} (:fsm/event (ex-data ex)))
+          "ex-data names the offending event for diagnosis"))))
 
 (deftest transition-with-event-data-test
   (testing "transition accepts event with data"

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -362,14 +362,17 @@
                      (if (= :anomalies/fsm-unknown-event (:anomaly/category (ex-data e)))
                        ::unknown-event
                        (throw e))))
-        state-changed? (and (not= ::unknown-event next-ctx)
-                            (not= prior-state (:execution/fsm-state next-ctx)))]
-    (if (or state-changed? (= :phase/retry event))
-      next-ctx
-      (phase-transition-failure ctx
-                                event
-                                (invalid-phase-transition-anomaly event)
-                                transition-to-failed-fn))))
+        fail (fn [] (phase-transition-failure ctx
+                                              event
+                                              (invalid-phase-transition-anomaly event)
+                                              transition-to-failed-fn))]
+    (cond
+      ;; Unknown event is always a terminal invalid transition here — never
+      ;; return the sentinel; never let :phase/retry leak it out.
+      (= ::unknown-event next-ctx) (fail)
+      (not= prior-state (:execution/fsm-state next-ctx)) next-ctx
+      (= :phase/retry event) next-ctx
+      :else (fail))))
 
 ;------------------------------------------------------------------------------ Layer 1.5: DAG integration helpers
 

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -351,8 +351,19 @@
    terminal failure."
   [ctx event _pipeline _transition-to-completed-fn transition-to-failed-fn]
   (let [prior-state (:execution/fsm-state ctx)
-        next-ctx (context/transition-execution ctx event)
-        state-changed? (not= prior-state (:execution/fsm-state next-ctx))]
+        ;; The FSM kernel now THROWS a typed :anomalies/fsm-unknown-event
+        ;; instead of silently returning the state unchanged (Fable §2.2). At
+        ;; this boundary an unknown phase event is a terminal invalid
+        ;; transition: catch it and route through the same fail path as a
+        ;; no-op transition — loud, but graceful, not a crashed run.
+        next-ctx (try
+                   (context/transition-execution ctx event)
+                   (catch clojure.lang.ExceptionInfo e
+                     (if (= :anomalies/fsm-unknown-event (:anomaly/category (ex-data e)))
+                       ::unknown-event
+                       (throw e))))
+        state-changed? (and (not= ::unknown-event next-ctx)
+                            (not= prior-state (:execution/fsm-state next-ctx)))]
     (if (or state-changed? (= :phase/retry event))
       next-ctx
       (phase-transition-failure ctx


### PR DESCRIPTION
## Summary

**Fable design review §2.2 — Priority #1.** "Smallest change, largest mystery-reduction."

The FSM kernel caught clj-statecharts' `got unknown event` throw and **returned the state unchanged, silently**:

```clojure
(catch clojure.lang.ExceptionInfo e
  (if (re-find #"got unknown event" (ex-message e))
    state          ;; <- silent no-op
    (throw e)))
```

Every "machine seemed stuck" / "event had no effect" / "workflow advanced wrongly" incident passed through that catch — the silent-downgrade disease written into the FSM kernel itself.

## Changes
- **`fsm/core` `transition`** re-throws a typed `:anomalies/fsm-unknown-event` ex-info (carrying `:fsm/state` + `:fsm/event`) instead of swallowing. An unknown event is either a programming error or an ignore that MUST be declared in the machine — both are now loud.
- **`execution/apply-phase-transition`** (the workflow execution boundary) catches that anomaly and routes it through the **existing** graceful terminal-failure path (`:invalid-transition` in `:execution/errors`), so behaviour there is unchanged — while every *other* caller (supervision, degradation, pr-lifecycle, heuristic) now surfaces unknown events loudly instead of no-op'ing.

## Audit
Ran the **full fsm / workflow / pr-lifecycle / heuristic / reliability suites — 0 failures**. No flow relied on the silent no-op; the only path that exercised it (`apply-phase-transition`) already wanted loud failure and is preserved.

## Follow-up
Emit a named `:fsm/unknown-event` stream event at boundaries — deferred, because the in-file emit pattern uses `requiring-resolve` (an anti-pattern the review itself flags). Worth doing once the workflow→event-stream load-order is sorted. The typed throw + `:invalid-transition` error already make the condition loud.

## Test plan
- `fsm interface-test`: unknown event now throws the typed anomaly with state/event in ex-data (was: asserted silent no-op).
- `workflow phase-transitions-test`: invalid event still routes to graceful terminal failure.
- `bb pre-commit` green (the one lint warning is pre-existing, unrelated).

Part of the Fable review program (priority #1 of 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)