### PR TITLE
docs: mark guarded-transitions RFC Implemented (Fable review #2)

### DIFF
--- a/docs/architecture/workflow-fsm-guarded-transitions.md
+++ b/docs/architecture/workflow-fsm-guarded-transitions.md
@@ -47,14 +47,14 @@ $8-15 run that should have terminated after 5 redirects burned through to
 forced kill. Three workaround PRs (#1010, #1011, #1013) patched symptoms
 without fixing the design.
 
-This RFC proposes adopting `clj-statecharts` end-to-end for workflow phase
+This RFC adopted `clj-statecharts` end-to-end for workflow phase
 transitions, with a named-guard registry layered on top for closed-set
 compile-time validation. `clj-statecharts` is already a runtime dependency,
 already wrapped in the `fsm` component, and already proven Babashka-compatible
 by other in-process FSMs. The redesign moves every transition decision
 into the FSM as a typed, enumerable guard — the bug class becomes
-structurally impossible to express. Migration is five independently
-mergeable phases. Net negative LOC.
+structurally impossible to express. Migration completed across five independently
+merged phases. Net negative LOC.
 
 ## Problem
 

--- a/docs/architecture/workflow-fsm-guarded-transitions.md
+++ b/docs/architecture/workflow-fsm-guarded-transitions.md
@@ -8,11 +8,29 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
+| **Status** | Implemented |
 | **Date** | 2026-06-02 |
+| **Implemented** | 2026-06-10 (verified during the Fable design review §2.1) |
 | **Authors** | Chris Lester (christopher@miniforge.ai) |
 | **Discussion** | PR #TBD |
 | **Implementation tracking** | task #32 |
+
+> **Implementation status (2026-06-10).** All five migration phases have
+> landed; recorded here so the doc reflects reality (the Fable review flagged
+> doc-vs-code drift as a risk).
+>
+> - **Phase 1** — named-guard registry: `workflow/guards.clj`,
+>   `workflow/standard_guards_and_actions.clj`.
+> - **Phases 2–3** — guarded `:phase/fail` array for review/verify/release/
+>   implement: `workflow/fsm.clj` `guarded-fail-transition`.
+> - **Phase 4** — channel-A redirect workaround deleted; `:redirect/inc-count`
+>   on the guarded array is the single accounting site.
+> - **Phase 5** — three compile-time invariants in `validate-execution-machine`
+>   (`fsm.clj`): every guarded `:phase/fail` array has a default branch; at
+>   most one `:redirect/inc-count` per array; the `:budget/redirects-spent?`
+>   guard exists and precedes the redirect branch in document order. Plus
+>   `validate-guard-references` (dangling-guard detection).
+> - **Phase 6** (Mermaid export) — optional, not implemented.
 
 ## Summary
 


### PR DESCRIPTION
## Summary

**Fable review Priority #2 — "adopt the guarded-transitions RFC."** Verified in source: it's *already fully implemented*. The burn the review cites (2026-05-28, 3h40m, \$8–15) predates the RFC's phases landing; the doc just still said **Status: Proposed**.

This corrects the doc — exactly the doc-vs-code drift the review's Part 3 flags — by recording the implementation phase-by-phase. No code change.

Verified implemented:
- **Phase 1** — named-guard registry (`workflow/guards.clj`, `workflow/standard_guards_and_actions.clj`)
- **Phases 2–3** — guarded `:phase/fail` array across review/verify/release/implement (`guarded-fail-transition`)
- **Phase 4** — channel-A redirect workaround deleted; `:redirect/inc-count` is the single accounting site
- **Phase 5** — three compile-time invariants in `validate-execution-machine`: default branch present; at-most-one redirect-counter per array (the structural invariant §2.1 emphasizes); `:budget/redirects-spent?` guard exists and precedes the redirect branch in document order — plus dangling-guard-reference detection
- **Phase 6** (Mermaid export) — optional, not implemented

So #2 needs no code; the residual from §2.1 (phase code returns verdicts only; mutation outside `fsm/transition` is a structural error) is the verdict-driven design already in place, with the FSM side fully enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)