### PR TITLE
feat(workflow): verdict taxonomy — infra/no-op/work-terminal classes (Fable #3 PR-A)

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -39,6 +39,7 @@
    omitted entirely — no runtime check needed. This is structurally
    identical to the RFC behavior with simpler runtime arithmetic."
   (:require
+   [clojure.set :as set]
    [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.workflow.actions :as actions]
    [ai.miniforge.workflow.guards :as guards]
@@ -47,62 +48,68 @@
 
 ;------------------------------------------------------------------------------ Verdict-driven guards
 
-(def terminal-verdicts
-  "The set of `:phase/verdict` values that route a phase failure straight
-   to the workflow terminal `:failed` state, bypassing any on-fail
-   redirect. Mirrors the legacy `:stagnated?` / `:needs-decomposition?`
-   flag bits from the workaround era; collapsed here into a single
-   FSM-readable signal."
-  #{;; Convergence-failure verdicts (review phase)
-    :stagnated
-    :needs-decomposition
-    :exhausted
-    ;; Verify-specific (Phase 3a): retrying implement does not unblock a
-    ;; timed-out test process or a provider rate-limit. Both terminate.
-    :verify/timeout
+;; Verdict taxonomy (Fable review §2.4). Three classes of failure verdict,
+;; each carrying different machine semantics. PR-A (this change) names the
+;; classes and keeps `terminal-verdicts` as their UNION — so routing is
+;; byte-for-byte unchanged. PR-B peels `infrastructure-verdicts` off the
+;; terminal path to retry-same-phase against an infra budget (transient
+;; failures a backoff can clear), where ~half the recorded burn incidents
+;; live.
+
+(def infrastructure-verdicts
+  "TRANSIENT infrastructure failures — a timeout, provider rate-limit,
+   backend/stream death, or dropped network. A retry after backoff CAN clear
+   these; they are not evidence the work is wrong. Today still terminal (kept
+   in `terminal-verdicts`); PR-B routes them to retry-same-phase against a
+   dedicated infra-retry budget instead of the redirect/work budget."
+  #{:verify/timeout
     :verify/rate-limited
-    ;; Release-specific (Phase 3b): curator-rejected (no files to ship).
-    ;; Retrying implement won't change the curator's decision — the
-    ;; diff is empty and the next pass would just produce another empty
-    ;; diff. Terminal.
-    :release/zero-files
-    ;; Implement-specific (Phase 3c). All three are cases where the
-    ;; on-fail :implement loop would just re-enter and hit the same
-    ;; wall — terminate the workflow instead.
-    ;;   :rate-limited — provider quota; budget retries won't change it
-    ;;   :empty-diff   — curator: no files written; retry would produce
-    ;;                   another empty diff
-    ;;   :already-implemented-invalid — the implementer claimed done
-    ;;                   but verify hadn't passed; retry won't fix the
-    ;;                   stale claim
     :implement/rate-limited
-    :implement/empty-diff
-    :implement/already-implemented-invalid
-    ;; PR-C of network-resilience stack: the implement phase exhausted
-    ;; its iteration budget retrying from the persisted checkpoint
-    ;; after PR-B's network-monitor detected sustained provider
-    ;; outages. Retrying again would just hit the same dead network on
-    ;; the next probe cycle. Terminal — operator surfaces the workflow
-    ;; for manual resume once connectivity is restored.
     :implement/network-dropped
-    ;; PR-B of phase-timeout stack (companion to network-resilience):
-    ;; the reviewer LLM call hit its adaptive timeout (stream-idle /
-    ;; stagnation / hard-limit / generic) with no real verdict
-    ;; produced. PR-A (#1058) made the reviewer agent take the
-    ;; `:reviewer/backend-timeout` error exit instead of synthesizing
-    ;; a false `:rejected`; this verdict surfaces that to the FSM.
-    ;; Distinct from `:exhausted` — `:exhausted` means the reviewer
-    ;; HAD a verdict the gate couldn't approve, this means the
-    ;; reviewer never produced one.
-    :review/backend-timeout
-    ;; PR-C of phase-timeout stack (companion to PR-B + network-
-    ;; resilience PR-C): the implementer LLM call exhausted its
-    ;; iteration budget retrying from the persisted checkpoint after
-    ;; consecutive stream-idle / stagnation / hard-limit timeouts.
-    ;; Same recovery shape as `:implement/network-dropped` — retriable
-    ;; up to the budget, then terminal. Retrying again would just hit
-    ;; the same slow provider on the next pass.
-    :implement/backend-timeout})
+    :implement/backend-timeout
+    :review/backend-timeout})
+
+(def no-op-verdicts
+  "EVIDENCE-OF-ABSENCE failures — the work produced nothing actionable, so a
+   retry would just reproduce the same empty result. Always fail closed.
+     :empty-diff / :zero-files — curator found no files written
+     :already-implemented-invalid — implementer claimed done but verify
+                                    hadn't passed; retry won't fix the claim"
+  #{:implement/empty-diff
+    :release/zero-files
+    :implement/already-implemented-invalid})
+
+(def work-terminal-verdicts
+  "WORK that ran its course — the review/repair loop exhausted its budget
+   without converging. Terminal (the end of the work-redirect path)."
+  #{:stagnated
+    :needs-decomposition
+    :exhausted})
+
+(def terminal-verdicts
+  "The set of `:phase/verdict` values that route a phase failure straight to
+   the workflow terminal `:failed` state, bypassing any on-fail redirect.
+
+   The UNION of the three terminal classes — identical membership to the
+   pre-taxonomy flat set, so `verdict-terminal?` routing is unchanged by the
+   PR-A split. PR-B removes `infrastructure-verdicts` from this union so
+   transient failures retry rather than terminate."
+  (set/union infrastructure-verdicts no-op-verdicts work-terminal-verdicts))
+
+(defn verdict-class
+  "Classify a phase `:phase/verdict` into the taxonomy (Fable §2.4):
+     :infrastructure — transient; retry-worthy (PR-B)
+     :no-op          — evidence of absence; fail closed
+     :work-terminal  — work budget exhausted; fail closed
+     :work           — an ordinary actionable failure → redirect / repair
+   Closed over the three sets; the default `:work` covers every
+   non-terminal verdict (e.g. `:repair-requested`)."
+  [verdict]
+  (cond
+    (contains? infrastructure-verdicts verdict) :infrastructure
+    (contains? no-op-verdicts verdict)          :no-op
+    (contains? work-terminal-verdicts verdict)  :work-terminal
+    :else                                       :work))
 
 (defn verdict-terminal?
   "Guard: true when the failing-phase event carries a terminal verdict.

--- a/components/workflow/test/ai/miniforge/workflow/standard_guards_and_actions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/standard_guards_and_actions_test.clj
@@ -1,0 +1,67 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.standard-guards-and-actions-test
+  "Verdict taxonomy (Fable §2.4). PR-A: the three classes name the existing
+   terminal set; the union must stay identical so routing is unchanged."
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.standard-guards-and-actions :as sut]))
+
+(deftest terminal-verdicts-union-is-unchanged
+  (testing "terminal-verdicts is exactly the union of the three classes —
+            membership identical to the pre-taxonomy flat set, so
+            verdict-terminal? routing does not change in PR-A"
+    (is (= sut/terminal-verdicts
+           (set/union sut/infrastructure-verdicts
+                      sut/no-op-verdicts
+                      sut/work-terminal-verdicts)))
+    (is (= #{:stagnated :needs-decomposition :exhausted
+             :verify/timeout :verify/rate-limited :release/zero-files
+             :implement/rate-limited :implement/empty-diff
+             :implement/already-implemented-invalid :implement/network-dropped
+             :review/backend-timeout :implement/backend-timeout}
+           sut/terminal-verdicts)
+        "pins the exact terminal set so any future change is deliberate")))
+
+(deftest verdict-classes-are-disjoint
+  (testing "no verdict belongs to more than one terminal class"
+    (is (empty? (set/intersection sut/infrastructure-verdicts sut/no-op-verdicts)))
+    (is (empty? (set/intersection sut/infrastructure-verdicts sut/work-terminal-verdicts)))
+    (is (empty? (set/intersection sut/no-op-verdicts sut/work-terminal-verdicts)))))
+
+(deftest verdict-class-classification
+  (testing "each terminal verdict classifies into its class"
+    (is (= :infrastructure (sut/verdict-class :verify/timeout)))
+    (is (= :infrastructure (sut/verdict-class :review/backend-timeout)))
+    (is (= :no-op (sut/verdict-class :implement/empty-diff)))
+    (is (= :no-op (sut/verdict-class :release/zero-files)))
+    (is (= :work-terminal (sut/verdict-class :stagnated)))
+    (is (= :work-terminal (sut/verdict-class :exhausted))))
+  (testing "anything else (ordinary actionable failure) is :work"
+    (is (= :work (sut/verdict-class :repair-requested)))
+    (is (= :work (sut/verdict-class :rejected)))
+    (is (= :work (sut/verdict-class nil)))))
+
+(deftest verdict-terminal?-unchanged
+  (testing "guard still fires for every terminal verdict, not for :work ones"
+    (is (true? (sut/verdict-terminal? {} {:phase/verdict :stagnated})))
+    (is (true? (sut/verdict-terminal? {} {:phase/verdict :verify/timeout})))
+    (is (false? (sut/verdict-terminal? {} {:phase/verdict :repair-requested})))
+    (is (false? (sut/verdict-terminal? {} {:phase/verdict nil})))))


### PR DESCRIPTION
## Summary

**Fable review §2.4 — Priority #3, PR-A (foundation, zero behavior change).**

The flat `terminal-verdicts` set conflated three kinds of failure that *should* carry different machine semantics. This names them so PR-B can route them differently — without changing any behavior here.

## Changes
- **`infrastructure-verdicts`** — transient: `verify/timeout`, `verify/rate-limited`, `implement/rate-limited`, `implement/network-dropped`, `implement/backend-timeout`, `review/backend-timeout`. A backoff *can* clear these.
- **`no-op-verdicts`** — evidence of absence: `implement/empty-diff`, `release/zero-files`, `implement/already-implemented-invalid`.
- **`work-terminal-verdicts`** — budget exhausted: `stagnated`, `needs-decomposition`, `exhausted`.
- **`terminal-verdicts`** is now the **union** of the three — membership identical to the old flat set, so `verdict-terminal?` routing is byte-for-byte unchanged (pinned by test).
- New **`verdict-class`** fn → `:infrastructure` / `:no-op` / `:work-terminal` / `:work`.

## Why split now
PR-B (separate, the risky FSM/runner change) peels `infrastructure-verdicts` off the terminal path to **retry-same-phase against a dedicated infra budget** — the review notes ~half the recorded burn incidents are infrastructure verdicts consuming work/redirect budgets. Naming the classes first de-risks that change and gives N3 its missing event vocabulary.

## Test plan
- `standard-guards-and-actions-test`: union == old flat set (pinned exactly); the three classes are disjoint; `verdict-class` classifies correctly; `verdict-terminal?` unchanged.
- `bb pre-commit` green (0 warnings).

Part of the Fable review program (#3, PR-A of A/B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)