### PR TITLE
feat(workflow): infra verdicts retry-same-phase on their own budget (Fable #3 PR-B)

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -110,10 +110,6 @@
   [index phase]
   (keyword (phase-state-name paused-phase-state-prefix index phase)))
 
-(defn- increment-redirect-count
-  [redirect-count]
-  (inc (or redirect-count 0)))
-
 (defn- matching-phase-index
   [phase [index config]]
   (when (= phase (:phase config))
@@ -230,14 +226,25 @@
      FSM-owned `:redirect-count` (single accounting site — Phase 4
      deletes the runner's parallel `redirect-event?` check).
    * Branch 4: default — no verdict, no on-fail, just fail."
-  [failure-target on-fail-configured?]
-  (if on-fail-configured?
-    [{:target :failed         :guard :verdict/terminal?}
-     {:target :failed         :guard :budget/redirects-spent?}
-     {:target failure-target  :actions [:redirect/inc-count]}
-     {:target :failed}]
-    [{:target :failed :guard :verdict/terminal?}
-     {:target :failed}]))
+  [failure-target on-fail-configured? self-state-id]
+  ;; Branch 0 (first): transient infrastructure verdict with infra budget left
+  ;; → retry the SAME phase (self-transition), bumping the dedicated
+  ;; :infra-retry-count. A backoff can clear timeouts/rate-limits; don't burn
+  ;; the redirect/work budget on them (Fable §2.4). When the infra budget is
+  ;; spent the guard is false and the verdict falls through to
+  ;; `:verdict/terminal?` → :failed.
+  (let [infra-branch {:target self-state-id
+                      :guard :verdict/infra-retriable?
+                      :actions [:infra/inc-count]}]
+    (if on-fail-configured?
+      [infra-branch
+       {:target :failed         :guard :verdict/terminal?}
+       {:target :failed         :guard :budget/redirects-spent?}
+       {:target failure-target  :actions [:redirect/inc-count]}
+       {:target :failed}]
+      [infra-branch
+       {:target :failed :guard :verdict/terminal?}
+       {:target :failed}])))
 
 (def ^:private guarded-phases
   "Phases whose `:phase/fail` dispatch routes through the verdict-driven
@@ -277,7 +284,8 @@
         ;; opt-in and applies the guarded form unconditionally.
         phase-fail-transition (if (guarded-phase? config)
                                 (guarded-fail-transition failure-target
-                                                         (some? on-fail-index))
+                                                         (some? on-fail-index)
+                                                         state-id)
                                 failure-target)]
     ;; Phase 4a: `:phase/terminal-fail` removed. The verdict-driven
     ;; guarded `:phase/fail` array (Phase 2b/3) is the superseding

--- a/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
@@ -31,6 +31,11 @@
 
 (defn max-phases           [] (get @defaults :max-phases 50))
 (defn max-redirects        [] (get @defaults :max-redirects 5))
+;; Infra-retry budget (Fable §2.4): transient infrastructure verdicts
+;; (timeout/rate-limit/backend-died) retry the SAME phase up to this many
+;; times — a budget DISTINCT from max-redirects, so a flaky provider can't
+;; burn the work/redirect budget.
+(defn max-infra-retries    [] (get @defaults :max-infra-retries 3))
 (defn max-consecutive-phase-retries
   "Cap on how many times the SAME phase may run in immediately consecutive
    pipeline iterations before the workflow fails loud. Distinct from

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -39,6 +39,7 @@
    omitted entirely — no runtime check needed. This is structurally
    identical to the RFC behavior with simpler runtime arithmetic."
   (:require
+   [clojure.set :as set]
    [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.workflow.actions :as actions]
    [ai.miniforge.workflow.guards :as guards]
@@ -47,62 +48,68 @@
 
 ;------------------------------------------------------------------------------ Verdict-driven guards
 
-(def terminal-verdicts
-  "The set of `:phase/verdict` values that route a phase failure straight
-   to the workflow terminal `:failed` state, bypassing any on-fail
-   redirect. Mirrors the legacy `:stagnated?` / `:needs-decomposition?`
-   flag bits from the workaround era; collapsed here into a single
-   FSM-readable signal."
-  #{;; Convergence-failure verdicts (review phase)
-    :stagnated
-    :needs-decomposition
-    :exhausted
-    ;; Verify-specific (Phase 3a): retrying implement does not unblock a
-    ;; timed-out test process or a provider rate-limit. Both terminate.
-    :verify/timeout
+;; Verdict taxonomy (Fable review §2.4). Three classes of failure verdict,
+;; each carrying different machine semantics. PR-A (this change) names the
+;; classes and keeps `terminal-verdicts` as their UNION — so routing is
+;; byte-for-byte unchanged. PR-B peels `infrastructure-verdicts` off the
+;; terminal path to retry-same-phase against an infra budget (transient
+;; failures a backoff can clear), where ~half the recorded burn incidents
+;; live.
+
+(def infrastructure-verdicts
+  "TRANSIENT infrastructure failures — a timeout, provider rate-limit,
+   backend/stream death, or dropped network. A retry after backoff CAN clear
+   these; they are not evidence the work is wrong. Today still terminal (kept
+   in `terminal-verdicts`); PR-B routes them to retry-same-phase against a
+   dedicated infra-retry budget instead of the redirect/work budget."
+  #{:verify/timeout
     :verify/rate-limited
-    ;; Release-specific (Phase 3b): curator-rejected (no files to ship).
-    ;; Retrying implement won't change the curator's decision — the
-    ;; diff is empty and the next pass would just produce another empty
-    ;; diff. Terminal.
-    :release/zero-files
-    ;; Implement-specific (Phase 3c). All three are cases where the
-    ;; on-fail :implement loop would just re-enter and hit the same
-    ;; wall — terminate the workflow instead.
-    ;;   :rate-limited — provider quota; budget retries won't change it
-    ;;   :empty-diff   — curator: no files written; retry would produce
-    ;;                   another empty diff
-    ;;   :already-implemented-invalid — the implementer claimed done
-    ;;                   but verify hadn't passed; retry won't fix the
-    ;;                   stale claim
     :implement/rate-limited
-    :implement/empty-diff
-    :implement/already-implemented-invalid
-    ;; PR-C of network-resilience stack: the implement phase exhausted
-    ;; its iteration budget retrying from the persisted checkpoint
-    ;; after PR-B's network-monitor detected sustained provider
-    ;; outages. Retrying again would just hit the same dead network on
-    ;; the next probe cycle. Terminal — operator surfaces the workflow
-    ;; for manual resume once connectivity is restored.
     :implement/network-dropped
-    ;; PR-B of phase-timeout stack (companion to network-resilience):
-    ;; the reviewer LLM call hit its adaptive timeout (stream-idle /
-    ;; stagnation / hard-limit / generic) with no real verdict
-    ;; produced. PR-A (#1058) made the reviewer agent take the
-    ;; `:reviewer/backend-timeout` error exit instead of synthesizing
-    ;; a false `:rejected`; this verdict surfaces that to the FSM.
-    ;; Distinct from `:exhausted` — `:exhausted` means the reviewer
-    ;; HAD a verdict the gate couldn't approve, this means the
-    ;; reviewer never produced one.
-    :review/backend-timeout
-    ;; PR-C of phase-timeout stack (companion to PR-B + network-
-    ;; resilience PR-C): the implementer LLM call exhausted its
-    ;; iteration budget retrying from the persisted checkpoint after
-    ;; consecutive stream-idle / stagnation / hard-limit timeouts.
-    ;; Same recovery shape as `:implement/network-dropped` — retriable
-    ;; up to the budget, then terminal. Retrying again would just hit
-    ;; the same slow provider on the next pass.
-    :implement/backend-timeout})
+    :implement/backend-timeout
+    :review/backend-timeout})
+
+(def no-op-verdicts
+  "EVIDENCE-OF-ABSENCE failures — the work produced nothing actionable, so a
+   retry would just reproduce the same empty result. Always fail closed.
+     :empty-diff / :zero-files — curator found no files written
+     :already-implemented-invalid — implementer claimed done but verify
+                                    hadn't passed; retry won't fix the claim"
+  #{:implement/empty-diff
+    :release/zero-files
+    :implement/already-implemented-invalid})
+
+(def work-terminal-verdicts
+  "WORK that ran its course — the review/repair loop exhausted its budget
+   without converging. Terminal (the end of the work-redirect path)."
+  #{:stagnated
+    :needs-decomposition
+    :exhausted})
+
+(def terminal-verdicts
+  "The set of `:phase/verdict` values that route a phase failure straight to
+   the workflow terminal `:failed` state, bypassing any on-fail redirect.
+
+   The UNION of the three terminal classes — identical membership to the
+   pre-taxonomy flat set, so `verdict-terminal?` routing is unchanged by the
+   PR-A split. PR-B removes `infrastructure-verdicts` from this union so
+   transient failures retry rather than terminate."
+  (set/union infrastructure-verdicts no-op-verdicts work-terminal-verdicts))
+
+(defn verdict-class
+  "Classify a phase `:phase/verdict` into the taxonomy (Fable §2.4):
+     :infrastructure — transient; retry-worthy (PR-B)
+     :no-op          — evidence of absence; fail closed
+     :work-terminal  — work budget exhausted; fail closed
+     :work           — an ordinary actionable failure → redirect / repair
+   Closed over the three sets; the default `:work` covers every
+   non-terminal verdict (e.g. `:repair-requested`)."
+  [verdict]
+  (cond
+    (contains? infrastructure-verdicts verdict) :infrastructure
+    (contains? no-op-verdicts verdict)          :no-op
+    (contains? work-terminal-verdicts verdict)  :work-terminal
+    :else                                       :work))
 
 (defn verdict-terminal?
   "Guard: true when the failing-phase event carries a terminal verdict.

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -131,6 +131,20 @@
         max-r (defaults/max-redirects)]
     (>= (get ctx :redirect-count 0) max-r)))
 
+(defn verdict-infra-retriable?
+  "Guard: true when the failing-phase verdict is a TRANSIENT infrastructure
+   verdict (timeout / rate-limit / backend-died / network-dropped) AND the
+   infra-retry budget is not yet spent. When true the guarded `:phase/fail`
+   array retries the SAME phase (a backoff can clear the failure) against the
+   dedicated infra budget — not the redirect/work budget. Once the budget is
+   spent this returns false and the verdict falls through to
+   `verdict-terminal?` → `:failed` (infra verdicts are still in
+   `terminal-verdicts`). Fable §2.4."
+  [state event]
+  (and (contains? infrastructure-verdicts (:phase/verdict event))
+       (< (get (fsm/context state) :infra-retry-count 0)
+          (defaults/max-infra-retries))))
+
 ;------------------------------------------------------------------------------ Actions
 
 (def redirect-inc-count
@@ -148,11 +162,21 @@
   (sc/assign (fn [ctx _event]
                (update ctx :redirect-count (fnil inc 0)))))
 
+(def infra-inc-count
+  "Action: bumps the FSM-context `:infra-retry-count` by 1 on each infra
+   retry. Separate counter from `:redirect-count` so transient
+   infrastructure retries never consume the work/redirect budget. Uses
+   `sc/assign` directly for the same reason as `redirect-inc-count`."
+  (sc/assign (fn [ctx _event]
+               (update ctx :infra-retry-count (fnil inc 0)))))
+
 ;------------------------------------------------------------------------------ Registration
 
 ;; Eager registration at namespace load — `(require '...standard-guards-and-actions)`
 ;; is enough to populate both registries. `compile-execution-machine` then
 ;; resolves the keyword refs.
 (guards/register-guard! :verdict/terminal?         verdict-terminal?)
+(guards/register-guard! :verdict/infra-retriable?  verdict-infra-retriable?)
 (guards/register-guard! :budget/redirects-spent?   budget-redirects-spent?)
 (actions/register-action! :redirect/inc-count      redirect-inc-count)
+(actions/register-action! :infra/inc-count         infra-inc-count)

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -30,9 +30,11 @@
    propagating bad state down the pipeline."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.phase.phase-result :as phase-result]
+   [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.workflow.execution :as exec]
-   [ai.miniforge.workflow.fsm :as workflow-fsm]))
+   [ai.miniforge.workflow.fsm :as workflow-fsm]
+   ;; loaded for its eager guard/action registration (infra-retry guards)
+   [ai.miniforge.workflow.standard-guards-and-actions]))
 
 ;; Phase 4b removed `exec/redirect-target` and the
 ;; `determine-phase-event-failure-with-redirect-target` test (which
@@ -218,3 +220,48 @@
           "happy path must not flag the ctx as failed")
       (is (not= prior-state (:execution/fsm-state out))
           "happy path must move the FSM forward"))))
+
+;; -------------------------------------------------------------------------- infra-retry (Fable §2.4 PR-B)
+;;
+;; A transient infrastructure verdict retries the SAME phase against a
+;; dedicated infra budget — not the redirect/work budget — then terminates
+;; once the budget is spent. Driven through the real compiled execution
+;; machine so the guarded-array behaviour matches production.
+
+(defn- guarded-phase-machine
+  "Compile a single guarded-phase (implement) workflow and park the FSM at it."
+  []
+  (let [m (workflow-fsm/compile-execution-machine
+           {:workflow/id :infra-retry-test
+            :workflow/version "1.0.0"
+            :workflow/pipeline [{:phase :implement}]})]
+    {:machine m
+     :state (->> (workflow-fsm/initialize-execution m)
+                 (workflow-fsm/start-execution m))}))
+
+(deftest infra-verdict-retries-same-phase-then-terminates
+  (testing "infra verdict retries the same phase up to the infra budget, then
+            terminates — and never touches the redirect/work budget"
+    (let [{:keys [machine state]} (guarded-phase-machine)
+          phase (:_state state)
+          fail-infra (fn [s] (fsm/transition machine s
+                                             {:type :phase/fail
+                                              :phase/verdict :implement/rate-limited}))
+          s1 (fail-infra state)
+          s2 (fail-infra s1)
+          s3 (fail-infra s2)]
+      (is (= phase (:_state s1)) "1st infra fail retries the same phase, not :failed")
+      (is (= phase (:_state s3)) "still at the phase while infra budget remains")
+      (is (= 3 (:infra-retry-count s3)) "the infra counter bumps each retry")
+      (is (= 0 (get s3 :redirect-count 0)) "redirect/work budget is untouched")
+      (let [s4 (fail-infra s3)]
+        (is (= :failed (:_state s4))
+            "infra budget exhausted (>= max-infra-retries) → terminal :failed")))))
+
+(deftest non-infra-verdict-does-not-consume-infra-budget
+  (testing "a work-terminal verdict goes straight to :failed without retrying"
+    (let [{:keys [machine state]} (guarded-phase-machine)
+          out (fsm/transition machine state
+                              {:type :phase/fail :phase/verdict :stagnated})]
+      (is (= :failed (:_state out)) "terminal work verdict → :failed immediately")
+      (is (= 0 (get out :infra-retry-count 0)) "no infra retry consumed"))))

--- a/components/workflow/test/ai/miniforge/workflow/standard_guards_and_actions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/standard_guards_and_actions_test.clj
@@ -1,0 +1,67 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.standard-guards-and-actions-test
+  "Verdict taxonomy (Fable §2.4). PR-A: the three classes name the existing
+   terminal set; the union must stay identical so routing is unchanged."
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.standard-guards-and-actions :as sut]))
+
+(deftest terminal-verdicts-union-is-unchanged
+  (testing "terminal-verdicts is exactly the union of the three classes —
+            membership identical to the pre-taxonomy flat set, so
+            verdict-terminal? routing does not change in PR-A"
+    (is (= sut/terminal-verdicts
+           (set/union sut/infrastructure-verdicts
+                      sut/no-op-verdicts
+                      sut/work-terminal-verdicts)))
+    (is (= #{:stagnated :needs-decomposition :exhausted
+             :verify/timeout :verify/rate-limited :release/zero-files
+             :implement/rate-limited :implement/empty-diff
+             :implement/already-implemented-invalid :implement/network-dropped
+             :review/backend-timeout :implement/backend-timeout}
+           sut/terminal-verdicts)
+        "pins the exact terminal set so any future change is deliberate")))
+
+(deftest verdict-classes-are-disjoint
+  (testing "no verdict belongs to more than one terminal class"
+    (is (empty? (set/intersection sut/infrastructure-verdicts sut/no-op-verdicts)))
+    (is (empty? (set/intersection sut/infrastructure-verdicts sut/work-terminal-verdicts)))
+    (is (empty? (set/intersection sut/no-op-verdicts sut/work-terminal-verdicts)))))
+
+(deftest verdict-class-classification
+  (testing "each terminal verdict classifies into its class"
+    (is (= :infrastructure (sut/verdict-class :verify/timeout)))
+    (is (= :infrastructure (sut/verdict-class :review/backend-timeout)))
+    (is (= :no-op (sut/verdict-class :implement/empty-diff)))
+    (is (= :no-op (sut/verdict-class :release/zero-files)))
+    (is (= :work-terminal (sut/verdict-class :stagnated)))
+    (is (= :work-terminal (sut/verdict-class :exhausted))))
+  (testing "anything else (ordinary actionable failure) is :work"
+    (is (= :work (sut/verdict-class :repair-requested)))
+    (is (= :work (sut/verdict-class :rejected)))
+    (is (= :work (sut/verdict-class nil)))))
+
+(deftest verdict-terminal?-unchanged
+  (testing "guard still fires for every terminal verdict, not for :work ones"
+    (is (true? (sut/verdict-terminal? {} {:phase/verdict :stagnated})))
+    (is (true? (sut/verdict-terminal? {} {:phase/verdict :verify/timeout})))
+    (is (false? (sut/verdict-terminal? {} {:phase/verdict :repair-requested})))
+    (is (false? (sut/verdict-terminal? {} {:phase/verdict nil})))))

--- a/components/workflow/test/ai/miniforge/workflow/standard_guards_and_actions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/standard_guards_and_actions_test.clj
@@ -65,3 +65,23 @@
     (is (true? (sut/verdict-terminal? {} {:phase/verdict :verify/timeout})))
     (is (false? (sut/verdict-terminal? {} {:phase/verdict :repair-requested})))
     (is (false? (sut/verdict-terminal? {} {:phase/verdict nil})))))
+
+(deftest verdict-infra-retriable?-test
+  (testing "infra verdict + infra budget left → retriable (retry same phase)"
+    (is (true? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 0}
+                                             {:phase/verdict :verify/timeout})))
+    (is (true? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 2}
+                                             {:phase/verdict :implement/rate-limited})))
+    (is (true? (sut/verdict-infra-retriable? {:_state :p}
+                                             {:phase/verdict :review/backend-timeout}))
+        "absent counter treated as 0"))
+  (testing "infra verdict + budget spent (>= max 3) → not retriable → falls to terminal"
+    (is (false? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 3}
+                                              {:phase/verdict :verify/timeout}))))
+  (testing "non-infra verdict is never infra-retriable, regardless of budget"
+    (is (false? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 0}
+                                              {:phase/verdict :stagnated})))
+    (is (false? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 0}
+                                              {:phase/verdict :implement/empty-diff})))
+    (is (false? (sut/verdict-infra-retriable? {:_state :p}
+                                              {:phase/verdict :repair-requested})))))


### PR DESCRIPTION
## Summary

**Fable review §2.4 — Priority #3, PR-B (the behavior change).** Stacked on #1122 (PR-A taxonomy).

Transient infrastructure verdicts (timeout / rate-limit / backend-died / network-dropped) were **terminal** — a flaky provider killed the run. The review found ~half the recorded burn incidents were infrastructure verdicts consuming the work/redirect budget. Now they **retry the same phase against a dedicated infra budget**; the redirect/work budget is never touched.

## Changes
- **`runner-defaults/max-infra-retries`** (default 3) — distinct from `max-redirects`.
- **`verdict-infra-retriable?`** guard (infra verdict AND infra budget left) + **`infra/inc-count`** action (bumps a separate `:infra-retry-count`); both registered.
- **Guarded `:phase/fail` array** gets a new FIRST branch: infra-retriable → **self-transition** (retry same phase) + `:infra/inc-count`. Budget spent → guard false → falls through to `:verdict/terminal?` → `:failed`.
- Removed two now-dead vars surfaced on the touched files (`increment-redirect-count`, an unused test require).

## Why no apply-phase-transition change
The counter lives in the fsm-state snapshot, so the self-transition changes state → the runner re-executes the phase naturally; the outer `max-iterations` is the backstop. The three Phase-5 compile-time invariants still hold (infra uses a separate action, not the redirect counter).

## Verified end-to-end (real compiled machine)
An `:implement/rate-limited` verdict retries `:phase-0-implement` 3× (`infra-retry-count`→3, **`redirect-count` stays 0**), then the 4th terminates to `:failed`. A `:stagnated` (work-terminal) verdict goes straight to `:failed` with no infra retry.

## Test plan
- `standard-guards-and-actions-test`: `verdict-infra-retriable?` (infra+budget→true, budget-spent→false, non-infra→false).
- `phase-transitions-test`: integration — infra verdict retries then terminates on budget; work-terminal verdict fails immediately.
- `bb pre-commit` green (0 warnings), incl. poly check + GraalVM.

Part of the Fable review program (#3, PR-B). **Merge #1122 (PR-A) first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)