### PR TITLE
feat(agent,mcp): retire the submit tool — worktree/container diff is the artifact (Fable #4)

### DIFF
--- a/bases/mcp-context-server/resources/mcp-context-server/tool-registry.edn
+++ b/bases/mcp-context-server/resources/mcp-context-server/tool-registry.edn
@@ -53,27 +53,4 @@
     :properties
     {"pattern" {:type "string" :description "Glob pattern to match files (e.g. \"**/*.clj\", \"src/**/*.ts\")"}}}}
   :required-params
-  {"pattern" {:check :non-blank :msg "pattern is required"}}}
-
- "submit"
- {:handler :submit
-  :tool-def
-  {:name "submit"
-   :description "Submit structured phase artifact metadata. Use after writing files with Write/Edit. The runtime derives file contents from the working tree and reads this metadata from artifact.edn."
-   :inputSchema
-   {:type "object"
-    :properties
-    {"code_summary" {:type "string" :description "Brief summary of changes made"}
-     "code_tests_needed" {:type "boolean" :description "Whether tests should be run for the changes"}
-     "code_dependencies_added" {:type "array"
-                                :items {:type "string"}
-                                :description "Dependency coordinates added by the change"}
-     "status" {:type "string" :description "Status for non-code submissions, for example already-implemented"}
-     "summary" {:type "string" :description "Summary for non-code submissions"}}}}
-  :param-aliases
-  {"code_summary"            :code/summary
-   "code_tests_needed"       :code/tests-needed?
-   "code_dependencies_added" :code/dependencies-added
-   "status"                  :status
-   "summary"                 :summary}
-  :required-params {}}}
+  {"pattern" {:check :non-blank :msg "pattern is required"}}}}

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -195,25 +195,9 @@
         (binding [*out* *err*]
           (println (msg/t :cache/misses-written {:count (count misses) :path path})))))))
 
-(defn- artifact-dir
-  []
-  (:artifact-dir @cache-state))
-
-(defn handle-submit
-  "Persist a structured artifact payload to artifact.edn.
-
-   Params arrive after the tool registry's `:param-aliases` rewrite
-   in `tools/handle-tool-call`, so callers see EDN-ready keyword keys
-   (e.g. `:code/summary`, `:code/tests-needed?`)."
-  [params]
-  (let [dir (artifact-dir)]
-    (when (str/blank? dir)
-      (throw (ex-info "artifact-dir is not configured" {:code -32603})))
-    (let [path (str dir "/artifact.edn")]
-      (io/make-parents path)
-      (spit path (pr-str params))
-      {:content [{:type "text"
-                  :text (str "Artifact submitted to " path)}]})))
+;; `handle-submit` (the artifact.edn metadata channel) removed: the artifact is
+;; the worktree/container diff (promotion); the curator derives the summary.
+;; Models ignored the opt-in submit tool anyway. See artifact_session/mcp-tools.
 
 (defn- record-miss!
   "Record a cache miss for meta-loop learning."

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
@@ -112,8 +112,7 @@
   []
   (tools/register-handler! :context-read  context-cache/handle-context-read)
   (tools/register-handler! :context-grep  context-cache/handle-context-grep)
-  (tools/register-handler! :context-glob  context-cache/handle-context-glob)
-  (tools/register-handler! :submit        context-cache/handle-submit))
+  (tools/register-handler! :context-glob  context-cache/handle-context-glob))
 
 (defn run-server
   "Run the MCP context server loop, reading JSON-RPC messages from stdin.

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -211,46 +211,9 @@
         (is (= "(ns b)" (get-in @cache/cache-state [:files "src/b.clj"])))
         (is (= "/tmp/repo-root" (:source-root @cache/cache-state)))))))
 
-(deftest handle-submit-writes-artifact-test
-  (testing "submit persists the aliased keyword-keyed payload"
-    (with-temp-dir
-      (fn [dir]
-        (cache/load-cache! dir "/tmp/repo-root")
-        (let [result (cache/handle-submit
-                       {:code/summary "Added event tools"
-                        :code/tests-needed? true
-                        :code/dependencies-added ["org/example"]})
-              artifact-file (io/file dir "artifact.edn")
-              artifact (edn/read-string (slurp artifact-file))]
-          (is (re-find #"Artifact submitted" (get-in result [:content 0 :text])))
-          (is (= {:code/summary "Added event tools"
-                  :code/tests-needed? true
-                  :code/dependencies-added ["org/example"]}
-                 artifact)))))))
-
-(deftest handle-tool-call-submit-end-to-end-aliases-wire-keys-test
-  (testing "an MCP submit call with wire-safe string keys round-trips to namespaced EDN"
-    ;; The MCP server registers handlers lazily; mimic that wiring here so
-    ;; the test can drive `tools/handle-tool-call` like an external caller.
-    (require 'ai.miniforge.mcp-context-server.tools)
-    (let [tools (requiring-resolve 'ai.miniforge.mcp-context-server.tools/handle-tool-call)
-          register (requiring-resolve 'ai.miniforge.mcp-context-server.tools/register-handler!)]
-      (register :submit cache/handle-submit)
-      (with-temp-dir
-        (fn [dir]
-          (cache/load-cache! dir "/tmp/repo-root")
-          (let [result (tools "submit"
-                              {"code_summary" "Wire-safe submit"
-                               "code_tests_needed" false
-                               "code_dependencies_added" []
-                               "summary" "non-code"})
-                artifact (edn/read-string (slurp (io/file dir "artifact.edn")))]
-            (is (re-find #"Artifact submitted" (get-in result [:content 0 :text])))
-            (is (= {:code/summary "Wire-safe submit"
-                    :code/tests-needed? false
-                    :code/dependencies-added []
-                    :summary "non-code"}
-                   artifact))))))))
+;; The submit/artifact.edn tests were removed with the submit tool — the
+;; artifact is now the worktree/container diff (promotion), not an agent
+;; metadata channel.
 
 (deftest handle-context-read-source-root-fallback-test
   (testing "relative file reads resolve from source-root when cache is empty"

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/tools_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/tools_test.clj
@@ -8,8 +8,7 @@
 ;; you may not use this file except in compliance with the License.
 
 (ns ai.miniforge.mcp-context-server.tools-test
-  (:require [clojure.set :as set]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [ai.miniforge.mcp-context-server.tools :as tools]))
 
@@ -88,11 +87,5 @@
                                   (str (pr-str k) " at " (vec path)))
                                 offenders))))))))
 
-(deftest submit-tool-alias-map-covers-every-declared-property
-  (testing "every input_schema property of the submit tool has a :param-aliases entry"
-    (let [submit (get (tools/tool-registry) "submit")
-          declared (set (keys (get-in submit [:tool-def :inputSchema :properties])))
-          aliased  (set (keys (get submit :param-aliases {})))]
-      (is (= declared aliased)
-          (str "submit tool declares properties without aliases: "
-               (set/difference declared aliased))))))
+;; submit-tool-alias-map test removed with the submit tool (artifact is now
+;; the worktree/container diff, not an agent metadata channel).

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -491,10 +491,14 @@
    iter discovered Write worked while Edit did not. Both issues trace
    back to keeping the structured form honest and adapters translating
    at the CLI boundary."
+  ;; No `:submit` — the artifact is the worktree/container diff (promotion),
+  ;; the definitive channel. Models trained to their native tools ignore an
+  ;; opt-in submit tool anyway (84:0 in dogfood), and a submit-without-files
+  ;; turn is exactly the empty-disk failure we want to eliminate. Files are
+  ;; the def; the curator derives the summary from the diff.
   [{:mcp/server :context :mcp/tool :context_read}
    {:mcp/server :context :mcp/tool :context_grep}
    {:mcp/server :context :mcp/tool :context_glob}
-   {:mcp/server :context :mcp/tool :submit}
    ;; Native write tools: implementer needs all three patch shapes.
    ;; `Write` for full-file rewrites (planner's plan.edn, implementer
    ;; new files, releaser PR drafts). `Edit` for single-region patches.

--- a/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
@@ -285,8 +285,9 @@
   (testing "context-server MCP tools are present"
     (let [mcp-entries (filter map? session/mcp-tools)]
       (is (every? #(= :context (:mcp/server %)) mcp-entries))
-      (is (= #{:context_read :context_grep :context_glob :submit}
-             (into #{} (map :mcp/tool) mcp-entries)))))
+      (is (= #{:context_read :context_grep :context_glob}
+             (into #{} (map :mcp/tool) mcp-entries))
+          "submit removed — the artifact is the worktree/container diff")))
 
   (testing "native Write is auto-approved — plan.edn submission path"
     ;; Iter 15 dogfood regression — Write wasn't in --allowedTools,

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -351,7 +351,6 @@
   (testing "mcp-tools translate to Mcp(...) + Write(**) rules"
     (let [allow (session/cursor-permission-allow session/mcp-tools nil)]
       (is (some #(= "Mcp(context:context_read)" %) allow))
-      (is (some #(= "Mcp(context:submit)" %) allow))
       (is (some #(= "Write(**)" %) allow))
       (testing "Write/Edit/MultiEdit collapse to a single Write(**) rule"
         (is (= 1 (count (filter #(= "Write(**)" %) allow)))))))


### PR DESCRIPTION
## Summary

**Fable review §1.2 + design intent — Priority #4 (artifact side).**

The artifact is the **worktree/container diff (promotion)** — the files *are* the def. `submit` was metadata-only (its own description: *"the runtime derives file contents from the working tree"*), and models trained to their native tools **ignored** the opt-in submit call anyway (84:0 in dogfood). A submit-without-files turn is exactly the empty-disk failure we want to eliminate.

## Changes
- **`artifact_session/mcp-tools`** — dropped `:submit` from the agent allowlist.
- **mcp-context-server** — removed the `submit` tool-registry entry, its server registration, and `handle-submit` (+ the now-dead private `artifact-dir` helper that only it used).
- Removed the submit/`artifact.edn` tests; dropped a now-unused require.

## Why it's safe
Submit was a **fallback everywhere, never primary**:
- **implement** → artifact is the code-file diff (curator collects from the worktree).
- **planner** → artifact is `.miniforge/plan.edn`, already its primary (`worktree-artifact` wins the precedence); submit + final-message-EDN were fallbacks.

The curator derives the summary from the diff, so the metadata submit carried isn't lost. `result_boundary` handles the now-always-nil `:artifact` input gracefully.

## Test plan
- `mcp-context-server` context-cache + tools suites green (submit tests removed).
- `bb pre-commit` green: poly check, lint **0 warnings**, smoke (302 ns), GraalVM/bb.

Part of the Fable program (#4, artifact side). Follow-ups: the **cache-under-native-tools hook** (token economy, must work in-container), then the `context_*` mirror tools + API-vs-harness lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)