### PR TITLE
feat(agent): force the implementer onto the MCP context cache (Fable #4)

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -621,6 +621,21 @@
       (io/make-parents f)
       (spit f session-id))))
 
+(def ^:private implementer-disallowed-tools
+  "Native read/search tools the implementer MUST NOT call — forces it onto the
+   MCP context cache (context_read/context_grep/context_glob), the same
+   mechanism the planner and tester use. The cache is read-through +
+   write-through (a miss reads from source-root, caches the content, records
+   the miss), so context_read serves any file, not just the pre-populated set,
+   and re-reads within the session hit.
+
+   Write/Edit/MultiEdit stay allowed (the implementer's whole job) and so does
+   Bash — the implementer may legitimately need a shell for build/git steps.
+   That leaves a `cat`/`rg`-via-Bash cache-bypass open; if dogfood shows the
+   implementer evading the cache through the shell, add \"Bash\" here (the
+   planner disallows it for exactly that reason)."
+  ["Read" "Grep" "Glob" "LS" "Agent"])
+
 (defn- invoke-implementer-session
   "Session body for the implementer: cache files, build mcp-opts, call LLM."
   [session llm-client user-prompt effective-system-prompt config context on-chunk
@@ -629,10 +644,12 @@
     (let [files-map (into {} (map (fn [f] [(:path f) (:content f)])
                                   existing-files))]
       (artifact-session/write-context-cache-for-session! session files-map)))
+  (artifact-session/write-cursor-permissions-for-session! session implementer-disallowed-tools)
   (let [budget-usd (budget/resolve-cost-budget-usd :implementer config context)
         max-turns (get @implementer-prompt-data :prompt/max-turns 10)
         resume-id (read-session-checkpoint working-dir)
         mcp-opts (cond-> (artifact-session/session->mcp-opts session budget-usd max-turns)
+                   true        (assoc :disallowed-tools implementer-disallowed-tools)
                    working-dir (assoc :workdir working-dir)
                    resume-id   (assoc :resume resume-id))
         result (if on-chunk
@@ -747,12 +764,15 @@
               :retry-prompt     (submission-retry-prompt (task->text input)
                                                          (:content normalized))
               :mcp-opts-fn      (fn [session]
+                                  (artifact-session/write-cursor-permissions-for-session!
+                                   session implementer-disallowed-tools)
                                   (let [budget-usd      (budget/resolve-cost-budget-usd
                                                          :implementer config context)
                                         retry-max-turns (get @implementer-prompt-data
                                                              :prompt/submission-retry-max-turns 6)]
                                     (cond-> (artifact-session/session->mcp-opts
                                              session budget-usd retry-max-turns)
+                                      true        (assoc :disallowed-tools implementer-disallowed-tools)
                                       working-dir (assoc :workdir working-dir))))})
         recovered (normalize-implementer-result raw context working-dir)]
     (when (or (:structured-artifact recovered)

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -685,6 +685,29 @@
                                               :task/type :implement})]
       (is (= :error (:status result))))))
 
+;; Tool-disallow-list — role-scoped restriction forcing the implementer onto
+;; the MCP context cache (Fable #4 context side). Mirrors planner/tester.
+
+(deftest implementer-disallowed-tools-contents-test
+  (testing "names the native read/search tools (forced onto context_*)"
+    (let [dt @#'implementer/implementer-disallowed-tools]
+      (doseq [t ["Read" "Grep" "Glob" "LS" "Agent"]]
+        (is (some #{t} dt) (str "expected " t " in disallowed-tools")))))
+
+  (testing "does NOT include the write tools — the implementer's whole job"
+    (let [dt @#'implementer/implementer-disallowed-tools]
+      (doseq [t ["Write" "Edit" "MultiEdit"]]
+        (is (nil? (some #{t} dt)) (str t " must stay allowed")))))
+
+  (testing "does NOT include the MCP context tools"
+    (let [dt @#'implementer/implementer-disallowed-tools]
+      (doseq [t ["context_read" "context_grep" "context_glob"]]
+        (is (nil? (some #{t} dt)) (str "MCP tool " t " must NOT be disallowed")))))
+
+  (testing "does NOT (yet) include Bash — kept for build/git; tighten if dogfood
+            shows cat/rg-via-Bash cache evasion"
+    (is (nil? (some #{"Bash"} @#'implementer/implementer-disallowed-tools)))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.agent.implementer-test)


### PR DESCRIPTION
## Summary

**Fable #4 context side + design intent.** The implementer was the last high-volume phase still reading **native** (`Read`/`Bash`/`Grep`/`Glob`) instead of the MCP context cache — so it got no caching and fed no miss-learning, unlike the **planner** and **tester** which already disallow native reads. This moves it onto the same proven mechanism.

## Changes
- **`implementer-disallowed-tools`** = `["Read" "Grep" "Glob" "LS" "Agent"]` — threaded into `mcp-opts` (`:disallowed-tools`) + `write-cursor-permissions-for-session!`, on **both** the main session and the submission-recovery session.
- Forces `context_read`/`context_grep`/`context_glob`.

## Why it's safe (read-through + write-through, verified)
`context_read` → `read-through`: cache hit returns instantly; a **miss** reads from source-root, **`cache-put!`s the content**, and records the miss. So forcing the implementer onto `context_read` can't block it on an un-cached file — it serves from cache or reads through, and re-reads **within the session hit**. (`grep`'s per-file read also `cache-put!`s.)

- **Kept** `Bash` (build/git) + `Write`/`Edit`/`MultiEdit` (the job). `Bash` leaves a `cat`/`rg`-via-shell cache bypass open — documented as the knob to tighten if dogfood shows evasion (the planner disallows `Bash` for exactly that reason).

## Not in this PR
- **Reviewer** — it's on a raw `llm/chat` path (diff in the prompt, no session/cache/tools, effectively API-mode). Moving it is a *rewire* that also touches the known reviewer-reachability gap (it only sees the diff). Tracked separately.
- **Cross-phase write-through** — within-session caching works; in-session reads aren't persisted into the *next* phase's pre-population (misses are recorded for the meta-loop). Separate enhancement.

## Test plan
- `implementer-disallowed-tools-contents-test`: names the native read tools; excludes Write/Edit/MultiEdit + the `context_*` tools + (documented) `Bash`.
- `bb pre-commit` green: poly check, lint **0 warnings**, smoke (305 tests), GraalVM.
- Suggest one dogfood after merge to confirm the implementer doesn't choke on a cache-miss path the unit tests don't cover.

Part of the Fable program (#4, context side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)