### PR TITLE
feat(agent): move the reviewer onto the MCP context cache, read-only (Fable #4)

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -1146,6 +1146,37 @@
                       write-mcp-config!)]
       (run-session session body-fn read-artifact cleanup-session! :host))))
 
+(defn with-readonly-session
+  "Like `with-session`, but for READ-ONLY agents (e.g. the reviewer) that
+   consume the MCP context cache but produce NO worktree artifact.
+
+   Sets up the session + MCP config (host or governed/capsule, mirroring
+   `with-session`), runs `body-fn`, and cleans up — but skips the artifact
+   read + the nothing-found WARN that `run-session` does, since a reviewer
+   has no work product to promote. Returns the `body-fn` result directly
+   (the LLM result), not a normalized artifact map.
+
+   Use when an agent needs cached reads (context_read/grep/glob) for
+   exploration but does not write files."
+  [context body-fn]
+  (let [run (fn [session cleanup-fn]
+              (try (body-fn session)
+                   (finally (cleanup-fn session))))]
+    (if (governed? context)
+      (let [executor (:execution/executor context)
+            env-id   (:execution/environment-id context)
+            workdir  (or (:execution/worktree-path context) "/workspace")
+            session  (-> (create-capsule-session! executor env-id workdir)
+                         write-capsule-mcp-config!)]
+        (run session cleanup-capsule-session!))
+      (let [workdir (:execution/worktree-path context)
+            session (-> (if workdir
+                          (create-session! {:workdir workdir
+                                            :source-root (:source-root context)})
+                          (create-session! {:source-root (:source-root context)}))
+                        write-mcp-config!)]
+        (run session cleanup-session!)))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Create a session

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -21,6 +21,8 @@
    Performs LLM-backed semantic code review plus deterministic gate validation.
    Falls back to gate-only review when no LLM backend is available."
   (:require
+   [ai.miniforge.agent.artifact-session :as artifact-session]
+   [ai.miniforge.agent.budget :as budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.reviewer.artifact :as artifact]
@@ -74,6 +76,15 @@
 ;; Enumeration-retry validator + well-formed-recovery? +
 ;; recover-review-enumeration moved to ai.miniforge.agent.reviewer.llm-response
 ;; (PR-F decomposition).
+
+(def ^:private reviewer-disallowed-tools
+  "Native tools the reviewer MUST NOT call. Forces reads onto the MCP context
+   cache (context_read/grep/glob) — same mechanism as planner/implementer/
+   tester — and blocks ALL mutation: the reviewer inspects, it never writes.
+   Read/Grep/Glob/LS/Agent → use the cached read tools; Write/Edit/MultiEdit/
+   Bash → off entirely. With cached reads it can check reachability (callers,
+   related files) without native exploration or modifying anything."
+  ["Read" "Grep" "Glob" "LS" "Agent" "Bash" "Write" "Edit" "MultiEdit"])
 
 (defn create-reviewer
   "Create a Reviewer agent with optional configuration overrides.
@@ -149,10 +160,29 @@
                   base-opts (cond-> {:system effective-system
                                      :max-turns max-turns}
                               monitor (assoc :progress-monitor monitor))
-                  response (if on-chunk
-                             (llm/chat-stream llm-client user-prompt on-chunk
-                                              base-opts)
-                             (llm/chat llm-client user-prompt base-opts))
+                  budget-usd (budget/resolve-cost-budget-usd :reviewer review-config context)
+                  ;; Run the main review inside a read-only artifact session so
+                  ;; the reviewer reads through the MCP context cache
+                  ;; (context_read/grep/glob) instead of native tools — same
+                  ;; mechanism as planner/implementer/tester. Read-only (no
+                  ;; Write/Edit/Bash) so it can cheaply check reachability via
+                  ;; the cache without modifying anything. with-readonly-session
+                  ;; skips artifact promotion/WARN (the reviewer has no work
+                  ;; product) and returns the LLM result directly. The
+                  ;; enumeration-retry below keeps base-opts — it re-asks over
+                  ;; the same content and needs no tools/cache.
+                  response (artifact-session/with-readonly-session
+                            context
+                            (fn [session]
+                              (artifact-session/write-cursor-permissions-for-session!
+                               session reviewer-disallowed-tools)
+                              (let [opts (merge base-opts
+                                                (assoc (artifact-session/session->mcp-opts
+                                                        session budget-usd max-turns)
+                                                       :disallowed-tools reviewer-disallowed-tools))]
+                                (if on-chunk
+                                  (llm/chat-stream llm-client user-prompt on-chunk opts)
+                                  (llm/chat llm-client user-prompt opts)))))
                   normalized (result-boundary/normalize-llm-result
                               {:response response
                                :parse-response llm-response/parse-review-response})

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -86,6 +86,24 @@
    related files) without native exploration or modifying anything."
   ["Read" "Grep" "Glob" "LS" "Agent" "Bash" "Write" "Edit" "MultiEdit"])
 
+(defn- invoke-reviewer-session
+  "Read-only session body for the reviewer: force the MCP-read tools, build the
+   chat opts (base-opts + session MCP opts + the disallow-list + worktree cwd),
+   and call the LLM. Returns the LLM response. Run via `with-readonly-session`
+   so reads go through the context cache and nothing is written."
+  [session llm-client user-prompt on-chunk base-opts budget-usd max-turns]
+  (artifact-session/write-cursor-permissions-for-session! session reviewer-disallowed-tools)
+  (let [opts (cond-> (merge base-opts
+                            (assoc (artifact-session/session->mcp-opts session budget-usd max-turns)
+                                   :disallowed-tools reviewer-disallowed-tools))
+               ;; Thread the worktree cwd like the other roles — CWD-dependent
+               ;; backends (e.g. Cursor's project-scoped .cursor/*) need it to
+               ;; read the session's permission allowlist and the right repo root.
+               (:workdir session) (assoc :workdir (:workdir session)))]
+    (if on-chunk
+      (llm/chat-stream llm-client user-prompt on-chunk opts)
+      (llm/chat llm-client user-prompt opts))))
+
 (defn create-reviewer
   "Create a Reviewer agent with optional configuration overrides.
 
@@ -173,23 +191,8 @@
                   ;; the same content and needs no tools/cache.
                   response (artifact-session/with-readonly-session
                             context
-                            (fn [session]
-                              (artifact-session/write-cursor-permissions-for-session!
-                               session reviewer-disallowed-tools)
-                              (let [opts (cond-> (merge base-opts
-                                                        (assoc (artifact-session/session->mcp-opts
-                                                                session budget-usd max-turns)
-                                                               :disallowed-tools reviewer-disallowed-tools))
-                                           ;; Thread the worktree cwd like the
-                                           ;; other roles — CWD-dependent
-                                           ;; backends (e.g. Cursor's project-
-                                           ;; scoped .cursor/*) need it to read
-                                           ;; the session's permission allowlist
-                                           ;; and the right repo root.
-                                           (:workdir session) (assoc :workdir (:workdir session)))]
-                                (if on-chunk
-                                  (llm/chat-stream llm-client user-prompt on-chunk opts)
-                                  (llm/chat llm-client user-prompt opts)))))
+                            #(invoke-reviewer-session % llm-client user-prompt on-chunk
+                                                      base-opts budget-usd max-turns))
                   normalized (result-boundary/normalize-llm-result
                               {:response response
                                :parse-response llm-response/parse-review-response})

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -176,10 +176,17 @@
                             (fn [session]
                               (artifact-session/write-cursor-permissions-for-session!
                                session reviewer-disallowed-tools)
-                              (let [opts (merge base-opts
-                                                (assoc (artifact-session/session->mcp-opts
-                                                        session budget-usd max-turns)
-                                                       :disallowed-tools reviewer-disallowed-tools))]
+                              (let [opts (cond-> (merge base-opts
+                                                        (assoc (artifact-session/session->mcp-opts
+                                                                session budget-usd max-turns)
+                                                               :disallowed-tools reviewer-disallowed-tools))
+                                           ;; Thread the worktree cwd like the
+                                           ;; other roles — CWD-dependent
+                                           ;; backends (e.g. Cursor's project-
+                                           ;; scoped .cursor/*) need it to read
+                                           ;; the session's permission allowlist
+                                           ;; and the right repo root.
+                                           (:workdir session) (assoc :workdir (:workdir session)))]
                                 (if on-chunk
                                   (llm/chat-stream llm-client user-prompt on-chunk opts)
                                   (llm/chat llm-client user-prompt opts)))))

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -716,3 +716,18 @@
 (comment
   (test/run-tests 'ai.miniforge.agent.artifact-session-test)
   :leave-this-here)
+
+(deftest with-readonly-session-test
+  (testing "runs body-fn with a configured session and returns its result
+            directly (no artifact-promotion map), for read-only agents"
+    (let [ran (atom false)
+          result (session/with-readonly-session
+                  {}
+                  (fn [s]
+                    (reset! ran true)
+                    (is (:mcp-config-path s) "session has an mcp-config path")
+                    (is (:mcp-allowed-tools s) "session carries the MCP tool allowlist")
+                    :review-result))]
+      (is @ran "body-fn ran")
+      (is (= :review-result result)
+          "returns the body-fn value directly, not a normalized artifact map"))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -916,7 +916,9 @@
       (doseq [t ["Write" "Edit" "MultiEdit" "Bash"]]
         (is (some #{t} dt) (str t " must be disallowed for a read-only reviewer")))))
 
-  (testing "does NOT disallow the MCP context tools"
-    (let [dt @#'reviewer/reviewer-disallowed-tools]
-      (doseq [t ["context_read" "context_grep" "context_glob"]]
-        (is (nil? (some #{t} dt)) (str "MCP tool " t " must NOT be disallowed"))))))
+  (testing "is exactly the native tool set — the MCP read tools are allowlisted
+            by their prefixed wire names (e.g. mcp__context__context_read) and
+            are never in this native disallow-list, so reads route through the
+            cache. Pinned so any change is deliberate."
+    (is (= #{"Read" "Grep" "Glob" "LS" "Agent" "Bash" "Write" "Edit" "MultiEdit"}
+           (set @#'reviewer/reviewer-disallowed-tools)))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -901,3 +901,22 @@
         (is (= 1 (count out))
             "the adjacent-file blocker is preserved as an advisory observation")
         (is (= "adjacent-file blocker" (:description (first out))))))))
+
+;; Tool-disallow-list — the reviewer is forced onto the MCP context cache and
+;; blocked from all mutation (Fable #4 context side, reviewer rewire).
+
+(deftest reviewer-disallowed-tools-contents-test
+  (testing "names the native read/search tools (forced onto context_*)"
+    (let [dt @#'reviewer/reviewer-disallowed-tools]
+      (doseq [t ["Read" "Grep" "Glob" "LS" "Agent"]]
+        (is (some #{t} dt) (str "expected " t " in disallowed-tools")))))
+
+  (testing "blocks ALL mutation — the reviewer inspects, never writes"
+    (let [dt @#'reviewer/reviewer-disallowed-tools]
+      (doseq [t ["Write" "Edit" "MultiEdit" "Bash"]]
+        (is (some #{t} dt) (str t " must be disallowed for a read-only reviewer")))))
+
+  (testing "does NOT disallow the MCP context tools"
+    (let [dt @#'reviewer/reviewer-disallowed-tools]
+      (doseq [t ["context_read" "context_grep" "context_glob"]]
+        (is (nil? (some #{t} dt)) (str "MCP tool " t " must NOT be disallowed"))))))


### PR DESCRIPTION
## Summary

**Fable #4 context side + design intent.** The reviewer was the last agent **off** the cache mechanism — raw `llm/chat` with the diff in the prompt, no session/tools. So it couldn't check reachability (callers, related files beyond the diff — the known reviewer-reachability gap) and got no caching. This puts it on the same mechanism as planner/implementer/tester, **read-only**.

## Changes
- **`artifact-session/with-readonly-session`** — like `with-session` but for agents that consume the cache and produce **no** worktree artifact. Sets up the session + MCP config (host or governed/capsule), runs `body-fn`, cleans up; **skips** the artifact-read + nothing-found WARN (a reviewer has no work product); returns the LLM result directly.
- **`reviewer-disallowed-tools`** = `["Read" "Grep" "Glob" "LS" "Agent" "Bash" "Write" "Edit" "MultiEdit"]` — forces `context_read/grep/glob` and blocks **all** mutation (the reviewer inspects, never writes).
- Reviewer's main LLM call now runs inside `with-readonly-session` with those tools. The diff stays in the prompt; the cached read tools are **additive** — it can now check reachability via read-through (cache hit, or source-root read + cache) without native exploration.

## Safety
- Downstream parse/gates/timeout logic is **unchanged** — it operates on the `response`, whose shape is identical.
- The **enumeration-retry** keeps `base-opts` (no session) — it re-asks over the same content and needs no tools/cache.
- Reuses the implementer/planner session machinery (proven in prod), incl. governed/capsule mode.

## Test plan
- `reviewer-disallowed-tools-contents-test`: forces native reads off, blocks all mutation, leaves `context_*`.
- `with-readonly-session-test`: runs body-fn, returns its value directly (not an artifact map), session carries mcp-config + allowlist.
- Existing reviewer suite (27 tests) green through the new session path.
- `bb pre-commit` green: poly check, smoke (306), GraalVM. (4 lint warnings on `reviewer_test.clj` are pre-existing — identical in `main` — not introduced here.)
- Suggest a dogfood after merge to confirm the reviewer's session path holds in governed/capsule mode.

Part of the Fable program (#4, context side — reviewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)