### PR TITLE
feat(mcp): cross-phase context cache with write-invalidation (Fable #4)

### DIFF
--- a/bases/mcp-context-server/resources/config/mcp-context-server/messages/en-US.edn
+++ b/bases/mcp-context-server/resources/config/mcp-context-server/messages/en-US.edn
@@ -6,6 +6,8 @@
   ;; Context cache lifecycle
   :cache/loaded                "Context cache loaded: {count} files"
   :cache/load-failed           "WARN: failed to load context cache: {error}"
+  :cache/saved                 "Context cache persisted: {count} files to {path}"
+  :cache/save-failed           "WARN: failed to persist context cache: {error}"
   :cache/misses-written        "Context misses written: {count} misses to {path}"
 
   ;; Context tool responses

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -176,7 +176,8 @@
    source-root. Under .miniforge/ (gitignored) so it rides workspace
    persistence into containers across phases."
   [source-root]
-  (when source-root (str source-root "/" persistent-cache-relpath)))
+  (when-not (str/blank? source-root)
+    (str source-root "/" persistent-cache-relpath)))
 
 (defn- read-cache-edn
   "Read {:files .. :mtimes ..} from an EDN cache file, or nil on missing/bad."
@@ -223,7 +224,7 @@
    nothing is cached. Best-effort: a write failure is logged, not thrown."
   []
   (let [{:keys [source-root files mtimes]} @cache-state]
-    (when-let [path (and source-root (seq files) (persistent-cache-path source-root))]
+    (when-let [path (and (seq files) (persistent-cache-path source-root))]
       (try
         (io/make-parents path)
         (spit path (pr-str {:files files :mtimes mtimes}))
@@ -286,7 +287,7 @@
 
 (defn- cache-put!
   "Store content in the cache for a path, stamping the file's current mtime so
-   `cache-fresh?` can later detect on-disk changes (write-invalidation)."
+   `cache-stale?` can later detect on-disk changes (write-invalidation)."
   [path content]
   (swap! cache-state #(-> %
                           (assoc-in [:files path] content)
@@ -320,13 +321,13 @@
    Records a miss only on a GENUINE miss (never cached), not on a
    staleness-driven refresh. Returns content string or nil."
   [path]
-  (if (and (cache-get path) (not (cache-stale? path)))
-    (cache-get path)
-    (let [genuine-miss? (nil? (cache-get path))]
+  (let [cached (cache-get path)]
+    (if (and cached (not (cache-stale? path)))
+      cached
       (try
         (let [content (slurp (resolve-source-path path))]
           (cache-put! path content)
-          (when genuine-miss?
+          (when (nil? cached)
             (record-miss! "context_read" {:path path} (estimate-tokens content)))
           content)
         (catch Exception _ nil)))))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -96,6 +96,7 @@
 ;; Shell fallbacks
 
 (declare source-root)
+(declare file-mtime)
 
 (defn shell-grep
   "Fall back to ripgrep for files not in cache.
@@ -146,14 +147,16 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Stateful cache operations
 
-;; Cache atom holding :files (path → content) and :misses (recorded cache misses).
+;; Cache atom holding :files (path → content), :mtimes (path → epoch-ms of the
+;; file when its content was cached, for write-invalidation), and :misses
+;; (recorded cache misses).
 (defonce cache-state
-  (atom {:files {} :misses [] :source-root nil :artifact-dir nil}))
+  (atom {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil}))
 
 (defn reset-state!
   "Reset cache state. Intended for test isolation."
   []
-  (reset! cache-state {:files {} :misses [] :source-root nil :artifact-dir nil}))
+  (reset! cache-state {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil}))
 
 (defn- source-root
   []
@@ -166,24 +169,69 @@
       (.getPath f)
       (.getPath (io/file (source-root) path)))))
 
+(def ^:private persistent-cache-relpath ".miniforge/context-cache.edn")
+
+(defn- persistent-cache-path
+  "Worktree-resident cross-phase cache file, or nil when there's no
+   source-root. Under .miniforge/ (gitignored) so it rides workspace
+   persistence into containers across phases."
+  [source-root]
+  (when source-root (str source-root "/" persistent-cache-relpath)))
+
+(defn- read-cache-edn
+  "Read {:files .. :mtimes ..} from an EDN cache file, or nil on missing/bad."
+  [path]
+  (let [f (and path (io/file path))]
+    (when (and f (.exists f))
+      (try (edn/read-string (slurp f))
+           (catch Exception _ nil)))))
+
 (defn load-cache!
-  "Load context-cache.edn from artifact-dir into the cache atom."
+  "Load the context cache from two sources (freshest wins):
+
+   1. the cross-phase PERSISTENT cache at <source-root>/.miniforge/
+      context-cache.edn — reads accumulated by earlier phases. Its stored
+      mtimes are restored, so any file changed since it was persisted is
+      detected as stale and re-read on access (no stale cross-phase content).
+   2. this phase's PRE-POPULATED cache at <artifact-dir>/context-cache.edn —
+      the orchestrator's curated, just-read file set. Merged ON TOP (wins)
+      and stamped with current disk mtimes."
   ([artifact-dir] (load-cache! artifact-dir nil))
   ([artifact-dir source-root]
-   (let [path (str artifact-dir "/context-cache.edn")
-         f (io/file path)]
-     (swap! cache-state assoc
-            :source-root source-root
-            :artifact-dir artifact-dir)
-     (when (.exists f)
-       (try
-         (let [data (edn/read-string (slurp f))]
-           (swap! cache-state assoc :files (get data :files {}))
-           (binding [*out* *err*]
-             (println (msg/t :cache/loaded {:count (count (:files data))}))))
-         (catch Exception e
-           (binding [*out* *err*]
-             (println (msg/t :cache/load-failed {:error (ex-message e)})))))))))
+   (swap! cache-state assoc :source-root source-root :artifact-dir artifact-dir)
+   (try
+     (let [persistent (read-cache-edn (persistent-cache-path source-root))
+           prepop     (read-cache-edn (str artifact-dir "/context-cache.edn"))
+           pre-files  (get prepop :files {})
+           files      (merge (get persistent :files {}) pre-files)
+           ;; persistent entries keep stored mtimes (stale ones re-read);
+           ;; pre-pop entries were just read fresh → stamp current mtime.
+           pre-mtimes (reduce-kv (fn [m p _] (assoc m p (file-mtime p))) {} pre-files)
+           mtimes     (merge (get persistent :mtimes {}) pre-mtimes)]
+       (swap! cache-state assoc :files files :mtimes mtimes)
+       (when (seq files)
+         (binding [*out* *err*]
+           (println (msg/t :cache/loaded {:count (count files)})))))
+     (catch Exception e
+       (binding [*out* *err*]
+         (println (msg/t :cache/load-failed {:error (ex-message e)})))))))
+
+(defn save-cache!
+  "Persist the accumulated in-memory cache (pre-populated + read-through
+   additions, with mtimes) to the worktree-resident cross-phase cache file so
+   the NEXT phase's server loads it. No-ops without a source-root or when
+   nothing is cached. Best-effort: a write failure is logged, not thrown."
+  []
+  (let [{:keys [source-root files mtimes]} @cache-state]
+    (when-let [path (and source-root (seq files) (persistent-cache-path source-root))]
+      (try
+        (io/make-parents path)
+        (spit path (pr-str {:files files :mtimes mtimes}))
+        (binding [*out* *err*]
+          (println (msg/t :cache/saved {:count (count files) :path path})))
+        (catch Exception e
+          (binding [*out* *err*]
+            (println (msg/t :cache/save-failed {:error (ex-message e)}))))))))
 
 (defn flush-misses!
   "Write accumulated cache misses to context-misses.edn in artifact-dir."
@@ -229,10 +277,33 @@
   [path]
   (get-in @cache-state [:files path]))
 
+(defn- file-mtime
+  "Last-modified epoch-ms of the resolved source file, or nil if absent."
+  [path]
+  (let [f (io/file (resolve-source-path path))]
+    (when (.exists f)
+      (.lastModified f))))
+
 (defn- cache-put!
-  "Store content in the cache for a path."
+  "Store content in the cache for a path, stamping the file's current mtime so
+   `cache-fresh?` can later detect on-disk changes (write-invalidation)."
   [path content]
-  (swap! cache-state assoc-in [:files path] content))
+  (swap! cache-state #(-> %
+                          (assoc-in [:files path] content)
+                          (assoc-in [:mtimes path] (file-mtime path)))))
+
+(defn- cache-stale?
+  "True only when the cached entry can be PROVEN out of date: we recorded an
+   mtime for it, the file still exists, and it was modified after we cached.
+   When there's no recorded mtime or no on-disk file, staleness cannot be
+   proven, so the cached content is trusted (preserves orchestrator-seeded /
+   pre-pop entries and virtual paths). Every entry cached via `cache-put!`
+   carries an mtime, so read-after-write — an agent writing a file it earlier
+   read through the cache — is correctly detected and re-read."
+  [path]
+  (let [cached (get-in @cache-state [:mtimes path])
+        disk   (file-mtime path)]
+    (boolean (and cached disk (> disk cached)))))
 
 (defn- cached-files
   "Return the current files map from the cache."
@@ -243,16 +314,22 @@
 ;; Read-through cache: resolve content from cache or filesystem
 
 (defn- read-through
-  "Resolve file content: cache hit returns instantly, miss reads from disk,
-   caches the content, and records the miss. Returns content string or nil."
+  "Resolve file content. Fresh cache hit returns instantly. A miss — or a
+   cached entry whose file changed on disk since it was cached — reads from
+   disk, re-caches (with the new mtime), and returns the current content.
+   Records a miss only on a GENUINE miss (never cached), not on a
+   staleness-driven refresh. Returns content string or nil."
   [path]
-  (or (cache-get path)
+  (if (and (cache-get path) (not (cache-stale? path)))
+    (cache-get path)
+    (let [genuine-miss? (nil? (cache-get path))]
       (try
         (let [content (slurp (resolve-source-path path))]
           (cache-put! path content)
-          (record-miss! "context_read" {:path path} (estimate-tokens content))
+          (when genuine-miss?
+            (record-miss! "context_read" {:path path} (estimate-tokens content)))
           content)
-        (catch Exception _ nil))))
+        (catch Exception _ nil)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; MCP response helpers

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
@@ -138,4 +138,7 @@
           (process-line line)
           (recur))))
     (finally
-      (context-cache/flush-misses! artifact-dir))))
+      (context-cache/flush-misses! artifact-dir)
+      ;; Persist the accumulated cache (incl. read-through additions) to the
+      ;; worktree so the next phase loads it — cross-phase write-through.
+      (context-cache/save-cache!))))

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -331,7 +331,8 @@
           (is (= "V1" (read-text (cache/handle-context-read {"path" "src/a.clj"})))
               "first read caches V1")
           (spit f "V2")
-          (.setLastModified f (+ (.lastModified f) 10000))
+          (is (.setLastModified f (+ (.lastModified f) 10000))
+              "precondition: filesystem must honor setLastModified for this test")
           (is (= "V2" (read-text (cache/handle-context-read {"path" "src/a.clj"})))
               "second read returns fresh V2, not the stale cached V1"))))))
 

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -312,3 +312,52 @@
       (fn [dir]
         (cache/flush-misses! dir)
         (is (not (.exists (io/file (str dir "/context-misses.edn")))))))))
+
+;------------------------------------------------------------------------------ Write-invalidation + cross-phase persistence (Fable #4)
+
+(defn- read-text [result]
+  (get-in result [:content 0 :text]))
+
+(deftest read-through-invalidates-on-disk-change-test
+  (testing "a cached read is re-read when the file changes on disk — no stale
+            content after a write (the safety guard for forcing write-heavy
+            agents onto context_read, and for cross-phase persistence)"
+    (with-temp-dir
+      (fn [dir]
+        (let [f (io/file dir "src/a.clj")]
+          (io/make-parents f)
+          (spit f "V1")
+          (cache/load-cache! dir dir)
+          (is (= "V1" (read-text (cache/handle-context-read {"path" "src/a.clj"})))
+              "first read caches V1")
+          (spit f "V2")
+          (.setLastModified f (+ (.lastModified f) 10000))
+          (is (= "V2" (read-text (cache/handle-context-read {"path" "src/a.clj"})))
+              "second read returns fresh V2, not the stale cached V1"))))))
+
+(deftest save-cache-persists-across-phases-test
+  (testing "save-cache! writes the accumulated cache to <source-root>/.miniforge,
+            and a fresh load (next phase) picks it up"
+    (with-temp-dir
+      (fn [dir]
+        (let [f (io/file dir "src/b.clj")]
+          (io/make-parents f)
+          (spit f "BBB")
+          (cache/load-cache! dir dir)
+          (cache/handle-context-read {"path" "src/b.clj"})
+          (cache/save-cache!)
+          (is (.exists (io/file dir ".miniforge/context-cache.edn"))
+              "persistent cache file written under .miniforge")
+          ;; Simulate the next phase: new process state, same worktree.
+          (cache/reset-state!)
+          (cache/load-cache! (str dir "/no-prepop") dir)
+          (is (= "BBB" (get-in @cache/cache-state [:files "src/b.clj"]))
+              "the earlier phase's read is present in the next phase's cache")
+          (is (contains? (:mtimes @cache/cache-state) "src/b.clj")
+              "its mtime is restored so staleness is still detectable"))))))
+
+(deftest save-cache-noop-without-source-root-test
+  (testing "save-cache! is a safe no-op when there's no source-root"
+    (cache/reset-state!)
+    (swap! cache/cache-state assoc :files {"x" "y"})
+    (is (nil? (cache/save-cache!)) "no throw, nothing to persist without a worktree")))


### PR DESCRIPTION
## Summary

**Fable #4 + design intent.** Make a file read in phase N available, cached, in phase N+1 — **without ever serving stale content**. Two coupled changes to the read-through cache:

### 1. Write-invalidation (correctness — also de-risks the force-MCP PRs)
The cache never checked whether a cached file changed on disk. So an agent that read a file through `context_read` and then **wrote** it would re-read **stale** content — a latent bug that #1126 (implementer) and #1127 (reviewer) *expand* by routing more agents onto `context_read` (where they previously read native = always fresh).

- `cache-put!` now stamps the file's mtime.
- `read-through` re-reads when an entry is **provably stale** (mtime recorded AND file exists AND newer). No-mtime / no-disk-file entries are **trusted** (preserves orchestrator pre-pop + virtual paths). Every entry we cache carries an mtime, so read-after-write is correctly invalidated.

### 2. Cross-phase persistence
- New **`save-cache!`** writes the accumulated cache (`{:files :mtimes}`, incl. read-through additions) to `<source-root>/.miniforge/context-cache.edn` at server shutdown.
- **`load-cache!`** merges that persistent cache (restoring stored mtimes, so anything changed since persist invalidates) **under** this phase's fresh pre-pop.
- `.miniforge/` is gitignored and rides workspace persistence into containers, so the cache carries across phases (host **and** capsule) with **no new plumbing** — the server already receives `source-root`.

## Why safe
Failure mode is benign: no/zero `source-root` → no persistence (read-through still works); over-aggressive mtime check → an extra read, **never** wrong content. The mtime guard means persistence can't serve stale code.

## Test plan
- `read-through-invalidates-on-disk-change-test`: read caches V1; file rewritten + mtime bumped; next read returns **V2** (the staleness guard).
- `save-cache-persists-across-phases-test`: a read in "phase 1" is present (with restored mtime) after `reset-state!` + reload in "phase 2".
- `save-cache-noop-without-source-root-test`: safe no-op.
- Existing cache/tools suites green (pure-cache hits preserved). `bb pre-commit`: poly check, lint **0 warnings**, GraalVM/bb (mtime via `.lastModified` is bb-clean).
- Suggest a dogfood to confirm cross-phase hits + that the implementer sees its own writes.

Part of the Fable program (#4 — cross-phase persistence). Independent of #1126/#1127 (different files); best merged alongside them since it de-risks their staleness exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)