### PR TITLE
fix(event-stream): warn to stderr on stdout/stderr-sink serialization failure

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -312,7 +312,8 @@
           (println output)
           (flush))
         (catch Exception _e
-          nil)))))
+          (binding [*out* *err*]
+            (println (str "WARNING: Event sink write failed: " (ex-message _e)))))))))
 
 (defn stderr-sink
   "Create a stderr sink that prints events to standard error.
@@ -339,7 +340,8 @@
             (binding [*out* *err*]
               (println output)))
           (catch Exception _e
-            nil))))))
+            (binding [*out* *err*]
+              (println (str "WARNING: Event sink write failed: " (ex-message _e))))))))))
 
 ;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
 

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -311,9 +311,9 @@
                        (pr-str event))]
           (println output)
           (flush))
-        (catch Exception _e
+        (catch Exception e
           (binding [*out* *err*]
-            (println (str "WARNING: Event sink write failed: " (ex-message _e)))))))))
+            (println (str "WARNING: Event sink write failed: " (ex-message e)))))))))
 
 (defn stderr-sink
   "Create a stderr sink that prints events to standard error.
@@ -339,9 +339,9 @@
                          (pr-str event))]
             (binding [*out* *err*]
               (println output)))
-          (catch Exception _e
+          (catch Exception e
             (binding [*out* *err*]
-              (println (str "WARNING: Event sink write failed: " (ex-message _e))))))))))
+              (println (str "WARNING: Event sink write failed: " (ex-message e))))))))))
 
 ;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
 


### PR DESCRIPTION
## What

`stdout-sink` and `stderr-sink` silently swallowed serialization exceptions with `(catch Exception _e nil)`. The `file-sink` in the same namespace correctly logs a warning to stderr on failure; the other two sinks had no such signal, meaning dropped events were invisible to operators.

## Why this matters

During a live replay or debug session, a serialization failure in `stdout-sink` (the default sink for most pipeline runs) would silently drop events. No log line, no metric, no way to know the sink was broken. This makes operational debugging much harder.

## Fix

Replace the silent `nil` return with a `WARNING:` line printed to `*err*`, matching the pattern already used in `file-sink`. No behavioural change to callers — the sink function still returns `nil` on failure.

## Testing

`bb test` covers the event-stream component. The change is a one-liner in each of the two affected catch blocks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWAi1uYeubbwHHarZCzzsQ)_