### PR TITLE
fix(bb): add workspace component to the bb dogfood classpath

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -588,6 +588,7 @@
                  "components/tool/resources"
                  "components/artifact/src"
                  "components/artifact/resources"
+                 "components/workspace/src"
                  "components/agent/src"
                  "components/agent/resources"
                  "components/task/src"


### PR DESCRIPTION
## Summary

**Regression from #1121, caught launching an rn-01 dogfood.** PR #1121 added the new `workspace` component and wired it into the JVM deps (root `deps.edn` :dev/:test/:conformance, the projects, and the `agent`/`phase-software-factory` component deps) — but **not** into `bb.edn`'s `miniforge` alias classpath.

`agent/implementer` requires `ai.miniforge.workspace.interface`, so `bb miniforge run` (the dogfood path) failed at **load**:

```
Could not locate ai/miniforge/workspace/interface.{bb,clj,cljc} on classpath.
  at components/agent/src/ai/miniforge/agent/implementer.clj:22
```

The `graalvm-compatibility-test` didn't catch it because it doesn't load the full `workflow → agent → implementer` chain under bb.

## Fix
Add `components/workspace/src` to the `miniforge` alias `:extra-paths` (right before `agent/src`, mirroring the `deps.edn` ordering). `bb miniforge --help` now loads the full CLI chain clean.

## Test plan
- `bb miniforge --help` loads the CLI (the failing require chain) with no `FileNotFoundException`.
- `bb pre-commit` green.

This unblocks all dogfooding. Worth a quick merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)