### PR TITLE
fix(implement): surface curator no-files diagnostic to the event stream

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -382,17 +382,20 @@
         curator-terminal?
         (= :curator/no-files-written
            (get-in curator-result [:error :data :code]))
-        ;; Surface the curator's collection diagnostic (per-source file counts,
-        ;; pre-session-snapshot?, collection-mode, worktree-path) when it
-        ;; fast-fails with no-files. It is computed in curate but otherwise
-        ;; only buried in the error data — emitting it makes "implementer wrote
-        ;; files but curator saw none" debuggable from the event stream instead
-        ;; of requiring a worktree autopsy (which is gone after cleanup).
-        _ (when curator-terminal?
-            (log/warn logger :implement :implement/curator-no-files-diagnostic
-                      {:data (get-in curator-result [:error :data :diagnostic])}))
         already-implemented-noop?
         (= :already-implemented (:status impl-result))
+        ;; Surface the curator's collection diagnostic (per-source file counts,
+        ;; pre-session-snapshot?, collection-mode, worktree-path) when the
+        ;; no-files result is actually propagated as the phase failure. It is
+        ;; computed in curate but otherwise only buried in the error data —
+        ;; emitting it makes "implementer wrote files but curator saw none"
+        ;; debuggable from the event stream instead of requiring a worktree
+        ;; autopsy (which is gone after cleanup). Gated on
+        ;; (not already-implemented-noop?) so the legitimate
+        ;; success-by-prior-work path (handled below) stays quiet.
+        _ (when (and curator-terminal? (not already-implemented-noop?))
+            (log/warn logger :implement :implement/curator-no-files-diagnostic
+                      {:data (get-in curator-result [:error :data :diagnostic])}))
         ;; "Degraded handoff" means the implementer agent reported a hard
         ;; error but the curator recovered files anyway. :already-implemented
         ;; is a deliberate skip (work was completed in a prior turn) — the

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -382,6 +382,15 @@
         curator-terminal?
         (= :curator/no-files-written
            (get-in curator-result [:error :data :code]))
+        ;; Surface the curator's collection diagnostic (per-source file counts,
+        ;; pre-session-snapshot?, collection-mode, worktree-path) when it
+        ;; fast-fails with no-files. It is computed in curate but otherwise
+        ;; only buried in the error data — emitting it makes "implementer wrote
+        ;; files but curator saw none" debuggable from the event stream instead
+        ;; of requiring a worktree autopsy (which is gone after cleanup).
+        _ (when curator-terminal?
+            (log/warn logger :implement :implement/curator-no-files-diagnostic
+                      {:data (get-in curator-result [:error :data :diagnostic])}))
         already-implemented-noop?
         (= :already-implemented (:status impl-result))
         ;; "Degraded handoff" means the implementer agent reported a hard


### PR DESCRIPTION
## Summary

**Found running the rn-01 dogfood:** the implementer wrote real source files to the task worktrees (confirmed in the stream dump — correct absolute paths, no pollution), yet the curator fast-failed with `:curator/no-files-written` → `:implement/empty-diff` → implement failure → no verify/review/release, no PR.

The curator already computes a rich **diagnostic** explaining *why* each collection source came up empty — per-source file counts (`from-result` / `via-executor` / `via-local`), `pre-session-snapshot?`, `collection-mode`, `worktree-path` — but it's only buried in the error `:data`, never emitted. So once the task worktree is cleaned up, "wrote files but curator saw none" is **undebuggable**.

This is the "silent downgrade / no observability" disease: the signal exists, it's just not surfaced.

## Change
Emit the diagnostic as `:implement/curator-no-files-diagnostic` (WARN) when `curator-terminal?`. **Instrumentation only — no behavior change.**

## Why
Unblocks diagnosing the recurring curator empty-diff failure (seen across multiple past dogfoods). The next run will show exactly which collection source failed and whether the snapshot/workdir were present — turning a worktree-autopsy into a log line.

## Test plan
- `bb pre-commit` green (poly check, lint 0 warnings, smoke, GraalVM).
- Next dogfood will carry the diagnostic; the actual collection fix follows once it pinpoints the source.

Found via the rn-01 dogfood validating the cache changes (#1125–1128). Companion: #1130 (bb classpath, also a dogfood blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)