### PR TITLE
fix(gate,workflow): canonical phase-output accessor; kill review-gate shape-drift (Fable #7, PR1)

### DIFF
--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -1,5 +1,9 @@
 {:gate/messages
- {;; Behavioral gate — registry description
+ {;; Review-approved gate — verdict not approved (carries the decision read)
+  :review/not-approved
+  "Review not approved (decision={decision})"
+
+  ;; Behavioral gate — registry description
   :behavioral/description
   "Validates harness telemetry event stream against policy packs (phase: observe)"
 

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -26,6 +26,7 @@
    - :plan-complete - Plan completeness check"
   (:require [ai.miniforge.gate.messages  :as msg]
             [ai.miniforge.gate.registry  :as registry]
+            [ai.miniforge.response.interface :as response]
             [slingshot.slingshot         :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -87,21 +88,23 @@
        :step-count (count steps)})))
 
 (defn check-review-approved
-  "Check if review is approved."
+  "Check if review is approved.
+
+   Reads the decision from the ONE canonical location
+   (`response/review-decision` → `:review/decision` on the phase output the
+   gate is handed). No fossil fallbacks (`[:metadata :approved]`,
+   `[:artifact/metadata :approved]`, `[:review :approved]`): if the decision
+   isn't where the contract says, the review is not approved — loudly —
+   rather than silently coerced from a legacy boolean flag. The gate runner
+   passes the phase `:output` (the verdict) as the artifact."
   [artifact _ctx]
-  (let [decision (get artifact :review/decision)
-        explicit-decision? (some? decision)
-        approved? (if explicit-decision?
-                    (or (= :approved decision)
-                        (= :conditionally-approved decision))
-                    (or (get-in artifact [:metadata :approved])
-                        (get-in artifact [:artifact/metadata :approved])
-                        (get-in artifact [:review :approved])))]
+  (let [decision (response/review-decision artifact)
+        approved? (contains? #{:approved :conditionally-approved} decision)]
     (if approved?
       {:passed? true}
       {:passed? false
        :errors [{:type :not-approved
-                 :message "Review not approved"}]})))
+                 :message (str "Review not approved (decision=" (pr-str decision) ")")}]})))
 
 (defn check-quality
   "Generic quality check - passes if no explicit failures."

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -104,7 +104,7 @@
       {:passed? true}
       {:passed? false
        :errors [{:type :not-approved
-                 :message (str "Review not approved (decision=" (pr-str decision) ")")}]})))
+                 :message (msg/t :review/not-approved {:decision (pr-str decision)})}]})))
 
 (defn check-quality
   "Generic quality check - passes if no explicit failures."

--- a/components/gate/test/ai/miniforge/gate/interface_test.clj
+++ b/components/gate/test/ai/miniforge/gate/interface_test.clj
@@ -271,24 +271,17 @@
       (is (not (:passed? result)))
       (is (= :not-approved (get-in (first (:errors result)) [:type]))))))
 
-(deftest check-gate-review-approved-fallback-paths-test
-  (testing "review-approved gate passes via :metadata :approved fallback"
-    (let [result (gate/check-gate :review-approved
-                                   {:metadata {:approved true}}
-                                   {})]
-      (is (:passed? result))))
+(deftest check-gate-review-approved-canonical-only-test
+  (testing "review-approved gate keys ONLY off the canonical :review/decision —
+            legacy metadata-flag shapes no longer approve (they were fossils
+            from before the verdict keyword and could approve an artifact with
+            no real verdict)."
+    (is (not (:passed? (gate/check-gate :review-approved {:metadata {:approved true}} {}))))
+    (is (not (:passed? (gate/check-gate :review-approved {:artifact/metadata {:approved true}} {}))))
+    (is (not (:passed? (gate/check-gate :review-approved {:review {:approved true}} {})))))
 
-  (testing "review-approved gate passes via :artifact/metadata :approved fallback"
-    (let [result (gate/check-gate :review-approved
-                                   {:artifact/metadata {:approved true}}
-                                   {})]
-      (is (:passed? result))))
-
-  (testing "review-approved gate passes via :review :approved fallback"
-    (let [result (gate/check-gate :review-approved
-                                   {:review {:approved true}}
-                                   {})]
-      (is (:passed? result))))
+  (testing "passes on the canonical :review/decision :approved"
+    (is (:passed? (gate/check-gate :review-approved {:review/decision :approved} {}))))
 
   (testing "review-approved gate fails when no approval signal present"
     (let [result (gate/check-gate :review-approved {} {})]

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -61,14 +61,14 @@
                  {})]
     (is (false? (:passed? result)))))
 
-(deftest check-review-approved-fallback-paths-still-honored
-  (testing "legacy artifact shapes without :review/decision fall back to metadata flags"
-    (is (= {:passed? true}
-           (policy/check-review-approved {:metadata {:approved true}} {})))
-    (is (= {:passed? true}
-           (policy/check-review-approved {:artifact/metadata {:approved true}} {})))
-    (is (= {:passed? true}
-           (policy/check-review-approved {:review {:approved true}} {})))))
+(deftest check-review-approved-fossil-paths-no-longer-honored
+  (testing "legacy metadata-flag shapes are NO LONGER accepted — the verdict
+            must be at the one canonical :review/decision location. A legacy
+            :approved boolean without :review/decision fails closed (it can no
+            longer silently approve an artifact that carries no real verdict)."
+    (is (false? (:passed? (policy/check-review-approved {:metadata {:approved true}} {}))))
+    (is (false? (:passed? (policy/check-review-approved {:artifact/metadata {:approved true}} {}))))
+    (is (false? (:passed? (policy/check-review-approved {:review {:approved true}} {}))))))
 
 (deftest check-review-approved-no-signal-fails-closed
   (testing "artifact with no decision and no metadata flag → :passed? false"

--- a/components/response/src/ai/miniforge/response/access.clj
+++ b/components/response/src/ai/miniforge/response/access.clj
@@ -17,44 +17,13 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.response.access
-  "Canonical accessors for phase-result / agent-result shapes.
-
-   ONE reader per logical value, so consumers never re-derive a key-path or
-   stack a defensive `or` fallback when a value's location seems uncertain.
-   Each accessor names the single canonical location; if the value isn't
-   there, that's a loud nil (and a loud gate/consumer failure) — never a
-   silent fall-through to a stale or wrong shape.
-
-   Background: the 2026-06-12 shape-drift audit found the same logical value
-   (review decision, phase artifact, status, …) read from 3–7 different
-   key-paths across the gate / phase / resume layers, because each time a
-   location moved a consumer added another `or` branch instead of fixing the
-   contract. That hid contract breaks and caused the recurring
-   review-approved-gate-rejects-an-approved-verdict bug. This namespace is the
-   single source of truth those consumers route through.
-
-   Canonical contract:
-   - A phase's gate-relevant payload is the agent response `:output`, reached
-     from a phase-result at `[:result :output]`. `phase-output` is THE reader.
-   - A review verdict's decision is `:review/decision` on that output.")
+  "Canonical readers for phase-result / agent-result shapes — one reader per
+   logical value. Public contract on `response.interface`.")
 
 (defn phase-output
-  "THE phase artifact that gates validate: the agent response `:output`,
-   canonical location `[:result :output]` on a phase-result.
-
-   Every phase publishes its gate-relevant payload here — the curated code
-   artifact (implement), the verdict (review), the plan (plan), etc. Gates
-   read the field they care about off this one map. Returns nil when absent;
-   a gate seeing nil should fail loudly rather than the caller guessing
-   another location."
   [phase-result]
   (get-in phase-result [:result :output]))
 
 (defn review-decision
-  "THE review verdict decision keyword (`:approved`, `:rejected`,
-   `:conditionally-approved`, `:changes-requested`), read from a phase
-   `:output` map (the reviewer artifact — i.e. the value `phase-output`
-   returns for the review phase). Canonical key `:review/decision`, no fossil
-   fallbacks. Returns nil when absent."
   [output]
   (get output :review/decision))

--- a/components/response/src/ai/miniforge/response/access.clj
+++ b/components/response/src/ai/miniforge/response/access.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response.access
+  "Canonical accessors for phase-result / agent-result shapes.
+
+   ONE reader per logical value, so consumers never re-derive a key-path or
+   stack a defensive `or` fallback when a value's location seems uncertain.
+   Each accessor names the single canonical location; if the value isn't
+   there, that's a loud nil (and a loud gate/consumer failure) — never a
+   silent fall-through to a stale or wrong shape.
+
+   Background: the 2026-06-12 shape-drift audit found the same logical value
+   (review decision, phase artifact, status, …) read from 3–7 different
+   key-paths across the gate / phase / resume layers, because each time a
+   location moved a consumer added another `or` branch instead of fixing the
+   contract. That hid contract breaks and caused the recurring
+   review-approved-gate-rejects-an-approved-verdict bug. This namespace is the
+   single source of truth those consumers route through.
+
+   Canonical contract:
+   - A phase's gate-relevant payload is the agent response `:output`, reached
+     from a phase-result at `[:result :output]`. `phase-output` is THE reader.
+   - A review verdict's decision is `:review/decision` on that output.")
+
+(defn phase-output
+  "THE phase artifact that gates validate: the agent response `:output`,
+   canonical location `[:result :output]` on a phase-result.
+
+   Every phase publishes its gate-relevant payload here — the curated code
+   artifact (implement), the verdict (review), the plan (plan), etc. Gates
+   read the field they care about off this one map. Returns nil when absent;
+   a gate seeing nil should fail loudly rather than the caller guessing
+   another location."
+  [phase-result]
+  (get-in phase-result [:result :output]))
+
+(defn review-decision
+  "THE review verdict decision keyword (`:approved`, `:rejected`,
+   `:conditionally-approved`, `:changes-requested`), read from a phase
+   `:output` map (the reviewer artifact — i.e. the value `phase-output`
+   returns for the review phase). Canonical key `:review/decision`, no fossil
+   fallbacks. Returns nil when absent."
+  [output]
+  (get output :review/decision))

--- a/components/response/src/ai/miniforge/response/interface.clj
+++ b/components/response/src/ai/miniforge/response/interface.clj
@@ -242,17 +242,17 @@
   "Default function to classify exceptions into anomalies."
   chain/default-anomaly-classifier)
 
-;------------------------------------------------------------------------------ Layer 5
-;; Canonical phase/agent-result accessors (one reader per logical value)
+;------------------------------------------------------------------------------ Canonical phase/agent-result accessors
+;; One reader per logical value — the single place consumers read these shapes.
 
 (def phase-output
-  "THE phase artifact gates validate — the agent response :output at
-   [:result :output] on a phase-result. See `access` ns."
+  "The phase artifact gates validate: the agent response :output, at the one
+   canonical location [:result :output] on a phase-result."
   access/phase-output)
 
 (def review-decision
-  "THE review verdict decision keyword, read from a phase :output map.
-   Canonical key :review/decision, no fossil fallbacks. See `access` ns."
+  "The review verdict decision, read from a phase :output map. Canonical key
+   :review/decision — no fossil fallbacks."
   access/review-decision)
 
 ;------------------------------------------------------------------------------ Layer 5

--- a/components/response/src/ai/miniforge/response/interface.clj
+++ b/components/response/src/ai/miniforge/response/interface.clj
@@ -29,6 +29,7 @@
    3. Query status:   (succeeded? chain)
    4. Get summary:    (summarize chain)"
   (:require
+   [ai.miniforge.response.access :as access]
    [ai.miniforge.response.chain :as chain]
    [ai.miniforge.response.anomaly :as anomaly]
    [ai.miniforge.response.builder :as builder]
@@ -240,6 +241,19 @@
 (def default-anomaly-classifier
   "Default function to classify exceptions into anomalies."
   chain/default-anomaly-classifier)
+
+;------------------------------------------------------------------------------ Layer 5
+;; Canonical phase/agent-result accessors (one reader per logical value)
+
+(def phase-output
+  "THE phase artifact gates validate — the agent response :output at
+   [:result :output] on a phase-result. See `access` ns."
+  access/phase-output)
+
+(def review-decision
+  "THE review verdict decision keyword, read from a phase :output map.
+   Canonical key :review/decision, no fossil fallbacks. See `access` ns."
+  access/review-decision)
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Anomaly utilities (keyword-based)

--- a/components/response/test/ai/miniforge/response/access_test.clj
+++ b/components/response/test/ai/miniforge/response/access_test.clj
@@ -1,0 +1,23 @@
+;; Title: Miniforge.ai
+;; Author: Christopher Lester (christopher@miniforge.ai)
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.response.access-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.response.access :as access]))
+
+(deftest phase-output-reads-canonical-location
+  (testing "phase-output is [:result :output] — the one place"
+    (is (= {:review/decision :approved}
+           (access/phase-output {:result {:output {:review/decision :approved}}})))
+    (is (nil? (access/phase-output {:result {:artifact {:review/decision :approved}}}))
+        "does NOT fall back to :artifact — that ambiguity was the bug")
+    (is (nil? (access/phase-output {})))))
+
+(deftest review-decision-reads-canonical-key
+  (testing "review-decision is :review/decision on the output map"
+    (is (= :approved (access/review-decision {:review/decision :approved})))
+    (is (= :rejected (access/review-decision {:review/decision :rejected})))
+    (is (nil? (access/review-decision {:metadata {:approved true}}))
+        "no fossil fallback to legacy :approved flags")
+    (is (nil? (access/review-decision {})))))

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -136,9 +136,12 @@
   (if (already-done? phase-result)
     phase-result
     (let [gate-keywords (get-in interceptor [:config :gates] [])
-          artifact (or (:artifact phase-result)
-                       (get-in phase-result [:result :artifact])
-                       (get-in phase-result [:result :output]))]
+          ;; Canonical: gates validate the phase's :output ([:result :output]) —
+          ;; one location, no shape-guessing. The old (or :artifact
+          ;; [:result :artifact] [:result :output]) could hand a gate the wrong
+          ;; map: the review gate got the code-under-review at :artifact instead
+          ;; of the verdict at :output, so it rejected every approved review.
+          artifact (response/phase-output phase-result)]
       (if (and (seq gate-keywords) artifact)
         (let [gate-result (gate/check-gates gate-keywords artifact ctx)]
           (if (:passed? gate-result)


### PR DESCRIPTION
## Summary

**PR1 of the shape-drift remediation** (audit 2026-06-12). Fixes the recurring **":review-approved gate rejects an :approved verdict"** bug — root-caused live in the rn-01 `canonical-sdlc` dogfood (4/4 tasks failed, no PR, despite the reviewer returning `:approved` every cycle).

It was **two stacked multi-location lookups** ("multiple places to get one value"):
1. `apply-gate-validation` picked the gate artifact via `(or (:artifact …) (get-in … [:result :artifact]) (get-in … [:result :output]))` — for review it grabbed the **code-under-review** (`:artifact`) instead of the **verdict** (`:output`).
2. `check-review-approved` then read `:review/decision` from **four** places (top-level + 3 legacy `:approved` metadata flags) — none of which is where the verdict lives.

## Fix — one canonical place + one accessor (Fable #7)
- **New `ai.miniforge.response.access`** (exposed via `response.interface`):
  - `phase-output` → `[:result :output]` — **the** artifact gates validate.
  - `review-decision` → `:review/decision` on that output.
- `apply-gate-validation` passes `response/phase-output` — one location, no shape-guessing.
- `check-review-approved` reads `response/review-decision`; the 3 fossil metadata-flag fallbacks are **deleted** (they could approve an artifact with no real verdict). The tests that pinned the fossils are inverted: legacy shapes now **fail closed**.

## Why this matters
This bug has killed dogfood SDLCs for months (#867 / 05-16 / 05-24b). The accessor namespace is the single source of truth the remaining offenders route through, so no one adds a new `or` branch when a location moves.

## Test plan
- `response.access-test` (canonical reads, no fallback), `gate.policy-test` + `gate.interface-test` (canonical-only; legacy shapes fail closed), `phase-transitions-test`.
- `bb pre-commit` green (0 *new* warnings; 2 pre-existing unrelated).
- **Dogfood verification in progress**: re-running rn-01 `canonical-sdlc` to confirm the review gate now passes an approved verdict and the SDLC ships a PR.

## Follow-ups (sequenced PRs, same audit)
workflow-resume `review-blocked?` (7-way) + `phase-result-status` (6-way); pr-info double-write dedup; agent-result telemetry/status normalization; `:success`/`:success?` + worktree-path accessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)