### PR TITLE
fix(resume,event-stream): canonical review-decision end-to-end; normalize the writer (Fable #7, PR2)

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -510,6 +510,7 @@
                :phase/outcome outcome)
         (cond->
           (:duration-ms result) (assoc :phase/duration-ms (:duration-ms result))
+          (:review-decision result) (assoc :phase/review-decision (:review-decision result))
           (:artifacts result) (assoc :phase/artifacts (:artifacts result))
           (:error result) (assoc :phase/error (:error result))
           transition-request (assoc :phase/transition-request transition-request)

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -153,6 +153,10 @@
     [:workflow/phase keyword?]
     [:phase/duration-ms {:optional true} int?]
     [:phase/outcome {:optional true} [:enum :success :failure :skipped]]
+    ;; Review verdict, present only for the review phase. Carried so resume can
+    ;; reconstruct a blocked review from events alone — the event is a writer of
+    ;; this datum, one canonical location, no lossy reconstruction.
+    [:phase/review-decision {:optional true} keyword?]
     [:phase/artifacts {:optional true} [:vector uuid?]]
     [:phase/transition-request {:optional true} TransitionRequest]
     [:phase/redirect-to {:optional true} keyword?]

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -118,9 +118,16 @@
        (filter #(= :workflow/phase-completed (:event/type %)))
        (reduce (fn [acc evt]
                  (assoc acc (:workflow/phase evt)
-                        {:outcome (:phase/outcome evt)
-                         :duration-ms (:phase/duration-ms evt)
-                         :timestamp (:event/timestamp evt)}))
+                        ;; Reconstruct into the canonical phase-result shape so
+                        ;; one accessor reads event-reconstructed and live
+                        ;; checkpoint results alike — the review verdict at the
+                        ;; one canonical location [:result :output :review/decision].
+                        (cond-> {:outcome (:phase/outcome evt)
+                                 :duration-ms (:phase/duration-ms evt)
+                                 :timestamp (:event/timestamp evt)}
+                          (:phase/review-decision evt)
+                          (assoc-in [:result :output :review/decision]
+                                    (:phase/review-decision evt)))))
                {})))
 
 (defn find-workflow-spec
@@ -200,13 +207,7 @@
   [phase-id phase-result]
   (and (= :review phase-id)
        (contains? blocking-review-decisions
-                  (or (:review/decision phase-result)
-                      (get-in phase-result [:result :review/decision])
-                      (get-in phase-result [:result :output :review/decision])
-                      (get-in phase-result [:phase/result :review/decision])
-                      (get-in phase-result [:phase/result :output :review/decision])
-                      (get-in phase-result [:result :decision])
-                      (:decision phase-result)))))
+                  (response/review-decision (response/phase-output phase-result)))))
 
 (defn- completed-phase-result?
   [phase-id phase-result]

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -63,7 +63,25 @@
           result (core/extract-phase-results events)]
       (is (= :success (get-in result [:plan :outcome])))
       (is (= 42 (get-in result [:plan :duration-ms])))
-      (is (= "2026-04-21T00:00:00Z" (get-in result [:plan :timestamp]))))))
+      (is (= "2026-04-21T00:00:00Z" (get-in result [:plan :timestamp])))))
+
+  (testing "review verdict is reconstructed into the canonical
+            [:result :output :review/decision] location — lossless from events,
+            so a blocked review is detectable on event-only resume"
+    (let [events [{:event/type :workflow/phase-completed
+                   :workflow/phase :review
+                   :phase/outcome :success
+                   :phase/review-decision :changes-requested
+                   :event/timestamp "2026-04-21T00:00:00Z"}]
+          result (core/extract-phase-results events)]
+      (is (= :changes-requested
+             (get-in result [:review :result :output :review/decision])))))
+
+  (testing "non-review phases carry no review decision (key absent, not nil)"
+    (let [events [{:event/type :workflow/phase-completed
+                   :workflow/phase :plan :phase/outcome :success}]
+          result (core/extract-phase-results events)]
+      (is (not (contains? (get-in result [:plan :result] {}) :output))))))
 
 (deftest extract-completed-dag-tasks-test
   (testing "collects :dag/task-id values from :dag/task-completed events"
@@ -312,7 +330,7 @@
                                     :plan {:status :completed}
                                     :implement {:status :completed}
                                     :review {:status :completed
-                                             :review/decision :changes-requested}
+                                             :result {:output {:review/decision :changes-requested}}}
                                     :release {:status :retrying}}}
    :damaged-manifest {:manifest {:workflow/phases-completed [:release :plan]}
                       :phase-results {:release {:status :retrying}

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -25,6 +25,7 @@
    [clojure.string :as str]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.self-healing.interface :as self-healing]
    [ai.miniforge.workflow.messages :as messages]
    [cheshire.core :as json]))
@@ -149,6 +150,9 @@
                          (when-let [msg (:message result)]
                            {:message msg})))
         transition-request (phase/transition-request result)
+        ;; Review verdict, from the one canonical location (the phase :output).
+        ;; Carried on the event so resume can reconstruct a blocked review.
+        review-decision (response/review-decision (response/phase-output result))
         tokens   (get-in result [:metrics :tokens]
                    (get-in result [:phase/metrics :tokens]))
         cost-usd (get-in result [:metrics :cost-usd]
@@ -178,6 +182,7 @@
                                 tool-call-count       (assoc :tool-call-count tool-call-count))))]
     (cond-> {:outcome outcome :duration-ms duration-ms}
       error-info              (assoc :error error-info)
+      review-decision         (assoc :review-decision review-decision)
       transition-request      (assoc :phase/transition-request transition-request)
       tokens                  (assoc :tokens tokens)
       cost-usd                (assoc :cost-usd cost-usd)


### PR DESCRIPTION
## Summary

**Shape-drift remediation PR2** (audit 2026-06-12). `workflow-resume`'s `review-blocked?` read the review decision from **seven** key-paths — the worst offender, and it gates resume→repair routing (a wrong pick resumes *past* a blocked review or repairs an *approved* one).

Per your sharpened rule — **one canonical location to write and read each datum; when we control the writers, a multi-shape reader is still the anti-pattern** — the fix is on the **write side**, including the *event*, which was silently dropping the decision (so event-only resume could never detect a blocked review):

- **event-stream**: `:workflow/phase-completed` now carries `:phase/review-decision` (optional). The event is a writer of this datum → reconstruction is **lossless**, not a guess.
- **`runner_events/build-phase-event-data`**: emits it from the ONE canonical source (`response/review-decision ∘ response/phase-output`).
- **`workflow-resume/extract-phase-results`**: reconstructs the **canonical** phase-result shape — verdict at `[:result :output :review/decision]` — so event-reconstructed and live checkpoint results read **identically**.
- **`review-blocked?`** now reads via `response/review-decision ∘ response/phase-output`: **one accessor**, the **seven fossil key-paths deleted**.

## Why this is the right fix
The earlier "legitimate polymorphism" framing was wrong: two shapes for one datum is the disease regardless of source, because *we* write both. Polymorphism is only legitimate for sources we don't control (e.g. GitHub vs GitLab API). So: normalize the writers, including the event one level down.

## Test plan
- `extract-phase-results-test`: review verdict reconstructs into `[:result :output :review/decision]`; non-review phases carry no decision key.
- `reconstruct-context-…-completed-checkpoint-phases-test`: fixture moved to the canonical shape; a blocked (`:changes-requested`) review is correctly excluded from completed phases.
- `bb pre-commit` green (0 warnings), incl. all event consumers + GraalVM.

## Scope note
`phase-result-status` (the 6-way **status** drift) is **PR2b** — it needs the phase machinery to write `:phase/status` canonically (always), a separate careful change.

Part of the canonical-place remediation (Fable #7). Follow-ups: PR2b (status), PR3 (pr-info double-write), PR4 (telemetry), PR5 (mechanical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)