### PR TITLE
fix(workflow): gate validation fails closed on a missing canonical artifact (Fable #7)

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -142,7 +142,11 @@
           ;; map: the review gate got the code-under-review at :artifact instead
           ;; of the verdict at :output, so it rejected every approved review.
           artifact (response/phase-output phase-result)]
-      (if (and (seq gate-keywords) artifact)
+      ;; Fail closed: when gates are configured, run them even if the canonical
+      ;; artifact is nil. Skipping on nil would let a phase that omits its
+      ;; :output bypass validation entirely — the gate runner turns a nil
+      ;; artifact into a failed gate result (loud), which is what we want.
+      (if (seq gate-keywords)
         (let [gate-result (gate/check-gates gate-keywords artifact ctx)]
           (if (:passed? gate-result)
             phase-result

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -131,7 +131,9 @@
   "Apply gate validation to phase result.
 
    Returns updated phase-result with :phase/status and :phase/gate-errors if gates fail.
-   Skips gate checks when phase indicates work is already done."
+   Skips gate checks when phase indicates work is already done. When gates are
+   configured they run even if the canonical artifact ([:result :output]) is
+   nil — a nil artifact fails the gate (fail-closed), never bypasses it."
   [interceptor phase-result ctx]
   (if (already-done? phase-result)
     phase-result

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -34,9 +34,7 @@
    [ai.miniforge.workflow.execution :as exec]
    [ai.miniforge.workflow.fsm :as workflow-fsm]
    ;; loaded for its eager guard/action registration (infra-retry guards)
-   [ai.miniforge.workflow.standard-guards-and-actions]
-   ;; loaded so the :review-approved gate is registered for the gate-validation tests
-   [ai.miniforge.gate.policy]))
+   [ai.miniforge.workflow.standard-guards-and-actions]))
 
 ;; Phase 4b removed `exec/redirect-target` and the
 ;; `determine-phase-event-failure-with-redirect-target` test (which

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -279,7 +279,11 @@
   (testing "gates configured + no canonical :output → phase fails (not skipped)"
     (let [out (exec/apply-gate-validation {:config {:gates [:review-approved]}}
                                           {:result {}} {})]
-      (is (= :failed (:phase/status out)))))
+      (is (= :failed (:phase/status out)))
+      ;; The gate actually RAN on the nil artifact and emitted an error — proof
+      ;; the fail-closed branch engaged rather than the old fail-open skip
+      ;; (which returned the phase-result untouched, no :phase/gate-errors).
+      (is (seq (:phase/gate-errors out)))))
   (testing "gates configured + approved verdict → phase-result returned UNCHANGED
             (apply-gate-validation adds nothing when gates pass)"
     (let [pr  {:result {:output {:review/decision :approved}}}

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -34,7 +34,9 @@
    [ai.miniforge.workflow.execution :as exec]
    [ai.miniforge.workflow.fsm :as workflow-fsm]
    ;; loaded for its eager guard/action registration (infra-retry guards)
-   [ai.miniforge.workflow.standard-guards-and-actions]))
+   [ai.miniforge.workflow.standard-guards-and-actions]
+   ;; loaded so the :review-approved gate is registered for the gate-validation tests
+   [ai.miniforge.gate.policy]))
 
 ;; Phase 4b removed `exec/redirect-target` and the
 ;; `determine-phase-event-failure-with-redirect-target` test (which
@@ -265,3 +267,23 @@
                               {:type :phase/fail :phase/verdict :stagnated})]
       (is (= :failed (:_state out)) "terminal work verdict → :failed immediately")
       (is (= 0 (get out :infra-retry-count 0)) "no infra retry consumed"))))
+
+;; -------------------------------------------------------------------------- apply-gate-validation (fail-closed)
+;;
+;; Gates validate the canonical phase :output ([:result :output]). When gates
+;; are configured they MUST run even if that output is absent — skipping on a
+;; nil artifact would let a phase bypass validation (fail-open). The gate
+;; runner turns a nil artifact into a failed gate result.
+
+(deftest apply-gate-validation-fails-closed-on-missing-output
+  (testing "gates configured + no canonical :output → phase fails (not skipped)"
+    (let [out (exec/apply-gate-validation {:config {:gates [:review-approved]}}
+                                          {:result {}} {})]
+      (is (= :failed (:phase/status out)))))
+  (testing "gates configured + approved verdict at the canonical location → passes"
+    (let [out (exec/apply-gate-validation {:config {:gates [:review-approved]}}
+                                          {:result {:output {:review/decision :approved}}} {})]
+      (is (not= :failed (:phase/status out)))))
+  (testing "no gates configured → unchanged (nothing to validate)"
+    (let [pr {:result {}}]
+      (is (= pr (exec/apply-gate-validation {:config {:gates []}} pr {}))))))

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -280,10 +280,13 @@
     (let [out (exec/apply-gate-validation {:config {:gates [:review-approved]}}
                                           {:result {}} {})]
       (is (= :failed (:phase/status out)))))
-  (testing "gates configured + approved verdict at the canonical location → passes"
-    (let [out (exec/apply-gate-validation {:config {:gates [:review-approved]}}
-                                          {:result {:output {:review/decision :approved}}} {})]
-      (is (not= :failed (:phase/status out)))))
+  (testing "gates configured + approved verdict → phase-result returned UNCHANGED
+            (apply-gate-validation adds nothing when gates pass)"
+    (let [pr  {:result {:output {:review/decision :approved}}}
+          out (exec/apply-gate-validation {:config {:gates [:review-approved]}} pr {})]
+      (is (= pr out) "unchanged on pass")
+      (is (not (contains? out :phase/status)))
+      (is (not (contains? out :phase/gate-errors)))))
   (testing "no gates configured → unchanged (nothing to validate)"
     (let [pr {:result {}}]
       (is (= pr (exec/apply-gate-validation {:config {:gates []}} pr {}))))))


### PR DESCRIPTION
## Summary

Follow-up to PR1 (#1132), addressing Copilot's fail-open concern on the dogfood-shipped PR #1133.

`apply-gate-validation` only ran gates when the canonical artifact (`[:result :output]`) was non-nil:
```clojure
(if (and (seq gate-keywords) artifact) …)   ; nil artifact → gates skipped → fail-OPEN
```
So a gated phase that omits its `:output` would **bypass validation entirely**. Now gates run whenever any are configured; the gate runner converts a nil artifact into a **failed** gate result, so a contract break fails **loud** instead of silently passing.

## Verified
`(gate/check-gates [:review-approved] nil {})` → `{:passed? false …}` (no throw) — confirmed fail-closed.

## Test plan
- `apply-gate-validation-fails-closed-on-missing-output`: gates + no `:output` → `:phase/status :failed`; approved verdict at the canonical location → passes; no gates → unchanged.
- `bb pre-commit` green (the one `max-redirects-exceeded-anomaly` warning is pre-existing dead code, unrelated).

Part of the canonical-place remediation (Fable #7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)