### PR TITLE
fix(workflow,response): one canonical location for release pr-info (Fable #7, PR3)

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -417,11 +417,13 @@
 
     (-> (phase/enter-context ctx :release :releaser gates budget start-time result)
         ;; Single derived projection of the canonical pr-info onto ctx-level
-        ;; :workflow/pr-info — the API surface several consumers read
-        ;; (runner_events completion event, CLI summary, evidence-bundle). Read
-        ;; through the same response/release-pr-info accessor every consumer
-        ;; uses ({:result result} is the phase-result shape it expects), so the
-        ;; projection and the authority share one key-path and can't drift.
+        ;; :workflow/pr-info, which several consumers still read directly
+        ;; (runner_events completion event, CLI summary, evidence-bundle) until
+        ;; they migrate to response/release-pr-info. The projected value is
+        ;; derived from the authority via that accessor ({:result result} is the
+        ;; phase-result shape it expects), so this copy can never hold a value
+        ;; the authority doesn't — a derived cache of one reader, not a second
+        ;; source of truth.
         (cond-> (phase/result-succeeded? result)
           (assoc :workflow/pr-info (response/release-pr-info {:result result}))))))))
 

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -415,10 +415,7 @@
         ;; Emit agent-completed telemetry event for release executor
         _ (phase/emit-agent-completed! ctx :release :releaser result)]
 
-    (-> (phase/enter-context ctx :release :releaser gates budget start-time result)
-        ;; Store PR info at top level for easy access
-        (cond-> (phase/result-succeeded? result)
-          (assoc-in [:workflow/pr-info] (get-in (:output result) [:workflow/pr-info]))))))))
+    (phase/enter-context ctx :release :releaser gates budget start-time result)))))
 
 (def ^:private verdicts
   "Phase 3b verdict tag set for release.
@@ -482,7 +479,6 @@
                        :failed
                        (phase/determine-phase-status
                         agent-status iterations max-iterations))
-        pr-info (get-in ctx [:workflow/pr-info])
         on-fail (get-in ctx [:phase-config :on-fail])
         ;; Verdict is only meaningful for terminal phase statuses
         ;; (:completed → :approved; :failed → one of the failure
@@ -506,8 +502,6 @@
         updated-ctx (-> updated-ctx
                         (assoc-in [:metrics :release :duration-ms] duration-ms)
                         (assoc-in [:metrics :release :repair-cycles] (dec iterations))
-                        (cond-> pr-info
-                          (assoc-in [:metrics :release :pr-info] pr-info))
                         (update-in [:execution :phases-completed] (fnil conj []) :release)
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :cost-usd] (fnil + 0.0) (:cost-usd metrics 0.0))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -420,8 +420,7 @@
         ;; :workflow/pr-info] onto ctx-level :workflow/pr-info — the API surface
         ;; several consumers read (runner_events completion event, CLI summary,
         ;; evidence-bundle). Derived from the authority, not an independent
-        ;; write, so it can't drift. (The independent [:metrics :release
-        ;; :pr-info] write is what PR3 removes.)
+        ;; write, so it can't drift.
         (cond-> (phase/result-succeeded? result)
           (assoc-in [:workflow/pr-info] (get-in (:output result) [:workflow/pr-info]))))))))
 

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -416,13 +416,14 @@
         _ (phase/emit-agent-completed! ctx :release :releaser result)]
 
     (-> (phase/enter-context ctx :release :releaser gates budget start-time result)
-        ;; Single derived projection of the canonical [:result :output
-        ;; :workflow/pr-info] onto ctx-level :workflow/pr-info — the API surface
-        ;; several consumers read (runner_events completion event, CLI summary,
-        ;; evidence-bundle). Derived from the authority, not an independent
-        ;; write, so it can't drift.
+        ;; Single derived projection of the canonical pr-info onto ctx-level
+        ;; :workflow/pr-info — the API surface several consumers read
+        ;; (runner_events completion event, CLI summary, evidence-bundle). Read
+        ;; through the same response/release-pr-info accessor every consumer
+        ;; uses ({:result result} is the phase-result shape it expects), so the
+        ;; projection and the authority share one key-path and can't drift.
         (cond-> (phase/result-succeeded? result)
-          (assoc-in [:workflow/pr-info] (get-in (:output result) [:workflow/pr-info]))))))))
+          (assoc :workflow/pr-info (response/release-pr-info {:result result}))))))))
 
 (def ^:private verdicts
   "Phase 3b verdict tag set for release.

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -415,7 +415,15 @@
         ;; Emit agent-completed telemetry event for release executor
         _ (phase/emit-agent-completed! ctx :release :releaser result)]
 
-    (phase/enter-context ctx :release :releaser gates budget start-time result)))))
+    (-> (phase/enter-context ctx :release :releaser gates budget start-time result)
+        ;; Single derived projection of the canonical [:result :output
+        ;; :workflow/pr-info] onto ctx-level :workflow/pr-info — the API surface
+        ;; several consumers read (runner_events completion event, CLI summary,
+        ;; evidence-bundle). Derived from the authority, not an independent
+        ;; write, so it can't drift. (The independent [:metrics :release
+        ;; :pr-info] write is what PR3 removes.)
+        (cond-> (phase/result-succeeded? result)
+          (assoc-in [:workflow/pr-info] (get-in (:output result) [:workflow/pr-info]))))))))
 
 (def ^:private verdicts
   "Phase 3b verdict tag set for release.

--- a/components/response/src/ai/miniforge/response/access.clj
+++ b/components/response/src/ai/miniforge/response/access.clj
@@ -27,3 +27,7 @@
 (defn review-decision
   [output]
   (get output :review/decision))
+
+(defn release-pr-info
+  [release-phase-result]
+  (:workflow/pr-info (phase-output release-phase-result)))

--- a/components/response/src/ai/miniforge/response/interface.clj
+++ b/components/response/src/ai/miniforge/response/interface.clj
@@ -255,6 +255,11 @@
    :review/decision — no fossil fallbacks."
   access/review-decision)
 
+(def release-pr-info
+  "The release PR info, from the release phase-result's one canonical location
+   [:result :output :workflow/pr-info]."
+  access/release-pr-info)
+
 ;------------------------------------------------------------------------------ Layer 5
 ;; Anomaly utilities (keyword-based)
 

--- a/components/response/test/ai/miniforge/response/access_test.clj
+++ b/components/response/test/ai/miniforge/response/access_test.clj
@@ -21,3 +21,11 @@
     (is (nil? (access/review-decision {:metadata {:approved true}}))
         "no fossil fallback to legacy :approved flags")
     (is (nil? (access/review-decision {})))))
+
+(deftest release-pr-info-reads-canonical-location
+  (testing "release-pr-info is [:result :output :workflow/pr-info] — the one place"
+    (is (= {:pr-number 7}
+           (access/release-pr-info {:result {:output {:workflow/pr-info {:pr-number 7}}}})))
+    (is (nil? (access/release-pr-info {:metrics {:release {:pr-info {:pr-number 7}}}}))
+        "no fossil fallback to the old [:metrics :release :pr-info] write")
+    (is (nil? (access/release-pr-info {})))))

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -1233,9 +1233,7 @@
   "Extract PR info from a sub-workflow result if the release phase produced one."
   [result task-def]
   (let [release-result (get-in result [:execution/phase-results :release])
-        pr-info (or (get-in release-result [:result :output :workflow/pr-info])
-                    ;; Also check metrics path where leave-release stores it
-                    (get-in result [:metrics :release :pr-info]))]
+        pr-info (response/release-pr-info release-result)]
     (when pr-info
       (merge pr-info
              {:task-id (:task/id task-def)

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -123,13 +123,13 @@
   "Resolve the PR(s) to observe from the execution context. Returns a vector
    of pr-info maps, or nil when there is nothing to observe.
 
-   DAG runs populate `[:execution/dag-pr-infos]`. For a single-PR run, the
-   release phase stores PR info at `[:execution/phase-results :release :result
-   :output :workflow/pr-info]` (with a `[:metrics :release :pr-info]`
-   fallback) — the SAME paths `dag-orchestrator/extract-pr-info-from-result`
-   reads. The prior single-PR fallback read `[:release :pr-info]` (one level
-   too shallow, wrong key), so observe always saw nil and skipped — a
-   single-PR dogfood opened its PR and exited without ever monitoring it."
+   DAG runs populate `[:execution/dag-pr-infos]`. For a single-PR run, the PR
+   info is read via `response/release-pr-info` from the one canonical location
+   (the release phase-result's `[:result :output :workflow/pr-info]`) — the
+   same accessor `dag-orchestrator/extract-pr-info-from-result` uses. (An
+   earlier shallow `[:release :pr-info]` read and a `[:metrics :release
+   :pr-info]` fallback are both gone — observe used to see nil and skip, so a
+   single-PR dogfood opened its PR and exited without ever monitoring it.)"
   [ctx]
   (let [dag-prs (get-in ctx [:execution/dag-pr-infos])]
     (cond

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -134,9 +134,8 @@
   (let [dag-prs (get-in ctx [:execution/dag-pr-infos])]
     (cond
       (seq dag-prs) (vec dag-prs)
-      :else (when-let [pr-info (or (get-in ctx [:execution/phase-results :release
-                                                :result :output :workflow/pr-info])
-                                   (get-in ctx [:metrics :release :pr-info]))]
+      :else (when-let [pr-info (response/release-pr-info
+                                (get-in ctx [:execution/phase-results :release]))]
               [pr-info]))))
 
 (defn enter-observe

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -33,9 +33,9 @@
            (#'sut/resolve-pr-infos
             {:execution/phase-results
              {:release {:result {:output {:workflow/pr-info sample-pr}}}}}))))
-  (testing "single-PR: metrics fallback path"
-    (is (= [sample-pr]
-           (#'sut/resolve-pr-infos {:metrics {:release {:pr-info sample-pr}}}))))
+  (testing "the deprecated [:metrics :release :pr-info] fallback is NO LONGER read
+            (one canonical location — the release output)"
+    (is (nil? (#'sut/resolve-pr-infos {:metrics {:release {:pr-info sample-pr}}}))))
   (testing "REGRESSION (the #979 handoff bug): the old shallow [:release :pr-info] key is NOT read"
     (is (nil? (#'sut/resolve-pr-infos
                {:execution/phase-results {:release {:pr-info sample-pr}}}))))

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -22,7 +22,9 @@
    [clojure.test :refer [deftest is testing]]))
 
 (def ^:private sample-pr
-  {:pr-number 42 :pr-url "https://github.com/o/r/pull/42" :pr-branch "mf/x"})
+  ;; Mirrors the production :workflow/pr-info shape built in
+  ;; phase-software-factory/release.clj (:pr-number/:pr-url/:branch/:commit-sha).
+  {:pr-number 42 :pr-url "https://github.com/o/r/pull/42" :branch "mf/x" :commit-sha "deadbeef"})
 
 (deftest resolve-pr-infos-test
   (testing "DAG path: returns the populated dag-pr-infos"


### PR DESCRIPTION
## Summary

**Shape-drift remediation PR3** (audit #6). The release PR info was **written to three places** and **read through fallback chains**, with the read logic **copy-pasted** across `observe-phase` and `dag-orchestrator` — the drift that caused the "opened a PR, never monitored it" bug.

Writers (before):
1. `[:result :output :workflow/pr-info]` — canonical (in the release output)
2. `[:workflow/pr-info]` (ctx top-level) — independent copy
3. `[:metrics :release :pr-info]` — copied by leave-release, read by observe-phase + dag-orchestrator

## Fix — one authority, one reader
- New **`response/release-pr-info`** → `[:result :output :workflow/pr-info]`, the single canonical authority.
- `release.clj`: removed the independent `[:metrics :release :pr-info]` write and its now-unused binding. The ctx-level `[:workflow/pr-info]` is **retained as a single derived projection** — several consumers (runner_events completion event, CLI summary, evidence-bundle) still read it, so it stays until those readers migrate to `release-pr-info`. It is now derived **through `response/release-pr-info` itself** (`{:result result}` is the phase-result shape the accessor expects), so the projection and the authority share one key-path and cannot drift.
- `observe-phase` + `dag-orchestrator` read through the **one accessor**; the copy-pasted `:metrics` fallbacks are gone (no more independent drift).

## Test plan
- `resolve-pr-infos-test`: reads the canonical release-output location; asserts the `[:metrics :release :pr-info]` and shallow `[:release :pr-info]` fossils are NO LONGER read. Fixture mirrors the production `:workflow/pr-info` shape (`:branch`, not `:pr-branch`).
- `release-test` (146 assertions) green; `bb pre-commit` green.

Part of canonical-place (Fable #7). Done: PR1✅(merged) PR2(#1134✅) gate-fail-closed(#1135) PR3. Remaining: PR4 (telemetry), PR5 (mechanical), PR2b (status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)