### PR TITLE
fix(agent-runtime): error_classifier emits the canonical failure class (Fable #7)

### DIFF
--- a/components/agent-runtime/deps.edn
+++ b/components/agent-runtime/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/task {:local/root "../task"}}
+ :deps {ai.miniforge/task {:local/root "../task"}
+        ai.miniforge/failure-classifier {:local/root "../failure-classifier"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/core.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/core.clj
@@ -22,7 +22,25 @@
    Orchestrates pattern matching, completed work extraction, and metadata generation."
   (:require
    [ai.miniforge.agent-runtime.error-classifier.patterns :as patterns]
-   [ai.miniforge.agent-runtime.error-classifier.reporting :as reporting]))
+   [ai.miniforge.agent-runtime.error-classifier.reporting :as reporting]
+   [ai.miniforge.failure-classifier.interface :as failure-classifier]))
+
+(def ^:private retry-type->failure-class
+  "Map the narrow retry-classification `:type` to the ONE canonical failure
+   class. The failure taxonomy (N1 §5.3.3) is owned by `failure-classifier`
+   (its single source of truth) — referenced here, never redefined. `:type`
+   stays as this classifier's retry tag; `:failure/class` is the canonical SLI
+   class derived from it."
+  {:agent-backend :failure.class/agent-error
+   :task-code     :failure.class/task-code
+   :external      :failure.class/external})
+
+(defn- ->failure-class
+  "Derive the canonical failure class for a retry `:type`, validated against
+   failure-classifier's set so we can never emit a non-canonical class."
+  [retry-type]
+  (let [c (get retry-type->failure-class retry-type :failure.class/unknown)]
+    (if (failure-classifier/valid-failure-class? c) c :failure.class/unknown)))
 
 ;;------------------------------------------------------------------------------ Layer 0
 ;; Error message extraction
@@ -131,7 +149,8 @@
      task-state - Optional map with task execution state
 
    Returns: Map with classification and metadata
-     {:type :agent-backend | :task-code | :external
+     {:type :agent-backend | :task-code | :external   ; retry tag
+      :failure/class <canonical failure-classifier class>  ; SLI taxonomy
       :vendor string
       :message string
       :original-error Exception or string
@@ -154,4 +173,7 @@
             :completed-work (or completed-work [])
             :report-url report-url
             :should-retry (should-retry? (:type pattern) completed-work)
+            ;; Canonical SLI failure class (failure-classifier, N1 §5.3.3),
+            ;; derived from the retry :type. One taxonomy, referenced not redefined.
+            :failure/class (->failure-class (:type pattern))
             :confidence confidence})))

--- a/components/agent-runtime/test/ai/miniforge/agent_runtime/error_classifier_test.clj
+++ b/components/agent-runtime/test/ai/miniforge/agent_runtime/error_classifier_test.clj
@@ -20,7 +20,21 @@
   "Unit tests for error classification and message generation."
   (:require [clojure.test :refer [deftest is testing are]]
             [clojure.string :as str]
-            [ai.miniforge.agent-runtime.interface :as classifier]))
+            [ai.miniforge.agent-runtime.interface :as classifier]
+            [ai.miniforge.failure-classifier.interface :as failure-classifier]))
+
+(deftest classify-error-emits-canonical-failure-class
+  (testing "classification carries a :failure/class from failure-classifier's
+            canonical set — one taxonomy, referenced not redefined"
+    (doseq [err ["connection refused" "Simple error string" "anything at all"]]
+      (is (failure-classifier/valid-failure-class?
+           (:failure/class (classifier/classify-error err nil)))
+          (str "non-canonical :failure/class for: " err))))
+  (testing "retry :type maps to the canonical class"
+    (is (= :failure.class/external
+           (:failure/class (classifier/classify-error "connection refused" nil))))
+    (is (= :failure.class/task-code
+           (:failure/class (classifier/classify-error "Simple error string" nil))))))
 
 ;------------------------------------------------------------------------------ Layer 0 Tests
 ;; Pattern matching and classification


### PR DESCRIPTION
## Summary

Canonical-place follow-up to the **#1133** finding: that dogfood PR tried to add a *second* failure taxonomy in `agent-runtime` — but the canonical one already lives in `failure-classifier/rules.edn` (N1 §5.3.3, "single source of truth"). Two competing canonical taxonomies is the exact anti-pattern.

## Fix — one taxonomy, referenced not redefined
- `agent-runtime` now depends on `failure-classifier` (clean: failure-classifier deps only response+schema, no cycle).
- `classify-error` emits **`:failure/class`** drawn from failure-classifier's canonical set — derived from the narrow retry `:type` (`:agent-backend`→`:agent-error`, `:task-code`→`:task-code`, `:external`→`:external`) and **validated** via `valid-failure-class?`, so a non-canonical class can't escape.
- `:type` stays as this classifier's **retry tag** (used by `should-retry?`/reporting/`llm_client` — unchanged); `:failure/class` is the canonical SLI class. Additive, no consumer breakage.

Now agent-runtime errors are classified into the one canonical taxonomy for the reliability/SLI stack — what rn-01 was reaching for, done without duplicating it.

## Test plan
- `classify-error-emits-canonical-failure-class`: every classification yields a `valid-failure-class?`; `:type`→canonical mapping pinned.
- `bb pre-commit` green (0 warnings), incl. poly check (new dep) + GraalVM/bb (the agent-runtime→failure-classifier require chain loads).

Part of canonical-place (Fable #7). Resolves the #1133 two-taxonomy finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)