### PR TITLE
test(phase-software-factory): stub renamed load-guidance-addendum in plan_test

### DIFF
--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/plan_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/plan_test.clj
@@ -67,7 +67,7 @@
 (deftest build-planner-task-threads-behavior-addendum-test
   (testing "build-planner-task computes and attaches :task/behavior-addendum"
     (let [stub-addendum "\n\n## Policy Rules — Required Behaviors\n\n1. Plan rule body."]
-      (with-redefs [phase/load-and-filter-behaviors
+      (with-redefs [phase/load-guidance-addendum
                     (fn [phase-kw _ctx]
                       (when (= :plan phase-kw) stub-addendum))
                     kb-helpers/inject-with-manifest
@@ -84,8 +84,8 @@
               "planner task must carry the phase-filtered addendum so create-planner can append it to the system prompt"))))))
 
 (deftest build-planner-task-omits-behavior-addendum-when-filter-returns-nil-test
-  (testing "no :task/behavior-addendum key when phase/load-and-filter-behaviors yields nil"
-    (with-redefs [phase/load-and-filter-behaviors (fn [_phase _ctx] nil)
+  (testing "no :task/behavior-addendum key when phase/load-guidance-addendum yields nil"
+    (with-redefs [phase/load-guidance-addendum (fn [_phase _ctx] nil)
                   kb-helpers/inject-with-manifest
                   (fn [_store _role _tags]
                     {:formatted nil :manifest nil})]


### PR DESCRIPTION
## Summary

Two `plan_test` addendum tests were **latently red on `main`** (same root cause as #1138, different brick).

`build-planner-task` was refactored to source `:task/behavior-addendum` from `phase/load-guidance-addendum` (the N13 compact guidance tier), but `plan_test` still stubbed the removed `phase/load-and-filter-behaviors`. The stub was never consulted, so the **real compiled standards pack** leaked into the task and the assertions failed (`stub-addendum` ≠ full pack; and the "omits when nil" case always saw the key).

Polylith change-scoped CI never re-ran this brick after the refactor, so the reds stayed invisible on `main`.

## Fix
Retarget both `with-redefs` to `phase/load-guidance-addendum` (same `[phase-kw ctx]` arity).

## Test plan
- `clojure -M:poly test brick:phase-software-factory` — green (was 2 failures in `plan_test`).
- `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)