### PR TITLE
fix(release-executor): create-pr! fails loud on phantom success + reuses existing PR

### DIFF
--- a/components/release-executor/resources/config/release-executor/messages/en-US.edn
+++ b/components/release-executor/resources/config/release-executor/messages/en-US.edn
@@ -20,6 +20,7 @@
   ;; pr creation
   :pr/create-unconfirmed "gh pr create reported success but printed no PR URL — cannot confirm a PR was opened (output: {output})"
   :pr/reuse-unresolved "A PR already exists for this branch but could not be resolved via gh pr view: {error}"
+  :pr/reuse-no-url "gh pr view returned no PR URL"
 
   ;; pipeline steps
   :step/metadata-generation-failed "Releaser agent failed to generate release metadata"

--- a/components/release-executor/resources/config/release-executor/messages/en-US.edn
+++ b/components/release-executor/resources/config/release-executor/messages/en-US.edn
@@ -17,6 +17,10 @@
   :gh/auth-login-hint "Run: gh auth login"
   :gh/install-hint "Install: brew install gh"
 
+  ;; pr creation
+  :pr/create-unconfirmed "gh pr create reported success but printed no PR URL — cannot confirm a PR was opened (output: {output})"
+  :pr/reuse-unresolved "A PR already exists for this branch but could not be resolved via gh pr view: {error}"
+
   ;; pipeline steps
   :step/metadata-generation-failed "Releaser agent failed to generate release metadata"
   :step/no-files-to-stage "No modified files in executor environment to stage for release"

--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -27,6 +27,7 @@
    dag/executor-execute!, never through host-side shell/sh."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.release-executor.messages :as msg]
    [ai.miniforge.release-executor.result :as result]
    [clojure.string :as str]))
 
@@ -247,10 +248,41 @@
              result))
          result)))))
 
+(defn- parse-pr-ref
+  "Parse a gh PR URL into {:pr-url :pr-number}, or nil when the output carries
+   no /pull/<n> reference (so a phantom success can be told from a real PR)."
+  [output]
+  (let [url (str/trim (or output ""))]
+    (when-let [match (re-find #"/pull/(\d+)" url)]
+      {:pr-url url :pr-number (parse-long (second match))})))
+
+(defn- pr-already-exists?
+  "True when a gh error indicates a PR already exists for the current branch."
+  [error]
+  (boolean (some-> error str/lower-case (str/includes? "already exists"))))
+
+(defn- reuse-existing-pr!
+  "Resolve the PR already open for the current branch via gh pr view, so a
+   release retry reuses it instead of opening a duplicate. Falls back to a
+   failure carrying the original create error when it can't be resolved."
+  [executor env-id exec-opts create-error]
+  (let [r (exec! executor env-id "gh pr view --json url --jq '.url'" exec-opts)]
+    (if-let [pr (and (result/succeeded? r) (parse-pr-ref (:output r "")))]
+      (result/shell-success pr)
+      (result/shell-failure (msg/t :pr/reuse-unresolved {:error create-error})
+                            {:pr-url nil :pr-number nil}))))
+
 (defn create-pr!
   "Create a pull request using gh CLI inside the sandbox container.
    Optional exec-opts supports :env for GH_TOKEN injection.
-   Returns {:success? bool :pr-number int :pr-url string :error string}"
+   Returns {:success? bool :pr-number int :pr-url string :error string}.
+
+   Two robustness guarantees beyond the bare gh call:
+   - A `gh pr create` that exits 0 but prints no PR URL is a FAILURE, not a
+     phantom success — release must never ship a PR doc claiming a PR it
+     never opened.
+   - A branch that already has an open PR (retry/resume) reuses that PR
+     rather than opening a duplicate."
   ([executor env-id pr-opts] (create-pr! executor env-id pr-opts {}))
   ([executor env-id {:keys [title body base-branch]} exec-opts]
    (let [base (or base-branch "main")
@@ -261,11 +293,18 @@
                   " --body '" escaped-body "'"
                   " --base " base)
          r (exec! executor env-id cmd exec-opts)]
-     (if (result/succeeded? r)
-       (let [pr-url (str/trim (:output r ""))
-             pr-num (when-let [match (re-find #"/pull/(\d+)" pr-url)]
-                      (parse-long (second match)))]
-         (result/shell-success {:pr-url pr-url :pr-number pr-num}))
+     (cond
+       (result/succeeded? r)
+       (if-let [pr (parse-pr-ref (:output r ""))]
+         (result/shell-success pr)
+         (result/shell-failure (msg/t :pr/create-unconfirmed
+                                      {:output (str/trim (:output r ""))})
+                               {:pr-url nil :pr-number nil}))
+
+       (pr-already-exists? (:error r))
+       (reuse-existing-pr! executor env-id exec-opts (:error r))
+
+       :else
        (result/shell-failure (:error r) {:pr-url nil :pr-number nil})))))
 
 (defn edit-pr-body!

--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -265,11 +265,17 @@
   "Resolve the PR already open for the current branch via gh pr view, so a
    release retry reuses it instead of opening a duplicate. Falls back to a
    failure carrying the original create error when it can't be resolved."
-  [executor env-id exec-opts create-error]
+  [executor env-id exec-opts _create-error]
   (let [r (exec! executor env-id "gh pr view --json url --jq '.url'" exec-opts)]
     (if-let [pr (and (result/succeeded? r) (parse-pr-ref (:output r "")))]
       (result/shell-success pr)
-      (result/shell-failure (msg/t :pr/reuse-unresolved {:error create-error})
+      ;; Surface the actual gh pr view resolution failure (its stderr, or the
+      ;; unparseable stdout when it exited 0 without a URL) — not the original
+      ;; "already exists" create error — so retries are debuggable.
+      (result/shell-failure (msg/t :pr/reuse-unresolved
+                                   {:error (or (not-empty (:error r))
+                                               (not-empty (str/trim (:output r "")))
+                                               (msg/t :pr/reuse-no-url))})
                             {:pr-url nil :pr-number nil}))))
 
 (defn create-pr!

--- a/components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj
@@ -421,8 +421,12 @@
           :release-meta {:release/pr-title "feat: test"
                          :release/pr-description "Short summary"
                          :release/pr-body "# Rich Body\n\n## Summary\nDetailed"}})
-        (is (= "# Rich Body\n\n## Summary\nDetailed"
-               (:body @seen-payload)))))))
+        ;; Assert the rich :release/pr-body is used (not the short description).
+        ;; with-provenance prepends a YAML frontmatter block, so match on
+        ;; inclusion rather than equality — the frontmatter is orthogonal here.
+        (is (clojure.string/includes? (:body @seen-payload)
+                                      "# Rich Body\n\n## Summary\nDetailed"))
+        (is (not (clojure.string/includes? (:body @seen-payload) "Short summary")))))))
 
 ;; ============================================================================
 ;; step-build-artifact

--- a/components/release-executor/test/ai/miniforge/release_executor/pr_body_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/pr_body_test.clj
@@ -142,39 +142,53 @@
     (let [state (make-state {:pr-number nil})]
       (is (= state (core/step-update-pr-body state))))))
 
+(defn- degraded-body-state
+  "A pipeline state whose agent body is degraded (blank), so
+   step-update-pr-body fires and posts the fallback render."
+  [overrides]
+  (make-state (merge {:release-meta {:release/pr-title "feat: test"
+                                     :release/pr-description "## Summary\nChange"
+                                     :release/pr-body ""}}
+                     overrides)))
+
 (deftest step-update-pr-body-calls-edit-pr-body-test
-  (testing "step-update-pr-body calls sandbox/edit-pr-body! and returns state"
-    (let [called (atom false)]
+  (testing "with a DEGRADED agent body, step-update-pr-body posts the
+            fallback-rendered body via sandbox/edit-pr-body! and returns state"
+    (let [called (atom false)
+          seen-body (atom nil)]
       (with-redefs [sandbox/edit-pr-body!
                     (fn [_exec _env-id pr-number body _opts]
                       (reset! called true)
+                      (reset! seen-body body)
                       (is (= 42 pr-number))
-                      (is (= "## Summary\nChange" body))
                       {:success? true})]
-        (let [state (make-state {})
+        (let [state (degraded-body-state {})
               result (core/step-update-pr-body state)]
-          (is @called)
+          (is @called "edit-pr-body! fires only when the agent body is degraded")
+          (is (clojure.string/includes? @seen-body "## Summary")
+              "posts the structured fallback render, not the empty agent body")
           ;; step-update-pr-body returns state (not the edit result)
           (is (= (:pr-number state) (:pr-number result)))
           (is (not (contains? result :failure))))))))
 
-(deftest step-update-pr-body-prefers-generated-doc-content-test
-  (testing "generated PR doc content overrides the initial fallback body"
-    (let [seen-body (atom nil)]
+(deftest step-update-pr-body-skips-when-agent-body-present-test
+  (testing "a real agent :release/pr-body is NOT overwritten — the guard skips
+            edit-pr-body! (replaces the old :pr-doc-content-preference test; the
+            GitHub PR body and the committed docs file are separate surfaces)"
+    (let [called (atom false)]
       (with-redefs [sandbox/edit-pr-body!
-                    (fn [_exec _env-id _pr-number body _opts]
-                      (reset! seen-body body)
-                      {:success? true})]
-        (core/step-update-pr-body
-         (make-state {:pr-doc-content "# Rich Doc\n\n## Summary\nGenerated"}))
-        (is (= "# Rich Doc\n\n## Summary\nGenerated" @seen-body))))))
+                    (fn [& _args] (reset! called true) {:success? true})]
+        ;; make-state's default release-meta carries a real pr-body
+        (core/step-update-pr-body (make-state {}))
+        (is (not @called) "present agent body → step skips, body preserved")))))
 
 (deftest step-update-pr-body-survives-exception-test
   (testing "step-update-pr-body catches exceptions and returns state (non-fatal)"
     (with-redefs [sandbox/edit-pr-body!
                   (fn [& _args]
                     (throw (ex-info "Network error" {})))]
-      (let [state (make-state {})
+      ;; degraded body so the step actually reaches edit-pr-body! and the catch
+      (let [state (degraded-body-state {})
             result (core/step-update-pr-body state)]
         ;; Non-fatal — no :failure key
         (is (not (contains? result :failure)))))))
@@ -186,7 +200,7 @@
                     (fn [_exec _env-id _pr-number _body opts]
                       (reset! seen-opts opts)
                       {:success? true})]
-        (let [state (make-state {:github-token "my-token"})]
+        (let [state (degraded-body-state {:github-token "my-token"})]
           (core/step-update-pr-body state)
           (is (= {"GH_TOKEN" "my-token"} (:env @seen-opts))))))))
 

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -317,7 +317,9 @@
           result (sandbox/create-pr! exec "env-1"
                                      {:title "PR" :body "" :base-branch "main"})]
       (is (not (:success? result)))
-      (is (nil? (:pr-number result))))))
+      (is (nil? (:pr-number result)))
+      (is (clojure.string/includes? (:error result) "no pull requests found")
+          "error surfaces the gh pr view resolution failure, not the create error"))))
 
 ;; ============================================================================
 ;; write-and-stage-files! tests

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -276,6 +276,49 @@
       (is (not (:success? result)))
       (is (some? (:error result))))))
 
+(deftest create-pr-unconfirmed-is-failure-test
+  (testing "gh pr create exits 0 but prints no PR URL → FAILURE, not a phantom
+            success (the original 'doc but no PR' symptom)"
+    (let [[exec _cmds] (create-mock-executor
+                        :responses {"gh pr create" {:exit-code 0
+                                                    :stdout ""
+                                                    :stderr ""}})
+          result (sandbox/create-pr! exec "env-1"
+                                     {:title "PR" :body "" :base-branch "main"})]
+      (is (not (:success? result)) "unconfirmed PR must not report success")
+      (is (nil? (:pr-number result)))
+      (is (some? (:error result))))))
+
+(deftest create-pr-reuses-existing-pr-test
+  (testing "a branch that already has an open PR reuses it (no duplicate)"
+    (let [[exec cmds] (create-mock-executor
+                       :responses {"gh pr create"
+                                   {:exit-code 1 :stdout ""
+                                    :stderr "a pull request for branch \"feat/x\" already exists"}
+                                   "gh pr view"
+                                   {:exit-code 0
+                                    :stdout "https://github.com/org/repo/pull/7\n" :stderr ""}})
+          result (sandbox/create-pr! exec "env-1"
+                                     {:title "PR" :body "" :base-branch "main"})]
+      (is (:success? result) "existing PR is reused as success")
+      (is (= 7 (:pr-number result)))
+      (is (= "https://github.com/org/repo/pull/7" (:pr-url result)))
+      (is (some #(clojure.string/includes? % "gh pr view") @cmds)
+          "resolves the existing PR via gh pr view"))))
+
+(deftest create-pr-already-exists-but-unresolvable-fails-test
+  (testing "PR already exists but gh pr view can't resolve it → failure (no phantom)"
+    (let [[exec _cmds] (create-mock-executor
+                        :responses {"gh pr create"
+                                    {:exit-code 1 :stdout ""
+                                     :stderr "a pull request already exists"}
+                                    "gh pr view"
+                                    {:exit-code 1 :stdout "" :stderr "no pull requests found"}})
+          result (sandbox/create-pr! exec "env-1"
+                                     {:title "PR" :body "" :base-branch "main"})]
+      (is (not (:success? result)))
+      (is (nil? (:pr-number result))))))
+
 ;; ============================================================================
 ;; write-and-stage-files! tests
 ;; ============================================================================


### PR DESCRIPTION
## Summary

Lands the **release-opens-real-pr** blocker (prerequisite for review-redirect-convergence).

A fully successful local `bb dogfood` run produced a PR doc (`docs/pull-requests/*.md`) but **never opened a GitHub PR**. Diagnosis (the release-executor PR pipeline is otherwise intact — dogfood PRs #1064/#1065 prove the happy path works): the defect is in `sandbox/create-pr!`.

When `gh pr create` exits 0 but prints no PR URL, `create-pr!` returned `shell-success` with `pr-number nil`. So `step-create-pr` "succeeded", state was not failed, and `step-generate-pr-doc` (which runs only when `:create-pr?` is true and state is not failed) wrote a doc carrying `{:pr-number nil :pr-url nil}`. A **phantom success** that silently dead-ends the ship loop at a doc.

## Fix (spec acceptance criteria 4 + 5)
`create-pr!`:
- **No phantom success:** exit 0 with no parseable `/pull/N` URL → `shell-failure` (anomaly). Release fails loud with the cause instead of silently shipping a doc-only "success".
- **No duplicate on retry:** a branch that already has an open PR → reuse it via `gh pr view` rather than opening a second PR.

Happy path (real URL) and `:create-pr? false` (doc-only) are unchanged.

## Stale-test alignment (same brick, restores it to green)
Running the full `release-executor` brick surfaced 4 latent reds invisible to change-scoped CI (per `project_latent_red_ci_gap`), left by #1113 (provenance frontmatter) and the `pr-body-needs-update?` refactor:
- `core_pipeline` rich-body test → match on inclusion (provenance frontmatter prepends), not equality.
- `pr_body` `step-update-pr-body` tests → the step now fires only on a degraded agent body and posts the fallback render; updated to that contract. The removed `:pr-doc-content`-preference test is replaced by a skip-when-agent-body-present test (PR body and docs file are separate surfaces).

## Test plan
- Full `release-executor` brick: 219 tests, 0 failures (4 new create-pr! cases; brick was carrying 4 latent reds before).
- `bb pre-commit` green.

## Not in scope
The `:create-pr?` plumbing, branch/push steps, observe-phase monitoring, GitHub auth setup, and the PR-doc generator are unchanged. No second PR-creation path introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)