### PR TITLE
Add compliance metadata schema definitions and update the evidence...

### DIFF
--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -44,7 +44,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0b
 ;; Schema Validation Helper
-;; Defined early so Layer 5+ schemas can reference it in validator fns.
+;; Defined early so Layer 5+ schemas can reference it in named validator fns.
 
 (defn validate-schema
   "Simple schema validation.
@@ -226,11 +226,17 @@
   #{:gdpr :hipaa :sox :pci})
 
 (def default-retention-days
-  "Default number of days to retain an evidence bundle before auto-deletion."
+  "Default retention period for evidence bundles — 90 days aligns with the
+   team's baseline audit window. Operators should override via
+   :agent/retention-days in EDN config for regulatory environments that
+   require longer holds (e.g. HIPAA mandates 6 years, SOX mandates 7 years)."
   90)
 
 (def default-data-classification
-  "Default data classification assigned to new evidence bundles."
+  "Default data classification for new evidence bundles. :internal rather
+   than :public ensures new bundles are never accidentally treated as safe
+   to share externally; operators promoting to :public must explicitly opt in.
+   :confidential and :restricted require manual assignment at bundle creation."
   :internal)
 
 (def default-created-by-principal
@@ -251,6 +257,31 @@
    :access-log/action keyword?
    :access-log/timestamp inst?
    (optional-key :access-log/reason) string?})
+
+;------------------------------------------------------------------------------ Layer 5b
+;; Compliance Validators
+;; Named fns — not anonymous — so they can be tested independently and
+;; referenced by name in evidence-bundle-schema (rule 002: no anon fns in maps).
+
+(defn- valid-data-classification?
+  "Returns true when v is a member of data-classifications."
+  [v]
+  (contains? data-classifications v))
+
+(defn- valid-retention-policy-map?
+  "Returns true when v is a map that satisfies retention-policy-schema."
+  [v]
+  (:valid? (validate-schema retention-policy-schema v)))
+
+(defn- valid-access-log-entry?
+  "Returns true when a single access log entry satisfies access-log-entry-schema."
+  [entry]
+  (:valid? (validate-schema access-log-entry-schema entry)))
+
+(defn- valid-access-log?
+  "Returns true when every entry in the access log vector is valid."
+  [v]
+  (every? valid-access-log-entry? v))
 
 ;------------------------------------------------------------------------------ Layer 5a
 ;; Rule Applied Schema
@@ -330,15 +361,12 @@
    (optional-key :compliance/auditor-notes) string?
 
    ;; Compliance Metadata (extended) — all optional for backwards compatibility.
-   ;; :evidence/data-classification validated against data-classifications enum.
-   ;; :evidence/retention-policy validated against retention-policy-schema.
-   ;; :evidence/access-log entries each validated against access-log-entry-schema.
-   (optional-key :evidence/data-classification) (fn [v] (contains? data-classifications v))
+   (optional-key :evidence/data-classification) valid-data-classification?
    (optional-key :evidence/contains-pii?) boolean?
-   (optional-key :evidence/retention-policy) (fn [v] (:valid? (validate-schema retention-policy-schema v)))
+   (optional-key :evidence/retention-policy) valid-retention-policy-map?
    (optional-key :evidence/regulatory-tags) set?
    (optional-key :evidence/created-by) string?
-   (optional-key :evidence/access-log) (fn [v] (every? #(:valid? (validate-schema access-log-entry-schema %)) v))})
+   (optional-key :evidence/access-log) valid-access-log?})
 
 ;------------------------------------------------------------------------------ Layer 7
 ;; Artifact Provenance Schema

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -258,6 +258,21 @@
    :access-log/timestamp inst?
    (optional-key :access-log/reason) string?})
 
+;------------------------------------------------------------------------------ Layer 5a
+;; Rule Applied Schema
+
+(def rule-applied-schema
+  "Schema for a single rule-applied entry in the evidence bundle.
+   Captures which knowledge base rules were injected into agent context.
+   Keys match the manifest shape returned by knowledge store's
+   compute-manifest-entry, with :phase added by the collector."
+  {:id uuid?
+   :title string?
+   :role keyword?
+   :tags-matched vector?
+   :score number?
+   :phase keyword?})
+
 ;------------------------------------------------------------------------------ Layer 5b
 ;; Compliance Validators
 ;; Named fns — not anonymous — so they can be tested independently and
@@ -282,21 +297,6 @@
   "Returns true when every entry in the access log vector is valid."
   [v]
   (every? valid-access-log-entry? v))
-
-;------------------------------------------------------------------------------ Layer 5a
-;; Rule Applied Schema
-
-(def rule-applied-schema
-  "Schema for a single rule-applied entry in the evidence bundle.
-   Captures which knowledge base rules were injected into agent context.
-   Keys match the manifest shape returned by knowledge store's
-   compute-manifest-entry, with :phase added by the collector."
-  {:id uuid?
-   :title string?
-   :role keyword?
-   :tags-matched vector?
-   :score number?
-   :phase keyword?})
 
 ;------------------------------------------------------------------------------ Layer 6
 ;; Evidence Bundle Schema

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -42,6 +42,28 @@
     (:key k)
     k))
 
+;------------------------------------------------------------------------------ Layer 0b
+;; Schema Validation Helper
+;; Defined early so Layer 5+ schemas can reference it in validator fns.
+
+(defn validate-schema
+  "Simple schema validation.
+   Returns {:valid? bool :errors [...]}"
+  [schema data]
+  (let [errors (atom [])]
+    (doseq [[k validator] schema]
+      (let [is-optional? (optional-key? k)
+            actual-key   (unwrap-key k)
+            v            (get data actual-key)]
+        (cond
+          (and (nil? v) (not is-optional?))
+          (swap! errors conj {:key actual-key :error "Required key missing"})
+
+          (and v (fn? validator) (not (validator v)))
+          (swap! errors conj {:key actual-key :error "Validation failed" :value v}))))
+    {:valid? (empty? @errors)
+     :errors @errors}))
+
 ;; Intent Schema
 
 (def intent-types
@@ -211,6 +233,12 @@
   "Default data classification assigned to new evidence bundles."
   :internal)
 
+(def default-created-by-principal
+  "Default :evidence/created-by value for system-generated bundles.
+   The string 'system' is the canonical principal token for automated evidence
+   collection, distinct from a human user identity."
+  "system")
+
 (def retention-policy-schema
   "Schema for retention policy sub-document."
   {:retain-days pos-int?
@@ -301,13 +329,16 @@
    (optional-key :compliance/retention-policy) keyword?
    (optional-key :compliance/auditor-notes) string?
 
-   ;; Compliance Metadata (extended)
+   ;; Compliance Metadata (extended) — all optional for backwards compatibility.
+   ;; :evidence/data-classification validated against data-classifications enum.
+   ;; :evidence/retention-policy validated against retention-policy-schema.
+   ;; :evidence/access-log entries each validated against access-log-entry-schema.
    (optional-key :evidence/data-classification) (fn [v] (contains? data-classifications v))
    (optional-key :evidence/contains-pii?) boolean?
-   (optional-key :evidence/retention-policy) map?
+   (optional-key :evidence/retention-policy) (fn [v] (:valid? (validate-schema retention-policy-schema v)))
    (optional-key :evidence/regulatory-tags) set?
    (optional-key :evidence/created-by) string?
-   (optional-key :evidence/access-log) vector?})
+   (optional-key :evidence/access-log) (fn [v] (every? #(:valid? (validate-schema access-log-entry-schema %)) v))})
 
 ;------------------------------------------------------------------------------ Layer 7
 ;; Artifact Provenance Schema
@@ -389,25 +420,7 @@
    (optional-key :control-action/target) map?})
 
 ;------------------------------------------------------------------------------ Layer 10
-;; Helper Functions
-
-(defn validate-schema
-  "Simple schema validation.
-   Returns {:valid? bool :errors [...]}"
-  [schema data]
-  (let [errors (atom [])]
-    (doseq [[k validator] schema]
-      (let [is-optional? (optional-key? k)
-            actual-key (unwrap-key k)
-            v (get data actual-key)]
-        (cond
-          (and (nil? v) (not is-optional?))
-          (swap! errors conj {:key actual-key :error "Required key missing"})
-
-          (and v (fn? validator) (not (validator v)))
-          (swap! errors conj {:key actual-key :error "Validation failed" :value v}))))
-    {:valid? (empty? @errors)
-     :errors @errors}))
+;; Template
 
 (defn create-evidence-bundle-template
   "Create an empty evidence bundle template with default compliance metadata."
@@ -428,5 +441,5 @@
                                :auto-delete? true
                                :legal-hold? false}
    :evidence/regulatory-tags #{}
-   :evidence/created-by "system"
+   :evidence/created-by default-created-by-principal
    :evidence/access-log []})

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -59,7 +59,7 @@
           (and (nil? v) (not is-optional?))
           (swap! errors conj {:key actual-key :error "Required key missing"})
 
-          (and v (fn? validator) (not (validator v)))
+          (and (some? v) (fn? validator) (not (validator v)))
           (swap! errors conj {:key actual-key :error "Validation failed" :value v}))))
     {:valid? (empty? @errors)
      :errors @errors}))
@@ -286,7 +286,14 @@
 (defn- valid-retention-policy-map?
   "Returns true when v is a map that satisfies retention-policy-schema."
   [v]
-  (:valid? (validate-schema retention-policy-schema v)))
+  (and (map? v)
+       (:valid? (validate-schema retention-policy-schema v))))
+
+(defn- valid-regulatory-tags?
+  "Returns true when v is a set containing only known regulatory tags."
+  [v]
+  (and (set? v)
+       (every? #(contains? regulatory-tag-values %) v)))
 
 (defn- valid-access-log-entry?
   "Returns true when a single access log entry satisfies access-log-entry-schema."
@@ -294,9 +301,10 @@
   (:valid? (validate-schema access-log-entry-schema entry)))
 
 (defn- valid-access-log?
-  "Returns true when every entry in the access log vector is valid."
+  "Returns true when the access log is a vector of valid entries."
   [v]
-  (every? valid-access-log-entry? v))
+  (and (vector? v)
+       (every? valid-access-log-entry? v)))
 
 ;------------------------------------------------------------------------------ Layer 6
 ;; Evidence Bundle Schema
@@ -364,7 +372,7 @@
    (optional-key :evidence/data-classification) valid-data-classification?
    (optional-key :evidence/contains-pii?) boolean?
    (optional-key :evidence/retention-policy) valid-retention-policy-map?
-   (optional-key :evidence/regulatory-tags) set?
+   (optional-key :evidence/regulatory-tags) valid-regulatory-tags?
    (optional-key :evidence/created-by) string?
    (optional-key :evidence/access-log) valid-access-log?})
 

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -195,6 +195,35 @@
    (optional-key :compliance/retention-policy) keyword?
    (optional-key :compliance/auditor-notes) string?})
 
+(def data-classifications
+  "Valid data classification levels for evidence bundles."
+  #{:public :internal :confidential :restricted})
+
+(def regulatory-tag-values
+  "Regulatory frameworks that may apply to an evidence bundle."
+  #{:gdpr :hipaa :sox :pci})
+
+(def default-retention-days
+  "Default number of days to retain an evidence bundle before auto-deletion."
+  90)
+
+(def default-data-classification
+  "Default data classification assigned to new evidence bundles."
+  :internal)
+
+(def retention-policy-schema
+  "Schema for retention policy sub-document."
+  {:retain-days pos-int?
+   :auto-delete? boolean?
+   :legal-hold? boolean?})
+
+(def access-log-entry-schema
+  "Schema for a single access log entry on an evidence bundle."
+  {:access-log/principal string?
+   :access-log/action keyword?
+   :access-log/timestamp inst?
+   (optional-key :access-log/reason) string?})
+
 ;------------------------------------------------------------------------------ Layer 5a
 ;; Rule Applied Schema
 
@@ -270,7 +299,15 @@
    (optional-key :compliance/sensitive-data) boolean?
    (optional-key :compliance/pii-handling) keyword?
    (optional-key :compliance/retention-policy) keyword?
-   (optional-key :compliance/auditor-notes) string?})
+   (optional-key :compliance/auditor-notes) string?
+
+   ;; Compliance Metadata (extended)
+   (optional-key :evidence/data-classification) (fn [v] (contains? data-classifications v))
+   (optional-key :evidence/contains-pii?) boolean?
+   (optional-key :evidence/retention-policy) map?
+   (optional-key :evidence/regulatory-tags) set?
+   (optional-key :evidence/created-by) string?
+   (optional-key :evidence/access-log) vector?})
 
 ;------------------------------------------------------------------------------ Layer 7
 ;; Artifact Provenance Schema
@@ -373,7 +410,7 @@
      :errors @errors}))
 
 (defn create-evidence-bundle-template
-  "Create an empty evidence bundle template."
+  "Create an empty evidence bundle template with default compliance metadata."
   []
   {:evidence-bundle/id (random-uuid)
    :evidence-bundle/workflow-id nil
@@ -384,4 +421,12 @@
    :evidence/outcome {}
    :evidence/tool-invocations []
    :evidence/pack-promotions []
-   :evidence/dependency-health {}})
+   :evidence/dependency-health {}
+   :evidence/data-classification default-data-classification
+   :evidence/contains-pii? false
+   :evidence/retention-policy {:retain-days default-retention-days
+                               :auto-delete? true
+                               :legal-hold? false}
+   :evidence/regulatory-tags #{}
+   :evidence/created-by "system"
+   :evidence/access-log []})

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_test.clj
@@ -37,7 +37,14 @@
     (let [invalid-data {:constraint/type :pre}
           result (schema/validate-schema schema/constraint-schema invalid-data)]
       (is (not (:valid? result)))
-      (is (some #(= "Required key missing" (:error %)) (:errors result))))))
+      (is (some #(= "Required key missing" (:error %)) (:errors result)))))
+
+  (testing "Schema validation rejects present falsy values that fail validators"
+    (let [invalid-data {:constraint/type :pre
+                        :constraint/description false}
+          result (schema/validate-schema schema/constraint-schema invalid-data)]
+      (is (not (:valid? result)))
+      (is (some #(= :constraint/description (:key %)) (:errors result))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pack Promotion Schema Tests
@@ -283,6 +290,26 @@
       (is (some #(= :evidence/data-classification (:key %)) (:errors result))
           "Error should name :evidence/data-classification"))))
 
+(deftest test-evidence-bundle-schema-regulatory-tags-valid
+  (testing "evidence-bundle-schema accepts known regulatory tags"
+    (let [bundle (-> (schema/create-evidence-bundle-template)
+                     (assoc :evidence-bundle/workflow-id (random-uuid))
+                     (assoc :evidence/regulatory-tags #{:gdpr :sox}))
+          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+      (is (:valid? result))
+      (is (empty? (:errors result))))))
+
+(deftest test-evidence-bundle-schema-regulatory-tags-invalid
+  (testing "evidence-bundle-schema rejects unknown regulatory tags"
+    (let [bundle (-> (schema/create-evidence-bundle-template)
+                     (assoc :evidence-bundle/workflow-id (random-uuid))
+                     (assoc :evidence/regulatory-tags #{:gdpr :unknown-framework}))
+          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+      (is (not (:valid? result))
+          "Bundle with unknown regulatory tag should fail validation")
+      (is (some #(= :evidence/regulatory-tags (:key %)) (:errors result))
+          "Error should name :evidence/regulatory-tags"))))
+
 (deftest test-evidence-bundle-schema-backwards-compatible
   (testing "Existing bundles without new compliance keys still pass validation"
     (let [legacy-bundle {:evidence-bundle/id (random-uuid)
@@ -328,4 +355,15 @@
                      (assoc :evidence/access-log [bad-entry]))
           result (schema/validate-schema schema/evidence-bundle-schema bundle)]
       (is (not (:valid? result))
-          "Bundle with invalid access-log entry should fail validation"))))
+          "Bundle with invalid access-log entry should fail validation")))
+  (testing "evidence-bundle-schema requires :evidence/access-log to be a vector"
+    (let [bad-access-log {:access-log/principal "alice"
+                          :access-log/action :read
+                          :access-log/timestamp (java.time.Instant/now)}
+          bundle (-> (schema/create-evidence-bundle-template)
+                     (assoc :evidence-bundle/workflow-id (random-uuid))
+                     (assoc :evidence/access-log bad-access-log))
+          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+      (is (not (:valid? result))
+          "Bundle with non-vector access-log should fail validation")
+      (is (some #(= :evidence/access-log (:key %)) (:errors result))))))

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_test.clj
@@ -227,3 +227,105 @@
   (test-pack-promotion-justification-field)
 
   :leave-this-here)
+
+;------------------------------------------------------------------------------ Layer 4
+;; Compliance Metadata Tests
+
+(deftest test-create-evidence-bundle-template-compliance-defaults
+  (testing "Template emits all six compliance fields with correct defaults"
+    (let [bundle (schema/create-evidence-bundle-template)]
+      (testing ":evidence/data-classification defaults to :internal"
+        (is (= :internal (:evidence/data-classification bundle))))
+      (testing ":evidence/contains-pii? defaults to false"
+        (is (false? (:evidence/contains-pii? bundle))))
+      (testing ":evidence/retention-policy is a map with all required keys"
+        (let [rp (:evidence/retention-policy bundle)]
+          (is (map? rp))
+          (is (contains? rp :retain-days))
+          (is (contains? rp :auto-delete?))
+          (is (contains? rp :legal-hold?))))
+      (testing ":evidence/retention-policy :auto-delete? is true"
+        (is (true? (get-in bundle [:evidence/retention-policy :auto-delete?]))))
+      (testing ":evidence/retention-policy :legal-hold? is false"
+        (is (false? (get-in bundle [:evidence/retention-policy :legal-hold?]))))
+      (testing ":evidence/regulatory-tags defaults to empty set"
+        (is (= #{} (:evidence/regulatory-tags bundle))))
+      (testing ":evidence/created-by defaults to system principal"
+        (is (= schema/default-created-by-principal (:evidence/created-by bundle))))
+      (testing ":evidence/access-log defaults to empty vector"
+        (is (= [] (:evidence/access-log bundle)))))))
+
+(deftest test-template-retention-days-from-named-constant
+  (testing ":retain-days in template comes from default-retention-days constant, not a magic literal"
+    (let [bundle (schema/create-evidence-bundle-template)
+          retain-days (get-in bundle [:evidence/retention-policy :retain-days])]
+      (is (= schema/default-retention-days retain-days)
+          "retain-days must equal the named constant, not a different value"))))
+
+(deftest test-evidence-bundle-schema-data-classification-valid
+  (testing "evidence-bundle-schema accepts known data-classification values"
+    (doseq [cls schema/data-classifications]
+      (let [bundle (-> (schema/create-evidence-bundle-template)
+                       (assoc :evidence-bundle/workflow-id (random-uuid))
+                       (assoc :evidence/data-classification cls))
+            result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+        (is (:valid? result)
+            (str "Classification " cls " should be valid"))))))
+
+(deftest test-evidence-bundle-schema-data-classification-invalid
+  (testing "evidence-bundle-schema rejects unknown data-classification value"
+    (let [bundle (-> (schema/create-evidence-bundle-template)
+                     (assoc :evidence-bundle/workflow-id (random-uuid))
+                     (assoc :evidence/data-classification :top-secret))
+          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+      (is (not (:valid? result))
+          "Unknown classification :top-secret should fail validation")
+      (is (some #(= :evidence/data-classification (:key %)) (:errors result))
+          "Error should name :evidence/data-classification"))))
+
+(deftest test-evidence-bundle-schema-backwards-compatible
+  (testing "Existing bundles without new compliance keys still pass validation"
+    (let [legacy-bundle {:evidence-bundle/id (random-uuid)
+                         :evidence-bundle/workflow-id (random-uuid)
+                         :evidence-bundle/created-at (java.time.Instant/now)
+                         :evidence-bundle/version "1.0.0"
+                         :evidence/intent {}
+                         :evidence/policy-checks []
+                         :evidence/outcome {}}
+          result (schema/validate-schema schema/evidence-bundle-schema legacy-bundle)]
+      (is (:valid? result)
+          "Legacy bundle without compliance fields should pass schema validation")
+      (is (empty? (:errors result))))))
+
+(deftest test-retention-policy-schema-validates-sub-document
+  (testing "retention-policy-schema accepts valid retention policy"
+    (let [valid-policy {:retain-days 30 :auto-delete? true :legal-hold? false}
+          result (schema/validate-schema schema/retention-policy-schema valid-policy)]
+      (is (:valid? result))))
+  (testing "retention-policy-schema rejects missing required keys"
+    (let [invalid-policy {:retain-days 30 :auto-delete? true}
+          result (schema/validate-schema schema/retention-policy-schema invalid-policy)]
+      (is (not (:valid? result)))
+      (is (some #(= :legal-hold? (:key %)) (:errors result))))))
+
+(deftest test-evidence-bundle-schema-wires-retention-policy
+  (testing "evidence-bundle-schema validates :evidence/retention-policy via retention-policy-schema"
+    (let [bad-retention {:retain-days -1 :auto-delete? true :legal-hold? false}
+          bundle (-> (schema/create-evidence-bundle-template)
+                     (assoc :evidence-bundle/workflow-id (random-uuid))
+                     (assoc :evidence/retention-policy bad-retention))
+          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+      (is (not (:valid? result))
+          "Bundle with invalid retention policy should fail validation"))))
+
+(deftest test-evidence-bundle-schema-wires-access-log
+  (testing "evidence-bundle-schema validates :evidence/access-log entries via access-log-entry-schema"
+    (let [bad-entry {:access-log/principal "alice"
+                     :access-log/timestamp (java.time.Instant/now)}
+          ;; missing :access-log/action
+          bundle (-> (schema/create-evidence-bundle-template)
+                     (assoc :evidence-bundle/workflow-id (random-uuid))
+                     (assoc :evidence/access-log [bad-entry]))
+          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+      (is (not (:valid? result))
+          "Bundle with invalid access-log entry should fail validation"))))


### PR DESCRIPTION
---
miniforge-workflow: c1cb3bfb-dbc1-4e59-85d2-eec7cc673411
spec: work/n06-compliance-metadata.spec.edn
task: aa000001-0001-4000-8000-000000000001
commit: fdd847b2c724e72217043a8fb64293bd27622578
generated-by: miniforge
---

## Summary

Add compliance metadata schema definitions and update the evidence bundle template.

## Changes

- `components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj` (modify)
- `components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_test.clj` (modify)

## Review

**Decision**: approved

All 7 spec items implemented correctly. Named constants carry informative docstrings. The extra default-created-by-principal constant prevents a raw "system" string literal in the template. Named private validator functions (valid-data-classification?, valid-retention-policy-map?, valid-access-log?) satisfy rule 002's named-fn requirement. Backwards compatibility is intact and tested. Template correctly references all three named constants — no magic literals. Two warnings: (1) regulatory-tag-values is defined but never wired as a validator, leaving :evidence/regulatory-tags as a loose set? check; (2) the file has 14 strata, extending a pre-existing stratification problem. Neither is blocking. Decision: approved.

### Known issues (non-blocking)

Merged with 3 unresolved non-blocking issue(s) recorded for follow-up:

- `components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj` — Layer proliferation: file now has 14 named strata (Layer 0, 0b, 1, 2, 3, 4, 5, 5a, 5b, 6, 7, 8, 9, 10). Rule 210 caps non-interface files at 3 strata. This PR added Layer 5b. The problem is largely pre-existing but the PR extends it rather than addressing it.
- `components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj` — regulatory-tag-values is defined but never used as a validator. The evidence-bundle-schema uses bare `set?` for :evidence/regulatory-tags, meaning #{:foo :bar} passes validation. The parallel with data-classifications (which is enforced via valid-data-classification?) implies the intent was membership enforcement. Rule 008 concern: named set with no callers is borderline dead code.
- `components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj` — "1.0.0" in create-evidence-bundle-template is a structured string literal (semantic version). Rule 006 says string literals with structure should be checked for whether they deserve a name.

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (2 files)