### PR TITLE
Wire compliance metadata defaults into bundle assembly and add...

### DIFF
--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -80,10 +80,12 @@
    - :evidence/data-classification
    - :evidence/contains-pii?
    - :evidence/retention-policy  (partial — merged one level deep)
-   - :evidence/regulatory-tags
-   - :evidence/created-by"
+  - :evidence/regulatory-tags
+  - :evidence/created-by"
   [workflow-spec opts]
-  (get workflow-spec :compliance (get opts :compliance {})))
+  (or (:compliance workflow-spec)
+      (:compliance opts)
+      {}))
 
 (defn- merge-compliance
   "Merge compliance defaults with operator overrides.
@@ -109,10 +111,12 @@
    Append-only contract: existing entries are never removed or mutated.
    Returns the updated bundle."
   [bundle entry]
-  (let [stamped (if (contains? entry :access-log/timestamp)
+  (let [stamped (if (some? (:access-log/timestamp entry))
                   entry
                   (assoc entry :access-log/timestamp (java.time.Instant/now)))]
-    (update bundle :evidence/access-log (fnil conj []) stamped)))
+    (update bundle :evidence/access-log
+            (fn [access-log]
+              (conj (vec (or access-log [])) stamped)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Phase Evidence Collection

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -71,6 +71,20 @@
    :evidence/regulatory-tags     #{}
    :evidence/created-by          schema/default-created-by-principal})
 
+(def ^:private compliance-override-keys
+  "Allowed keys for workflow-spec and opts compliance override maps."
+  #{:evidence/data-classification
+    :evidence/contains-pii?
+    :evidence/retention-policy
+    :evidence/regulatory-tags
+    :evidence/created-by})
+
+(defn- normalize-compliance-overrides
+  "Return only documented compliance override keys from m, or nil for non-maps."
+  [m]
+  (when (map? m)
+    (select-keys m compliance-override-keys)))
+
 (defn- extract-compliance-overrides
   "Read compliance overrides from workflow-spec or opts.
    Checks the :compliance key on the spec map first, then falls back to opts.
@@ -80,11 +94,11 @@
    - :evidence/data-classification
    - :evidence/contains-pii?
    - :evidence/retention-policy  (partial — merged one level deep)
-  - :evidence/regulatory-tags
-  - :evidence/created-by"
+   - :evidence/regulatory-tags
+   - :evidence/created-by"
   [workflow-spec opts]
-  (or (:compliance workflow-spec)
-      (:compliance opts)
+  (or (normalize-compliance-overrides (:compliance workflow-spec))
+      (normalize-compliance-overrides (:compliance opts))
       {}))
 
 (defn- merge-compliance

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -55,6 +55,67 @@
    :intent/declared-at (java.time.Instant/now)
    :intent/author (get workflow-spec :author "system")})
 
+;------------------------------------------------------------------------------ Layer 0.5
+;; Compliance Defaults and Overrides
+
+(defn- build-default-compliance-metadata
+  "Return the default compliance map for assembled evidence bundles.
+   Uses schema-defined defaults so the single source of truth lives in schema.clj.
+   Covers the assembly path; the template function covers manual construction."
+  []
+  {:evidence/data-classification schema/default-data-classification
+   :evidence/contains-pii?       false
+   :evidence/retention-policy    {:retain-days  schema/default-retention-days
+                                  :auto-delete? true
+                                  :legal-hold?  false}
+   :evidence/regulatory-tags     #{}
+   :evidence/created-by          schema/default-created-by-principal})
+
+(defn- extract-compliance-overrides
+  "Read compliance overrides from workflow-spec or opts.
+   Checks the :compliance key on the spec map first, then falls back to opts.
+   Returns a map of overrides to merge into the bundle, or {} when absent.
+
+   Allowed override keys:
+   - :evidence/data-classification
+   - :evidence/contains-pii?
+   - :evidence/retention-policy  (partial — merged one level deep)
+   - :evidence/regulatory-tags
+   - :evidence/created-by"
+  [workflow-spec opts]
+  (or (get workflow-spec :compliance)
+      (get opts :compliance)
+      {}))
+
+(defn- merge-compliance
+  "Merge compliance defaults with operator overrides.
+   :evidence/retention-policy is merged one level deep so callers may supply
+   only the keys they wish to change (e.g. just {:retain-days 365}) without
+   losing the other retention fields from the defaults."
+  [defaults overrides]
+  (let [base (merge defaults overrides)]
+    (if (and (contains? overrides :evidence/retention-policy)
+             (map? (get defaults :evidence/retention-policy))
+             (map? (get overrides :evidence/retention-policy)))
+      (assoc base :evidence/retention-policy
+             (merge (get defaults :evidence/retention-policy)
+                    (get overrides :evidence/retention-policy)))
+      base)))
+
+;------------------------------------------------------------------------------ Layer 0.5
+;; Access Log
+
+(defn append-access-log-entry
+  "Append an access log entry to the bundle's :evidence/access-log.
+   Stamps :access-log/timestamp on the entry when absent.
+   Append-only contract: existing entries are never removed or mutated.
+   Returns the updated bundle."
+  [bundle entry]
+  (let [stamped (if (contains? entry :access-log/timestamp)
+                  entry
+                  (assoc entry :access-log/timestamp (java.time.Instant/now)))]
+    (update bundle :evidence/access-log (fnil conj []) stamped)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Phase Evidence Collection
 
@@ -445,6 +506,18 @@
 (defn assemble-evidence-bundle
   "Assemble complete evidence bundle from workflow state and context.
    Merges N11 §9.1 execution evidence fields from :execution/output.
+
+   Compliance defaults (data-classification :internal, retention 90 days, no PII)
+   are applied after the main cond-> chain. Callers may override any compliance
+   field by supplying a :compliance map on the workflow-spec or opts:
+
+     opts:          {:compliance {:evidence/data-classification :confidential}}
+     workflow-spec: {:compliance {:evidence/contains-pii? true
+                                  :evidence/retention-policy {:retain-days 365}}}
+
+   :evidence/retention-policy overrides are merged one level deep — partial
+   overrides (e.g. only :retain-days) leave the other retention fields intact.
+
    Returns evidence bundle ready for storage."
   [workflow-id workflow-state artifact-store & [opts]]
   (let [workflow-spec (:workflow/spec workflow-state)
@@ -463,6 +536,11 @@
 
         ;; N11 §9.1: extract execution evidence from workflow result
         execution-evidence (collect-execution-evidence workflow-state)
+
+        ;; Compliance: defaults from schema + caller overrides from spec/opts
+        compliance-defaults (build-default-compliance-metadata)
+        compliance-overrides (extract-compliance-overrides workflow-spec opts)
+        compliance-data (merge-compliance compliance-defaults compliance-overrides)
 
         ;; Get artifacts for semantic validation
         artifacts (when artifact-store
@@ -506,6 +584,12 @@
                  (assoc :evidence/rules-applied rules-applied)
                  semantic-validation
                  (assoc :evidence/semantic-validation semantic-validation))
+
+        ;; Wire compliance defaults then caller overrides into the assembled bundle.
+        ;; Runs after the cond-> chain so that spec/opts overrides take precedence
+        ;; over the template defaults.  The scanner step below may still add
+        ;; :compliance/* scan-detected keys on top.
+        bundle (merge bundle compliance-data)
 
         ;; Run sensitive data scanner before hashing
         scan-result (try

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -55,7 +55,7 @@
    :intent/declared-at (java.time.Instant/now)
    :intent/author (get workflow-spec :author "system")})
 
-;------------------------------------------------------------------------------ Layer 0.5
+;------------------------------------------------------------------------------ Layer 1
 ;; Compliance Defaults and Overrides
 
 (defn- build-default-compliance-metadata
@@ -83,9 +83,7 @@
    - :evidence/regulatory-tags
    - :evidence/created-by"
   [workflow-spec opts]
-  (or (get workflow-spec :compliance)
-      (get opts :compliance)
-      {}))
+  (get workflow-spec :compliance (get opts :compliance {})))
 
 (defn- merge-compliance
   "Merge compliance defaults with operator overrides.
@@ -102,7 +100,7 @@
                     (get overrides :evidence/retention-policy)))
       base)))
 
-;------------------------------------------------------------------------------ Layer 0.5
+;------------------------------------------------------------------------------ Layer 1
 ;; Access Log
 
 (defn append-access-log-entry

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
@@ -370,7 +370,8 @@
 
 (def default-retention-days
   "Default retention period for evidence bundles — 90 days.
-   Override via :agent/retention-days in EDN config for regulatory environments."
+   Callers can override per-bundle retention through :evidence/retention-policy
+   in workflow-spec or opts compliance metadata."
   schema/default-retention-days)
 
 (def default-data-classification

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
@@ -265,12 +265,38 @@
    - workflow-state: Current workflow state
    - artifact-store: Artifact store instance
 
-   Returns evidence bundle map (not yet stored).
+   Compliance defaults (data-classification :internal, 90-day retention, no PII)
+   are applied automatically. Override via a :compliance map on the workflow-spec
+   or the optional opts argument:
 
-   Example:
-     (assemble-evidence-bundle workflow-id state artifact-store)"
+     (assemble-evidence-bundle wf-id state store
+       {:compliance {:evidence/data-classification :confidential
+                     :evidence/contains-pii? true
+                     :evidence/retention-policy {:retain-days 365}}})
+
+   :evidence/retention-policy overrides merge one level deep — supply only the
+   keys you need to change.
+
+   Returns evidence bundle map (not yet stored)."
   [workflow-id workflow-state artifact-store]
   (collector/assemble-evidence-bundle workflow-id workflow-state artifact-store))
+
+(defn append-access-log-entry
+  "Append an access log entry to the bundle's :evidence/access-log.
+   Stamps :access-log/timestamp on the entry when absent.
+   Append-only contract: existing entries are never removed or mutated.
+   Returns the updated bundle.
+
+   Entry map should include at minimum:
+   - :access-log/principal  string  — identity of the accessor
+   - :access-log/action     keyword — e.g. :read, :export, :validate
+
+   Example:
+     (append-access-log-entry bundle
+       {:access-log/principal \"alice@example.com\"
+        :access-log/action    :read})"
+  [bundle entry]
+  (collector/append-access-log-entry bundle entry))
 
 (defn auto-collect-evidence
   "Automatically collect evidence when workflow reaches terminal state.
@@ -331,6 +357,26 @@
 (def semantic-validation-rules
   "Validation rules per N6 section 2.4.1."
   schema/semantic-validation-rules)
+
+(def data-classifications
+  "Valid data classification levels for evidence bundles.
+   Members: :public :internal :confidential :restricted."
+  schema/data-classifications)
+
+(def regulatory-tag-values
+  "Regulatory frameworks that may apply to an evidence bundle.
+   Members: :gdpr :hipaa :sox :pci."
+  schema/regulatory-tag-values)
+
+(def default-retention-days
+  "Default retention period for evidence bundles — 90 days.
+   Override via :agent/retention-days in EDN config for regulatory environments."
+  schema/default-retention-days)
+
+(def default-data-classification
+  "Default data classification for new evidence bundles — :internal.
+   Operators must explicitly assign :public, :confidential, or :restricted."
+  schema/default-data-classification)
 
 (defn create-evidence-template
   "Create an empty evidence bundle template.

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
@@ -278,8 +278,8 @@
    keys you need to change.
 
    Returns evidence bundle map (not yet stored)."
-  [workflow-id workflow-state artifact-store]
-  (collector/assemble-evidence-bundle workflow-id workflow-state artifact-store))
+  [workflow-id workflow-state artifact-store & [opts]]
+  (collector/assemble-evidence-bundle workflow-id workflow-state artifact-store opts))
 
 (defn append-access-log-entry
   "Append an access log entry to the bundle's :evidence/access-log.

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -227,9 +227,9 @@
 
 (def default-retention-days
   "Default retention period for evidence bundles — 90 days aligns with the
-   team's baseline audit window. Operators should override via
-   :agent/retention-days in EDN config for regulatory environments that
-   require longer holds (e.g. HIPAA mandates 6 years, SOX mandates 7 years)."
+   team's baseline audit window. Callers can override per-bundle retention
+   through :evidence/retention-policy in workflow-spec or opts compliance
+   metadata for regulatory environments that require longer holds."
   90)
 
 (def default-data-classification

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj
@@ -1,0 +1,199 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.evidence-bundle.collector-compliance-test
+  "Unit tests for append-access-log-entry and the compliance-override path
+   in assemble-evidence-bundle.
+
+   Covers:
+   - append-access-log-entry standalone contract
+   - build-default-compliance-metadata via assembled bundle
+   - extract-compliance-overrides via assembled bundle (spec-level, opts-level)
+   - merge-compliance partial :evidence/retention-policy override"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.evidence-bundle.collector :as collector]
+   [ai.miniforge.evidence-bundle.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Fixtures
+
+(def ^:private base-workflow-state
+  {:workflow/status :completed
+   :workflow/spec   {:intent/type :update
+                     :description "test workflow"}
+   :workflow/phases {}})
+
+(def ^:private workflow-id
+  #uuid "00000000-0000-0000-0000-000000000042")
+
+;------------------------------------------------------------------------------ Layer 1
+;; append-access-log-entry
+
+(deftest append-access-log-entry-appends-entry
+  (testing "entry is conj'd onto :evidence/access-log"
+    (let [bundle {:evidence/access-log []}
+          entry  {:access-log/principal "alice"
+                  :access-log/action    :read
+                  :access-log/timestamp (java.time.Instant/now)}
+          result (collector/append-access-log-entry bundle entry)]
+      (is (= 1 (count (:evidence/access-log result))))
+      (is (= "alice" (:access-log/principal (first (:evidence/access-log result))))))))
+
+(deftest append-access-log-entry-preserves-existing
+  (testing "prior entries remain after append"
+    (let [prior  {:access-log/principal "bob"
+                  :access-log/action    :export
+                  :access-log/timestamp (java.time.Instant/now)}
+          bundle {:evidence/access-log [prior]}
+          entry  {:access-log/principal "alice"
+                  :access-log/action    :read
+                  :access-log/timestamp (java.time.Instant/now)}
+          result (collector/append-access-log-entry bundle entry)]
+      (is (= 2 (count (:evidence/access-log result))))
+      (is (= "bob" (:access-log/principal (first (:evidence/access-log result)))))
+      (is (= "alice" (:access-log/principal (second (:evidence/access-log result))))))))
+
+(deftest append-access-log-entry-stamps-missing-timestamp
+  (testing ":access-log/timestamp is added when absent"
+    (let [bundle {:evidence/access-log []}
+          entry  {:access-log/principal "carol"
+                  :access-log/action    :validate}
+          result (collector/append-access-log-entry bundle entry)
+          logged (first (:evidence/access-log result))]
+      (is (contains? logged :access-log/timestamp))
+      (is (instance? java.time.Instant (:access-log/timestamp logged))))))
+
+(deftest append-access-log-entry-preserves-existing-timestamp
+  (testing ":access-log/timestamp is not overwritten when already present"
+    (let [ts     (java.time.Instant/parse "2024-01-01T00:00:00Z")
+          bundle {:evidence/access-log []}
+          entry  {:access-log/principal "dave"
+                  :access-log/action    :read
+                  :access-log/timestamp ts}
+          result (collector/append-access-log-entry bundle entry)
+          logged (first (:evidence/access-log result))]
+      (is (= ts (:access-log/timestamp logged))))))
+
+(deftest append-access-log-entry-initializes-nil-access-log
+  (testing "fnil initializes missing :evidence/access-log as a vector"
+    (let [bundle {}
+          entry  {:access-log/principal "eve"
+                  :access-log/action    :read
+                  :access-log/timestamp (java.time.Instant/now)}
+          result (collector/append-access-log-entry bundle entry)]
+      (is (vector? (:evidence/access-log result)))
+      (is (= 1 (count (:evidence/access-log result)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Compliance defaults via assembly
+
+(deftest assemble-sets-default-data-classification
+  (testing "assembled bundle carries schema/default-data-classification when no override"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil)]
+      (is (= schema/default-data-classification
+             (:evidence/data-classification bundle))))))
+
+(deftest assemble-sets-default-retention-days
+  (testing "assembled bundle carries schema/default-retention-days when no override"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil)]
+      (is (= schema/default-retention-days
+             (get-in bundle [:evidence/retention-policy :retain-days]))))))
+
+(deftest assemble-sets-default-contains-pii-false
+  (testing "assembled bundle has :evidence/contains-pii? false by default"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil)]
+      (is (false? (:evidence/contains-pii? bundle))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Compliance overrides via opts
+
+(deftest assemble-opts-override-data-classification
+  (testing "opts :compliance can override :evidence/data-classification"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/data-classification :confidential}})]
+      (is (= :confidential (:evidence/data-classification bundle))))))
+
+(deftest assemble-opts-override-contains-pii
+  (testing "opts :compliance can set :evidence/contains-pii? true"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/contains-pii? true}})]
+      (is (true? (:evidence/contains-pii? bundle))))))
+
+(deftest assemble-opts-override-created-by
+  (testing "opts :compliance can override :evidence/created-by"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/created-by "operator-alice"}})]
+      (is (= "operator-alice" (:evidence/created-by bundle))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Compliance overrides via workflow-spec
+
+(deftest assemble-spec-override-data-classification
+  (testing "workflow-spec :compliance key overrides :evidence/data-classification"
+    (let [state  (assoc base-workflow-state
+                        :workflow/spec
+                        {:intent/type :update
+                         :description "classified run"
+                         :compliance  {:evidence/data-classification :restricted}})
+          bundle (collector/assemble-evidence-bundle workflow-id state nil)]
+      (is (= :restricted (:evidence/data-classification bundle))))))
+
+(deftest assemble-spec-overrides-take-priority-over-opts
+  (testing "workflow-spec :compliance wins over opts :compliance"
+    (let [state  (assoc base-workflow-state
+                        :workflow/spec
+                        {:intent/type :update
+                         :description "spec vs opts"
+                         :compliance  {:evidence/data-classification :restricted}})
+          bundle (collector/assemble-evidence-bundle
+                  workflow-id state nil
+                  {:compliance {:evidence/data-classification :confidential}})]
+      ;; spec is checked first by extract-compliance-overrides
+      (is (= :restricted (:evidence/data-classification bundle))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Partial retention-policy merge
+
+(deftest assemble-partial-retention-policy-merge
+  (testing ":evidence/retention-policy override is merged one level deep"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/retention-policy {:retain-days 365}}})]
+      ;; caller only supplied :retain-days; auto-delete? and legal-hold? survive
+      (is (= 365 (get-in bundle [:evidence/retention-policy :retain-days])))
+      (is (contains? (:evidence/retention-policy bundle) :auto-delete?))
+      (is (contains? (:evidence/retention-policy bundle) :legal-hold?)))))
+
+(deftest assemble-full-retention-policy-override
+  (testing "full :evidence/retention-policy override replaces all sub-keys"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/retention-policy
+                                {:retain-days  2555
+                                 :auto-delete? false
+                                 :legal-hold?  true}}})]
+      (is (= 2555 (get-in bundle [:evidence/retention-policy :retain-days])))
+      (is (false? (get-in bundle [:evidence/retention-policy :auto-delete?])))
+      (is (true?  (get-in bundle [:evidence/retention-policy :legal-hold?]))))))

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj
@@ -115,7 +115,7 @@
       (is (= ts (:access-log/timestamp logged))))))
 
 (deftest append-access-log-entry-initializes-nil-access-log
-  (testing "fnil initializes missing :evidence/access-log as a vector"
+  (testing "missing :evidence/access-log is initialized as a vector"
     (let [bundle {}
           entry  {:access-log/principal "eve"
                   :access-log/action    :read
@@ -208,6 +208,27 @@
                   workflow-id state nil
                   {:compliance {:evidence/data-classification :confidential}})]
       (is (= :confidential (:evidence/data-classification bundle))))))
+
+(deftest assemble-non-map-spec-compliance-falls-back-to-opts
+  (testing "workflow-spec :compliance non-map does not suppress opts :compliance"
+    (let [state  (assoc base-workflow-state
+                        :workflow/spec
+                        {:intent/type :update
+                         :description "invalid spec compliance"
+                         :compliance  :not-a-map})
+          bundle (collector/assemble-evidence-bundle
+                  workflow-id state nil
+                  {:compliance {:evidence/data-classification :confidential}})]
+      (is (= :confidential (:evidence/data-classification bundle))))))
+
+(deftest assemble-filters-compliance-override-keys
+  (testing "override maps cannot replace non-compliance evidence keys"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/data-classification :confidential
+                                :evidence/outcome {:outcome/success false}}})]
+      (is (= :confidential (:evidence/data-classification bundle)))
+      (is (not= {:outcome/success false} (:evidence/outcome bundle))))))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Partial retention-policy merge

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj
@@ -69,6 +69,20 @@
       (is (= "bob" (:access-log/principal (first (:evidence/access-log result)))))
       (is (= "alice" (:access-log/principal (second (:evidence/access-log result))))))))
 
+(deftest append-access-log-entry-normalizes-existing-log-to-vector
+  (testing "existing non-vector access logs keep append ordering"
+    (let [prior  {:access-log/principal "bob"
+                  :access-log/action    :export
+                  :access-log/timestamp (java.time.Instant/now)}
+          bundle {:evidence/access-log (list prior)}
+          entry  {:access-log/principal "alice"
+                  :access-log/action    :read
+                  :access-log/timestamp (java.time.Instant/now)}
+          result (collector/append-access-log-entry bundle entry)
+          log    (:evidence/access-log result)]
+      (is (vector? log))
+      (is (= ["bob" "alice"] (mapv :access-log/principal log))))))
+
 (deftest append-access-log-entry-stamps-missing-timestamp
   (testing ":access-log/timestamp is added when absent"
     (let [bundle {:evidence/access-log []}
@@ -77,6 +91,16 @@
           result (collector/append-access-log-entry bundle entry)
           logged (first (:evidence/access-log result))]
       (is (contains? logged :access-log/timestamp))
+      (is (instance? java.time.Instant (:access-log/timestamp logged))))))
+
+(deftest append-access-log-entry-stamps-nil-timestamp
+  (testing ":access-log/timestamp nil is treated as missing"
+    (let [bundle {:evidence/access-log []}
+          entry  {:access-log/principal "carol"
+                  :access-log/action    :validate
+                  :access-log/timestamp nil}
+          result (collector/append-access-log-entry bundle entry)
+          logged (first (:evidence/access-log result))]
       (is (instance? java.time.Instant (:access-log/timestamp logged))))))
 
 (deftest append-access-log-entry-preserves-existing-timestamp
@@ -173,6 +197,18 @@
       ;; spec is checked first by extract-compliance-overrides
       (is (= :restricted (:evidence/data-classification bundle))))))
 
+(deftest assemble-nil-spec-compliance-falls-back-to-opts
+  (testing "workflow-spec :compliance nil does not suppress opts :compliance"
+    (let [state  (assoc base-workflow-state
+                        :workflow/spec
+                        {:intent/type :update
+                         :description "nil spec compliance"
+                         :compliance  nil})
+          bundle (collector/assemble-evidence-bundle
+                  workflow-id state nil
+                  {:compliance {:evidence/data-classification :confidential}})]
+      (is (= :confidential (:evidence/data-classification bundle))))))
+
 ;------------------------------------------------------------------------------ Layer 5
 ;; Partial retention-policy merge
 
@@ -183,8 +219,8 @@
                   {:compliance {:evidence/retention-policy {:retain-days 365}}})]
       ;; caller only supplied :retain-days; auto-delete? and legal-hold? survive
       (is (= 365 (get-in bundle [:evidence/retention-policy :retain-days])))
-      (is (contains? (:evidence/retention-policy bundle) :auto-delete?))
-      (is (contains? (:evidence/retention-policy bundle) :legal-hold?)))))
+      (is (true? (get-in bundle [:evidence/retention-policy :auto-delete?])))
+      (is (false? (get-in bundle [:evidence/retention-policy :legal-hold?]))))))
 
 (deftest assemble-full-retention-policy-override
   (testing "full :evidence/retention-policy override replaces all sub-keys"


### PR DESCRIPTION
---
miniforge-workflow: c1cb3bfb-dbc1-4e59-85d2-eec7cc673411
spec: work/n06-compliance-metadata.spec.edn
task: aa000001-0002-4000-8000-000000000002
commit: c5520aa98519b45dad4397da898dd92c41c0fe26
generated-by: miniforge
---

## Summary

Wire compliance metadata defaults into bundle assembly and add access-log helper.

## Changes

- `components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj` (create)
- `components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj` (modify)
- `components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj` (modify)

## Review

**Decision**: approved

Implementation correct and complete. All four collector.clj items shipped: build-default-compliance-metadata, extract-compliance-overrides, merge-compliance wired into assemble-evidence-bundle, append-access-log-entry. All four interface.clj items shipped: schema constants re-exported, append-access-log-entry re-exported, assemble-evidence-bundle docstring updated. Tests ship alongside code (15 tests, 24 assertions, all green). One warning: extract-compliance-overrides drops opts-only compliance keys silently when workflow-spec carries any :compliance key — the either/or semantics match the spec but the silent drop deserves a test and clearer documentation. No blocking issues in scope. The 5 FSM errors in loop.outer_test are pre-existing and outside this PR's scope.

### Known issues (non-blocking)

Merged with 2 unresolved non-blocking issue(s) recorded for follow-up:

- `components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj` — extract-compliance-overrides uses strict either/or semantics: if workflow-spec carries any :compliance key, the entire opts :compliance map is dropped silently. A caller that sets {:evidence/data-classification :restricted} on the spec and {:evidence/contains-pii? true} on opts will find the PII flag silently absent from the bundle. The docstring says 'falls back to opts' which accurately describes the behavior, but the silent drop of opts-only keys is a trap. No test covers the case where spec and opts carry *different* keys.
- `components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj` — Two separate 'Layer 1' sections are introduced (;; Compliance Defaults and Overrides and ;; Access Log). The existing file already had multiple Layer 1 sections, so this is consistent, but the layering rules expect monotonic headings. Both new sections belong at Layer 1 — just merge them under a single '--- Layer 1' heading or differentiate with sub-comments.

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (3 files)