### PR TITLE
fix(response): normalize result metrics at the constructor boundary (non-nil tokens)

### DIFF
--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -167,6 +167,25 @@
         (is (nil? (get-in final-result [:phase :result :output]))
             "Result should NOT contain serialized :output / :code/files")))))
 
+(deftest leave-implement-tolerates-nil-tokens-metrics-test
+  (testing "an agent result with an EXPLICIT nil :tokens (file-artifact fallback
+            path) does not NPE in leave — tokens coerce to 0, verdict survives"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                (response/success nil {:tokens nil :duration-ms 1200}))
+                  agent/curate-implement-output mock-curator-success]
+      (let [ctx (-> (create-base-context)
+                    (assoc :execution/environment-id (random-uuid)))
+            ctx-with-config (assoc ctx :phase-config {:phase :implement})
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) ctx-with-config)
+            ;; Pre-fix this threw a message-less NullPointerException.
+            final-result ((:leave interceptor) enter-result)]
+        (is (= :completed (get-in final-result [:phase :status])))
+        (is (number? (get-in final-result [:execution/metrics :tokens]))
+            "nil agent tokens accumulate as 0, not a throw")
+        (is (number? (get-in final-result [:phase :metrics :cost-usd])))))))
+
 (deftest implement-reads-plan-from-context-test
   (testing "implement phase reads plan from execution phase results"
     (let [plan-read-atom (atom nil)]

--- a/components/response/src/ai/miniforge/response/builder.clj
+++ b/components/response/src/ai/miniforge/response/builder.clj
@@ -24,6 +24,21 @@
   (:require [clojure.string]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Metrics normalization
+
+(defn normalize-metrics
+  "Guarantee the canonical metrics contract: `:tokens` and `:duration-ms` are
+   always present non-nil numbers. `(merge {:tokens 0} {:tokens nil})` yields
+   `{:tokens nil}` — an explicit nil in a caller-supplied metrics map silently
+   overrides the default and violates the documented `{:tokens N :duration-ms N}`
+   shape, which then throws a message-less NPE in any downstream arithmetic.
+   Normalizing here, at the constructor boundary, means no reader has to defend."
+  [metrics tokens duration-ms]
+  (-> (merge {:tokens (or tokens 0) :duration-ms (or duration-ms 0)} metrics)
+      (update :tokens #(or % 0))
+      (update :duration-ms #(or % 0))))
+
+;------------------------------------------------------------------------------ Layer 0
 ;; Success responses
 
 (defn success
@@ -45,9 +60,7 @@
   ([output]
    (success output {}))
   ([output {:keys [metrics artifact tokens duration-ms]}]
-   (let [default-metrics {:tokens (or tokens 0)
-                         :duration-ms (or duration-ms 0)}
-         merged-metrics (merge default-metrics metrics)]
+   (let [merged-metrics (normalize-metrics metrics tokens duration-ms)]
      (cond-> {:status :success
               :output output
               :metrics merged-metrics}
@@ -146,9 +159,7 @@
   ([message]
    (error message {}))
   ([message {:keys [data metrics output tokens duration-ms]}]
-   (let [default-metrics {:tokens (or tokens 0)
-                         :duration-ms (or duration-ms 0)}
-         merged-metrics (merge default-metrics metrics)]
+   (let [merged-metrics (normalize-metrics metrics tokens duration-ms)]
      (cond-> {:status :error
               :error (error-details message data)
               :metrics merged-metrics}

--- a/components/response/src/ai/miniforge/response/builder.clj
+++ b/components/response/src/ai/miniforge/response/builder.clj
@@ -26,13 +26,15 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Metrics normalization
 
-(defn normalize-metrics
-  "Guarantee the canonical metrics contract: `:tokens` and `:duration-ms` are
-   always present non-nil numbers. `(merge {:tokens 0} {:tokens nil})` yields
-   `{:tokens nil}` — an explicit nil in a caller-supplied metrics map silently
-   overrides the default and violates the documented `{:tokens N :duration-ms N}`
-   shape, which then throws a message-less NPE in any downstream arithmetic.
-   Normalizing here, at the constructor boundary, means no reader has to defend."
+(defn- normalize-metrics
+  "Ensure `:tokens` and `:duration-ms` are always PRESENT and non-nil,
+   replacing a missing or explicit-nil value with 0. `(merge {:tokens 0}
+   {:tokens nil})` yields `{:tokens nil}` — an explicit nil in a
+   caller-supplied metrics map silently overrides the default and violates the
+   documented `{:tokens N :duration-ms N}` shape, which then throws a
+   message-less NPE in any downstream arithmetic. Normalizing here, at the
+   constructor boundary, means no reader has to defend. (Does not coerce
+   non-nil non-numeric values — callers supply numbers or nil.)"
   [metrics tokens duration-ms]
   (-> (merge {:tokens (or tokens 0) :duration-ms (or duration-ms 0)} metrics)
       (update :tokens #(or % 0))

--- a/components/response/test/ai/miniforge/response/builder_test.clj
+++ b/components/response/test/ai/miniforge/response/builder_test.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response.builder-test
+  "Boundary contract for the response builders: a constructed result's
+   :metrics ALWAYS has non-nil numeric :tokens and :duration-ms, even when a
+   caller passes a metrics map carrying an explicit nil. This is the boundary
+   normalization that prevents message-less NPEs in downstream metric
+   arithmetic (the 2026-06-14 n06 dogfood implement-leave crash)."
+  (:require
+   [ai.miniforge.response.interface :as response]
+   [clojure.test :refer [deftest is testing]]))
+
+(defn- metrics [r] (:metrics r))
+
+(deftest success-metrics-never-nil-test
+  (testing "explicit nil :tokens in the metrics map is normalized to 0, not passed through"
+    (let [m (metrics (response/success :out {:metrics {:tokens nil :duration-ms nil}}))]
+      (is (= 0 (:tokens m)))
+      (is (= 0 (:duration-ms m)))))
+  (testing "absent metrics → numeric defaults"
+    (let [m (metrics (response/success :out))]
+      (is (number? (:tokens m)))
+      (is (number? (:duration-ms m)))))
+  (testing "real values are preserved"
+    (let [m (metrics (response/success :out {:metrics {:tokens 1500 :duration-ms 3000}}))]
+      (is (= 1500 (:tokens m)))
+      (is (= 3000 (:duration-ms m)))))
+  (testing "top-level :tokens/:duration-ms opts still honored"
+    (let [m (metrics (response/success :out {:tokens 42 :duration-ms 7}))]
+      (is (= 42 (:tokens m)))
+      (is (= 7 (:duration-ms m))))))
+
+(deftest error-and-failure-metrics-never-nil-test
+  (testing "error normalizes an explicit nil :tokens"
+    (let [m (metrics (response/error "boom" {:metrics {:tokens nil :duration-ms nil}}))]
+      (is (= 0 (:tokens m)))
+      (is (= 0 (:duration-ms m)))))
+  (testing "failure (delegates to error) normalizes an explicit nil :tokens"
+    (let [m (metrics (response/failure "boom" {:metrics {:tokens nil}}))]
+      (is (= 0 (:tokens m)))
+      (is (number? (:duration-ms m))))))


### PR DESCRIPTION
## Summary

The n06 dogfood crashed with a message-less `NullPointerException` in `leave-implement`. Root cause is a **boundary-validation miss in the response builders**, not in the reader.

`response/success` / `response/error` build metrics as `(merge {:tokens 0 :duration-ms 0} caller-metrics)`. But `(merge {:tokens 0} {:tokens nil})` → `{:tokens nil}` — an **explicit nil** in a caller-supplied metrics map silently overrides the constructor’s own default, violating the documented `{:tokens N :duration-ms N}` contract. (`(get m k default)` only applies the default to *absent* keys, so the nil then survives into downstream arithmetic and throws; `execute-leave` swallows the NPE, discarding the phase verdict the FSM needs and failing the whole run.) The `file-artifact-fallback` path that produced this run’s result is exactly where a nil-tokens metrics map comes from.

## Fix — at the writer/boundary, not the readers
- `response/success` + `response/error` route metrics through a shared `normalize-metrics` that guarantees non-nil numeric `:tokens`/`:duration-ms` even when a caller passes an explicit nil. Results are now **born conforming** to the contract.
- **Reverted** the defensive coercion I first put in `leave-implement` — a redundant tolerant reader once the writer is correct (one-canonical-place: normalize writers, not readers).

## On schema validation (the boundary point)
Our existing result schemas already reject a *present* nil (`:common/non-neg-int` doesn’t accept nil). The actual miss was twofold: the builder **produced** the nil, and nothing validated metrics at this boundary. Enforcement here is **by construction** — `response` is a foundational hot path, so per-call malli is the wrong tool; the constructor guaranteeing the invariant is stronger (can’t be bypassed by any builder caller) and free. A hard runtime `validate!` of metrics at the *phase-input* boundary (catching non-builder producers too) belongs with the `phase-boundary-contracts` work — flagged, not bundled.

## Tests
- `builder_test`: success/error/failure normalize an explicit nil `:tokens`/`:duration-ms` → 0; real values preserved; top-level opts honored.
- `implement_test`: end-to-end regression — an agent result with nil `:tokens` no longer NPEs in leave; verdict/metrics survive.
- response brick green; `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)