### PR TITLE
fix(agent): correct implementer tool guidance for the Read-disabled environment

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -52,8 +52,8 @@ Required delivery sequence:
    - **New file** → use `Write` with the complete contents.
    - **Existing file** → edit it with `Bash` (a heredoc `cat > file`, `sed`,
      `patch`, etc.). Do NOT use `Write`/`Edit` on an existing file: the native
-     `Read` tool is disabled here (read files with the `context_read` MCP tool),
-     and `Write`/`Edit` refuse to touch an existing file until it has been read
+     `Read` tool is disabled here (read files with the `mcp__context__context_read`
+     MCP tool), and `Write`/`Edit` refuse to touch an existing file until read
      with the native `Read` tool — so on an existing file they fail. Go straight
      to `Bash`; don't burn turns discovering this.
 
@@ -178,13 +178,14 @@ Specifically:
   use `Write` to create it at that path. Write will succeed.
 - Do NOT conclude \"files not accessible\" from failed reads of new paths.
 - Do NOT produce a report or summary instead of writing files because reads failed.
-- Do NOT halt or produce narration when Write is the correct next action.
+- Do NOT halt or produce narration when writing a file is the correct next action.
 
 ## Turn Budget — HARD LIMIT
 
 You have at most 40 tool calls total.
-**Your FIRST action must be a Write or Edit tool call — NOT reading files,
-NOT planning in chat, NOT printing the code first.**
+**Your FIRST action must write a file — `Write` for a new file, `Bash` for an
+existing one — NOT reading files, NOT planning in chat, NOT printing the code
+first.** (Never `Write`/`Edit` an existing file here; see the delivery sequence.)
 After at most 3 file reads, you MUST start writing.
 A good-enough implementation written to disk on time is better than a perfect
 plan that never lands as files.
@@ -205,7 +206,8 @@ Do NOT explore further. Do NOT call context_read/context_grep/context_glob.
 Your only job is to DELIVER the implementation NOW by writing the files.
 
 Primary submission path:
-  Use the Write (or Edit) tool to create/modify each file. The files on disk
+  Write each file — `Write` for new files, `Bash` for existing ones (native
+  `Write`/`Edit` fail on existing files in this environment). The files on disk
   ARE the submission.
 
 Fallback only if Write is unavailable:

--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -48,15 +48,23 @@ a tool call is **not delivered** and will be discarded by the runtime.
 
 Required delivery sequence:
 
-1. **Use Write (or Edit) tools to create or modify each file.** One tool call
-   per file. Provide the complete file contents in each call — no placeholders,
-   no \"rest unchanged\" markers, no Clojure EDN maps in chat as a substitute.
+1. **Write each file to the working directory. Pick the tool by file state:**
+   - **New file** → use `Write` with the complete contents.
+   - **Existing file** → edit it with `Bash` (a heredoc `cat > file`, `sed`,
+     `patch`, etc.). Do NOT use `Write`/`Edit` on an existing file: the native
+     `Read` tool is disabled here (read files with the `context_read` MCP tool),
+     and `Write`/`Edit` refuse to touch an existing file until it has been read
+     with the native `Read` tool — so on an existing file they fail. Go straight
+     to `Bash`; don't burn turns discovering this.
+
+   Provide the complete file contents — no placeholders, no \"rest unchanged\"
+   markers, no Clojure EDN maps in chat as a substitute.
 2. **After writing all files, call the `submit` MCP tool** with a brief
-   `code_summary` describing what you changed and why. If `submit` is not
-   available in your environment, the runtime falls back to collecting
-   whatever files you wrote with Write/Edit — so Write/Edit alone is
-   sufficient delivery. `submit` is the structured confirmation path; never
-   the only path.
+   `code_summary` describing what you changed and why. `submit` is the
+   structured confirmation path, not the only path: delivery is the set of
+   files present in the working directory, collected from the worktree
+   regardless of which tool wrote them (`Write` or `Bash`). So your changes
+   land whether or not `submit` is available — but always call it when present.
 
 Do NOT:
 - Emit a `{:code/files [...]}` map in this conversation in place of Write
@@ -82,7 +90,8 @@ rejects slashes; the runtime maps them back to the namespaced EDN keys
 it persists `artifact.edn`.
 
 Note: `code_files` is NOT part of the submit payload. The runtime derives
-the file list from your Write/Edit tool calls.
+the file list from the working directory (the worktree diff), so files you
+edit with `Bash` count exactly like files you create with `Write`.
 
 ## Guidelines
 
@@ -144,7 +153,8 @@ If `Write` is unavailable, the same EDN map in your final message is an
 acceptable fallback. The runtime normalizes both paths.
 
 Only use this when ALL acceptance criteria are already met by existing code.
-If even partial changes are needed, proceed with normal Write/Edit delivery.
+If even partial changes are needed, proceed with normal file delivery (step 1:
+`Write` for new files, `Bash` for existing ones).
 
 ## CRITICAL: Do NOT Re-Read Files Already In This Prompt
 


### PR DESCRIPTION
## Summary

Follow-up from the n06 dogfood diagnosis. The implementer prompt actively misdirected the agent:
- "Use Write (or Edit) tools to create or modify each file"
- "the runtime falls back to collecting whatever files you wrote with Write/Edit — so Write/Edit alone is sufficient delivery"

Both are wrong in the implement environment. `implementer-disallowed-tools` blocks native `Read` (deliberately — to force the token-efficient `context_read` MCP cache), and claude’s `Write`/`Edit` refuse to modify an **existing** file until it has been read with the native `Read` tool. So on existing files `Write`/`Edit` fail, and the agent burns turns rediscovering the `Bash` workaround on every run (n06 stream: `Write`→fail, `Edit`→fail, then `Bash`).

## Fix (prompt only)
- New file → `Write`. Existing file → `Bash` (heredoc/`sed`/`patch`). Don’t try `Write`/`Edit` on existing files; go straight to `Bash`.
- Clarify delivery is the **worktree diff** — files written by `Bash` count exactly like `Write`, so `submit` is confirmation, not the only path. (Fixes the stale "derives the file list from your Write/Edit tool calls" note.)

This is the bounded fix that stops the wasted turns while preserving the deliberate cache-forcing design. The proper long-term fix is an MCP `write`/apply-patch tool that edits existing files without tripping claude’s read-before-edit guard and keeps the cache coherent — flagged as follow-up, not bundled.

## Test plan
- EDN parses; `bb pre-commit` green. Prompt-only change (no code paths altered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)