### PR TITLE
feat(schema,phase): validate agent-result metrics at the phase-input boundary

### DIFF
--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -4,6 +4,7 @@
         ai.miniforge/workspace {:local/root "../workspace"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/phase {:local/root "../phase"}
+        ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/agent {:local/root "../agent"}
         ai.miniforge/knowledge {:local/root "../knowledge"}
         ai.miniforge/repo-index {:local/root "../repo-index"}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -33,6 +33,7 @@
    [ai.miniforge.repo-index.interface :as repo-index]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
+   [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
    [clojure.string :as str]))
 
@@ -642,6 +643,24 @@
                :code/file-actions (mapv :action files)
                :code/file-count (count files))))))
 
+(defn- ensure-valid-metrics
+  "Phase-input boundary validation for the agent result's `:metrics`. The
+   response builders guarantee non-nil numeric `:tokens`/`:duration-ms`, but a
+   producer that bypasses them (or a future regression) could send a nil that
+   then throws a message-less NPE in the cost/accumulation arithmetic below.
+   Validate against `schema/Metrics`; on violation, log loudly and coerce to a
+   valid shape (telemetry must not crash the phase) rather than fail silently."
+  [metrics logger]
+  (if (schema/valid? schema/Metrics metrics)
+    metrics
+    (let [coerced (-> metrics
+                      (update :tokens #(if (nat-int? %) % 0))
+                      (update :duration-ms #(if (nat-int? %) % 0)))]
+      (when logger
+        (log/warn logger :implement :metrics/boundary-invalid
+                  {:data {:received metrics :coerced coerced}}))
+      coerced)))
+
 (defn leave-implement
   "Post-processing for implementation phase.
 
@@ -650,6 +669,7 @@
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
         duration-ms (if start-time (- end-time start-time) 0)
+        logger (get-in ctx [:execution/logger])
         result (get-in ctx [:phase :result])
         agent-status (:status result)
         rate-limited? (and (= :error agent-status) (rate-limit-in-result? result))
@@ -725,7 +745,9 @@
                        curator-empty-diff? :failed
                        :else (phase/determine-phase-status
                                effective-status iterations max-iterations))
-        metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
+        metrics (ensure-valid-metrics
+                  (get result :metrics {:tokens 0 :duration-ms duration-ms})
+                  logger)
         cost-usd (get result :cost-usd
                    (get metrics :cost-usd
                      (* (get metrics :tokens 0) 0.000015)))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -653,7 +653,10 @@
   [metrics logger]
   (if (schema/valid? schema/Metrics metrics)
     metrics
-    (let [coerced (-> metrics
+    ;; Resilient to ANY invalid shape — a non-map :metrics (string/vector) must
+    ;; coerce too, not throw before we can log/recover.
+    (let [base    (if (map? metrics) metrics {})
+          coerced (-> base
                       (update :tokens #(if (nat-int? %) % 0))
                       (update :duration-ms #(if (nat-int? %) % 0)))]
       (when logger

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -204,7 +204,19 @@
             final-result ((:leave interceptor) tampered)]
         (is (number? (get-in final-result [:execution/metrics :tokens]))
             "boundary coerced the invalid metrics; no NPE")
-        (is (number? (get-in final-result [:phase :metrics :cost-usd])))))))
+        (is (number? (get-in final-result [:phase :metrics :cost-usd]))))))
+  (testing "a non-map :metrics (wrong shape entirely) is coerced, not thrown"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                (response/success nil {:tokens 10 :duration-ms 100}))
+                  agent/curate-implement-output mock-curator-success]
+      (let [ctx (assoc (create-base-context) :execution/environment-id (random-uuid))
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) (assoc ctx :phase-config {:phase :implement}))
+            tampered (assoc-in enter-result [:phase :result :metrics] "not-a-map")
+            final-result ((:leave interceptor) tampered)]
+        (is (number? (get-in final-result [:execution/metrics :tokens]))
+            "non-map metrics coerced to a valid shape; no throw")))))
 
 (deftest implement-reads-plan-from-context-test
   (testing "implement phase reads plan from execution phase results"

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -186,6 +186,26 @@
             "nil agent tokens accumulate as 0, not a throw")
         (is (number? (get-in final-result [:phase :metrics :cost-usd])))))))
 
+(deftest leave-implement-boundary-coerces-raw-invalid-metrics-test
+  (testing "metrics that bypass the response builders (raw nil :tokens) are
+            caught at the phase-input boundary and coerced, not NPE'd"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                (response/success nil {:tokens 10 :duration-ms 100}))
+                  agent/curate-implement-output mock-curator-success]
+      (let [ctx (-> (create-base-context)
+                    (assoc :execution/environment-id (random-uuid)))
+            ctx-with-config (assoc ctx :phase-config {:phase :implement})
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) ctx-with-config)
+            ;; Inject a raw, schema-invalid metrics map AFTER enter — simulates
+            ;; a producer that did not go through response/success.
+            tampered (assoc-in enter-result [:phase :result :metrics] {:tokens nil})
+            final-result ((:leave interceptor) tampered)]
+        (is (number? (get-in final-result [:execution/metrics :tokens]))
+            "boundary coerced the invalid metrics; no NPE")
+        (is (number? (get-in final-result [:phase :metrics :cost-usd])))))))
+
 (deftest implement-reads-plan-from-context-test
   (testing "implement phase reads plan from execution phase results"
     (let [plan-read-atom (atom nil)]

--- a/components/schema/src/ai/miniforge/schema/core.clj
+++ b/components/schema/src/ai/miniforge/schema/core.clj
@@ -172,6 +172,18 @@
    [:cost-usd {:optional true} :common/pos-number]
    [:duration-ms {:optional true} :common/non-neg-int]])
 
+(def Metrics
+  "Schema for an agent/phase result's `:metrics` map. `:tokens` and
+   `:duration-ms` are REQUIRED and non-nil — they are consumed by cost and
+   accumulation arithmetic, so a missing or nil value is a boundary violation
+   (it throws a message-less NPE downstream). `:non-neg-int` already rejects a
+   present nil; making the keys required also rejects an absent one."
+  [:map {:registry registry}
+   [:tokens :common/non-neg-int]
+   [:duration-ms :common/non-neg-int]
+   [:cost-usd {:optional true} :common/pos-number]
+   [:iterations {:optional true} :common/non-neg-int]])
+
 (def Workflow
   "Schema for an outer loop SDLC delivery instance."
   [:map {:registry registry}

--- a/components/schema/src/ai/miniforge/schema/interface.clj
+++ b/components/schema/src/ai/miniforge/schema/interface.clj
@@ -78,6 +78,13 @@
    `:workflow/consumed` in [[Workflow]]."
   core/WorkflowBudget)
 
+(def Metrics
+  "Malli `:map` schema for an agent/phase result's `:metrics`: REQUIRED non-nil
+   `:tokens` and `:duration-ms` (consumed by cost/accumulation arithmetic),
+   optional `:cost-usd`, `:iterations`. Validate agent-result metrics against
+   this at the phase-input boundary so a nil fails loud instead of NPE-ing."
+  core/Metrics)
+
 (def LogEntry
   "Malli `:map` schema for a structured EDN log entry. Required: `:log/id`,
    `:log/timestamp`, `:log/level`, `:log/category`, `:log/event`. Optional:

--- a/components/schema/test/ai/miniforge/schema/interface_test.clj
+++ b/components/schema/test/ai/miniforge/schema/interface_test.clj
@@ -202,6 +202,18 @@
                           #"Schema validation failed"
                           (schema/validate schema/Agent {:agent/id "bad"})))))
 
+(deftest metrics-schema-test
+  (testing "valid metrics pass"
+    (is (schema/valid? schema/Metrics {:tokens 0 :duration-ms 0}))
+    (is (schema/valid? schema/Metrics {:tokens 1500 :duration-ms 3000 :cost-usd 0.02})))
+  (testing "explicit nil :tokens is rejected (the NPE class)"
+    (is (not (schema/valid? schema/Metrics {:tokens nil :duration-ms 0}))))
+  (testing "missing required key is rejected"
+    (is (not (schema/valid? schema/Metrics {:duration-ms 0})))
+    (is (not (schema/valid? schema/Metrics {:tokens 0}))))
+  (testing "negative tokens rejected"
+    (is (not (schema/valid? schema/Metrics {:tokens -1 :duration-ms 0})))))
+
 ;; Enum access tests
 
 (deftest enum-values-test


### PR DESCRIPTION
## Summary

Follow-up #2 to the implement-leave NPE. #1147 fixed the **writer** (response builders normalize metrics). This adds the **boundary-validation** half: a canonical `Metrics` schema + a runtime validate at the phase-input boundary, so a metrics map that bypasses the builders (or a future regression) is caught and handled loudly instead of NPE-ing deep in cost/accumulation arithmetic.

This is legitimate boundary discipline (validating untrusted agent-result input crossing into the phase), distinct from the writer-side fix — not a redundant tolerant reader.

## Changes
- **schema**: new `Metrics` schema — `:tokens` and `:duration-ms` REQUIRED + non-nil (`:common/non-neg-int` rejects a present nil; required rejects an absent key), `:cost-usd`/`:iterations` optional. Exported on `schema.interface`.
- **phase-software-factory/implement**: `ensure-valid-metrics` validates the agent result’s `:metrics` against `schema/Metrics` at `leave-implement` (the phase-input boundary). On violation it logs `:metrics/boundary-invalid` and coerces to a valid shape — telemetry must not crash the phase, but the anomaly is now observable. (New `phase-software-factory → schema` dep; `poly check` OK.)

## Tests
- `schema`: `Metrics` rejects nil/absent/negative `:tokens`; accepts valid maps.
- `phase-software-factory`: `leave-implement` coerces a raw schema-invalid metrics map (one that bypassed the builders) without NPE.
- Full `phase-software-factory` + `schema` brick tests green; `bb pre-commit` green.

## Scope note
Applied at the implement boundary (the proven crash site); `ensure-valid-metrics` + the `Metrics` schema are the reusable contract other phase leaves can adopt. A workspace-wide phase-boundary validation harness is the `phase-boundary-contracts` spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)