### PR TITLE
feat(mcp-context-server,agent): context_write MCP tool — agent-agnostic edit path

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -418,8 +418,8 @@
    from a pre-populated cache with filesystem fallback. Invoked automatically;
    not intended for direct user use."
   [m]
-  (let [{:keys [artifact-dir]} (get-opts m)]
-    (mcp-context-server/start-server artifact-dir)))
+  (let [{:keys [artifact-dir source-root workdir]} (get-opts m)]
+    (mcp-context-server/start-server artifact-dir source-root workdir)))
 
 (defn lsp-mcp-bridge-cmd
   "Run the LSP-to-MCP bridge server (spawned by Claude Code/Desktop/Codex as MCP server).
@@ -478,7 +478,9 @@
    ;; MCP context server (internal — spawned as subprocess by agent)
    {:cmds ["context-server"]
     :fn context-server-cmd
-    :spec {:artifact-dir {:alias :a :require true}}}
+    :spec {:artifact-dir {:alias :a :require true}
+           :source-root  {:alias :s}
+           :workdir      {:alias :w}}}
 
    ;; LSP-to-MCP bridge server (internal — spawned by Claude Code/Desktop/Codex)
    {:cmds ["lsp-mcp-bridge"]

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -415,8 +415,9 @@
   "Run the MCP context server (internal — spawned as subprocess by the agent).
 
    Reads JSON-RPC 2.0 from stdin, serves context_read/context_grep/context_glob
-   from a pre-populated cache with filesystem fallback. Invoked automatically;
-   not intended for direct user use."
+   from a pre-populated cache with filesystem fallback, plus context_write which
+   writes to --workdir (the agent's worktree). Invoked automatically; not
+   intended for direct user use."
   [m]
   (let [{:keys [artifact-dir source-root workdir]} (get-opts m)]
     (mcp-context-server/start-server artifact-dir source-root workdir)))

--- a/bases/mcp-context-server/resources/config/mcp-context-server/messages/en-US.edn
+++ b/bases/mcp-context-server/resources/config/mcp-context-server/messages/en-US.edn
@@ -13,4 +13,7 @@
   ;; Context tool responses
   :context/read-error          "Error reading {path}: file not found or unreadable"
   :context/no-grep-matches     "No matches found."
-  :context/no-glob-matches     "No files matched the pattern."}}
+  :context/no-glob-matches     "No files matched the pattern."
+  :context/write-ok            "Wrote {path} ({bytes} bytes)"
+  :context/write-error         "context_write requires a non-blank path and string content (path: {path})"
+  :context/write-failed        "Error writing {path}: {error}"}}

--- a/bases/mcp-context-server/resources/config/mcp-context-server/messages/en-US.edn
+++ b/bases/mcp-context-server/resources/config/mcp-context-server/messages/en-US.edn
@@ -16,4 +16,5 @@
   :context/no-glob-matches     "No files matched the pattern."
   :context/write-ok            "Wrote {path} ({bytes} bytes)"
   :context/write-error         "context_write requires a non-blank path and string content (path: {path})"
+  :context/write-unsafe        "Refusing to write {path}: path must be relative to the working directory (no absolute paths or '..' escapes)"
   :context/write-failed        "Error writing {path}: {error}"}}

--- a/bases/mcp-context-server/resources/mcp-context-server/tool-registry.edn
+++ b/bases/mcp-context-server/resources/mcp-context-server/tool-registry.edn
@@ -53,4 +53,19 @@
     :properties
     {"pattern" {:type "string" :description "Glob pattern to match files (e.g. \"**/*.clj\", \"src/**/*.ts\")"}}}}
   :required-params
-  {"pattern" {:check :non-blank :msg "pattern is required"}}}}
+  {"pattern" {:check :non-blank :msg "pattern is required"}}}
+
+ "context_write"
+ {:handler :context-write
+  :tool-def
+  {:name "context_write"
+   :description "Create or overwrite a file in the working directory with the full contents you provide, and refresh the context cache so a later context_read returns it. Use this to create new files AND to edit existing ones — it needs no prior read, so it is the reliable cross-agent way to modify existing files. Provide the COMPLETE file contents (no placeholders or 'rest unchanged' markers)."
+   :inputSchema
+   {:type "object"
+    :required ["path" "content"]
+    :properties
+    {"path"    {:type "string" :description "File path relative to the working directory"}
+     "content" {:type "string" :description "Complete file contents to write"}}}}
+  :required-params
+  {"path"    {:check :non-blank :msg "path is required"}
+   "content" {:check :string    :msg "content is required (string)"}}}}

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -459,16 +459,33 @@
         (str/join "\n" matches)
         (msg/t :context/no-glob-matches)))))
 
+(defn- within-write-root?
+  "True when the resolved target canonicalizes to a path inside write-root.
+   Blocks absolute paths and `..` traversal that would let an MCP client
+   overwrite files outside the worktree."
+  [target]
+  (let [root-c   (.getCanonicalPath (io/file (write-root)))
+        target-c (.getCanonicalPath (io/file target))]
+    (or (= target-c root-c)
+        (str/starts-with? target-c (str root-c java.io.File/separator)))))
+
 (defn handle-context-write
   "Handler for the context_write MCP tool. Writes the full file content to the
    worktree (write-root) and refreshes the cache so a later context_read returns
    the new content. Agent-agnostic edit path — works for any MCP client and,
-   unlike native Write/Edit, needs no prior native Read of the file."
+   unlike native Write/Edit, needs no prior native Read of the file. Paths are
+   relative to the worktree; absolute paths and `..` escapes are rejected."
   [params]
   (let [path    (get params "path")
         content (get params "content")]
-    (if (or (str/blank? path) (not (string? content)))
+    (cond
+      (or (str/blank? path) (not (string? content)))
       (error-response (msg/t :context/write-error {:path (str path)}))
+
+      (not (within-write-root? (resolve-write-path path)))
+      (error-response (msg/t :context/write-unsafe {:path (str path)}))
+
+      :else
       (try
         (let [target (io/file (resolve-write-path path))]
           (io/make-parents target)
@@ -479,7 +496,9 @@
           (swap! cache-state #(-> %
                                   (assoc-in [:files path] content)
                                   (assoc-in [:mtimes path] (.lastModified target))))
-          (text-response (msg/t :context/write-ok {:path path :bytes (count content)})))
+          (text-response (msg/t :context/write-ok
+                                {:path path
+                                 :bytes (alength (.getBytes ^String content "UTF-8"))})))
         (catch Exception e
           (error-response (msg/t :context/write-failed
                                  {:path path :error (ex-message e)})))))))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -151,16 +151,30 @@
 ;; file when its content was cached, for write-invalidation), and :misses
 ;; (recorded cache misses).
 (defonce cache-state
-  (atom {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil}))
+  (atom {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil :workdir nil}))
 
 (defn reset-state!
   "Reset cache state. Intended for test isolation."
   []
-  (reset! cache-state {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil}))
+  (reset! cache-state {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil :workdir nil}))
+
+(defn set-workdir!
+  "Set the write target for context_write — the agent's worktree, distinct from
+   `:source-root` (the read reference). Reads resolve against source-root;
+   writes land in the worktree where the run collects the diff. Agent-agnostic:
+   every backend's context server is launched with the same command, so this
+   applies to Claude/Codex/Cursor alike."
+  [workdir]
+  (swap! cache-state assoc :workdir workdir))
 
 (defn- source-root
   []
   (or (:source-root @cache-state) "."))
+
+(defn- write-root
+  "Root for context_write: the worktree (`:workdir`) when set, else source-root."
+  []
+  (or (:workdir @cache-state) (source-root)))
 
 (defn- resolve-source-path
   [path]
@@ -168,6 +182,14 @@
     (if (.isAbsolute f)
       (.getPath f)
       (.getPath (io/file (source-root) path)))))
+
+(defn- resolve-write-path
+  "Resolve a write path against write-root (the worktree)."
+  [path]
+  (let [f (io/file path)]
+    (if (.isAbsolute f)
+      (.getPath f)
+      (.getPath (io/file (write-root) path)))))
 
 (def ^:private persistent-cache-relpath ".miniforge/context-cache.edn")
 
@@ -436,3 +458,28 @@
       (if (seq matches)
         (str/join "\n" matches)
         (msg/t :context/no-glob-matches)))))
+
+(defn handle-context-write
+  "Handler for the context_write MCP tool. Writes the full file content to the
+   worktree (write-root) and refreshes the cache so a later context_read returns
+   the new content. Agent-agnostic edit path — works for any MCP client and,
+   unlike native Write/Edit, needs no prior native Read of the file."
+  [params]
+  (let [path    (get params "path")
+        content (get params "content")]
+    (if (or (str/blank? path) (not (string? content)))
+      (error-response (msg/t :context/write-error {:path (str path)}))
+      (try
+        (let [target (io/file (resolve-write-path path))]
+          (io/make-parents target)
+          (spit target content)
+          ;; Cache the written content stamped with the new file's mtime so
+          ;; read-through serves this write — cache-stale? trusts a freshly
+          ;; stamped entry over an older/absent source-root copy.
+          (swap! cache-state #(-> %
+                                  (assoc-in [:files path] content)
+                                  (assoc-in [:mtimes path] (.lastModified target))))
+          (text-response (msg/t :context/write-ok {:path path :bytes (count content)})))
+        (catch Exception e
+          (error-response (msg/t :context/write-failed
+                                 {:path path :error (ex-message e)})))))))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/interface.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/interface.clj
@@ -34,11 +34,15 @@
    Blocks until stdin is closed.
 
    Arguments:
-   - artifact-dir — directory path for context cache and miss tracking"
+   - artifact-dir — directory path for context cache and miss tracking
+   - source-root — read-side filesystem fallback root
+   - workdir — write target for context_write (the agent's worktree)"
   ([artifact-dir]
    (server/run-server artifact-dir nil))
   ([artifact-dir source-root]
-   (server/run-server artifact-dir source-root)))
+   (server/run-server artifact-dir source-root))
+  ([artifact-dir source-root workdir]
+   (server/run-server artifact-dir source-root workdir)))
 
 (defn handle-tool-call
   "Invoke a tool handler directly (for testing without JSON-RPC).

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/main.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/main.clj
@@ -33,14 +33,17 @@
                                 (assoc opts :artifact-dir (second args)))
         "--source-root" (recur (drop 2 args)
                                (assoc opts :source-root (second args)))
+        "--workdir" (recur (drop 2 args)
+                           (assoc opts :workdir (second args)))
         (recur (rest args) opts)))))
 
 (defn -main [& args]
   (let [opts (parse-args args)
         artifact-dir (:artifact-dir opts)
-        source-root (:source-root opts)]
+        source-root (:source-root opts)
+        workdir (:workdir opts)]
     (when-not artifact-dir
       (binding [*out* *err*]
         (println "ERROR: --artifact-dir is required"))
       (System/exit 1))
-    (server/run-server artifact-dir source-root)))
+    (server/run-server artifact-dir source-root workdir)))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
@@ -112,7 +112,8 @@
   []
   (tools/register-handler! :context-read  context-cache/handle-context-read)
   (tools/register-handler! :context-grep  context-cache/handle-context-grep)
-  (tools/register-handler! :context-glob  context-cache/handle-context-glob))
+  (tools/register-handler! :context-glob  context-cache/handle-context-glob)
+  (tools/register-handler! :context-write context-cache/handle-context-write))
 
 (defn run-server
   "Run the MCP context server loop, reading JSON-RPC messages from stdin.
@@ -125,19 +126,24 @@
 
    Arguments:
    - artifact-dir — directory path for context cache and miss tracking
-   - source-root — repo root for filesystem fallback"
-  [artifact-dir source-root]
-  (log-stderr "miniforge-context MCP server started, artifact-dir:" artifact-dir "source-root:" source-root)
-  (context-cache/load-cache! artifact-dir source-root)
-  (register-context-handlers!)
-  (try
-    (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in "UTF-8"))]
-      (loop []
-        (when-let [line (.readLine reader)]
-          (process-line line)
-          (recur))))
-    (finally
-      (context-cache/flush-misses! artifact-dir)
-      ;; Persist the accumulated cache (incl. read-through additions) to the
-      ;; worktree so the next phase loads it — cross-phase write-through.
-      (context-cache/save-cache!))))
+   - source-root — repo root for read-side filesystem fallback
+   - workdir — write target for context_write (the agent's worktree); defaults
+     to source-root when absent"
+  ([artifact-dir source-root] (run-server artifact-dir source-root nil))
+  ([artifact-dir source-root workdir]
+   (log-stderr "miniforge-context MCP server started, artifact-dir:" artifact-dir
+               "source-root:" source-root "workdir:" workdir)
+   (context-cache/load-cache! artifact-dir source-root)
+   (context-cache/set-workdir! workdir)
+   (register-context-handlers!)
+   (try
+     (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in "UTF-8"))]
+       (loop []
+         (when-let [line (.readLine reader)]
+           (process-line line)
+           (recur))))
+     (finally
+       (context-cache/flush-misses! artifact-dir)
+       ;; Persist the accumulated cache (incl. read-through additions) to the
+       ;; worktree so the next phase loads it — cross-phase write-through.
+       (context-cache/save-cache!)))))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/tools.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/tools.clj
@@ -35,7 +35,10 @@
   "Keyword → predicate map for validation rules in the registry config.
    These are the only functions that bridge EDN config to runtime behavior."
   {:non-empty (fn [v] (and v (seq v)))
-   :non-blank (fn [v] (and (string? v) (not (str/blank? v))))})
+   :non-blank (fn [v] (and (string? v) (not (str/blank? v))))
+   ;; :string accepts the empty string (truncating a file is a valid write),
+   ;; unlike :non-blank.
+   :string    (fn [v] (string? v))})
 
 (defn resolve-validator
   "Resolve a keyword validator to its predicate function."

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -325,3 +325,38 @@
     (cache/reset-state!)
     (swap! cache/cache-state assoc :files {"x" "y"})
     (is (nil? (cache/save-cache!)) "no throw, nothing to persist without a worktree")))
+
+;------------------------------------------------------------------------------ Layer 3
+;; context_write handler
+
+(deftest handle-context-write-writes-to-workdir-and-caches-test
+  (with-temp-dir
+    (fn [dir]
+      (cache/reset-state!)
+      (cache/set-workdir! dir)
+      (let [resp (cache/handle-context-write {"path" "src/new.clj" "content" "(ns new)"})]
+        (is (not (:isError resp)) "write succeeds")
+        (testing "file landed in the worktree (workdir), not source-root"
+          (is (= "(ns new)" (slurp (io/file dir "src/new.clj")))))
+        (testing "read-after-write coherence — context_read returns the new content"
+          (let [read-resp (cache/handle-context-read {"path" "src/new.clj"})]
+            (is (= "(ns new)" (-> read-resp :content first :text)))))))))
+
+(deftest handle-context-write-overwrites-existing-test
+  (with-temp-dir
+    (fn [dir]
+      (cache/reset-state!)
+      (cache/set-workdir! dir)
+      (spit (io/file dir "a.clj") "(ns a)")
+      (let [resp (cache/handle-context-write {"path" "a.clj" "content" "(ns a-v2)"})]
+        (is (not (:isError resp)))
+        (is (= "(ns a-v2)" (slurp (io/file dir "a.clj"))))
+        (is (= "(ns a-v2)" (-> (cache/handle-context-read {"path" "a.clj"}) :content first :text))
+            "an existing file is edited and the cache reflects it")))))
+
+(deftest handle-context-write-rejects-bad-input-test
+  (cache/reset-state!)
+  (is (:isError (cache/handle-context-write {"path" "" "content" "x"}))
+      "blank path rejected")
+  (is (:isError (cache/handle-context-write {"path" "f" "content" nil}))
+      "nil content rejected"))

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -360,3 +360,17 @@
       "blank path rejected")
   (is (:isError (cache/handle-context-write {"path" "f" "content" nil}))
       "nil content rejected"))
+
+(deftest handle-context-write-rejects-path-escapes-test
+  (with-temp-dir
+    (fn [dir]
+      (cache/reset-state!)
+      (cache/set-workdir! dir)
+      (testing "`..` traversal escaping the worktree is refused"
+        (is (:isError (cache/handle-context-write
+                       {"path" "../escape.clj" "content" "x"})))
+        (is (not (.exists (io/file dir ".." "escape.clj")))))
+      (testing "absolute paths are refused"
+        (is (:isError (cache/handle-context-write
+                       {"path" "/tmp/abs-escape.clj" "content" "x"})))
+        (is (not (.exists (io/file "/tmp/abs-escape.clj"))))))))

--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -48,14 +48,17 @@ a tool call is **not delivered** and will be discarded by the runtime.
 
 Required delivery sequence:
 
-1. **Write each file to the working directory. Pick the tool by file state:**
-   - **New file** → use `Write` with the complete contents.
-   - **Existing file** → edit it with `Bash` (a heredoc `cat > file`, `sed`,
-     `patch`, etc.). Do NOT use `Write`/`Edit` on an existing file: the native
-     `Read` tool is disabled here (read files with the `mcp__context__context_read`
-     MCP tool), and `Write`/`Edit` refuse to touch an existing file until read
-     with the native `Read` tool — so on an existing file they fail. Go straight
-     to `Bash`; don't burn turns discovering this.
+1. **Write each file to the working directory with `context_write` (the MCP
+   tool).** Pass the path + the COMPLETE file contents. It creates new files
+   AND edits existing ones, needs no prior read, and refreshes the cache so a
+   later `context_read` sees your change. This is the reliable path on every
+   backend (Claude/Codex/Cursor).
+   - Why not native `Write`/`Edit` for existing files: the native `Read` tool is
+     disabled here (read with `mcp__context__context_read`), and `Write`/`Edit`
+     refuse to modify a file until it has been read with the native `Read` — so
+     they fail on existing files. Use `context_write`.
+   - If `context_write` is unavailable in your environment, fall back to native
+     `Write` for NEW files and `Bash` (heredoc/`sed`) for EXISTING ones.
 
    Provide the complete file contents — no placeholders, no \"rest unchanged\"
    markers, no Clojure EDN maps in chat as a substitute.
@@ -63,8 +66,8 @@ Required delivery sequence:
    `code_summary` describing what you changed and why. `submit` is the
    structured confirmation path, not the only path: delivery is the set of
    files present in the working directory, collected from the worktree
-   regardless of which tool wrote them (`Write` or `Bash`). So your changes
-   land whether or not `submit` is available — but always call it when present.
+   regardless of which tool wrote them. So your changes land whether or not
+   `submit` is available — but always call it when present.
 
 Do NOT:
 - Emit a `{:code/files [...]}` map in this conversation in place of Write
@@ -183,9 +186,8 @@ Specifically:
 ## Turn Budget — HARD LIMIT
 
 You have at most 40 tool calls total.
-**Your FIRST action must write a file — `Write` for a new file, `Bash` for an
-existing one — NOT reading files, NOT planning in chat, NOT printing the code
-first.** (Never `Write`/`Edit` an existing file here; see the delivery sequence.)
+**Your FIRST action must write a file — use `context_write` (new or existing
+files) — NOT reading files, NOT planning in chat, NOT printing the code first.**
 After at most 3 file reads, you MUST start writing.
 A good-enough implementation written to disk on time is better than a perfect
 plan that never lands as files.
@@ -206,9 +208,10 @@ Do NOT explore further. Do NOT call context_read/context_grep/context_glob.
 Your only job is to DELIVER the implementation NOW by writing the files.
 
 Primary submission path:
-  Write each file — `Write` for new files, `Bash` for existing ones (native
-  `Write`/`Edit` fail on existing files in this environment). The files on disk
-  ARE the submission.
+  Write each file with `context_write` (new or existing files). If it is
+  unavailable, fall back to native `Write` for new files and `Bash` for existing
+  ones (native `Write`/`Edit` fail on existing files in this environment). The
+  files on disk ARE the submission.
 
 Fallback only if Write is unavailable:
   Write `.miniforge/implement.edn` with a `{:code/files [...]}` map, or end your

--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -48,17 +48,18 @@ a tool call is **not delivered** and will be discarded by the runtime.
 
 Required delivery sequence:
 
-1. **Write each file to the working directory with `context_write` (the MCP
-   tool).** Pass the path + the COMPLETE file contents. It creates new files
+1. **Write each file to the working directory with the `mcp__context__context_write`
+   MCP tool.** Pass the path + the COMPLETE file contents. It creates new files
    AND edits existing ones, needs no prior read, and refreshes the cache so a
-   later `context_read` sees your change. This is the reliable path on every
-   backend (Claude/Codex/Cursor).
+   later `mcp__context__context_read` sees your change. This is the reliable
+   path on every backend (Claude/Codex/Cursor).
    - Why not native `Write`/`Edit` for existing files: the native `Read` tool is
      disabled here (read with `mcp__context__context_read`), and `Write`/`Edit`
      refuse to modify a file until it has been read with the native `Read` — so
-     they fail on existing files. Use `context_write`.
-   - If `context_write` is unavailable in your environment, fall back to native
-     `Write` for NEW files and `Bash` (heredoc/`sed`) for EXISTING ones.
+     they fail on existing files. Use `mcp__context__context_write`.
+   - If `mcp__context__context_write` is unavailable in your environment, fall
+     back to native `Write` for NEW files and `Bash` (heredoc/`sed`) for
+     EXISTING ones.
 
    Provide the complete file contents — no placeholders, no \"rest unchanged\"
    markers, no Clojure EDN maps in chat as a substitute.
@@ -186,9 +187,9 @@ Specifically:
 ## Turn Budget — HARD LIMIT
 
 You have at most 40 tool calls total.
-**Your FIRST action must write a file — use `context_write` (new or existing
-files) — NOT reading files, NOT planning in chat, NOT printing the code first.**
-After at most 3 file reads, you MUST start writing.
+**Your FIRST action must write a file — use `mcp__context__context_write` (new or
+existing files) — NOT reading files, NOT planning in chat, NOT printing the code
+first.** After at most 3 file reads, you MUST start writing.
 A good-enough implementation written to disk on time is better than a perfect
 plan that never lands as files.
 
@@ -208,10 +209,10 @@ Do NOT explore further. Do NOT call context_read/context_grep/context_glob.
 Your only job is to DELIVER the implementation NOW by writing the files.
 
 Primary submission path:
-  Write each file with `context_write` (new or existing files). If it is
-  unavailable, fall back to native `Write` for new files and `Bash` for existing
-  ones (native `Write`/`Edit` fail on existing files in this environment). The
-  files on disk ARE the submission.
+  Write each file with `mcp__context__context_write` (new or existing files). If
+  it is unavailable, fall back to native `Write` for new files and `Bash` for
+  existing ones (native `Write`/`Edit` fail on existing files in this
+  environment). The files on disk ARE the submission.
 
 Fallback only if Write is unavailable:
   Write `.miniforge/implement.edn` with a `{:code/files [...]}` map, or end your

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -244,16 +244,18 @@
    3. mf context-server (production — bundled in the miniforge binary)
    4. miniforge context-server (fallback binary name)
 
-   The server reads context-cache.edn from artifact-dir on startup and
-   serves context_read/context_grep/context_glob to the inner LLM agent."
-  [artifact-dir source-root workdir]
-  (let [mcp-args (cond-> ["--artifact-dir" artifact-dir]
-                   source-root (into ["--source-root" source-root])
-                   ;; Write target for context_write — the agent's worktree.
-                   ;; Embedded in every backend's MCP config (claude/codex/
-                   ;; cursor all launch the server via this same command).
-                   workdir     (into ["--workdir" workdir]))
-        bb-root  (find-bb-root)]
+   The server reads context-cache.edn from artifact-dir on startup and serves
+   context_read/context_grep/context_glob and context_write to the inner LLM
+   agent. `workdir` (the agent's worktree) is the context_write target."
+  ([artifact-dir source-root] (server-command artifact-dir source-root nil))
+  ([artifact-dir source-root workdir]
+   (let [mcp-args (cond-> ["--artifact-dir" artifact-dir]
+                    source-root (into ["--source-root" source-root])
+                    ;; Write target for context_write — the agent's worktree.
+                    ;; Embedded in every backend's MCP config (claude/codex/
+                    ;; cursor all launch the server via this same command).
+                    workdir     (into ["--workdir" workdir]))
+         bb-root  (find-bb-root)]
     (cond
       (System/getenv "MINIFORGE_MCP_CMD")
       {:command (System/getenv "MINIFORGE_MCP_CMD") :args mcp-args}
@@ -269,7 +271,7 @@
       {:command "mf" :args (into ["context-server"] mcp-args)}
 
       :else
-      {:command "miniforge" :args (into ["context-server"] mcp-args)})))
+      {:command "miniforge" :args (into ["context-server"] mcp-args)}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; MCP config generation

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -246,9 +246,13 @@
 
    The server reads context-cache.edn from artifact-dir on startup and
    serves context_read/context_grep/context_glob to the inner LLM agent."
-  [artifact-dir source-root]
+  [artifact-dir source-root workdir]
   (let [mcp-args (cond-> ["--artifact-dir" artifact-dir]
-                   source-root (into ["--source-root" source-root]))
+                   source-root (into ["--source-root" source-root])
+                   ;; Write target for context_write — the agent's worktree.
+                   ;; Embedded in every backend's MCP config (claude/codex/
+                   ;; cursor all launch the server via this same command).
+                   workdir     (into ["--workdir" workdir]))
         bb-root  (find-bb-root)]
     (cond
       (System/getenv "MINIFORGE_MCP_CMD")
@@ -499,6 +503,11 @@
   [{:mcp/server :context :mcp/tool :context_read}
    {:mcp/server :context :mcp/tool :context_grep}
    {:mcp/server :context :mcp/tool :context_glob}
+   ;; Agent-agnostic edit path: writes to the worktree + refreshes the cache,
+   ;; needs no prior native Read. The reliable way to modify EXISTING files
+   ;; across Claude/Codex/Cursor (native Write/Edit require a prior Read, which
+   ;; the implementer disallows to force the cache).
+   {:mcp/server :context :mcp/tool :context_write}
    ;; Native write tools: implementer needs all three patch shapes.
    ;; `Write` for full-file rewrites (planner's plan.edn, implementer
    ;; new files, releaser PR drafts). `Edit` for single-region patches.
@@ -528,7 +537,7 @@
 
    Returns: session (for threading)"
   [session]
-  (let [srv-cmd       (server-command (:dir session) (:source-root session))
+  (let [srv-cmd       (server-command (:dir session) (:source-root session) (:workdir session))
         config-root   (:config-root session)
         mcp-config    {"mcpServers" {"context" {"command" (:command srv-cmd)
                                                 "args"    (:args srv-cmd)}}}


### PR DESCRIPTION
## Summary

Follow-up #1, made agent-agnostic per the requirement that it work for Codex/OpenCode, not just Claude.

The implementer reads through the MCP context cache (native `Read` is disabled to force token efficiency), but Claude’s `Write`/`Edit` refuse to modify an existing file until it has been read with the native `Read` — so edits fell back to `Bash` (#1148). That guidance is **Claude-specific**. `context_write` is the agent-agnostic fix: an MCP tool every backend can call (Claude/Codex/Cursor all load the same context server from their session MCP config), needing no prior read.

## Changes
- **mcp-context-server**: new `context_write` tool (`tool-registry.edn` + `:context-write` handler). Writes the full content to the **worktree** — a new `:workdir`, distinct from the read-side `:source-root` — and refreshes the cache so a later `context_read` returns it (read-after-write coherence). New `:string` validator allows empty content (truncation). `run-server`/`start-server`/`-main` + the CLI `context-server` command gain `--workdir`; the bb/`mf`/binary launch paths all thread it.
- **agent**: `context_write` added to the agent-agnostic `mcp-tools` allowlist (each backend adapter translates it — Claude `--allowedTools`, Codex `approval_policy=never`, Cursor `.cursor/cli.json`); `server-command` embeds `--workdir` (the session worktree) into every backend’s MCP config.
- **implementer prompt**: `context_write` is now the primary write path (new AND existing files) on all backends; native `Write`/`Bash` are the fallback. Replaces the Claude-specific Bash-for-existing-files guidance from #1148.

## Agent coverage
Claude, Codex, and Cursor all receive the context server via their session MCP config (`mcp-config.json` / `.codex/config.toml` / `.cursor/mcp.json`), so `context_write` reaches all three. OpenCode owns its own MCP config (miniforge doesn’t write it), so `context_write` reaches it only when the user wires the context server there — identical to how the existing `context_read`/`grep`/`glob` tools already work for OpenCode.

## Tests
- `context_write` writes to workdir (not source-root); read-after-write coherence; overwrite an existing file; bad-input rejection (blank path / nil content).
- `poly check` OK; `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)