### PR TITLE
fix(llm): pass argv vector directly in capsule-exec-fn to prevent shell injection

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1832,8 +1832,7 @@
    - workdir     - workspace directory inside capsule"
   [execute-fn executor env-id workdir]
   (fn [cmd]
-    (let [command-str (clojure.string/join " " cmd)
-          result (execute-fn executor env-id command-str {:workdir workdir})]
+    (let [result (execute-fn executor env-id cmd {:workdir workdir})]
       (if (and (map? result) (:data result))
         {:out (get-in result [:data :stdout] "")
          :err (get-in result [:data :stderr] "")


### PR DESCRIPTION
## What

`capsule-exec-fn` in `components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj` was collapsing the safe argv vector it received into a space-joined string with `(clojure.string/join " " cmd)`, then passing that string to `dag-executor/execute!`. The executor's `exec-in-container` already contains a branch that routes string commands through `["sh" "-c" command]`, so the joined prompt text — including any shell metacharacters — was being executed by a shell interpreter inside the OCI capsule.

## The fix

```diff
-    (let [command-str (clojure.string/join " " cmd)
-          result (execute-fn executor env-id command-str {:workdir workdir})]
+    (let [result (execute-fn executor env-id cmd {:workdir workdir})]
```

Pass `cmd` (the already-safe argv vector) directly. `exec-in-container` already has the correct vector path: `(if (string? command) ["sh" "-c" command] command)` — the bug was solely in `capsule-exec-fn` discarding the vector form before reaching it.

## Why it matters

Governed mode (capsule execution) is the security-hardened path — the OCI container is there to contain the agent. By collapsing the argv to a shell string, any adversarial content in the prompt (backticks, `$()`, `;`, `&&`, newlines injected by a malicious repo's spec files or `.cursorrules`) would execute inside the task container. The `claude` backend already routes the prompt via `:stdin` specifically to keep it out of argv; this fix closes the complementary shell-string path in the executor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUuEbW27ST1JaD69hYZRrD)_