### PR TITLE
fix: replace dynamic event stream publication

### DIFF
--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -45,6 +45,7 @@
    ;; registry on load, so pack-gate evaluation sees :lint/:format/:syntax/
    ;; :no-secrets capabilities without an explicit caller.
    [ai.miniforge.gate.capabilities]
+   [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.gate.registry :as registry]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]))
@@ -106,16 +107,15 @@
 ;; Gate operations
 
 (defn emit-gate-event!
-  "Emit a gate lifecycle event via requiring-resolve (no hard dep on event-stream)."
+  "Emit a gate lifecycle event when the context carries an event stream."
   [ctx gate-kw event-type & [extra]]
   (try
     (when-let [stream (get ctx :event-stream)]
-      (when-let [publish-fn (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (let [constructor (case event-type
-                            :started (requiring-resolve 'ai.miniforge.event-stream.interface/gate-started)
-                            :passed (requiring-resolve 'ai.miniforge.event-stream.interface/gate-passed)
-                            :failed (requiring-resolve 'ai.miniforge.event-stream.interface/gate-failed))]
-          (publish-fn stream (constructor stream (:workflow/id ctx) gate-kw extra)))))
+      (let [constructor (case event-type
+                          :started events/gate-started
+                          :passed events/gate-passed
+                          :failed events/gate-failed)]
+        (events/publish! stream (constructor stream (:workflow/id ctx) gate-kw extra))))
     (catch Exception _ nil)))
 
 (defn check-gate

--- a/components/tool/deps.edn
+++ b/components/tool/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/schema  {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -24,6 +24,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.tool.tracking :as tracking]))
 
@@ -108,17 +109,16 @@
   (find-tools [this query] "Find tools matching query."))
 
 (defn emit-tool-event!
-  "Emit a tool lifecycle event via requiring-resolve (no hard dep on event-stream)."
+  "Emit a tool lifecycle event when the context carries an event stream."
   [context tool-id event-type & [extra]]
   (try
     (when-let [stream (:event-stream context)]
-      (when-let [publish-fn (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (let [wf-id (:workflow/id context)
-              agent-id (:agent/id context)
-              constructor (case event-type
-                            :invoked (requiring-resolve 'ai.miniforge.event-stream.interface/tool-invoked)
-                            :completed (requiring-resolve 'ai.miniforge.event-stream.interface/tool-completed))]
-          (publish-fn stream (constructor stream wf-id agent-id tool-id extra)))))
+      (let [wf-id (:workflow/id context)
+            agent-id (:agent/id context)
+            constructor (case event-type
+                          :invoked events/tool-invoked
+                          :completed events/tool-completed)]
+        (events/publish! stream (constructor stream wf-id agent-id tool-id extra))))
     (catch Exception _ nil)))
 
 (defrecord FunctionTool [id name description parameters handler metadata]

--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -37,6 +37,7 @@
    - [:prev/last-phase-result ...] — navigates into previous step's last phase result
    - keyword                 — reads from chain input"
   (:require
+   [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.loader :as loader]
    [ai.miniforge.workflow.runner :as runner]))
@@ -97,11 +98,9 @@
 
 (defn emit!
   "Emit a chain event if event-stream is present in opts."
-  [opts constructor-sym & args]
+  [opts constructor & args]
   (when-let [stream (:event-stream opts)]
-    (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)
-          constructor (requiring-resolve constructor-sym)]
-      (publish! stream (apply constructor stream args)))))
+    (events/publish! stream (apply constructor stream args))))
 
 ;------------------------------------------------------------------------------ Layer 2: Chain execution
 
@@ -126,7 +125,7 @@
         chain-id (:chain/id chain-def)
         steps (:chain/steps chain-def)
         load-workflow loader/load-workflow]
-    (emit! opts 'ai.miniforge.event-stream.interface/chain-started
+    (emit! opts events/chain-started
            chain-id (count steps))
     (loop [remaining steps
            prev-output nil
@@ -135,7 +134,7 @@
       (if (empty? remaining)
         ;; All steps completed successfully
         (let [duration-ms (- (System/currentTimeMillis) start-time)]
-          (emit! opts 'ai.miniforge.event-stream.interface/chain-completed
+          (emit! opts events/chain-completed
                  chain-id duration-ms (count steps))
           {:chain/id chain-id
            :chain/status :completed
@@ -147,7 +146,7 @@
         (let [step (first remaining)
               step-id (:step/id step)
               workflow-id (:step/workflow-id step)
-              _ (emit! opts 'ai.miniforge.event-stream.interface/chain-step-started
+              _ (emit! opts events/chain-step-started
                        chain-id step-id idx workflow-id)
               input-bindings (:step/input-bindings step)
               resolved-input (resolve-bindings input-bindings prev-output chain-input)
@@ -166,9 +165,9 @@
           (if (phase/failed? result)
             ;; Step failed — emit failure events and stop
             (let [error (get result :execution/error "Step execution failed")]
-              (emit! opts 'ai.miniforge.event-stream.interface/chain-step-failed
+              (emit! opts events/chain-step-failed
                      chain-id step-id idx error)
-              (emit! opts 'ai.miniforge.event-stream.interface/chain-failed
+              (emit! opts events/chain-failed
                      chain-id step-id error)
               {:chain/id chain-id
                :chain/status :failed
@@ -178,7 +177,7 @@
 
             ;; Step succeeded — emit completion and continue
             (do
-              (emit! opts 'ai.miniforge.event-stream.interface/chain-step-completed
+              (emit! opts events/chain-step-completed
                      chain-id step-id idx)
               (recur (rest remaining)
                      output

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -37,6 +37,7 @@
    resolution sub-workflow."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.response.interface :as response]
@@ -1490,10 +1491,9 @@
   [event-stream workflow-id reset-at auto-resume? completed-ids wait-ms]
   (when (and event-stream reset-at)
     (try
-      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (publish! event-stream
-                  (make-resume-hint-event workflow-id reset-at auto-resume?
-                                          completed-ids wait-ms)))
+      (events/publish! event-stream
+                       (make-resume-hint-event workflow-id reset-at auto-resume?
+                                               completed-ids wait-ms))
       (catch Exception _ nil))))
 
 (defn- checkpoint-log-data

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -28,6 +28,7 @@
   (:require
    [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]))
 
@@ -217,13 +218,12 @@
   [event-stream workflow-id task-id result]
   (when event-stream
     (try
-      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (publish! event-stream
-                  {:event/type :dag/task-completed
-                   :event/timestamp (str (java.time.Instant/now))
-                   :workflow/id workflow-id
-                   :dag/task-id task-id
-                   :dag/result (select-keys result [:data :status])}))
+      (events/publish! event-stream
+                       {:event/type :dag/task-completed
+                        :event/timestamp (str (java.time.Instant/now))
+                        :workflow/id workflow-id
+                        :dag/task-id task-id
+                        :dag/result (select-keys result [:data :status])})
       (catch Exception _ nil))))
 
 (defn emit-dag-task-failed!
@@ -236,13 +236,12 @@
   [event-stream workflow-id task-id result]
   (when event-stream
     (try
-      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (publish! event-stream
-                  {:event/type :dag/task-failed
-                   :event/timestamp (str (java.time.Instant/now))
-                   :workflow/id workflow-id
-                   :dag/task-id task-id
-                   :dag/result (select-keys result [:error :status])}))
+      (events/publish! event-stream
+                       {:event/type :dag/task-failed
+                        :event/timestamp (str (java.time.Instant/now))
+                        :workflow/id workflow-id
+                        :dag/task-id task-id
+                        :dag/result (select-keys result [:error :status])})
       (catch Exception _ nil))))
 
 (defn emit-dag-paused!
@@ -250,13 +249,12 @@
   [event-stream workflow-id completed-ids reason]
   (when event-stream
     (try
-      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (publish! event-stream
-                  {:event/type :dag/paused
-                   :event/timestamp (str (java.time.Instant/now))
-                   :workflow/id workflow-id
-                   :dag/completed-task-ids (vec completed-ids)
-                   :dag/pause-reason reason}))
+      (events/publish! event-stream
+                       {:event/type :dag/paused
+                        :event/timestamp (str (java.time.Instant/now))
+                        :workflow/id workflow-id
+                        :dag/completed-task-ids (vec completed-ids)
+                        :dag/pause-reason reason})
       (catch Exception _ nil))))
 
 ;--- Layer 2: Batch Analysis + Rate Limit Handling

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -24,6 +24,7 @@
   (:require [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]
+            [ai.miniforge.event-stream.interface :as events]
             [ai.miniforge.gate.interface :as gate]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.response.interface :as response]
@@ -515,15 +516,14 @@
   [ctx outcome reason extra]
   (when-let [stream (resolve-event-stream ctx)]
     (try
-      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)
-            event (merge
+      (let [event (merge
                     {:event/type :workflow/dag-considered
                      :event/timestamp (str (java.time.Instant/now))
                      :workflow/id (resolve-workflow-id ctx)
                      :dag/outcome outcome
                      :dag/reason reason}
                     extra)]
-        (publish! stream event))
+        (events/publish! stream event))
       (catch Exception _ nil))))
 
 (defn- emit-dag-activated!
@@ -535,12 +535,11 @@
   [ctx plan]
   (when-let [stream (resolve-event-stream ctx)]
     (try
-      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (publish! stream {:event/type      :workflow/dag-activated
-                          :event/timestamp (str (java.time.Instant/now))
-                          :workflow/id     (resolve-workflow-id ctx)
-                          :plan/id         (:plan/id plan)
-                          :plan/task-count (count (:plan/tasks plan))}))
+      (events/publish! stream {:event/type      :workflow/dag-activated
+                               :event/timestamp (str (java.time.Instant/now))
+                               :workflow/id     (resolve-workflow-id ctx)
+                               :plan/id         (:plan/id plan)
+                               :plan/task-count (count (:plan/tasks plan))})
       (catch Exception _ nil))))
 
 (defn- emit-dag-skipped!
@@ -552,12 +551,11 @@
   [ctx reason extra]
   (when-let [stream (resolve-event-stream ctx)]
     (try
-      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (publish! stream (merge {:event/type      :workflow/dag-skipped
-                                 :event/timestamp (str (java.time.Instant/now))
-                                 :workflow/id     (resolve-workflow-id ctx)
-                                 :dag/reason      reason}
-                                extra)))
+      (events/publish! stream (merge {:event/type      :workflow/dag-skipped
+                                      :event/timestamp (str (java.time.Instant/now))
+                                      :workflow/id     (resolve-workflow-id ctx)
+                                      :dag/reason      reason}
+                                     extra))
       (catch Exception _ nil))))
 
 (defn- merge-sub-worktree-changes!


### PR DESCRIPTION
## Summary
- replace event-stream `requiring-resolve` call sites in gate, tool, and workflow with direct interface calls
- add the explicit `tool -> event-stream` Polylith dependency that was previously hidden at runtime
- preserve existing event payloads while making the dependency graph match actual behavior

## Standards impact
- starts remediation for standards/miniforge/languages/clojure-no-requiring-resolve
- reduces Clojure `requiring-resolve` occurrences from 229 to 211
- keeps the wave inside the commit budget: 126 / 200 lines

## Validation
- `clojure -M:poly check`
- `clojure -M:poly test brick:gate`
- `clojure -M:poly test brick:tool`
- `clojure -M:poly test brick:workflow`
- `bb pre-commit` before commit
- commit hook `bb pre-commit` passed