### PR TITLE
fix: replace dynamic agent event publication

### DIFF
--- a/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
@@ -21,6 +21,7 @@
 
    Implements N1 Architecture Specification section 6.2."
   (:require
+   [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.response.interface :as response]
    [malli.core :as m]))
 
@@ -197,8 +198,7 @@
    inter-agent-message-received constructor, which wraps create-envelope
    and therefore includes the required event/sequence-number field.
 
-   Uses requiring-resolve to avoid a hard compile-time dependency on
-   the event-stream component. Silently no-ops on any failure.
+   Silently no-ops on any failure.
 
    Arguments:
    - stream          — event-stream atom (from :event-stream on context)
@@ -206,16 +206,14 @@
    - from-agent      — keyword identifying the sending agent
    - to-agent        — keyword identifying the receiving agent
    - message-type    — keyword (:clarification-request, :concern, :suggestion, ...)
-   - constructor-sym — fully-qualified symbol for the event-stream constructor var
+   - constructor     — event-stream constructor var
 
    Returns the published event map, or nil when unavailable."
-  [stream workflow-id from-agent to-agent message-type constructor-sym]
+  [stream workflow-id from-agent to-agent message-type constructor]
   (try
     (when stream
-      (let [publish-fn  (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)
-            constructor (requiring-resolve constructor-sym)]
-        (publish-fn stream
-                    (constructor stream workflow-id from-agent to-agent message-type))))
+      (events/publish! stream
+                       (constructor stream workflow-id from-agent to-agent message-type)))
     (catch Exception _ nil)))
 
 ;------------------------------------------------------------------------------ Layer 5
@@ -252,11 +250,11 @@
           message-type (:message/type routed-msg)
           sent-event   (emit-inter-agent-event!
                          stream workflow-id from-agent to-agent message-type
-                         'ai.miniforge.event-stream.interface/inter-agent-message-sent)]
+                         events/inter-agent-message-sent)]
       ;; Emit :agent/message-received on behalf of the recipient agent.
       (emit-inter-agent-event!
         stream workflow-id from-agent to-agent message-type
-        'ai.miniforge.event-stream.interface/inter-agent-message-received)
+        events/inter-agent-message-received)
       {:message routed-msg
        :event sent-event})))
 

--- a/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
@@ -206,7 +206,7 @@
    - from-agent      — keyword identifying the sending agent
    - to-agent        — keyword identifying the receiving agent
    - message-type    — keyword (:clarification-request, :concern, :suggestion, ...)
-   - constructor     — event-stream constructor var
+   - constructor     — event-stream constructor function
 
    Returns the published event map, or nil when unavailable."
   [stream workflow-id from-agent to-agent message-type constructor]

--- a/components/agent/src/ai/miniforge/agent/tool_supervisor.clj
+++ b/components/agent/src/ai/miniforge/agent/tool_supervisor.clj
@@ -184,7 +184,7 @@
 (defn emit-tool-use-event!
   "Emit a tool-use-evaluated event to the event stream (if available).
 
-   Silently no-ops if no stream is bound."
+   Silently no-ops if no event stream or workflow id is bound."
   [tool-name result & [{:keys [event-stream workflow-id phase]}]]
   (try
     (when (and event-stream workflow-id)

--- a/components/agent/src/ai/miniforge/agent/tool_supervisor.clj
+++ b/components/agent/src/ai/miniforge/agent/tool_supervisor.clj
@@ -36,6 +36,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.string :as str]
+   [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.agent.meta-evaluator :as meta-eval])
   (:import
    [java.io PushbackReader]))
@@ -178,27 +179,25 @@
            :meta-eval eval-result})))))
 
 ;------------------------------------------------------------------------------ Layer 1.7
-;; Event emission (soft dependency via requiring-resolve)
+;; Event emission
 
 (defn emit-tool-use-event!
   "Emit a tool-use-evaluated event to the event stream (if available).
 
-   Uses requiring-resolve to avoid hard dependency on event-stream component.
-   Silently no-ops if event-stream is not loaded or no stream is bound."
+   Silently no-ops if no stream is bound."
   [tool-name result & [{:keys [event-stream workflow-id phase]}]]
   (try
     (when (and event-stream workflow-id)
-      (let [emit-fn (requiring-resolve 'ai.miniforge.event-stream.core/tool-use-evaluated)
-            publish-fn (requiring-resolve 'ai.miniforge.event-stream.core/publish!)
-            meta-eval (:meta-eval result)
-            event (emit-fn event-stream workflow-id tool-name
-                           (:decision result)
-                           (cond-> {}
-                             (:reasoning meta-eval) (assoc :reasoning (:reasoning meta-eval))
-                             (:meta-eval? meta-eval) (assoc :meta-eval? true)
-                             (:confidence meta-eval) (assoc :confidence (:confidence meta-eval))
-                             phase (assoc :phase phase)))]
-        (publish-fn event-stream event)))
+      (let [meta-eval (:meta-eval result)
+            event (events/tool-use-evaluated
+                    event-stream workflow-id tool-name
+                    (:decision result)
+                    (cond-> {}
+                      (:reasoning meta-eval) (assoc :reasoning (:reasoning meta-eval))
+                      (:meta-eval? meta-eval) (assoc :meta-eval? true)
+                      (:confidence meta-eval) (assoc :confidence (:confidence meta-eval))
+                      phase (assoc :phase phase)))]
+        (events/publish! event-stream event)))
     (catch Exception _e
       ;; Silently ignore — event emission is observability, not critical path
       nil)))

--- a/components/agent/test/ai/miniforge/agent/messaging_integration_test.clj
+++ b/components/agent/test/ai/miniforge/agent/messaging_integration_test.clj
@@ -40,7 +40,7 @@
           workflow-id (random-uuid)
           result      (msg-impl/emit-inter-agent-event!
                         stream workflow-id :implementer :planner :clarification-request
-                        'ai.miniforge.event-stream.interface/inter-agent-message-sent)]
+                        event-stream/inter-agent-message-sent)]
       (is (some? result))
       (is (= :agent/message-sent (:event/type result)))
       (is (= :implementer (:from-agent/id result)))
@@ -54,7 +54,7 @@
   (testing "emit-inter-agent-event! with nil stream is a safe no-op"
     (let [result (msg-impl/emit-inter-agent-event!
                    nil (random-uuid) :a :b :concern
-                   'ai.miniforge.event-stream.interface/inter-agent-message-sent)]
+                   event-stream/inter-agent-message-sent)]
       (is (nil? result)))))
 
 (deftest test-send-message-emits-events-with-stream


### PR DESCRIPTION
## Summary
- replace agent inter-message event publication `requiring-resolve` calls with direct event-stream interface calls
- replace tool supervision event publication through `event-stream.core` with the public event-stream interface
- update the messaging integration test to pass constructor vars instead of symbols

## Standards impact
- continues remediation for standards/miniforge/languages/clojure-no-requiring-resolve
- reduces Clojure `requiring-resolve` occurrences from 211 to 204 after #1154
- keeps the wave inside the commit budget: 47 / 200 lines

## Validation
- `clojure -M:poly check`
- `clj-kondo --lint` on changed files
- `clojure -M:poly test brick:agent` reaches changed messaging tests successfully; it then fails on the existing main-branch `ai.miniforge.agent.implementer-test/implementer-repair-test` baseline failure
- confirmed the same full-agent brick failure on clean main at #1154
- staged `bb pre-commit` passed
- commit hook `bb pre-commit` passed