### PR TITLE
fix(specs): correct invalid :spec/intent :type to the validator enum

### DIFF
--- a/work/backend-failover.spec.edn
+++ b/work/backend-failover.spec.edn
@@ -29,7 +29,7 @@
   create a new client for it, and retry the call transparently. Config drives
   which backends are eligible and in what order."
 
- :spec/intent {:type :fix
+ :spec/intent {:type :bugfix
                :scope ["components/self-healing/src"
                        "components/llm/src"]}
 

--- a/work/rn-01-failure-taxonomy.spec.edn
+++ b/work/rn-01-failure-taxonomy.spec.edn
@@ -20,7 +20,7 @@
   Target state: 10-class enum with every failure event carrying :failure/class."
 
  :spec/intent
- {:type :reliability-foundation
+ {:type :feature
   :scope ["components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier"
           "components/event-stream/src/ai/miniforge/event_stream/schema.clj"
           "components/event-stream/src/ai/miniforge/event_stream/core.clj"]}

--- a/work/rn-02-workflow-tiers.spec.edn
+++ b/work/rn-02-workflow-tiers.spec.edn
@@ -16,7 +16,7 @@
   Target state: Every workflow carries a tier, available throughout execution."
 
  :spec/intent
- {:type :reliability-foundation
+ {:type :feature
   :scope ["components/workflow/src/ai/miniforge/workflow"
           "components/dag-executor/src/ai/miniforge/dag_executor"]}
 

--- a/work/rn-03-reliability-events.spec.edn
+++ b/work/rn-03-reliability-events.spec.edn
@@ -19,7 +19,7 @@
   Target state: 6 new event types with Malli schemas and constructors."
 
  :spec/intent
- {:type :reliability-foundation
+ {:type :feature
   :scope ["components/event-stream/src/ai/miniforge/event_stream/schema.clj"
           "components/event-stream/src/ai/miniforge/event_stream/core.clj"]}
 

--- a/work/rn-04-sli-slo-engine.spec.edn
+++ b/work/rn-04-sli-slo-engine.spec.edn
@@ -20,7 +20,7 @@
   Target state: New component computing 7 SLIs with per-tier SLO evaluation."
 
  :spec/intent
- {:type :new-component
+ {:type :feature
   :scope ["components/reliability-metrics (NEW)"
           "components/observer (extend)"]}
 

--- a/work/rn-05-degradation-modes.spec.edn
+++ b/work/rn-05-degradation-modes.spec.edn
@@ -17,7 +17,7 @@
   Target state: Formal 3-state machine with event-driven transitions."
 
  :spec/intent
- {:type :enhancement
+ {:type :feature
   :scope ["components/workflow/src/ai/miniforge/workflow"
           "components/reliability-metrics (extend)"]}
 

--- a/work/rn-06-outcome-evidence.spec.edn
+++ b/work/rn-06-outcome-evidence.spec.edn
@@ -16,7 +16,7 @@
   Target state: Every evidence bundle carries reliability context."
 
  :spec/intent
- {:type :schema-extension
+ {:type :feature
   :scope ["components/evidence-bundle/src/ai/miniforge/evidence_bundle"]}
 
  :normative-refs

--- a/work/rn-07-autonomy-model.spec.edn
+++ b/work/rn-07-autonomy-model.spec.edn
@@ -18,7 +18,7 @@
   Target state: Single A0-A5 model with cross-spec mapping."
 
  :spec/intent
- {:type :new-component
+ {:type :feature
   :scope ["components/autonomy (NEW)"
           "components/event-stream (extend)"
           "components/workflow (extend)"]}

--- a/work/rn-08-safe-mode.spec.edn
+++ b/work/rn-08-safe-mode.spec.edn
@@ -17,7 +17,7 @@
   Target state: Full safe-mode state machine with auto-triggers and exit."
 
  :spec/intent
- {:type :enhancement
+ {:type :feature
   :scope ["components/event-stream/src/ai/miniforge/event_stream/control.clj"
           "components/reliability-metrics (extend)"
           "components/autonomy (extend)"]}

--- a/work/rn-09-trust-boundaries.spec.edn
+++ b/work/rn-09-trust-boundaries.spec.edn
@@ -17,7 +17,7 @@
   Target state: All 5 boundaries enforced with invariant validation."
 
  :spec/intent
- {:type :enhancement
+ {:type :feature
   :scope ["components/policy-pack/src/ai/miniforge/policy_pack"
           "components/gate/src/ai/miniforge/gate"]}
 

--- a/work/rn-10-validation-layers.spec.edn
+++ b/work/rn-10-validation-layers.spec.edn
@@ -17,7 +17,7 @@
   Target state: 5 layers with enforced ordering."
 
  :spec/intent
- {:type :enhancement
+ {:type :feature
   :scope ["components/gate/src/ai/miniforge/gate"
           "components/policy-pack/src/ai/miniforge/policy_pack"]}
 

--- a/work/rn-14-tool-response-validation.spec.edn
+++ b/work/rn-14-tool-response-validation.spec.edn
@@ -17,7 +17,7 @@
   Target state: Schema validation + sanitization at capsule boundary."
 
  :spec/intent
- {:type :enhancement
+ {:type :feature
   :scope ["components/tool/src/ai/miniforge/tool"
           "components/tool-registry/src/ai/miniforge/tool_registry"]}
 

--- a/work/rn-15-evaluation-pipeline.spec.edn
+++ b/work/rn-15-evaluation-pipeline.spec.edn
@@ -18,7 +18,7 @@
   Target state: Full evaluation pipeline with golden sets and 3 execution modes."
 
  :spec/intent
- {:type :new-component
+ {:type :feature
   :scope ["components/evaluation (NEW)"
           "components/workflow (extend replay.clj)"
           "components/evidence-bundle (golden-set artifacts)"]}

--- a/work/rn-16-index-quality.spec.edn
+++ b/work/rn-16-index-quality.spec.edn
@@ -17,7 +17,7 @@
   Target state: Quality scoring with canary-based degradation detection."
 
  :spec/intent
- {:type :new-component
+ {:type :feature
   :scope ["components/index-quality (NEW)"
           "components/canary (NEW)"
           "components/event-stream (extend with repo-index events)"]}

--- a/work/workflow-redesign-use-case-targeted.spec.edn
+++ b/work/workflow-redesign-use-case-targeted.spec.edn
@@ -34,7 +34,7 @@
   - Clear mapping from user intent to workflow type"
 
  :spec/intent
- {:type :architectural-redesign
+ {:type :refactor
   :scope ["Remove simple/lean/canonical workflows"
           "Implement 5 use-case targeted workflows"
           "Update workflow selector logic"

--- a/work/workflow-resume-fsm-advance-investigation.spec.edn
+++ b/work/workflow-resume-fsm-advance-investigation.spec.edn
@@ -64,7 +64,7 @@
      so the next FSM/snapshot drift fails at test time."
 
  :spec/intent
- {:type :fix
+ {:type :bugfix
   :scope ["components/workflow/src/ai/miniforge/workflow/runner_environment.clj"
           "components/workflow/src/ai/miniforge/workflow/context.clj"
           "components/workflow/src/ai/miniforge/workflow/runner.clj"

--- a/work/workflow-resume-status-handling.spec.edn
+++ b/work/workflow-resume-status-handling.spec.edn
@@ -51,7 +51,7 @@
   when the FSM evaluator stalls."
 
  :spec/intent
- {:type :fix
+ {:type :bugfix
   :scope ["bases/cli/src/ai/miniforge/cli/main/commands/resume.clj"
           "components/workflow-resume/src"
           "components/workflow/src"]}


### PR DESCRIPTION
## Summary

17 `work/*.spec.edn` files (the rn-* "Fable" reliability program + a few others) declared a `:spec/intent :type` outside the spec validator’s enum (`:refactor`/`:feature`/`:bugfix`/`:general`/`:chore`/`:docs`/`:test`/`:performance`). `bb dogfood` rejected them at parse time:

```
Error: Invalid workflow spec:
  - [:spec/intent {:type ["should be either :refactor, :feature, ..."]}]
```

So none of these were runnable. (Surfaced trying to dogfood rn-03.)

## Fix — map each to the closest valid value
- `:fix` → `:bugfix` — backend-failover, workflow-resume-fsm-advance-investigation, workflow-resume-status-handling
- `:architectural-redesign` → `:refactor` — workflow-redesign-use-case-targeted
- `:reliability-foundation` / `:new-component` / `:enhancement` / `:schema-extension` → `:feature` — rn-01, rn-02, rn-03, rn-04, rn-05, rn-06, rn-07, rn-08, rn-09, rn-10, rn-14, rn-15, rn-16

Intent-`:type` only (one line per file). Top-level `:type` and `:workflow/type` are left exactly as authored.

## Out of scope
Specs with **no** `:spec/intent` at all (codex-cli-integration, llm-workflow-recommendation, pr-monitor-loop, etc.) are an older/different shape — not touched here.

## Test plan
- Every changed spec parses and now has a valid `:spec/intent :type` (verified by EDN-parsing all `work/*.spec.edn` against the enum). `bb pre-commit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)