### PR TITLE
refactor(event-stream): require listener collaborators directly

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -65,10 +65,7 @@
    Uses schema-defined privacy levels with fallback overrides for
    specific event types that need stricter filtering."
   [event-type]
-  (let [;; Get privacy from schema (if available)
-        privacy (try
-                  (schema/event-privacy event-type)
-                  (catch Exception _e :internal))]
+  (let [privacy (schema/event-privacy event-type)]
     (get privacy->min-capability privacy :observe)))
 
 (defn matches-workflow?

--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -28,7 +28,9 @@
    The registry wraps event-stream subscription with capability metadata and
    enforcement."
   (:require
+   [ai.miniforge.event-stream.control :as control]
    [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.event-stream.schema :as schema]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -65,9 +67,7 @@
   [event-type]
   (let [;; Get privacy from schema (if available)
         privacy (try
-                  (let [privacy-fn (requiring-resolve
-                                    'ai.miniforge.event-stream.schema/event-privacy)]
-                    (privacy-fn event-type))
+                  (schema/event-privacy event-type)
                   (catch Exception _e :internal))]
     (get privacy->min-capability privacy :observe)))
 
@@ -230,5 +230,4 @@
                                 :capability (:listener/capability listener)
                                 :required :control}))
     ;; Delegate to control/execute-control-action!
-    (let [execute-fn (requiring-resolve 'ai.miniforge.event-stream.control/execute-control-action!)]
-      (execute-fn stream action execution-fn))))
+    (control/execute-control-action! stream action execution-fn)))


### PR DESCRIPTION
## Summary
- Replace same-component requiring-resolve calls in event-stream listeners with direct requires for schema and control
- Preserve listener capability filtering and control-action execution behavior while making the dependency graph explicit

## Standards
- Addresses clojure-no-requiring-resolve by removing two hidden same-component lazy edges
- Keeps the stratum local to event-stream: listeners build on schema/control/core vocabulary rather than dynamic runtime lookup

## Validation
- clj-kondo --lint components/event-stream/src/ai/miniforge/event_stream/listeners.clj
- clojure -M:poly test brick:event-stream
- bb pre-commit