### PR TITLE
fix(reviewer): route stagnation/hard-limit timeouts to backend-timeout, not false :rejected

### DIFF
--- a/components/agent/src/ai/miniforge/agent/result_boundary.clj
+++ b/components/agent/src/ai/miniforge/agent/result_boundary.clj
@@ -133,6 +133,23 @@
   [normalized]
   (= :network-drop (llm-timeout-type normalized)))
 
+(def ^:private adaptive-timeout-types
+  "The adaptive-timeout `:type`s that mean the LLM call ended WITHOUT producing
+   a usable verdict — the provider was reachable but the turn never completed.
+   `:network-drop` is excluded: it is connectivity-loss with dedicated
+   retry/resume handling (PR-C auto-resumer), not a no-verdict timeout."
+  #{:stream-idle :stagnation :hard-limit})
+
+(defn backend-timeout-error?
+  "True when the normalized boundary carries ANY adaptive LLM timeout
+   (`:stream-idle` / `:stagnation` / `:hard-limit`) — the call timed out before
+   the model produced a verdict. Callers (e.g. the reviewer) must treat this as
+   an INFRA failure (a backend-timeout verdict to retry / terminate), NOT as a
+   parse failure that synthesizes a content `:rejected`. Broader than
+   `stream-idle-error?`, which catches only one of the three types."
+  [normalized]
+  (boolean (adaptive-timeout-types (llm-timeout-type normalized))))
+
 (defn error-response
   "Build a failure response that preserves the backend error shape plus
    common response metadata for post-mortem."

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -225,13 +225,20 @@
                     ;; at 360s with no parsed response; the framework
                     ;; promoted the timeout text into `:review/blocking-
                     ;; issues` via the parse-failed branch and synthesized
-                    ;; a false `:rejected`. Adding the boundary-level
-                    ;; stream-idle check covers that path so a real
-                    ;; infra timeout takes the `timeout-only-error-result`
-                    ;; exit instead of masquerading as a code-review
-                    ;; rejection.
-                    backend-stream-idle? (result-boundary/stream-idle-error? normalized)
-                    backend-timeout? (or timeout-only-review? backend-stream-idle?)
+                    ;; a false `:rejected`. The boundary-level check below
+                    ;; covers that path so a real infra timeout takes the
+                    ;; `timeout-only-error-result` exit instead of
+                    ;; masquerading as a code-review rejection.
+                    ;;
+                    ;; ANY adaptive LLM timeout (stream-idle / stagnation /
+                    ;; hard-limit) means the reviewer produced no verdict — route
+                    ;; to the backend-timeout (infra) path, not a synthesized
+                    ;; :rejected. The 2026-06-05 fix only covered :stream-idle; a
+                    ;; 2026-06-14 dogfood (rn-03) stagnation-timed-out and was
+                    ;; promoted into a false :rejected via the parse-failed
+                    ;; branch, redirecting implement to "fix" a non-rejection.
+                    backend-adaptive-timeout? (result-boundary/backend-timeout-error? normalized)
+                    backend-timeout? (or timeout-only-review? backend-adaptive-timeout?)
                     ;; "initial" = the first-call decision/issues fed into the
                     ;; enumeration validator. Named to contrast with
                     ;; `recovered-review` below; these are already normalized,
@@ -389,7 +396,7 @@
                                         :llm-decision llm-decision
                                         :llm-parse-failed? parse-failed?
                                         :timeout-only-review? timeout-only-review?
-                                        :backend-stream-idle? backend-stream-idle?
+                                        :backend-adaptive-timeout? backend-adaptive-timeout?
                                         :gates-passed (:passed counts)
                                         :gates-failed (:failed counts)
                                         :failing-gate-ids failing-gate-ids

--- a/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
+++ b/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
@@ -151,6 +151,22 @@
     (is (false? (sut/network-drop-error?
                   {:llm-error {:timeout {:type :stagnation :elapsed-ms 180000}}})))))
 
+(deftest backend-timeout-error?-covers-all-adaptive-no-verdict-timeouts
+  ;; A 2026-06-14 dogfood (rn-03) reviewer STAGNATION-timed-out; the
+  ;; stream-idle-only check missed it, so it fell through to a synthesized
+  ;; :rejected with the timeout text as a blocking issue. This predicate covers
+  ;; all three no-verdict adaptive timeouts so any of them routes to the
+  ;; backend-timeout (infra) path.
+  (testing "stream-idle / stagnation / hard-limit all match"
+    (is (true? (sut/backend-timeout-error? {:llm-error {:timeout {:type :stream-idle :elapsed-ms 360000}}})))
+    (is (true? (sut/backend-timeout-error? {:llm-error {:timeout {:type :stagnation :elapsed-ms 318398}}})))
+    (is (true? (sut/backend-timeout-error? {:llm-error {:timeout {:type :hard-limit :elapsed-ms 600000}}}))))
+  (testing "network-drop is excluded (dedicated retry/resume handling)"
+    (is (false? (sut/backend-timeout-error? {:llm-error {:timeout {:type :network-drop :elapsed-ms 30000}}}))))
+  (testing "non-timeout / missing-error maps do NOT match"
+    (is (false? (sut/backend-timeout-error? {:llm-error {:type "cli_error"}})))
+    (is (false? (sut/backend-timeout-error? {})))))
+
 (deftest error-response-preserves-backend-error-shape
   (testing "error-response carries raw backend data and response metadata through"
     (let [normalized {:llm-error {:message "Adaptive timeout"

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -192,6 +192,21 @@
                :elapsed-ms elapsed-ms
                :stats {:lines-read 0}}}))
 
+(defn- stagnation-llm-error
+  "Build the LLM-error shape `streaming-error-response` produces when the
+   STAGNATION adaptive timeout fires (provider streamed, but made no forward
+   progress for the configured window). The 2026-06-14 dogfood (`rn-03`) hit
+   exactly this path on review cycle #3 — and the OLD stream-idle-only check
+   missed it, synthesizing a false :rejected."
+  [elapsed-ms]
+  (let [message (str "Adaptive timeout: Stagnation timeout: no progress for "
+                     elapsed-ms "ms (type: stagnation, elapsed: " elapsed-ms "ms)")]
+    {:type backend-timeout-type
+     :message message
+     :timeout {:type :stagnation
+               :message (str "no progress for " elapsed-ms "ms")
+               :elapsed-ms elapsed-ms}}))
+
 ;------------------------------------------------------------------------------ Core functionality tests
 
 (deftest test-create-reviewer
@@ -453,6 +468,43 @@
           (is (vector? (get-in result [:error :data :blocking-issues]))
               "vector shape preserved end-to-end — pinned because PR #1058 review
                flagged the original implementation returning nil here."))))))
+
+(deftest test-reviewer-boundary-stagnation-is-agent-error
+  ;; The 2026-06-14 dogfood (`rn-03`) shape: on review cycle #3 the reviewer
+  ;; LLM streamed but stagnated (no forward progress for 318398ms) and returned
+  ;; NO parsed review. The OLD boundary check tested only `stream-idle-error?`,
+  ;; so this fell through to the parse-failed branch — the framework promoted
+  ;; the timeout text into `:review/blocking-issues` and synthesized a false
+  ;; `:rejected` (decision routed back to IMPLEMENT, wasting a redirect cycle
+  ;; "fixing" a non-rejection). The widened `backend-timeout-error?` covers
+  ;; `:stagnation` (and `:hard-limit`) too, so this must take the same
+  ;; `:reviewer/backend-timeout` exit as the stream-idle variant.
+  (testing "stagnation on the LLM-call boundary (no parsed review) → :reviewer/backend-timeout"
+    (let [stagnation-elapsed-ms 318398
+          err (stagnation-llm-error stagnation-elapsed-ms)]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                    llm/chat (fn [_client _prompt _opts]
+                               (mock-llm-response ""
+                                                  :success? false
+                                                  :tokens timeout-review-token-count
+                                                  :error err))
+                    llm/success? :success?
+                    llm/get-content :content
+                    llm/get-error :error]
+        (let [reviewer (reviewer/create-reviewer {:llm-backend ::mock-backend
+                                                  :gates []})
+              result (core/invoke reviewer {} sample-artifact)]
+          (is (= :error (:status result))
+              "Stagnation must surface as an agent-level error, not a synthetic :rejected review")
+          (is (= :reviewer/backend-timeout
+                 (get-in result [:error :data :code]))
+              "Error code must be :reviewer/backend-timeout — distinguishes infra timeout from real defect")
+          (is (= (:message err)
+                 (get-in result [:error :message]))
+              "Error message preserves the adaptive-timeout text verbatim for operator post-mortem")
+          (is (= []
+                 (get-in result [:error :data :blocking-issues]))
+              "blocking-issues defaults to an empty vector — never a synthetic rejection"))))))
 
 (deftest test-reviewer-timeout-only-shape-does-not-hide-real-gate-failures
   (testing "timeout-only classification requires the deterministic gates to approve"


### PR DESCRIPTION
## Summary

The reviewer's boundary-level infra-timeout check tested only `stream-idle-error?`. When the reviewer LLM call ends with a `:stagnation` or `:hard-limit` adaptive timeout, there is no parsed review, so the call fell through to the parse-failed branch: the framework promoted the timeout text into `:review/blocking-issues` and synthesized a false `:rejected`. Because `:rejected` redirects to IMPLEMENT, a reviewer infra timeout wasted a redirect cycle "fixing" a non-rejection.

This widens the boundary classification:

- New `result-boundary/backend-timeout-error?` returns true for any of the three no-verdict adaptive timeouts: `:stream-idle` / `:stagnation` / `:hard-limit`. `:network-drop` stays excluded — it has dedicated retry/resume handling (PR-C auto-resumer), not a no-verdict timeout.
- The reviewer now branches on `backend-timeout-error?` instead of the stream-idle-only predicate, so any of the three takes the `:reviewer/backend-timeout` exit (infra error to retry/terminate), not a synthesized content `:rejected`.

Surfaced by the 2026-06-14 `rn-03` dogfood: review cycle #3 stagnation-timed-out (318398ms) and was reported as a `:rejected` blocking issue (`"Adaptive timeout: Stagnation timeout: no progress for 318398ms (type: stagnation)"`).

## Test plan

- `result_boundary_test`: `backend-timeout-error?-covers-all-adaptive-no-verdict-timeouts` — true for stream-idle/stagnation/hard-limit, false for network-drop / non-timeout / missing-error maps.
- `reviewer_test`: `test-reviewer-boundary-stagnation-is-agent-error` — a stagnation boundary timeout with no parsed review yields `:status :error` + `:reviewer/backend-timeout` (not a synthetic `:rejected`); blocking-issues is `[]`.
- Existing `test-reviewer-boundary-stream-idle-is-agent-error` still green (stream-idle path unchanged).
- `bb pre-commit` passes (312 + 6 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)