### PR TITLE
refactor(core): require local serializers directly

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -317,8 +317,7 @@
                        :edn (if compact?
                               (pr-str event)
                               (with-out-str (pprint/pprint event)))
-                       :json (let [gen-str (requiring-resolve 'cheshire.core/generate-string)]
-                               (str (gen-str event {:pretty (not compact?)})))
+                       :json (str (json/generate-string event {:pretty (not compact?)}))
                        (pr-str event))]
           (println output)
           (flush))
@@ -345,8 +344,7 @@
         (try
           (let [output (case format
                          :edn (pr-str event)
-                         :json (let [gen-str (requiring-resolve 'cheshire.core/generate-string)]
-                                 (gen-str event))
+                         :json (json/generate-string event)
                          (pr-str event))]
             (binding [*out* *err*]
               (println output)))

--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -40,6 +40,7 @@
    [ai.miniforge.knowledge.messages :as messages]
    [ai.miniforge.knowledge.policy-lookup :as policy-lookup]
    [ai.miniforge.knowledge.trust]
+   [ai.miniforge.knowledge.yaml :as yaml]
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -516,12 +517,12 @@
 (def split-frontmatter
   "Split markdown content into frontmatter and body.
    Returns {:frontmatter string :body string} or nil if no frontmatter."
-  (requiring-resolve 'ai.miniforge.knowledge.yaml/split-frontmatter))
+  yaml/split-frontmatter)
 
 (def parse-yaml-frontmatter
   "Parse YAML frontmatter into EDN map.
    Handles basic YAML: key: value, arrays, lists."
-  (requiring-resolve 'ai.miniforge.knowledge.yaml/parse-yaml-frontmatter))
+  yaml/parse-yaml-frontmatter)
 
 ;------------------------------------------------------------------------------ Layer 8
 ;; Rule and documentation loading


### PR DESCRIPTION
## Summary
- Replace dynamic YAML parser exports in knowledge.interface with direct knowledge.yaml references
- Replace dynamic JSON generation in event-stream sinks with the already-required cheshire alias

## Standards
- Removes four clojure-no-requiring-resolve violations without introducing new component edges
- Leaves logging sink construction out of this wave because core <-> sinks currently needs a real split to avoid a cycle

## Validation
- clj-kondo --lint components/knowledge/src/ai/miniforge/knowledge/interface.clj components/event-stream/src/ai/miniforge/event_stream/sinks.clj
- clojure -M:poly test brick:knowledge
- clojure -M:poly test brick:event-stream
- bb pre-commit