### PR TITLE
refactor(policy-pack): require internal helpers directly

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/external.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/external.clj
@@ -26,8 +26,9 @@
    Layer 1: Pack selection
    Layer 2: Evaluation and reporting"
   (:require
-   [clojure.string :as str]
-   [ai.miniforge.policy-pack.core :as core]))
+   [ai.miniforge.policy-pack.core :as core]
+   [ai.miniforge.policy-pack.registry :as registry]
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Diff parsing
@@ -87,10 +88,9 @@
 (defn files-match-globs?
   "True if any path in `paths` matches any pattern in `globs`."
   [paths globs]
-  (let [glob-fn @(requiring-resolve 'ai.miniforge.policy-pack.registry/glob-matches?)]
-    (some (fn [path]
-            (some #(path-matches-glob? glob-fn % path) globs))
-          paths)))
+  (some (fn [path]
+          (some #(path-matches-glob? registry/glob-matches? % path) globs))
+        paths))
 
 (defn pack-applies?
   "True if a pack applies to the given changed files.

--- a/components/policy-pack/src/ai/miniforge/policy_pack/intent.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/intent.clj
@@ -32,6 +32,7 @@
      :refactor → Creates: 0, Updates: 0, Destroys: 0
      :migrate  → Creates: >0, Destroys: >0"
   (:require
+   [ai.miniforge.policy-pack.detection :as detection]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -143,12 +144,10 @@
    Arguments:
    - plan-output — Raw terraform plan output string
 
-   Returns:
+  Returns:
    - {:creates int :updates int :destroys int}"
   [plan-output]
-  (if-let [f (requiring-resolve 'ai.miniforge.policy-pack.detection/plan-resource-counts)]
-    (f plan-output)
-    {:creates 0 :updates 0 :destroys 0}))
+  (detection/plan-resource-counts plan-output))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Kubernetes diff parsing

--- a/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
@@ -7,7 +7,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.policy-pack.ast :as sut]
-   [ai.miniforge.policy-pack.schema :as schema]))
+   [ai.miniforge.policy-pack.detection :as detection]))
 
 (deftest file-extension-test
   (testing "extracts extension from simple filename"
@@ -75,27 +75,25 @@
 
 (deftest state-comparison-detection-test
   (testing "detects drift between desired and current state"
-    (let [detect (requiring-resolve 'ai.miniforge.policy-pack.detection/detect-state-comparison)
-          rule    {:rule/id :test/drift :rule/enforcement {:action :warn :message "Drift"}}
+    (let [rule    {:rule/id :test/drift :rule/enforcement {:action :warn :message "Drift"}}
           context {:desired-state {:replicas 3 :image "v2"}
                    :current-state {:replicas 1 :image "v1"}}
-          result  (detect rule {} context)]
+          result  (detection/detect-state-comparison rule {} context)]
       (is (some? result))
       (is (= :state-comparison (:type result)))))
 
   (testing "returns nil when no drift"
-    (let [detect  (requiring-resolve 'ai.miniforge.policy-pack.detection/detect-state-comparison)
-          rule    {:rule/id :test/drift :rule/enforcement {:action :warn :message "Drift"}}
+    (let [rule    {:rule/id :test/drift :rule/enforcement {:action :warn :message "Drift"}}
           context {:desired-state {:replicas 3} :current-state {:replicas 3}}
-          result  (detect rule {} context)]
+          result  (detection/detect-state-comparison rule {} context)]
       (is (nil? result)))))
 
 (deftest plan-resource-counts-test
   (testing "counts creates, updates, destroys from plan output"
-    (let [counts (requiring-resolve 'ai.miniforge.policy-pack.detection/plan-resource-counts)
-          plan   "# aws_vpc.main will be created\n# aws_route.old will be destroyed\n# aws_subnet.main will be updated"]
-      (is (= {:creates 1 :updates 1 :destroys 1} (counts plan)))))
+    (let [plan "# aws_vpc.main will be created\n# aws_route.old will be destroyed\n# aws_subnet.main will be updated"]
+      (is (= {:creates 1 :updates 1 :destroys 1}
+             (detection/plan-resource-counts plan)))))
 
   (testing "empty plan returns zeros"
-    (let [counts (requiring-resolve 'ai.miniforge.policy-pack.detection/plan-resource-counts)]
-      (is (= {:creates 0 :updates 0 :destroys 0} (counts "no resources"))))))
+    (is (= {:creates 0 :updates 0 :destroys 0}
+           (detection/plan-resource-counts "no resources")))))


### PR DESCRIPTION
## Summary
- replace policy-pack internal requiring-resolve calls with direct namespace requires
- use registry/glob-matches? and detection helpers directly in production code
- update policy-pack AST tests to call detection helpers directly and drop an unused require

## Standards
- addresses clojure-no-requiring-resolve violations without adding cross-component edges
- verified namespace edges before replacing lazy calls to avoid hiding cycles

## Validation
- clj-kondo --lint components/policy-pack/src/ai/miniforge/policy_pack/intent.clj components/policy-pack/src/ai/miniforge/policy_pack/external.clj components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
- clojure -M:poly test brick:policy-pack
- bb pre-commit