### PR TITLE
refactor(phase-deployment): require validation libraries directly

### DIFF
--- a/components/phase-deployment/deps.edn
+++ b/components/phase-deployment/deps.edn
@@ -6,7 +6,9 @@
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/response {:local/root "../response"}
         ai.miniforge/evidence-bundle {:local/root "../evidence-bundle"}
-        ai.miniforge/policy-pack {:local/root "../policy-pack"}}
+        ai.miniforge/policy-pack {:local/root "../policy-pack"}
+        cheshire/cheshire {:mvn/version "5.13.0"}
+        metosin/malli {:mvn/version "0.16.4"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {ai.miniforge/gate {:local/root "../gate"}}}}}

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/config_resolver.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/config_resolver.clj
@@ -31,7 +31,9 @@
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.schema.interface :as schema]
             [clojure.set :as set]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [malli.core :as m]
+            [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Placeholder parsing + schemas
@@ -267,7 +269,7 @@
        (schema/success :resolved-values resolved
                        {:log @log-acc})))))
 
-;; Schema validation (uses Malli via requiring-resolve)
+;; Schema validation
 
 (defn validate-config
   "Validate resolved config against a Malli schema.
@@ -281,12 +283,10 @@
       :errors  nil or humanized error map}"
   [config config-schema]
   (try
-    (let [validate-fn (requiring-resolve 'malli.core/validate)
-          explain-fn  (requiring-resolve 'malli.core/explain)
-          humanize-fn (requiring-resolve 'malli.error/humanize)]
-      (if (validate-fn config-schema config)
-        (schema/valid)
-        (schema/invalid-with-errors (humanize-fn (explain-fn config-schema config)))))
+    (if (m/validate config-schema config)
+      (schema/valid)
+      (schema/invalid-with-errors
+       (me/humanize (m/explain config-schema config))))
     (catch Exception e
       (schema/invalid-with-errors
        {:_schema (msg/t :config-resolver/validation-error

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj
@@ -20,9 +20,10 @@
   "Custom policy check functions for deployment safety rules.
 
    Referenced by detection entries in the deployment-safety policy pack
-   via :check-fn symbols."
+  via :check-fn symbols."
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.schema.interface :as schema]
+            [cheshire.core :as json]
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -43,8 +44,7 @@
   [content]
   (if (string? content)
     (try
-      (let [parse-fn (requiring-resolve 'cheshire.core/parse-string)]
-        (parse-fn content true))
+      (json/parse-string content true)
       (catch Exception _ {}))
     content))
 

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
@@ -20,6 +20,7 @@
   "Shared deployment shell execution helpers."
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.schema.interface :as schema]
+            [cheshire.core :as json]
             [clojure.java.shell :as shell]
             [clojure.string :as str]))
 
@@ -63,8 +64,7 @@
    (if-let [parsed (when (and (string? (:stdout result))
                               (not (str/blank? (:stdout result))))
                      (try
-                       (let [parse-fn (requiring-resolve 'cheshire.core/parse-string)]
-                         (parse-fn (:stdout result) true))
+                       (json/parse-string (:stdout result) true)
                        (catch Exception _ nil)))]
      (assoc result :parsed parsed)
      result)))


### PR DESCRIPTION
## Summary
- add explicit phase-deployment dependencies for Cheshire and Malli
- replace Malli validation requiring-resolve calls with direct malli aliases
- replace deployment JSON parser requiring-resolve calls with direct cheshire aliases

## Standards
- addresses clojure-no-requiring-resolve by making real dependencies explicit instead of hiding them behind dynamic resolution
- keeps the wave scoped to phase-deployment library dependencies

## Validation
- clj-kondo --lint components/phase-deployment/src/ai/miniforge/phase_deployment/config_resolver.clj components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
- clojure -M:poly test brick:phase-deployment
- bb pre-commit