### PR TITLE
refactor(cli): require workflow and event controls directly

### DIFF
--- a/bases/cli/deps.edn
+++ b/bases/cli/deps.edn
@@ -7,6 +7,7 @@
         org.babashka/cli {:mvn/version "0.8.60"}
         babashka/fs      {:mvn/version "0.5.22"}
         babashka/process {:mvn/version "0.5.22"}
+        cheshire/cheshire {:mvn/version "5.13.0"}
 
         ;; Configuration management (BB-compatible)
         aero/aero        {:mvn/version "1.1.6"}

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -39,6 +39,7 @@
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.automation-edge-correlator.interface :as correlator]
+   [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.workflow-resume.interface :as wr]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -46,6 +47,16 @@
 
 (def events-dir
   (app-config/events-dir))
+
+(def load-workflow
+  "Workflow loader dependency, exposed as a var so tests can rebind the
+   CLI boundary without dynamic namespace resolution."
+  workflow/load-workflow)
+
+(def run-pipeline
+  "Workflow runner dependency, exposed as a var so tests can rebind the
+   CLI boundary without dynamic namespace resolution."
+  workflow/run-pipeline)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Thin delegations kept for compatibility with existing callers/tests
@@ -121,11 +132,6 @@
                 (display/print-info
                   (messages/t :resume/events-found
                               {:count (:event-count reconstructed)})))
-
-            ;; Resolve workflow interface lazily — avoids pulling the
-            ;; workflow component onto the cold-start path.
-            load-workflow (requiring-resolve 'ai.miniforge.workflow.interface/load-workflow)
-            run-pipeline (requiring-resolve 'ai.miniforge.workflow.interface/run-pipeline)
 
             {:keys [workflow-type workflow-version]} (resolve-resume-workflow reconstructed)
             {:keys [workflow]} (load-workflow workflow-type workflow-version {})

--- a/bases/cli/src/ai/miniforge/cli/observability.clj
+++ b/bases/cli/src/ai/miniforge/cli/observability.clj
@@ -28,6 +28,7 @@
    [clojure.string :as str]
    [clojure.java.io :as io]
    [clojure.edn :as edn]
+   [cheshire.core :as json]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.messages :as messages]))
 
@@ -459,15 +460,14 @@
    by filename (which is timestamp-prefixed)."
   [dir]
   (when (.exists ^java.io.File dir)
-    (let [json-parse (requiring-resolve 'cheshire.core/parse-string)]
-      (->> (.listFiles ^java.io.File dir)
-           (filter #(.endsWith (.getName ^java.io.File %) ".json"))
-           (sort-by #(.getName ^java.io.File %))
-           (keep (fn [f]
-                   (try
-                     (let [raw (json-parse (slurp f) false)]
-                       (strip-transit-prefix raw))
-                     (catch Exception _e nil))))))))
+    (->> (.listFiles ^java.io.File dir)
+         (filter #(.endsWith (.getName ^java.io.File %) ".json"))
+         (sort-by #(.getName ^java.io.File %))
+         (keep (fn [f]
+                 (try
+                   (let [raw (json/parse-string (slurp f) false)]
+                     (strip-transit-prefix raw))
+                   (catch Exception _e nil)))))))
 
 (defn- ts-short
   "Render the :event/timestamp field (may be a plain string after transit

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/dashboard.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/dashboard.clj
@@ -29,7 +29,8 @@
    [clojure.edn :as edn]
    [cheshire.core :as json]
    [ai.miniforge.cli.app-config :as app-config]
-   [ai.miniforge.cli.workflow-runner.display :as display]))
+   [ai.miniforge.cli.workflow-runner.display :as display]
+   [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Auto-discovery
@@ -89,11 +90,11 @@
                                     data (edn/read-string content)
                                     command (keyword (:command data))]
                                 (case command
-                                  :pause (do ((requiring-resolve 'ai.miniforge.event-stream.interface/pause!) control-state)
+                                  :pause (do (es/pause! control-state)
                                              (println "\u23f8  Workflow paused by dashboard"))
-                                  :resume (do ((requiring-resolve 'ai.miniforge.event-stream.interface/resume!) control-state)
+                                  :resume (do (es/resume! control-state)
                                               (println "\u25b6  Workflow resumed by dashboard"))
-                                  :stop (do ((requiring-resolve 'ai.miniforge.event-stream.interface/cancel!) control-state)
+                                  :stop (do (es/cancel! control-state)
                                             (println "\u23f9  Workflow stopped by dashboard"))
                                   nil)
                                 (.delete file))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
@@ -134,20 +134,14 @@
                                                     (fn [] nil))
                   main-display/print-info (fn [& _] nil)
                   main-display/print-error (fn [& _] nil)
-                  clojure.core/requiring-resolve
-                  (fn [sym]
-                    (cond
-                      (= sym 'ai.miniforge.workflow.interface/load-workflow)
-                      (fn [_workflow-type _workflow-version _opts]
-                        {:workflow {:workflow/id :canonical-sdlc
-                                    :workflow/version "1.0.0"
-                                    :workflow/pipeline [{:phase :verify}]}})
-
-                      (= sym 'ai.miniforge.workflow.interface/run-pipeline)
-                      (fn [workflow _input opts]
-                        (reset! run-pipeline-workflow workflow)
-                        (reset! run-pipeline-opts opts)
-                        {:execution/status :completed})))]
+                  sut/load-workflow (fn [_workflow-type _workflow-version _opts]
+                                      {:workflow {:workflow/id :canonical-sdlc
+                                                  :workflow/version "1.0.0"
+                                                  :workflow/pipeline [{:phase :verify}]}})
+                  sut/run-pipeline (fn [workflow _input opts]
+                                     (reset! run-pipeline-workflow workflow)
+                                     (reset! run-pipeline-opts opts)
+                                     {:execution/status :completed})]
       (let [result (sut/resume-workflow workflow-id {:quiet true})]
         (is (= :completed (:execution/status result)))
         (is (= [{:phase :verify}]
@@ -190,17 +184,11 @@
                   dashboard/start-command-poller! (fn [_ _] (fn [] nil))
                   main-display/print-info (fn [& _] nil)
                   main-display/print-error (fn [& _] nil)
-                  clojure.core/requiring-resolve
-                  (fn [sym]
-                    (cond
-                      (= sym 'ai.miniforge.workflow.interface/load-workflow)
-                      (fn [& _]
-                        {:workflow {:workflow/id :canonical-sdlc
-                                    :workflow/version "1.0.0"
-                                    :workflow/pipeline [{:phase :verify}]}})
-
-                      (= sym 'ai.miniforge.workflow.interface/run-pipeline)
-                      (fn [& _] {:execution/status :running})))]
+                  sut/load-workflow (fn [& _]
+                                      {:workflow {:workflow/id :canonical-sdlc
+                                                  :workflow/version "1.0.0"
+                                                  :workflow/pipeline [{:phase :verify}]}})
+                  sut/run-pipeline (fn [& _] {:execution/status :running})]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"non-terminal status :running"
@@ -248,22 +236,16 @@
                                                     (fn [] nil))
                   main-display/print-info (fn [& _] nil)
                   main-display/print-error (fn [& _] nil)
-                  clojure.core/requiring-resolve
-                  (fn [sym]
-                    (cond
-                      (= sym 'ai.miniforge.workflow.interface/load-workflow)
-                      (fn [_workflow-type _workflow-version _opts]
-                        {:workflow {:workflow/id :canonical-sdlc
-                                    :workflow/version "1.0.0"
-                                    :workflow/pipeline [{:phase :plan}
-                                                        {:phase :implement}
-                                                        {:phase :verify}]}})
-
-                      (= sym 'ai.miniforge.workflow.interface/run-pipeline)
-                      (fn [workflow _input opts]
-                        (reset! run-pipeline-workflow workflow)
-                        (reset! run-pipeline-opts opts)
-                        {:execution/status :completed})))]
+                  sut/load-workflow (fn [_workflow-type _workflow-version _opts]
+                                      {:workflow {:workflow/id :canonical-sdlc
+                                                  :workflow/version "1.0.0"
+                                                  :workflow/pipeline [{:phase :plan}
+                                                                      {:phase :implement}
+                                                                      {:phase :verify}]}})
+                  sut/run-pipeline (fn [workflow _input opts]
+                                     (reset! run-pipeline-workflow workflow)
+                                     (reset! run-pipeline-opts opts)
+                                     {:execution/status :completed})]
       (let [result (sut/resume-workflow workflow-id {:quiet true})]
         (is (= :completed (:execution/status result)))
         (is (= [{:phase :implement} {:phase :verify}]


### PR DESCRIPTION
## Summary
- add explicit CLI Cheshire dependency and parse workflow event JSON through a direct alias
- replace dashboard event-stream command controls with direct interface calls
- replace resume workflow loading/running dynamic resolution with direct interface-backed vars
- update resume tests to rebind those explicit boundary vars instead of stubbing requiring-resolve

## Standards
- removes resolver indirection where project composition already includes the real dependencies
- keeps the missing logging cleanup resolver out of scope because the referenced function does not exist and needs a separate implementation decision

## Validation
- clj-kondo --lint bases/cli/deps.edn bases/cli/src/ai/miniforge/cli/observability.clj bases/cli/src/ai/miniforge/cli/workflow_runner/dashboard.clj bases/cli/src/ai/miniforge/cli/main/commands/resume.clj bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
- bb pre-commit