### PR TITLE
refactor(cli): require workflow selection dependencies directly

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
@@ -30,6 +30,7 @@
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-recommendation-config :as recommendation-config]
    [ai.miniforge.cli.workflow-selection-config :as selection-config]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.response.interface :as response]))
 
@@ -148,8 +149,7 @@
   [llm-client prompt]
   (when llm-client
     (try
-      (let [complete-fn (requiring-resolve 'ai.miniforge.llm.interface/complete)
-            result (complete-fn llm-client {:prompt prompt :max-tokens 500})]
+      (let [result (llm/complete llm-client {:prompt prompt :max-tokens 500})]
         (when (:success result)
           (:content result)))
       (catch Exception e

--- a/bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.cli.workflow-selection-config
   "Resource-driven workflow selection profile resolution."
   (:require
+   [ai.miniforge.workflow.interface :as workflow]
    [clojure.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -47,10 +48,14 @@
 
 (defn- workflow-characteristics
   "Resolve workflow characteristics through the workflow interface."
-  [workflow]
-  (when-let [characteristics-fn (requiring-resolve
-                                  'ai.miniforge.workflow.interface/workflow-characteristics)]
-    (characteristics-fn workflow)))
+  [workflow-def]
+  (workflow/workflow-characteristics workflow-def))
+
+(defn- available-workflow-definitions
+  "Return full workflow definitions from the registry for fallback scoring."
+  []
+  (workflow/ensure-initialized!)
+  (keep workflow/get-workflow (workflow/list-workflow-ids)))
 
 (defn- simplest-workflow-id
   "Choose the simplest available workflow by phase count and max iterations."
@@ -90,9 +95,9 @@
 
    Profiles are app-owned configuration. If a configured profile points at a
    workflow not present on the active classpath, fall back to generic workflow
-   characteristics."
+  characteristics."
   ([profile]
-   (let [available-workflows ((requiring-resolve 'ai.miniforge.workflow.interface/list-workflows))]
+   (let [available-workflows (available-workflow-definitions)]
      (resolve-selection-profile profile available-workflows)))
   ([profile available-workflows]
    (let [configured-id (get (configured-selection-profiles) profile)


### PR DESCRIPTION
## Summary
- require workflow.interface directly in workflow selection config
- call workflow characteristics and list-workflows through that alias
- require llm.interface directly for workflow recommendation completion

## Standards
- removes clojure-no-requiring-resolve violations from workflow selection/recommendation paths where project composition already includes workflow and llm components

## Validation
- clj-kondo --lint bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
- bb pre-commit