### PR TITLE
refactor(cli): require runtime helpers directly

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_review_monitor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_review_monitor.clj
@@ -104,8 +104,7 @@
 (defn- run-pass!
   "One pass over the in-scope open PR set."
   [base-repo author review-opts]
-  (let [poller-fn (requiring-resolve 'ai.miniforge.pr-lifecycle.pr-poller/poll-open-prs)
-        r         (poller-fn base-repo author)]
+  (let [r (pr-lifecycle/poll-open-prs base-repo author)]
     (cond
       (not (dag/ok? r))
       (display/print-error

--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.cli.workflow-runner :as workflow-runner]
    [ai.miniforge.cli.main.commands.plan-executor :as plan-executor]
    [ai.miniforge.cli.main.commands.resume :as resume]
+   [ai.miniforge.agent-runtime.interface :as agent-runtime]
    [slingshot.slingshot :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -37,8 +38,7 @@
   "Attempt runtime error classification. Returns classification or nil."
   [e]
   (try
-    (when-let [classifier (requiring-resolve 'ai.miniforge.agent-runtime.interface/classify-error)]
-      (classifier e (ex-data e)))
+    (agent-runtime/classify-error e (ex-data e))
     (catch Exception _ nil)))
 
 (defn- print-run-error-and-exit!

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.cli.worktree :as worktree]
    [ai.miniforge.cli.workflow-runner.display :as display]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -183,11 +184,10 @@
      (let [cfg (config/load-config)
            llm-backend (config/get-llm-backend
                         cfg
-                        (or backend-override
-                            (get-in workflow [:workflow/config :llm-backend])
-                            (:spec/llm-backend spec)))]
-       (when-let [create-client (requiring-resolve 'ai.miniforge.llm.interface/create-client)]
-         (create-client {:backend llm-backend})))
+                            (or backend-override
+                                (get-in workflow [:workflow/config :llm-backend])
+                                (:spec/llm-backend spec)))]
+       (llm/create-client {:backend llm-backend}))
      (catch Exception e
        (when-not quiet
          (println (display/colorize :yellow (str "Warning: Could not create LLM client (" (ex-message e) "), agents will use fallback mode"))))


### PR DESCRIPTION
## Summary
- call agent-runtime error classification through a direct interface alias
- create workflow LLM clients through a direct llm.interface alias
- poll PRs through the pr-lifecycle interface instead of an internal resolver

## Standards
- removes clojure-no-requiring-resolve violations where public component interfaces already expose the needed functions
- avoids internal pr-poller coupling by using pr-lifecycle.interface/poll-open-prs

## Validation
- clj-kondo --lint bases/cli/src/ai/miniforge/cli/main/commands/run.clj bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj bases/cli/src/ai/miniforge/cli/main/commands/pr_review_monitor.clj
- bb pre-commit