### PR TITLE
Add constructor functions for the 2 new repo-index event types in

### DIFF
--- a/components/event-stream/resources/config/event-stream/messages/en-US.edn
+++ b/components/event-stream/resources/config/event-stream/messages/en-US.edn
@@ -86,4 +86,11 @@
   "fleet-sink: interrupted during flush: {error}"
 
   :fleet-sink.system/flush-error
-  "fleet-sink: flush error: {error}"}}
+  "fleet-sink: flush error: {error}"
+
+  ;; Repository index intelligence events (RN-19/20)
+  :repo-index/quality-measured
+  "Repo-index quality: {index-id} score={quality-score} coverage={coverage}"
+
+  :repo-index/coverage-changed
+  "Repo-index coverage changed: {index-id} {previous-coverage} -> {coverage}"}}

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1498,6 +1498,42 @@
      affected-workflow-run-id (assoc :affected/workflow-run-id
                                      affected-workflow-run-id))))
 
+;------------------------------------------------------------------------------ Layer 9.5
+;; Repository index intelligence events (RN-19/20)
+
+(defn repo-index-quality-measured
+  "Emit when the repo-index component re-scores an index entry (RN-19).
+   quality-score and coverage must be in [0.0, 1.0]; staleness-ms must be >= 0.
+   Optional opts map accepts :tree-sha (git tree SHA string the measurement is
+   pinned to)."
+  [stream index-id quality-score staleness-ms coverage & [opts]]
+  (-> (create-envelope stream :repo-index/quality-measured nil
+                       (messages/t :repo-index/quality-measured
+                                   {:index-id index-id
+                                    :quality-score (format "%.3f" (double quality-score))
+                                    :coverage (format "%.3f" (double coverage))}))
+      (assoc :index/id index-id
+             :index/quality-score quality-score
+             :index/staleness-ms staleness-ms
+             :index/coverage coverage)
+      (cond-> (:tree-sha opts) (assoc :index/tree-sha (:tree-sha opts)))))
+
+(defn repo-index-coverage-changed
+  "Emit when tracked-file coverage crosses a threshold or changes materially
+   between index refreshes (RN-20). coverage and previous-coverage must be in
+   [0.0, 1.0]. Optional opts map accepts :tree-sha (git tree SHA string the
+   new reading is pinned to)."
+  [stream index-id coverage previous-coverage & [opts]]
+  (-> (create-envelope stream :repo-index/coverage-changed nil
+                       (messages/t :repo-index/coverage-changed
+                                   {:index-id index-id
+                                    :previous-coverage (format "%.3f" (double previous-coverage))
+                                    :coverage (format "%.3f" (double coverage))}))
+      (assoc :index/id index-id
+             :index/coverage coverage
+             :index/previous-coverage previous-coverage)
+      (cond-> (:tree-sha opts) (assoc :index/tree-sha (:tree-sha opts)))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Create event stream

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -34,6 +34,12 @@
 (def ^:private redirect-transition-type
   :transition/redirect)
 
+(def ^:private index-ratio-fmt
+  "printf format specifier for index quality/coverage ratios — 3 decimal places
+   matching the schema-constrained precision of :index/quality-score, :index/coverage,
+   and :index/previous-coverage fields."
+  "%.3f")
+
 (defn- redirect-target
   "Project a redirect target for legacy consumers.
 
@@ -1510,8 +1516,8 @@
   (-> (create-envelope stream :repo-index/quality-measured nil
                        (messages/t :repo-index/quality-measured
                                    {:index-id index-id
-                                    :quality-score (format "%.3f" (double quality-score))
-                                    :coverage (format "%.3f" (double coverage))}))
+                                    :quality-score (format index-ratio-fmt (double quality-score))
+                                    :coverage (format index-ratio-fmt (double coverage))}))
       (assoc :index/id index-id
              :index/quality-score quality-score
              :index/staleness-ms staleness-ms
@@ -1527,8 +1533,8 @@
   (-> (create-envelope stream :repo-index/coverage-changed nil
                        (messages/t :repo-index/coverage-changed
                                    {:index-id index-id
-                                    :previous-coverage (format "%.3f" (double previous-coverage))
-                                    :coverage (format "%.3f" (double coverage))}))
+                                    :previous-coverage (format index-ratio-fmt (double previous-coverage))
+                                    :coverage (format index-ratio-fmt (double coverage))}))
       (assoc :index/id index-id
              :index/coverage coverage
              :index/previous-coverage previous-coverage)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -754,3 +754,24 @@
    string for empty/nil input). Pure: no IO. Arities: (events) uses a
    60s default gap; (events opts) takes {:gap-threshold-ms long}."
   timeline/render-timeline)
+;------------------------------------------------------------------------------ Layer 9.5
+;; Repository index intelligence event constructors (RN-19/20)
+
+(def repo-index-quality-measured
+  "Build and return a :repo-index/quality-measured event envelope map
+   (RN-19) emitted when the repo-index component re-scores an index entry.
+   Required: stream, index-id (string), quality-score (number in [0.0,1.0]),
+   staleness-ms (non-negative int), coverage (number in [0.0,1.0]). Optional
+   opts map carries :tree-sha (git tree SHA string the measurement is pinned
+   to). Emits :workflow/id nil — index re-scoring runs outside any workflow
+   context when triggered by background refresh."
+  events/repo-index-quality-measured)
+
+(def repo-index-coverage-changed
+  "Build and return a :repo-index/coverage-changed event envelope map
+   (RN-20) emitted when tracked-file coverage crosses a threshold or changes
+   materially between index refreshes. Required: stream, index-id (string),
+   coverage (number in [0.0,1.0]), previous-coverage (number in [0.0,1.0]).
+   Optional opts map carries :tree-sha (git tree SHA string the new reading
+   is pinned to). Emits :workflow/id nil."
+  events/repo-index-coverage-changed)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -754,6 +754,7 @@
    string for empty/nil input). Pure: no IO. Arities: (events) uses a
    60s default gap; (events opts) takes {:gap-threshold-ms long}."
   timeline/render-timeline)
+
 ;------------------------------------------------------------------------------ Layer 9.5
 ;; Repository index intelligence event constructors (RN-19/20)
 

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -503,3 +503,19 @@
    (:workflow/phase, :agent/backend, :agent/session-id). Must be emitted
    before the first tool call so resume-on-kill has a valid session id."
   core/agent-session-captured)
+;------------------------------------------------------------------------------ Layer 9.5
+;; Repository index intelligence event constructors (RN-19/20)
+
+(def repo-index-quality-measured
+  "Build and return a :repo-index/quality-measured event envelope map
+   (RN-19) for a re-scored index entry (:index/id, :index/quality-score,
+   :index/staleness-ms, :index/coverage); optional :tree-sha as
+   :index/tree-sha."
+  core/repo-index-quality-measured)
+
+(def repo-index-coverage-changed
+  "Build and return a :repo-index/coverage-changed event envelope map
+   (RN-20) for a material change in tracked-file coverage (:index/id,
+   :index/coverage, :index/previous-coverage); optional :tree-sha as
+   :index/tree-sha."
+  core/repo-index-coverage-changed)

--- a/components/event-stream/test/ai/miniforge/event_stream/repo_index_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/repo_index_events_test.clj
@@ -1,0 +1,214 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.repo-index-events-test
+  "Constructor tests for the two repo-index intelligence event types (RN-19/20):
+     :repo-index/quality-measured   (repo-index-quality-measured)
+     :repo-index/coverage-changed   (repo-index-coverage-changed)
+
+   Coverage:
+     1. Happy path — correct :event/type, required domain fields, :workflow/id nil.
+     2. Optional :tree-sha present → :index/tree-sha assoc'd onto the map.
+     3. Optional :tree-sha absent → key not in map.
+     4. :message is non-nil and non-blank.
+     5. Envelope fields (id, timestamp, version, sequence-number) are present and typed.
+     6. Schema conformance via malli for both event types."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.string :as str]
+   [malli.core :as m]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.event-stream.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Named constants — no magic literals in test bodies
+
+(def ^:private index-id          "owner/repo")
+(def ^:private quality-score     0.87)
+(def ^:private staleness-ms      45000)
+(def ^:private coverage          0.95)
+(def ^:private previous-coverage 0.80)
+(def ^:private tree-sha          "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+
+(defn- stream [] (es/create-event-stream))
+
+;------------------------------------------------------------------------------ Layer 1
+;; repo-index-quality-measured happy path
+
+(deftest quality-measured-event-type-test
+  (testing "emits :repo-index/quality-measured event type"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage)]
+      (is (= :repo-index/quality-measured (:event/type ev))))))
+
+(deftest quality-measured-workflow-id-nil-test
+  (testing ":workflow/id is nil — index re-scoring runs outside any workflow"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage)]
+      (is (nil? (:workflow/id ev))))))
+
+(deftest quality-measured-domain-fields-test
+  (testing "required domain fields carry the supplied values"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage)]
+      (is (= index-id      (:index/id ev)))
+      (is (= quality-score (:index/quality-score ev)))
+      (is (= staleness-ms  (:index/staleness-ms ev)))
+      (is (= coverage      (:index/coverage ev))))))
+
+(deftest quality-measured-message-non-blank-test
+  (testing ":message is a non-nil, non-blank string"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage)]
+      (is (string? (:message ev)))
+      (is (not (str/blank? (:message ev)))))))
+
+(deftest quality-measured-envelope-fields-test
+  (testing "standard envelope fields are present and correctly typed"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage)]
+      (is (uuid? (:event/id ev)))
+      (is (inst? (:event/timestamp ev)))
+      (is (string? (:event/version ev)))
+      (is (int? (:event/sequence-number ev))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; repo-index-quality-measured optional :tree-sha
+
+(deftest quality-measured-tree-sha-present-test
+  (testing "optional :tree-sha opt → :index/tree-sha is assoc'd"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage
+              {:tree-sha tree-sha})]
+      (is (= tree-sha (:index/tree-sha ev))))))
+
+(deftest quality-measured-tree-sha-absent-test
+  (testing "omitting opts → :index/tree-sha key not in map"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage)]
+      (is (not (contains? ev :index/tree-sha))))))
+
+(deftest quality-measured-empty-opts-no-tree-sha-test
+  (testing "empty opts map → :index/tree-sha key not in map"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage {})]
+      (is (not (contains? ev :index/tree-sha))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; repo-index-quality-measured schema conformance
+
+(deftest quality-measured-schema-conforms-test
+  (testing "emitted event passes RepoIndexQualityMeasured malli schema"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage)]
+      (is (m/validate schema/RepoIndexQualityMeasured ev)))))
+
+(deftest quality-measured-schema-with-tree-sha-conforms-test
+  (testing "event with optional :tree-sha passes schema"
+    (let [ev (es/repo-index-quality-measured
+              (stream) index-id quality-score staleness-ms coverage
+              {:tree-sha tree-sha})]
+      (is (m/validate schema/RepoIndexQualityMeasured ev)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; repo-index-coverage-changed happy path
+
+(deftest coverage-changed-event-type-test
+  (testing "emits :repo-index/coverage-changed event type"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage)]
+      (is (= :repo-index/coverage-changed (:event/type ev))))))
+
+(deftest coverage-changed-workflow-id-nil-test
+  (testing ":workflow/id is nil — coverage re-evaluation is background work"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage)]
+      (is (nil? (:workflow/id ev))))))
+
+(deftest coverage-changed-domain-fields-test
+  (testing "required domain fields carry the supplied values"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage)]
+      (is (= index-id          (:index/id ev)))
+      (is (= coverage          (:index/coverage ev)))
+      (is (= previous-coverage (:index/previous-coverage ev))))))
+
+(deftest coverage-changed-message-non-blank-test
+  (testing ":message is a non-nil, non-blank string"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage)]
+      (is (string? (:message ev)))
+      (is (not (str/blank? (:message ev)))))))
+
+(deftest coverage-changed-envelope-fields-test
+  (testing "standard envelope fields are present and correctly typed"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage)]
+      (is (uuid? (:event/id ev)))
+      (is (inst? (:event/timestamp ev)))
+      (is (string? (:event/version ev)))
+      (is (int? (:event/sequence-number ev))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; repo-index-coverage-changed optional :tree-sha
+
+(deftest coverage-changed-tree-sha-present-test
+  (testing "optional :tree-sha opt → :index/tree-sha is assoc'd"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage
+              {:tree-sha tree-sha})]
+      (is (= tree-sha (:index/tree-sha ev))))))
+
+(deftest coverage-changed-tree-sha-absent-test
+  (testing "omitting opts → :index/tree-sha key not in map"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage)]
+      (is (not (contains? ev :index/tree-sha))))))
+
+(deftest coverage-changed-empty-opts-no-tree-sha-test
+  (testing "empty opts map → :index/tree-sha key not in map"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage {})]
+      (is (not (contains? ev :index/tree-sha))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; repo-index-coverage-changed schema conformance
+
+(deftest coverage-changed-schema-conforms-test
+  (testing "emitted event passes RepoIndexCoverageChanged malli schema"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage)]
+      (is (m/validate schema/RepoIndexCoverageChanged ev)))))
+
+(deftest coverage-changed-schema-with-tree-sha-conforms-test
+  (testing "event with optional :tree-sha passes schema"
+    (let [ev (es/repo-index-coverage-changed
+              (stream) index-id coverage previous-coverage
+              {:tree-sha tree-sha})]
+      (is (m/validate schema/RepoIndexCoverageChanged ev)))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Interface delegation — public API is reachable through interface.clj
+
+(deftest quality-measured-accessible-via-interface-test
+  (testing "repo-index-quality-measured is accessible through the public interface"
+    (is (fn? es/repo-index-quality-measured))))
+
+(deftest coverage-changed-accessible-via-interface-test
+  (testing "repo-index-coverage-changed is accessible through the public interface"
+    (is (fn? es/repo-index-coverage-changed))))


### PR DESCRIPTION
---
miniforge-workflow: d60df000-f2e4-4993-9ec1-244e29d209b7
spec: work/rn-03-reliability-events.spec.edn
task: 22222222-2222-4222-8222-222222222222
commit: e63d2a2c1ed27dafde6ad6206a93da16fca8c559
generated-by: miniforge
---

## Summary

Add constructor functions for the 2 new repo-index event types in

## Changes

- `components/event-stream/test/ai/miniforge/event_stream/repo_index_events_test.clj` (create)
- `components/event-stream/resources/config/event-stream/messages/en-US.edn` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/core.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/interface/events.clj` (modify)

## Review

**Decision**: approved

Two new repo-index event constructors (repo-index-quality-measured, repo-index-coverage-changed) wired correctly through core → interface/events → interface. Logic is sound: create-envelope called with nil workflow-id (correct — background work), messages/t used for the :message field, named constant index-ratio-fmt with an intent-bearing docstring covers the format string, cond-> with :tree-sha correctly handles nil opts. Tests pass (22 tests, 35 assertions, 0 failures). The only findings are the layer-numbering gap in both interface files (monotone but jarring), a missing blank line in events.clj, and absent boundary validation for numeric preconditions. Pre-existing loop FSM test failures and missing PR doc are out-of-scope observations.

### Known issues (non-blocking)

Merged with 4 unresolved non-blocking issue(s) recorded for follow-up:

- `components/event-stream/src/ai/miniforge/event_stream/interface/events.clj` — Layer jump from 3.5 to 9.5 inside a pure pass-through file. Monotonically increasing — no actual dependency inversion — but the 6-stratum gap makes the file's organization opaque to readers who don't know the jump mirrors core.clj's own numbering.
- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` — Layer jump from 5 to 9.5. Same root cause as events.clj: the section header tracks core.clj's numbering rather than the interface file's own stratum sequence. The file now has 7 distinct layer labels (0, 1, 2, 3, 4, 5, 9.5), which exceeds the >5 split-signal threshold mentioned in the clojure style guide.
- `components/event-stream/src/ai/miniforge/event_stream/interface/events.clj` — No blank line between the end of the Layer 3.5 section (`agent-session-captured` def) and the Layer 9.5 section header. Every other section transition in the file has one.
- `components/event-stream/src/ai/miniforge/event_stream/core.clj` — Docstrings on `repo-index-quality-measured` and `repo-index-coverage-changed` state numeric range preconditions ([0.0, 1.0] for scores/coverage, >= 0 for staleness-ms) but no validation occurs at the interface boundary. All existing event constructors in this component follow the same un-validated pattern, so this is consistent — but the gap between the documented contract and enforced contract is worth flagging.

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (5 files)