### PR TITLE
fix(logging): implement rotated log cleanup

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/observability.clj
+++ b/bases/cli/src/ai/miniforge/cli/observability.clj
@@ -30,7 +30,8 @@
    [clojure.edn :as edn]
    [cheshire.core :as json]
    [ai.miniforge.cli.app-config :as app-config]
-   [ai.miniforge.cli.messages :as messages]))
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.logging.interface :as logging]))
 
 ;;------------------------------------------------------------------------------ ANSI Colors
 
@@ -413,11 +414,8 @@
     "list" (list-files-command find-log-files "log files")
     "cat" (cat-file-command file)
     "cleanup" (let [logs-dir (app-config/logs-dir)
-                    deleted (requiring-resolve 'ai.miniforge.logging.core/cleanup-old-rotated-logs)]
-                (if deleted
-                  (let [count (deleted logs-dir 7)]
-                    (println (colorize :green (messages/t :observability/cleanup-result {:count count}))))
-                  (println (colorize :yellow (messages/t :observability/cleanup-not-available)))))
+                    count (logging/cleanup-old-rotated-logs logs-dir 7)]
+                (println (colorize :green (messages/t :observability/cleanup-result {:count count}))))
     (println (colorize :red (messages/t :observability/unknown-subcommand {:subcommand subcommand})))))
 
 ;;------------------------------------------------------------------------------ Layer 2.5: Workflow timeline (show)

--- a/components/logging/src/ai/miniforge/logging/core.clj
+++ b/components/logging/src/ai/miniforge/logging/core.clj
@@ -157,6 +157,25 @@
           rotated-path (str file-path "." timestamp)]
       (.renameTo (io/file file-path) (io/file rotated-path)))))
 
+(defn cleanup-old-rotated-logs
+  "Delete rotated log files in `logs-dir` older than `retention-days`.
+
+   Rotated files are named like `<workflow-id>.log.yyyyMMdd-HHmmss`.
+   Returns the number of files deleted."
+  [logs-dir retention-days]
+  (let [dir (io/file logs-dir)
+        retention-days (max 0 (long retention-days))
+        cutoff (- (System/currentTimeMillis)
+                  (* retention-days 24 60 60 1000))
+        rotated-log? #(boolean (re-matches #".+\.log\.\d{8}-\d{6}" (.getName ^java.io.File %)))]
+    (if-not (.exists dir)
+      0
+      (->> (.listFiles dir)
+           (filter rotated-log?)
+           (filter #(< (.lastModified ^java.io.File %) cutoff))
+           (filter #(.delete ^java.io.File %))
+           count))))
+
 (defn file-output-fn
   "Output function that writes logs to per-workflow files.
 

--- a/components/logging/src/ai/miniforge/logging/interface.clj
+++ b/components/logging/src/ai/miniforge/logging/interface.clj
@@ -166,6 +166,12 @@
   [logger level category event & body]
   `(timed ~logger ~level ~category ~event (fn [] ~@body)))
 
+(defn cleanup-old-rotated-logs
+  "Delete rotated log files in `logs-dir` older than `retention-days`.
+   Returns the number of files deleted."
+  [logs-dir retention-days]
+  (core/cleanup-old-rotated-logs logs-dir retention-days))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; HTTP request builder — used by both the in-brick fleet sink and the
 ;; event-stream fleet sink. Pass-through to `ai.miniforge.logging.http`.

--- a/components/logging/test/ai/miniforge/logging/interface_test.clj
+++ b/components/logging/test/ai/miniforge/logging/interface_test.clj
@@ -206,6 +206,32 @@
       (is (= :done result))
       (is (= 1 @calls)))))
 
+(deftest cleanup-old-rotated-logs-test
+  (testing "deletes only rotated logs older than the retention window"
+    (let [dir (java.nio.file.Files/createTempDirectory "miniforge-logs-test" (make-array java.nio.file.attribute.FileAttribute 0))
+          old-rotated (.toFile (.resolve dir "workflow.log.20250101-000000"))
+          new-rotated (.toFile (.resolve dir "workflow.log.20260101-000000"))
+          active-log (.toFile (.resolve dir "workflow.log"))
+          old-plain (.toFile (.resolve dir "plain.txt"))]
+      (try
+        (doseq [f [old-rotated new-rotated active-log old-plain]]
+          (spit f "x"))
+        (let [old-time (- (System/currentTimeMillis) (* 10 24 60 60 1000))
+              new-time (System/currentTimeMillis)]
+          (.setLastModified old-rotated old-time)
+          (.setLastModified old-plain old-time)
+          (.setLastModified new-rotated new-time)
+          (.setLastModified active-log old-time))
+        (is (= 1 (log/cleanup-old-rotated-logs (.toString dir) 7)))
+        (is (not (.exists old-rotated)))
+        (is (.exists new-rotated))
+        (is (.exists active-log))
+        (is (.exists old-plain))
+        (finally
+          (doseq [f [old-rotated new-rotated active-log old-plain]]
+            (when (.exists f) (.delete f)))
+          (.delete (.toFile dir)))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.logging.interface-test)


### PR DESCRIPTION
## Summary
- implement logging cleanup for rotated log files older than a retention window
- expose cleanup through logging.interface
- call the logging interface directly from the CLI logs cleanup command
- add a focused interface test that preserves active logs and non-log files

## Standards
- removes a dead requiring-resolve path by making the missing behavior real and routing the CLI through the component interface
- leaves the separate logging core/sinks cycle sites out of scope for a dedicated design split

## Validation
- clj-kondo --lint components/logging/src/ai/miniforge/logging/core.clj components/logging/src/ai/miniforge/logging/interface.clj components/logging/test/ai/miniforge/logging/interface_test.clj bases/cli/src/ai/miniforge/cli/observability.clj
- clojure -M:poly test brick:logging
- bb pre-commit