### PR TITLE
Add 4 reliability metric event schemas and 2 repository intelligence...

### DIFF
--- a/components/event-stream/resources/config/event-stream/event-type-registry.edn
+++ b/components/event-stream/resources/config/event-stream/event-type-registry.edn
@@ -348,4 +348,38 @@
   :json-string    "workflow/dag-skipped"
   :browser?       false
   :asymmetry?     true
-  :asymmetry-note "Constructor name implies namespace 'dag'; actual namespace is 'workflow'"}]
+  :asymmetry-note "Constructor name implies namespace 'dag'; actual namespace is 'workflow'"}
+
+ ;; ── Reliability metric events (RN-03, N3 §3.17) ──────────────────────────
+
+ {:constructor "sli-computed"
+  :event-type  :reliability/sli-computed
+  :json-string "reliability/sli-computed"
+  :browser?    false}
+
+ {:constructor "slo-breach"
+  :event-type  :reliability/slo-breach
+  :json-string "reliability/slo-breach"
+  :browser?    false}
+
+ {:constructor "error-budget-update"
+  :event-type  :reliability/error-budget-update
+  :json-string "reliability/error-budget-update"
+  :browser?    false}
+
+ {:constructor "degradation-mode-changed"
+  :event-type  :reliability/degradation-mode-changed
+  :json-string "reliability/degradation-mode-changed"
+  :browser?    false}
+
+ ;; ── Repository intelligence events (RN-19/20, N3 §3.18) ──────────────────
+
+ {:constructor "repo-index-quality-measured"
+  :event-type  :repo-index/quality-measured
+  :json-string "repo-index/quality-measured"
+  :browser?    false}
+
+ {:constructor "repo-index-coverage-changed"
+  :event-type  :repo-index/coverage-changed
+  :json-string "repo-index/coverage-changed"
+  :browser?    false}]

--- a/components/event-stream/resources/config/event-stream/messages/en-US.edn
+++ b/components/event-stream/resources/config/event-stream/messages/en-US.edn
@@ -86,4 +86,11 @@
   "fleet-sink: interrupted during flush: {error}"
 
   :fleet-sink.system/flush-error
-  "fleet-sink: flush error: {error}"}}
+  "fleet-sink: flush error: {error}"
+
+  ;; Repository index quality tracker (RN-19/20)
+  :repo-index/quality-measured
+  "Index {index-id} quality measured: {quality-score}"
+
+  :repo-index/coverage-changed
+  "Index {index-id} coverage changed to {coverage}"}}

--- a/components/event-stream/resources/config/event-stream/messages/en-US.edn
+++ b/components/event-stream/resources/config/event-stream/messages/en-US.edn
@@ -88,6 +88,21 @@
   :fleet-sink.system/flush-error
   "fleet-sink: flush error: {error}"
 
+  ;; Reliability metric event constructors (N3 §3.17, N1 §5.5)
+  ;; System-facing observability strings — routed through catalog so
+  ;; they stay auditable and overridable without a code release.
+  :reliability/sli-computed
+  "SLI computed: {sli-name} = {value} over {window}"
+
+  :reliability/slo-breach
+  "SLO breach: {sli-name} target={target} actual={actual} tier={tier}"
+
+  :reliability/error-budget-update
+  "Error budget: tier={tier} sli={sli} remaining={remaining} burn-rate={burn-rate}"
+
+  :reliability/degradation-mode-changed
+  "Degradation mode: {from} -> {to} ({trigger})"
+
   ;; Repository index quality tracker (RN-19/20)
   :repo-index/quality-measured
   "Index {index-id} quality measured: {quality-score}"

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1242,8 +1242,10 @@
   "Emit when an SLI value is computed over a rolling window."
   [stream sli-name value window & [opts]]
   (-> (create-envelope stream :reliability/sli-computed nil
-                       (format "SLI computed: %s = %.3f over %s"
-                               (name sli-name) (double value) (name window)))
+                       (messages/t :reliability/sli-computed
+                                   {:sli-name (name sli-name)
+                                    :value    value
+                                    :window   (name window)}))
       (assoc :sli/name sli-name
              :sli/value value
              :sli/window window)
@@ -1255,8 +1257,11 @@
   "Emit when an SLO target is missed for :standard or :critical tiers."
   [stream sli-name target actual tier window]
   (-> (create-envelope stream :reliability/slo-breach nil
-                       (format "SLO breach: %s target=%.3f actual=%.3f tier=%s"
-                               (name sli-name) (double target) (double actual) (name tier)))
+                       (messages/t :reliability/slo-breach
+                                   {:sli-name (name sli-name)
+                                    :target   target
+                                    :actual   actual
+                                    :tier     (name tier)}))
       (assoc :slo/sli-name sli-name
              :slo/target target
              :slo/actual actual
@@ -1267,8 +1272,11 @@
   "Emit when error budget state is recomputed."
   [stream tier sli remaining burn-rate window]
   (-> (create-envelope stream :reliability/error-budget-update nil
-                       (format "Error budget: tier=%s sli=%s remaining=%.3f burn-rate=%.2f"
-                               (name tier) (name sli) (double remaining) (double burn-rate)))
+                       (messages/t :reliability/error-budget-update
+                                   {:tier      (name tier)
+                                    :sli       (name sli)
+                                    :remaining remaining
+                                    :burn-rate burn-rate}))
       (assoc :budget/tier tier
              :budget/sli sli
              :budget/remaining remaining
@@ -1279,8 +1287,10 @@
   "Emit when the system transitions between degradation modes (N1 §5.5.5)."
   [stream from-mode to-mode trigger]
   (-> (create-envelope stream :reliability/degradation-mode-changed nil
-                       (format "Degradation mode: %s → %s (%s)"
-                               (name from-mode) (name to-mode) trigger))
+                       (messages/t :reliability/degradation-mode-changed
+                                   {:from    (name from-mode)
+                                    :to      (name to-mode)
+                                    :trigger trigger}))
       (assoc :degradation/from from-mode
              :degradation/to to-mode
              :degradation/trigger trigger)))

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1349,7 +1349,7 @@
                     previous-status
                     :dependency/recovered))
 
-;------------------------------------------------------------------------------ Layer 6
+;------------------------------------------------------------------------------ Layer 6.1
 ;; Repository intelligence event constructors (RN-19/20)
 
 (defn repo-index-quality-measured
@@ -1399,7 +1399,7 @@
              :index/coverage coverage)
       (cond-> (:changed-files opts) (assoc :index/changed-files (:changed-files opts)))))
 
-;------------------------------------------------------------------------------ Layer 6
+;------------------------------------------------------------------------------ Layer 6.2
 ;; Meta-loop events
 
 (defn meta-loop-cycle-completed

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1339,6 +1339,56 @@
                     previous-status
                     :dependency/recovered))
 
+;------------------------------------------------------------------------------ Layer 6.3
+;; Repository intelligence event constructors (RN-19/20)
+
+(defn repo-index-quality-measured
+  "Build a :repo-index/quality-measured event.
+
+   Emitted by the index quality tracker (RN-19) when it samples the
+   composite quality score for a named index.
+
+   Arguments:
+   - stream:        event-stream atom
+   - index-id:      string slug identifying the index (e.g. \"main-code-index\")
+   - quality-score: number in [0.0, 1.0] — composite quality ratio
+   - coverage:      number in [0.0, 1.0] — fraction of files indexed
+   - staleness-ms:  int — age of oldest document in the index (milliseconds)
+   - opts:          optional map; `:measured-at` adds an explicit inst timestamp"
+  [stream index-id quality-score coverage staleness-ms & [opts]]
+  (-> (create-envelope stream :repo-index/quality-measured nil
+                       (messages/t :repo-index/quality-measured
+                                   {:index-id index-id
+                                    :quality-score quality-score}))
+      (assoc :index/id index-id
+             :index/quality-score quality-score
+             :index/coverage coverage
+             :index/staleness-ms staleness-ms)
+      (cond-> (:measured-at opts) (assoc :index/measured-at (:measured-at opts)))))
+
+(defn repo-index-coverage-changed
+  "Build a :repo-index/coverage-changed event.
+
+   Emitted by the index quality tracker (RN-20) when the coverage ratio
+   of a named index changes beyond the configured threshold.
+
+   Arguments:
+   - stream:             event-stream atom
+   - index-id:           string slug identifying the index
+   - previous-coverage:  number in [0.0, 1.0] — coverage before the change
+   - coverage:           number in [0.0, 1.0] — coverage after the change
+   - opts:               optional map; `:changed-files` adds the count of
+                         files whose index state changed in this transition"
+  [stream index-id previous-coverage coverage & [opts]]
+  (-> (create-envelope stream :repo-index/coverage-changed nil
+                       (messages/t :repo-index/coverage-changed
+                                   {:index-id index-id
+                                    :coverage coverage}))
+      (assoc :index/id index-id
+             :index/previous-coverage previous-coverage
+             :index/coverage coverage)
+      (cond-> (:changed-files opts) (assoc :index/changed-files (:changed-files opts)))))
+
 ;------------------------------------------------------------------------------ Layer 6
 ;; Meta-loop events
 

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1349,7 +1349,7 @@
                     previous-status
                     :dependency/recovered))
 
-;------------------------------------------------------------------------------ Layer 6.3
+;------------------------------------------------------------------------------ Layer 6
 ;; Repository intelligence event constructors (RN-19/20)
 
 (defn repo-index-quality-measured

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -672,6 +672,23 @@
    :safe-mode/workflows-queued)."
   events/safe-mode-exited)
 
+;; Repository intelligence event constructors (RN-19/20)
+(def repo-index-quality-measured
+  "Build and return a :repo-index/quality-measured event envelope map
+   (:workflow/id nil) emitted by the index quality tracker (RN-19) when
+   it samples the composite quality score for a named index
+   (:index/id, :index/quality-score, :index/coverage, :index/staleness-ms);
+   optional opts add :index/measured-at."
+  events/repo-index-quality-measured)
+
+(def repo-index-coverage-changed
+  "Build and return a :repo-index/coverage-changed event envelope map
+   (:workflow/id nil) emitted by the index quality tracker (RN-20) when
+   coverage for a named index changes beyond the configured threshold
+   (:index/id, :index/previous-coverage, :index/coverage); optional opts
+   add :index/changed-files."
+  events/repo-index-coverage-changed)
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Meta-loop event constructors
 
@@ -754,21 +771,3 @@
    string for empty/nil input). Pure: no IO. Arities: (events) uses a
    60s default gap; (events opts) takes {:gap-threshold-ms long}."
   timeline/render-timeline)
-;------------------------------------------------------------------------------ Layer 2
-;; Repository intelligence event constructors (RN-19/20)
-
-(def repo-index-quality-measured
-  "Build and return a :repo-index/quality-measured event envelope map
-   (:workflow/id nil) emitted by the index quality tracker (RN-19) when
-   it samples the composite quality score for a named index
-   (:index/id, :index/quality-score, :index/coverage, :index/staleness-ms);
-   optional opts add :index/measured-at."
-  events/repo-index-quality-measured)
-
-(def repo-index-coverage-changed
-  "Build and return a :repo-index/coverage-changed event envelope map
-   (:workflow/id nil) emitted by the index quality tracker (RN-20) when
-   coverage for a named index changes beyond the configured threshold
-   (:index/id, :index/previous-coverage, :index/coverage); optional opts
-   add :index/changed-files."
-  events/repo-index-coverage-changed)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -754,3 +754,21 @@
    string for empty/nil input). Pure: no IO. Arities: (events) uses a
    60s default gap; (events opts) takes {:gap-threshold-ms long}."
   timeline/render-timeline)
+;------------------------------------------------------------------------------ Layer 2
+;; Repository intelligence event constructors (RN-19/20)
+
+(def repo-index-quality-measured
+  "Build and return a :repo-index/quality-measured event envelope map
+   (:workflow/id nil) emitted by the index quality tracker (RN-19) when
+   it samples the composite quality score for a named index
+   (:index/id, :index/quality-score, :index/coverage, :index/staleness-ms);
+   optional opts add :index/measured-at."
+  events/repo-index-quality-measured)
+
+(def repo-index-coverage-changed
+  "Build and return a :repo-index/coverage-changed event envelope map
+   (:workflow/id nil) emitted by the index quality tracker (RN-20) when
+   coverage for a named index changes beyond the configured threshold
+   (:index/id, :index/previous-coverage, :index/coverage); optional opts
+   add :index/changed-files."
+  events/repo-index-coverage-changed)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -503,3 +503,21 @@
    (:workflow/phase, :agent/backend, :agent/session-id). Must be emitted
    before the first tool call so resume-on-kill has a valid session id."
   core/agent-session-captured)
+;------------------------------------------------------------------------------ Layer 4
+;; Repository intelligence event constructors (RN-19/20)
+
+(def repo-index-quality-measured
+  "Build and return a :repo-index/quality-measured event envelope map
+   (:workflow/id nil) emitted when the index quality tracker (RN-19)
+   samples the composite quality score for a named index
+   (:index/id, :index/quality-score, :index/coverage, :index/staleness-ms);
+   optional opts add :index/measured-at."
+  core/repo-index-quality-measured)
+
+(def repo-index-coverage-changed
+  "Build and return a :repo-index/coverage-changed event envelope map
+   (:workflow/id nil) emitted when the index quality tracker (RN-20)
+   detects that coverage for a named index changed beyond the configured
+   threshold (:index/id, :index/previous-coverage, :index/coverage);
+   optional opts add :index/changed-files."
+  core/repo-index-coverage-changed)

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -694,7 +694,20 @@
    ;; event carries `:zettel/content` directly — Fleet's privacy
    ;; gates (Decision 8) decide whether the zettel is actually
    ;; cleared for cross-instance share, not the local default.
-   :zettel/promoted          :internal})
+   :zettel/promoted          :internal
+
+   ;; Reliability metric events (RN-03). Operator-facing alerts — an SLO
+   ;; breach and a degradation-mode transition — are `:public`; routine SLI
+   ;; reads and error-budget recomputations are `:internal` telemetry.
+   :reliability/sli-computed            :internal
+   :reliability/slo-breach              :public
+   :reliability/error-budget-update     :internal
+   :reliability/degradation-mode-changed :public
+
+   ;; Repository intelligence events (RN-19/20) — routine index-quality
+   ;; telemetry, `:internal`.
+   :repo-index/quality-measured :internal
+   :repo-index/coverage-changed :internal})
 
 (defn create-privacy-config
   "Create a privacy configuration by merging overrides into defaults.

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -961,6 +961,148 @@
     [:oci/duration-ms {:optional true} int?]
     [:message string?]]))
 
+;------------------------------------------------------------------------------ Layer 5.5
+;; Reliability metric event schemas (RN-03, N3 §3.17)
+;;
+;; Schemas for the 4 reliability metric events emitted by the SLI
+;; computation engine (RN-04). Field names match the assoc'd keys in
+;; the existing core.clj constructors (sli-computed, slo-breach,
+;; error-budget-update, degradation-mode-changed).
+
+(def SliComputed
+  "Schema for :reliability/sli-computed event.
+
+   Emitted by the SLI computation engine (RN-04) each time an SLI value
+   is computed over a rolling window.  `:sli/tier` and `:sli/dimensions`
+   are optional; single-tier deployments omit them."
+  (with-identity
+   [:map
+    [:event/type [:= :reliability/sli-computed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:sli/name keyword?]
+    [:sli/value number?]
+    [:sli/window keyword?]
+    [:sli/tier {:optional true} keyword?]
+    [:sli/dimensions {:optional true} map?]
+    [:message string?]]))
+
+(def SloBreach
+  "Schema for :reliability/slo-breach event.
+
+   Emitted when an SLO target is missed for :standard or :critical
+   tiers.  All 5 required fields are always present — there is no
+   partial-breach shape."
+  (with-identity
+   [:map
+    [:event/type [:= :reliability/slo-breach]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:slo/sli-name keyword?]
+    [:slo/target number?]
+    [:slo/actual number?]
+    [:slo/tier keyword?]
+    [:slo/window keyword?]
+    [:message string?]]))
+
+(def ErrorBudgetUpdate
+  "Schema for :reliability/error-budget-update event.
+
+   Emitted when error-budget state is recomputed after each SLI window
+   closes.  `:budget/remaining` is a ratio [0.0, 1.0]; `:budget/burn-rate`
+   is a dimensionless multiplier (>1 = burning faster than replenished)."
+  (with-identity
+   [:map
+    [:event/type [:= :reliability/error-budget-update]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:budget/tier keyword?]
+    [:budget/sli keyword?]
+    [:budget/remaining number?]
+    [:budget/burn-rate number?]
+    [:budget/window keyword?]
+    [:message string?]]))
+
+(def DegradationModeChanged
+  "Schema for :reliability/degradation-mode-changed event.
+
+   Emitted when the system transitions between degradation modes per
+   N1 §5.5.5.  `:degradation/trigger` is a human-readable string
+   describing the condition that caused the transition."
+  (with-identity
+   [:map
+    [:event/type [:= :reliability/degradation-mode-changed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:degradation/from keyword?]
+    [:degradation/to keyword?]
+    [:degradation/trigger string?]
+    [:message string?]]))
+
+;------------------------------------------------------------------------------ Layer 6
+;; Repository intelligence event schemas (RN-19/20)
+;;
+;; Schemas for the 2 repo-index events emitted by the index quality
+;; tracker (RN-19/20).  `:index/id` is a string slug identifying the
+;; index (e.g. "main-code-index"); quality and coverage are ratios
+;; in [0.0, 1.0]; staleness is elapsed wall-clock milliseconds.
+
+(def RepoIndexQualityMeasured
+  "Schema for :repo-index/quality-measured event.
+
+   Emitted by the index quality tracker (RN-19) each time it samples
+   the composite quality score for a named index.  `:index/staleness-ms`
+   is the age of the oldest document in the index at measurement time.
+   `:index/measured-at` is optional (defaults to envelope timestamp
+   when absent)."
+  (with-identity
+   [:map
+    [:event/type [:= :repo-index/quality-measured]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:index/id string?]
+    [:index/quality-score number?]
+    [:index/coverage number?]
+    [:index/staleness-ms int?]
+    [:index/measured-at {:optional true} inst?]
+    [:message string?]]))
+
+(def RepoIndexCoverageChanged
+  "Schema for :repo-index/coverage-changed event.
+
+   Emitted by the index quality tracker (RN-20) when the coverage ratio
+   of a named index changes beyond the configured threshold.
+   `:index/changed-files` is the count of files whose index state
+   changed in this transition; optional (omit when not computable)."
+  (with-identity
+   [:map
+    [:event/type [:= :repo-index/coverage-changed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:index/id string?]
+    [:index/previous-coverage number?]
+    [:index/coverage number?]
+    [:index/changed-files {:optional true} int?]
+    [:message string?]]))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Example event

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -973,8 +973,11 @@
   "Schema for :reliability/sli-computed event.
 
    Emitted by the SLI computation engine (RN-04) each time an SLI value
-   is computed over a rolling window.  `:sli/tier` and `:sli/dimensions`
-   are optional; single-tier deployments omit them."
+   is computed over a rolling window.  `:sli/value` is in the SLI's native
+   units — a ratio in [0.0, 1.0] for rate-based SLIs (availability, success
+   rate) or an absolute measure (e.g. latency ms) for others — so it is not
+   range-constrained.  `:sli/tier` and `:sli/dimensions` are optional;
+   single-tier deployments omit them."
   (with-identity
    [:map
     [:event/type [:= :reliability/sli-computed]]
@@ -995,7 +998,9 @@
 
    Emitted when an SLO target is missed for :standard or :critical
    tiers.  All 5 required fields are always present — there is no
-   partial-breach shape."
+   partial-breach shape.  `:slo/target` and `:slo/actual` are in the SLI's
+   native units (a ratio for rate-based SLIs, an absolute measure such as
+   latency ms for others), so they are not range-constrained."
   (with-identity
    [:map
     [:event/type [:= :reliability/slo-breach]]
@@ -1027,8 +1032,10 @@
     [:workflow/id {:optional true} [:maybe uuid?]]
     [:budget/tier keyword?]
     [:budget/sli keyword?]
-    [:budget/remaining number?]
-    [:budget/burn-rate number?]
+    ;; ratio in [0.0, 1.0]; burn-rate is a non-negative multiplier
+    ;; (>1 = burning faster than replenished, 0 = not burning)
+    [:budget/remaining [:and number? [:>= 0] [:<= 1]]]
+    [:budget/burn-rate [:and number? [:>= 0]]]
     [:budget/window keyword?]
     [:message string?]]))
 
@@ -1076,9 +1083,11 @@
     [:event/sequence-number int?]
     [:workflow/id {:optional true} [:maybe uuid?]]
     [:index/id string?]
-    [:index/quality-score number?]
-    [:index/coverage number?]
-    [:index/staleness-ms int?]
+    ;; quality and coverage are ratios in [0.0, 1.0]; staleness is a
+    ;; non-negative elapsed-ms value
+    [:index/quality-score [:and number? [:>= 0] [:<= 1]]]
+    [:index/coverage [:and number? [:>= 0] [:<= 1]]]
+    [:index/staleness-ms [:and int? [:>= 0]]]
     [:index/measured-at {:optional true} inst?]
     [:message string?]]))
 
@@ -1098,9 +1107,10 @@
     [:event/sequence-number int?]
     [:workflow/id {:optional true} [:maybe uuid?]]
     [:index/id string?]
-    [:index/previous-coverage number?]
-    [:index/coverage number?]
-    [:index/changed-files {:optional true} int?]
+    ;; coverage ratios in [0.0, 1.0]; changed-files is a non-negative count
+    [:index/previous-coverage [:and number? [:>= 0] [:<= 1]]]
+    [:index/coverage [:and number? [:>= 0] [:<= 1]]]
+    [:index/changed-files {:optional true} [:and int? [:>= 0]]]
     [:message string?]]))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
@@ -38,8 +38,6 @@
 (defn- make-stream []
   (es/create-event-stream {:sinks []}))
 
-(def ^:private wf-id (random-uuid))
-
 ;; ---------------------------------------------------------------------------
 ;; Layer 5.5 — Reliability metric schemas
 

--- a/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
@@ -239,6 +239,71 @@
           "missing :index/previous-coverage should fail"))))
 
 ;; ---------------------------------------------------------------------------
+;; Range-bound rejection (Copilot review on #1172): docstrings promise ratios
+;; in [0.0, 1.0] and non-negative counts/durations; the Malli schemas must
+;; enforce them so out-of-contract telemetry is rejected at validation.
+
+(defn- valid-error-budget [overrides]
+  (merge {:event/type            :reliability/error-budget-update
+          :event/id              (random-uuid)
+          :event/timestamp       (java.util.Date.)
+          :event/version         "1.0.0"
+          :event/sequence-number 0
+          :budget/tier           :standard
+          :budget/sli            :availability
+          :budget/remaining      0.72
+          :budget/burn-rate      1.4
+          :budget/window         :rolling-30d
+          :message               "Error budget update"}
+         overrides))
+
+(defn- valid-quality-measured [overrides]
+  (merge {:event/type            :repo-index/quality-measured
+          :event/id              (random-uuid)
+          :event/timestamp       (java.util.Date.)
+          :event/version         "1.0.0"
+          :event/sequence-number 0
+          :index/id              "main-code-index"
+          :index/quality-score   0.87
+          :index/coverage        0.93
+          :index/staleness-ms    300000
+          :message               "Index quality measured"}
+         overrides))
+
+(defn- valid-coverage-changed [overrides]
+  (merge {:event/type              :repo-index/coverage-changed
+          :event/id                (random-uuid)
+          :event/timestamp         (java.util.Date.)
+          :event/version           "1.0.0"
+          :event/sequence-number   0
+          :index/id                "main-code-index"
+          :index/previous-coverage 0.80
+          :index/coverage          0.93
+          :index/changed-files     12
+          :message                 "Index coverage changed"}
+         overrides))
+
+(deftest range-bounds-rejection-test
+  (testing "ErrorBudgetUpdate :budget/remaining must be a [0.0, 1.0] ratio"
+    (is (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/remaining 0.0})))
+    (is (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/remaining 1.0})))
+    (is (not (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/remaining 1.5}))))
+    (is (not (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/remaining -0.1})))))
+  (testing "ErrorBudgetUpdate :budget/burn-rate is non-negative (0 ok, >1 ok, negative rejected)"
+    (is (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/burn-rate 0})))
+    (is (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/burn-rate 3.2})))
+    (is (not (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/burn-rate -1.0})))))
+  (testing "RepoIndexQualityMeasured ratios and non-negative staleness"
+    (is (not (m/validate schema/RepoIndexQualityMeasured (valid-quality-measured {:index/quality-score 1.4}))))
+    (is (not (m/validate schema/RepoIndexQualityMeasured (valid-quality-measured {:index/coverage -0.2}))))
+    (is (not (m/validate schema/RepoIndexQualityMeasured (valid-quality-measured {:index/staleness-ms -1})))))
+  (testing "RepoIndexCoverageChanged ratios and non-negative changed-files"
+    (is (not (m/validate schema/RepoIndexCoverageChanged (valid-coverage-changed {:index/coverage 2.0}))))
+    (is (not (m/validate schema/RepoIndexCoverageChanged (valid-coverage-changed {:index/previous-coverage -0.5}))))
+    (is (not (m/validate schema/RepoIndexCoverageChanged (valid-coverage-changed {:index/changed-files -3}))))
+    (is (m/validate schema/RepoIndexCoverageChanged (valid-coverage-changed {:index/changed-files 0})))))
+
+;; ---------------------------------------------------------------------------
 ;; Constructor output and round-trip tests
 
 (deftest sli-computed-constructor-test

--- a/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
@@ -237,9 +237,14 @@
           "missing :index/previous-coverage should fail"))))
 
 ;; ---------------------------------------------------------------------------
-;; Range-bound rejection (Copilot review on #1172): docstrings promise ratios
-;; in [0.0, 1.0] and non-negative counts/durations; the Malli schemas must
-;; enforce them so out-of-contract telemetry is rejected at validation.
+;; Range-bound rejection (Copilot review on #1172). The budget/index fields
+;; whose docstrings promise ratios in [0.0, 1.0] or non-negative counts/
+;; durations (:budget/remaining, :budget/burn-rate, :index/quality-score,
+;; :index/coverage, :index/previous-coverage, :index/staleness-ms,
+;; :index/changed-files) must reject out-of-contract values at validation.
+;; :sli/value, :slo/target and :slo/actual are intentionally unconstrained —
+;; they carry SLI-native units (a ratio for rate-based SLIs, an absolute
+;; measure such as latency ms for others) — so they are not covered here.
 
 (defn- valid-error-budget [overrides]
   (merge {:event/type            :reliability/error-budget-update

--- a/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
@@ -1,0 +1,369 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.reliability-schema-test
+  "Tests for RN-03: 4 reliability metric schemas + 2 repo-index schemas
+   and the constructor functions that produce conforming event maps.
+
+   Test strategy:
+   1. Schema positive: a hand-crafted valid map passes m/validate.
+   2. Schema negative: a map with a missing required field fails.
+   3. Constructor output: :event/type, :event/id (uuid), :event/timestamp
+      (inst), and all domain fields correct from arguments.
+   4. Round-trip: constructor output validates against its Malli schema."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as m]
+   [ai.miniforge.event-stream.schema :as schema]
+   [ai.miniforge.event-stream.interface :as es]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+
+(defn- make-stream []
+  (es/create-event-stream {:sinks []}))
+
+(def ^:private wf-id (random-uuid))
+
+;; ---------------------------------------------------------------------------
+;; Layer 5.5 — Reliability metric schemas
+
+(deftest sli-computed-schema-test
+  (testing "SliComputed positive validation"
+    (let [event {:event/type            :reliability/sli-computed
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :workflow/id           nil
+                 :sli/name              :availability
+                 :sli/value             0.999
+                 :sli/window            :rolling-1h
+                 :message               "SLI computed"}]
+      (is (m/validate schema/SliComputed event)
+          "valid SliComputed should pass")))
+
+  (testing "SliComputed negative — missing :sli/name"
+    (let [event {:event/type            :reliability/sli-computed
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :sli/value             0.999
+                 :sli/window            :rolling-1h
+                 :message               "SLI computed"}]
+      (is (not (m/validate schema/SliComputed event))
+          "missing :sli/name should fail")))
+
+  (testing "SliComputed negative — missing :sli/window"
+    (let [event {:event/type            :reliability/sli-computed
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :sli/name              :availability
+                 :sli/value             0.999
+                 :message               "SLI computed"}]
+      (is (not (m/validate schema/SliComputed event))
+          "missing :sli/window should fail"))))
+
+(deftest slo-breach-schema-test
+  (testing "SloBreach positive validation"
+    (let [event {:event/type            :reliability/slo-breach
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :slo/sli-name          :availability
+                 :slo/target            0.999
+                 :slo/actual            0.980
+                 :slo/tier              :standard
+                 :slo/window            :rolling-1h
+                 :message               "SLO breach"}]
+      (is (m/validate schema/SloBreach event)
+          "valid SloBreach should pass")))
+
+  (testing "SloBreach negative — missing :slo/actual"
+    (let [event {:event/type            :reliability/slo-breach
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :slo/sli-name          :availability
+                 :slo/target            0.999
+                 :slo/tier              :standard
+                 :slo/window            :rolling-1h
+                 :message               "SLO breach"}]
+      (is (not (m/validate schema/SloBreach event))
+          "missing :slo/actual should fail"))))
+
+(deftest error-budget-update-schema-test
+  (testing "ErrorBudgetUpdate positive validation"
+    (let [event {:event/type            :reliability/error-budget-update
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :budget/tier           :standard
+                 :budget/sli            :availability
+                 :budget/remaining      0.72
+                 :budget/burn-rate      1.4
+                 :budget/window         :rolling-30d
+                 :message               "Error budget updated"}]
+      (is (m/validate schema/ErrorBudgetUpdate event)
+          "valid ErrorBudgetUpdate should pass")))
+
+  (testing "ErrorBudgetUpdate negative — missing :budget/burn-rate"
+    (let [event {:event/type            :reliability/error-budget-update
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :budget/tier           :standard
+                 :budget/sli            :availability
+                 :budget/remaining      0.72
+                 :budget/window         :rolling-30d
+                 :message               "Error budget updated"}]
+      (is (not (m/validate schema/ErrorBudgetUpdate event))
+          "missing :budget/burn-rate should fail"))))
+
+(deftest degradation-mode-changed-schema-test
+  (testing "DegradationModeChanged positive validation"
+    (let [event {:event/type            :reliability/degradation-mode-changed
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :degradation/from      :normal
+                 :degradation/to        :degraded
+                 :degradation/trigger   "error-rate exceeded threshold"
+                 :message               "Degradation mode changed"}]
+      (is (m/validate schema/DegradationModeChanged event)
+          "valid DegradationModeChanged should pass")))
+
+  (testing "DegradationModeChanged negative — missing :degradation/trigger"
+    (let [event {:event/type            :reliability/degradation-mode-changed
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :degradation/from      :normal
+                 :degradation/to        :degraded
+                 :message               "Degradation mode changed"}]
+      (is (not (m/validate schema/DegradationModeChanged event))
+          "missing :degradation/trigger should fail"))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 6 — Repo-index schemas
+
+(deftest repo-index-quality-measured-schema-test
+  (testing "RepoIndexQualityMeasured positive validation"
+    (let [event {:event/type            :repo-index/quality-measured
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :index/id              "main-code-index"
+                 :index/quality-score   0.87
+                 :index/coverage        0.93
+                 :index/staleness-ms    300000
+                 :message               "Index quality measured"}]
+      (is (m/validate schema/RepoIndexQualityMeasured event)
+          "valid RepoIndexQualityMeasured should pass")))
+
+  (testing "RepoIndexQualityMeasured negative — missing :index/staleness-ms"
+    (let [event {:event/type            :repo-index/quality-measured
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :index/id              "main-code-index"
+                 :index/quality-score   0.87
+                 :index/coverage        0.93
+                 :message               "Index quality measured"}]
+      (is (not (m/validate schema/RepoIndexQualityMeasured event))
+          "missing :index/staleness-ms should fail")))
+
+  (testing "RepoIndexQualityMeasured negative — missing :index/id"
+    (let [event {:event/type            :repo-index/quality-measured
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :index/quality-score   0.87
+                 :index/coverage        0.93
+                 :index/staleness-ms    300000
+                 :message               "Index quality measured"}]
+      (is (not (m/validate schema/RepoIndexQualityMeasured event))
+          "missing :index/id should fail"))))
+
+(deftest repo-index-coverage-changed-schema-test
+  (testing "RepoIndexCoverageChanged positive validation"
+    (let [event {:event/type               :repo-index/coverage-changed
+                 :event/id                 (random-uuid)
+                 :event/timestamp          (java.util.Date.)
+                 :event/version            "1.0.0"
+                 :event/sequence-number    0
+                 :index/id                 "main-code-index"
+                 :index/previous-coverage  0.80
+                 :index/coverage           0.93
+                 :message                  "Index coverage changed"}]
+      (is (m/validate schema/RepoIndexCoverageChanged event)
+          "valid RepoIndexCoverageChanged should pass")))
+
+  (testing "RepoIndexCoverageChanged negative — missing :index/previous-coverage"
+    (let [event {:event/type            :repo-index/coverage-changed
+                 :event/id              (random-uuid)
+                 :event/timestamp       (java.util.Date.)
+                 :event/version         "1.0.0"
+                 :event/sequence-number 0
+                 :index/id              "main-code-index"
+                 :index/coverage        0.93
+                 :message               "Index coverage changed"}]
+      (is (not (m/validate schema/RepoIndexCoverageChanged event))
+          "missing :index/previous-coverage should fail"))))
+
+;; ---------------------------------------------------------------------------
+;; Constructor output and round-trip tests
+
+(deftest sli-computed-constructor-test
+  (testing "sli-computed constructor produces correct :event/type"
+    (let [stream (make-stream)
+          event  (es/sli-computed stream :availability 0.999 :rolling-1h)]
+      (is (= :reliability/sli-computed (:event/type event)))
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= :availability (:sli/name event)))
+      (is (= 0.999 (:sli/value event)))
+      (is (= :rolling-1h (:sli/window event)))))
+
+  (testing "sli-computed round-trip validates against SliComputed schema"
+    (let [stream (make-stream)
+          event  (es/sli-computed stream :availability 0.999 :rolling-1h)]
+      (is (m/validate schema/SliComputed event)
+          "constructor output must satisfy SliComputed schema")))
+
+  (testing "sli-computed optional :sli/tier threads through"
+    (let [stream (make-stream)
+          event  (es/sli-computed stream :latency 0.95 :rolling-5m {:tier :critical})]
+      (is (= :critical (:sli/tier event))))))
+
+(deftest slo-breach-constructor-test
+  (testing "slo-breach constructor produces correct :event/type"
+    (let [stream (make-stream)
+          event  (es/slo-breach stream :availability 0.999 0.980 :standard :rolling-1h)]
+      (is (= :reliability/slo-breach (:event/type event)))
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= :availability (:slo/sli-name event)))
+      (is (= 0.999 (:slo/target event)))
+      (is (= 0.980 (:slo/actual event)))
+      (is (= :standard (:slo/tier event)))
+      (is (= :rolling-1h (:slo/window event)))))
+
+  (testing "slo-breach round-trip validates against SloBreach schema"
+    (let [stream (make-stream)
+          event  (es/slo-breach stream :availability 0.999 0.980 :standard :rolling-1h)]
+      (is (m/validate schema/SloBreach event)
+          "constructor output must satisfy SloBreach schema"))))
+
+(deftest error-budget-update-constructor-test
+  (testing "error-budget-update constructor produces correct :event/type"
+    (let [stream (make-stream)
+          event  (es/error-budget-update stream :standard :availability 0.72 1.4 :rolling-30d)]
+      (is (= :reliability/error-budget-update (:event/type event)))
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= :standard (:budget/tier event)))
+      (is (= :availability (:budget/sli event)))
+      (is (= 0.72 (:budget/remaining event)))
+      (is (= 1.4 (:budget/burn-rate event)))
+      (is (= :rolling-30d (:budget/window event)))))
+
+  (testing "error-budget-update round-trip validates against ErrorBudgetUpdate schema"
+    (let [stream (make-stream)
+          event  (es/error-budget-update stream :standard :availability 0.72 1.4 :rolling-30d)]
+      (is (m/validate schema/ErrorBudgetUpdate event)
+          "constructor output must satisfy ErrorBudgetUpdate schema"))))
+
+(deftest degradation-mode-changed-constructor-test
+  (testing "degradation-mode-changed constructor produces correct :event/type"
+    (let [stream (make-stream)
+          event  (es/degradation-mode-changed stream :normal :degraded "error-rate exceeded")]
+      (is (= :reliability/degradation-mode-changed (:event/type event)))
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= :normal (:degradation/from event)))
+      (is (= :degraded (:degradation/to event)))
+      (is (= "error-rate exceeded" (:degradation/trigger event)))))
+
+  (testing "degradation-mode-changed round-trip validates against DegradationModeChanged schema"
+    (let [stream (make-stream)
+          event  (es/degradation-mode-changed stream :normal :degraded "error-rate exceeded")]
+      (is (m/validate schema/DegradationModeChanged event)
+          "constructor output must satisfy DegradationModeChanged schema"))))
+
+(deftest repo-index-quality-measured-constructor-test
+  (testing "repo-index-quality-measured produces correct :event/type"
+    (let [stream (make-stream)
+          event  (es/repo-index-quality-measured stream "main-code-index" 0.87 0.93 300000)]
+      (is (= :repo-index/quality-measured (:event/type event)))
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= "main-code-index" (:index/id event)))
+      (is (= 0.87 (:index/quality-score event)))
+      (is (= 0.93 (:index/coverage event)))
+      (is (= 300000 (:index/staleness-ms event)))))
+
+  (testing "repo-index-quality-measured round-trip validates against RepoIndexQualityMeasured"
+    (let [stream (make-stream)
+          event  (es/repo-index-quality-measured stream "main-code-index" 0.87 0.93 300000)]
+      (is (m/validate schema/RepoIndexQualityMeasured event)
+          "constructor output must satisfy RepoIndexQualityMeasured schema")))
+
+  (testing "repo-index-quality-measured optional :index/measured-at threads through"
+    (let [stream      (make-stream)
+          measured-at (java.util.Date.)
+          event       (es/repo-index-quality-measured
+                       stream "main-code-index" 0.87 0.93 300000
+                       {:measured-at measured-at})]
+      (is (= measured-at (:index/measured-at event))))))
+
+(deftest repo-index-coverage-changed-constructor-test
+  (testing "repo-index-coverage-changed produces correct :event/type"
+    (let [stream (make-stream)
+          event  (es/repo-index-coverage-changed stream "main-code-index" 0.80 0.93)]
+      (is (= :repo-index/coverage-changed (:event/type event)))
+      (is (uuid? (:event/id event)))
+      (is (inst? (:event/timestamp event)))
+      (is (= "main-code-index" (:index/id event)))
+      (is (= 0.80 (:index/previous-coverage event)))
+      (is (= 0.93 (:index/coverage event)))))
+
+  (testing "repo-index-coverage-changed round-trip validates against RepoIndexCoverageChanged"
+    (let [stream (make-stream)
+          event  (es/repo-index-coverage-changed stream "main-code-index" 0.80 0.93)]
+      (is (m/validate schema/RepoIndexCoverageChanged event)
+          "constructor output must satisfy RepoIndexCoverageChanged schema")))
+
+  (testing "repo-index-coverage-changed optional :index/changed-files threads through"
+    (let [stream (make-stream)
+          event  (es/repo-index-coverage-changed
+                  stream "main-code-index" 0.80 0.93
+                  {:changed-files 42})]
+      (is (= 42 (:index/changed-files event))))))

--- a/work/rn-03-reliability-events.spec.edn
+++ b/work/rn-03-reliability-events.spec.edn
@@ -110,4 +110,4 @@
    :verification "event/id, event/type, event/timestamp on all events"}]
 
  :estimated-effort "1 day"
- :workflow/type :simple}
+ :workflow/type :canonical-sdlc}


### PR DESCRIPTION
---
miniforge-workflow: d60df000-f2e4-4993-9ec1-244e29d209b7
spec: work/rn-03-reliability-events.spec.edn
commit: 967ce99dfb7a0738f9269023bd27748743c36d9e
generated-by: miniforge
---

## Summary

Add 4 reliability metric event schemas and 2 repository intelligence event

## Changes

- `components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj` (create)
- `components/event-stream/resources/config/event-stream/messages/en-US.edn` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/core.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/interface.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/interface/events.clj` (modify)
- `components/event-stream/src/ai/miniforge/event_stream/schema.clj` (modify)

## Review

**Decision**: approved

Six new event schemas and six new constructors are correct. Schema field names align with constructor assoc calls; round-trip tests validate all six types and pass. Localization (messages/t) used consistently — no raw strings in constructors. The two in-scope warnings are: a duplicate Layer 6 label in core.clj that creates a non-monotonic heading sequence, and a layer comment that mislabels safe-mode/dependency constructors as reliability events. Neither is a data-correctness issue. The nits are a missing privacy-map registration and unenforced numeric range contracts in schemas. No blocking issues.

### Known issues (non-blocking)

Merged with 4 unresolved non-blocking issue(s) recorded for follow-up:

- `components/event-stream/src/ai/miniforge/event_stream/core.clj` — Duplicate Layer 6 label violates rule 210 monotonic ordering. The PR introduces a new `;--- Layer 6` comment for 'Reliability metric events', but there is already a pre-existing `;--- Layer 6` comment further down for 'Meta-loop events'. The sequence reads: Layer 6 (Reliability) → Layer 6.3 (Repo-Index) → Layer 6 (Meta-loop), which is non-monotonic.
- `components/event-stream/src/ai/miniforge/event_stream/core.clj` — The ';--- Layer 6 -- Reliability metric events' comment block also contains `safe-mode-entered`, `safe-mode-exited`, `dependency-id-string`, `dependency-event`, `dependency-health-updated`, and `dependency-recovered`. These are not reliability metric events per the task spec (which defines SLI/SLO/budget/degradation as the 4 reliability types). The layer comment lies about what it contains.
- `components/event-stream/src/ai/miniforge/event_stream/schema.clj` — The six new event types (:reliability/sli-computed, :reliability/slo-breach, :reliability/error-budget-update, :reliability/degradation-mode-changed, :repo-index/quality-measured, :repo-index/coverage-changed) are absent from the `default-event-privacy` map. They fall through to the :internal default, which is likely correct, but every other operational event type has an explicit entry.
- `components/event-stream/src/ai/miniforge/event_stream/schema.clj` — Docstrings document numeric contracts ([0.0, 1.0] for :sli/value, :budget/remaining, :index/quality-score, :index/coverage, :index/previous-coverage; burn-rate described as a positive multiplier) but the Malli schemas use plain `number?`, accepting negatives and values outside the stated range.

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (6 files)