### PR TITLE
fix(release-executor): write PR doc with a relative sandbox path

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -566,11 +566,14 @@
     (failed? state) state
     (not (:create-pr? state)) state
     :else
-    (let [{:keys [worktree-path release-meta pr-number pr-url branch
+    (let [{:keys [release-meta pr-number pr-url branch
                   executor environment-id logger code-artifacts workflow-data]} state
           filename (pr-doc-filename (:release/pr-title release-meta))
+          ;; Relative to the container workdir (the worktree root). The sandbox
+          ;; rejects absolute paths (assert-safe-container-path!), so this must
+          ;; NOT be prefixed with worktree-path — the executor resolves it
+          ;; against the workdir. The git add below already uses rel-path.
           rel-path (str "docs/pull-requests/" filename)
-          full-path (str worktree-path "/" rel-path)
           content (render-pr-doc-full
                    release-meta
                    {:pr-number pr-number :pr-url pr-url :branch branch}
@@ -578,7 +581,7 @@
                    workflow-data)]
       (try
         ;; Write via executor (governed) — never touch host filesystem
-        (sandbox/write-file! executor environment-id full-path content)
+        (sandbox/write-file! executor environment-id rel-path content)
         (when logger
           (log/info logger :release-executor :pr-doc-generated
                     {:data {:path rel-path}}))

--- a/components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj
@@ -683,6 +683,37 @@
           result (sut/step-generate-pr-doc state)]
       (is (not (sut/failed? result))))))
 
+(deftest step-generate-pr-doc-writes-relative-path-test
+  ;; The 2026-06-15 rn-03 dogfood logged `pr-doc-generation-failed - Path
+  ;; traversal rejected: sandbox path must be relative` on every release: the
+  ;; step passed an ABSOLUTE `worktree-path/docs/...` to sandbox/write-file!,
+  ;; but assert-safe-container-path! rejects any leading `/`. The doc must be
+  ;; written with a path relative to the container workdir (the git add already
+  ;; uses rel-path). Pin the contract so the regression cannot return.
+  (testing "write-file! receives a relative docs/pull-requests path, never absolute"
+    (let [seen-path (atom :unset)]
+      (with-redefs [sandbox/write-file! (fn [_exec _env path _content]
+                                          (reset! seen-path path)
+                                          {:success? true})
+                    sandbox/exec! (fn [& _] {:success? true :output ""})]
+        (let [result (sut/step-generate-pr-doc
+                      {:create-pr? true
+                       :worktree-path "/abs/host/worktree"
+                       :executor :mock
+                       :environment-id "env-1"
+                       :branch "mf/feature"
+                       :release-meta {:release/pr-title "feat: add thing"}})]
+          (is (not (sut/failed? result)))
+          (is (string? @seen-path) "write-file! must have been called")
+          (is (not (str/starts-with? @seen-path "/"))
+              "path must be relative — absolute paths are rejected by the sandbox")
+          (is (not (str/includes? @seen-path "/abs/host/worktree"))
+              "path must not embed the host worktree-path")
+          (is (str/starts-with? @seen-path "docs/pull-requests/")
+              "doc lands under docs/pull-requests/ relative to the container workdir")
+          (is (= @seen-path (:pr-doc-path result))
+              "the written path is the rel-path recorded on state"))))))
+
 ;; ============================================================================
 ;; render-pr-body-fallback — GitHub PR body, NOT the docs-file
 ;;


### PR DESCRIPTION
## Summary

`step-generate-pr-doc` passed an absolute `worktree-path/docs/pull-requests/<file>` to `sandbox/write-file!`, but `assert-safe-container-path!` rejects any leading `/` — sandbox paths must be relative to the container workdir. So every release logged:

```
pr-doc-generation-failed - Path traversal rejected: sandbox path must be relative
```

and the generated PR doc was silently dropped. The failure is non-fatal, so PRs still opened — just without their `docs/pull-requests/` entry.

The adjacent `git add` already used `rel-path`; the write now does too. Drops the unused `full-path` / `worktree-path` bindings.

Regression that #1094 surfaced: it added `assert-safe-container-path!` (relative-only) without updating this caller.

## Test plan

- New `step-generate-pr-doc-writes-relative-path-test` (core_pipeline_test): redefs `sandbox/write-file!` to capture the path, asserts it is relative, starts with `docs/pull-requests/`, does not embed the host `worktree-path`, and equals `:pr-doc-path` on the returned state.
- `bb pre-commit` passes (312 + 6 tests, 0 failures; release-executor pipeline suite 64 tests green).

Surfaced by the 2026-06-15 rn-03 dogfood (fired on all 4 releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)