### PR TITLE
ci: run on all pull-request base branches, not just main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # Run on ALL pull requests regardless of base branch. Stacked / autonomous
+  # PRs target intermediate `mf/**` branches (not main); a `branches: [main]`
+  # filter here silently skipped CI on every such PR. A bare `pull_request`
+  # trigger fires for any base, so stacked PRs get linted, tested, and built
+  # like any other.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

`ci.yml` used `pull_request: branches: [main]`, so CI only ran when a PR's **base** branch was `main`. Stacked / autonomous PRs target intermediate `mf/**` branches, so every such PR silently received zero checks.

Observed on the 2026-06-15 rn-03 dogfood: #1168 and #1171 (both stacked on `mf/...` branches) reported "no checks reported on the branch" — they merged-readiness could not be verified.

A bare `pull_request:` trigger fires for any base branch, so stacked PRs are linted, tested, and built like any other. `push` stays limited to `main` (no per-branch-push duplicate runs).

## Test plan

- Pure CI-config change; `bb pre-commit` passes (312 + 6 tests).
- This PR itself targets `main`, so it still triggers CI under the new config (and would under the old). The behavioural change is only observable on PRs whose base is not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)