### PR TITLE
fix(phase): use direct agent messaging protocol

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]
    [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
    [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.agent.interface.protocols.messaging :as messaging]
    [ai.miniforge.context-pack.interface :as context-pack]
    [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.repo-index.interface :as repo-index]
@@ -255,9 +256,7 @@
   [ctx]
   (when-let [msg-router (:message-router ctx)]
     (try
-      (let [get-msgs (requiring-resolve
-                       'ai.miniforge.agent.interface.protocols.messaging/get-messages-for-agent)
-            msgs (get-msgs msg-router :implementer (:execution/id ctx))]
+      (let [msgs (messaging/get-messages-for-agent msg-router :implementer (:execution/id ctx))]
         (when (seq msgs)
           {:peer-messages (vec msgs)}))
       (catch Exception _e nil))))


### PR DESCRIPTION
## Summary
- replace implementer peer-advice dynamic lookup with the direct agent messaging protocol namespace
- leave workflow PR monitor and TUI dynamic loads untouched because they need separate boundary/cycle work
- reduce the Clojure requiring-resolve baseline from 160 to 159

## Validation
- clj-kondo --lint components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
- clojure -M:poly test brick:phase-software-factory
- bb pre-commit