### PR TITLE
fix(agent): use direct LLM interface calls

### DIFF
--- a/components/agent/src/ai/miniforge/agent/meta_evaluator.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_evaluator.clj
@@ -29,7 +29,8 @@
    - Budget: ~500 input tokens, ~100 output tokens per call"
   (:require
    [cheshire.core :as json]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [ai.miniforge.llm.interface :as llm]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Prompt construction
@@ -116,12 +117,11 @@ Respond with ONLY a JSON object, no other text:
   [context opts]
   (try
     (let [llm-client (:llm-client opts)
-          complete-fn (requiring-resolve 'ai.miniforge.llm.interface.protocols.llm-client/complete*)
           prompt (build-eval-prompt context)
           request {:prompt prompt
                    :system system-prompt
                    :max-tokens 150}
-          response (complete-fn llm-client request)]
+          response (llm/complete llm-client request)]
       (if (:success response)
         (parse-eval-response (:content response))
         ;; LLM call failed -> allow (fail-open)

--- a/components/agent/src/ai/miniforge/agent/tool_supervisor.clj
+++ b/components/agent/src/ai/miniforge/agent/tool_supervisor.clj
@@ -37,6 +37,7 @@
    [cheshire.core :as json]
    [clojure.string :as str]
    [ai.miniforge.event-stream.interface :as events]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.agent.meta-evaluator :as meta-eval])
   (:import
    [java.io PushbackReader]))
@@ -241,9 +242,7 @@
                    ;; Meta-eval enabled: two-layer evaluation
                    (let [llm-client (when-let [backend (keyword (get meta-eval-config :backend "claude"))]
                                       (try
-                                        (let [create-client (requiring-resolve
-                                                             'ai.miniforge.llm.protocols.records.llm-client/create-client)]
-                                          (create-client {:backend backend}))
+                                        (llm/create-client {:backend backend})
                                         (catch Exception _e nil)))]
                      (evaluate-with-meta tool-name tool-input-kw
                                          {:llm-client llm-client


### PR DESCRIPTION
## Summary
- replace meta-evaluator dynamic protocol lookup with llm.interface/complete
- replace tool supervisor dynamic client construction with llm.interface/create-client
- reduce the Clojure requiring-resolve baseline from 159 to 157

## Validation
- clj-kondo --lint components/agent/src/ai/miniforge/agent/meta_evaluator.clj components/agent/src/ai/miniforge/agent/tool_supervisor.clj
- clojure -M:poly test brick:agent
- bb pre-commit