### PR TITLE
fix(gate): call policy pack interface directly

### DIFF
--- a/components/gate/src/ai/miniforge/gate/lint.clj
+++ b/components/gate/src/ai/miniforge/gate/lint.clj
@@ -20,7 +20,8 @@
   "Lint validation gate.
 
    Checks that code passes linting rules."
-  (:require [ai.miniforge.gate.registry :as registry]))
+  (:require [ai.miniforge.gate.registry :as registry]
+            [ai.miniforge.policy-pack.interface :as policy-pack]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Content extraction helpers
@@ -47,12 +48,11 @@
    Returns nil if policy-pack is not loaded."
   [artifact ctx]
   (try
-    (let [check-fn (requiring-resolve 'ai.miniforge.policy-pack.core/check-artifact)
-          packs (:policy-packs ctx)]
+    (let [packs (:policy-packs ctx)]
       (when (seq packs)
-        (let [result (check-fn packs artifact
-                               {:task-type :implement
-                                :phase :implement})]
+        (let [result (policy-pack/check-artifact packs artifact
+                                                 {:task-type :implement
+                                                  :phase :implement})]
           {:passed? (empty? (:blocking result))
            :errors (mapv (fn [v]
                            {:type :policy-violation

--- a/components/gate/src/ai/miniforge/gate/lint.clj
+++ b/components/gate/src/ai/miniforge/gate/lint.clj
@@ -44,8 +44,8 @@
     []))
 
 (defn run-policy-pack-check
-  "Delegate lint checking to policy-pack if available.
-   Returns nil if policy-pack is not loaded."
+  "Delegate lint checking to policy-pack when policy packs are configured.
+   Returns nil when no policy packs are configured or when checking fails."
   [artifact ctx]
   (try
     (let [packs (:policy-packs ctx)]
@@ -56,14 +56,15 @@
           {:passed? (empty? (:blocking result))
            :errors (mapv (fn [v]
                            {:type :policy-violation
-                            :message (:violation/message v)
-                            :severity (:violation/severity v)
-                            :rule-id (:violation/rule-id v)})
+                            :message (:message v)
+                            :severity (:severity v)
+                            :rule-id (:code v)})
                          (:blocking result))
            :warnings (mapv (fn [v]
                              {:type :policy-warning
-                              :message (:violation/message v)
-                              :severity (:violation/severity v)})
+                              :message (:message v)
+                              :severity (:severity v)
+                              :rule-id (:code v)})
                            (:warnings result))})))
     (catch Exception _e nil)))
 

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -26,6 +26,7 @@
    - :plan-complete - Plan completeness check"
   (:require [ai.miniforge.gate.messages  :as msg]
             [ai.miniforge.gate.registry  :as registry]
+            [ai.miniforge.policy-pack.interface :as policy-pack]
             [ai.miniforge.response.interface :as response]
             [slingshot.slingshot         :refer [try+]]))
 
@@ -254,14 +255,13 @@
      {:passed? bool :errors [] :warnings [] :approval-required []}"
   [artifact ctx]
   (try+
-    (let [check-fn (requiring-resolve 'ai.miniforge.policy-pack.core/check-artifact)
-          packs (get ctx :policy-packs [])
+    (let [packs (get ctx :policy-packs [])
           task-type (get ctx :task-type :implement)
           phase (get ctx :phase :implement)]
       (if (empty? packs)
         {:passed? true :warnings [{:type :no-policy-packs
                                     :message "No policy packs loaded"}]}
-        (let [result   (check-fn packs artifact {:task-type task-type :phase phase})
+        (let [result   (policy-pack/check-artifact packs artifact {:task-type task-type :phase phase})
               cascade  (evaluate-severity-cascade (:violations result []))
               blocking          (:blocking cascade)
               approval-required (:approval-required cascade)

--- a/components/gate/test/ai/miniforge/gate/lint_test.clj
+++ b/components/gate/test/ai/miniforge/gate/lint_test.clj
@@ -1,0 +1,44 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.lint-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.gate.lint :as lint]
+            [ai.miniforge.policy-pack.interface :as policy-pack]))
+
+(deftest run-policy-pack-check-preserves-policy-pack-result-shape
+  (testing "policy-pack errors and warnings keep their public message/severity keys"
+    (with-redefs [policy-pack/check-artifact
+                  (fn [_packs _artifact _context]
+                    {:blocking [{:code :no-secrets
+                                 :message "Found secret"
+                                 :severity :critical}]
+                     :warnings [{:code :no-todos
+                                 :message "Found TODO"
+                                 :severity :minor}]})]
+      (is (= {:passed? false
+              :errors [{:type :policy-violation
+                        :message "Found secret"
+                        :severity :critical
+                        :rule-id :no-secrets}]
+              :warnings [{:type :policy-warning
+                          :message "Found TODO"
+                          :severity :minor
+                          :rule-id :no-todos}]}
+             (lint/run-policy-pack-check {:content "SECRET TODO"}
+                                         {:policy-packs [:standards]}))))))

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -19,7 +19,8 @@
 (ns ai.miniforge.gate.policy-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.gate.messages :as msg]
-            [ai.miniforge.gate.policy :as policy]))
+            [ai.miniforge.gate.policy :as policy]
+            [ai.miniforge.policy-pack.interface :as policy-pack]))
 
 ;; -------------------------------------------------------------------------- check-review-approved
 ;; Cross-component contract: the reviewer agent (components/agent) produces an
@@ -83,8 +84,9 @@
 
 (deftest check-policy-pack-fails-closed-on-exception
   (testing "any exception during evaluation blocks the artifact"
-    (with-redefs [clojure.core/requiring-resolve
-                  (fn [_sym] (throw (RuntimeException. "policy loader crashed")))]
+    (with-redefs [policy-pack/check-artifact
+                  (fn [_packs _artifact _context]
+                    (throw (RuntimeException. "policy loader crashed")))]
       (let [result (policy/check-policy-pack {:content "test"}
                                              {:policy-packs ["some-pack"]})]
         (is (false? (:passed? result)))


### PR DESCRIPTION
## Summary
- replace gate policy-pack dynamic lookups with direct policy-pack interface calls
- update the policy exception-path test to stub the direct interface function
- reduce the Clojure requiring-resolve baseline from 156 to 153

## Validation
- clj-kondo --lint components/gate/src/ai/miniforge/gate/lint.clj components/gate/src/ai/miniforge/gate/policy.clj components/gate/test/ai/miniforge/gate/policy_test.clj
- clojure -M:poly test brick:gate
- bb pre-commit