### PR TITLE
fix(operator): call llm interfaces directly

### DIFF
--- a/components/operator/deps.edn
+++ b/components/operator/deps.edn
@@ -3,6 +3,7 @@
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/knowledge {:local/root "../knowledge"}
+        ai.miniforge/llm {:local/root "../llm"}
         ai.miniforge/workflow {:local/root "../workflow"}
         ai.miniforge/anomaly {:local/root "../anomaly"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -21,6 +21,8 @@
    Manages meta-loop: observe signals, detect patterns, propose improvements."
   (:require
    [ai.miniforge.operator.protocol :as proto]
+   [ai.miniforge.operator.llm-improvement-generator :as llm-improvement-generator]
+   [ai.miniforge.operator.llm-pattern-detector :as llm-pattern-detector]
    [ai.miniforge.workflow.interface :as wf]
    [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.logging.interface :as log]))
@@ -410,23 +412,19 @@
                                   :reason reason}})))
 
 (defn create-llm-pattern-detector*
-  "Create an LLM-powered pattern detector via requiring-resolve.
-   Returns nil if the namespace cannot be loaded."
+  "Create an LLM-powered pattern detector.
+   Returns nil if construction fails."
   [llm-backend]
   (try
-    (let [create-fn (requiring-resolve
-                     'ai.miniforge.operator.llm-pattern-detector/create-llm-pattern-detector)]
-      (create-fn {:llm-client llm-backend}))
+    (llm-pattern-detector/create-llm-pattern-detector {:llm-client llm-backend})
     (catch Exception _e nil)))
 
 (defn create-llm-improvement-generator*
-  "Create an LLM-powered improvement generator via requiring-resolve.
-   Returns nil if the namespace cannot be loaded."
+  "Create an LLM-powered improvement generator.
+   Returns nil if construction fails."
   [llm-backend]
   (try
-    (let [create-fn (requiring-resolve
-                     'ai.miniforge.operator.llm-improvement-generator/create-llm-improvement-generator)]
-      (create-fn {:llm-client llm-backend}))
+    (llm-improvement-generator/create-llm-improvement-generator {:llm-client llm-backend})
     (catch Exception _e nil)))
 
 (defn create-operator

--- a/components/operator/src/ai/miniforge/operator/llm_improvement_generator.clj
+++ b/components/operator/src/ai/miniforge/operator/llm_improvement_generator.clj
@@ -25,11 +25,12 @@
 
    Architecture:
    - Fail-open: LLM errors return empty proposals (never block the operator)
-   - Uses requiring-resolve to avoid hard dependency on llm component
+   - Uses the public llm interface
    - Budget: ~1000 input tokens, ~600 output tokens per generation call"
   (:require
    [cheshire.core :as json]
    [clojure.string :as str]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.operator.defaults :as defaults]
    [ai.miniforge.operator.protocol :as proto]))
 
@@ -131,15 +132,13 @@
     (if (empty? patterns)
       []
       (try
-        (let [complete-fn (requiring-resolve
-                           'ai.miniforge.llm.interface.protocols.llm-client/complete*)
-              sys-prompt  (get config :system-prompt defaults/improvement-generator-system-prompt)
+        (let [sys-prompt  (get config :system-prompt defaults/improvement-generator-system-prompt)
               types       (get config :improvement-types defaults/improvement-types)
               prompt      (build-generate-prompt patterns context)
               request     {:prompt     prompt
                            :system     sys-prompt
                            :max-tokens (get config :max-tokens 600)}
-              response    (complete-fn llm-client request)]
+              response    (llm/complete llm-client request)]
           (if (:success response)
             (parse-generate-response (:content response) types)
             ;; LLM call failed -> fail-open with empty proposals

--- a/components/operator/src/ai/miniforge/operator/llm_pattern_detector.clj
+++ b/components/operator/src/ai/miniforge/operator/llm_pattern_detector.clj
@@ -25,11 +25,12 @@
 
    Architecture:
    - Fail-open: LLM errors return empty pattern list (never block the operator)
-   - Uses requiring-resolve to avoid hard dependency on llm component
+   - Uses the public llm interface
    - Budget: ~1000 input tokens, ~500 output tokens per analysis call"
   (:require
    [cheshire.core :as json]
    [clojure.string :as str]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.operator.defaults :as defaults]
    [ai.miniforge.operator.protocol :as proto]))
 
@@ -131,14 +132,12 @@
     (if (empty? signals)
       []
       (try
-        (let [complete-fn (requiring-resolve
-                           'ai.miniforge.llm.interface.protocols.llm-client/complete*)
-              prompt      (build-detect-prompt signals)
+        (let [prompt      (build-detect-prompt signals)
               sys-prompt  (get config :system-prompt defaults/pattern-detector-system-prompt)
               request     {:prompt     prompt
                            :system     sys-prompt
                            :max-tokens (get config :max-tokens 500)}
-              response    (complete-fn llm-client request)]
+              response    (llm/complete llm-client request)]
           (if (:success response)
             (parse-detect-response (:content response))
             ;; LLM call failed -> fail-open with empty patterns

--- a/components/operator/test/ai/miniforge/operator/core_test.clj
+++ b/components/operator/test/ai/miniforge/operator/core_test.clj
@@ -22,6 +22,7 @@
    exercised by intervention_test.clj end-to-end via the public interface; this
    file targets the data-shaping helpers that have no such coupling."
   (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.llm.interface.protocols.llm-client :as llm-client]
             [ai.miniforge.operator.core :as sut]
             [ai.miniforge.operator.protocol :as proto]))
 
@@ -43,6 +44,12 @@
 (defn- repair-signal-for
   [error-type]
   (signal :repair-pattern :error-type error-type))
+
+(defrecord FakeLLMClient [response]
+  llm-client/LLMClient
+  (complete* [_this _request] response)
+  (complete-stream* [_this _request _on-chunk] response)
+  (get-config [_this] {}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; default-config
@@ -175,6 +182,12 @@
     (is (= #{:repeated-phase-failure :frequent-rollback :recurring-repair}
            (proto/get-pattern-types (sut/create-pattern-detector))))))
 
+(deftest create-llm-pattern-detector-direct-constructor-test
+  (testing "LLM pattern detector construction uses the direct component namespace"
+    (let [detector (sut/create-llm-pattern-detector*
+                    (->FakeLLMClient {:success true :content "[]" }))]
+      (is (satisfies? proto/PatternDetector detector)))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Improvement generators
 
@@ -239,6 +252,12 @@
   (testing "get-supported-patterns reports the three handled pattern types"
     (is (= #{:repeated-phase-failure :frequent-rollback :recurring-repair}
            (proto/get-supported-patterns (sut/create-improvement-generator))))))
+
+(deftest create-llm-improvement-generator-direct-constructor-test
+  (testing "LLM improvement generator construction uses the direct component namespace"
+    (let [generator (sut/create-llm-improvement-generator*
+                     (->FakeLLMClient {:success true :content "[]" }))]
+      (is (satisfies? proto/ImprovementGenerator generator)))))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; SimpleGovernance

--- a/components/operator/test/ai/miniforge/operator/llm_improvement_generator_test.clj
+++ b/components/operator/test/ai/miniforge/operator/llm_improvement_generator_test.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.llm-improvement-generator-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.llm.interface.protocols.llm-client :as llm-client]
+            [ai.miniforge.operator.llm-improvement-generator :as sut]
+            [ai.miniforge.operator.protocol :as proto]))
+
+(defrecord FakeLLMClient [response requests]
+  llm-client/LLMClient
+  (complete* [_this request]
+    (swap! requests conj request)
+    response)
+  (complete-stream* [_this request _on-chunk]
+    (swap! requests conj request)
+    response)
+  (get-config [_this] {}))
+
+(deftest generate-improvements-uses-public-llm-interface-test
+  (testing "LLM improvement generator calls the client and parses JSON improvements"
+    (let [requests (atom [])
+          client (->FakeLLMClient {:success true
+                                   :content "[{\"type\":\"prompt-change\",\"target\":\"reviewer\",\"change\":{\"prompt\":\"shorter\"},\"rationale\":\"clearer\",\"confidence\":0.8,\"source-pattern-type\":\"anti-pattern\"}]"}
+                                  requests)
+          generator (sut/create-llm-improvement-generator {:llm-client client})
+          result (proto/generate-improvements generator
+                                             [{:pattern/type :anti-pattern
+                                               :pattern/affected :reviewer
+                                               :pattern/occurrences 2
+                                               :pattern/confidence 0.7
+                                               :pattern/description "too much"
+                                               :pattern/rationale "verbose"}]
+                                             {:workflow-id "wf-1"})
+          [improvement] result]
+      (is (= 1 (count @requests)))
+      (is (uuid? (:improvement/id improvement)))
+      (is (= :prompt-change (:improvement/type improvement)))
+      (is (= "reviewer" (:improvement/target improvement)))
+      (is (= {:prompt "shorter"} (:improvement/change improvement)))
+      (is (= "clearer" (:improvement/rationale improvement)))
+      (is (= 0.8 (:improvement/confidence improvement)))
+      (is (= :anti-pattern (:improvement/source-pattern-type improvement)))
+      (is (= :proposed (:improvement/status improvement)))
+      (is (= :llm (:improvement/source improvement))))))

--- a/components/operator/test/ai/miniforge/operator/llm_pattern_detector_test.clj
+++ b/components/operator/test/ai/miniforge/operator/llm_pattern_detector_test.clj
@@ -1,0 +1,53 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.llm-pattern-detector-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.llm.interface.protocols.llm-client :as llm-client]
+            [ai.miniforge.operator.llm-pattern-detector :as sut]
+            [ai.miniforge.operator.protocol :as proto]))
+
+(defrecord FakeLLMClient [response requests]
+  llm-client/LLMClient
+  (complete* [_this request]
+    (swap! requests conj request)
+    response)
+  (complete-stream* [_this request _on-chunk]
+    (swap! requests conj request)
+    response)
+  (get-config [_this] {}))
+
+(deftest detect-uses-public-llm-interface-test
+  (testing "LLM pattern detector calls the client and parses JSON patterns"
+    (let [requests (atom [])
+          client (->FakeLLMClient {:success true
+                                   :content "[{\"type\":\"anti-pattern\",\"description\":\"x\",\"affected\":\"implement\",\"occurrences\":2,\"confidence\":0.75,\"rationale\":\"because\"}]"}
+                                  requests)
+          detector (sut/create-llm-pattern-detector {:llm-client client})
+          result (proto/detect detector [{:signal/type :workflow-failed
+                                          :signal/data {:phase :implement}
+                                          :signal/timestamp 1}])]
+      (is (= 1 (count @requests)))
+      (is (= [{:pattern/type :anti-pattern
+               :pattern/description "x"
+               :pattern/affected "implement"
+               :pattern/occurrences 2
+               :pattern/confidence 0.75
+               :pattern/rationale "because"
+               :pattern/source :llm}]
+             result)))))


### PR DESCRIPTION
## Summary
- declare the operator component's llm dependency explicitly
- replace dynamic operator helper and LLM completion lookups with direct public interface calls
- add LLM-backed operator tests using a fake LLMClient
- reduce the Clojure requiring-resolve baseline from 153 to 145

## Validation
- clj-kondo --lint components/operator/src/ai/miniforge/operator/core.clj components/operator/src/ai/miniforge/operator/llm_pattern_detector.clj components/operator/src/ai/miniforge/operator/llm_improvement_generator.clj components/operator/test/ai/miniforge/operator/core_test.clj components/operator/test/ai/miniforge/operator/llm_pattern_detector_test.clj components/operator/test/ai/miniforge/operator/llm_improvement_generator_test.clj
- clojure -M:poly test brick:operator
- bb pre-commit