### PR TITLE
fix(workflow): call resilience dependencies directly

### DIFF
--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/interface.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/interface.clj
@@ -35,6 +35,7 @@
   (:require
    [ai.miniforge.agent-runtime.error-classifier.core :as core]
    [ai.miniforge.agent-runtime.error-classifier.messages :as messages]
+   [ai.miniforge.agent-runtime.error-classifier.patterns :as patterns]
    [ai.miniforge.agent-runtime.error-classifier.reporting :as reporting]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -66,6 +67,12 @@
          :report-url \"https://github.com/anthropics/claude-code/issues/new?...\"
          :should-retry false}"
   core/classify-error)
+
+(def external-patterns
+  "Compiled external-service error patterns used for shared recovery decisions.
+   Each entry is a pattern map from the error classifier with keys such as
+   :regex, :type, :vendor, and :rate-limit?."
+  patterns/external-patterns)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Message formatting

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -7,6 +7,7 @@
         ai.miniforge/anomaly {:local/root "../anomaly"}    ; Canonical anomaly maps for exceptions-as-data
         ai.miniforge/response {:local/root "../response"}  ; Response chains
         ai.miniforge/fsm {:local/root "../fsm"}            ; State machines
+        ai.miniforge/agent-runtime {:local/root "../agent-runtime"}
         ai.miniforge/agent {:local/root "../agent"}
         ai.miniforge/task {:local/root "../task"}
         ai.miniforge/loop {:local/root "../loop"}

--- a/components/workflow/src/ai/miniforge/workflow/comparison.clj
+++ b/components/workflow/src/ai/miniforge/workflow/comparison.clj
@@ -17,7 +17,9 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.comparison
-  "Workflow execution comparison utilities.")
+  "Workflow execution comparison utilities."
+  (:require
+   [ai.miniforge.heuristic.interface :as heuristic]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Summary creation
@@ -92,6 +94,5 @@
    (save-workflow workflow {}))
   ([workflow opts]
    (let [heuristic-type (keyword "workflow" (name (:workflow/id workflow)))
-         version (:workflow/version workflow)
-         save-heuristic (requiring-resolve 'ai.miniforge.heuristic.interface/save-heuristic)]
-     (save-heuristic heuristic-type version {:data workflow} opts))))
+         version (:workflow/version workflow)]
+     (heuristic/save-heuristic heuristic-type version {:data workflow} opts))))

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -26,10 +26,12 @@
    - Layer 2: Batch analysis + rate limit handling
    - Layer 3: Resume — restore DAG progress from machine snapshots"
   (:require
+   [ai.miniforge.agent-runtime.interface :as agent-runtime]
    [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.self-healing.interface :as self-healing]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]))
 
 ;--- Layer 0: Rate Limit Detection
@@ -38,13 +40,11 @@
   "Load and compile rate-limit patterns from external error patterns.
    Returns a seq of compiled regex patterns."
   []
-  (try
-    (let [load-fn (requiring-resolve 'ai.miniforge.agent-runtime.error-classifier.patterns/external-patterns)]
-      (->> @load-fn
-           (filter :rate-limit?)
-           (map :regex)))
-    (catch Exception _
-      ;; Fallback patterns if error-classifier not available
+  (let [patterns (->> agent-runtime/external-patterns
+                      (filter :rate-limit?)
+                      (map :regex))]
+    (if (seq patterns)
+      patterns
       (map re-pattern
            ["(?i)you've hit your limit"
             "(?i)rate.?limit"
@@ -166,10 +166,9 @@
    Records the current backend's failure, then returns the first candidate."
   [current-backend allowed-backends]
   (try
-    (let [record-call! (requiring-resolve 'ai.miniforge.self-healing.backend-health/record-backend-call!)]
-      (record-call! current-backend false)
-      (first (filter #(not= % (keyword current-backend))
-                     (map keyword allowed-backends))))
+    (self-healing/record-backend-call! current-backend false)
+    (first (filter #(not= % (keyword current-backend))
+                   (map keyword allowed-backends)))
     (catch Exception _
       ;; If backend-health isn't available, still pick from allowed list
       (first (filter #(not= % (keyword current-backend))
@@ -200,8 +199,7 @@
     (let [candidate (find-healthy-backend current-backend allowed-backends)]
       (if candidate
         (try
-          (let [trigger-switch! (requiring-resolve 'ai.miniforge.self-healing.backend-health/trigger-backend-switch!)
-                result (trigger-switch! current-backend candidate)]
+          (let [result (self-healing/trigger-backend-switch! current-backend candidate)]
             (log/info logger :dag-resilience :failover/switched
                       {:data {:from current-backend :to candidate}})
             {:switched? true :new-backend candidate :switch-result result})

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -170,7 +170,7 @@
     (first (filter #(not= % (keyword current-backend))
                    (map keyword allowed-backends)))
     (catch Exception _
-      ;; If backend-health isn't available, still pick from allowed list
+      ;; If backend-health persistence fails, still pick from the allowed list.
       (first (filter #(not= % (keyword current-backend))
                      (map keyword allowed-backends))))))
 


### PR DESCRIPTION
## Summary
- expose external error patterns through the agent-runtime public interface
- replace workflow resilience dynamic lookups with direct agent-runtime and self-healing interface calls
- replace workflow comparison heuristic dynamic lookup with the heuristic interface
- reduce the Clojure requiring-resolve baseline from 145 to 141

## Validation
- clj-kondo --lint components/agent-runtime/src/ai/miniforge/agent_runtime/interface.clj components/workflow/src/ai/miniforge/workflow/comparison.clj components/workflow/src/ai/miniforge/workflow/dag_resilience.clj components/workflow/deps.edn
- clojure -M:poly test brick:agent-runtime
- clojure -M:poly test brick:workflow
- bb pre-commit