### PR TITLE
fix(observe): detach PR-monitor loop so the SDLC reaches :done

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -23,7 +23,8 @@
    This is the N2 §7 implementation. The Observe phase is the final
    phase of the standard SDLC workflow: plan → implement → verify →
    review → release → observe."
-  (:require [ai.miniforge.phase.interface :as phase]
+  (:require [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
@@ -141,12 +142,17 @@
 (defn enter-observe
   "Execute the Observe phase.
 
-   Reads PR info from context (set by Release phase), creates and runs
-   the PR monitor loop until a terminal condition is reached:
-   - All PRs merged
-   - Budget exhausted (human escalation emitted)
-   - PRs closed externally
-   - No open PRs remain
+   Reads PR info from context (set by Release phase) and starts the PR
+   monitor loop on a DETACHED future, then returns immediately with
+   `:observe/status :monitoring`. The monitor polls each PR until a
+   terminal condition (all merged, budget exhausted, closed externally,
+   or no open PRs) — but that can take up to :abandon-after-hours, so it
+   must not block the workflow thread. The future is exposed on ctx at
+   `:execution/pr-monitor-future` for a long-lived deployment to await or
+   cancel; a one-shot run completes the SDLC and exits.
+
+   Skips (status :skipped) when there are no PRs to observe or no
+   self-author can be resolved.
 
    pr-lifecycle is a direct dependency of the workflow component."
   [ctx]
@@ -180,23 +186,38 @@
                         {:observe/status :skipped
                          :observe/reason "No self-author resolved (gh unauthenticated?) — cannot poll PRs"})))
          (let [monitor (pr-lifecycle/create-pr-monitor monitor-config)
-               evidence (pr-lifecycle/run-pr-monitor-loop monitor self-author)
-
-               result-data {:observe/status :completed
-                         :observe/evidence evidence
-                         :observe/prs-monitored (count pr-infos)
-                         :observe/duration-hours (:duration-hours evidence)
-                         :observe/comments-received (:comments-received evidence)
-                         :observe/comments-addressed (:comments-addressed evidence)
-                         :observe/fixes-pushed (count (:fixes-pushed evidence))
-                         :observe/questions-answered (count (:questions-answered evidence))}]
-
-        (-> ctx
-            (assoc-in [:phase :name] :observe)
-            (assoc-in [:phase :started-at] start-time)
-            (assoc-in [:phase :status] :completed)
-            (assoc-in [:phase :result] (response/success result-data))
-            (assoc :execution/pr-lifecycle-evidence evidence))))))))
+               ;; Run the monitor OFF the workflow thread. The PR-monitor loop
+               ;; polls for up to :abandon-after-hours (72h by default), so a
+               ;; synchronous call stalls the workflow at :observe for days and
+               ;; the SDLC never reaches :done — on a dogfood/CI run that reads
+               ;; as a hang (the loop sits in a 60s Thread/sleep at 0% CPU).
+               ;; Detach it: the workflow completes immediately and the monitor
+               ;; runs out-of-band for as long as the host process lives. The
+               ;; future is exposed on ctx so a long-lived deployment can
+               ;; await/cancel it; a one-shot run exits and the daemon work
+               ;; stops with it. (pr-lifecycle documents this same
+               ;; `(future (run-pr-monitor-loop ...))` pattern.)
+               monitor-future (future
+                                (try
+                                  (pr-lifecycle/run-pr-monitor-loop monitor self-author)
+                                  (catch Throwable t
+                                    (when logger
+                                      (log/error logger :observe :observe/monitor-failed
+                                                 {:message (ex-message t)}))
+                                    {:observe/monitor-error (ex-message t)})))
+               result-data {:observe/status :monitoring
+                            :observe/prs-monitored (count pr-infos)
+                            :observe/monitor-detached? true}]
+           (when logger
+             (log/info logger :observe :observe/monitor-detached
+                       {:data {:prs-monitored (count pr-infos)
+                               :self-author self-author}}))
+           (-> ctx
+               (assoc-in [:phase :name] :observe)
+               (assoc-in [:phase :started-at] start-time)
+               (assoc-in [:phase :status] :completed)
+               (assoc-in [:phase :result] (response/success result-data))
+               (assoc :execution/pr-monitor-future monitor-future))))))))
 
 (defn leave-observe
   "Post-processing for Observe phase. Records evidence and duration metrics."

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.workflow.observe-phase-test
   (:require
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
    [ai.miniforge.workflow.observe-phase :as sut]
    [clojure.test :refer [deftest is testing]]))
 
@@ -55,6 +56,48 @@
     (is (= :default (:agent sut/default-config)))
     (is (= 259200 (get-in sut/default-config [:budget :time-seconds])))
     (is (= [] (:gates sut/default-config)))))
+
+(deftest enter-observe-detaches-monitor-test
+  ;; The 2026-06-15 rn-03 dogfood reached :observe and then "hung" for 45+ min:
+  ;; the phase ran the PR-monitor loop synchronously, and that loop polls for up
+  ;; to :abandon-after-hours (72h). Observe must NOT block the workflow thread —
+  ;; it starts the monitor on a detached future and returns :monitoring at once.
+  (testing "enter-observe returns :monitoring immediately without waiting on the monitor loop"
+    (let [loop-released (promise)        ; lets the monitor loop finish on demand
+          loop-entered (promise)         ; signals the loop actually ran
+          monitor-sentinel (Object.)]
+      (with-redefs [sut/resolve-monitor-config (fn [& _] {:self-author "miniforge[bot]"})
+                    pr-lifecycle/create-pr-monitor (fn [_] monitor-sentinel)
+                    pr-lifecycle/run-pr-monitor-loop
+                    (fn [monitor author]
+                      (deliver loop-entered {:monitor monitor :author author})
+                      @loop-released      ; block until the test releases it
+                      {:comments-received 0})]
+        (let [ctx (sut/enter-observe {:execution/dag-pr-infos [sample-pr]})
+              result (get-in ctx [:phase :result])]
+          ;; Phase returned while the monitor loop is still blocked — proof it
+          ;; did not run synchronously.
+          (is (= :completed (get-in ctx [:phase :status])))
+          (is (= :monitoring (get-in result [:output :observe/status])))
+          (is (true? (get-in result [:output :observe/monitor-detached?])))
+          (is (= 1 (get-in result [:output :observe/prs-monitored])))
+          (is (future? (:execution/pr-monitor-future ctx)))
+          (is (not (realized? loop-released))
+              "the monitor loop must still be blocked — observe did not await it")
+          ;; The detached loop did receive the monitor + author and is running.
+          (is (= {:monitor monitor-sentinel :author "miniforge[bot]"}
+                 (deref loop-entered 2000 :timed-out)))
+          ;; Release it and confirm the future carries the loop's result.
+          (deliver loop-released true)
+          (is (= {:comments-received 0}
+                 (deref (:execution/pr-monitor-future ctx) 2000 :timed-out))))))))
+
+(deftest enter-observe-skips-when-no-prs-test
+  (testing "no PRs to observe -> :skipped, no monitor future"
+    (let [ctx (sut/enter-observe {})]
+      (is (= :completed (get-in ctx [:phase :status])))
+      (is (= :skipped (get-in ctx [:phase :result :output :observe/status])))
+      (is (nil? (:execution/pr-monitor-future ctx))))))
 
 (deftest resolve-monitor-config-test
   (testing "context overrides are merged over shared monitor defaults"


### PR DESCRIPTION
## Summary

`enter-observe` ran `pr-lifecycle/run-pr-monitor-loop` **synchronously** on the workflow thread. That loop polls each open PR until merge / external close / budget exhaustion — up to `:abandon-after-hours` (72h default), sleeping 60s between polls. So once Release shipped still-open PRs, the workflow sat at `:observe` for up to three days at 0% CPU and never reached `:done`.

On a dogfood/CI run this reads as a hang. Observed 2026-06-15 (workflow `d60df000`): 45+ min of silence — 91 `:workflow/phase-heartbeat` events, **zero** `:pr-monitor/*` progress events — before a manual kill. The JVM was alive; the thread was parked in `Thread/sleep`.

Fix: start the monitor on a **detached future** and return immediately with `:observe/status :monitoring`. The workflow completes and the monitor runs out-of-band for as long as the host process lives. The future is exposed at `:execution/pr-monitor-future` so a long-lived deployment can await or cancel it; a one-shot run completes the SDLC and exits. `pr-lifecycle` already documents this `(future (run-pr-monitor-loop ...))` usage.

The phase still reports status `:completed`, so the FSM advances `:observe → :done`.

### Scope / safety
- Nothing downstream consumes the old synchronous `:observe/evidence` or `:observe/status :completed` (grep-verified across components + bases), so the result-shape change is safe.
- Not in this PR (followups): the monitor loop is observability-dark — `:pr-monitor/loop-started` / per-poll events exist as constructors but are never published to the workflow event bus (`monitor_loop.clj`); and the long-term out-of-process supervisor (survive CLI exit) is a separate concern.

## Test plan

- New `enter-observe-detaches-monitor-test`: redefs `run-pr-monitor-loop` to block on a promise; asserts `enter-observe` returns `:completed` / `:observe/status :monitoring` while the loop is still blocked (proof it didn't await), exposes a `future?` at `:execution/pr-monitor-future`, the detached loop received the monitor + author, and the future carries the loop's result once released.
- New `enter-observe-skips-when-no-prs-test`: no PRs → `:skipped`, no monitor future.
- `bb pre-commit` passes (312 + 6 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)