### PR TITLE
fix(evidence): call integration dependencies directly

### DIFF
--- a/components/evidence-bundle/deps.edn
+++ b/components/evidence-bundle/deps.edn
@@ -2,9 +2,11 @@
  :deps {ai.miniforge/anomaly      {:local/root "../anomaly"}
         ai.miniforge/artifact     {:local/root "../artifact"}
         ai.miniforge/content-hash {:local/root "../content-hash"}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/logging      {:local/root "../logging"}
         ai.miniforge/response     {:local/root "../response"}
-        ai.miniforge/schema       {:local/root "../schema"}}
+        ai.miniforge/schema       {:local/root "../schema"}
+        ai.miniforge/workflow     {:local/root "../workflow"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}}}}

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -21,8 +21,12 @@
    Provides helpers for gathering phase results, artifacts, and metadata."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.artifact.interface :as artifact]
    [ai.miniforge.content-hash.interface :as content-hash]
+   [ai.miniforge.evidence-bundle.protocols.impl.semantic-validator :as semantic-validator]
    [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.scanner :as scanner]
+   [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -296,8 +300,7 @@
   [event-stream query]
   (try
     (when event-stream
-      (let [get-events-fn (requiring-resolve 'ai.miniforge.event-stream.core/get-events)]
-        (vec (get-events-fn event-stream query))))
+      (vec (event-stream/get-events event-stream query)))
     (catch Exception _e
       [])))
 
@@ -560,18 +563,15 @@
 
         ;; Get artifacts for semantic validation
         artifacts (when artifact-store
-                    (let [query-fn (requiring-resolve 'ai.miniforge.artifact.interface/query)]
-                      (filter
-                       #(= workflow-id (get-in % [:artifact/provenance :provenance/workflow-id]))
-                       (query-fn artifact-store {}))))
+                    (filter
+                     #(= workflow-id (get-in % [:artifact/provenance :provenance/workflow-id]))
+                     (artifact/query artifact-store {})))
 
         ;; Perform semantic validation if implementer artifacts exist
         impl-artifacts (filter #(= :implement (get-in % [:artifact/provenance :provenance/phase]))
                                artifacts)
         semantic-validation (when (seq impl-artifacts)
-                              (let [validator (requiring-resolve
-                                               'ai.miniforge.evidence-bundle.protocols.impl.semantic-validator/validate-intent-impl)]
-                                (validator intent impl-artifacts)))
+                              (semantic-validator/validate-intent-impl intent impl-artifacts))
 
         base-bundle (merge
                      (schema/create-evidence-bundle-template)
@@ -609,12 +609,9 @@
 
         ;; Run sensitive data scanner before hashing
         scan-result (try
-                      (let [scan-fn (requiring-resolve
-                                      'ai.miniforge.evidence-bundle.scanner/scan-artifact)
-                            compliance-fn (requiring-resolve
-                                            'ai.miniforge.evidence-bundle.scanner/compliance-metadata)]
-                        (compliance-fn (scan-fn bundle)))
-                      (catch Exception _e nil))
+                      (scanner/compliance-metadata (scanner/scan-artifact bundle))
+                      (catch Exception _e
+                        {}))
 
         ;; Merge compliance metadata
         bundle (cond-> bundle

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/provenance_tracer.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/provenance_tracer.clj
@@ -18,7 +18,9 @@
 
 (ns ai.miniforge.evidence-bundle.protocols.impl.provenance-tracer
   "Implementation functions for ProvenanceTracer protocol.
-   Traces artifact chains and provenance.")
+   Traces artifact chains and provenance."
+  (:require
+   [ai.miniforge.artifact.interface :as artifact]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Provenance Query Helpers
@@ -26,8 +28,7 @@
 (defn get-artifact-with-provenance
   "Get artifact with full provenance information."
   [artifact-store artifact-id]
-  (when-let [artifact ((requiring-resolve 'ai.miniforge.artifact.interface/load-artifact)
-                       artifact-store artifact-id)]
+  (when-let [artifact (artifact/load-artifact artifact-store artifact-id)]
     artifact))
 
 (defn get-source-artifacts
@@ -40,8 +41,7 @@
 (defn get-workflow-artifacts
   "Get all artifacts for a workflow."
   [artifact-store workflow-id]
-  (let [query-fn (requiring-resolve 'ai.miniforge.artifact.interface/query)
-        artifacts (query-fn artifact-store {})]
+  (let [artifacts (artifact/query artifact-store {})]
     (filter #(= workflow-id (get-in % [:artifact/provenance :provenance/workflow-id]))
             artifacts)))
 

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/scanner.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/scanner.clj
@@ -1,0 +1,61 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.evidence-bundle.scanner
+  "Sensitive-data scanner for assembled evidence bundles.")
+
+(def ^:private sensitive-patterns
+  [{:finding/type :email
+    :finding/pattern #"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"}
+   {:finding/type :ssn
+    :finding/pattern #"\b\d{3}-\d{2}-\d{4}\b"}
+   {:finding/type :aws-access-key
+    :finding/pattern #"\bAKIA[0-9A-Z]{16}\b"}])
+
+(def ^:private pii-finding-types
+  #{:email :ssn})
+
+(defn- bundle-text
+  [bundle]
+  (binding [*print-length* 1000
+            *print-level* 20]
+    (pr-str bundle)))
+
+(defn scan-artifact
+  "Scan an evidence bundle and return sensitive-data findings.
+
+   The scanner reports finding types only; matched secret values are not
+   copied into evidence."
+  [bundle]
+  (let [text (bundle-text bundle)]
+    {:scan/findings
+     (vec
+      (keep (fn [{:finding/keys [type pattern]}]
+              (when (re-find pattern text)
+                {:finding/type type}))
+            sensitive-patterns))}))
+
+(defn compliance-metadata
+  "Convert scan results into evidence compliance metadata."
+  [scan-result]
+  (let [findings (:scan/findings scan-result)
+        contains-pii? (some #(contains? pii-finding-types (:finding/type %)) findings)]
+    (if (seq findings)
+      (cond-> {:compliance/sensitive-findings findings}
+        contains-pii? (assoc :evidence/contains-pii? true))
+      {})))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/workflow_integration.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/workflow_integration.clj
@@ -21,7 +21,8 @@
    Provides WorkflowObserver implementation for evidence bundle generation."
   (:require
    [ai.miniforge.evidence-bundle.interface :as evidence]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.workflow.interface :as workflow]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Observer Record
@@ -116,16 +117,13 @@
 
    Returns the workflow instance (for chaining).
 
-   Example:
+  Example:
      (-> (workflow/create-workflow)
          (attach-to-workflow evidence-collector)
          (workflow/start spec context))"
-  [workflow collector]
-  (when-let [add-observer (try
-                            (requiring-resolve 'ai.miniforge.workflow.interface/add-observer)
-                            (catch Exception _ nil))]
-    (add-observer workflow collector))
-  workflow)
+  [workflow-instance collector]
+  (workflow/add-observer workflow-instance collector)
+  workflow-instance)
 
 (defn create-and-attach-evidence-collector
   "Create evidence collector and attach to workflow in one step.
@@ -153,8 +151,7 @@
 ;------------------------------------------------------------------------------ Rich Comment
 
 (comment
-  (require '[ai.miniforge.workflow.interface :as workflow]
-           '[ai.miniforge.artifact.interface :as artifact])
+  (require '[ai.miniforge.artifact.interface :as artifact])
 
   ;; Create artifact store
   (def artifact-store (artifact/create-transit-store))

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
@@ -1,0 +1,47 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.evidence-bundle.scanner-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.evidence-bundle.scanner :as scanner]))
+
+(deftest scan-artifact-reports-finding-types-only
+  (testing "sensitive values are detected but not copied into evidence"
+    (let [result (scanner/scan-artifact
+                  {:evidence/intent
+                   {:intent/description "Contact alice@example.com"}})
+          metadata (scanner/compliance-metadata result)]
+      (is (= [{:finding/type :email}] (:scan/findings result)))
+      (is (= {:evidence/contains-pii? true
+              :compliance/sensitive-findings [{:finding/type :email}]}
+             metadata)))))
+
+(deftest compliance-metadata-is-empty-without-findings
+  (testing "absence of findings does not overwrite caller-provided compliance flags"
+    (is (= {} (scanner/compliance-metadata (scanner/scan-artifact
+                                            {:evidence/intent
+                                             {:intent/description "No sensitive data"}}))))))
+
+(deftest compliance-metadata-keeps-secrets-separate-from-pii
+  (testing "secret findings do not imply personal information"
+    (let [result (scanner/scan-artifact
+                  {:evidence/intent
+                   {:intent/description "Key AKIAABCDEFGHIJKLMNOP"}})]
+      (is (= {:compliance/sensitive-findings [{:finding/type :aws-access-key}]}
+             (scanner/compliance-metadata result))))))


### PR DESCRIPTION
## Summary
- declare evidence-bundle dependencies on event-stream and workflow explicitly
- replace artifact, event-stream, semantic-validator, and workflow dynamic lookups with direct public calls
- add the missing evidence-bundle sensitive-data scanner surface with focused tests
- reduce the Clojure requiring-resolve baseline from 128 to 120

## Validation
- clj-kondo --lint components/evidence-bundle/deps.edn components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/provenance_tracer.clj components/evidence-bundle/src/ai/miniforge/evidence_bundle/workflow_integration.clj components/evidence-bundle/src/ai/miniforge/evidence_bundle/scanner.clj components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
- clojure -M:poly test brick:evidence-bundle
- bb pre-commit