### PR TITLE
fix(pr-train): publish merge events directly

### DIFF
--- a/components/pr-train/deps.edn
+++ b/components/pr-train/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
         metosin/malli {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -20,6 +20,7 @@
   "Core implementation of PR Train management.
    Provides PRTrainManager protocol and in-memory implementation."
   (:require
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.pr-train.state :as state]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -255,12 +256,11 @@
           (swap! trains assoc train-id final)
           (when event-stream
             (try
-              (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-                (publish! event-stream
-                          {:event/type :pr/merged
-                           :pr/number pr-number
-                           :train/id train-id
-                           :timestamp (java.util.Date.)}))
+              (es/publish! event-stream
+                           {:event/type :pr/merged
+                            :pr/number pr-number
+                            :train/id train-id
+                            :timestamp (java.util.Date.)})
               (catch Exception _ nil)))
           final))))
 


### PR DESCRIPTION
## Summary
- declare pr-train's event-stream dependency explicitly
- replace the dynamic merge-event publisher lookup with a direct event-stream interface call
- reduce the Clojure requiring-resolve baseline from 120 to 119

## Validation
- clj-kondo --lint components/pr-train/deps.edn components/pr-train/src/ai/miniforge/pr_train/core.clj
- clojure -M:poly test brick:pr-train
- bb pre-commit