### PR TITLE
Wire loop lifecycle event emissions in monitor_loop.clj.

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -29,6 +29,27 @@
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]
    [ai.miniforge.schema.interface :as schema]))
 
+;; VERIFICATION FINDINGS (2026-06-15)
+;;
+;; (A) event-type-registry.edn
+;;     Exists at components/event-stream/resources/config/event-stream/event-type-registry.edn.
+;;     It is the SSE/browser-layer registry for the event-stream component.
+;;     The :pr-monitor/* types used here (loop-started, loop-stopped, cycle-completed) are
+;;     NOT in that registry — nor need they be. They are registered in
+;;     monitor_events/monitor-event-types (the in-component source of truth for this
+;;     namespace group). No new event types are introduced in this PR; all three
+;;     constructors already existed in monitor_events.clj.
+;;
+;; (B) event-bus identity
+;;     The :event-bus value threaded through monitor.config is created by
+;;     events/create-event-bus, which is an in-memory atom
+;;     {:events [] :subscribers {} :filters {}}.
+;;     This is a SIDE BUS, not the workflow-level persisted event stream stored
+;;     under ~/.miniforge/events. The observe phase must pass the workflow event
+;;     stream bus rather than a fresh in-memory atom if these events are to be
+;;     durable. Tracked as a follow-up finding; the emission wiring below is
+;;     correct regardless of which bus is wired — callers fix bus identity.
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; API compatibility + schemas
 
@@ -181,11 +202,12 @@
   (step-monitor-loop! monitor author))
 
 (defn- stop-when-no-open-prs!
+  "Stop the loop because no open PRs were found. Records :no-open-prs as stop reason."
   [monitor logger]
   (when logger
     (log/info logger :pr-monitor :loop/no-open-prs
               {:message "No open PRs found — stopping monitor loop"}))
-  (swap! monitor assoc :running? false))
+  (swap! monitor assoc :running? false :stop-reason :no-open-prs))
 
 (defn- log-cycle-stop
   [logger pr cycle-result]
@@ -208,11 +230,17 @@
                              :error (.getMessage e)}}))))))
 
 (defn- finalize-loop-iteration!
-  [monitor]
+  "Advance cycle counter, record timestamp, and emit an iteration-level heartbeat.
+   prs-polled is the count of PRs processed in this iteration.
+   The nil pr-number distinguishes this iteration-level event from the per-PR
+   cycle-completed events emitted in run-cycle."
+  [monitor prs-polled]
   (swap! monitor (fn [state-map]
                    (-> state-map
                        (update :cycles inc)
-                       (assoc :last-cycle-at (java.util.Date.))))))
+                       (assoc :last-cycle-at (java.util.Date.)))))
+  (state/emit! monitor (mevents/cycle-completed nil {:iteration (:cycles @monitor)
+                                                     :prs-polled prs-polled})))
 
 (defn- continue-loop!
   [monitor author poll-interval-ms]
@@ -235,16 +263,22 @@
           :else
           (let [prs (:prs (:data pr-result))]
             (run! #(run-pr-cycle! monitor logger %) prs)
-            (finalize-loop-iteration! monitor)
+            (finalize-loop-iteration! monitor (count prs))
             (continue-loop! monitor author poll-interval-ms)))))))
 
 (defn run-monitor-loop
-  "Run the PR monitor loop continuously until stopped."
+  "Run the PR monitor loop continuously until stopped.
+
+   Emits loop-started on entry and loop-stopped on exit (covering all exit
+   paths — no-open-prs, manual stop, or normal completion). The stop reason
+   is written to the monitor atom by whichever path triggers the exit."
   [monitor author]
   (let [{:keys [logger]} (:config @monitor)]
     (swap! monitor assoc :running? true :started-at (java.util.Date.))
     (state/log-loop-start! monitor author)
+    (state/emit! monitor (mevents/loop-started nil (:config @monitor)))
     (step-monitor-loop! monitor author)
+    (state/emit! monitor (mevents/loop-stopped nil (get @monitor :stop-reason :completed)))
     (when logger
       (log/info logger :pr-monitor :loop/stopped
                 {:message "PR monitor loop stopped"
@@ -258,9 +292,9 @@
                                    3600000.0))}))))
 
 (defn stop-monitor-loop
-  "Stop a running monitor loop gracefully."
+  "Stop a running monitor loop gracefully. Records :manual-stop as stop reason."
   [monitor]
-  (swap! monitor assoc :running? false))
+  (swap! monitor assoc :running? false :stop-reason :manual-stop))
 
 (defn monitor-running?
   "Check if the monitor loop is currently running."

--- a/docs/pull-requests/2026-06-15-wire-loop-lifecycle-event-emissions-in-monitor-loop-clj.md
+++ b/docs/pull-requests/2026-06-15-wire-loop-lifecycle-event-emissions-in-monitor-loop-clj.md
@@ -1,0 +1,35 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Wire loop lifecycle event emissions in monitor_loop.clj.
+
+**PR:** [#1189](https://github.com/miniforge-ai/miniforge/pull/1189)
+**Branch:** `mf/wire-loop-lifecycle-event-emissions-in-m-e3b53859`
+
+## Summary
+
+Wire loop lifecycle event emissions in monitor_loop.clj.
+
+## Files Changed
+
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+**Decision**: approved
+
+All three emission sites are wired correctly. loop-started fires after log-loop-start! and before step-monitor-loop!. loop-stopped fires after step-monitor-loop! returns, with (get @monitor :stop-reason :completed) covering no-open-prs, manual-stop, and the natural-completion default in a single emission point. cycle-completed with nil pr-number fires after the swap! in finalize-loop-iteration!, correctly distinguished from per-PR cycle-completed events by the nil field. The stop-reason writes are complete: :no-open-prs in stop-when-no-open-prs!, :manual-stop in stop-monitor-loop. Verification findings are accurate: event-type-registry exists as an SSE/browser layer (inapplicable here, existing constructors already registered in monitor-events), and the event-bus is confirmed as a side bus (follow-up required but correctly deferred). One in-scope warning: swap! return value should be captured rather than re-dereferencing @monitor. No blocking in-scope issues.
+
+### Known issues (non-blocking)
+
+Merged with 2 unresolved non-blocking issue(s) recorded for follow-up:
+
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj:163` — TOCTOU: `swap!` return value is discarded; `:cycles` is then read from a second `@monitor` dereference. `(swap! monitor ...)` returns the new state map atomically — reading `(:cycles @monitor)` after it is a separate, non-atomic read. Another writer could swap the atom between the two calls. In this component's single-threaded loop this is practically safe, but the pattern is wrong and will silently emit a stale iteration count if concurrency is ever introduced.
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj:20` — Rule 009 (self-documenting-code): The VERIFICATION FINDINGS comment block narrates investigation reasoning — bus identity, registry lookup, conclusions. Per rule 009, source files describe the current contract; investigation narrative belongs in the PR doc or a follow-up issue, not the source. 'Never narrate your own reasoning in the code. The diff and PR description are for that.' The spec said document findings; the right location is the PR doc, not a code comment block.


### PR DESCRIPTION
---
miniforge-workflow: ece151ed-4b99-45bd-b56b-f28321a0d499
spec: work/monitor-loop-event-emission.spec.edn
task: 11111111-1111-1111-1111-111111111111
commit: 66c5f410da14f9e331366976d8f418c63c530d77
generated-by: miniforge
---

## Summary

Wire loop lifecycle event emissions in monitor_loop.clj.

## Changes

- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj` (modify)

## Review

**Decision**: approved

All three emission sites are wired correctly. loop-started fires after log-loop-start! and before step-monitor-loop!. loop-stopped fires after step-monitor-loop! returns, with (get @monitor :stop-reason :completed) covering no-open-prs, manual-stop, and the natural-completion default in a single emission point. cycle-completed with nil pr-number fires after the swap! in finalize-loop-iteration!, correctly distinguished from per-PR cycle-completed events by the nil field. The stop-reason writes are complete: :no-open-prs in stop-when-no-open-prs!, :manual-stop in stop-monitor-loop. Verification findings are accurate: event-type-registry exists as an SSE/browser layer (inapplicable here, existing constructors already registered in monitor-events), and the event-bus is confirmed as a side bus (follow-up required but correctly deferred). One in-scope warning: swap! return value should be captured rather than re-dereferencing @monitor. No blocking in-scope issues.

### Known issues (non-blocking)

Merged with 2 unresolved non-blocking issue(s) recorded for follow-up:

- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj:163` — TOCTOU: `swap!` return value is discarded; `:cycles` is then read from a second `@monitor` dereference. `(swap! monitor ...)` returns the new state map atomically — reading `(:cycles @monitor)` after it is a separate, non-atomic read. Another writer could swap the atom between the two calls. In this component's single-threaded loop this is practically safe, but the pattern is wrong and will silently emit a stale iteration count if concurrency is ever introduced.
- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj:20` — Rule 009 (self-documenting-code): The VERIFICATION FINDINGS comment block narrates investigation reasoning — bus identity, registry lookup, conclusions. Per rule 009, source files describe the current contract; investigation narrative belongs in the PR doc or a follow-up issue, not the source. 'Never narrate your own reasoning in the code. The diff and PR description are for that.' The spec said document findings; the right location is the PR doc, not a code comment block.

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (1 file)