### PR TITLE
fix(gate): check behavioral policies directly

### DIFF
--- a/components/gate/src/ai/miniforge/gate/behavioral.clj
+++ b/components/gate/src/ai/miniforge/gate/behavioral.clj
@@ -33,6 +33,7 @@
   (:require [ai.miniforge.gate.messages :as msg]
             [ai.miniforge.gate.policy   :as policy]
             [ai.miniforge.gate.registry :as registry]
+            [ai.miniforge.policy-pack.interface :as policy-pack]
             [ai.miniforge.response.interface :as response]))
 
 ;;------------------------------------------------------------------------------ Layer 1
@@ -66,47 +67,9 @@
            :errors errors
            :message m)))
 
-(defn- soft-dep-resolve-fn
-  "Build a policy-pack-shaped check fn that lazily resolves `sym` at
-   call time.
-
-   `sym` is a fully-qualified Clojure symbol identifying a 3-arg
-   `(check-artifact packs artifact opts)` function in a *soft*
-   dependency — i.e. a namespace that may not be on the classpath
-   (gate's `deps.edn` deliberately omits policy-pack).
-
-   On call, the returned fn:
-     - tries `(requiring-resolve sym)`, wrapping any thrown
-       Exception (FileNotFoundException, ClassNotFoundException, etc.)
-       in a consistent `ex-info` whose message ends with `unavailable`
-       and whose `ex-data` carries `:sym` plus the original cause type;
-     - if `requiring-resolve` returns `nil` (rare, but possible if the
-       ns loads but the var is missing), throws the same ex-info shape;
-     - otherwise calls the resolved fn with the supplied args.
-
-   `check-behavioral`'s outer `try/catch` converts any throw here into
-   a `:behavioral-check-error` warning."
-  [sym]
-  (fn [packs artifact opts]
-    (let [unavailable-msg (msg/t :behavioral/soft-dep-unavailable {:sym sym})
-          resolved (try
-                     (requiring-resolve sym)
-                     (catch Exception e
-                       (throw (ex-info unavailable-msg
-                                       {:sym sym
-                                        :cause-type (some-> e class .getName)}
-                                       e))))]
-      (when-not resolved
-        (throw (ex-info unavailable-msg
-                        {:sym sym})))
-      (resolved packs artifact opts))))
-
 (def ^:private default-check-fn
-  "Production default for `:check-fn`. Lazily resolves
-   `ai.miniforge.policy-pack.core/check-artifact` on each invocation
-   so gate works with policy-pack on the classpath and degrades to a
-   `:behavioral-check-error` warning otherwise."
-  (soft-dep-resolve-fn 'ai.miniforge.policy-pack.core/check-artifact))
+  "Production default for `:check-fn`."
+  #'policy-pack/check-artifact)
 
 (defn check-behavioral
   "Check a telemetry artifact against loaded policy packs for behavioral violations.

--- a/components/gate/test/ai/miniforge/gate/behavioral_test.clj
+++ b/components/gate/test/ai/miniforge/gate/behavioral_test.clj
@@ -21,6 +21,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.gate.behavioral :as behavioral]
             [ai.miniforge.gate.registry   :as registry]
+            [ai.miniforge.policy-pack.interface :as policy-pack]
             [ai.miniforge.response.interface :as response]))
 
 ;;------------------------------------------------------------------------------ Fixtures
@@ -50,12 +51,8 @@
       (is (true? (:passed? result)))
       (is (= :no-policy-packs (-> result :warnings first :type))))))
 
-;; Tests inject a `:check-fn` via the ctx map rather than redefining
-;; `clojure.core/requiring-resolve`.  The previous `with-redefs` approach
-;; mutated a global var root and races with any other parallel test that
-;; transitively calls `requiring-resolve` (e.g. dag-executor.state-test
-;; before the soft-dep was removed there).  Local DI keeps the stub scoped
-;; to the call site and removes the cross-brick hazard.
+;; Tests inject a `:check-fn` via the ctx map. Local DI keeps stubs scoped to
+;; the call site and avoids global mutation for normal policy-pack behavior.
 
 (defn- stub-check-fn
   "Build a stub policy-pack check fn that returns the given violations."
@@ -148,27 +145,19 @@
       (is (true? (:passed? result)))
       (is (= :behavioral-check-error (-> result :warnings first :type))))))
 
-(deftest check-behavioral-soft-dep-resolution-failure-test
+(deftest check-behavioral-default-check-fn-exception-test
   (testing
-   (str "Exercises the production default :check-fn path. soft-dep-resolve-fn "
-        "is the factory that builds default-check-fn; calling it with a "
-        "deliberately-bogus symbol gives a check-fn that mirrors the failure "
-        "the production default hits when policy-pack is genuinely absent. "
-        "Deterministic regardless of brick-isolation mode (no classpath "
-        "assumptions). Keeps coverage on the requiring-resolve branch even "
-        "though tests no longer redefine clojure.core/requiring-resolve.")
-    (let [bogus-sym 'no.such.namespace.exists/check-artifact
-          ;; Reach private factory via #'ns/private-fn. Same-namespace
-          ;; access only; no global mutation, no cross-brick risk.
-          check-fn  (#'behavioral/soft-dep-resolve-fn bogus-sym)
-          result    (behavioral/check-behavioral
-                     sample-artifact
-                     {:policy-packs [{:id :test-pack}]
-                      :phase        :observe
-                      :check-fn     check-fn})]
-      (is (true? (:passed? result)))
-      (is (= :behavioral-check-error (-> result :warnings first :type)))
-      (is (re-find #"unavailable" (-> result :warnings first :message))))))
+   "The production default :check-fn path demotes runtime failures to warnings."
+    (with-redefs [policy-pack/check-artifact
+                  (throwing-check-fn "policy-pack unavailable")]
+      (let [result (behavioral/check-behavioral
+                    sample-artifact
+                    {:policy-packs [{:id :test-pack}]
+                     :phase        :observe})]
+        (is (true? (:passed? result)))
+        (is (= :behavioral-check-error (-> result :warnings first :type)))
+        (is (re-find #"policy-pack unavailable"
+                     (-> result :warnings first :message)))))))
 
 (deftest check-behavioral-rejects-non-fn-check-fn-test
   (testing


### PR DESCRIPTION
## Summary
- replace the stale behavioral gate policy-pack soft dependency with the public policy-pack interface
- keep local :check-fn injection for tests/callers while removing dynamic requiring-resolve machinery
- update behavioral gate tests for the direct default path
- reduce the requiring-resolve baseline by 7 hits on top of #1188

## Validation
- clj-kondo --lint components/gate/src/ai/miniforge/gate/behavioral.clj components/gate/test/ai/miniforge/gate/behavioral_test.clj
- clojure -M:poly test brick:gate
- bb pre-commit