### PR TITLE
fix(phase): load policy packs directly

### DIFF
--- a/components/phase/deps.edn
+++ b/components/phase/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/policy-pack {:local/root "../policy-pack"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {}}}}

--- a/components/phase/src/ai/miniforge/phase/agent_behavior.clj
+++ b/components/phase/src/ai/miniforge/phase/agent_behavior.clj
@@ -19,8 +19,7 @@
 (ns ai.miniforge.phase.agent-behavior
   "Extract :rule/agent-behavior from policy packs and format as prompt addendum.
 
-   Bridges policy-pack rules and agent prompts. Uses requiring-resolve for
-   the policy-pack dependency (same soft-dependency pattern as event-stream).
+   Bridges policy-pack rules and agent prompts.
    Loads built-in rules and standards rules from classpath EDN resources.
 
    Always-inject semantics:
@@ -42,6 +41,7 @@
    Layer 1: Rule loading (built-in + standards + user/repo/extra packs)
    Layer 2: Full pipeline"
   (:require [ai.miniforge.config.interface :as config]
+            [ai.miniforge.policy-pack.interface :as policy-pack]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]))
@@ -206,8 +206,8 @@
 (defn- load-dir-pack-rules
   "Load rules from all pack directories specified in policy-packs-config.
 
-   Calls ai.miniforge.policy-pack.interface/load-all-packs via requiring-resolve
-   (soft dependency). Skips packs whose :pack/id is in disabled-ids.
+   Calls ai.miniforge.policy-pack.interface/load-all-packs. Skips packs whose
+   :pack/id is in disabled-ids.
 
    Arguments:
    - policy-packs-config - Map from :policy-packs section of merged config
@@ -219,15 +219,13 @@
     (let [pack-dirs (collect-pack-dirs policy-packs-config)]
       (if (empty? pack-dirs)
         []
-        (if-let [load-all (requiring-resolve 'ai.miniforge.policy-pack.interface/load-all-packs)]
-          (vec
-           (for [dir      pack-dirs
-                 :let     [result (load-all dir)]
-                 pack     (:loaded result)
-                 :when    (not (contains? disabled-ids (:pack/id pack)))
-                 rule     (:pack/rules pack)]
-             rule))
-          [])))
+        (vec
+         (for [dir      pack-dirs
+               :let     [result (policy-pack/load-all-packs dir)]
+               pack     (:loaded result)
+               :when    (not (contains? disabled-ids (:pack/id pack)))
+               rule     (:pack/rules pack)]
+           rule))))
     (catch Exception _ [])))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -412,13 +410,9 @@
                                   (or always-inject []))
 
           ;; Other rules: full context filtering
-          other-matched (if-let [filter-fn (requiring-resolve
-                                            'ai.miniforge.policy-pack.core/filter-applicable-rules)]
-                          (filter-fn (or context-gated [])
-                                     (assoc context :phase phase))
-                          ;; Fallback when policy-pack component is unavailable
-                          (filterv #(rule-matches-phase? % phase)
-                                   (or context-gated [])))
+          other-matched (policy-pack/filter-applicable-rules
+                         (or context-gated [])
+                         (assoc context :phase phase))
 
           filtered  (into always-matched other-matched)
           behaviors (extract-agent-behaviors filtered)

--- a/projects/data-foundry/deps.edn
+++ b/projects/data-foundry/deps.edn
@@ -26,16 +26,20 @@
         ai.miniforge/connector-jira            {:local/root "../../components/connector-jira"}
         ai.miniforge/connector-pipeline-output {:local/root "../../components/connector-pipeline-output"}
         ai.miniforge/connector-sarif           {:local/root "../../components/connector-sarif"}
+        ai.miniforge/algorithms                {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly                   {:local/root "../../components/anomaly"}
         ai.miniforge/coerce                    {:local/root "../../components/coerce"}
         ai.miniforge/config                    {:local/root "../../components/config"}
+        ai.miniforge/content-hash              {:local/root "../../components/content-hash"}
         ai.miniforge/dag-executor              {:local/root "../../components/dag-executor"}
         ai.miniforge/dag-primitives            {:local/root "../../components/dag-primitives"}
         ai.miniforge/data-quality              {:local/root "../../components/data-quality"}
         ai.miniforge/event-stream              {:local/root "../../components/event-stream"}
+        ai.miniforge/knowledge                 {:local/root "../../components/knowledge"}
         ai.miniforge/logging                   {:local/root "../../components/logging"}
         ai.miniforge/messages                  {:local/root "../../components/messages"}
         ai.miniforge/phase                     {:local/root "../../components/phase"}
+        ai.miniforge/policy-pack               {:local/root "../../components/policy-pack"}
         ai.miniforge/response                  {:local/root "../../components/response"}
         ai.miniforge/schema                    {:local/root "../../components/schema"}}
 

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -65,6 +65,7 @@
         ai.miniforge/messages {:local/root "../../components/messages"}
         ai.miniforge/patterns {:local/root "../../components/patterns"}
         ai.miniforge/compliance-scanner {:local/root "../../components/compliance-scanner"}
+        ai.miniforge/workflow-compliance-scanner {:local/root "../../components/workflow-compliance-scanner"}
         ai.miniforge/connector-linter {:local/root "../../components/connector-linter"}
         ai.miniforge/context-pack {:local/root "../../components/context-pack"}
         ai.miniforge/dag-primitives {:local/root "../../components/dag-primitives"}

--- a/workspace.edn
+++ b/workspace.edn
@@ -71,6 +71,7 @@
                                           "tool-registry"
                                           "tui-views"
                                           "workflow-chain-software-factory"
+                                          "workflow-compliance-scanner"
                                           "workflow-financial-etl"
                                           "workflow-software-factory"]}
             ;; bb-utils is an aggregator — it deliberately bundles every shared Babashka


### PR DESCRIPTION
## Summary
- make phase declare and call the policy-pack public interface directly
- remove policy-pack requiring-resolve fallbacks from agent behavior loading/filtering
- update project composition so data-foundry carries the policy-pack dependency graph used by phase
- add workflow-compliance-scanner to miniforge-tui as a runtime-loader necessary component
- reduce the requiring-resolve baseline by 4 hits on top of #1190

## Validation
- clj-kondo --lint components/phase/deps.edn components/phase/src/ai/miniforge/phase/agent_behavior.clj projects/data-foundry/deps.edn projects/miniforge-tui/deps.edn workspace.edn
- clojure -M:poly check
- clojure -M:poly test brick:phase
- bb pre-commit