### PR TITLE
fix(logging): remove dynamic sink lookup

### DIFF
--- a/components/logging/src/ai/miniforge/logging/core.clj
+++ b/components/logging/src/ai/miniforge/logging/core.clj
@@ -22,6 +22,8 @@
    Layer 1: Logger protocol and default implementation"
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.logging.format :as log-format]
+   [ai.miniforge.logging.sinks :as sinks]
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -48,24 +50,17 @@
 (defn level-enabled?
   "Check if a log level should be emitted given the configured minimum level."
   [configured-level entry-level]
-  (let [level-order {:trace 0 :debug 1 :info 2 :warn 3 :error 4 :fatal 5}
-        configured-ord (get level-order configured-level 0)
-        entry-ord (get level-order entry-level 0)]
-    (>= entry-ord configured-ord)))
+  (log-format/level-enabled? configured-level entry-level))
 
 (defn format-edn
   "Format a log entry as an EDN string for output."
   [entry]
-  (pr-str entry))
+  (log-format/format-edn entry))
 
 (defn format-human
   "Format a log entry as a human-readable string."
   [entry]
-  (let [{:log/keys [timestamp level category event message]} entry]
-    (str (when timestamp (.toInstant timestamp))
-         " [" (name level) "] "
-         (name category) "/" (name event)
-         (when message (str " - " message)))))
+  (log-format/format-human entry))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Logger protocol and implementations
@@ -252,13 +247,11 @@
    (let [output-fn (cond
                      ;; Explicit sinks provided
                      sinks
-                     (let [multi-sink (requiring-resolve 'ai.miniforge.logging.sinks/multi-sink)]
-                       (multi-sink sinks))
+                     (sinks/multi-sink sinks)
 
                      ;; Create sinks from config
                      config
-                     (let [create-from-config (requiring-resolve 'ai.miniforge.logging.sinks/create-sinks-from-config)]
-                       (create-from-config config))
+                     (sinks/create-sinks-from-config config)
 
                      ;; Legacy output mode
                      :else

--- a/components/logging/src/ai/miniforge/logging/format.clj
+++ b/components/logging/src/ai/miniforge/logging/format.clj
@@ -1,0 +1,44 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.logging.format
+  "Pure log level and formatting helpers shared by logger core and sinks.")
+
+(def ^:private level-order
+  {:trace 0 :debug 1 :info 2 :warn 3 :error 4 :fatal 5})
+
+(defn level-enabled?
+  "Check if a log level should be emitted given the configured minimum level."
+  [configured-level entry-level]
+  (let [configured-ord (get level-order configured-level 0)
+        entry-ord (get level-order entry-level 0)]
+    (>= entry-ord configured-ord)))
+
+(defn format-edn
+  "Format a log entry as an EDN string for output."
+  [entry]
+  (pr-str entry))
+
+(defn format-human
+  "Format a log entry as a human-readable string."
+  [entry]
+  (let [{:log/keys [timestamp level category event message]} entry]
+    (str (when timestamp (.toInstant timestamp))
+         " [" (name level) "] "
+         (name category) "/" (name event)
+         (when message (str " - " message)))))

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -27,12 +27,12 @@
    - :multi  - Combine multiple sinks"
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.logging.format :as log-format]
+   [ai.miniforge.logging.http :as http]
+   [ai.miniforge.logging.messages :as messages]
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [ai.miniforge.logging.core :as core]
-   [ai.miniforge.logging.http :as http]
-   [ai.miniforge.logging.messages :as messages]
    [slingshot.slingshot :refer [try+]])
   (:import
    [java.net.http HttpClient HttpResponse$BodyHandlers]))
@@ -78,9 +78,9 @@
   [& [opts]]
   (let [max-size-mb (:max-size-mb opts 10)
         format-fn (case (:format opts :human)
-                    :edn core/format-edn
-                    :human core/format-human
-                    core/format-human)]
+                    :edn log-format/format-edn
+                    :human log-format/format-human
+                    log-format/format-human)]
     (fn [entry]
       (when-let [workflow-id (:workflow/id entry)]
         (try
@@ -105,12 +105,12 @@
    Returns: Sink function (fn [log-entry] -> nil)"
   [& [opts]]
   (let [format-fn (case (:format opts :human)
-                    :edn core/format-edn
-                    :human core/format-human
-                    core/format-human)
+                    :edn log-format/format-edn
+                    :human log-format/format-human
+                    log-format/format-human)
         min-level (:min-level opts :trace)]
     (fn [entry]
-      (when (core/level-enabled? min-level (:log/level entry))
+      (when (log-format/level-enabled? min-level (:log/level entry))
         (try
           (println (format-fn entry))
           (catch Exception _e
@@ -127,12 +127,12 @@
    Returns: Sink function (fn [log-entry] -> nil)"
   [& [opts]]
   (let [format-fn (case (:format opts :human)
-                    :edn core/format-edn
-                    :human core/format-human
-                    core/format-human)
+                    :edn log-format/format-edn
+                    :human log-format/format-human
+                    log-format/format-human)
         min-level (:min-level opts :warn)]
     (fn [entry]
-      (when (core/level-enabled? min-level (:log/level entry))
+      (when (log-format/level-enabled? min-level (:log/level entry))
         (try
           (binding [*out* *err*]
             (println (format-fn entry)))


### PR DESCRIPTION
## Summary
- add a pure logging.format namespace for level checks and entry formatting
- make logging.sinks depend on the pure formatting layer instead of logging.core
- replace logging.core requiring-resolve sink lookups with direct sink calls

## Validation
- clj-kondo --lint components/logging/src/ai/miniforge/logging/core.clj components/logging/src/ai/miniforge/logging/sinks.clj components/logging/src/ai/miniforge/logging/format.clj components/logging/test/ai/miniforge/logging/interface_test.clj
- clojure -M:poly check
- clojure -M:poly test brick:logging
- bb pre-commit