### PR TITLE
fix(pipeline-pack-store): require datalevin store directly

### DIFF
--- a/components/pipeline-pack-store/src/ai/miniforge/pipeline_pack_store/datalevin_store.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/pipeline_pack_store/datalevin_store.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 (ns ai.miniforge.pipeline-pack-store.datalevin-store
   "Datalevin implementation of PackStore protocol."
   (:require

--- a/components/pipeline-pack-store/src/ai/miniforge/pipeline_pack_store/interface.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/pipeline_pack_store/interface.clj
@@ -1,18 +1,38 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 (ns ai.miniforge.pipeline-pack-store.interface
   "Public API for pipeline pack persistence.
 
-   Uses requiring-resolve to defer Datalevin (native dep) loading.
-   This is a legitimate extension point — Datalevin pulls in JNI
-   native libraries that should not load at namespace-require time."
+   JVM-only: this component is Datalevin-backed and has no non-JVM
+   implementation. Runtime compatibility is declared explicitly via
+   namespace metadata instead of hidden behind dynamic resolution."
+  {:miniforge/runtime :jvm-only}
   (:require
+   [ai.miniforge.pipeline-pack-store.datalevin-store :as datalevin-store]
    [ai.miniforge.pipeline-pack-store.protocol :as proto]))
 
 ;; -- Store creation --
 (defn create-store
   "Create a pack store. Options:
      :dir - directory for persistent storage (nil = in-memory for tests)"
-  ([] ((requiring-resolve 'ai.miniforge.pipeline-pack-store.datalevin-store/create-store)))
-  ([opts] ((requiring-resolve 'ai.miniforge.pipeline-pack-store.datalevin-store/create-store) opts)))
+  ([] (datalevin-store/create-store))
+  ([opts] (datalevin-store/create-store opts)))
 
 ;; -- Protocol delegations --
 (defn save-pack

--- a/components/pipeline-pack-store/src/ai/miniforge/pipeline_pack_store/interface.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/pipeline_pack_store/interface.clj
@@ -30,7 +30,8 @@
 ;; -- Store creation --
 (defn create-store
   "Create a pack store. Options:
-     :dir - directory for persistent storage (nil = in-memory for tests)"
+     :dir    - directory for persistent storage (nil = in-memory for tests)
+     :schema - optional Datalevin schema override"
   ([] (datalevin-store/create-store))
   ([opts] (datalevin-store/create-store opts)))
 

--- a/components/pipeline-pack-store/test/ai/miniforge/pipeline_pack_store/interface_test.clj
+++ b/components/pipeline-pack-store/test/ai/miniforge/pipeline_pack_store/interface_test.clj
@@ -92,11 +92,9 @@
 
 ;; -- Metrics persisted with pack --
 
-(deftest metrics-persisted-test
-  (testing "Metrics from registry are stored"
+(deftest pack-loads-with-metric-registry-test
+  (testing "Pack with metric registry saves and loads"
     (store/save-pack *store* sample-pack)
-    ;; M1 is stored as a metric entity, not a pack entity.
-    ;; For now just verify the pack itself loaded.
     (is (some? (store/load-pack *store* "test-pack")))))
 
 ;; -- Snapshots --

--- a/components/pipeline-pack-store/test/ai/miniforge/pipeline_pack_store/interface_test.clj
+++ b/components/pipeline-pack-store/test/ai/miniforge/pipeline_pack_store/interface_test.clj
@@ -95,11 +95,9 @@
 (deftest metrics-persisted-test
   (testing "Metrics from registry are stored"
     (store/save-pack *store* sample-pack)
-    (let [m1 (store/load-pack *store* "M1")]
-      ;; M1 is stored as a metric entity, not a pack entity
-      ;; But we can query via Datalevin directly through the store
-      ;; For now just verify the pack itself loaded
-      (is (some? (store/load-pack *store* "test-pack"))))))
+    ;; M1 is stored as a metric entity, not a pack entity.
+    ;; For now just verify the pack itself loaded.
+    (is (some? (store/load-pack *store* "test-pack")))))
 
 ;; -- Snapshots --
 


### PR DESCRIPTION
## Summary
- replace pipeline-pack-store's dynamic Datalevin factory lookup with a direct namespace require
- mark the pipeline-pack-store public interface as explicitly JVM-only for the BB/Graal compatibility gate
- add required source headers on touched pipeline-pack-store implementation files
- remove an unused test binding that surfaced during focused lint

## Validation
- clj-kondo --lint components/pipeline-pack-store/src/ai/miniforge/pipeline_pack_store/interface.clj components/pipeline-pack-store/src/ai/miniforge/pipeline_pack_store/datalevin_store.clj components/pipeline-pack-store/test/ai/miniforge/pipeline_pack_store/interface_test.clj
- clojure -M:poly check
- clojure -M:dev:test -e "(require 'ai.miniforge.pipeline-pack-store.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.pipeline-pack-store.interface-test)"
- bb pre-commit