### PR TITLE
fix(tui-engine): split screen protocol

### DIFF
--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen.clj
@@ -20,29 +20,32 @@
   "Screen protocol and mock implementation for TUI rendering.
 
    The protocol defines the terminal abstraction. MockScreen is pure Clojure
-   for testing. LanternaScreen is loaded dynamically via create-screen to
-   avoid Java class loading in Babashka/GraalVM contexts.")
+   for testing. LanternaScreen provides the real terminal implementation."
+  (:require
+   [ai.miniforge.tui-engine.screen.lanterna :as lanterna]
+   [ai.miniforge.tui-engine.screen.protocol :as protocol]))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Screen protocol
 
-(defprotocol IScreen
-  "Abstraction over terminal screen for rendering and input.
-   Implementations: LanternaScreen (real terminal), MockScreen (testing)."
-  (start-screen! [this] "Enter alternate screen mode.")
-  (stop-screen! [this] "Exit alternate screen mode, restore terminal.")
-  (get-size [this] "Return [cols rows].")
-  (put-string! [this col row text fg bg bold?] "Write styled string at position.")
-  (clear! [this] "Clear the screen buffer.")
-  (refresh! [this] "Flush buffer to terminal (delta rendering).")
-  (poll-input [this] "Non-blocking read. Returns key map or nil."))
+(def IScreen
+  "Protocol contract for terminal screen implementations."
+  protocol/IScreen)
+
+(def start-screen! "Enter alternate screen mode." protocol/start-screen!)
+(def stop-screen! "Exit alternate screen mode, restore terminal." protocol/stop-screen!)
+(def get-size "Return [cols rows]." protocol/get-size)
+(def put-string! "Write styled string at position." protocol/put-string!)
+(def clear! "Clear the screen buffer." protocol/clear!)
+(def refresh! "Flush buffer to terminal." protocol/refresh!)
+(def poll-input "Non-blocking read. Returns key map or nil." protocol/poll-input)
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Mock screen for testing
 
 (defrecord MockScreen [state]
   ;; state is an atom: {:started? bool, :cells {[col row] {:char :fg :bg :bold?}}, :size [c r]}
-  IScreen
+  protocol/IScreen
   (start-screen! [_]
     (swap! state assoc :started? true))
 
@@ -109,12 +112,9 @@
   (swap! (:state mock-screen) assoc :put-count 0))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
-;; Factory (dynamically loads Lanterna)
+;; Factory
 
 (defn create-screen
-  "Create a Lanterna terminal screen.
-   Dynamically loads the Lanterna implementation to avoid Java class loading
-   at namespace load time (required for Babashka/GraalVM compatibility)."
+  "Create a Lanterna terminal screen."
   [& [opts]]
-  (let [create-fn (requiring-resolve 'ai.miniforge.tui-engine.screen.lanterna/create-lanterna-screen)]
-    (create-fn opts)))
+  (lanterna/create-lanterna-screen opts))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
@@ -19,29 +19,63 @@
 (ns ai.miniforge.tui-engine.screen.lanterna
   "Lanterna Screen implementation.
 
-   Loaded dynamically by screen/create-screen to avoid Java class loading
-   at namespace load time (required for Babashka/GraalVM compatibility)."
+   Real terminal implementation for screen/create-screen. Java classes are
+   resolved inside the factory path so this namespace remains loadable in
+   Babashka compatibility checks that never instantiate a real terminal."
   (:require
-   [ai.miniforge.tui-engine.screen :as screen])
-  (:import
-   [com.googlecode.lanterna TextCharacter TextColor$ANSI TextColor$Indexed TextColor$RGB]
-   [com.googlecode.lanterna.screen TerminalScreen Screen$RefreshType]
-   [com.googlecode.lanterna.terminal DefaultTerminalFactory]))
+   [ai.miniforge.tui-engine.screen.protocol :as protocol]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Reflective Lanterna class access
+
+(defn- class-named [class-name]
+  (Class/forName class-name))
+
+(defn- static-field [class-name field-name]
+  (.get (.getField (class-named class-name) field-name) nil))
+
+(defn- arity-match? [arity member]
+  (= arity (count (.getParameterTypes member))))
+
+(defn- construct [class-name & args]
+  (let [constructor (->> (.getConstructors (class-named class-name))
+                         (filter (partial arity-match? (count args)))
+                         first)]
+    (when-not constructor
+      (throw (ex-info "No matching Lanterna constructor."
+                      {:class class-name
+                       :arity (count args)})))
+    (.newInstance constructor (object-array args))))
+
+(defn- invoke [target method-name & args]
+  (let [method (->> (.getMethods (class target))
+                    (filter #(= method-name (.getName %)))
+                    (filter (partial arity-match? (count args)))
+                    first)]
+    (when-not method
+      (throw (ex-info "No matching Lanterna method."
+                      {:class (.getName (class target))
+                       :method method-name
+                       :arity (count args)})))
+    (.invoke method target (object-array args))))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Color mapping
 
 (def color-map
   "Map from keyword colors to Lanterna TextColor.ANSI constants."
-  {:black   TextColor$ANSI/BLACK
-   :red     TextColor$ANSI/RED
-   :green   TextColor$ANSI/GREEN
-   :yellow  TextColor$ANSI/YELLOW
-   :blue    TextColor$ANSI/BLUE
-   :magenta TextColor$ANSI/MAGENTA
-   :cyan    TextColor$ANSI/CYAN
-   :white   TextColor$ANSI/WHITE
-   :default TextColor$ANSI/DEFAULT})
+  {:black   "BLACK"
+   :red     "RED"
+   :green   "GREEN"
+   :yellow  "YELLOW"
+   :blue    "BLUE"
+   :magenta "MAGENTA"
+   :cyan    "CYAN"
+   :white   "WHITE"
+   :default "DEFAULT"})
+
+(defn- ansi-color [field-name]
+  (static-field "com.googlecode.lanterna.TextColor$ANSI" field-name))
 
 (defn resolve-lanterna-color
   "Resolve a color value to a Lanterna TextColor.
@@ -51,90 +85,97 @@
    - vector   [r g b]              → TextColor.RGB"
   [color]
   (cond
-    (keyword? color) (get color-map color TextColor$ANSI/DEFAULT)
-    (integer? color) (TextColor$Indexed. (int color))
+    (keyword? color) (ansi-color (get color-map color "DEFAULT"))
+    (integer? color) (construct "com.googlecode.lanterna.TextColor$Indexed" (int color))
     (vector? color)  (let [[r g b] color]
-                       (TextColor$RGB. (int r) (int g) (int b)))
-    :else            TextColor$ANSI/DEFAULT))
+                       (construct "com.googlecode.lanterna.TextColor$RGB"
+                                  (int r) (int g) (int b)))
+    :else            (ansi-color "DEFAULT")))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
-;; Pre-allocated SGR arrays (avoid reflection + allocation on every character)
+;; SGR arrays
 
-(def ^{:tag "[Lcom.googlecode.lanterna.SGR;"} sgr-bold
-  (into-array com.googlecode.lanterna.SGR [com.googlecode.lanterna.SGR/BOLD]))
+(defn- sgr-array [field-names]
+  (let [sgr-class (class-named "com.googlecode.lanterna.SGR")
+        arr (make-array sgr-class (count field-names))]
+    (doseq [[idx field-name] (map-indexed vector field-names)]
+      (aset arr idx (static-field "com.googlecode.lanterna.SGR" field-name)))
+    arr))
 
-(def ^{:tag "[Lcom.googlecode.lanterna.SGR;"} sgr-none
-  (into-array com.googlecode.lanterna.SGR []))
+(def ^:private sgr-bold (delay (sgr-array ["BOLD"])))
+(def ^:private sgr-none (delay (sgr-array [])))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Lanterna implementation
 
-(defrecord LanternaScreen [^TerminalScreen screen]
-  screen/IScreen
+(defrecord LanternaScreen [screen]
+  protocol/IScreen
   (start-screen! [_]
-    (.startScreen screen))
+    (invoke screen "startScreen"))
 
   (stop-screen! [_]
-    (.stopScreen screen))
+    (invoke screen "stopScreen"))
 
   (get-size [_]
     ;; doResizeIfNecessary picks up SIGWINCH and updates the cached size.
     ;; Returns non-null only when the terminal was actually resized.
-    (.doResizeIfNecessary screen)
-    (let [size (.getTerminalSize screen)]
-      [(.getColumns size) (.getRows size)]))
+    (invoke screen "doResizeIfNecessary")
+    (let [size (invoke screen "getTerminalSize")]
+      [(invoke size "getColumns") (invoke size "getRows")]))
 
   (put-string! [_ col row text fg bg bold?]
     (let [fg-color (resolve-lanterna-color fg)
           bg-color (resolve-lanterna-color bg)
-          sgr-arr (if bold? sgr-bold sgr-none)]
+          sgr-arr (if bold? @sgr-bold @sgr-none)]
       (dotimes [i (count text)]
         (let [ch (.charAt ^String text i)
-              tc (TextCharacter. ch fg-color bg-color sgr-arr)]
-          (.setCharacter screen (+ col i) row tc)))))
+              tc (construct "com.googlecode.lanterna.TextCharacter"
+                            ch fg-color bg-color sgr-arr)]
+          (invoke screen "setCharacter" (+ col i) row tc)))))
 
   (clear! [_]
-    (.clear screen))
+    (invoke screen "clear"))
 
   (refresh! [_]
-    (.refresh screen Screen$RefreshType/COMPLETE))
+    (invoke screen "refresh"
+            (static-field "com.googlecode.lanterna.screen.Screen$RefreshType" "COMPLETE")))
 
   (poll-input [_]
-    (when-let [key (.pollInput screen)]
-      (let [kind (.getKeyType key)
-            shift? (.isShiftDown key)]
+    (when-let [key (invoke screen "pollInput")]
+      (let [kind (invoke key "getKeyType")
+            shift? (invoke key "isShiftDown")]
         (cond
-          (= kind com.googlecode.lanterna.input.KeyType/Character)
-          {:type :character :char (.getCharacter key)}
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "Character"))
+          {:type :character :char (invoke key "getCharacter")}
 
-          (= kind com.googlecode.lanterna.input.KeyType/Enter)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "Enter"))
           {:type :enter}
 
-          (= kind com.googlecode.lanterna.input.KeyType/Escape)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "Escape"))
           {:type :escape}
 
-          (= kind com.googlecode.lanterna.input.KeyType/Backspace)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "Backspace"))
           {:type :backspace}
 
-          (= kind com.googlecode.lanterna.input.KeyType/ArrowUp)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "ArrowUp"))
           {:type (if shift? :shift-arrow-up :arrow-up)}
 
-          (= kind com.googlecode.lanterna.input.KeyType/ArrowDown)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "ArrowDown"))
           {:type (if shift? :shift-arrow-down :arrow-down)}
 
-          (= kind com.googlecode.lanterna.input.KeyType/ArrowLeft)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "ArrowLeft"))
           {:type :arrow-left}
 
-          (= kind com.googlecode.lanterna.input.KeyType/ArrowRight)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "ArrowRight"))
           {:type :arrow-right}
 
-          (= kind com.googlecode.lanterna.input.KeyType/Tab)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "Tab"))
           {:type :tab}
 
-          (= kind com.googlecode.lanterna.input.KeyType/ReverseTab)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "ReverseTab"))
           {:type :reverse-tab}
 
-          (= kind com.googlecode.lanterna.input.KeyType/EOF)
+          (= kind (static-field "com.googlecode.lanterna.input.KeyType" "EOF"))
           {:type :eof}
 
           :else
@@ -146,7 +187,7 @@
 (defn create-lanterna-screen
   "Create a Lanterna terminal screen."
   [_opts]
-  (let [factory (DefaultTerminalFactory.)
-        terminal (.createTerminal factory)
-        screen (TerminalScreen. terminal)]
+  (let [factory (construct "com.googlecode.lanterna.terminal.DefaultTerminalFactory")
+        terminal (invoke factory "createTerminal")
+        screen (construct "com.googlecode.lanterna.screen.TerminalScreen" terminal)]
     (->LanternaScreen screen)))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
@@ -28,35 +28,53 @@
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Reflective Lanterna class access
 
+(def ^:private class-cache (atom {}))
+(def ^:private field-cache (atom {}))
+(def ^:private constructor-cache (atom {}))
+(def ^:private method-cache (atom {}))
+
+(defn- cached [cache key load-fn]
+  (if-let [value (get @cache key)]
+    value
+    (let [value (load-fn)]
+      (swap! cache assoc key value)
+      value)))
+
 (defn- class-named [class-name]
-  (Class/forName class-name))
+  (cached class-cache class-name #(Class/forName class-name)))
 
 (defn- static-field [class-name field-name]
-  (.get (.getField (class-named class-name) field-name) nil))
+  (cached field-cache [class-name field-name]
+          #(.get (.getField (class-named class-name) field-name) nil)))
 
 (defn- arity-match? [arity member]
   (= arity (count (.getParameterTypes member))))
 
 (defn- construct [class-name & args]
-  (let [constructor (->> (.getConstructors (class-named class-name))
-                         (filter (partial arity-match? (count args)))
-                         first)]
+  (let [arity (count args)
+        constructor (cached constructor-cache [class-name arity]
+                            #(->> (.getConstructors (class-named class-name))
+                                  (filter (partial arity-match? arity))
+                                  first))]
     (when-not constructor
       (throw (ex-info "No matching Lanterna constructor."
                       {:class class-name
-                       :arity (count args)})))
+                       :arity arity})))
     (.newInstance constructor (object-array args))))
 
 (defn- invoke [target method-name & args]
-  (let [method (->> (.getMethods (class target))
-                    (filter #(= method-name (.getName %)))
-                    (filter (partial arity-match? (count args)))
-                    first)]
+  (let [target-class (class target)
+        arity (count args)
+        method (cached method-cache [target-class method-name arity]
+                       #(->> (.getMethods target-class)
+                             (filter (fn [method] (= method-name (.getName method))))
+                             (filter (partial arity-match? arity))
+                             first))]
     (when-not method
       (throw (ex-info "No matching Lanterna method."
-                      {:class (.getName (class target))
+                      {:class (.getName target-class)
                        :method method-name
-                       :arity (count args)})))
+                       :arity arity})))
     (.invoke method target (object-array args))))
 
 ;; ─────────────────────────────────────────────────────────────────────────────

--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen/protocol.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen/protocol.clj
@@ -1,0 +1,31 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.screen.protocol
+  "Terminal screen protocol shared by concrete screen implementations.")
+
+(defprotocol IScreen
+  "Abstraction over terminal screen for rendering and input.
+   Implementations: LanternaScreen (real terminal), MockScreen (testing)."
+  (start-screen! [this] "Enter alternate screen mode.")
+  (stop-screen! [this] "Exit alternate screen mode, restore terminal.")
+  (get-size [this] "Return [cols rows].")
+  (put-string! [this col row text fg bg bold?] "Write styled string at position.")
+  (clear! [this] "Clear the screen buffer.")
+  (refresh! [this] "Flush buffer to terminal (delta rendering).")
+  (poll-input [this] "Non-blocking read. Returns key map or nil."))


### PR DESCRIPTION
## Summary
- move the screen protocol into a lower screen.protocol namespace
- keep screen as the public mock/factory facade and call Lanterna through a direct require
- make the Lanterna adapter BB-loadable by resolving Java classes only when creating a real terminal
- remove the dynamic requiring-resolve factory lookup from tui-engine.screen

## Validation
- clj-kondo --lint components/tui-engine/src/ai/miniforge/tui_engine/screen.clj components/tui-engine/src/ai/miniforge/tui_engine/screen/protocol.clj components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj components/tui-engine/test/ai/miniforge/tui_engine/screen_test.clj
- clojure -M:dev:test -e "(require 'ai.miniforge.tui-engine.screen-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.tui-engine.screen-test)"
- bb pre-commit