### PR TITLE
fix(response): drop present-nil :cost-usd so cost accumulation can't NPE

### DIFF
--- a/components/response/src/ai/miniforge/response/builder.clj
+++ b/components/response/src/ai/miniforge/response/builder.clj
@@ -34,11 +34,20 @@
    documented `{:tokens N :duration-ms N}` shape, which then throws a
    message-less NPE in any downstream arithmetic. Normalizing here, at the
    constructor boundary, means no reader has to defend. (Does not coerce
-   non-nil non-numeric values — callers supply numbers or nil.)"
+   non-nil non-numeric values — callers supply numbers or nil.)
+
+   `:cost-usd` is optional, so it is not forced present — but a PRESENT-and-nil
+   `:cost-usd` is dropped. Every reader coalesces it with a default
+   (`(:cost-usd m 0.0)` or a token-based estimate), and `get`/keyword-with-
+   default returns a present nil rather than the default — so a present-nil
+   cost survived into `(fnil + 0.0) cost` and NPE'd cost accumulation in the
+   implement phase. Dropping it lets each reader's own default/estimate apply."
   [metrics tokens duration-ms]
-  (-> (merge {:tokens (or tokens 0) :duration-ms (or duration-ms 0)} metrics)
-      (update :tokens #(or % 0))
-      (update :duration-ms #(or % 0))))
+  (cond-> (-> (merge {:tokens (or tokens 0) :duration-ms (or duration-ms 0)} metrics)
+              (update :tokens #(or % 0))
+              (update :duration-ms #(or % 0)))
+    (and (contains? metrics :cost-usd) (nil? (:cost-usd metrics)))
+    (dissoc :cost-usd)))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Success responses

--- a/components/response/test/ai/miniforge/response/builder_test.clj
+++ b/components/response/test/ai/miniforge/response/builder_test.clj
@@ -46,6 +46,29 @@
       (is (= 42 (:tokens m)))
       (is (= 7 (:duration-ms m))))))
 
+(deftest success-metrics-drops-present-nil-cost-usd-test
+  ;; The 2026-06-16 dogfood crashed the implement phase with a message-less
+  ;; NPE: build-code-response wrote :cost-usd nil into metrics (the LLM turn
+  ;; reported no cost), and the cost accumulator `(fnil + 0.0) cost` saw the
+  ;; present nil — readers coalesce cost-usd with a default, but get/keyword-
+  ;; with-default returns a present nil, not the default. Drop a present-nil
+  ;; :cost-usd at the constructor so every reader's default/estimate applies.
+  (testing "present-but-nil :cost-usd is dropped, not passed through"
+    (let [m (metrics (response/success :out {:metrics {:tokens 5 :duration-ms 100 :cost-usd nil}}))]
+      (is (not (contains? m :cost-usd))
+          "a present-nil :cost-usd must not survive — readers fall back to their own default")
+      (is (= 5 (:tokens m)))
+      (is (= 100 (:duration-ms m)))))
+  (testing "a real numeric :cost-usd is preserved"
+    (let [m (metrics (response/success :out {:metrics {:tokens 5 :duration-ms 100 :cost-usd 0.42}}))]
+      (is (= 0.42 (:cost-usd m)))))
+  (testing "absent :cost-usd stays absent (optional)"
+    (let [m (metrics (response/success :out {:metrics {:tokens 5 :duration-ms 100}}))]
+      (is (not (contains? m :cost-usd)))))
+  (testing "error path also drops a present-nil :cost-usd"
+    (let [m (metrics (response/error "boom" {:metrics {:tokens 5 :duration-ms 100 :cost-usd nil}}))]
+      (is (not (contains? m :cost-usd))))))
+
 (deftest error-and-failure-metrics-never-nil-test
   (testing "error normalizes an explicit nil :tokens"
     (let [m (metrics (response/error "boom" {:metrics {:tokens nil :duration-ms nil}}))]


### PR DESCRIPTION
## Summary

A 2026-06-16 dogfood crashed the implement phase with a message-less `NullPointerException` in `:leave-error`. Root cause: `build-code-response` wrote `:cost-usd nil` into result metrics (the LLM turn reported no cost), and the cost accumulator in `implement.clj`:

```clojure
(update-in [:execution/metrics :cost-usd] (fnil + 0.0) cost-usd)
```

evaluated `(+ 0.0 nil)` — auto-unboxing `nil` to a primitive double throws an NPE with no message (`ex-message nil`, `ex-class NullPointerException`).

The nil reached the accumulator because every reader coalesces cost with a default — `(:cost-usd metrics 0.0)` in plan/release/review/verify, a nested get-with-token-estimate in implement — but `get`/keyword-with-default returns a **present** nil rather than the default. So a present-nil cost silently overrode every reader's fallback.

Regression from `da8f0232` (rewrote an `or`-chain into get-with-default). #1147/#1149 fixed the same present-nil class for `:tokens`/`:duration-ms` but not `:cost-usd`.

## Fix

At the single writer funnel — `normalize-metrics`, used by both `success` and `error` — drop a present-and-nil `:cost-usd` so each reader's own default/estimate applies. This protects all five phase cost accumulators (plan/implement/verify/review/release), which share the same reader pattern, not just the one that crashed. `:cost-usd` stays optional (absent is fine); only present-nil is dropped.

## Test plan

- New `success-metrics-drops-present-nil-cost-usd-test` (builder_test): builds the real production shape — `{:tokens 5 :duration-ms 100 :cost-usd nil}` via `response/success`/`response/error` — and asserts the present-nil cost is dropped, a real numeric cost is preserved, and an absent cost stays absent. The existing implement_test fixtures omit the key, so get-default masked the bug.
- `bb pre-commit` passes (312 + 6); response builder + phase-software-factory implement suites green (48 tests).

Surfaced by the 2026-06-16 monitor-loop-event-emission dogfood (integration task crashed after several redirect cycles — more implement turns → higher chance of a no-cost turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)