### PR TITLE
Add monitor-worklist namespace to pr-lifecycle component.

### DIFF
--- a/components/pr-lifecycle/resources/config/pr-lifecycle/messages/system.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/messages/system.edn
@@ -1,0 +1,40 @@
+{:pr-lifecycle/system
+ {;; WorklistEntry schema validation failure (operator tooling, not user UI)
+  :worklist/validation-failed
+  "WorklistEntry schema validation failed"
+
+  ;; persist-worklist! — schema guard rejected the entry
+  :worklist/invalid-entry
+  "Invalid WorklistEntry"
+
+  ;; persist-worklist! — filesystem write failed
+  :worklist/write-failed
+  "Failed to write worklist"
+
+  ;; load-worklist — path does not exist
+  :worklist/not-found
+  "Worklist not found"
+
+  ;; load-worklist — file exists but EDN is malformed or fails schema
+  :worklist/corrupt
+  "Corrupt worklist"
+
+  ;; load-worklist — filesystem read failed
+  :worklist/read-failed
+  "Failed to read worklist"
+
+  ;; fetch-pr-state — gh exited 0 but --json state field absent
+  :worklist/gh-no-state
+  "gh pr view returned no state field"
+
+  ;; fetch-pr-state — gh exited non-zero
+  :worklist/gh-nonzero-exit
+  "gh pr view exited non-zero"
+
+  ;; fetch-pr-state — gh process could not be started
+  :worklist/gh-start-failed
+  "gh pr view process failed to start"
+
+  ;; prune-closed-prs — a gh call failed; worklist left unchanged
+  :worklist/gh-prune-failed
+  "gh pr view failed during prune — worklist unchanged"}}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -51,6 +51,7 @@
    [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
    [ai.miniforge.pr-lifecycle.monitor-loop :as monitor]
    [ai.miniforge.pr-lifecycle.monitor-budget :as mbudget]
+   [ai.miniforge.pr-lifecycle.monitor-worklist :as mworklist]
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]
    [ai.miniforge.pr-lifecycle.responder :as responder]))
 
@@ -901,6 +902,69 @@
   "Return the shared PR monitor defaults map."
   mconfig/monitor-defaults)
 
+;------------------------------------------------------------------------------ Layer 6
+;; PR Monitor Worklist
+
+(def WorklistEntry
+  "Malli schema for the persisted work-list EDN written to disk.
+
+   - :worklist/repo-key   — 12-hex-char prefix of SHA-256(remote-origin-url)
+   - :worklist/prs        — vector of WorklistPrEntry maps
+   - :worklist/updated-at — last-write instant
+
+   Each PR entry carries its own :pr/poll-interval and
+   :pr/abandon-after-hours so no operational literal is hard-coded
+   in the component (rule 8)."
+  mworklist/WorklistEntry)
+
+(def worklist-path
+  "Compute the absolute path for the work-list EDN file.
+
+   Arguments:
+   - home-dir — miniforge home directory (from app-config/home-dir)
+   - rkey     — repo key returned by `worklist-repo-key`
+
+   Returns: <home-dir>/pr-monitor/<rkey>.edn"
+  mworklist/worklist-path)
+
+(def worklist-repo-key
+  "Derive a stable, filesystem-safe key from `remote-url` (e.g. the
+   value of `git remote get-url origin`).
+
+   Returns a 12-character lowercase hex prefix of the SHA-256 digest."
+  mworklist/repo-key)
+
+(def persist-worklist!
+  "Validate `entry` against WorklistEntry and write it as EDN to `path`.
+   Creates parent directories as needed.
+
+   Returns:
+   - `(schema/success :worklist entry)` on success.
+   - `(schema/failure :worklist <msg>)` on validation or I/O failure."
+  mworklist/persist-worklist!)
+
+(def load-worklist
+  "Read and validate a WorklistEntry EDN from `path`.
+
+   Returns:
+   - `(schema/success :worklist entry)` on success.
+   - `(schema/failure :worklist <msg>)` when path is missing, unreadable,
+     or content does not satisfy WorklistEntry."
+  mworklist/load-worklist)
+
+(def prune-closed-prs
+  "Remove merged or closed PR entries from `entry` by querying GitHub.
+
+   For each PR in `:worklist/prs`, shells `gh pr view <number> --repo
+   <repo> --json state`. Drops entries whose state is not \"OPEN\".
+
+   Returns:
+   - The pruned WorklistEntry when all `gh` calls succeed (may be the
+     original map when every PR is still open).
+   - An anomaly map if any `gh` invocation fails — worklist is left
+     unchanged rather than silently dropping unchecked PRs."
+  mworklist/prune-closed-prs)
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Quick example: Full PR lifecycle
@@ -966,6 +1030,20 @@
   ;; Get evidence
   (pr-monitor-evidence m)
   ; => {:comments-received 5 :comments-addressed 3 :fixes-pushed [...] ...}
+
+  ;; Monitor worklist example
+  (let [rkey (worklist-repo-key "https://github.com/org/repo.git")
+        path (worklist-path (System/getenv "MINIFORGE_HOME") rkey)]
+    (persist-worklist! path
+                       {:worklist/repo-key   rkey
+                        :worklist/prs        [{:pr/url              "https://github.com/org/repo/pull/42"
+                                               :pr/number           42
+                                               :pr/repo             "org/repo"
+                                               :pr/added-at         (java.util.Date.)
+                                               :pr/poll-interval    60
+                                               :pr/abandon-after-hours 72}]
+                        :worklist/updated-at (java.util.Date.)}))
+  ; => {:success? true :worklist {...}}
 
   :leave-this-here)
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
@@ -89,8 +89,10 @@
   "OPEN")
 
 (def ^:private gh-state-pattern
-  "Regex to extract the state field from `gh pr view --json state` output."
-  #"\"state\":\"([^\"]+)\"")
+  "Regex to extract the state field from `gh pr view --json state` output.
+   Tolerates optional whitespace around the colon — `gh`'s JSON is compact
+   today, but a pretty-printed `\"state\": \"OPEN\"` must still match."
+  #"\"state\"\s*:\s*\"([^\"]+)\"")
 
 (def WorklistPrEntry
   "Malli schema for a single PR entry inside a WorklistEntry.
@@ -257,7 +259,11 @@
       (if (empty? remaining)
         (if (= (count kept) (count prs))
           entry
-          (assoc entry :worklist/prs kept))
+          ;; PRs were dropped — :worklist/prs changed, so bump the
+          ;; last-write instant (matches the persist path's updated-at).
+          (assoc entry
+                 :worklist/prs kept
+                 :worklist/updated-at (java.util.Date.)))
         (let [pr-entry (first remaining)
               state    (fetch-pr-state pr-entry)]
           (if (anomaly/anomaly? state)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
@@ -1,0 +1,289 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-worklist
+  "Persisted PR monitor work-list — schema, path helpers, and disk I/O.
+
+   Layer 0: WorklistEntry Malli schema and named storage constants.
+   Layer 1: Pure helpers — repo-key derivation, worklist-path computation.
+   Layer 2: Side-effecting persist!/load/prune functions.
+
+   The work-list tracks which PRs a monitor instance is watching.
+   It is keyed by a hash of the git remote origin URL so multiple repos
+   coexist under the same monitor directory without collision.
+
+   Storage layout: <home-dir>/pr-monitor/<repo-key>.edn
+
+   Operational parameters (poll-interval, abandon-after-hours) travel
+   inside the persisted PR entry map — no operational literal is
+   hard-coded here (rule 8).
+
+   Boundary contract (rules 3, 4):
+   - persist!/load  → schema/success or schema/failure; never throw.
+   - prune-closed-prs → WorklistEntry (pruned or original) or anomaly map."
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [clojure.edn :as edn]
+   [malli.core :as m]
+   [malli.error :as me]
+   [slingshot.slingshot :refer [try+]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.schema.interface :as schema])
+  (:import
+   [java.nio.charset StandardCharsets]
+   [java.security MessageDigest]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Named constants and Malli schema
+
+(def ^:private pr-monitor-dir-name
+  "Subdirectory name under home-dir for all work-list files."
+  "pr-monitor")
+
+(def ^:private sha-algorithm
+  "Hash algorithm for repo-key derivation."
+  "SHA-256")
+
+(def ^:private repo-key-prefix-length
+  "Number of hex characters taken from the SHA-256 digest as the repo-key."
+  12)
+
+(def ^:private open-pr-state
+  "GitHub PR state string indicating the PR is still open."
+  "OPEN")
+
+(def ^:private gh-state-pattern
+  "Regex to extract the state field from `gh pr view --json state` output."
+  #"\"state\":\"([^\"]+)\"")
+
+(def WorklistPrEntry
+  "Malli schema for a single PR entry inside a WorklistEntry.
+
+   Operational parameters (:pr/poll-interval, :pr/abandon-after-hours)
+   travel with the entry — no operational literal is hard-coded in this
+   namespace (rule 8)."
+  [:map
+   [:pr/url :string]
+   [:pr/number :int]
+   [:pr/repo :string]
+   [:pr/added-at inst?]
+   [:pr/poll-interval {:optional true} :int]
+   [:pr/abandon-after-hours {:optional true} :int]])
+
+(def WorklistEntry
+  "Malli schema for the persisted work-list EDN file.
+
+   - :worklist/repo-key   — 12-hex-char prefix of SHA-256(remote-origin-url)
+   - :worklist/prs        — vector of WorklistPrEntry maps
+   - :worklist/updated-at — last-write instant"
+  [:map
+   [:worklist/repo-key :string]
+   [:worklist/prs [:vector WorklistPrEntry]]
+   [:worklist/updated-at inst?]])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pure helpers
+
+(defn- sha256-hex
+  "Return the full lowercase hex SHA-256 digest of `s`."
+  [s]
+  (let [md    (MessageDigest/getInstance sha-algorithm)
+        bytes (.digest md (.getBytes ^String s StandardCharsets/UTF_8))]
+    (apply str (map #(format "%02x" (bit-and % 0xff)) bytes))))
+
+(defn repo-key
+  "Derive a stable, filesystem-safe key from `remote-url` (typically the
+   value of `git remote get-url origin`).
+
+   Returns the first `repo-key-prefix-length` characters of the lowercase
+   hex SHA-256 digest — long enough to be collision-resistant across the
+   repos a single monitor instance will track."
+  [remote-url]
+  (subs (sha256-hex remote-url) 0 repo-key-prefix-length))
+
+(defn worklist-path
+  "Compute the absolute path for the work-list EDN file.
+
+   - `home-dir` — miniforge home directory (from app-config/home-dir)
+   - `rkey`     — repo key returned by `repo-key`
+
+   Returns: <home-dir>/pr-monitor/<rkey>.edn"
+  [home-dir rkey]
+  (str home-dir "/" pr-monitor-dir-name "/" rkey ".edn"))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Internal validation helper
+
+(defn- validate-entry
+  "Return `entry` when it satisfies WorklistEntry, or an :invalid-input anomaly."
+  [entry]
+  (if (m/validate WorklistEntry entry)
+    entry
+    (anomaly/validation-anomaly
+     "WorklistEntry schema validation failed"
+     :WorklistEntry
+     entry
+     (me/humanize (m/explain WorklistEntry entry)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Disk I/O
+
+(defn persist-worklist!
+  "Validate `entry` against WorklistEntry and write it as EDN to `path`.
+   Creates parent directories as needed.
+
+   Returns:
+   - `(schema/success :worklist entry)` on success.
+   - `(schema/failure :worklist <msg>)` on validation or I/O failure."
+  [path entry]
+  (let [validated (validate-entry entry)]
+    (if (anomaly/anomaly? validated)
+      (schema/failure :worklist
+                      (str "Invalid WorklistEntry: "
+                           (get-in validated [:anomaly/data :errors])))
+      (try+
+       (fs/create-dirs (fs/parent path))
+       (spit path (pr-str entry))
+       (schema/success :worklist entry)
+       (catch Object ex
+         (schema/failure :worklist
+                         (str "Failed to write worklist to " path ": "
+                              (ex-message ex))))))))
+
+(defn load-worklist
+  "Read and validate a WorklistEntry EDN from `path`.
+
+   Returns:
+   - `(schema/success :worklist entry)` on success.
+   - `(schema/failure :worklist <msg>)` when path is missing, unreadable,
+     or content does not satisfy WorklistEntry."
+  [path]
+  (cond
+    (not (fs/exists? path))
+    (schema/failure :worklist (str "Worklist not found: " path))
+
+    :else
+    (try+
+     (let [entry (edn/read-string (slurp path))
+           validated (validate-entry entry)]
+       (if (anomaly/anomaly? validated)
+         (schema/failure :worklist
+                         (str "Corrupt worklist at " path ": "
+                              (get-in validated [:anomaly/data :errors])))
+         (schema/success :worklist entry)))
+     (catch Object ex
+       (schema/failure :worklist
+                       (str "Failed to read worklist at " path ": "
+                            (ex-message ex)))))))
+
+(defn- fetch-pr-state
+  "Shell `gh pr view <number> --repo <repo> --json state` and return the
+   state string (e.g. \"OPEN\", \"MERGED\", \"CLOSED\"), or an anomaly
+   on process failure or missing output field.
+
+   Uses `:throw false` so the process exit code is checked explicitly
+   rather than raising a Java exception for non-zero exits."
+  [{:pr/keys [number repo]}]
+  (try+
+   (let [proc @(process/process ["gh" "pr" "view" (str number)
+                                 "--repo" repo "--json" "state"]
+                                {:out :string :err :string :throw false})]
+     (if (zero? (:exit proc))
+       (or (second (re-find gh-state-pattern (:out proc)))
+           (anomaly/anomaly :fault
+                            "gh pr view returned no state field"
+                            {:pr/number number :pr/repo repo
+                             :out (:out proc)}))
+       (anomaly/anomaly :fault
+                        "gh pr view exited non-zero"
+                        {:pr/number number :pr/repo repo
+                         :exit (:exit proc) :err (:err proc)})))
+   (catch Object ex
+     (anomaly/anomaly :fault
+                      "gh pr view process failed to start"
+                      {:pr/number number :pr/repo repo
+                       :anomaly/ex-message (ex-message ex)}))))
+
+(defn prune-closed-prs
+  "Remove merged or closed PR entries from `entry` by querying GitHub.
+
+   For each PR in `:worklist/prs`, shells `gh pr view <number> --repo
+   <repo> --json state`. Drops entries whose state is not \"OPEN\".
+
+   Returns:
+   - The pruned WorklistEntry when all `gh` calls succeed (may be the
+     original map when every PR is still open).
+   - An anomaly map if any `gh` invocation fails — safer to leave the
+     list unchanged than to silently drop PRs we could not check."
+  [entry]
+  (let [prs (:worklist/prs entry)]
+    (loop [remaining prs
+           kept      []]
+      (if (empty? remaining)
+        (if (= (count kept) (count prs))
+          entry
+          (assoc entry :worklist/prs kept))
+        (let [pr-entry (first remaining)
+              state    (fetch-pr-state pr-entry)]
+          (if (anomaly/anomaly? state)
+            (anomaly/anomaly :fault
+                             "gh pr view failed during prune — worklist unchanged"
+                             {:failed-pr pr-entry :cause state})
+            (recur (rest remaining)
+                   (if (= state open-pr-state)
+                     (conj kept pr-entry)
+                     kept))))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Derive repo key from a remote URL
+  (repo-key "https://github.com/miniforge-ai/miniforge.git")
+  ;; => "3f8a1c2b0e94" (first 12 hex chars of SHA-256)
+
+  ;; Compute work-list path
+  (worklist-path "/Users/chris/.miniforge"
+                 (repo-key "https://github.com/miniforge-ai/miniforge.git"))
+  ;; => "/Users/chris/.miniforge/pr-monitor/3f8a1c2b0e94.edn"
+
+  ;; Construct and persist a worklist
+  (let [entry {:worklist/repo-key    "3f8a1c2b0e94"
+               :worklist/prs         [{:pr/url              "https://github.com/org/repo/pull/42"
+                                       :pr/number           42
+                                       :pr/repo             "org/repo"
+                                       :pr/added-at         (java.util.Date.)
+                                       :pr/poll-interval    60
+                                       :pr/abandon-after-hours 72}]
+               :worklist/updated-at  (java.util.Date.)}
+        path  "/tmp/test-worklist.edn"]
+    (persist-worklist! path entry))
+  ;; => {:success? true :worklist {...}}
+
+  ;; Load it back
+  (load-worklist "/tmp/test-worklist.edn")
+  ;; => {:success? true :worklist {...}}
+
+  ;; Missing file
+  (load-worklist "/tmp/no-such-file.edn")
+  ;; => {:success? false :worklist nil :error "Worklist not found: ..."}
+
+  ;; Prune closed PRs (requires gh auth)
+  ;; (prune-closed-prs entry)
+  ;; => updated-entry or anomaly
+
+  :leave-this-here)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
@@ -20,7 +20,8 @@
   "Persisted PR monitor work-list — schema, path helpers, and disk I/O.
 
    Layer 0: WorklistEntry Malli schema and named storage constants.
-   Layer 1: Pure helpers — repo-key derivation, worklist-path computation.
+   Layer 1: Pure helpers — repo-key derivation, worklist-path computation,
+            entry validation.
    Layer 2: Side-effecting persist!/load/prune functions.
 
    The work-list tracks which PRs a monitor instance is watching.
@@ -35,7 +36,12 @@
 
    Boundary contract (rules 3, 4):
    - persist!/load  → schema/success or schema/failure; never throw.
-   - prune-closed-prs → WorklistEntry (pruned or original) or anomaly map."
+   - prune-closed-prs → WorklistEntry (pruned or original) or anomaly map.
+
+   All messages routed through (t :key) from the system message catalog
+   (resources/config/pr-lifecycle/messages/system.edn). Dynamic context
+   (path, pr/number, repo) travels in the anomaly :data map, not the
+   message string (rule 50)."
   (:require
    [babashka.fs :as fs]
    [babashka.process :as process]
@@ -44,6 +50,7 @@
    [malli.error :as me]
    [slingshot.slingshot :refer [try+]]
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.messages.interface :as msg]
    [ai.miniforge.schema.interface :as schema])
   (:import
    [java.nio.charset StandardCharsets]
@@ -52,9 +59,18 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Named constants and Malli schema
 
+(def ^:private t
+  "Component-scoped message translator. All emitted strings go through this."
+  (msg/create-translator "config/pr-lifecycle/messages/system.edn"
+                         :pr-lifecycle/system))
+
 (def ^:private pr-monitor-dir-name
   "Subdirectory name under home-dir for all work-list files."
   "pr-monitor")
+
+(def ^:private worklist-file-extension
+  "File extension for persisted work-list EDN files."
+  ".edn")
 
 (def ^:private sha-algorithm
   "Hash algorithm for repo-key derivation."
@@ -63,6 +79,10 @@
 (def ^:private repo-key-prefix-length
   "Number of hex characters taken from the SHA-256 digest as the repo-key."
   12)
+
+(def ^:private unsigned-byte-mask
+  "Mask for converting a signed Java byte to unsigned (0–255) for hex formatting."
+  0xff)
 
 (def ^:private open-pr-state
   "GitHub PR state string indicating the PR is still open."
@@ -105,7 +125,7 @@
   [s]
   (let [md    (MessageDigest/getInstance sha-algorithm)
         bytes (.digest md (.getBytes ^String s StandardCharsets/UTF_8))]
-    (apply str (map #(format "%02x" (bit-and % 0xff)) bytes))))
+    (apply str (map #(format "%02x" (bit-and % unsigned-byte-mask)) bytes))))
 
 (defn repo-key
   "Derive a stable, filesystem-safe key from `remote-url` (typically the
@@ -125,24 +145,22 @@
 
    Returns: <home-dir>/pr-monitor/<rkey>.edn"
   [home-dir rkey]
-  (str home-dir "/" pr-monitor-dir-name "/" rkey ".edn"))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Internal validation helper
+  (str (fs/path home-dir pr-monitor-dir-name (str rkey worklist-file-extension))))
 
 (defn- validate-entry
-  "Return `entry` when it satisfies WorklistEntry, or an :invalid-input anomaly."
+  "Return `entry` when it satisfies WorklistEntry, or an :invalid-input anomaly.
+   Pure — no I/O."
   [entry]
   (if (m/validate WorklistEntry entry)
     entry
     (anomaly/validation-anomaly
-     "WorklistEntry schema validation failed"
+     (t :worklist/validation-failed)
      :WorklistEntry
      entry
      (me/humanize (m/explain WorklistEntry entry)))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Disk I/O
+;; Disk I/O and GitHub shell calls
 
 (defn persist-worklist!
   "Validate `entry` against WorklistEntry and write it as EDN to `path`.
@@ -150,21 +168,23 @@
 
    Returns:
    - `(schema/success :worklist entry)` on success.
-   - `(schema/failure :worklist <msg>)` on validation or I/O failure."
+   - `(schema/failure :worklist <msg>)` on validation or I/O failure.
+   Dynamic context (path, errors) in the :error value, not the message key."
   [path entry]
   (let [validated (validate-entry entry)]
     (if (anomaly/anomaly? validated)
       (schema/failure :worklist
-                      (str "Invalid WorklistEntry: "
-                           (get-in validated [:anomaly/data :errors])))
+                      {:message (t :worklist/invalid-entry)
+                       :errors  (get-in validated [:anomaly/data :errors])})
       (try+
        (fs/create-dirs (fs/parent path))
        (spit path (pr-str entry))
        (schema/success :worklist entry)
        (catch Object ex
          (schema/failure :worklist
-                         (str "Failed to write worklist to " path ": "
-                              (ex-message ex))))))))
+                         {:message (t :worklist/write-failed)
+                          :path    path
+                          :cause   (ex-message ex)}))))))
 
 (defn load-worklist
   "Read and validate a WorklistEntry EDN from `path`.
@@ -176,29 +196,28 @@
   [path]
   (cond
     (not (fs/exists? path))
-    (schema/failure :worklist (str "Worklist not found: " path))
+    (schema/failure :worklist {:message (t :worklist/not-found) :path path})
 
     :else
     (try+
-     (let [entry (edn/read-string (slurp path))
+     (let [entry     (edn/read-string (slurp path))
            validated (validate-entry entry)]
        (if (anomaly/anomaly? validated)
          (schema/failure :worklist
-                         (str "Corrupt worklist at " path ": "
-                              (get-in validated [:anomaly/data :errors])))
+                         {:message (t :worklist/corrupt)
+                          :path    path
+                          :errors  (get-in validated [:anomaly/data :errors])})
          (schema/success :worklist entry)))
      (catch Object ex
        (schema/failure :worklist
-                       (str "Failed to read worklist at " path ": "
-                            (ex-message ex)))))))
+                       {:message (t :worklist/read-failed)
+                        :path    path
+                        :cause   (ex-message ex)})))))
 
 (defn- fetch-pr-state
   "Shell `gh pr view <number> --repo <repo> --json state` and return the
-   state string (e.g. \"OPEN\", \"MERGED\", \"CLOSED\"), or an anomaly
-   on process failure or missing output field.
-
-   Uses `:throw false` so the process exit code is checked explicitly
-   rather than raising a Java exception for non-zero exits."
+   state string (\"OPEN\", \"MERGED\", \"CLOSED\"), or an anomaly on
+   process failure or missing output field."
   [{:pr/keys [number repo]}]
   (try+
    (let [proc @(process/process ["gh" "pr" "view" (str number)
@@ -207,18 +226,18 @@
      (if (zero? (:exit proc))
        (or (second (re-find gh-state-pattern (:out proc)))
            (anomaly/anomaly :fault
-                            "gh pr view returned no state field"
+                            (t :worklist/gh-no-state)
                             {:pr/number number :pr/repo repo
                              :out (:out proc)}))
        (anomaly/anomaly :fault
-                        "gh pr view exited non-zero"
+                        (t :worklist/gh-nonzero-exit)
                         {:pr/number number :pr/repo repo
                          :exit (:exit proc) :err (:err proc)})))
    (catch Object ex
      (anomaly/anomaly :fault
-                      "gh pr view process failed to start"
+                      (t :worklist/gh-start-failed)
                       {:pr/number number :pr/repo repo
-                       :anomaly/ex-message (ex-message ex)}))))
+                       :cause (ex-message ex)}))))
 
 (defn prune-closed-prs
   "Remove merged or closed PR entries from `entry` by querying GitHub.
@@ -229,8 +248,8 @@
    Returns:
    - The pruned WorklistEntry when all `gh` calls succeed (may be the
      original map when every PR is still open).
-   - An anomaly map if any `gh` invocation fails — safer to leave the
-     list unchanged than to silently drop PRs we could not check."
+   - An anomaly map if any `gh` invocation fails — worklist is left
+     unchanged rather than silently dropping unchecked PRs."
   [entry]
   (let [prs (:worklist/prs entry)]
     (loop [remaining prs
@@ -243,7 +262,7 @@
               state    (fetch-pr-state pr-entry)]
           (if (anomaly/anomaly? state)
             (anomaly/anomaly :fault
-                             "gh pr view failed during prune — worklist unchanged"
+                             (t :worklist/gh-prune-failed)
                              {:failed-pr pr-entry :cause state})
             (recur (rest remaining)
                    (if (= state open-pr-state)
@@ -262,14 +281,14 @@
   ;; => "/Users/chris/.miniforge/pr-monitor/3f8a1c2b0e94.edn"
 
   ;; Construct and persist a worklist
-  (let [entry {:worklist/repo-key    "3f8a1c2b0e94"
-               :worklist/prs         [{:pr/url              "https://github.com/org/repo/pull/42"
-                                       :pr/number           42
-                                       :pr/repo             "org/repo"
-                                       :pr/added-at         (java.util.Date.)
-                                       :pr/poll-interval    60
-                                       :pr/abandon-after-hours 72}]
-               :worklist/updated-at  (java.util.Date.)}
+  (let [entry {:worklist/repo-key   "3f8a1c2b0e94"
+               :worklist/prs        [{:pr/url    "https://github.com/org/repo/pull/42"
+                                      :pr/number 42
+                                      :pr/repo   "org/repo"
+                                      :pr/added-at (java.util.Date.)
+                                      :pr/poll-interval       60
+                                      :pr/abandon-after-hours 72}]
+               :worklist/updated-at (java.util.Date.)}
         path  "/tmp/test-worklist.edn"]
     (persist-worklist! path entry))
   ;; => {:success? true :worklist {...}}
@@ -280,7 +299,7 @@
 
   ;; Missing file
   (load-worklist "/tmp/no-such-file.edn")
-  ;; => {:success? false :worklist nil :error "Worklist not found: ..."}
+  ;; => {:success? false :worklist nil :error {:message "Worklist not found" :path ...}}
 
   ;; Prune closed PRs (requires gh auth)
   ;; (prune-closed-prs entry)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj
@@ -25,6 +25,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [babashka.fs :as fs]
+   [babashka.process :as process]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.pr-lifecycle.monitor-worklist :as worklist]))
@@ -159,7 +160,7 @@
 
 (deftest prune-keeps-open-drops-merged-closed-test
   (testing "keeps OPEN entries, drops MERGED and CLOSED"
-    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+    (with-redefs [ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
                   (fn [{:pr/keys [number]}]
                     (case (int number)
                       1 "OPEN"
@@ -172,15 +173,44 @@
         (is (= [open-pr] (:worklist/prs result))))))
 
   (testing "returns original map identity when all PRs are OPEN"
-    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+    (with-redefs [ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
                   (fn [_] "OPEN")]
       (let [entry  (make-entry [open-pr])
             result (worklist/prune-closed-prs entry)]
-        (is (= entry result))))))
+        (is (= entry result)))))
+
+  (testing "bumps :worklist/updated-at when PRs are actually dropped (Copilot #1198)"
+    (with-redefs [ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                  (fn [{:pr/keys [number]}] (if (= 1 (int number)) "OPEN" "MERGED"))]
+      (let [entry  (assoc (make-entry [open-pr merged-pr])
+                          :worklist/updated-at #inst "2000-01-01T00:00:00.000-00:00")
+            result (worklist/prune-closed-prs entry)]
+        (is (= [open-pr] (:worklist/prs result)))
+        (is (.after ^java.util.Date (:worklist/updated-at result)
+                    (:worklist/updated-at entry))
+            "dropping a PR must advance the last-write instant")))))
+
+(deftest fetch-pr-state-tolerates-whitespace-json-test
+  ;; Copilot #1198: gh's --json is compact today, but a pretty-printed
+  ;; `"state": "OPEN"` (whitespace around the colon) must still parse.
+  (testing "whitespace around the colon in gh JSON still extracts the state"
+    (with-redefs [process/process (fn [& _] (future {:exit 0
+                                                     :out "{\n  \"state\": \"OPEN\"\n}"
+                                                     :err ""}))]
+      (is (= "OPEN"
+             (#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+              {:pr/number 1 :pr/repo "org/repo"})))))
+  (testing "compact JSON still parses"
+    (with-redefs [process/process (fn [& _] (future {:exit 0
+                                                     :out "{\"state\":\"MERGED\"}"
+                                                     :err ""}))]
+      (is (= "MERGED"
+             (#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+              {:pr/number 2 :pr/repo "org/repo"}))))))
 
 (deftest prune-gh-failure-test
   (testing "returns anomaly when fetch-pr-state returns anomaly"
-    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+    (with-redefs [ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
                   (fn [pr]
                     (anomaly/anomaly :fault "gh failed" {:pr pr}))]
       (let [result (worklist/prune-closed-prs (make-entry [open-pr]))]
@@ -189,7 +219,7 @@
 
   (testing "short-circuits on first failure, does not call gh for remaining PRs"
     (let [call-count (atom 0)]
-      (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+      (with-redefs [ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
                     (fn [_]
                       (swap! call-count inc)
                       (anomaly/anomaly :fault "gh failed" {}))]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj
@@ -1,0 +1,202 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-worklist-test
+  "Tests for the PR monitor work-list namespace.
+
+   I/O tests use `babashka.fs/with-temp-dir` for filesystem isolation.
+   `fetch-pr-state` (private) is stubbed via `with-redefs` for prune tests."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [babashka.fs :as fs]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.schema.interface :as schema]
+   [ai.miniforge.pr-lifecycle.monitor-worklist :as worklist]))
+
+;------------------------------------------------------------------------------ Fixtures
+
+(def ^:private known-url "https://github.com/miniforge-ai/miniforge.git")
+
+(defn- make-pr-entry
+  "Build a minimal valid WorklistPrEntry."
+  [number repo]
+  {:pr/url      (str "https://github.com/" repo "/pull/" number)
+   :pr/number   number
+   :pr/repo     repo
+   :pr/added-at (java.util.Date.)})
+
+(defn- make-entry
+  "Build a minimal valid WorklistEntry for testing."
+  ([]
+   (make-entry [(make-pr-entry 42 "org/repo")]))
+  ([prs]
+   {:worklist/repo-key   "abc123def456"
+    :worklist/prs        prs
+    :worklist/updated-at (java.util.Date.)}))
+
+(def ^:private open-pr   (make-pr-entry 1 "org/repo"))
+(def ^:private merged-pr (make-pr-entry 2 "org/repo"))
+(def ^:private closed-pr (make-pr-entry 3 "org/repo"))
+
+;------------------------------------------------------------------------------ Layer 1: repo-key
+
+(deftest repo-key-deterministic-test
+  (testing "same URL always produces the same key"
+    (is (= (worklist/repo-key known-url)
+           (worklist/repo-key known-url))))
+
+  (testing "different URLs produce different keys"
+    (is (not= (worklist/repo-key known-url)
+              (worklist/repo-key "https://github.com/other/repo.git"))))
+
+  (testing "key length is exactly 12 characters"
+    (is (= 12 (count (worklist/repo-key known-url)))))
+
+  (testing "key is lowercase hex"
+    (is (re-matches #"[0-9a-f]+" (worklist/repo-key known-url)))))
+
+;------------------------------------------------------------------------------ Layer 1: worklist-path
+
+(deftest worklist-path-test
+  (testing "assembles path under pr-monitor subdir with .edn extension"
+    (let [home "/home/user/.miniforge"
+          rkey "abc123def456"
+          path (worklist/worklist-path home rkey)]
+      (is (str/includes? path "pr-monitor"))
+      (is (str/includes? path rkey))
+      (is (str/ends-with? path ".edn"))))
+
+  (testing "path starts with home-dir"
+    (let [home "/custom/home"
+          path (worklist/worklist-path home "deadbeef1234")]
+      (is (str/starts-with? path home)))))
+
+;------------------------------------------------------------------------------ Layer 2: persist-worklist!
+
+(deftest persist-worklist-happy-test
+  (testing "creates dirs and writes EDN, returns schema/success"
+    (fs/with-temp-dir [tmp {}]
+      (let [rkey  "abc123def456"
+            path  (worklist/worklist-path (str tmp) rkey)
+            entry (make-entry)]
+        (let [result (worklist/persist-worklist! path entry)]
+          (is (schema/succeeded? result))
+          (is (= entry (:worklist result)))
+          (is (fs/exists? path)))))))
+
+(deftest persist-worklist-invalid-entry-test
+  (testing "returns schema/failure on schema mismatch, no file written"
+    (fs/with-temp-dir [tmp {}]
+      (let [path  (str (fs/path tmp "worklist.edn"))
+            ;; Missing required :worklist/updated-at
+            entry {:worklist/repo-key "abc123def456"
+                   :worklist/prs      []}]
+        (let [result (worklist/persist-worklist! path entry)]
+          (is (schema/failed? result))
+          (is (not (fs/exists? path))))))))
+
+(deftest persist-worklist-io-error-test
+  (testing "returns schema/failure when a file blocks directory creation"
+    (fs/with-temp-dir [tmp {}]
+      ;; Place a regular file where fs/create-dirs would need to create a dir
+      (let [blocker (str (fs/path tmp "pr-monitor"))]
+        (spit blocker "not-a-dir")
+        (let [path   (str (fs/path tmp "pr-monitor" "abc123def456.edn"))
+              entry  (make-entry)
+              result (worklist/persist-worklist! path entry)]
+          (is (schema/failed? result)))))))
+
+;------------------------------------------------------------------------------ Layer 2: load-worklist
+
+(deftest load-worklist-happy-test
+  (testing "round-trips a persisted entry"
+    (fs/with-temp-dir [tmp {}]
+      (let [rkey  "abc123def456"
+            path  (worklist/worklist-path (str tmp) rkey)
+            entry (make-entry)]
+        (worklist/persist-worklist! path entry)
+        (let [result (worklist/load-worklist path)]
+          (is (schema/succeeded? result))
+          (is (= entry (:worklist result))))))))
+
+(deftest load-worklist-missing-test
+  (testing "returns schema/failure for a non-existent path"
+    (let [result (worklist/load-worklist "/no/such/path/worklist.edn")]
+      (is (schema/failed? result))
+      (is (some? (:error result))))))
+
+(deftest load-worklist-corrupt-edn-test
+  (testing "returns schema/failure for unparseable EDN"
+    (fs/with-temp-dir [tmp {}]
+      (let [path (str (fs/path tmp "worklist.edn"))]
+        (spit path "this is not valid EDN }{{{")
+        (is (schema/failed? (worklist/load-worklist path))))))
+
+  (testing "returns schema/failure for EDN that fails WorklistEntry schema"
+    (fs/with-temp-dir [tmp {}]
+      (let [path (str (fs/path tmp "worklist.edn"))]
+        ;; Valid EDN but wrong shape
+        (spit path (pr-str {:not-a-worklist true}))
+        (is (schema/failed? (worklist/load-worklist path)))))))
+
+;------------------------------------------------------------------------------ Layer 2: prune-closed-prs
+
+(deftest prune-keeps-open-drops-merged-closed-test
+  (testing "keeps OPEN entries, drops MERGED and CLOSED"
+    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                  (fn [{:pr/keys [number]}]
+                    (case (int number)
+                      1 "OPEN"
+                      2 "MERGED"
+                      3 "CLOSED"
+                      "OPEN"))]
+      (let [entry  (make-entry [open-pr merged-pr closed-pr])
+            result (worklist/prune-closed-prs entry)]
+        (is (not (anomaly/anomaly? result)))
+        (is (= [open-pr] (:worklist/prs result))))))
+
+  (testing "returns original map identity when all PRs are OPEN"
+    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                  (fn [_] "OPEN")]
+      (let [entry  (make-entry [open-pr])
+            result (worklist/prune-closed-prs entry)]
+        (is (= entry result))))))
+
+(deftest prune-gh-failure-test
+  (testing "returns anomaly when fetch-pr-state returns anomaly"
+    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                  (fn [pr]
+                    (anomaly/anomaly :fault "gh failed" {:pr pr}))]
+      (let [result (worklist/prune-closed-prs (make-entry [open-pr]))]
+        (is (anomaly/anomaly? result))
+        (is (= :fault (:anomaly/type result))))))
+
+  (testing "short-circuits on first failure, does not call gh for remaining PRs"
+    (let [call-count (atom 0)]
+      (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                    (fn [_]
+                      (swap! call-count inc)
+                      (anomaly/anomaly :fault "gh failed" {}))]
+        (worklist/prune-closed-prs (make-entry [open-pr merged-pr]))
+        (is (= 1 @call-count))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.pr-lifecycle.monitor-worklist-test)
+  :leave-this-here)

--- a/docs/pull-requests/2026-06-15-add-monitor-worklist-namespace-to-pr-lifecycle-component.md
+++ b/docs/pull-requests/2026-06-15-add-monitor-worklist-namespace-to-pr-lifecycle-component.md
@@ -1,0 +1,41 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Add monitor-worklist namespace to pr-lifecycle component.
+
+**PR:** [#1198](https://github.com/miniforge-ai/miniforge/pull/1198)
+**Branch:** `mf/add-monitor-worklist-namespace-to-pr-lif-db6b9274`
+
+## Summary
+
+Add monitor-worklist namespace to pr-lifecycle component.
+
+## Files Changed
+
+- `components/pr-lifecycle/resources/config/pr-lifecycle/messages/system.edn` (create)
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj` (modify)
+- `components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj` (create)
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj` (modify)
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+**Decision**: approved
+
+Scoped files are correct. Named constants, localization, try+, anomaly returns, schema validation placement, and interface passthrough shape all conform to the active standards. Two nits on implementation style (apply str, two-arm cond) and a warning on the JSON regex fragility in fetch-pr-state — the gh --json output is typically compact, but the regex needs a \s* guard to survive optional whitespace. No blocking issues in scope.
+
+### Known issues (non-blocking)
+
+Merged with 4 unresolved non-blocking issue(s) recorded for follow-up:
+
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj:56` — gh-state-pattern regex does not allow whitespace between the JSON colon and the value. Pattern #"\"state\":\"([^\"]+)\"" fails on {"state": "OPEN"} (space after colon). GitHub CLI --json typically emits compact JSON, but that is not guaranteed and the fragility violates the intent of the named-constant docstring ('regex to extract the state field').
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj:148` — prune-closed-prs returns the pruned WorklistEntry without updating :worklist/updated-at. Callers that persist the result get a map whose timestamp still reflects the pre-prune write, not the time of pruning. The spec says the field tracks 'last-write instant', so a prune that removes entries is semantically a write.
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj:70` — (apply str (map #(format ...) bytes)) is idiomatic but accumulates a lazy seq through apply. clojure.string/join is the conventional form for collecting strings.
+- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj:102` — load-worklist uses (cond (not ...) ... :else ...) with exactly two arms. A plain if reads more directly.


### PR DESCRIPTION
---
miniforge-workflow: 5cd7a1e1-5b44-4fcf-895c-a51e2ad7f6c6
spec: work/observe-monitor-survives-cli-exit.spec.edn
task: 11111111-1111-1111-1111-111111111111
commit: 597ac95bef7e6a605e85c527f6a1defedcbca41b
generated-by: miniforge
---

## Summary

Add monitor-worklist namespace to pr-lifecycle component.

## Changes

- `components/pr-lifecycle/resources/config/pr-lifecycle/messages/system.edn` (create)
- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj` (modify)
- `components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj` (create)
- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj` (modify)
- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj` (modify)

## Review

**Decision**: approved

Scoped files are correct. Named constants, localization, try+, anomaly returns, schema validation placement, and interface passthrough shape all conform to the active standards. Two nits on implementation style (apply str, two-arm cond) and a warning on the JSON regex fragility in fetch-pr-state — the gh --json output is typically compact, but the regex needs a \s* guard to survive optional whitespace. No blocking issues in scope.

### Known issues (non-blocking)

Merged with 4 unresolved non-blocking issue(s) recorded for follow-up:

- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj:56` — gh-state-pattern regex does not allow whitespace between the JSON colon and the value. Pattern #"\"state\":\"([^\"]+)\"" fails on {"state": "OPEN"} (space after colon). GitHub CLI --json typically emits compact JSON, but that is not guaranteed and the fragility violates the intent of the named-constant docstring ('regex to extract the state field').
- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj:148` — prune-closed-prs returns the pruned WorklistEntry without updating :worklist/updated-at. Callers that persist the result get a map whose timestamp still reflects the pre-prune write, not the time of pruning. The spec says the field tracks 'last-write instant', so a prune that removes entries is semantically a write.
- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj:70` — (apply str (map #(format ...) bytes)) is idiomatic but accumulates a lazy seq through apply. clojure.string/join is the conventional form for collecting strings.
- `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj:102` — load-worklist uses (cond (not ...) ... :else ...) with exactly two arms. A plain if reads more directly.

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (5 files)