### PR TITLE
fix(cli): call workflow dag interface directly

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
@@ -25,7 +25,7 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.automation-edge-correlator.interface :as correlator]
-   [ai.miniforge.phase.interface :as phase])
+   [ai.miniforge.workflow.interface :as workflow])
   (:import
    [java.util UUID]))
 
@@ -136,13 +136,15 @@
       (display/print-info (str "Executing plan: " plan-id " (" task-count " tasks)"))
       (display/print-info (str "Format: " (name format-type))))
     (try
-      (let [execute-dag (requiring-resolve 'ai.miniforge.workflow.dag-orchestrator/execute-plan-as-dag)
-            result (execute-dag plan ctx)]
+      (let [result (workflow/execute-plan-as-dag plan ctx)]
         (when-not quiet
-          (let [completed (count (filter phase/succeeded? (vals result)))
-                failed (count (filter phase/failed? (vals result)))]
+          (let [completed (:tasks-completed result 0)
+                failed (:tasks-failed result 0)
+                unreached (:tasks-unreached result 0)]
             (display/print-info (str "Plan execution complete: "
-                                     completed " completed, " failed " failed"))))
+                                     completed " completed, " failed " failed"
+                                     (when (pos? unreached)
+                                       (str ", " unreached " unreached"))))))
         result)
       (catch Exception e
         (display/print-error (str "Plan execution failed: " (ex-message e)))

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -240,6 +240,13 @@
    [workflow]. Returns {:valid? boolean :errors [...] :warnings [...]}."
   pipeline/validate-pipeline)
 
+(def execute-plan-as-dag
+  "Execute a normalized plan through the DAG orchestrator. Args:
+   [plan context]. Returns an aggregate DAG execution summary with
+   :success?, :tasks-completed, :tasks-failed, :tasks-unreached,
+   :artifacts, and :metrics."
+  pipeline/execute-plan-as-dag)
+
 (def load-checkpoint-data
   "Load durable checkpoint data for a run and validate it at the boundary.
    Args: [workflow-run-id] or [workflow-run-id opts]. Returns the validated

--- a/components/workflow/src/ai/miniforge/workflow/interface/pipeline.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/pipeline.clj
@@ -21,6 +21,7 @@
   (:require
    [ai.miniforge.workflow.chain :as chain]
    [ai.miniforge.workflow.chain-loader :as chain-loader]
+   [ai.miniforge.workflow.dag-orchestrator :as dag-orchestrator]
    [ai.miniforge.workflow.runner :as runner]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -55,3 +56,12 @@
 (defn list-chains
   []
   (chain-loader/list-chains))
+
+(defn execute-plan-as-dag
+  "Execute a normalized plan through the DAG orchestrator.
+
+   Args: [plan context]. Returns an aggregate DAG execution summary with
+   :success?, :tasks-completed, :tasks-failed, :tasks-unreached,
+   :artifacts, and :metrics."
+  [plan context]
+  (dag-orchestrator/execute-plan-as-dag plan context))


### PR DESCRIPTION
## Summary
- expose DAG plan execution through the workflow public interface
- switch the CLI plan executor from requiring-resolve to the workflow interface
- keep the CLI out of workflow internals while preserving the existing execution path

## Validation
- clj-kondo --lint bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj components/workflow/src/ai/miniforge/workflow/interface.clj components/workflow/src/ai/miniforge/workflow/interface/pipeline.clj
- clojure -M:poly check
- clojure -M:dev:test -e "(require 'ai.miniforge.cli.main.commands.plan-executor 'ai.miniforge.workflow.interface) :ok"
- bb pre-commit