### PR TITLE
fix(artifact): require transit store directly

### DIFF
--- a/components/artifact/src/ai/miniforge/artifact/interface.clj
+++ b/components/artifact/src/ai/miniforge/artifact/interface.clj
@@ -20,7 +20,8 @@
   "Public API for the artifact component."
   (:require
    [ai.miniforge.artifact.core :as core]
-   [ai.miniforge.artifact.interface.protocols.artifact-store :as p]))
+   [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
+   [ai.miniforge.artifact.protocols.records.transit-store :as transit-store]))
 
 ;; Re-export protocol for public API
 (def ArtifactStore
@@ -71,8 +72,8 @@
      (create-transit-store)                              ; Uses ~/.miniforge/artifacts
      (create-transit-store {:dir \"/tmp/test\"})          ; Uses /tmp/test/artifacts
      (create-transit-store {:logger my-logger})"
-  ([] ((requiring-resolve 'ai.miniforge.artifact.protocols.records.transit-store/create-transit-store)))
-  ([opts] ((requiring-resolve 'ai.miniforge.artifact.protocols.records.transit-store/create-transit-store) opts)))
+  ([] (transit-store/create-transit-store))
+  ([opts] (transit-store/create-transit-store opts)))
 
 (defn close-store [store] (p/close store))
 (defn save! [store artifact] (p/save store artifact))


### PR DESCRIPTION
## Summary
- replace the artifact Transit store requiring-resolve bridge with a direct component require
- keep the Datalevin constructor untouched because that needs a separate JVM-only boundary fix
- preserve the BB-compatible artifact interface load path

## Validation
- clj-kondo --lint components/artifact/src/ai/miniforge/artifact/interface.clj components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
- clojure -M:poly check
- clojure -M:dev:test -e "(require 'ai.miniforge.artifact.interface 'ai.miniforge.artifact.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.artifact.interface-test)"
- bb pre-commit