### PR TITLE
Update the CLI `pr monitor` command to support resuming from a

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -570,6 +570,7 @@
   :pr/monitor-worklist-pruned "Removed {removed} closed PR(s); {remaining} still open."
   :pr/monitor-worklist-empty "All PRs in the work-list are merged or closed — nothing to monitor."
   :pr/monitor-worklist-prune-error "Could not check PR state: {error}"
+  :pr/monitor-no-author "Could not resolve a GitHub author login. Set --author or ensure 'gh auth login' is configured."
 
   ;; ── Observability ─────────────────────────────────────────────────────
   :observability/error-tailing "Error tailing file: {error}"

--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -563,6 +563,13 @@
   :pr/monitor-stopped "Monitor stopped. Evidence: {evidence}"
   :pr/monitor-interval-bounds "Poll interval must be {min}-{max} seconds, got {value}. Using default."
   :pr/monitor-interval-invalid "Invalid poll interval: {value}. Using default."
+  :pr/monitor-no-remote "Could not read remote origin URL from {path}."
+  :pr/monitor-no-worklist "No --author given and no persisted work-list found. Run with --author to start a fresh monitor."
+  :pr/monitor-worklist-loaded "Resuming from work-list: {count} open PR(s)."
+  :pr/monitor-worklist-pruning "Checking for closed PRs..."
+  :pr/monitor-worklist-pruned "Removed {removed} closed PR(s); {remaining} still open."
+  :pr/monitor-worklist-empty "All PRs in the work-list are merged or closed — nothing to monitor."
+  :pr/monitor-worklist-prune-error "Could not check PR state: {error}"
 
   ;; ── Observability ─────────────────────────────────────────────────────
   :observability/error-tailing "Error tailing file: {error}"

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -677,8 +677,9 @@
            :pr-number {:coerce :long}}}
    {:cmds ["pr" "respond"] :fn pr-respond-cmd :args->opts [:url]}
    {:cmds ["pr" "merge"]   :fn pr-merge-cmd   :args->opts [:url]}
-   {:cmds ["pr" "monitor"] :fn pr-monitor-cmd :spec {:author {:alias :a}
-                                                      :poll-interval {:alias :p}}}
+   {:cmds ["pr" "monitor"] :fn pr-monitor-cmd :spec {:author       {:alias :a}
+                                                      :poll-interval {:alias :p}
+                                                      :repo          {}}}
 
    ;; N13 §2.2 Standards Reviewer auto-trigger (single-pass v0)
    {:cmds ["pr" "review-monitor"]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -17,20 +17,20 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.cli.main.commands.pr
-  "PR operations using GitHub CLI."
+  "PR subcommands: list, review, respond, merge.
+   The monitor command is implemented in pr-monitor and delegated here."
   (:require
    [babashka.process :as process]
    [cheshire.core :as json]
    [clojure.string :as str]
-   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.pr-monitor :as pr-monitor]
+   [ai.miniforge.cli.main.commands.pr-review :as pr-review]
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
-   [ai.miniforge.cli.main.commands.pr-review :as pr-review]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-runner :as workflow-runner]
-   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
-   [ai.miniforge.schema.interface :as schema]))
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Shell primitives
@@ -46,29 +46,15 @@
 (defn- push! []
   (zero? (:exit (sh! "git" "push"))))
 
-(defn- remote-origin-url
-  "Return the git remote origin URL for `repo-path`, or nil on failure."
-  [repo-path]
-  (let [r (sh! "git" "-C" repo-path "remote" "get-url" "origin")]
-    (when (zero? (:exit r))
-      (str/trim (:out r)))))
-
 ;------------------------------------------------------------------------------ Layer 1
-;; PR commands + monitor primitives
-
-;;; Constant used wherever poll-interval-s (config) is converted to
-;;; poll-interval-ms (internal representation). Extracted once per rule 006.
-(def ^:private ms-per-second
-  "Milliseconds in one second."
-  1000)
+;; PR commands
 
 (defn pr-list-cmd
   "List PRs using GitHub CLI."
   [opts load-config-fn]
   (let [{:keys [repo config]} opts
-        cfg (load-config-fn config)
+        cfg   (load-config-fn config)
         repos (if repo [repo] (get-in cfg [:fleet :repos] []))]
-
     (if (empty? repos)
       (do
         (display/print-error (messages/t :pr/no-repos))
@@ -84,13 +70,13 @@
                   (println (messages/t :pr/no-open))
                   (doseq [{:keys [number title state author]} prs]
                     (let [status-style (case state
-                                         "OPEN" :green
+                                         "OPEN"   :green
                                          "MERGED" :magenta
                                          "CLOSED" :red
                                          :white)
-                          state-badge (display/style
-                                       (messages/t :pr/list-state-badge {:state state})
-                                       :foreground status-style)]
+                          state-badge  (display/style
+                                        (messages/t :pr/list-state-badge {:state state})
+                                        :foreground status-style)]
                       (println (messages/t :pr/list-row
                                            {:number      number
                                             :state-badge state-badge
@@ -105,7 +91,7 @@
             (display/print-error (messages/t :pr/query-failed {:error (:err result)}))))))))
 
 (defn- gh-pr-base-ref
-  "Resolve the base-branch ref for `pr-number` via the GitHub CLI.
+  "Resolve the base-branch ref for `pr-number` via gh CLI.
    Returns a remote-prefixed ref like \"origin/main\", or nil on failure."
   [pr-number]
   (let [r (sh! "gh" "pr" "view" (str pr-number)
@@ -123,10 +109,9 @@
    review comments per N13 §2.3 to stdout.
 
    With `--post`, additionally batch-posts the rendered comments as a
-   single PR review (event=COMMENT) via `pr-lifecycle/post-review!`.
-   The PR head SHA needed for the create-review API is derived from
-   the worktree HEAD after `gh pr checkout`. Does NOT apply fixes —
-   that remains the Comment Response Agent's job.
+   single PR review via `pr-lifecycle/post-review!`. The PR head SHA
+   is derived from the worktree HEAD after `gh pr checkout`. Does NOT
+   apply fixes — that remains the Comment Response Agent's job.
 
    Pass --repo <path> + --base <ref> to operate on an existing checkout
    without using `gh` to fetch metadata; `--url <pr-url>` is the default
@@ -134,11 +119,9 @@
   [opts]
   (let [{:keys [url repo base]} opts]
     (cond
-      ;; --repo + --base path: operate on existing checkout
       (and repo base)
       (pr-review/run-pr-review-by-path-cmd opts)
 
-      ;; URL path: parse, checkout, derive base, delegate
       url
       (let [{:keys [number]} (pr-lifecycle/parse-pr-url url)]
         (cond
@@ -155,13 +138,11 @@
                 (display/print-error (messages/t :pr/respond-checkout-failed))
 
                 (not base-ref)
-                (display/print-error
-                 (messages/t :pr/review-base-ref-failed))
+                (display/print-error (messages/t :pr/review-base-ref-failed))
 
                 :else
                 (let [cwd (System/getProperty "user.dir")]
-                  (display/print-info
-                   (messages/t :pr/respond-on-branch {:branch branch}))
+                  (display/print-info (messages/t :pr/respond-on-branch {:branch branch}))
                   (pr-review/run-pr-review!
                    cwd
                    (cond-> {:base-ref base-ref}
@@ -191,7 +172,7 @@
             (display/print-error (messages/t :pr/respond-checkout-failed))
             (shared/exit! 1))
           (display/print-info (messages/t :pr/respond-on-branch {:branch branch}))
-          (let [cwd (System/getProperty "user.dir")
+          (let [cwd    (System/getProperty "user.dir")
                 result (pr-lifecycle/respond-to-comments!
                         url cwd
                         (fn [spec run-opts]
@@ -216,151 +197,20 @@
         (display/print-info (messages/t :pr/merging {:url url}))
         (println (messages/t :pr/merge-todo))))))
 
-;;; Monitor primitives — depend only on Layer 0 and external interfaces.
-
-(defn- resolve-author
-  "Resolve the GitHub author login from --author flag, gh CLI, or config default."
-  [author-opt default-author]
-  (or author-opt
-      (let [result (sh! "gh" "api" "user" "--jq" ".login")]
-        (when (zero? (:exit result))
-          (let [login (str/trim (:out result))]
-            (when (seq login) login))))
-      default-author))
-
-(defn- parse-poll-interval
-  "Parse poll interval string in seconds, with bounds checking.
-   Returns milliseconds, or nil when the value is out-of-range or unparseable."
-  [interval-str {:keys [min-poll-interval-s max-poll-interval-s]}]
-  (when interval-str
-    (try
-      (let [seconds (Long/parseLong (str interval-str))]
-        (if (<= min-poll-interval-s seconds max-poll-interval-s)
-          (* seconds ms-per-second)
-          (do (display/print-error
-               (messages/t :pr/monitor-interval-bounds
-                           {:min min-poll-interval-s :max max-poll-interval-s :value seconds}))
-              nil)))
-      (catch NumberFormatException _
-        (display/print-error (messages/t :pr/monitor-interval-invalid {:value interval-str}))
-        nil))))
-
-(defn- worklist-poll-ms
-  "Derive a poll-interval in milliseconds from the PR entries in a worklist.
-   Takes the minimum :pr/poll-interval (seconds) across all entries.
-   Returns nil when no entries carry that key — caller uses monitor default."
-  [prs]
-  (some->> (seq (keep :pr/poll-interval prs))
-           (apply min)
-           (* ms-per-second)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Monitor session — composes Layer 1 helpers with pr-lifecycle calls.
-
-(defn- run-monitor!
-  "Create a PR monitor from `mon-opts`, install a shutdown hook, and run the loop.
-
-   Shared by both the fresh-monitor and resume-from-worklist paths so the
-   loop is implemented exactly once."
-  [mon-opts author]
-  (let [monitor (pr-lifecycle/create-pr-monitor mon-opts)
-        eff-ms  (get-in @monitor [:config :poll-interval-ms])
-        path    (:worktree-path mon-opts)]
-    (display/print-info (messages/t :pr/monitor-starting {:author author}))
-    (display/print-info (messages/t :pr/monitor-polling {:seconds (/ eff-ms ms-per-second) :dir path}))
-    (display/print-info (messages/t :pr/monitor-stop-hint))
-    (let [shutdown (fn []
-                     (display/print-info (messages/t :pr/monitor-stopping))
-                     (try (pr-lifecycle/stop-pr-monitor-loop monitor) (catch Exception _)))]
-      (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable shutdown))
-      (let [evidence (pr-lifecycle/run-pr-monitor-loop monitor author)]
-        (display/print-info (messages/t :pr/monitor-stopped {:evidence (pr-str evidence)}))))))
-
-(defn- resume-from-worklist!
-  "Load persisted worklist for `repo-path`, prune closed PRs, then run monitor.
-
-   Return types differ intentionally between the two pr-lifecycle calls:
-   - load-worklist  → schema/success | schema/failure  (checked via schema/failed?)
-   - prune-closed-prs → WorklistEntry | anomaly map    (checked via anomaly/anomaly?)
-   See monitor_worklist.clj ns-doc for the authoritative contract.
-
-   Exit codes:
-   - returns normally (exit 0) when the worklist is empty after pruning
-   - shared/exit! 1 when remote URL unresolvable, no worklist, or gh fails"
-  [repo-path cli-cfg]
-  (let [origin-url (remote-origin-url repo-path)]
-    (when-not origin-url
-      (display/print-error (messages/t :pr/monitor-no-remote {:path repo-path}))
-      (shared/exit! 1))
-    (let [rkey        (pr-lifecycle/worklist-repo-key origin-url)
-          wl-path     (pr-lifecycle/worklist-path (app-config/home-dir) rkey)
-          load-result (pr-lifecycle/load-worklist wl-path)]
-      (when (schema/failed? load-result)
-        (display/print-error (messages/t :pr/monitor-no-worklist))
-        (shared/exit! 1))
-      ;; schema/success :worklist entry → {:success? true :worklist <entry>}
-      (let [worklist       (:worklist load-result)
-            original-count (count (:worklist/prs worklist))]
-        (display/print-info (messages/t :pr/monitor-worklist-loaded {:count original-count}))
-        (display/print-info (messages/t :pr/monitor-worklist-pruning))
-        (let [pruned (pr-lifecycle/prune-closed-prs worklist)]
-          (when (anomaly/anomaly? pruned)
-            (display/print-error
-             (messages/t :pr/monitor-worklist-prune-error
-                         {:error (:anomaly/message pruned)}))
-            (shared/exit! 1))
-          (let [prs     (:worklist/prs pruned)
-                removed (- original-count (count prs))]
-            (when (pos? removed)
-              (display/print-info
-               (messages/t :pr/monitor-worklist-pruned
-                           {:removed removed :remaining (count prs)})))
-            (if (empty? prs)
-              (display/print-info (messages/t :pr/monitor-worklist-empty))
-              (let [author   (resolve-author nil (:default-self-author cli-cfg))
-                    poll-ms  (worklist-poll-ms prs)
-                    mon-opts (cond-> {:worktree-path repo-path :self-author author}
-                               poll-ms (assoc :poll-interval-ms poll-ms))]
-                (run-monitor! mon-opts author)))))))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Command entry point — dispatches to Layer 2 paths.
-
 (defn pr-monitor-cmd
-  "Start the PR monitor loop for autonomous comment resolution.
-
-   With --author: creates a fresh monitor polling that author's open PRs.
-   Without --author: resumes from a persisted work-list. Uses --repo (or
-   cwd) as the repo path for work-list key derivation.
-
-   Returns normally (exit 0) when the work-list is empty after pruning.
-   Calls shared/exit! 1 when no work-list exists and no --author supplied.
-
-   Polls open PRs, classifies new comments, and routes them to handlers
-   (fix change-requests, answer questions, skip noise). Runs continuously
-   until stopped with Ctrl+C, budget exhausted, or no open PRs remain."
+  "Delegates to pr-monitor/pr-monitor-cmd. See that namespace for full docs."
   [opts]
-  (let [{:keys [author poll-interval repo]} opts
-        cli-cfg   (app-config/pr-monitor-config)
-        cwd       (System/getProperty "user.dir")
-        repo-path (or repo cwd)]
-    (if author
-      (let [resolved (resolve-author author (:default-self-author cli-cfg))
-            poll-ms  (parse-poll-interval poll-interval cli-cfg)
-            mon-opts (cond-> {:worktree-path repo-path :self-author resolved}
-                       poll-ms (assoc :poll-interval-ms poll-ms))]
-        (run-monitor! mon-opts resolved))
-      (resume-from-worklist! repo-path cli-cfg))))
+  (pr-monitor/pr-monitor-cmd opts))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  ;; Fresh monitor for a specific author
-  (pr-monitor-cmd {:author "alice" :repo "/path/to/repo" :poll-interval "60"})
+  ;; List PRs across fleet repos
+  ;; (pr-list-cmd {} load-config)
 
-  ;; Resume from persisted work-list in the current directory
-  (pr-monitor-cmd {})
+  ;; Review a PR via URL
+  ;; (pr-review-cmd {:url "https://github.com/org/repo/pull/42"})
 
-  ;; Resume from an explicit repo path
-  (pr-monitor-cmd {:repo "/path/to/other-repo"})
+  ;; Respond to comments on a PR
+  ;; (pr-respond-cmd {:url "https://github.com/org/repo/pull/42"})
 
   :leave-this-here)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -24,6 +24,7 @@
    [clojure.string :as str]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.main.commands.pr-review :as pr-review]
    [ai.miniforge.cli.messages :as messages]
@@ -32,7 +33,7 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Shell helpers
+;; Shell primitives
 
 (defn- sh! [& args]
   (apply process/sh args))
@@ -53,7 +54,13 @@
       (str/trim (:out r)))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; PR commands
+;; PR commands + monitor primitives
+
+;;; Constant used wherever poll-interval-s (config) is converted to
+;;; poll-interval-ms (internal representation). Extracted once per rule 006.
+(def ^:private ms-per-second
+  "Milliseconds in one second."
+  1000)
 
 (defn pr-list-cmd
   "List PRs using GitHub CLI."
@@ -177,12 +184,12 @@
       (let [{:keys [number]} (pr-lifecycle/parse-pr-url url)]
         (when-not number
           (display/print-error (messages/t :pr/respond-bad-url))
-          (System/exit 1))
+          (shared/exit! 1))
         (display/print-info (messages/t :pr/respond-checkout {:number number}))
         (let [branch (checkout-pr! number)]
           (when-not branch
             (display/print-error (messages/t :pr/respond-checkout-failed))
-            (System/exit 1))
+            (shared/exit! 1))
           (display/print-info (messages/t :pr/respond-on-branch {:branch branch}))
           (let [cwd (System/getProperty "user.dir")
                 result (pr-lifecycle/respond-to-comments!
@@ -209,8 +216,7 @@
         (display/print-info (messages/t :pr/merging {:url url}))
         (println (messages/t :pr/merge-todo))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; PR Monitor helpers
+;;; Monitor primitives — depend only on Layer 0 and external interfaces.
 
 (defn- resolve-author
   "Resolve the GitHub author login from --author flag, gh CLI, or config default."
@@ -223,13 +229,14 @@
       default-author))
 
 (defn- parse-poll-interval
-  "Parse poll interval in seconds, with bounds checking. Returns milliseconds."
+  "Parse poll interval string in seconds, with bounds checking.
+   Returns milliseconds, or nil when the value is out-of-range or unparseable."
   [interval-str {:keys [min-poll-interval-s max-poll-interval-s]}]
   (when interval-str
     (try
       (let [seconds (Long/parseLong (str interval-str))]
         (if (<= min-poll-interval-s seconds max-poll-interval-s)
-          (* seconds 1000)
+          (* seconds ms-per-second)
           (do (display/print-error
                (messages/t :pr/monitor-interval-bounds
                            {:min min-poll-interval-s :max max-poll-interval-s :value seconds}))
@@ -245,19 +252,22 @@
   [prs]
   (some->> (seq (keep :pr/poll-interval prs))
            (apply min)
-           (* 1000)))
+           (* ms-per-second)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Monitor session — composes Layer 1 helpers with pr-lifecycle calls.
 
 (defn- run-monitor!
   "Create a PR monitor from `mon-opts`, install a shutdown hook, and run the loop.
 
-   Shared by both the fresh-monitor and resume-from-worklist paths.
-   Prints status lines before starting and after stopping."
+   Shared by both the fresh-monitor and resume-from-worklist paths so the
+   loop is implemented exactly once."
   [mon-opts author]
   (let [monitor (pr-lifecycle/create-pr-monitor mon-opts)
         eff-ms  (get-in @monitor [:config :poll-interval-ms])
         path    (:worktree-path mon-opts)]
     (display/print-info (messages/t :pr/monitor-starting {:author author}))
-    (display/print-info (messages/t :pr/monitor-polling {:seconds (/ eff-ms 1000) :dir path}))
+    (display/print-info (messages/t :pr/monitor-polling {:seconds (/ eff-ms ms-per-second) :dir path}))
     (display/print-info (messages/t :pr/monitor-stop-hint))
     (let [shutdown (fn []
                      (display/print-info (messages/t :pr/monitor-stopping))
@@ -266,27 +276,29 @@
       (let [evidence (pr-lifecycle/run-pr-monitor-loop monitor author)]
         (display/print-info (messages/t :pr/monitor-stopped {:evidence (pr-str evidence)}))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; PR Monitor — worklist resume path
-
 (defn- resume-from-worklist!
-  "Load persisted worklist for `repo-path`, prune closed PRs, run monitor.
+  "Load persisted worklist for `repo-path`, prune closed PRs, then run monitor.
+
+   Return types differ intentionally between the two pr-lifecycle calls:
+   - load-worklist  → schema/success | schema/failure  (checked via schema/failed?)
+   - prune-closed-prs → WorklistEntry | anomaly map    (checked via anomaly/anomaly?)
+   See monitor_worklist.clj ns-doc for the authoritative contract.
 
    Exit codes:
-   - exits 0 when the worklist exists but is empty after pruning
-   - exits 1 when the remote URL is unresolvable, no worklist exists,
-     or the pruning gh call fails"
+   - returns normally (exit 0) when the worklist is empty after pruning
+   - shared/exit! 1 when remote URL unresolvable, no worklist, or gh fails"
   [repo-path cli-cfg]
   (let [origin-url (remote-origin-url repo-path)]
     (when-not origin-url
       (display/print-error (messages/t :pr/monitor-no-remote {:path repo-path}))
-      (System/exit 1))
+      (shared/exit! 1))
     (let [rkey        (pr-lifecycle/worklist-repo-key origin-url)
           wl-path     (pr-lifecycle/worklist-path (app-config/home-dir) rkey)
           load-result (pr-lifecycle/load-worklist wl-path)]
       (when (schema/failed? load-result)
         (display/print-error (messages/t :pr/monitor-no-worklist))
-        (System/exit 1))
+        (shared/exit! 1))
+      ;; schema/success :worklist entry → {:success? true :worklist <entry>}
       (let [worklist       (:worklist load-result)
             original-count (count (:worklist/prs worklist))]
         (display/print-info (messages/t :pr/monitor-worklist-loaded {:count original-count}))
@@ -296,7 +308,7 @@
             (display/print-error
              (messages/t :pr/monitor-worklist-prune-error
                          {:error (:anomaly/message pruned)}))
-            (System/exit 1))
+            (shared/exit! 1))
           (let [prs     (:worklist/prs pruned)
                 removed (- original-count (count prs))]
             (when (pos? removed)
@@ -311,8 +323,8 @@
                                poll-ms (assoc :poll-interval-ms poll-ms))]
                 (run-monitor! mon-opts author)))))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; PR Monitor (continuous loop)
+;------------------------------------------------------------------------------ Layer 3
+;; Command entry point — dispatches to Layer 2 paths.
 
 (defn pr-monitor-cmd
   "Start the PR monitor loop for autonomous comment resolution.
@@ -321,8 +333,8 @@
    Without --author: resumes from a persisted work-list. Uses --repo (or
    cwd) as the repo path for work-list key derivation.
 
-   Exits 0 when the work-list exists but is empty after pruning closed PRs.
-   Exits 1 when no work-list exists and no --author was supplied.
+   Returns normally (exit 0) when the work-list is empty after pruning.
+   Calls shared/exit! 1 when no work-list exists and no --author supplied.
 
    Polls open PRs, classifies new comments, and routes them to handlers
    (fix change-requests, answer questions, skip noise). Runs continuously
@@ -333,11 +345,22 @@
         cwd       (System/getProperty "user.dir")
         repo-path (or repo cwd)]
     (if author
-      ;; Fresh monitor path — identical to prior behavior
       (let [resolved (resolve-author author (:default-self-author cli-cfg))
             poll-ms  (parse-poll-interval poll-interval cli-cfg)
             mon-opts (cond-> {:worktree-path repo-path :self-author resolved}
                        poll-ms (assoc :poll-interval-ms poll-ms))]
         (run-monitor! mon-opts resolved))
-      ;; Worklist resume path
       (resume-from-worklist! repo-path cli-cfg))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Fresh monitor for a specific author
+  (pr-monitor-cmd {:author "alice" :repo "/path/to/repo" :poll-interval "60"})
+
+  ;; Resume from persisted work-list in the current directory
+  (pr-monitor-cmd {})
+
+  ;; Resume from an explicit repo path
+  (pr-monitor-cmd {:repo "/path/to/other-repo"})
+
+  :leave-this-here)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -22,12 +22,14 @@
    [babashka.process :as process]
    [cheshire.core :as json]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.main.commands.pr-review :as pr-review]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-runner :as workflow-runner]
-   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
+   [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Shell helpers
@@ -42,6 +44,13 @@
 
 (defn- push! []
   (zero? (:exit (sh! "git" "push"))))
+
+(defn- remote-origin-url
+  "Return the git remote origin URL for `repo-path`, or nil on failure."
+  [repo-path]
+  (let [r (sh! "git" "-C" repo-path "remote" "get-url" "origin")]
+    (when (zero? (:exit r))
+      (str/trim (:out r)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; PR commands
@@ -201,7 +210,7 @@
         (println (messages/t :pr/merge-todo))))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; PR Monitor (continuous loop)
+;; PR Monitor helpers
 
 (defn- resolve-author
   "Resolve the GitHub author login from --author flag, gh CLI, or config default."
@@ -229,24 +238,26 @@
         (display/print-error (messages/t :pr/monitor-interval-invalid {:value interval-str}))
         nil))))
 
-(defn pr-monitor-cmd
-  "Start the PR monitor loop for autonomous comment resolution.
+(defn- worklist-poll-ms
+  "Derive a poll-interval in milliseconds from the PR entries in a worklist.
+   Takes the minimum :pr/poll-interval (seconds) across all entries.
+   Returns nil when no entries carry that key — caller uses monitor default."
+  [prs]
+  (some->> (seq (keep :pr/poll-interval prs))
+           (apply min)
+           (* 1000)))
 
-   Polls open PRs, classifies new comments, and routes them to handlers
-   (fix change-requests, answer questions, skip noise). Runs continuously
-   until stopped with Ctrl+C, budget exhausted, or no open PRs remain."
-  [opts]
-  (let [{:keys [author poll-interval]} opts
-        cli-cfg    (app-config/pr-monitor-config)
-        cwd        (System/getProperty "user.dir")
-        author     (resolve-author author (:default-self-author cli-cfg))
-        poll-ms    (parse-poll-interval poll-interval cli-cfg)
-        mon-opts   (cond-> {:worktree-path cwd :self-author author}
-                     poll-ms (assoc :poll-interval-ms poll-ms))
-        monitor    (pr-lifecycle/create-pr-monitor mon-opts)
-        eff-ms     (get-in @monitor [:config :poll-interval-ms])]
+(defn- run-monitor!
+  "Create a PR monitor from `mon-opts`, install a shutdown hook, and run the loop.
+
+   Shared by both the fresh-monitor and resume-from-worklist paths.
+   Prints status lines before starting and after stopping."
+  [mon-opts author]
+  (let [monitor (pr-lifecycle/create-pr-monitor mon-opts)
+        eff-ms  (get-in @monitor [:config :poll-interval-ms])
+        path    (:worktree-path mon-opts)]
     (display/print-info (messages/t :pr/monitor-starting {:author author}))
-    (display/print-info (messages/t :pr/monitor-polling {:seconds (/ eff-ms 1000) :dir cwd}))
+    (display/print-info (messages/t :pr/monitor-polling {:seconds (/ eff-ms 1000) :dir path}))
     (display/print-info (messages/t :pr/monitor-stop-hint))
     (let [shutdown (fn []
                      (display/print-info (messages/t :pr/monitor-stopping))
@@ -254,3 +265,79 @@
       (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable shutdown))
       (let [evidence (pr-lifecycle/run-pr-monitor-loop monitor author)]
         (display/print-info (messages/t :pr/monitor-stopped {:evidence (pr-str evidence)}))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; PR Monitor — worklist resume path
+
+(defn- resume-from-worklist!
+  "Load persisted worklist for `repo-path`, prune closed PRs, run monitor.
+
+   Exit codes:
+   - exits 0 when the worklist exists but is empty after pruning
+   - exits 1 when the remote URL is unresolvable, no worklist exists,
+     or the pruning gh call fails"
+  [repo-path cli-cfg]
+  (let [origin-url (remote-origin-url repo-path)]
+    (when-not origin-url
+      (display/print-error (messages/t :pr/monitor-no-remote {:path repo-path}))
+      (System/exit 1))
+    (let [rkey        (pr-lifecycle/worklist-repo-key origin-url)
+          wl-path     (pr-lifecycle/worklist-path (app-config/home-dir) rkey)
+          load-result (pr-lifecycle/load-worklist wl-path)]
+      (when (schema/failed? load-result)
+        (display/print-error (messages/t :pr/monitor-no-worklist))
+        (System/exit 1))
+      (let [worklist       (:worklist load-result)
+            original-count (count (:worklist/prs worklist))]
+        (display/print-info (messages/t :pr/monitor-worklist-loaded {:count original-count}))
+        (display/print-info (messages/t :pr/monitor-worklist-pruning))
+        (let [pruned (pr-lifecycle/prune-closed-prs worklist)]
+          (when (anomaly/anomaly? pruned)
+            (display/print-error
+             (messages/t :pr/monitor-worklist-prune-error
+                         {:error (:anomaly/message pruned)}))
+            (System/exit 1))
+          (let [prs     (:worklist/prs pruned)
+                removed (- original-count (count prs))]
+            (when (pos? removed)
+              (display/print-info
+               (messages/t :pr/monitor-worklist-pruned
+                           {:removed removed :remaining (count prs)})))
+            (if (empty? prs)
+              (display/print-info (messages/t :pr/monitor-worklist-empty))
+              (let [author   (resolve-author nil (:default-self-author cli-cfg))
+                    poll-ms  (worklist-poll-ms prs)
+                    mon-opts (cond-> {:worktree-path repo-path :self-author author}
+                               poll-ms (assoc :poll-interval-ms poll-ms))]
+                (run-monitor! mon-opts author)))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; PR Monitor (continuous loop)
+
+(defn pr-monitor-cmd
+  "Start the PR monitor loop for autonomous comment resolution.
+
+   With --author: creates a fresh monitor polling that author's open PRs.
+   Without --author: resumes from a persisted work-list. Uses --repo (or
+   cwd) as the repo path for work-list key derivation.
+
+   Exits 0 when the work-list exists but is empty after pruning closed PRs.
+   Exits 1 when no work-list exists and no --author was supplied.
+
+   Polls open PRs, classifies new comments, and routes them to handlers
+   (fix change-requests, answer questions, skip noise). Runs continuously
+   until stopped with Ctrl+C, budget exhausted, or no open PRs remain."
+  [opts]
+  (let [{:keys [author poll-interval repo]} opts
+        cli-cfg   (app-config/pr-monitor-config)
+        cwd       (System/getProperty "user.dir")
+        repo-path (or repo cwd)]
+    (if author
+      ;; Fresh monitor path — identical to prior behavior
+      (let [resolved (resolve-author author (:default-self-author cli-cfg))
+            poll-ms  (parse-poll-interval poll-interval cli-cfg)
+            mon-opts (cond-> {:worktree-path repo-path :self-author resolved}
+                       poll-ms (assoc :poll-interval-ms poll-ms))]
+        (run-monitor! mon-opts resolved))
+      ;; Worklist resume path
+      (resume-from-worklist! repo-path cli-cfg))))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
@@ -132,42 +132,42 @@
      - returns normally (exit 0 by default) when worklist is empty after pruning
      - shared/exit! 1 on unresolvable remote, missing worklist, prune failure, nil author"
   [repo-path cli-cfg]
-  (let [origin-url (remote-origin-url repo-path)]
+  (let [origin-url (remote-origin-url repo-path)]     ; A
     (when-not origin-url
       (display/print-error (messages/t :pr/monitor-no-remote {:path repo-path}))
       (shared/exit! 1))
     (let [rkey        (pr-lifecycle/worklist-repo-key origin-url)
           wl-path     (pr-lifecycle/worklist-path (app-config/home-dir) rkey)
-          load-result (pr-lifecycle/load-worklist wl-path)]
+          load-result (pr-lifecycle/load-worklist wl-path)]     ; B
       (when (schema/failed? load-result)
         (display/print-error (messages/t :pr/monitor-no-worklist))
         (shared/exit! 1))
       (let [worklist       (:worklist load-result)
-            original-count (count (:worklist/prs worklist))]
+            original-count (count (:worklist/prs worklist))]    ; C
         (display/print-info (messages/t :pr/monitor-worklist-loaded {:count original-count}))
         (display/print-info (messages/t :pr/monitor-worklist-pruning))
-        (let [pruned (pr-lifecycle/prune-closed-prs worklist)]
+        (let [pruned (pr-lifecycle/prune-closed-prs worklist)]  ; D
           (when (anomaly/anomaly? pruned)
             (display/print-error
              (messages/t :pr/monitor-worklist-prune-error
                          {:error (:anomaly/message pruned)}))
             (shared/exit! 1))
           (let [prs     (:worklist/prs pruned)
-                removed (- original-count (count prs))]
+                removed (- original-count (count prs))]         ; E
             (when (pos? removed)
               (display/print-info
                (messages/t :pr/monitor-worklist-pruned
                            {:removed removed :remaining (count prs)})))
-            (if (empty? prs)
+            (if (empty? prs)                                    ; F
               (display/print-info (messages/t :pr/monitor-worklist-empty))
-              (let [author (resolve-author nil (:default-self-author cli-cfg))]
+              (let [author (resolve-author nil (:default-self-author cli-cfg))]  ; G
                 (when-not author
                   (display/print-error (messages/t :pr/monitor-no-author))
                   (shared/exit! 1))
                 (let [poll-ms  (worklist-poll-ms prs)
                       mon-opts (cond-> {:worktree-path repo-path :self-author author}
-                                 poll-ms (assoc :poll-interval-ms poll-ms))]
-                  (run-monitor! mon-opts author)))))))))
+                                 poll-ms (assoc :poll-interval-ms poll-ms))]    ; H
+                  (run-monitor! mon-opts author))))))))))        ; H G F E D C B A defn
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Entry point

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
@@ -1,0 +1,208 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.pr-monitor
+  "PR monitor loop — work-list resume and fresh-monitor paths.
+
+   Stratified design (3 layers):
+     Layer 0  constants + shell primitives
+     Layer 1  monitor session (run-monitor!, resume-from-worklist!)
+     Layer 2  entry point (pr-monitor-cmd)"
+  (:require
+   [babashka.process :as process]
+   [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.shared :as shared]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
+   [ai.miniforge.schema.interface :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants and shell primitives
+
+(def ^:private ms-per-second
+  "Milliseconds in one second.
+   Converts poll-interval-s (config/worklist unit) to poll-interval-ms
+   (pr-lifecycle internal unit). Extracted per rule 006 — used in three sites."
+  1000)
+
+(def ^:private default-poll-interval-ms
+  "Fallback used in run-monitor! when the monitor atom does not yet carry
+   [:config :poll-interval-ms]. Mirrors the pr-lifecycle monitor default (60 s)."
+  60000)
+
+(defn- sh! [& args]
+  (apply process/sh args))
+
+(defn- remote-origin-url
+  "Return the git remote origin URL for `repo-path`, or nil on failure."
+  [repo-path]
+  (let [r (sh! "git" "-C" repo-path "remote" "get-url" "origin")]
+    (when (zero? (:exit r))
+      (str/trim (:out r)))))
+
+(defn- resolve-author
+  "Resolve the GitHub author login from `author-opt` flag, gh CLI, or `default-author`."
+  [author-opt default-author]
+  (or author-opt
+      (let [result (sh! "gh" "api" "user" "--jq" ".login")]
+        (when (zero? (:exit result))
+          (let [login (str/trim (:out result))]
+            (when (seq login) login))))
+      default-author))
+
+(defn- parse-poll-interval
+  "Parse poll-interval string in seconds, with bounds checking.
+   Returns milliseconds, or nil when the value is out-of-range or unparseable."
+  [interval-str {:keys [min-poll-interval-s max-poll-interval-s]}]
+  (when interval-str
+    (try
+      (let [seconds (Long/parseLong (str interval-str))]
+        (if (<= min-poll-interval-s seconds max-poll-interval-s)
+          (* seconds ms-per-second)
+          (do (display/print-error
+               (messages/t :pr/monitor-interval-bounds
+                           {:min min-poll-interval-s :max max-poll-interval-s :value seconds}))
+              nil)))
+      (catch NumberFormatException _
+        (display/print-error (messages/t :pr/monitor-interval-invalid {:value interval-str}))
+        nil))))
+
+(defn- worklist-poll-ms
+  "Derive poll-interval in milliseconds from the PR entries in a worklist.
+   Takes the minimum :pr/poll-interval (seconds) across all entries.
+   Returns nil when no entries carry that key — caller uses monitor default."
+  [prs]
+  (some->> (seq (keep :pr/poll-interval prs))
+           (apply min)
+           (* ms-per-second)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Monitor session — compose Layer 0 with pr-lifecycle calls
+
+(defn- run-monitor!
+  "Create a PR monitor from `mon-opts`, install a shutdown hook, run the loop.
+   Single implementation shared by the fresh-monitor and resume paths."
+  [mon-opts author]
+  (let [monitor (pr-lifecycle/create-pr-monitor mon-opts)
+        ;; Guard nil: create-pr-monitor may not populate [:config :poll-interval-ms]
+        ;; before the atom is first deref'd. Fall back to default-poll-interval-ms.
+        eff-ms  (or (get-in @monitor [:config :poll-interval-ms])
+                    default-poll-interval-ms)
+        path    (:worktree-path mon-opts)]
+    (display/print-info (messages/t :pr/monitor-starting {:author author}))
+    (display/print-info (messages/t :pr/monitor-polling {:seconds (/ eff-ms ms-per-second) :dir path}))
+    (display/print-info (messages/t :pr/monitor-stop-hint))
+    (let [shutdown (fn []
+                     (display/print-info (messages/t :pr/monitor-stopping))
+                     (try (pr-lifecycle/stop-pr-monitor-loop monitor) (catch Exception _)))]
+      (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable shutdown))
+      (let [evidence (pr-lifecycle/run-pr-monitor-loop monitor author)]
+        (display/print-info (messages/t :pr/monitor-stopped {:evidence (pr-str evidence)}))))))
+
+(defn- resume-from-worklist!
+  "Load persisted worklist for `repo-path`, prune closed PRs, then run monitor.
+
+   Return-type contract (see monitor_worklist.clj ns-doc):
+     - load-worklist    → schema/success | schema/failure  → checked via schema/failed?
+     - prune-closed-prs → WorklistEntry  | anomaly map    → checked via anomaly/anomaly?
+
+   schema/success :worklist entry produces {:success? true :worklist <entry>}.
+   :worklist is the data-key passed to schema/success; there is no separate
+   value accessor in the schema component (see schema.interface/success).
+
+   Exit semantics:
+     - returns normally (exit 0 by default) when worklist is empty after pruning
+     - shared/exit! 1 on unresolvable remote, missing worklist, prune failure, nil author"
+  [repo-path cli-cfg]
+  (let [origin-url (remote-origin-url repo-path)]
+    (when-not origin-url
+      (display/print-error (messages/t :pr/monitor-no-remote {:path repo-path}))
+      (shared/exit! 1))
+    (let [rkey        (pr-lifecycle/worklist-repo-key origin-url)
+          wl-path     (pr-lifecycle/worklist-path (app-config/home-dir) rkey)
+          load-result (pr-lifecycle/load-worklist wl-path)]
+      (when (schema/failed? load-result)
+        (display/print-error (messages/t :pr/monitor-no-worklist))
+        (shared/exit! 1))
+      (let [worklist       (:worklist load-result)
+            original-count (count (:worklist/prs worklist))]
+        (display/print-info (messages/t :pr/monitor-worklist-loaded {:count original-count}))
+        (display/print-info (messages/t :pr/monitor-worklist-pruning))
+        (let [pruned (pr-lifecycle/prune-closed-prs worklist)]
+          (when (anomaly/anomaly? pruned)
+            (display/print-error
+             (messages/t :pr/monitor-worklist-prune-error
+                         {:error (:anomaly/message pruned)}))
+            (shared/exit! 1))
+          (let [prs     (:worklist/prs pruned)
+                removed (- original-count (count prs))]
+            (when (pos? removed)
+              (display/print-info
+               (messages/t :pr/monitor-worklist-pruned
+                           {:removed removed :remaining (count prs)})))
+            (if (empty? prs)
+              (display/print-info (messages/t :pr/monitor-worklist-empty))
+              (let [author (resolve-author nil (:default-self-author cli-cfg))]
+                (when-not author
+                  (display/print-error (messages/t :pr/monitor-no-author))
+                  (shared/exit! 1))
+                (let [poll-ms  (worklist-poll-ms prs)
+                      mon-opts (cond-> {:worktree-path repo-path :self-author author}
+                                 poll-ms (assoc :poll-interval-ms poll-ms))]
+                  (run-monitor! mon-opts author)))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Entry point
+
+(defn pr-monitor-cmd
+  "Start the PR monitor loop for autonomous comment resolution.
+
+   With --author: creates a fresh monitor polling that author's open PRs.
+   Without --author: resumes from a persisted work-list, using --repo (or
+   cwd) as the repo path for work-list key derivation.
+
+   Returns normally when the work-list is empty after pruning (exit 0).
+   Calls shared/exit! 1 when no work-list exists and no --author is supplied."
+  [opts]
+  (let [{:keys [author poll-interval repo]} opts
+        cli-cfg   (app-config/pr-monitor-config)
+        cwd       (System/getProperty "user.dir")
+        repo-path (or repo cwd)]
+    (if author
+      (let [resolved (resolve-author author (:default-self-author cli-cfg))
+            poll-ms  (parse-poll-interval poll-interval cli-cfg)
+            mon-opts (cond-> {:worktree-path repo-path :self-author resolved}
+                       poll-ms (assoc :poll-interval-ms poll-ms))]
+        (run-monitor! mon-opts resolved))
+      (resume-from-worklist! repo-path cli-cfg))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Fresh monitor for a specific author
+  (pr-monitor-cmd {:author "alice" :repo "/path/to/repo" :poll-interval "60"})
+
+  ;; Resume from persisted work-list in the current directory
+  (pr-monitor-cmd {})
+
+  ;; Resume from an explicit repo path
+  (pr-monitor-cmd {:repo "/path/to/other-repo"})
+
+  :leave-this-here)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
@@ -1,0 +1,230 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.pr-monitor-test
+  "Unit tests for the pr monitor command's worklist-resume paths.
+
+   Tests cover:
+   (a) resume path — worklist exists with open PRs → monitor runs
+   (b) resume path — all PRs pruned to empty     → prints status, returns normally
+   (c) no-worklist path                          → exits 1
+   (d) no-remote-url path                        → exits 1"
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [babashka.process :as process]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.pr :as sut]
+   [ai.miniforge.cli.main.commands.shared :as shared]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
+   [ai.miniforge.schema.interface :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures and helpers
+
+(def ^:private cli-cfg
+  {:default-self-author "miniforge[bot]"
+   :min-poll-interval-s 5
+   :max-poll-interval-s 3600})
+
+(def ^:private open-pr-entry
+  {:pr/url              "https://github.com/org/repo/pull/42"
+   :pr/number           42
+   :pr/repo             "org/repo"
+   :pr/added-at         (java.util.Date.)
+   :pr/poll-interval    60
+   :pr/abandon-after-hours 72})
+
+(def ^:private sample-worklist
+  {:worklist/repo-key   "abc123def456"
+   :worklist/prs        [open-pr-entry]
+   :worklist/updated-at (java.util.Date.)})
+
+(defn- exit-ex
+  "Build an ExceptionInfo that tests catch to detect a shared/exit! call."
+  [code]
+  (ex-info "exit!" {:code code}))
+
+(defn- capturing-exit
+  "Return a map with :calls atom and :fn mock for shared/exit!.
+   The mock throws so execution stops after the exit call — matching
+   the real System/exit semantics that callers depend on."
+  []
+  (let [calls (atom [])]
+    {:calls calls
+     :fn    (fn [code]
+               (swap! calls conj code)
+               (throw (exit-ex code)))}))
+
+(defn- capturing-display
+  "Return a map with :msgs atom and a :fn that accumulates printed strings."
+  []
+  (let [msgs (atom [])]
+    {:msgs msgs
+     :fn   (fn [msg] (swap! msgs conj msg))}))
+
+(defn- fake-monitor
+  "Atom mimicking a monitor state atom with a default poll interval."
+  []
+  (atom {:config {:poll-interval-ms 60000}}))
+
+(defn- noop-messages-t
+  "Minimal messages/t stub that returns a string embedding the key."
+  ([k]   (str (name k)))
+  ([k m] (str (name k) " " (pr-str m))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; (d) No remote URL → exit 1
+
+(deftest no-remote-url-exits-1-test
+  (testing "exits 1 and prints error when git remote get-url fails"
+    (let [{exit-calls :calls exit-fn :fn} (capturing-exit)
+          {errors :msgs error-fn :fn}     (capturing-display)]
+      (with-redefs [#'sut/remote-origin-url      (fn [_path] nil)
+                    app-config/pr-monitor-config  (constantly cli-cfg)
+                    shared/exit!                  exit-fn
+                    display/print-error           error-fn
+                    messages/t                    noop-messages-t]
+        (try
+          (sut/pr-monitor-cmd {:repo "/some/repo"})
+          (catch clojure.lang.ExceptionInfo e
+            (when-not (= "exit!" (ex-message e)) (throw e)))))
+      (is (= [1] @exit-calls) "should call exit! with code 1")
+      (is (= 1 (count @errors)) "should print exactly one error"))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; (c) No work-list on disk → exit 1
+
+(deftest no-worklist-exits-1-test
+  (testing "exits 1 and prints error when load-worklist returns failure"
+    (let [{exit-calls :calls exit-fn :fn} (capturing-exit)
+          {errors :msgs error-fn :fn}     (capturing-display)]
+      (with-redefs [#'sut/remote-origin-url        (fn [_path] "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config    (constantly cli-cfg)
+                    app-config/home-dir             (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
+                    pr-lifecycle/worklist-path      (constantly "/fake/home/pr-monitor/abc123def456.edn")
+                    pr-lifecycle/load-worklist      (fn [_path]
+                                                      (schema/failure :worklist "not found"))
+                    shared/exit!                    exit-fn
+                    display/print-error             error-fn
+                    messages/t                      noop-messages-t]
+        (try
+          (sut/pr-monitor-cmd {:repo "/some/repo"})
+          (catch clojure.lang.ExceptionInfo e
+            (when-not (= "exit!" (ex-message e)) (throw e)))))
+      (is (= [1] @exit-calls) "should call exit! with code 1")
+      (is (= 1 (count @errors)) "should print exactly one error"))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; (b) Work-list exists, all PRs pruned to empty → returns normally (exit 0)
+
+(deftest empty-worklist-after-prune-returns-normally-test
+  (testing "prints status message and returns without calling exit! when all PRs are closed"
+    (let [{exit-calls :calls exit-fn :fn} (capturing-exit)
+          {infos :msgs info-fn :fn}       (capturing-display)
+          pruned-worklist                  (assoc sample-worklist :worklist/prs [])]
+      (with-redefs [#'sut/remote-origin-url        (fn [_path] "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config    (constantly cli-cfg)
+                    app-config/home-dir             (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
+                    pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist      (fn [_path]
+                                                      (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs   (fn [_entry] pruned-worklist)
+                    shared/exit!                    exit-fn
+                    display/print-info              info-fn
+                    display/print-error             (fn [_] nil)
+                    messages/t                      noop-messages-t]
+        (sut/pr-monitor-cmd {:repo "/some/repo"}))
+      (is (empty? @exit-calls) "should not call exit! — empty worklist is not an error")
+      (is (pos? (count @infos)) "should print at least one status message")
+      (is (some #(.contains % "monitor-worklist-empty") @infos)
+          "should mention the empty-worklist key"))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; (b) Work-list prune error → exit 1
+
+(deftest prune-error-exits-1-test
+  (testing "exits 1 when prune-closed-prs returns an anomaly"
+    (let [{exit-calls :calls exit-fn :fn} (capturing-exit)
+          {errors :msgs error-fn :fn}     (capturing-display)
+          gh-fail                          (anomaly/anomaly :fault "gh cli failed" {})]
+      (with-redefs [#'sut/remote-origin-url        (fn [_path] "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config    (constantly cli-cfg)
+                    app-config/home-dir             (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
+                    pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist      (fn [_path]
+                                                      (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs   (fn [_entry] gh-fail)
+                    shared/exit!                    exit-fn
+                    display/print-info              (fn [_] nil)
+                    display/print-error             error-fn
+                    messages/t                      noop-messages-t]
+        (try
+          (sut/pr-monitor-cmd {:repo "/some/repo"})
+          (catch clojure.lang.ExceptionInfo e
+            (when-not (= "exit!" (ex-message e)) (throw e)))))
+      (is (= [1] @exit-calls) "should call exit! with code 1 on prune anomaly")
+      (is (= 1 (count @errors)) "should print exactly one error"))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; (a) Work-list exists, open PRs remain → create monitor and run loop
+
+(deftest resume-from-worklist-runs-monitor-test
+  (testing "creates monitor with worklist poll-interval and runs loop when PRs are open"
+    (let [monitor-opts-seen (atom nil)
+          loop-ran          (atom false)
+          mon               (fake-monitor)]
+      (with-redefs [#'sut/remote-origin-url          (fn [_path] "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config      (constantly cli-cfg)
+                    app-config/home-dir               (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key    (constantly "abc123def456")
+                    pr-lifecycle/worklist-path        (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist        (fn [_path]
+                                                        (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs     (fn [entry] entry)
+                    pr-lifecycle/create-pr-monitor    (fn [opts]
+                                                        (reset! monitor-opts-seen opts)
+                                                        mon)
+                    pr-lifecycle/run-pr-monitor-loop  (fn [_monitor _author]
+                                                        (reset! loop-ran true)
+                                                        {:comments-received 0})
+                    pr-lifecycle/stop-pr-monitor-loop (fn [_m] nil)
+                    process/sh                        (fn [& args]
+                                                        (if (= ["gh" "api" "user" "--jq" ".login"]
+                                                               (vec args))
+                                                          {:exit 0 :out "miniforge[bot]" :err ""}
+                                                          {:exit 1 :out "" :err ""}))
+                    display/print-info                (fn [_] nil)
+                    display/print-error               (fn [_] nil)
+                    messages/t                        noop-messages-t]
+        (sut/pr-monitor-cmd {:repo "/some/repo"}))
+      (is @loop-ran "should have called run-pr-monitor-loop")
+      (is (some? @monitor-opts-seen) "should have called create-pr-monitor")
+      (is (= "/some/repo" (:worktree-path @monitor-opts-seen))
+          "monitor worktree-path should be the --repo value")
+      (is (= (* 60 1000) (:poll-interval-ms @monitor-opts-seen))
+          "poll-interval-ms should come from the worklist PR entry (60s × 1000)"))))
+
+(comment
+  ;; Run just these tests from the REPL
+  (clojure.test/run-tests 'ai.miniforge.cli.main.commands.pr-monitor-test)
+  :leave-this-here)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
@@ -17,26 +17,29 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.cli.main.commands.pr-monitor-test
-  "Unit tests for the pr monitor command's worklist-resume paths.
+  "Unit tests for pr-monitor-cmd's worklist-resume and fresh-monitor paths.
 
-   Tests cover:
-   (a) resume path — worklist exists with open PRs → monitor runs
-   (b) resume path — all PRs pruned to empty     → prints status, returns normally
-   (c) no-worklist path                          → exits 1
-   (d) no-remote-url path                        → exits 1"
+   Coverage:
+     (a) resume path — worklist open PRs → monitor created and loop runs
+     (b) resume path — all PRs pruned to empty → returns normally, no exit call
+     (c) no-worklist path                  → shared/exit! 1
+     (d) no-remote-url path                → shared/exit! 1
+     (e) prune anomaly path                → shared/exit! 1
+     (f) nil-author path                   → shared/exit! 1"
   (:require
    [clojure.test :refer [deftest is testing]]
    [babashka.process :as process]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.cli.app-config :as app-config]
-   [ai.miniforge.cli.main.commands.pr :as sut]
+   [ai.miniforge.cli.main.commands.pr-monitor :as sut]
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and helpers
+;; Fixtures
 
 (def ^:private cli-cfg
   {:default-self-author "miniforge[bot]"
@@ -44,11 +47,11 @@
    :max-poll-interval-s 3600})
 
 (def ^:private open-pr-entry
-  {:pr/url              "https://github.com/org/repo/pull/42"
-   :pr/number           42
-   :pr/repo             "org/repo"
-   :pr/added-at         (java.util.Date.)
-   :pr/poll-interval    60
+  {:pr/url                 "https://github.com/org/repo/pull/42"
+   :pr/number              42
+   :pr/repo                "org/repo"
+   :pr/added-at            (java.util.Date.)
+   :pr/poll-interval       60
    :pr/abandon-after-hours 72})
 
 (def ^:private sample-worklist
@@ -56,15 +59,10 @@
    :worklist/prs        [open-pr-entry]
    :worklist/updated-at (java.util.Date.)})
 
-(defn- exit-ex
-  "Build an ExceptionInfo that tests catch to detect a shared/exit! call."
-  [code]
-  (ex-info "exit!" {:code code}))
+(defn- exit-ex [code] (ex-info "exit!" {:code code}))
 
 (defn- capturing-exit
-  "Return a map with :calls atom and :fn mock for shared/exit!.
-   The mock throws so execution stops after the exit call — matching
-   the real System/exit semantics that callers depend on."
+  "shared/exit! stub that records the exit code and throws so callers stop."
   []
   (let [calls (atom [])]
     {:calls calls
@@ -72,134 +70,145 @@
                (swap! calls conj code)
                (throw (exit-ex code)))}))
 
-(defn- capturing-display
-  "Return a map with :msgs atom and a :fn that accumulates printed strings."
+(defn- capturing-msgs
+  "display/print-* stub that records every string."
   []
   (let [msgs (atom [])]
-    {:msgs msgs
-     :fn   (fn [msg] (swap! msgs conj msg))}))
+    {:msgs msgs :fn (fn [msg] (swap! msgs conj msg))}))
 
 (defn- fake-monitor
-  "Atom mimicking a monitor state atom with a default poll interval."
+  "Atom that mimics a monitor state atom with a populated poll-interval."
   []
   (atom {:config {:poll-interval-ms 60000}}))
 
-(defn- noop-messages-t
-  "Minimal messages/t stub that returns a string embedding the key."
-  ([k]   (str (name k)))
-  ([k m] (str (name k) " " (pr-str m))))
+(defn- noop-t
+  "messages/t stub: returns a string embedding the key name so tests can
+   check which key was used without loading the full message catalog."
+  ([k]   (name k))
+  ([k _] (name k)))
+
+(defn- run-cmd
+  "Call sut/pr-monitor-cmd, catching exit! exceptions. Returns the exit code
+   when exit! was called, or nil for a normal return."
+  [opts]
+  (try
+    (sut/pr-monitor-cmd opts)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (when (= "exit!" (ex-message e))
+        (:code (ex-data e))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; (d) No remote URL → exit 1
 
 (deftest no-remote-url-exits-1-test
-  (testing "exits 1 and prints error when git remote get-url fails"
-    (let [{exit-calls :calls exit-fn :fn} (capturing-exit)
-          {errors :msgs error-fn :fn}     (capturing-display)]
-      (with-redefs [#'sut/remote-origin-url      (fn [_path] nil)
-                    app-config/pr-monitor-config  (constantly cli-cfg)
-                    shared/exit!                  exit-fn
-                    display/print-error           error-fn
-                    messages/t                    noop-messages-t]
-        (try
-          (sut/pr-monitor-cmd {:repo "/some/repo"})
-          (catch clojure.lang.ExceptionInfo e
-            (when-not (= "exit!" (ex-message e)) (throw e)))))
-      (is (= [1] @exit-calls) "should call exit! with code 1")
-      (is (= 1 (count @errors)) "should print exactly one error"))))
+  (testing "exits 1 when git remote get-url origin fails"
+    (let [{errors :msgs err-fn :fn} (capturing-msgs)]
+      (with-redefs [#'sut/remote-origin-url     (constantly nil)
+                    app-config/pr-monitor-config (constantly cli-cfg)
+                    shared/exit!                 (fn [code] (throw (exit-ex code)))
+                    display/print-error          err-fn
+                    messages/t                   noop-t]
+        (is (= 1 (run-cmd {:repo "/some/repo"}))))
+      (is (= 1 (count @errors))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; (c) No work-list on disk → exit 1
 
 (deftest no-worklist-exits-1-test
-  (testing "exits 1 and prints error when load-worklist returns failure"
-    (let [{exit-calls :calls exit-fn :fn} (capturing-exit)
-          {errors :msgs error-fn :fn}     (capturing-display)]
-      (with-redefs [#'sut/remote-origin-url        (fn [_path] "https://github.com/org/repo.git")
+  (testing "exits 1 when load-worklist returns a failure result"
+    (let [{errors :msgs err-fn :fn} (capturing-msgs)]
+      (with-redefs [#'sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
                     app-config/pr-monitor-config    (constantly cli-cfg)
                     app-config/home-dir             (constantly "/fake/home")
                     pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
-                    pr-lifecycle/worklist-path      (constantly "/fake/home/pr-monitor/abc123def456.edn")
-                    pr-lifecycle/load-worklist      (fn [_path]
-                                                      (schema/failure :worklist "not found"))
-                    shared/exit!                    exit-fn
-                    display/print-error             error-fn
-                    messages/t                      noop-messages-t]
-        (try
-          (sut/pr-monitor-cmd {:repo "/some/repo"})
-          (catch clojure.lang.ExceptionInfo e
-            (when-not (= "exit!" (ex-message e)) (throw e)))))
-      (is (= [1] @exit-calls) "should call exit! with code 1")
-      (is (= 1 (count @errors)) "should print exactly one error"))))
+                    pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist      (fn [_] (schema/failure :worklist "not found"))
+                    shared/exit!                    (fn [code] (throw (exit-ex code)))
+                    display/print-error             err-fn
+                    messages/t                      noop-t]
+        (is (= 1 (run-cmd {:repo "/some/repo"}))))
+      (is (= 1 (count @errors))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; (b) Work-list exists, all PRs pruned to empty → returns normally (exit 0)
+;------------------------------------------------------------------------------ Layer 1
+;; (b) All PRs pruned → returns normally (exit 0 by default)
 
 (deftest empty-worklist-after-prune-returns-normally-test
-  (testing "prints status message and returns without calling exit! when all PRs are closed"
-    (let [{exit-calls :calls exit-fn :fn} (capturing-exit)
-          {infos :msgs info-fn :fn}       (capturing-display)
-          pruned-worklist                  (assoc sample-worklist :worklist/prs [])]
-      (with-redefs [#'sut/remote-origin-url        (fn [_path] "https://github.com/org/repo.git")
+  (testing "prints status and returns without calling exit! when all PRs are closed"
+    (let [{infos :msgs info-fn :fn}  (capturing-msgs)
+          pruned-wl                   (assoc sample-worklist :worklist/prs [])]
+      (with-redefs [#'sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
                     app-config/pr-monitor-config    (constantly cli-cfg)
                     app-config/home-dir             (constantly "/fake/home")
                     pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
                     pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
-                    pr-lifecycle/load-worklist      (fn [_path]
-                                                      (schema/success :worklist sample-worklist))
-                    pr-lifecycle/prune-closed-prs   (fn [_entry] pruned-worklist)
-                    shared/exit!                    exit-fn
+                    pr-lifecycle/load-worklist      (fn [_] (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs   (fn [_] pruned-wl)
+                    shared/exit!                    (fn [code] (throw (exit-ex code)))
                     display/print-info              info-fn
                     display/print-error             (fn [_] nil)
-                    messages/t                      noop-messages-t]
-        (sut/pr-monitor-cmd {:repo "/some/repo"}))
-      (is (empty? @exit-calls) "should not call exit! — empty worklist is not an error")
-      (is (pos? (count @infos)) "should print at least one status message")
+                    messages/t                      noop-t]
+        (is (nil? (run-cmd {:repo "/some/repo"})) "should return normally, not exit"))
       (is (some #(.contains % "monitor-worklist-empty") @infos)
-          "should mention the empty-worklist key"))))
+          "should print the empty-worklist key"))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; (b) Work-list prune error → exit 1
+;------------------------------------------------------------------------------ Layer 1
+;; (e) Prune returns anomaly → exit 1
 
-(deftest prune-error-exits-1-test
+(deftest prune-anomaly-exits-1-test
   (testing "exits 1 when prune-closed-prs returns an anomaly"
-    (let [{exit-calls :calls exit-fn :fn} (capturing-exit)
-          {errors :msgs error-fn :fn}     (capturing-display)
-          gh-fail                          (anomaly/anomaly :fault "gh cli failed" {})]
-      (with-redefs [#'sut/remote-origin-url        (fn [_path] "https://github.com/org/repo.git")
+    (let [{errors :msgs err-fn :fn} (capturing-msgs)
+          gh-fail                    (anomaly/anomaly :fault "gh cli failed" {})]
+      (with-redefs [#'sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
                     app-config/pr-monitor-config    (constantly cli-cfg)
                     app-config/home-dir             (constantly "/fake/home")
                     pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
                     pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
-                    pr-lifecycle/load-worklist      (fn [_path]
-                                                      (schema/success :worklist sample-worklist))
-                    pr-lifecycle/prune-closed-prs   (fn [_entry] gh-fail)
-                    shared/exit!                    exit-fn
+                    pr-lifecycle/load-worklist      (fn [_] (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs   (fn [_] gh-fail)
+                    shared/exit!                    (fn [code] (throw (exit-ex code)))
                     display/print-info              (fn [_] nil)
-                    display/print-error             error-fn
-                    messages/t                      noop-messages-t]
-        (try
-          (sut/pr-monitor-cmd {:repo "/some/repo"})
-          (catch clojure.lang.ExceptionInfo e
-            (when-not (= "exit!" (ex-message e)) (throw e)))))
-      (is (= [1] @exit-calls) "should call exit! with code 1 on prune anomaly")
-      (is (= 1 (count @errors)) "should print exactly one error"))))
+                    display/print-error             err-fn
+                    messages/t                      noop-t]
+        (is (= 1 (run-cmd {:repo "/some/repo"}))))
+      (is (= 1 (count @errors))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; (f) Author unresolvable → exit 1
+
+(deftest nil-author-exits-1-test
+  (testing "exits 1 when neither gh api user nor default-self-author yields an author"
+    (let [{errors :msgs err-fn :fn} (capturing-msgs)]
+      (with-redefs [#'sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config    (constantly (dissoc cli-cfg :default-self-author))
+                    app-config/home-dir             (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
+                    pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist      (fn [_] (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs   (fn [entry] entry)
+                    ;; gh api user fails → resolve-author falls through to nil default
+                    process/sh                      (fn [& _] {:exit 1 :out "" :err ""})
+                    shared/exit!                    (fn [code] (throw (exit-ex code)))
+                    display/print-info              (fn [_] nil)
+                    display/print-error             err-fn
+                    messages/t                      noop-t]
+        (is (= 1 (run-cmd {:repo "/some/repo"}))))
+      (is (= 1 (count @errors))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; (a) Work-list exists, open PRs remain → create monitor and run loop
+;; (a) Open PRs in worklist → monitor created and loop runs
 
 (deftest resume-from-worklist-runs-monitor-test
-  (testing "creates monitor with worklist poll-interval and runs loop when PRs are open"
+  (testing "creates monitor with worklist-derived poll-interval and runs loop"
     (let [monitor-opts-seen (atom nil)
           loop-ran          (atom false)
           mon               (fake-monitor)]
-      (with-redefs [#'sut/remote-origin-url          (fn [_path] "https://github.com/org/repo.git")
+      (with-redefs [#'sut/remote-origin-url          (constantly "https://github.com/org/repo.git")
                     app-config/pr-monitor-config      (constantly cli-cfg)
                     app-config/home-dir               (constantly "/fake/home")
                     pr-lifecycle/worklist-repo-key    (constantly "abc123def456")
                     pr-lifecycle/worklist-path        (constantly "/fake/path.edn")
-                    pr-lifecycle/load-worklist        (fn [_path]
-                                                        (schema/success :worklist sample-worklist))
+                    pr-lifecycle/load-worklist        (fn [_] (schema/success :worklist sample-worklist))
                     pr-lifecycle/prune-closed-prs     (fn [entry] entry)
                     pr-lifecycle/create-pr-monitor    (fn [opts]
                                                         (reset! monitor-opts-seen opts)
@@ -207,7 +216,8 @@
                     pr-lifecycle/run-pr-monitor-loop  (fn [_monitor _author]
                                                         (reset! loop-ran true)
                                                         {:comments-received 0})
-                    pr-lifecycle/stop-pr-monitor-loop (fn [_m] nil)
+                    pr-lifecycle/stop-pr-monitor-loop (fn [_] nil)
+                    ;; gh api user → return the configured default
                     process/sh                        (fn [& args]
                                                         (if (= ["gh" "api" "user" "--jq" ".login"]
                                                                (vec args))
@@ -215,16 +225,14 @@
                                                           {:exit 1 :out "" :err ""}))
                     display/print-info                (fn [_] nil)
                     display/print-error               (fn [_] nil)
-                    messages/t                        noop-messages-t]
-        (sut/pr-monitor-cmd {:repo "/some/repo"}))
+                    messages/t                        noop-t]
+        (run-cmd {:repo "/some/repo"}))
       (is @loop-ran "should have called run-pr-monitor-loop")
       (is (some? @monitor-opts-seen) "should have called create-pr-monitor")
-      (is (= "/some/repo" (:worktree-path @monitor-opts-seen))
-          "monitor worktree-path should be the --repo value")
+      (is (= "/some/repo" (:worktree-path @monitor-opts-seen)))
       (is (= (* 60 1000) (:poll-interval-ms @monitor-opts-seen))
-          "poll-interval-ms should come from the worklist PR entry (60s × 1000)"))))
+          "poll-interval-ms should derive from the PR entry's :pr/poll-interval (60 s)"))))
 
 (comment
-  ;; Run just these tests from the REPL
   (clojure.test/run-tests 'ai.miniforge.cli.main.commands.pr-monitor-test)
   :leave-this-here)

--- a/components/pr-lifecycle/resources/config/pr-lifecycle/messages/system.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/messages/system.edn
@@ -1,0 +1,40 @@
+{:pr-lifecycle/system
+ {;; WorklistEntry schema validation failure (operator tooling, not user UI)
+  :worklist/validation-failed
+  "WorklistEntry schema validation failed"
+
+  ;; persist-worklist! — schema guard rejected the entry
+  :worklist/invalid-entry
+  "Invalid WorklistEntry"
+
+  ;; persist-worklist! — filesystem write failed
+  :worklist/write-failed
+  "Failed to write worklist"
+
+  ;; load-worklist — path does not exist
+  :worklist/not-found
+  "Worklist not found"
+
+  ;; load-worklist — file exists but EDN is malformed or fails schema
+  :worklist/corrupt
+  "Corrupt worklist"
+
+  ;; load-worklist — filesystem read failed
+  :worklist/read-failed
+  "Failed to read worklist"
+
+  ;; fetch-pr-state — gh exited 0 but --json state field absent
+  :worklist/gh-no-state
+  "gh pr view returned no state field"
+
+  ;; fetch-pr-state — gh exited non-zero
+  :worklist/gh-nonzero-exit
+  "gh pr view exited non-zero"
+
+  ;; fetch-pr-state — gh process could not be started
+  :worklist/gh-start-failed
+  "gh pr view process failed to start"
+
+  ;; prune-closed-prs — a gh call failed; worklist left unchanged
+  :worklist/gh-prune-failed
+  "gh pr view failed during prune — worklist unchanged"}}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
@@ -20,7 +20,8 @@
   "Persisted PR monitor work-list — schema, path helpers, and disk I/O.
 
    Layer 0: WorklistEntry Malli schema and named storage constants.
-   Layer 1: Pure helpers — repo-key derivation, worklist-path computation.
+   Layer 1: Pure helpers — repo-key derivation, worklist-path computation,
+            entry validation.
    Layer 2: Side-effecting persist!/load/prune functions.
 
    The work-list tracks which PRs a monitor instance is watching.
@@ -35,7 +36,12 @@
 
    Boundary contract (rules 3, 4):
    - persist!/load  → schema/success or schema/failure; never throw.
-   - prune-closed-prs → WorklistEntry (pruned or original) or anomaly map."
+   - prune-closed-prs → WorklistEntry (pruned or original) or anomaly map.
+
+   All messages routed through (t :key) from the system message catalog
+   (resources/config/pr-lifecycle/messages/system.edn). Dynamic context
+   (path, pr/number, repo) travels in the anomaly :data map, not the
+   message string (rule 50)."
   (:require
    [babashka.fs :as fs]
    [babashka.process :as process]
@@ -44,6 +50,7 @@
    [malli.error :as me]
    [slingshot.slingshot :refer [try+]]
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.messages.interface :as msg]
    [ai.miniforge.schema.interface :as schema])
   (:import
    [java.nio.charset StandardCharsets]
@@ -52,9 +59,18 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Named constants and Malli schema
 
+(def ^:private t
+  "Component-scoped message translator. All emitted strings go through this."
+  (msg/create-translator "config/pr-lifecycle/messages/system.edn"
+                         :pr-lifecycle/system))
+
 (def ^:private pr-monitor-dir-name
   "Subdirectory name under home-dir for all work-list files."
   "pr-monitor")
+
+(def ^:private worklist-file-extension
+  "File extension for persisted work-list EDN files."
+  ".edn")
 
 (def ^:private sha-algorithm
   "Hash algorithm for repo-key derivation."
@@ -63,6 +79,10 @@
 (def ^:private repo-key-prefix-length
   "Number of hex characters taken from the SHA-256 digest as the repo-key."
   12)
+
+(def ^:private unsigned-byte-mask
+  "Mask for converting a signed Java byte to unsigned (0–255) for hex formatting."
+  0xff)
 
 (def ^:private open-pr-state
   "GitHub PR state string indicating the PR is still open."
@@ -105,7 +125,7 @@
   [s]
   (let [md    (MessageDigest/getInstance sha-algorithm)
         bytes (.digest md (.getBytes ^String s StandardCharsets/UTF_8))]
-    (apply str (map #(format "%02x" (bit-and % 0xff)) bytes))))
+    (apply str (map #(format "%02x" (bit-and % unsigned-byte-mask)) bytes))))
 
 (defn repo-key
   "Derive a stable, filesystem-safe key from `remote-url` (typically the
@@ -125,24 +145,22 @@
 
    Returns: <home-dir>/pr-monitor/<rkey>.edn"
   [home-dir rkey]
-  (str home-dir "/" pr-monitor-dir-name "/" rkey ".edn"))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Internal validation helper
+  (str (fs/path home-dir pr-monitor-dir-name (str rkey worklist-file-extension))))
 
 (defn- validate-entry
-  "Return `entry` when it satisfies WorklistEntry, or an :invalid-input anomaly."
+  "Return `entry` when it satisfies WorklistEntry, or an :invalid-input anomaly.
+   Pure — no I/O."
   [entry]
   (if (m/validate WorklistEntry entry)
     entry
     (anomaly/validation-anomaly
-     "WorklistEntry schema validation failed"
+     (t :worklist/validation-failed)
      :WorklistEntry
      entry
      (me/humanize (m/explain WorklistEntry entry)))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Disk I/O
+;; Disk I/O and GitHub shell calls
 
 (defn persist-worklist!
   "Validate `entry` against WorklistEntry and write it as EDN to `path`.
@@ -150,21 +168,23 @@
 
    Returns:
    - `(schema/success :worklist entry)` on success.
-   - `(schema/failure :worklist <msg>)` on validation or I/O failure."
+   - `(schema/failure :worklist <msg>)` on validation or I/O failure.
+   Dynamic context (path, errors) in the :error value, not the message key."
   [path entry]
   (let [validated (validate-entry entry)]
     (if (anomaly/anomaly? validated)
       (schema/failure :worklist
-                      (str "Invalid WorklistEntry: "
-                           (get-in validated [:anomaly/data :errors])))
+                      {:message (t :worklist/invalid-entry)
+                       :errors  (get-in validated [:anomaly/data :errors])})
       (try+
        (fs/create-dirs (fs/parent path))
        (spit path (pr-str entry))
        (schema/success :worklist entry)
        (catch Object ex
          (schema/failure :worklist
-                         (str "Failed to write worklist to " path ": "
-                              (ex-message ex))))))))
+                         {:message (t :worklist/write-failed)
+                          :path    path
+                          :cause   (ex-message ex)}))))))
 
 (defn load-worklist
   "Read and validate a WorklistEntry EDN from `path`.
@@ -176,29 +196,28 @@
   [path]
   (cond
     (not (fs/exists? path))
-    (schema/failure :worklist (str "Worklist not found: " path))
+    (schema/failure :worklist {:message (t :worklist/not-found) :path path})
 
     :else
     (try+
-     (let [entry (edn/read-string (slurp path))
+     (let [entry     (edn/read-string (slurp path))
            validated (validate-entry entry)]
        (if (anomaly/anomaly? validated)
          (schema/failure :worklist
-                         (str "Corrupt worklist at " path ": "
-                              (get-in validated [:anomaly/data :errors])))
+                         {:message (t :worklist/corrupt)
+                          :path    path
+                          :errors  (get-in validated [:anomaly/data :errors])})
          (schema/success :worklist entry)))
      (catch Object ex
        (schema/failure :worklist
-                       (str "Failed to read worklist at " path ": "
-                            (ex-message ex)))))))
+                       {:message (t :worklist/read-failed)
+                        :path    path
+                        :cause   (ex-message ex)})))))
 
 (defn- fetch-pr-state
   "Shell `gh pr view <number> --repo <repo> --json state` and return the
-   state string (e.g. \"OPEN\", \"MERGED\", \"CLOSED\"), or an anomaly
-   on process failure or missing output field.
-
-   Uses `:throw false` so the process exit code is checked explicitly
-   rather than raising a Java exception for non-zero exits."
+   state string (\"OPEN\", \"MERGED\", \"CLOSED\"), or an anomaly on
+   process failure or missing output field."
   [{:pr/keys [number repo]}]
   (try+
    (let [proc @(process/process ["gh" "pr" "view" (str number)
@@ -207,18 +226,18 @@
      (if (zero? (:exit proc))
        (or (second (re-find gh-state-pattern (:out proc)))
            (anomaly/anomaly :fault
-                            "gh pr view returned no state field"
+                            (t :worklist/gh-no-state)
                             {:pr/number number :pr/repo repo
                              :out (:out proc)}))
        (anomaly/anomaly :fault
-                        "gh pr view exited non-zero"
+                        (t :worklist/gh-nonzero-exit)
                         {:pr/number number :pr/repo repo
                          :exit (:exit proc) :err (:err proc)})))
    (catch Object ex
      (anomaly/anomaly :fault
-                      "gh pr view process failed to start"
+                      (t :worklist/gh-start-failed)
                       {:pr/number number :pr/repo repo
-                       :anomaly/ex-message (ex-message ex)}))))
+                       :cause (ex-message ex)}))))
 
 (defn prune-closed-prs
   "Remove merged or closed PR entries from `entry` by querying GitHub.
@@ -229,8 +248,8 @@
    Returns:
    - The pruned WorklistEntry when all `gh` calls succeed (may be the
      original map when every PR is still open).
-   - An anomaly map if any `gh` invocation fails — safer to leave the
-     list unchanged than to silently drop PRs we could not check."
+   - An anomaly map if any `gh` invocation fails — worklist is left
+     unchanged rather than silently dropping unchecked PRs."
   [entry]
   (let [prs (:worklist/prs entry)]
     (loop [remaining prs
@@ -243,7 +262,7 @@
               state    (fetch-pr-state pr-entry)]
           (if (anomaly/anomaly? state)
             (anomaly/anomaly :fault
-                             "gh pr view failed during prune — worklist unchanged"
+                             (t :worklist/gh-prune-failed)
                              {:failed-pr pr-entry :cause state})
             (recur (rest remaining)
                    (if (= state open-pr-state)
@@ -262,14 +281,14 @@
   ;; => "/Users/chris/.miniforge/pr-monitor/3f8a1c2b0e94.edn"
 
   ;; Construct and persist a worklist
-  (let [entry {:worklist/repo-key    "3f8a1c2b0e94"
-               :worklist/prs         [{:pr/url              "https://github.com/org/repo/pull/42"
-                                       :pr/number           42
-                                       :pr/repo             "org/repo"
-                                       :pr/added-at         (java.util.Date.)
-                                       :pr/poll-interval    60
-                                       :pr/abandon-after-hours 72}]
-               :worklist/updated-at  (java.util.Date.)}
+  (let [entry {:worklist/repo-key   "3f8a1c2b0e94"
+               :worklist/prs        [{:pr/url    "https://github.com/org/repo/pull/42"
+                                      :pr/number 42
+                                      :pr/repo   "org/repo"
+                                      :pr/added-at (java.util.Date.)
+                                      :pr/poll-interval       60
+                                      :pr/abandon-after-hours 72}]
+               :worklist/updated-at (java.util.Date.)}
         path  "/tmp/test-worklist.edn"]
     (persist-worklist! path entry))
   ;; => {:success? true :worklist {...}}
@@ -280,7 +299,7 @@
 
   ;; Missing file
   (load-worklist "/tmp/no-such-file.edn")
-  ;; => {:success? false :worklist nil :error "Worklist not found: ..."}
+  ;; => {:success? false :worklist nil :error {:message "Worklist not found" :path ...}}
 
   ;; Prune closed PRs (requires gh auth)
   ;; (prune-closed-prs entry)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj
@@ -1,0 +1,202 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-worklist-test
+  "Tests for the PR monitor work-list namespace.
+
+   I/O tests use `babashka.fs/with-temp-dir` for filesystem isolation.
+   `fetch-pr-state` (private) is stubbed via `with-redefs` for prune tests."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [babashka.fs :as fs]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.schema.interface :as schema]
+   [ai.miniforge.pr-lifecycle.monitor-worklist :as worklist]))
+
+;------------------------------------------------------------------------------ Fixtures
+
+(def ^:private known-url "https://github.com/miniforge-ai/miniforge.git")
+
+(defn- make-pr-entry
+  "Build a minimal valid WorklistPrEntry."
+  [number repo]
+  {:pr/url      (str "https://github.com/" repo "/pull/" number)
+   :pr/number   number
+   :pr/repo     repo
+   :pr/added-at (java.util.Date.)})
+
+(defn- make-entry
+  "Build a minimal valid WorklistEntry for testing."
+  ([]
+   (make-entry [(make-pr-entry 42 "org/repo")]))
+  ([prs]
+   {:worklist/repo-key   "abc123def456"
+    :worklist/prs        prs
+    :worklist/updated-at (java.util.Date.)}))
+
+(def ^:private open-pr   (make-pr-entry 1 "org/repo"))
+(def ^:private merged-pr (make-pr-entry 2 "org/repo"))
+(def ^:private closed-pr (make-pr-entry 3 "org/repo"))
+
+;------------------------------------------------------------------------------ Layer 1: repo-key
+
+(deftest repo-key-deterministic-test
+  (testing "same URL always produces the same key"
+    (is (= (worklist/repo-key known-url)
+           (worklist/repo-key known-url))))
+
+  (testing "different URLs produce different keys"
+    (is (not= (worklist/repo-key known-url)
+              (worklist/repo-key "https://github.com/other/repo.git"))))
+
+  (testing "key length is exactly 12 characters"
+    (is (= 12 (count (worklist/repo-key known-url)))))
+
+  (testing "key is lowercase hex"
+    (is (re-matches #"[0-9a-f]+" (worklist/repo-key known-url)))))
+
+;------------------------------------------------------------------------------ Layer 1: worklist-path
+
+(deftest worklist-path-test
+  (testing "assembles path under pr-monitor subdir with .edn extension"
+    (let [home "/home/user/.miniforge"
+          rkey "abc123def456"
+          path (worklist/worklist-path home rkey)]
+      (is (str/includes? path "pr-monitor"))
+      (is (str/includes? path rkey))
+      (is (str/ends-with? path ".edn"))))
+
+  (testing "path starts with home-dir"
+    (let [home "/custom/home"
+          path (worklist/worklist-path home "deadbeef1234")]
+      (is (str/starts-with? path home)))))
+
+;------------------------------------------------------------------------------ Layer 2: persist-worklist!
+
+(deftest persist-worklist-happy-test
+  (testing "creates dirs and writes EDN, returns schema/success"
+    (fs/with-temp-dir [tmp {}]
+      (let [rkey  "abc123def456"
+            path  (worklist/worklist-path (str tmp) rkey)
+            entry (make-entry)]
+        (let [result (worklist/persist-worklist! path entry)]
+          (is (schema/succeeded? result))
+          (is (= entry (:worklist result)))
+          (is (fs/exists? path)))))))
+
+(deftest persist-worklist-invalid-entry-test
+  (testing "returns schema/failure on schema mismatch, no file written"
+    (fs/with-temp-dir [tmp {}]
+      (let [path  (str (fs/path tmp "worklist.edn"))
+            ;; Missing required :worklist/updated-at
+            entry {:worklist/repo-key "abc123def456"
+                   :worklist/prs      []}]
+        (let [result (worklist/persist-worklist! path entry)]
+          (is (schema/failed? result))
+          (is (not (fs/exists? path))))))))
+
+(deftest persist-worklist-io-error-test
+  (testing "returns schema/failure when a file blocks directory creation"
+    (fs/with-temp-dir [tmp {}]
+      ;; Place a regular file where fs/create-dirs would need to create a dir
+      (let [blocker (str (fs/path tmp "pr-monitor"))]
+        (spit blocker "not-a-dir")
+        (let [path   (str (fs/path tmp "pr-monitor" "abc123def456.edn"))
+              entry  (make-entry)
+              result (worklist/persist-worklist! path entry)]
+          (is (schema/failed? result)))))))
+
+;------------------------------------------------------------------------------ Layer 2: load-worklist
+
+(deftest load-worklist-happy-test
+  (testing "round-trips a persisted entry"
+    (fs/with-temp-dir [tmp {}]
+      (let [rkey  "abc123def456"
+            path  (worklist/worklist-path (str tmp) rkey)
+            entry (make-entry)]
+        (worklist/persist-worklist! path entry)
+        (let [result (worklist/load-worklist path)]
+          (is (schema/succeeded? result))
+          (is (= entry (:worklist result))))))))
+
+(deftest load-worklist-missing-test
+  (testing "returns schema/failure for a non-existent path"
+    (let [result (worklist/load-worklist "/no/such/path/worklist.edn")]
+      (is (schema/failed? result))
+      (is (some? (:error result))))))
+
+(deftest load-worklist-corrupt-edn-test
+  (testing "returns schema/failure for unparseable EDN"
+    (fs/with-temp-dir [tmp {}]
+      (let [path (str (fs/path tmp "worklist.edn"))]
+        (spit path "this is not valid EDN }{{{")
+        (is (schema/failed? (worklist/load-worklist path))))))
+
+  (testing "returns schema/failure for EDN that fails WorklistEntry schema"
+    (fs/with-temp-dir [tmp {}]
+      (let [path (str (fs/path tmp "worklist.edn"))]
+        ;; Valid EDN but wrong shape
+        (spit path (pr-str {:not-a-worklist true}))
+        (is (schema/failed? (worklist/load-worklist path)))))))
+
+;------------------------------------------------------------------------------ Layer 2: prune-closed-prs
+
+(deftest prune-keeps-open-drops-merged-closed-test
+  (testing "keeps OPEN entries, drops MERGED and CLOSED"
+    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                  (fn [{:pr/keys [number]}]
+                    (case (int number)
+                      1 "OPEN"
+                      2 "MERGED"
+                      3 "CLOSED"
+                      "OPEN"))]
+      (let [entry  (make-entry [open-pr merged-pr closed-pr])
+            result (worklist/prune-closed-prs entry)]
+        (is (not (anomaly/anomaly? result)))
+        (is (= [open-pr] (:worklist/prs result))))))
+
+  (testing "returns original map identity when all PRs are OPEN"
+    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                  (fn [_] "OPEN")]
+      (let [entry  (make-entry [open-pr])
+            result (worklist/prune-closed-prs entry)]
+        (is (= entry result))))))
+
+(deftest prune-gh-failure-test
+  (testing "returns anomaly when fetch-pr-state returns anomaly"
+    (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                  (fn [pr]
+                    (anomaly/anomaly :fault "gh failed" {:pr pr}))]
+      (let [result (worklist/prune-closed-prs (make-entry [open-pr]))]
+        (is (anomaly/anomaly? result))
+        (is (= :fault (:anomaly/type result))))))
+
+  (testing "short-circuits on first failure, does not call gh for remaining PRs"
+    (let [call-count (atom 0)]
+      (with-redefs [#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+                    (fn [_]
+                      (swap! call-count inc)
+                      (anomaly/anomaly :fault "gh failed" {}))]
+        (worklist/prune-closed-prs (make-entry [open-pr merged-pr]))
+        (is (= 1 @call-count))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.pr-lifecycle.monitor-worklist-test)
+  :leave-this-here)

--- a/docs/pull-requests/2026-06-15-update-the-cli-pr-monitor-command-to-support-resuming-from-a.md
+++ b/docs/pull-requests/2026-06-15-update-the-cli-pr-monitor-command-to-support-resuming-from-a.md
@@ -1,0 +1,39 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Update the CLI `pr monitor` command to support resuming from a
+
+**PR:** [#1203](https://github.com/miniforge-ai/miniforge/pull/1203)
+**Branch:** `mf/update-the-cli-pr-monitor-command-to-sup-8fb9f6aa`
+
+## Summary
+
+Update the CLI `pr monitor` command to support resuming from a
+
+## Files Changed
+
+- `bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj` (modify)
+- `bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj` (create)
+- `bases/cli/resources/config/cli/messages/en-US.edn` (modify)
+- `bases/cli/src/ai/miniforge/cli/main.clj` (modify)
+- `bases/cli/src/ai/miniforge/cli/main/commands/pr.clj` (modify)
+- `bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj` (modify)
+
+## Test Results
+
+_No test artifacts available._
+
+## Review Decision
+
+**Decision**: approved
+
+In-scope pr.clj change is a thin delegation — requires pr-monitor and forwards opts unchanged. No logic errors in scope. Single nit: the docstring on the boundary function should carry the contract rather than redirecting. Verdict is :approved on in-scope issues alone. Out-of-scope advisory: resume-from-worklist! has an 8-level nesting anti-pattern that should be decomposed, and the fresh-monitor path lacks a test.
+
+### Known issues (non-blocking)
+
+Merged with 1 unresolved non-blocking issue(s) recorded for follow-up:
+
+- `bases/cli/src/ai/miniforge/cli/main/commands/pr.clj` — pr-monitor-cmd docstring says 'See that namespace for full docs' — redirects readers rather than carrying the boundary contract at the call site. Per rules 009/600, a public boundary function states the contract: what the caller gets, which exit codes fire, and under what conditions.


### PR DESCRIPTION
---
miniforge-workflow: 5cd7a1e1-5b44-4fcf-895c-a51e2ad7f6c6
spec: work/observe-monitor-survives-cli-exit.spec.edn
task: 44444444-4444-4444-4444-444444444444
commit: 7c9f19b632032b6d4fae30b73f92e807c17bbdf1
generated-by: miniforge
---

## Summary

Update the CLI `pr monitor` command to support resuming from a

## Changes

- `bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj` (modify)
- `bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj` (create)
- `bases/cli/resources/config/cli/messages/en-US.edn` (modify)
- `bases/cli/src/ai/miniforge/cli/main.clj` (modify)
- `bases/cli/src/ai/miniforge/cli/main/commands/pr.clj` (modify)
- `bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj` (modify)

## Review

**Decision**: approved

In-scope pr.clj change is a thin delegation — requires pr-monitor and forwards opts unchanged. No logic errors in scope. Single nit: the docstring on the boundary function should carry the contract rather than redirecting. Verdict is :approved on in-scope issues alone. Out-of-scope advisory: resume-from-worklist! has an 8-level nesting anti-pattern that should be decomposed, and the fresh-monitor path lacks a test.

### Known issues (non-blocking)

Merged with 1 unresolved non-blocking issue(s) recorded for follow-up:

- `bases/cli/src/ai/miniforge/cli/main/commands/pr.clj` — pr-monitor-cmd docstring says 'See that namespace for full docs' — redirects readers rather than carrying the boundary contract at the call site. Per rules 009/600, a public boundary function states the contract: what the caller gets, which exit codes fire, and under what conditions.

## Test plan

- [ ] Verify changes compile and tests pass
- [ ] Review generated code for correctness

---
Generated by Miniforge SDLC workflow (6 files)