### PR TITLE
fix(phase): wire telemetry event stream directly

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -21,7 +21,6 @@
   (:require
    [ai.miniforge.event-stream.messages :as messages]
    [ai.miniforge.event-stream.snowflake :as snowflake]
-   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.event-stream.sinks :as sinks]))
@@ -34,18 +33,31 @@
 (def ^:private redirect-transition-type
   :transition/redirect)
 
+(def ^:private phase-transition-request-key
+  :phase/transition-request)
+
+(def ^:private transition-type-key
+  :transition/type)
+
+(def ^:private transition-target-key
+  :transition/target)
+
+(defn- phase-transition-request
+  [result]
+  (get result phase-transition-request-key))
+
 (defn- redirect-target
   "Project a redirect target for legacy consumers.
 
    The workflow runner now emits :phase/transition-request. This helper keeps
    :phase/redirect-to available only when the transition request represents a
-   redirect, so older event consumers do not break while the newer event shape
-   remains authoritative."
+  redirect, so older event consumers do not break while the newer event shape
+  remains authoritative."
   [result]
-  (let [transition-request (phase/transition-request result)
-        transition-type (get transition-request :transition/type)]
+  (let [request (phase-transition-request result)
+        transition-type (get request transition-type-key)]
     (when (= redirect-transition-type transition-type)
-      (get transition-request :transition/target))))
+      (get request transition-target-key))))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event persistence via configurable sinks
@@ -501,7 +513,7 @@
 
 (defn phase-completed [stream workflow-id phase & [result]]
   (let [outcome (get result :outcome :success)
-        transition-request (phase/transition-request result)
+        request (phase-transition-request result)
         redirect-to (or (redirect-target result)
                         (:redirect-to result))]
     (-> (create-envelope stream :workflow/phase-completed workflow-id
@@ -513,7 +525,7 @@
           (:review-decision result) (assoc :phase/review-decision (:review-decision result))
           (:artifacts result) (assoc :phase/artifacts (:artifacts result))
           (:error result) (assoc :phase/error (:error result))
-          transition-request (assoc :phase/transition-request transition-request)
+          request (assoc :phase/transition-request request)
           redirect-to (assoc :phase/redirect-to redirect-to)
           (:tokens result) (assoc :phase/tokens (:tokens result))
           (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))

--- a/components/phase/deps.edn
+++ b/components/phase/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}}
  :aliases
  {:test {:extra-paths ["test"]

--- a/components/phase/src/ai/miniforge/phase/telemetry.clj
+++ b/components/phase/src/ai/miniforge/phase/telemetry.clj
@@ -17,7 +17,7 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.phase.telemetry
-  "Soft-dependency telemetry helpers for phase implementations.
+  "Telemetry helpers for phase implementations.
 
    Provides five capabilities for phase interceptors:
    1. Streaming callbacks — relay agent LLM chunks to event-stream subscribers
@@ -26,9 +26,10 @@
    4. Milestone transitions — emit milestone-reached events on successful phases
    5. Event-stream resolution — locate the stream in varied execution contexts
 
-   All functions are safe no-ops when the event-stream component is absent
-   (soft dependency via requiring-resolve)."
-)
+   All functions are safe no-ops when the event stream is absent from the
+   execution context, and when event-stream publishing fails."
+  (:require
+   [ai.miniforge.event-stream.interface :as event-stream]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event-stream resolution
@@ -62,8 +63,7 @@
   "Publish an event to the stream, swallowing errors to avoid breaking phases."
   [stream event]
   (try
-    (let [publish-fn (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (publish-fn stream event))
+    (event-stream/publish! stream event)
     (catch Exception _ nil)))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -72,19 +72,17 @@
 (defn create-streaming-callback
   "Create an event-stream backed streaming callback for a phase agent.
 
-   Returns nil when the execution context has no event stream or the
-   event-stream component is not available."
+   Returns nil when the execution context has no event stream, or when callback
+   construction fails."
   [ctx agent-id]
   (when-let [stream (resolve-event-stream ctx)]
-    (when-let [create-cb (try
-                           (requiring-resolve
-                            'ai.miniforge.event-stream.interface/create-streaming-callback)
-                           (catch Exception _ nil))]
-      (create-cb stream
-                 (resolve-workflow-id ctx)
-                 agent-id
-                 {:print? (not (:quiet ctx))
-                  :quiet? (boolean (:quiet ctx))}))))
+    (try
+      (event-stream/create-streaming-callback stream
+                                              (resolve-workflow-id ctx)
+                                              agent-id
+                                              {:print? (not (:quiet ctx))
+                                               :quiet? (boolean (:quiet ctx))})
+      (catch Exception _ nil))))
 
 (defn create-streaming-callback-or-noop
   "Create a streaming callback, or a no-op function if event stream is unavailable.
@@ -109,8 +107,8 @@
    Also emits a :phase/milestone-started event marking the phase as an
    in-progress milestone checkpoint.
 
-   Safe no-op when no event stream is available or the event-stream
-   component cannot be resolved. Called from phase :enter functions.
+   Safe no-op when no event stream is available or publishing fails.
+   Called from phase :enter functions.
 
    Arguments:
    - ctx      — execution context map
@@ -119,9 +117,7 @@
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
-        (let [phase-started-fn (requiring-resolve
-                                 'ai.miniforge.event-stream.interface/phase-started)
-              event            (phase-started-fn stream workflow-id phase-kw)]
+        (let [event (event-stream/phase-started stream workflow-id phase-kw)]
           (safe-publish! stream event))
         (catch Exception _ nil)))
     ;; Milestone checkpoint: phase start = milestone start
@@ -134,8 +130,8 @@
    - On :success — emits :phase/milestone-completed and :workflow/milestone-reached
    - On any other outcome — emits :phase/milestone-failed
 
-   Safe no-op when no event stream is available or the event-stream
-   component cannot be resolved. Called from phase :leave functions.
+   Safe no-op when no event stream is available or publishing fails.
+   Called from phase :leave functions.
 
    Arguments:
    - ctx      — execution context map
@@ -146,9 +142,7 @@
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
-        (let [phase-completed-fn (requiring-resolve
-                                   'ai.miniforge.event-stream.interface/phase-completed)
-              event              (phase-completed-fn stream workflow-id phase-kw result)]
+        (let [event (event-stream/phase-completed stream workflow-id phase-kw result)]
           (safe-publish! stream event))
         (catch Exception _ nil))
       ;; Milestone transitions: success = completed, anything else = failed
@@ -168,9 +162,7 @@
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
-        (let [agent-started-fn (requiring-resolve
-                                 'ai.miniforge.event-stream.interface/agent-started)
-              event            (agent-started-fn stream workflow-id agent-id)]
+        (let [event (event-stream/agent-started stream workflow-id agent-id)]
           (safe-publish! stream event))
         (catch Exception _ nil)))))
 
@@ -181,9 +173,7 @@
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
-        (let [agent-completed-fn (requiring-resolve
-                                   'ai.miniforge.event-stream.interface/agent-completed)
-              event              (agent-completed-fn stream workflow-id agent-id)]
+        (let [event (event-stream/agent-completed stream workflow-id agent-id)]
           (safe-publish! stream event))
         (catch Exception _ nil)))))
 
@@ -196,8 +186,7 @@
    Called automatically from emit-phase-completed! when :outcome is :success.
    Can also be called directly to mark an explicit milestone transition.
 
-   Safe no-op when no event stream is available or the event-stream
-   component cannot be resolved.
+   Safe no-op when no event stream is available or publishing fails.
 
    Arguments:
    - ctx      — execution context map
@@ -207,9 +196,7 @@
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
-        (let [milestone-reached-fn (requiring-resolve
-                                     'ai.miniforge.event-stream.interface/milestone-reached)
-              event                (milestone-reached-fn stream workflow-id phase-kw)]
+        (let [event (event-stream/milestone-reached stream workflow-id phase-kw)]
           (safe-publish! stream event))
         (catch Exception _ nil)))))
 
@@ -228,9 +215,7 @@
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
-        (let [constructor (requiring-resolve
-                            'ai.miniforge.event-stream.interface/milestone-started)
-              event       (constructor stream workflow-id phase-kw)]
+        (let [event (event-stream/milestone-started stream workflow-id phase-kw)]
           (safe-publish! stream event))
         (catch Exception _ nil)))))
 
@@ -249,10 +234,11 @@
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
-        (let [constructor (requiring-resolve
-                            'ai.miniforge.event-stream.interface/milestone-completed)
-              event       (constructor stream workflow-id phase-kw
-                                       (str (name phase-kw) " milestone completed"))]
+        (let [event (event-stream/milestone-completed
+                     stream
+                     workflow-id
+                     phase-kw
+                     (str (name phase-kw) " milestone completed"))]
           (safe-publish! stream event))
         (catch Exception _ nil)))))
 
@@ -273,9 +259,7 @@
           reason      (or (get-in result [:error :message])
                           (str (name phase-kw) " milestone failed"))]
       (try
-        (let [constructor (requiring-resolve
-                            'ai.miniforge.event-stream.interface/milestone-failed)
-              event       (constructor stream workflow-id phase-kw reason)]
+        (let [event (event-stream/milestone-failed stream workflow-id phase-kw reason)]
           (safe-publish! stream event))
         (catch Exception _ nil)))))
 


### PR DESCRIPTION
## Summary
- remove the event-stream -> phase dependency by reading transition request event data directly
- add an explicit phase -> event-stream component dependency for telemetry emission
- replace phase telemetry requiring-resolve calls with direct event-stream interface calls

## Validation
- clj-kondo --lint components/event-stream/src/ai/miniforge/event_stream/core.clj components/phase/src/ai/miniforge/phase/telemetry.clj
- clojure -M:poly check
- clojure -M:dev:test -e "(require 'ai.miniforge.phase.telemetry-test 'ai.miniforge.event-stream.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.phase.telemetry-test 'ai.miniforge.event-stream.core-test)"
- bb pre-commit