### PR TITLE
feat(observe): persist PR-monitor worklist before detaching, for resume

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -227,11 +227,13 @@
              result  (pr-lifecycle/persist-worklist! path entry)]
          (when (and logger (schema/failed? result))
            (log/warn logger :observe :observe/worklist-persist-failed
-                     {:data {:path path}})))
+                     {:data {:path path :remote-url remote-url :result result}})))
        (catch Object e
          (when logger
            (log/warn logger :observe :observe/worklist-persist-failed
-                     {:data {:error (str e)}})))))))
+                     {:data {:error (str e)
+                             :worktree-path worktree-path
+                             :remote-url remote-url}})))))))
 
 (defn enter-observe
   "Execute the Observe phase.

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -23,14 +23,18 @@
    This is the N2 §7 implementation. The Observe phase is the final
    phase of the standard SDLC workflow: plan → implement → verify →
    review → release → observe."
-  (:require [ai.miniforge.logging.interface :as log]
+  (:require [ai.miniforge.clock.interface :as clock]
+            [ai.miniforge.config.interface :as config]
+            [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
+            [babashka.process :as process]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [slingshot.slingshot :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Config loading + defaults
@@ -88,6 +92,49 @@
 (phase/register-phase-defaults! :observe default-config)
 
 ;------------------------------------------------------------------------------ Layer 1
+;; Pure worklist helpers
+
+(def ^:private ms-per-second
+  "Milliseconds per second. Converts poll-interval-ms to the integer-seconds
+   value the worklist entry stores under :pr/poll-interval."
+  1000)
+
+(defn- pr-url->repo
+  "Extract `owner/repo` from a GitHub-style PR URL, or nil."
+  [pr-url]
+  (when (string? pr-url)
+    (let [parts (str/split pr-url #"/")]
+      (when-let [pull-idx (some #(when (= "pull" (nth parts % nil)) %)
+                                (range (count parts)))]
+        (when (>= pull-idx 2)
+          (str (nth parts (- pull-idx 2))
+               "/"
+               (nth parts (dec pull-idx))))))))
+
+(defn- pr-info->worklist-entry
+  "Map a pr-info map to a WorklistPrEntry. Returns nil when required
+   fields (url, number, repo) cannot be resolved. Accepts both the
+   `:pr/url`/`:pr/number` (DAG) and `:pr-url`/`:pr-number` (release)
+   key shapes. poll-interval-ms and abandon-after-hours travel from the
+   resolved monitor-config — no operational literal is introduced here.
+
+   `now` is a java.util.Date stamped by the caller; never calls the
+   clock internally so tests can pin the timestamp to a fixed value."
+  [pr-info poll-interval-ms abandon-after-hours now]
+  (let [url    (or (:pr/url pr-info) (:pr-url pr-info))
+        number (some-> (or (:pr/number pr-info) (:pr-number pr-info) (:pr/id pr-info)) int)
+        repo   (or (:pr/repo pr-info) (pr-url->repo url))]
+    (when (and url number repo)
+      (cond-> {:pr/url      url
+               :pr/number   number
+               :pr/repo     repo
+               :pr/added-at now}
+        poll-interval-ms
+        (assoc :pr/poll-interval (int (/ poll-interval-ms ms-per-second)))
+        abandon-after-hours
+        (assoc :pr/abandon-after-hours (int abandon-after-hours))))))
+
+;------------------------------------------------------------------------------ Layer 2
 ;; Interceptor implementation
 
 (defn- resolve-monitor-config
@@ -139,6 +186,53 @@
                                 (get-in ctx [:execution/phase-results :release]))]
               [pr-info]))))
 
+(defn- remote-origin-url
+  "Shell `git config --get remote.origin.url` in worktree-path.
+   Returns the trimmed URL string, or nil on blank/nil path or process failure."
+  [worktree-path]
+  (when-not (str/blank? worktree-path)
+    (try+
+     (let [proc @(process/process ["git" "config" "--get" "remote.origin.url"]
+                                  {:dir worktree-path :out :string :err :string :throw false})]
+       (when (zero? (:exit proc))
+         (str/trim (:out proc))))
+     (catch Object _ nil))))
+
+(defn- try-persist-worklist!
+  "Best-effort: persist the PR monitor worklist before detaching the
+   monitor future. Derives the repo key from the git remote origin URL,
+   resolves the worklist path under `config/miniforge-home`, and writes
+   the entry. Logs a warning on failure but never throws — the in-process
+   monitor continues regardless. All operational values (poll-interval,
+   abandon-after-hours) come from the already-resolved monitor-config.
+
+   Timestamps are obtained from `clock/now-ms` so tests can pin them
+   via `with-redefs`. The self-author is not persisted — resume re-derives
+   it from the git login (`current-github-login`), matching how
+   resolve-monitor-config resolves it here."
+  [monitor-config pr-infos logger]
+  (let [worktree-path  (:worktree-path monitor-config)
+        poll-ms        (:poll-interval-ms monitor-config)
+        abandon-hours  (:abandon-after-hours monitor-config)
+        now            (java.util.Date. (clock/now-ms))
+        remote-url     (remote-origin-url worktree-path)]
+    (when remote-url
+      (try+
+       (let [rkey    (pr-lifecycle/worklist-repo-key remote-url)
+             path    (pr-lifecycle/worklist-path (config/miniforge-home) rkey)
+             entries (keep #(pr-info->worklist-entry % poll-ms abandon-hours now) pr-infos)
+             entry   {:worklist/repo-key   rkey
+                      :worklist/prs        (vec entries)
+                      :worklist/updated-at now}
+             result  (pr-lifecycle/persist-worklist! path entry)]
+         (when (and logger (schema/failed? result))
+           (log/warn logger :observe :observe/worklist-persist-failed
+                     {:data {:path path}})))
+       (catch Object e
+         (when logger
+           (log/warn logger :observe :observe/worklist-persist-failed
+                     {:data {:error (str e)}})))))))
+
 (defn enter-observe
   "Execute the Observe phase.
 
@@ -150,6 +244,10 @@
    must not block the workflow thread. The future is exposed on ctx at
    `:execution/pr-monitor-future` for a long-lived deployment to await or
    cancel; a one-shot run completes the SDLC and exits.
+
+   Before detaching the monitor future, the PR worklist is persisted to
+   disk (best-effort). This enables resume across process restarts without
+   holding state in memory.
 
    Skips (status :skipped) when there are no PRs to observe or no
    self-author can be resolved.
@@ -185,7 +283,13 @@
                        (response/success
                         {:observe/status :skipped
                          :observe/reason "No self-author resolved (gh unauthenticated?) — cannot poll PRs"})))
-         (let [monitor (pr-lifecycle/create-pr-monitor monitor-config)
+         (let [monitor       (pr-lifecycle/create-pr-monitor monitor-config)
+               ;; Persist the worklist before detaching the future so a
+               ;; process restart can resume monitoring without re-running
+               ;; the full SDLC. Best-effort — failure is logged but the
+               ;; in-process monitor continues regardless. try-persist-worklist!
+               ;; enforces its own never-throws contract via try+.
+               _             (try-persist-worklist! monitor-config pr-infos logger)
                ;; Run the monitor OFF the workflow thread. The PR-monitor loop
                ;; polls for up to :abandon-after-hours (72h by default), so a
                ;; synchronous call stalls the workflow at :observe for days and
@@ -240,7 +344,7 @@
   [ctx ex]
   (phase/handle-error ctx ex 0 false))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 3
 ;; Registry method
 
 (defmethod phase/get-phase-interceptor-method :observe
@@ -269,5 +373,18 @@
   ;; :execution/event-bus — PR lifecycle event bus
   ;; :execution/self-author — miniforge's GitHub login
   ;; :config :pr-monitor/* — monitor config overrides
+
+  ;; Worklist helper examples
+  (pr-url->repo "https://github.com/org/repo/pull/42")
+  ;; => "org/repo"
+
+  (pr-info->worklist-entry {:pr-url "https://github.com/org/repo/pull/42"
+                            :pr-number 42}
+                           60000
+                           72
+                           (java.util.Date.))
+  ;; => {:pr/url "..." :pr/number 42 :pr/repo "org/repo"
+  ;;     :pr/added-at #inst "..." :pr/poll-interval 60
+  ;;     :pr/abandon-after-hours 72}
 
   :leave-this-here)

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -18,14 +18,205 @@
 
 (ns ai.miniforge.workflow.observe-phase-test
   (:require
+   [ai.miniforge.clock.interface :as clock]
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
+   [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.workflow.observe-phase :as sut]
    [clojure.test :refer [deftest is testing]]))
 
+;; Named test constants — all duplicated literals centralised here (rule 006).
+;; Values are arbitrary stubs; tests care about plumbing, not specific numbers.
+
+(def ^:private test-poll-interval-ms
+  "Stub poll interval used across observe-phase tests. Value is arbitrary;
+   tests care about plumbing, not the specific ms figure."
+  60000)
+
+(def ^:private test-abandon-after-hours
+  "Stub abandon window used across observe-phase tests."
+  72)
+
+(def ^:private test-deref-timeout-ms
+  "Upper bound for deref calls in async observe-phase tests. 2s is ample
+   headroom; tests that need the loop to *not* run synchronously will see
+   it complete far sooner."
+  2000)
+
+(def ^:private test-max-total-fix-attempts
+  "Stub max-total-fix-attempts-per-pr used in resolve-monitor-config-test.
+   Both the mock and the assertion reference this constant so they stay in sync."
+  10)
+
+(def ^:private test-override-poll-interval-ms
+  "Stub poll-interval-ms context override used in resolve-monitor-config-test.
+   Referenced in both the context map and the assertion."
+  15000)
+
+(def ^:private three-days-in-seconds
+  "72h expressed as seconds — the default observe-phase budget.time-seconds value."
+  259200)
+
 (def ^:private sample-pr
-  ;; Mirrors the production :workflow/pr-info shape built in
-  ;; phase-software-factory/release.clj (:pr-number/:pr-url/:branch/:commit-sha).
+  ;; Single-PR release key shape (:pr-number/:pr-url/:branch/:commit-sha),
+  ;; as built by phase-software-factory/release.clj. Used in tests where the
+  ;; specific key shape is not under test.
   {:pr-number 42 :pr-url "https://github.com/o/r/pull/42" :branch "mf/x" :commit-sha "deadbeef"})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Private helper tests: pr-url->repo, pr-info->worklist-entry,
+;; remote-origin-url, try-persist-worklist!, resolve-pr-infos,
+;; resolve-monitor-config, and config loading.
+
+(deftest pr-url->repo-test
+  (testing "standard GitHub PR URL extracts owner/repo"
+    (is (= "org/repo" (#'sut/pr-url->repo "https://github.com/org/repo/pull/42"))))
+  (testing "URL with numeric PR number still parses"
+    (is (= "myorg/myrepo" (#'sut/pr-url->repo "https://github.com/myorg/myrepo/pull/1"))))
+  (testing "non-GitHub URL without 'pull' segment returns nil"
+    (is (nil? (#'sut/pr-url->repo "https://gitlab.com/org/repo/merge_requests/1"))))
+  (testing "nil returns nil"
+    (is (nil? (#'sut/pr-url->repo nil))))
+  (testing "non-string value returns nil"
+    (is (nil? (#'sut/pr-url->repo 42))))
+  (testing "bare repo URL with no pull path returns nil"
+    (is (nil? (#'sut/pr-url->repo "https://github.com/org/repo"))))
+  (testing "malformed string with no slashes returns nil"
+    (is (nil? (#'sut/pr-url->repo "not-a-url"))))
+  (testing "empty string returns nil"
+    (is (nil? (#'sut/pr-url->repo "")))))
+
+(deftest pr-info->worklist-entry-test
+  (let [fixed-now (java.util.Date. 0)]
+    (testing ":pr/url + :pr/number key shape (DAG release shape)"
+      (let [entry (#'sut/pr-info->worklist-entry
+                   {:pr/url "https://github.com/org/repo/pull/42" :pr/number 42}
+                   test-poll-interval-ms test-abandon-after-hours fixed-now)]
+        (is (= "https://github.com/org/repo/pull/42" (:pr/url entry)))
+        (is (= 42 (:pr/number entry)))
+        (is (= "org/repo" (:pr/repo entry)))
+        (is (= fixed-now (:pr/added-at entry)))
+        (is (= 60 (:pr/poll-interval entry)))
+        (is (= test-abandon-after-hours (:pr/abandon-after-hours entry)))))
+
+    (testing ":pr-url + :pr-number key shape (single-PR release shape)"
+      (let [entry (#'sut/pr-info->worklist-entry
+                   {:pr-url "https://github.com/org/repo/pull/7" :pr-number 7}
+                   30000 48 fixed-now)]
+        (is (= "https://github.com/org/repo/pull/7" (:pr/url entry)))
+        (is (= 7 (:pr/number entry)))
+        (is (= "org/repo" (:pr/repo entry)))))
+
+    (testing "missing url returns nil"
+      (is (nil? (#'sut/pr-info->worklist-entry
+                 {:pr/number 1}
+                 test-poll-interval-ms test-abandon-after-hours fixed-now))))
+
+    (testing "missing number returns nil"
+      (is (nil? (#'sut/pr-info->worklist-entry
+                 {:pr/url "https://github.com/org/repo/pull/1"}
+                 test-poll-interval-ms test-abandon-after-hours fixed-now))))
+
+    (testing "non-GitHub URL with no parseable repo and no explicit :pr/repo returns nil"
+      (is (nil? (#'sut/pr-info->worklist-entry
+                 {:pr/url "https://notgithub.example.com/pr/1" :pr/number 1}
+                 test-poll-interval-ms test-abandon-after-hours fixed-now))))
+
+    (testing "explicit :pr/repo overrides URL parsing"
+      (let [entry (#'sut/pr-info->worklist-entry
+                   {:pr/url "https://notgithub.example.com/pr/1"
+                    :pr/number 1
+                    :pr/repo "myorg/myrepo"}
+                   test-poll-interval-ms test-abandon-after-hours fixed-now)]
+        (is (= "myorg/myrepo" (:pr/repo entry)))))
+
+    (testing "nil poll-interval-ms omits :pr/poll-interval key"
+      (let [entry (#'sut/pr-info->worklist-entry
+                   {:pr/url "https://github.com/org/repo/pull/1" :pr/number 1}
+                   nil test-abandon-after-hours fixed-now)]
+        (is (some? entry))
+        (is (not (contains? entry :pr/poll-interval)))))
+
+    (testing "nil abandon-after-hours omits :pr/abandon-after-hours key"
+      (let [entry (#'sut/pr-info->worklist-entry
+                   {:pr/url "https://github.com/org/repo/pull/1" :pr/number 1}
+                   test-poll-interval-ms nil fixed-now)]
+        (is (some? entry))
+        (is (not (contains? entry :pr/abandon-after-hours)))))
+
+    (testing "timestamp comes from the now argument, not wall clock"
+      (let [t     (java.util.Date. 123456789)
+            entry (#'sut/pr-info->worklist-entry
+                   {:pr/url "https://github.com/org/repo/pull/1" :pr/number 1}
+                   test-poll-interval-ms test-abandon-after-hours t)]
+        (is (= t (:pr/added-at entry)))))))
+
+(deftest remote-origin-url-test
+  (testing "blank worktree-path returns nil without shelling out"
+    (is (nil? (#'sut/remote-origin-url ""))))
+  (testing "nil worktree-path returns nil without shelling out"
+    (is (nil? (#'sut/remote-origin-url nil))))
+  (testing "whitespace-only worktree-path returns nil without shelling out"
+    (is (nil? (#'sut/remote-origin-url "   ")))))
+
+(deftest try-persist-worklist!-never-throws-test
+  ;; try-persist-worklist! must NEVER throw regardless of what the downstream
+  ;; persistence call does. All four sub-cases exercise this contract.
+  (let [remote-url-var (ns-resolve 'ai.miniforge.workflow.observe-phase
+                                   'remote-origin-url)]
+    (testing "exception from persist-worklist! is swallowed, not rethrown"
+      (with-redefs-fn
+        {remote-url-var                    (fn [_] "https://github.com/org/repo.git")
+         #'pr-lifecycle/worklist-repo-key  (fn [_] "org/repo")
+         #'pr-lifecycle/worklist-path      (fn [_ _] "/tmp/wl.edn")
+         #'pr-lifecycle/persist-worklist!  (fn [_ _] (throw (ex-info "disk full" {})))
+         #'config/miniforge-home           (constantly "/tmp")
+         #'clock/now-ms                    (constantly 0)}
+        (fn []
+          (is (nil? (#'sut/try-persist-worklist!
+                     {:worktree-path       "/tmp/repo"
+                      :poll-interval-ms    test-poll-interval-ms
+                      :abandon-after-hours test-abandon-after-hours}
+                     [{:pr/url "https://github.com/org/repo/pull/1" :pr/number 1}]
+                     nil))
+              "exception from persist-worklist! must not propagate"))))
+
+    (testing "RuntimeException from worklist-repo-key is also swallowed"
+      (with-redefs-fn
+        {remote-url-var                   (fn [_] "https://github.com/org/repo.git")
+         #'pr-lifecycle/worklist-repo-key (fn [_] (throw (RuntimeException. "no key")))
+         #'clock/now-ms                   (constantly 0)}
+        (fn []
+          (is (nil? (#'sut/try-persist-worklist!
+                     {:worktree-path       "/tmp/repo"
+                      :poll-interval-ms    test-poll-interval-ms
+                      :abandon-after-hours test-abandon-after-hours}
+                     [] nil))))))
+
+    (testing "blank worktree-path skips the persist block without throwing"
+      ;; remote-origin-url returns nil for blank path → the when block is never entered
+      (with-redefs [clock/now-ms (constantly 0)]
+        (is (nil? (#'sut/try-persist-worklist!
+                   {:worktree-path       ""
+                    :poll-interval-ms    test-poll-interval-ms
+                    :abandon-after-hours test-abandon-after-hours}
+                   [] nil)))))
+
+    (testing "persist-worklist! returning a success result produces nil with no warning"
+      (with-redefs-fn
+        {remote-url-var                    (fn [_] "https://github.com/org/repo.git")
+         #'pr-lifecycle/worklist-repo-key  (fn [_] "org/repo")
+         #'pr-lifecycle/worklist-path      (fn [_ _] "/tmp/wl.edn")
+         #'pr-lifecycle/persist-worklist!  (fn [_ _] (schema/success :worklist {}))
+         #'config/miniforge-home           (constantly "/tmp")
+         #'clock/now-ms                    (constantly 0)}
+        (fn []
+          (is (nil? (#'sut/try-persist-worklist!
+                     {:worktree-path       "/tmp/repo"
+                      :poll-interval-ms    test-poll-interval-ms
+                      :abandon-after-hours test-abandon-after-hours}
+                     [{:pr/url "https://github.com/org/repo/pull/1" :pr/number 1}]
+                     nil))))))))
 
 (deftest resolve-pr-infos-test
   (testing "DAG path: returns the populated dag-pr-infos"
@@ -54,26 +245,46 @@
 (deftest default-config-loaded-from-edn-test
   (testing "observe phase defaults come from resource config"
     (is (= :default (:agent sut/default-config)))
-    (is (= 259200 (get-in sut/default-config [:budget :time-seconds])))
+    (is (= three-days-in-seconds (get-in sut/default-config [:budget :time-seconds])))
     (is (= [] (:gates sut/default-config)))))
 
+(deftest resolve-monitor-config-test
+  (testing "context overrides are merged over shared monitor defaults"
+    (with-redefs [sut/load-monitor-defaults
+                  (fn []
+                    {:poll-interval-ms            test-poll-interval-ms
+                     :self-author                 nil
+                     :max-fix-attempts-per-comment 3
+                     :max-total-fix-attempts-per-pr test-max-total-fix-attempts
+                     :abandon-after-hours         test-abandon-after-hours})]
+      (let [cfg (#'sut/resolve-monitor-config
+                 {:execution/worktree-path "/tmp/repo"
+                  :execution/self-author   "miniforge[bot]"
+                  :config {:pr-monitor/poll-interval-ms test-override-poll-interval-ms}}
+                 nil nil nil)]
+        (is (= test-override-poll-interval-ms (:poll-interval-ms cfg)))
+        (is (= "miniforge[bot]" (:self-author cfg)))
+        (is (= test-max-total-fix-attempts (:max-total-fix-attempts-per-pr cfg)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; enter-observe integration tests: detach contract, skip paths, persistence wiring.
+
 (deftest enter-observe-detaches-monitor-test
-  ;; The 2026-06-15 rn-03 dogfood reached :observe and then "hung" for 45+ min:
-  ;; the phase ran the PR-monitor loop synchronously, and that loop polls for up
-  ;; to :abandon-after-hours (72h). Observe must NOT block the workflow thread —
-  ;; it starts the monitor on a detached future and returns :monitoring at once.
+  ;; Observe must NOT block the workflow thread — it starts the monitor on a
+  ;; detached future and returns :monitoring immediately. A synchronous loop
+  ;; could block for up to :abandon-after-hours.
   (testing "enter-observe returns :monitoring immediately without waiting on the monitor loop"
-    (let [loop-released (promise)        ; lets the monitor loop finish on demand
-          loop-entered (promise)         ; signals the loop actually ran
+    (let [loop-released    (promise)
+          loop-entered     (promise)
           monitor-sentinel (Object.)]
-      (with-redefs [sut/resolve-monitor-config (fn [& _] {:self-author "miniforge[bot]"})
+      (with-redefs [sut/resolve-monitor-config    (fn [& _] {:self-author "miniforge[bot]"})
                     pr-lifecycle/create-pr-monitor (fn [_] monitor-sentinel)
                     pr-lifecycle/run-pr-monitor-loop
                     (fn [monitor author]
                       (deliver loop-entered {:monitor monitor :author author})
-                      @loop-released      ; block until the test releases it
+                      @loop-released
                       {:comments-received 0})]
-        (let [ctx (sut/enter-observe {:execution/dag-pr-infos [sample-pr]})
+        (let [ctx    (sut/enter-observe {:execution/dag-pr-infos [sample-pr]})
               result (get-in ctx [:phase :result])]
           ;; Phase returned while the monitor loop is still blocked — proof it
           ;; did not run synchronously.
@@ -84,13 +295,11 @@
           (is (future? (:execution/pr-monitor-future ctx)))
           (is (not (realized? loop-released))
               "the monitor loop must still be blocked — observe did not await it")
-          ;; The detached loop did receive the monitor + author and is running.
           (is (= {:monitor monitor-sentinel :author "miniforge[bot]"}
-                 (deref loop-entered 2000 :timed-out)))
-          ;; Release it and confirm the future carries the loop's result.
+                 (deref loop-entered test-deref-timeout-ms :timed-out)))
           (deliver loop-released true)
           (is (= {:comments-received 0}
-                 (deref (:execution/pr-monitor-future ctx) 2000 :timed-out))))))))
+                 (deref (:execution/pr-monitor-future ctx) test-deref-timeout-ms :timed-out))))))))
 
 (deftest enter-observe-skips-when-no-prs-test
   (testing "no PRs to observe -> :skipped, no monitor future"
@@ -99,19 +308,145 @@
       (is (= :skipped (get-in ctx [:phase :result :output :observe/status])))
       (is (nil? (:execution/pr-monitor-future ctx))))))
 
-(deftest resolve-monitor-config-test
-  (testing "context overrides are merged over shared monitor defaults"
-    (with-redefs [sut/load-monitor-defaults
-                  (fn []
-                    {:poll-interval-ms 60000
-                     :self-author nil
-                     :max-fix-attempts-per-comment 3
-                     :max-total-fix-attempts-per-pr 10
-                     :abandon-after-hours 72})]
-      (let [config (#'sut/resolve-monitor-config
-                    {:execution/worktree-path "/tmp/repo"
-                     :execution/self-author "miniforge[bot]"
-                     :config {:pr-monitor/poll-interval-ms 15000}} nil nil nil)]
-        (is (= 15000 (:poll-interval-ms config)))
-        (is (= "miniforge[bot]" (:self-author config)))
-        (is (= 10 (:max-total-fix-attempts-per-pr config)))))))
+(deftest enter-observe-calls-persist-worklist!-test
+  ;; Verify persistence wiring: when pr-infos are present and self-author resolves,
+  ;; persist-worklist! is called once with an entry that carries the PR data.
+  ;; Both key shapes (single-PR :pr-url/:pr-number and DAG :pr/url/:pr/number) are
+  ;; tested to confirm both paths reach the persistence call correctly.
+  (let [remote-url-var      (ns-resolve 'ai.miniforge.workflow.observe-phase
+                                        'remote-origin-url)
+        resolve-monitor-var (ns-resolve 'ai.miniforge.workflow.observe-phase
+                                        'resolve-monitor-config)]
+
+    (testing "single-PR key shape (:pr-url/:pr-number) → persist-worklist! called with correct entry"
+      (let [persist-calls (atom [])]
+        (with-redefs-fn
+          {remote-url-var              (fn [_] "https://github.com/org/repo.git")
+           resolve-monitor-var         (fn [& _]
+                                         {:self-author         "miniforge[bot]"
+                                          :worktree-path       "/tmp/repo"
+                                          :poll-interval-ms    test-poll-interval-ms
+                                          :abandon-after-hours test-abandon-after-hours})
+           #'pr-lifecycle/worklist-repo-key   (fn [_] "org/repo")
+           #'pr-lifecycle/worklist-path       (fn [_ _] "/tmp/wl.edn")
+           #'pr-lifecycle/persist-worklist!   (fn [path entry]
+                                                (swap! persist-calls conj {:path path :entry entry})
+                                                (schema/success :worklist {}))
+           #'config/miniforge-home            (constantly "/tmp")
+           #'clock/now-ms                     (constantly 0)
+           #'pr-lifecycle/create-pr-monitor   (fn [_] ::sentinel)
+           #'pr-lifecycle/run-pr-monitor-loop (fn [& _] {:done true})}
+          (fn []
+            (let [ctx (sut/enter-observe {:execution/dag-pr-infos [sample-pr]})]
+              (is (= 1 (count @persist-calls))
+                  "persist-worklist! must be called exactly once")
+              (let [{:keys [path entry]} (first @persist-calls)]
+                (is (= "/tmp/wl.edn" path)
+                    "path must come from the worklist-path helper")
+                (is (= "org/repo" (:worklist/repo-key entry))
+                    "entry must carry the repo key derived from the git remote")
+                (is (= 1 (count (:worklist/prs entry)))
+                    "one pr-info in context → one PR entry in the worklist")
+                (let [pr-entry (first (:worklist/prs entry))]
+                  (is (= (:pr-url sample-pr) (:pr/url pr-entry))
+                      "PR url must be propagated to the worklist entry")
+                  (is (= (:pr-number sample-pr) (:pr/number pr-entry))
+                      "PR number must be propagated to the worklist entry")))
+              ;; Result shape must be :monitoring on the persistence success path
+              (is (= :monitoring (get-in ctx [:phase :result :output :observe/status]))
+                  "phase result must be :monitoring on the persistence success path")
+              (is (true? (get-in ctx [:phase :result :output :observe/monitor-detached?]))
+                  ":monitor-detached? must be true on the persistence success path"))))))
+
+    (testing "DAG namespaced key shape (:pr/url/:pr/number) → persist-worklist! called with correct entry"
+      (let [dag-pr        {:pr/url    "https://github.com/org/repo/pull/99"
+                           :pr/number 99
+                           :pr/repo   "org/repo"}
+            persist-calls (atom [])]
+        (with-redefs-fn
+          {remote-url-var              (fn [_] "https://github.com/org/repo.git")
+           resolve-monitor-var         (fn [& _]
+                                         {:self-author         "miniforge[bot]"
+                                          :worktree-path       "/tmp/repo"
+                                          :poll-interval-ms    test-poll-interval-ms
+                                          :abandon-after-hours test-abandon-after-hours})
+           #'pr-lifecycle/worklist-repo-key   (fn [_] "org/repo")
+           #'pr-lifecycle/worklist-path       (fn [_ _] "/tmp/wl.edn")
+           #'pr-lifecycle/persist-worklist!   (fn [path entry]
+                                                (swap! persist-calls conj {:path path :entry entry})
+                                                (schema/success :worklist {}))
+           #'config/miniforge-home            (constantly "/tmp")
+           #'clock/now-ms                     (constantly 0)
+           #'pr-lifecycle/create-pr-monitor   (fn [_] ::sentinel)
+           #'pr-lifecycle/run-pr-monitor-loop (fn [& _] {:done true})}
+          (fn []
+            (let [ctx (sut/enter-observe {:execution/dag-pr-infos [dag-pr]})]
+              (is (= 1 (count @persist-calls))
+                  "persist-worklist! must be called once for the DAG namespaced shape")
+              (let [pr-entry (first (:worklist/prs (:entry (first @persist-calls))))]
+                (is (= (:pr/url dag-pr) (:pr/url pr-entry))
+                    "namespaced :pr/url must be propagated to the worklist entry")
+                (is (= (:pr/number dag-pr) (:pr/number pr-entry))
+                    "namespaced :pr/number must be propagated to the worklist entry"))
+              (is (= :monitoring (get-in ctx [:phase :result :output :observe/status]))
+                  "phase result must be :monitoring for the DAG namespaced shape path"))))))))
+
+(deftest enter-observe-empty-prs-skips-persistence-test
+  ;; When there are no pr-infos, enter-observe returns :skipped before reaching
+  ;; the persistence call. persist-worklist! must never be invoked.
+  (testing "no pr-infos → persist-worklist! is never invoked"
+    (let [persist-call-count (atom 0)]
+      (with-redefs [pr-lifecycle/persist-worklist! (fn [& _]
+                                                     (swap! persist-call-count inc)
+                                                     (schema/success :worklist {}))]
+        (sut/enter-observe {})
+        (is (zero? @persist-call-count)
+            "persist-worklist! must not be called when there are no PRs to observe")))))
+
+(deftest enter-observe-persist-failure-result-shape-unchanged-test
+  ;; try-persist-worklist! is best-effort: a failure return from persist-worklist!
+  ;; logs a warning but must not alter the phase result shape. The caller sees
+  ;; :monitoring with :monitor-detached? true regardless.
+  (testing "persist-worklist! returning a failure anomaly → phase result still :monitoring"
+    (let [remote-url-var      (ns-resolve 'ai.miniforge.workflow.observe-phase
+                                          'remote-origin-url)
+          resolve-monitor-var (ns-resolve 'ai.miniforge.workflow.observe-phase
+                                          'resolve-monitor-config)]
+      (with-redefs-fn
+        {remote-url-var              (fn [_] "https://github.com/org/repo.git")
+         resolve-monitor-var         (fn [& _]
+                                       {:self-author         "miniforge[bot]"
+                                        :worktree-path       "/tmp/repo"
+                                        :poll-interval-ms    test-poll-interval-ms
+                                        :abandon-after-hours test-abandon-after-hours})
+         #'pr-lifecycle/worklist-repo-key   (fn [_] "org/repo")
+         #'pr-lifecycle/worklist-path       (fn [_ _] "/tmp/wl.edn")
+         #'pr-lifecycle/persist-worklist!   (fn [_ _] (schema/failure :worklist "disk full"))
+         #'config/miniforge-home            (constantly "/tmp")
+         #'clock/now-ms                     (constantly 0)
+         #'pr-lifecycle/create-pr-monitor   (fn [_] ::sentinel)
+         #'pr-lifecycle/run-pr-monitor-loop (fn [& _] {:done true})}
+        (fn []
+          (let [ctx    (sut/enter-observe {:execution/dag-pr-infos [sample-pr]})
+                result (get-in ctx [:phase :result])]
+            (is (= :completed (get-in ctx [:phase :status]))
+                "persist failure must not set phase status to :failed")
+            (is (= :monitoring (get-in result [:output :observe/status]))
+                "observe/status must remain :monitoring despite persist failure")
+            (is (true? (get-in result [:output :observe/monitor-detached?]))
+                ":monitor-detached? must remain true despite persist failure")
+            (is (future? (:execution/pr-monitor-future ctx))
+                "monitor future must still be created despite persist failure")))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; REPL: run all observe-phase tests in isolation
+  (clojure.test/run-tests 'ai.miniforge.workflow.observe-phase-test)
+
+  ;; Run only the persistence-wiring tests
+  (clojure.test/test-vars
+   [#'enter-observe-calls-persist-worklist!-test
+    #'enter-observe-empty-prs-skips-persistence-test
+    #'enter-observe-persist-failure-result-shape-unchanged-test])
+
+  :leave-this-here)

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -61,7 +61,7 @@
   ;; Single-PR release key shape (:pr-number/:pr-url/:branch/:commit-sha),
   ;; as built by phase-software-factory/release.clj. Used in tests where the
   ;; specific key shape is not under test.
-  {:pr-number 42 :pr-url "https://github.com/o/r/pull/42" :branch "mf/x" :commit-sha "deadbeef"})
+  {:pr-number 42 :pr-url "https://github.com/org/repo/pull/42" :branch "mf/x" :commit-sha "deadbeef"})
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Private helper tests: pr-url->repo, pr-info->worklist-entry,


### PR DESCRIPTION
## Summary

Second half of the survive-CLI-exit work (the `monitor-worklist` namespace landed in #1198). `enter-observe` now best-effort persists the PR-monitor worklist (open PRs + poll/budget config) to a gitignored runtime path before detaching the monitor future (#1183). A process restart can then resume monitoring without re-running the workflow; the in-process detached monitor still runs when the process stays alive.

Self-author is intentionally not persisted — resume re-derives it from the git login (`current-github-login`), matching how `resolve-monitor-config` resolves it. Timestamps come from `clock/now-ms` so tests pin them.

## Provenance / why consolidated

This is consolidated from the 2026-06-16 spec-2 dogfood stack (`work/observe-monitor-survives-cli-exit`). The original task PRs (#1202 wiring, #1204 tests) were stacked on a **stale** pre-#1197/#1198 main, so their raw diffs would have reverted the cost-usd NPE fix (#1197) and the monitor-worklist fixes (#1198). Merging the root (#1198) and deleting its branch also closed #1202. Rather than untangle the stack, this PR re-applies only the observe_phase wiring + tests onto current main; the worklist namespace + interface exports it depends on are already present. #1202/#1203/#1204 will be closed as superseded.

## Test plan

- `observe-phase-test`: 12 tests / 73 assertions green — `try-persist-worklist!` never throws (disk-full, key-failure, blank-path, success cases), persists before detaching, and the phase still returns `:monitoring` / reaches `:done`.
- `bb pre-commit` passes (312 + 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)