### PR TITLE
fix(artifact): split datalevin store creation by runtime

### DIFF
--- a/components/artifact/src/ai/miniforge/artifact/interface.cljc
+++ b/components/artifact/src/ai/miniforge/artifact/interface.cljc
@@ -19,6 +19,8 @@
 (ns ai.miniforge.artifact.interface
   "Public API for the artifact component."
   (:require
+   #?@(:bb []
+       :clj [[ai.miniforge.artifact.datalevin-store :as datalevin-store]])
    [ai.miniforge.artifact.core :as core]
    [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
    [ai.miniforge.artifact.protocols.records.transit-store :as transit-store]))
@@ -37,6 +39,19 @@
    currently document argument contracts or failure modes)."
   p/ArtifactStore)
 
+#?(:bb
+   (defn- create-datalevin-store
+     [opts]
+     (throw (ex-info "Datalevin artifact store is JVM-only; use create-transit-store under Babashka"
+                     {:store :datalevin
+                      :runtime :bb
+                      :opts opts})))
+
+   :clj
+   (defn- create-datalevin-store
+     [opts]
+     (datalevin-store/create-datalevin-store opts)))
+
 (defn create-store
   "Create a Datalevin-based artifact store (JVM only).
    For Babashka compatibility, use create-transit-store instead.
@@ -49,8 +64,8 @@
    Examples:
      (create-store)                          ; in-memory
      (create-store {:dir \"data/artifacts\"})  ; persistent"
-  ([] ((requiring-resolve 'ai.miniforge.artifact.datalevin-store/create-datalevin-store)))
-  ([opts] ((requiring-resolve 'ai.miniforge.artifact.datalevin-store/create-datalevin-store) opts)))
+  ([] (create-store {}))
+  ([opts] (create-datalevin-store opts)))
 
 (defn create-transit-store
   "Create a Transit-based artifact store (Babashka compatible).


### PR DESCRIPTION
## Summary
- rename artifact interface to .cljc so JVM-only Datalevin wiring can use reader conditionals
- require the Datalevin store directly on JVM instead of using requiring-resolve
- preserve Babashka compatibility by making create-store fail explicitly and keeping create-transit-store available

## Validation
- clj-kondo --lint components/artifact/src/ai/miniforge/artifact/interface.cljc components/artifact/src/ai/miniforge/artifact/datalevin_store.clj components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
- clojure -M:dev:test -e "(require 'ai.miniforge.artifact.interface-test 'ai.miniforge.artifact.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.artifact.interface-test 'ai.miniforge.artifact.core-test)"
- bb pre-commit