### PR TITLE
feat(cli): pr monitor resumes from the persisted work-list

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -563,6 +563,14 @@
   :pr/monitor-stopped "Monitor stopped. Evidence: {evidence}"
   :pr/monitor-interval-bounds "Poll interval must be {min}-{max} seconds, got {value}. Using default."
   :pr/monitor-interval-invalid "Invalid poll interval: {value}. Using default."
+  :pr/monitor-no-remote "Could not read remote origin URL from {path}."
+  :pr/monitor-no-worklist "No --author given and no persisted work-list found. Run with --author to start a fresh monitor."
+  :pr/monitor-worklist-loaded "Resuming from work-list: {count} open PR(s)."
+  :pr/monitor-worklist-pruning "Checking for closed PRs..."
+  :pr/monitor-worklist-pruned "Removed {removed} closed PR(s); {remaining} still open."
+  :pr/monitor-worklist-empty "All PRs in the work-list are merged or closed — nothing to monitor."
+  :pr/monitor-worklist-prune-error "Could not check PR state: {error}"
+  :pr/monitor-no-author "Could not resolve a GitHub author login. Set --author or ensure 'gh auth login' is configured."
 
   ;; ── Observability ─────────────────────────────────────────────────────
   :observability/error-tailing "Error tailing file: {error}"

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -678,7 +678,8 @@
    {:cmds ["pr" "respond"] :fn pr-respond-cmd :args->opts [:url]}
    {:cmds ["pr" "merge"]   :fn pr-merge-cmd   :args->opts [:url]}
    {:cmds ["pr" "monitor"] :fn pr-monitor-cmd :spec {:author {:alias :a}
-                                                      :poll-interval {:alias :p}}}
+                                                      :poll-interval {:alias :p}
+                                                      :repo {}}}
 
    ;; N13 §2.2 Standards Reviewer auto-trigger (single-pass v0)
    {:cmds ["pr" "review-monitor"]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -24,6 +24,7 @@
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.main.commands.pr-monitor :as pr-monitor]
    [ai.miniforge.cli.main.commands.pr-review :as pr-review]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-runner :as workflow-runner]
@@ -203,54 +204,9 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; PR Monitor (continuous loop)
 
-(defn- resolve-author
-  "Resolve the GitHub author login from --author flag, gh CLI, or config default."
-  [author-opt default-author]
-  (or author-opt
-      (let [result (sh! "gh" "api" "user" "--jq" ".login")]
-        (when (zero? (:exit result))
-          (let [login (str/trim (:out result))]
-            (when (seq login) login))))
-      default-author))
-
-(defn- parse-poll-interval
-  "Parse poll interval in seconds, with bounds checking. Returns milliseconds."
-  [interval-str {:keys [min-poll-interval-s max-poll-interval-s]}]
-  (when interval-str
-    (try
-      (let [seconds (Long/parseLong (str interval-str))]
-        (if (<= min-poll-interval-s seconds max-poll-interval-s)
-          (* seconds 1000)
-          (do (display/print-error
-               (messages/t :pr/monitor-interval-bounds
-                           {:min min-poll-interval-s :max max-poll-interval-s :value seconds}))
-              nil)))
-      (catch NumberFormatException _
-        (display/print-error (messages/t :pr/monitor-interval-invalid {:value interval-str}))
-        nil))))
-
 (defn pr-monitor-cmd
-  "Start the PR monitor loop for autonomous comment resolution.
-
-   Polls open PRs, classifies new comments, and routes them to handlers
-   (fix change-requests, answer questions, skip noise). Runs continuously
-   until stopped with Ctrl+C, budget exhausted, or no open PRs remain."
+  "Delegates to pr-monitor/pr-monitor-cmd, which supports both a fresh
+   `--author` start and resuming from the persisted work-list (written by
+   the observe phase). See that namespace for full docs."
   [opts]
-  (let [{:keys [author poll-interval]} opts
-        cli-cfg    (app-config/pr-monitor-config)
-        cwd        (System/getProperty "user.dir")
-        author     (resolve-author author (:default-self-author cli-cfg))
-        poll-ms    (parse-poll-interval poll-interval cli-cfg)
-        mon-opts   (cond-> {:worktree-path cwd :self-author author}
-                     poll-ms (assoc :poll-interval-ms poll-ms))
-        monitor    (pr-lifecycle/create-pr-monitor mon-opts)
-        eff-ms     (get-in @monitor [:config :poll-interval-ms])]
-    (display/print-info (messages/t :pr/monitor-starting {:author author}))
-    (display/print-info (messages/t :pr/monitor-polling {:seconds (/ eff-ms 1000) :dir cwd}))
-    (display/print-info (messages/t :pr/monitor-stop-hint))
-    (let [shutdown (fn []
-                     (display/print-info (messages/t :pr/monitor-stopping))
-                     (try (pr-lifecycle/stop-pr-monitor-loop monitor) (catch Exception _)))]
-      (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable shutdown))
-      (let [evidence (pr-lifecycle/run-pr-monitor-loop monitor author)]
-        (display/print-info (messages/t :pr/monitor-stopped {:evidence (pr-str evidence)}))))))
+  (pr-monitor/pr-monitor-cmd opts))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
@@ -120,6 +120,13 @@
 (defn- resume-from-worklist!
   "Load persisted worklist for `repo-path`, prune closed PRs, then run monitor.
 
+   Scope note: the work-list is used as a resume GATE (only resume when a
+   persisted list with still-open PRs exists) and as the POLL-CADENCE source
+   (worklist-poll-ms). The monitor loop itself polls the author's open PRs via
+   pr-poller — the work-list PRs are a subset of that set, not an explicit
+   filter. Strict per-PR scoping would need a pr-lifecycle API that accepts an
+   explicit PR set; tracked as a follow-up.
+
    Return-type contract (see monitor_worklist.clj ns-doc):
      - load-worklist    → schema/success | schema/failure  → checked via schema/failed?
      - prune-closed-prs → WorklistEntry  | anomaly map    → checked via anomaly/anomaly?

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
@@ -1,0 +1,208 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.pr-monitor
+  "PR monitor loop — work-list resume and fresh-monitor paths.
+
+   Stratified design (3 layers):
+     Layer 0  constants + shell primitives
+     Layer 1  monitor session (run-monitor!, resume-from-worklist!)
+     Layer 2  entry point (pr-monitor-cmd)"
+  (:require
+   [babashka.process :as process]
+   [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.shared :as shared]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
+   [ai.miniforge.schema.interface :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants and shell primitives
+
+(def ^:private ms-per-second
+  "Milliseconds in one second.
+   Converts poll-interval-s (config/worklist unit) to poll-interval-ms
+   (pr-lifecycle internal unit). Extracted per rule 006 — used in three sites."
+  1000)
+
+(def ^:private default-poll-interval-ms
+  "Fallback used in run-monitor! when the monitor atom does not yet carry
+   [:config :poll-interval-ms]. Mirrors the pr-lifecycle monitor default (60 s)."
+  60000)
+
+(defn- sh! [& args]
+  (apply process/sh args))
+
+(defn- remote-origin-url
+  "Return the git remote origin URL for `repo-path`, or nil on failure."
+  [repo-path]
+  (let [r (sh! "git" "-C" repo-path "remote" "get-url" "origin")]
+    (when (zero? (:exit r))
+      (str/trim (:out r)))))
+
+(defn- resolve-author
+  "Resolve the GitHub author login from `author-opt` flag, gh CLI, or `default-author`."
+  [author-opt default-author]
+  (or author-opt
+      (let [result (sh! "gh" "api" "user" "--jq" ".login")]
+        (when (zero? (:exit result))
+          (let [login (str/trim (:out result))]
+            (when (seq login) login))))
+      default-author))
+
+(defn- parse-poll-interval
+  "Parse poll-interval string in seconds, with bounds checking.
+   Returns milliseconds, or nil when the value is out-of-range or unparseable."
+  [interval-str {:keys [min-poll-interval-s max-poll-interval-s]}]
+  (when interval-str
+    (try
+      (let [seconds (Long/parseLong (str interval-str))]
+        (if (<= min-poll-interval-s seconds max-poll-interval-s)
+          (* seconds ms-per-second)
+          (do (display/print-error
+               (messages/t :pr/monitor-interval-bounds
+                           {:min min-poll-interval-s :max max-poll-interval-s :value seconds}))
+              nil)))
+      (catch NumberFormatException _
+        (display/print-error (messages/t :pr/monitor-interval-invalid {:value interval-str}))
+        nil))))
+
+(defn- worklist-poll-ms
+  "Derive poll-interval in milliseconds from the PR entries in a worklist.
+   Takes the minimum :pr/poll-interval (seconds) across all entries.
+   Returns nil when no entries carry that key — caller uses monitor default."
+  [prs]
+  (some->> (seq (keep :pr/poll-interval prs))
+           (apply min)
+           (* ms-per-second)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Monitor session — compose Layer 0 with pr-lifecycle calls
+
+(defn- run-monitor!
+  "Create a PR monitor from `mon-opts`, install a shutdown hook, run the loop.
+   Single implementation shared by the fresh-monitor and resume paths."
+  [mon-opts author]
+  (let [monitor (pr-lifecycle/create-pr-monitor mon-opts)
+        ;; Guard nil: create-pr-monitor may not populate [:config :poll-interval-ms]
+        ;; before the atom is first deref'd. Fall back to default-poll-interval-ms.
+        eff-ms  (or (get-in @monitor [:config :poll-interval-ms])
+                    default-poll-interval-ms)
+        path    (:worktree-path mon-opts)]
+    (display/print-info (messages/t :pr/monitor-starting {:author author}))
+    (display/print-info (messages/t :pr/monitor-polling {:seconds (/ eff-ms ms-per-second) :dir path}))
+    (display/print-info (messages/t :pr/monitor-stop-hint))
+    (let [shutdown (fn []
+                     (display/print-info (messages/t :pr/monitor-stopping))
+                     (try (pr-lifecycle/stop-pr-monitor-loop monitor) (catch Exception _)))]
+      (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable shutdown))
+      (let [evidence (pr-lifecycle/run-pr-monitor-loop monitor author)]
+        (display/print-info (messages/t :pr/monitor-stopped {:evidence (pr-str evidence)}))))))
+
+(defn- resume-from-worklist!
+  "Load persisted worklist for `repo-path`, prune closed PRs, then run monitor.
+
+   Return-type contract (see monitor_worklist.clj ns-doc):
+     - load-worklist    → schema/success | schema/failure  → checked via schema/failed?
+     - prune-closed-prs → WorklistEntry  | anomaly map    → checked via anomaly/anomaly?
+
+   schema/success :worklist entry produces {:success? true :worklist <entry>}.
+   :worklist is the data-key passed to schema/success; there is no separate
+   value accessor in the schema component (see schema.interface/success).
+
+   Exit semantics:
+     - returns normally (exit 0 by default) when worklist is empty after pruning
+     - shared/exit! 1 on unresolvable remote, missing worklist, prune failure, nil author"
+  [repo-path cli-cfg]
+  (let [origin-url (remote-origin-url repo-path)]     ; A
+    (when-not origin-url
+      (display/print-error (messages/t :pr/monitor-no-remote {:path repo-path}))
+      (shared/exit! 1))
+    (let [rkey        (pr-lifecycle/worklist-repo-key origin-url)
+          wl-path     (pr-lifecycle/worklist-path (app-config/home-dir) rkey)
+          load-result (pr-lifecycle/load-worklist wl-path)]     ; B
+      (when (schema/failed? load-result)
+        (display/print-error (messages/t :pr/monitor-no-worklist))
+        (shared/exit! 1))
+      (let [worklist       (:worklist load-result)
+            original-count (count (:worklist/prs worklist))]    ; C
+        (display/print-info (messages/t :pr/monitor-worklist-loaded {:count original-count}))
+        (display/print-info (messages/t :pr/monitor-worklist-pruning))
+        (let [pruned (pr-lifecycle/prune-closed-prs worklist)]  ; D
+          (when (anomaly/anomaly? pruned)
+            (display/print-error
+             (messages/t :pr/monitor-worklist-prune-error
+                         {:error (:anomaly/message pruned)}))
+            (shared/exit! 1))
+          (let [prs     (:worklist/prs pruned)
+                removed (- original-count (count prs))]         ; E
+            (when (pos? removed)
+              (display/print-info
+               (messages/t :pr/monitor-worklist-pruned
+                           {:removed removed :remaining (count prs)})))
+            (if (empty? prs)                                    ; F
+              (display/print-info (messages/t :pr/monitor-worklist-empty))
+              (let [author (resolve-author nil (:default-self-author cli-cfg))]  ; G
+                (when-not author
+                  (display/print-error (messages/t :pr/monitor-no-author))
+                  (shared/exit! 1))
+                (let [poll-ms  (worklist-poll-ms prs)
+                      mon-opts (cond-> {:worktree-path repo-path :self-author author}
+                                 poll-ms (assoc :poll-interval-ms poll-ms))]    ; H
+                  (run-monitor! mon-opts author))))))))))        ; H G F E D C B A defn
+
+;------------------------------------------------------------------------------ Layer 2
+;; Entry point
+
+(defn pr-monitor-cmd
+  "Start the PR monitor loop for autonomous comment resolution.
+
+   With --author: creates a fresh monitor polling that author's open PRs.
+   Without --author: resumes from a persisted work-list, using --repo (or
+   cwd) as the repo path for work-list key derivation.
+
+   Returns normally when the work-list is empty after pruning (exit 0).
+   Calls shared/exit! 1 when no work-list exists and no --author is supplied."
+  [opts]
+  (let [{:keys [author poll-interval repo]} opts
+        cli-cfg   (app-config/pr-monitor-config)
+        cwd       (System/getProperty "user.dir")
+        repo-path (or repo cwd)]
+    (if author
+      (let [resolved (resolve-author author (:default-self-author cli-cfg))
+            poll-ms  (parse-poll-interval poll-interval cli-cfg)
+            mon-opts (cond-> {:worktree-path repo-path :self-author resolved}
+                       poll-ms (assoc :poll-interval-ms poll-ms))]
+        (run-monitor! mon-opts resolved))
+      (resume-from-worklist! repo-path cli-cfg))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Fresh monitor for a specific author
+  (pr-monitor-cmd {:author "alice" :repo "/path/to/repo" :poll-interval "60"})
+
+  ;; Resume from persisted work-list in the current directory
+  (pr-monitor-cmd {})
+
+  ;; Resume from an explicit repo path
+  (pr-monitor-cmd {:repo "/path/to/other-repo"})
+
+  :leave-this-here)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
@@ -25,7 +25,8 @@
      (c) no-worklist path                  → shared/exit! 1
      (d) no-remote-url path                → shared/exit! 1
      (e) prune anomaly path                → shared/exit! 1
-     (f) nil-author path                   → shared/exit! 1"
+     (f) nil-author path                   → shared/exit! 1
+     (g) fresh --author path               → run-monitor!, no work-list load"
   (:require
    [clojure.test :refer [deftest is testing]]
    [babashka.process :as process]
@@ -60,15 +61,6 @@
    :worklist/updated-at (java.util.Date.)})
 
 (defn- exit-ex [code] (ex-info "exit!" {:code code}))
-
-(defn- capturing-exit
-  "shared/exit! stub that records the exit code and throws so callers stop."
-  []
-  (let [calls (atom [])]
-    {:calls calls
-     :fn    (fn [code]
-               (swap! calls conj code)
-               (throw (exit-ex code)))}))
 
 (defn- capturing-msgs
   "display/print-* stub that records every string."
@@ -232,6 +224,30 @@
       (is (= "/some/repo" (:worktree-path @monitor-opts-seen)))
       (is (= (* 60 1000) (:poll-interval-ms @monitor-opts-seen))
           "poll-interval-ms should derive from the PR entry's :pr/poll-interval (60 s)"))))
+
+(deftest fresh-author-path-skips-worklist-test
+  (testing "(g) --author starts a fresh monitor and never loads a work-list (Copilot #1209)"
+    (let [loaded?           (atom false)
+          monitor-opts-seen (atom nil)
+          loop-author       (atom nil)
+          mon               (fake-monitor)]
+      (with-redefs [pr-lifecycle/load-worklist        (fn [_]
+                                                        (reset! loaded? true)
+                                                        (schema/failure :worklist "should not be called"))
+                    pr-lifecycle/create-pr-monitor    (fn [opts] (reset! monitor-opts-seen opts) mon)
+                    pr-lifecycle/run-pr-monitor-loop  (fn [_monitor author]
+                                                        (reset! loop-author author)
+                                                        {:comments-received 0})
+                    pr-lifecycle/stop-pr-monitor-loop (fn [_] nil)
+                    app-config/pr-monitor-config      (constantly cli-cfg)
+                    display/print-info                (fn [_] nil)
+                    display/print-error               (fn [_] nil)
+                    messages/t                        noop-t]
+        (run-cmd {:author "alice" :repo "/some/repo"}))
+      (is (false? @loaded?) "fresh --author path must NOT load a work-list")
+      (is (= "alice" @loop-author) "monitors the supplied author")
+      (is (= "/some/repo" (:worktree-path @monitor-opts-seen)))
+      (is (= "alice" (:self-author @monitor-opts-seen))))))
 
 (comment
   (clojure.test/run-tests 'ai.miniforge.cli.main.commands.pr-monitor-test)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
@@ -1,0 +1,238 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.pr-monitor-test
+  "Unit tests for pr-monitor-cmd's worklist-resume and fresh-monitor paths.
+
+   Coverage:
+     (a) resume path — worklist open PRs → monitor created and loop runs
+     (b) resume path — all PRs pruned to empty → returns normally, no exit call
+     (c) no-worklist path                  → shared/exit! 1
+     (d) no-remote-url path                → shared/exit! 1
+     (e) prune anomaly path                → shared/exit! 1
+     (f) nil-author path                   → shared/exit! 1"
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [babashka.process :as process]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.pr-monitor :as sut]
+   [ai.miniforge.cli.main.commands.shared :as shared]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
+   [ai.miniforge.schema.interface :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Fixtures
+
+(def ^:private cli-cfg
+  {:default-self-author "miniforge[bot]"
+   :min-poll-interval-s 5
+   :max-poll-interval-s 3600})
+
+(def ^:private open-pr-entry
+  {:pr/url                 "https://github.com/org/repo/pull/42"
+   :pr/number              42
+   :pr/repo                "org/repo"
+   :pr/added-at            (java.util.Date.)
+   :pr/poll-interval       60
+   :pr/abandon-after-hours 72})
+
+(def ^:private sample-worklist
+  {:worklist/repo-key   "abc123def456"
+   :worklist/prs        [open-pr-entry]
+   :worklist/updated-at (java.util.Date.)})
+
+(defn- exit-ex [code] (ex-info "exit!" {:code code}))
+
+(defn- capturing-exit
+  "shared/exit! stub that records the exit code and throws so callers stop."
+  []
+  (let [calls (atom [])]
+    {:calls calls
+     :fn    (fn [code]
+               (swap! calls conj code)
+               (throw (exit-ex code)))}))
+
+(defn- capturing-msgs
+  "display/print-* stub that records every string."
+  []
+  (let [msgs (atom [])]
+    {:msgs msgs :fn (fn [msg] (swap! msgs conj msg))}))
+
+(defn- fake-monitor
+  "Atom that mimics a monitor state atom with a populated poll-interval."
+  []
+  (atom {:config {:poll-interval-ms 60000}}))
+
+(defn- noop-t
+  "messages/t stub: returns a string embedding the key name so tests can
+   check which key was used without loading the full message catalog."
+  ([k]   (name k))
+  ([k _] (name k)))
+
+(defn- run-cmd
+  "Call sut/pr-monitor-cmd, catching exit! exceptions. Returns the exit code
+   when exit! was called, or nil for a normal return."
+  [opts]
+  (try
+    (sut/pr-monitor-cmd opts)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (when (= "exit!" (ex-message e))
+        (:code (ex-data e))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; (d) No remote URL → exit 1
+
+(deftest no-remote-url-exits-1-test
+  (testing "exits 1 when git remote get-url origin fails"
+    (let [{errors :msgs err-fn :fn} (capturing-msgs)]
+      (with-redefs [sut/remote-origin-url     (constantly nil)
+                    app-config/pr-monitor-config (constantly cli-cfg)
+                    shared/exit!                 (fn [code] (throw (exit-ex code)))
+                    display/print-error          err-fn
+                    messages/t                   noop-t]
+        (is (= 1 (run-cmd {:repo "/some/repo"}))))
+      (is (= 1 (count @errors))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; (c) No work-list on disk → exit 1
+
+(deftest no-worklist-exits-1-test
+  (testing "exits 1 when load-worklist returns a failure result"
+    (let [{errors :msgs err-fn :fn} (capturing-msgs)]
+      (with-redefs [sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config    (constantly cli-cfg)
+                    app-config/home-dir             (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
+                    pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist      (fn [_] (schema/failure :worklist "not found"))
+                    shared/exit!                    (fn [code] (throw (exit-ex code)))
+                    display/print-error             err-fn
+                    messages/t                      noop-t]
+        (is (= 1 (run-cmd {:repo "/some/repo"}))))
+      (is (= 1 (count @errors))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; (b) All PRs pruned → returns normally (exit 0 by default)
+
+(deftest empty-worklist-after-prune-returns-normally-test
+  (testing "prints status and returns without calling exit! when all PRs are closed"
+    (let [{infos :msgs info-fn :fn}  (capturing-msgs)
+          pruned-wl                   (assoc sample-worklist :worklist/prs [])]
+      (with-redefs [sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config    (constantly cli-cfg)
+                    app-config/home-dir             (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
+                    pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist      (fn [_] (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs   (fn [_] pruned-wl)
+                    shared/exit!                    (fn [code] (throw (exit-ex code)))
+                    display/print-info              info-fn
+                    display/print-error             (fn [_] nil)
+                    messages/t                      noop-t]
+        (is (nil? (run-cmd {:repo "/some/repo"})) "should return normally, not exit"))
+      (is (some #(.contains % "monitor-worklist-empty") @infos)
+          "should print the empty-worklist key"))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; (e) Prune returns anomaly → exit 1
+
+(deftest prune-anomaly-exits-1-test
+  (testing "exits 1 when prune-closed-prs returns an anomaly"
+    (let [{errors :msgs err-fn :fn} (capturing-msgs)
+          gh-fail                    (anomaly/anomaly :fault "gh cli failed" {})]
+      (with-redefs [sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config    (constantly cli-cfg)
+                    app-config/home-dir             (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
+                    pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist      (fn [_] (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs   (fn [_] gh-fail)
+                    shared/exit!                    (fn [code] (throw (exit-ex code)))
+                    display/print-info              (fn [_] nil)
+                    display/print-error             err-fn
+                    messages/t                      noop-t]
+        (is (= 1 (run-cmd {:repo "/some/repo"}))))
+      (is (= 1 (count @errors))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; (f) Author unresolvable → exit 1
+
+(deftest nil-author-exits-1-test
+  (testing "exits 1 when neither gh api user nor default-self-author yields an author"
+    (let [{errors :msgs err-fn :fn} (capturing-msgs)]
+      (with-redefs [sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config    (constantly (dissoc cli-cfg :default-self-author))
+                    app-config/home-dir             (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key  (constantly "abc123def456")
+                    pr-lifecycle/worklist-path      (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist      (fn [_] (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs   (fn [entry] entry)
+                    ;; gh api user fails → resolve-author falls through to nil default
+                    process/sh                      (fn [& _] {:exit 1 :out "" :err ""})
+                    shared/exit!                    (fn [code] (throw (exit-ex code)))
+                    display/print-info              (fn [_] nil)
+                    display/print-error             err-fn
+                    messages/t                      noop-t]
+        (is (= 1 (run-cmd {:repo "/some/repo"}))))
+      (is (= 1 (count @errors))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; (a) Open PRs in worklist → monitor created and loop runs
+
+(deftest resume-from-worklist-runs-monitor-test
+  (testing "creates monitor with worklist-derived poll-interval and runs loop"
+    (let [monitor-opts-seen (atom nil)
+          loop-ran          (atom false)
+          mon               (fake-monitor)]
+      (with-redefs [sut/remote-origin-url          (constantly "https://github.com/org/repo.git")
+                    app-config/pr-monitor-config      (constantly cli-cfg)
+                    app-config/home-dir               (constantly "/fake/home")
+                    pr-lifecycle/worklist-repo-key    (constantly "abc123def456")
+                    pr-lifecycle/worklist-path        (constantly "/fake/path.edn")
+                    pr-lifecycle/load-worklist        (fn [_] (schema/success :worklist sample-worklist))
+                    pr-lifecycle/prune-closed-prs     (fn [entry] entry)
+                    pr-lifecycle/create-pr-monitor    (fn [opts]
+                                                        (reset! monitor-opts-seen opts)
+                                                        mon)
+                    pr-lifecycle/run-pr-monitor-loop  (fn [_monitor _author]
+                                                        (reset! loop-ran true)
+                                                        {:comments-received 0})
+                    pr-lifecycle/stop-pr-monitor-loop (fn [_] nil)
+                    ;; gh api user → return the configured default
+                    process/sh                        (fn [& args]
+                                                        (if (= ["gh" "api" "user" "--jq" ".login"]
+                                                               (vec args))
+                                                          {:exit 0 :out "miniforge[bot]" :err ""}
+                                                          {:exit 1 :out "" :err ""}))
+                    display/print-info                (fn [_] nil)
+                    display/print-error               (fn [_] nil)
+                    messages/t                        noop-t]
+        (run-cmd {:repo "/some/repo"}))
+      (is @loop-ran "should have called run-pr-monitor-loop")
+      (is (some? @monitor-opts-seen) "should have called create-pr-monitor")
+      (is (= "/some/repo" (:worktree-path @monitor-opts-seen)))
+      (is (= (* 60 1000) (:poll-interval-ms @monitor-opts-seen))
+          "poll-interval-ms should derive from the PR entry's :pr/poll-interval (60 s)"))))
+
+(comment
+  (clojure.test/run-tests 'ai.miniforge.cli.main.commands.pr-monitor-test)
+  :leave-this-here)

--- a/bases/cli/test/ai/miniforge/cli/main_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main_test.clj
@@ -22,7 +22,7 @@
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.main :as sut]
-   [ai.miniforge.cli.main.commands.pr :as cmd-pr]
+   [ai.miniforge.cli.main.commands.pr-monitor :as cmd-pr-monitor]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.workflow-resume.interface :as wr]))
 
@@ -76,9 +76,9 @@
     (let [entries (filter #(= ["pr" "monitor"] (:cmds %)) sut/dispatch-table)]
       (is (= 1 (count entries)) "Exactly one pr monitor entry")
       (is (some? (:fn (first entries))) "Has a handler function")
-      (is (= {:author {:alias :a} :poll-interval {:alias :p}}
+      (is (= {:author {:alias :a} :poll-interval {:alias :p} :repo {}}
              (:spec (first entries)))
-          "Spec includes --author and --poll-interval"))))
+          "Spec includes --author, --poll-interval, and --repo"))))
 
 (deftest workflow-status-summary-marks-quiet-running-checkpoints-stale-test
   (testing "running workflows with old last events are surfaced as stale"
@@ -150,14 +150,14 @@
 
 (deftest parse-poll-interval-test
   (testing "Valid interval returns milliseconds"
-    (is (= 30000 (#'cmd-pr/parse-poll-interval "30" test-bounds))))
+    (is (= 30000 (#'cmd-pr-monitor/parse-poll-interval "30" test-bounds))))
   (testing "Nil interval returns nil (domain default applies)"
-    (is (nil? (#'cmd-pr/parse-poll-interval nil test-bounds))))
+    (is (nil? (#'cmd-pr-monitor/parse-poll-interval nil test-bounds))))
   (testing "Out-of-bounds interval returns nil with error message"
     (let [output (with-out-str
-                   (is (nil? (#'cmd-pr/parse-poll-interval "1" test-bounds))))]
+                   (is (nil? (#'cmd-pr-monitor/parse-poll-interval "1" test-bounds))))]
       (is (re-find #"5-3600" output))))
   (testing "Non-numeric interval returns nil with error message"
     (let [output (with-out-str
-                   (is (nil? (#'cmd-pr/parse-poll-interval "abc" test-bounds))))]
+                   (is (nil? (#'cmd-pr-monitor/parse-poll-interval "abc" test-bounds))))]
       (is (re-find #"Invalid" output)))))


### PR DESCRIPTION
## Summary

Final piece of survive-CLI-exit. Refactors the inline `pr-monitor-cmd` into a dedicated `pr-monitor` namespace that supports **both** a fresh `--author` start and **resuming from the work-list** the observe phase persists (#1206). On resume it loads the work-list, prunes merged/closed PRs, and runs the monitor loop for the remaining open PRs — so the autonomous comment→fix→resolve loop can continue out-of-band after a one-shot `bb miniforge run` exits.

Together with #1198 (worklist namespace) and #1206 (observe persists the worklist), this completes the chain:
`run → observe persists worklist on exit → \`miniforge pr monitor\` resumes → comments get fixed/resolved`.

## Provenance

Consolidated from the closed #1203 (its base branch was deleted when the stack root #1198 merged). The new `pr_monitor.clj` + test are taken as-is; `pr.clj`'s inline command is replaced with a delegate (its orphaned `resolve-author`/`parse-poll-interval` helpers now live in `pr_monitor.clj`); 8 new `:pr/monitor-*` messages added; `:repo` added to the dispatch spec. Also drops a `#'`-var-quote `with-redefs` compile bug in the generated test.

## Test plan

- `pr_monitor_test` (runs in CI Test job): covers no-remote exit, no-worklist exit, resume happy-path, prune, empty-after-prune, fresh `--author` start.
- `bb pre-commit` passes (312 + 6 smoke). Full cli base tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)