### PR TITLE
fix(agent): require injected capsule executor

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -781,22 +781,22 @@
 ;------------------------------------------------------------------------------ Layer 2.5
 ;; Capsule-aware session lifecycle (N11 §6.3-6.4)
 
-(defn- resolve-exec!
-  "Resolve the executor execute! function once. All capsule functions
-   use the :exec! key on the session instead of repeated requiring-resolve."
+(defn- missing-execute-fn!
   []
-  @(requiring-resolve 'ai.miniforge.dag-executor.executor/execute!))
+  (throw (ex-info "Capsule artifact sessions require :execution/execute-fn"
+                  {:missing :execution/execute-fn
+                   :component :agent/artifact-session})))
 
 (defn create-capsule-session!
   "Create an artifact session inside a task capsule.
    Session directory is created inside the capsule's workspace via executor.
    Returns session map with capsule-relative paths and resolved exec! fn.
 
-   Three-arity form resolves execute! from the dag-executor component at runtime.
-   Four-arity form accepts an explicit execute-fn to avoid requiring-resolve
-   at call time (useful in tests and dependency-injection contexts)."
+   Three-arity form fails with a configuration error because agent must not
+   reach upward into dag-executor. Four-arity form accepts the execute-fn
+   injected by workflow."
   ([executor env-id workdir]
-   (create-capsule-session! executor env-id workdir (resolve-exec!)))
+   (create-capsule-session! executor env-id workdir (missing-execute-fn!)))
   ([executor env-id workdir execute-fn]
    (let [exec!       execute-fn
          session-dir (str workdir "/.miniforge-session")
@@ -871,17 +871,23 @@
 
 (defmacro with-capsule-artifact-session
   "Execute body with a capsule-aware artifact session (N11 §6.3).
-   Like with-artifact-session but session files live inside the task capsule."
-  [[session-sym executor env-id workdir] & body]
-  `(let [session# (-> (create-capsule-session! ~executor ~env-id ~workdir)
-                      write-capsule-mcp-config!)
-         ~session-sym session#]
-     (try
-       (let [result# (do ~@body)]
-         {:llm-result result#
-          :artifact (read-capsule-artifact session#)})
-       (finally
-         (cleanup-capsule-session! session#)))))
+   Like with-artifact-session but session files live inside the task capsule.
+   Binding form: [session executor env-id workdir execute-fn]."
+  [[session-sym executor env-id workdir execute-fn] & body]
+  (let [execute-fn-form (or execute-fn
+                            `(throw (ex-info
+                                      "Capsule artifact sessions require :execution/execute-fn"
+                                      {:missing :execution/execute-fn
+                                       :component :agent/artifact-session})))]
+    `(let [session# (-> (create-capsule-session! ~executor ~env-id ~workdir ~execute-fn-form)
+                        write-capsule-mcp-config!)
+           ~session-sym session#]
+       (try
+         (let [result# (do ~@body)]
+           {:llm-result result#
+            :artifact (read-capsule-artifact session#)})
+         (finally
+           (cleanup-capsule-session! session#))))))
 
 (defn cleanup-session!
   "Delete the temporary session directory and clean up injected configs.
@@ -1146,11 +1152,12 @@
    Returns normalized map:
    {:llm-result :artifact :context-misses :pre-session-snapshot :session-mode}"
   [context body-fn]
-  (if (governed? context)
-    (let [executor (:execution/executor context)
-          env-id   (:execution/environment-id context)
-          workdir  (or (:execution/worktree-path context) "/workspace")
-          session  (-> (create-capsule-session! executor env-id workdir)
+    (if (governed? context)
+      (let [executor (:execution/executor context)
+            env-id   (:execution/environment-id context)
+            workdir  (or (:execution/worktree-path context) "/workspace")
+            exec!    (or (:execution/execute-fn context) (missing-execute-fn!))
+            session  (-> (create-capsule-session! executor env-id workdir exec!)
                        write-capsule-mcp-config!)]
       (run-session session body-fn read-capsule-artifact cleanup-capsule-session! :capsule))
     (let [workdir (:execution/worktree-path context)
@@ -1181,7 +1188,8 @@
       (let [executor (:execution/executor context)
             env-id   (:execution/environment-id context)
             workdir  (or (:execution/worktree-path context) "/workspace")
-            session  (-> (create-capsule-session! executor env-id workdir)
+            exec!    (or (:execution/execute-fn context) (missing-execute-fn!))
+            session  (-> (create-capsule-session! executor env-id workdir exec!)
                          write-capsule-mcp-config!)]
         (run session cleanup-capsule-session!))
       (let [workdir (:execution/worktree-path context)

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -719,8 +719,7 @@
   [context session-mode working-dir]
   (let [base-refs (base-ref-candidates context)]
     (if (= :capsule session-mode)
-      (when-let [exec! (or (:execution/execute-fn context)
-                           @(requiring-resolve 'ai.miniforge.dag-executor.executor/execute!))]
+      (when-let [exec! (:execution/execute-fn context)]
         (file-artifacts/collect-worktree-files-via-executor
          exec!
          (:execution/executor context)
@@ -734,12 +733,13 @@
   [context session-mode working-dir pre-session-snapshot]
   (or (collect-promoted-artifact context session-mode working-dir)
       (if (= :capsule session-mode)
-        (file-artifacts/collect-written-files-via-executor
-         pre-session-snapshot
-         @(requiring-resolve 'ai.miniforge.dag-executor.executor/execute!)
-         (:execution/executor context)
-         (:execution/environment-id context)
-         working-dir)
+        (when-let [exec! (:execution/execute-fn context)]
+          (file-artifacts/collect-written-files-via-executor
+           pre-session-snapshot
+           exec!
+           (:execution/executor context)
+           (:execution/environment-id context)
+           working-dir))
         (file-artifacts/collect-written-files pre-session-snapshot
                                               working-dir))))
 

--- a/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
@@ -24,7 +24,6 @@
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
    [ai.miniforge.agent.artifact-session :as session]
-   [ai.miniforge.dag-executor.executor :as executor]
    [ai.miniforge.dag-executor.result :as result]))
 
 ;------------------------------------------------------------------------------ helpers
@@ -117,51 +116,54 @@
 
 (deftest with-session-governed-mode-test
   (testing "governed mode with executor uses capsule session"
-    (let [log (atom [])]
-      (with-redefs [executor/execute! (mock-execute! log)]
-        (let [context {:execution/mode :governed
-                       :execution/executor :mock-executor
-                       :execution/environment-id "env-123"
-                       :execution/worktree-path capsule-workdir}
-              result (session/with-session context
-                       (fn [session]
-                         (is (true? (:capsule? session)))
-                         (is (= capsule-session-dir (:dir session)))
-                         (is (= :mock-executor (:executor session)))
-                         :capsule-response))]
-          (is (= :capsule-response (:llm-result result)))
-          (is (= :capsule (:session-mode result)))
-          (is (nil? (:context-misses result)))
-          (is (map? (:pre-session-snapshot result)))
-          ;; Should have executed mkdir, config writes, and cleanup
-          (is (pos? (count @log))))))))
+    (let [log (atom [])
+          exec! (mock-execute! log)
+          context {:execution/mode :governed
+                   :execution/executor :mock-executor
+                   :execution/environment-id "env-123"
+                   :execution/worktree-path capsule-workdir
+                   :execution/execute-fn exec!}
+          result (session/with-session context
+                   (fn [session]
+                     (is (true? (:capsule? session)))
+                     (is (= capsule-session-dir (:dir session)))
+                     (is (= :mock-executor (:executor session)))
+                     :capsule-response))]
+      (is (= :capsule-response (:llm-result result)))
+      (is (= :capsule (:session-mode result)))
+      (is (nil? (:context-misses result)))
+      (is (map? (:pre-session-snapshot result)))
+      ;; Should have executed mkdir, config writes, and cleanup
+      (is (pos? (count @log))))))
 
 (deftest with-session-governed-reads-artifact-test
   (testing "governed mode reads and parses artifact from capsule"
-    (let [log (atom [])]
-      (with-redefs [executor/execute! (mock-execute-with-artifact! log)]
-        (let [context {:execution/mode :governed
-                       :execution/executor :mock
-                       :execution/environment-id "env-456"
-                       :execution/worktree-path capsule-workdir}
-              result (session/with-session context
-                       (fn [_session] :done))]
-          (is (some? (:artifact result)))
-          (is (uuid? (:code/id (:artifact result)))))))))
+    (let [log (atom [])
+          exec! (mock-execute-with-artifact! log)
+          context {:execution/mode :governed
+                   :execution/executor :mock
+                   :execution/environment-id "env-456"
+                   :execution/worktree-path capsule-workdir
+                   :execution/execute-fn exec!}
+          result (session/with-session context
+                   (fn [_session] :done))]
+      (is (some? (:artifact result)))
+      (is (uuid? (:code/id (:artifact result)))))))
 
 (deftest with-session-governed-cleanup-on-exception-test
   (testing "capsule session cleans up even on exception"
     (let [log (atom [])
+          exec! (mock-execute! log)
           context {:execution/mode :governed
                    :execution/executor :mock
                    :execution/environment-id "env-789"
-                   :execution/worktree-path capsule-workdir}]
-      (with-redefs [executor/execute! (mock-execute! log)]
-        (is (thrown? Exception
-              (session/with-session context
-                (fn [_session]
-                  (throw (ex-info "test error" {}))))))
-        (is (some #(= capsule-cleanup-command %) @log))))))
+                   :execution/worktree-path capsule-workdir
+                   :execution/execute-fn exec!}]
+      (is (thrown? Exception
+            (session/with-session context
+              (fn [_session]
+                (throw (ex-info "test error" {}))))))
+      (is (some #(= capsule-cleanup-command %) @log)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Context cache dispatch tests


### PR DESCRIPTION
## Summary
- remove agent -> dag-executor lazy resolution by requiring capsule sessions to receive :execution/execute-fn
- pass the workflow-injected execute function through governed artifact sessions
- update implementer capsule artifact collection and capsule tests to use the injected executor function

## Validation
- clj-kondo --lint components/agent/src/ai/miniforge/agent/artifact_session.clj components/agent/src/ai/miniforge/agent/implementer.clj components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
- clojure -M:dev:test -e "(require 'ai.miniforge.agent.artifact-session-capsule-test 'ai.miniforge.agent.implementer-test 'ai.miniforge.agent.implementer-extended-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.agent.artifact-session-capsule-test 'ai.miniforge.agent.implementer-test 'ai.miniforge.agent.implementer-extended-test)"
- clojure -M:poly check
- bb pre-commit