### PR TITLE
feat(pr-monitor): emit loop lifecycle events from the monitor loop

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -29,6 +29,16 @@
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]
    [ai.miniforge.schema.interface :as schema]))
 
+;; The :pr-monitor/{loop-started,cycle-completed,loop-stopped} events emitted
+;; below are defined in monitor_events/monitor-event-types (this group's source
+;; of truth); no new event types are introduced here.
+;;
+;; Bus caveat: emissions go to monitor.config's :event-bus. When that is a fresh
+;; events/create-event-bus atom it is an in-memory SIDE bus, not the persisted
+;; workflow stream under ~/.miniforge/events — callers (e.g. the observe phase)
+;; must pass the workflow bus for these events to be durable. The wiring here is
+;; correct regardless of which bus is supplied.
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; API compatibility + schemas
 
@@ -181,11 +191,12 @@
   (step-monitor-loop! monitor author))
 
 (defn- stop-when-no-open-prs!
+  "Stop the loop because no open PRs were found. Records :no-open-prs as stop reason."
   [monitor logger]
   (when logger
     (log/info logger :pr-monitor :loop/no-open-prs
               {:message "No open PRs found — stopping monitor loop"}))
-  (swap! monitor assoc :running? false))
+  (swap! monitor assoc :running? false :stop-reason :no-open-prs))
 
 (defn- log-cycle-stop
   [logger pr cycle-result]
@@ -208,11 +219,19 @@
                              :error (.getMessage e)}}))))))
 
 (defn- finalize-loop-iteration!
-  [monitor]
-  (swap! monitor (fn [state-map]
-                   (-> state-map
-                       (update :cycles inc)
-                       (assoc :last-cycle-at (java.util.Date.))))))
+  "Advance cycle counter, record timestamp, and emit an iteration-level heartbeat.
+   prs-polled is the count of PRs processed in this iteration.
+   The nil pr-number distinguishes this iteration-level event from the per-PR
+   cycle-completed events emitted in run-cycle."
+  [monitor prs-polled]
+  ;; Use the swap! return value for :iteration — re-reading @monitor would be a
+  ;; second, non-atomic read that could observe a different :cycles.
+  (let [updated (swap! monitor (fn [state-map]
+                                 (-> state-map
+                                     (update :cycles inc)
+                                     (assoc :last-cycle-at (java.util.Date.)))))]
+    (state/emit! monitor (mevents/cycle-completed nil {:iteration (:cycles updated)
+                                                       :prs-polled prs-polled}))))
 
 (defn- continue-loop!
   [monitor author poll-interval-ms]
@@ -235,16 +254,24 @@
           :else
           (let [prs (:prs (:data pr-result))]
             (run! #(run-pr-cycle! monitor logger %) prs)
-            (finalize-loop-iteration! monitor)
+            (finalize-loop-iteration! monitor (count prs))
             (continue-loop! monitor author poll-interval-ms)))))))
 
 (defn run-monitor-loop
-  "Run the PR monitor loop continuously until stopped."
+  "Run the PR monitor loop continuously until stopped.
+
+   Emits loop-started on entry and loop-stopped on exit (covering all exit
+   paths — no-open-prs, manual stop, or normal completion). The stop reason
+   is written to the monitor atom by whichever path triggers the exit."
   [monitor author]
   (let [{:keys [logger]} (:config @monitor)]
-    (swap! monitor assoc :running? true :started-at (java.util.Date.))
+    ;; Clear any :stop-reason from a prior run on this atom so loop-stopped
+    ;; reports THIS run's reason (nil → :completed at exit), not a stale one.
+    (swap! monitor assoc :running? true :started-at (java.util.Date.) :stop-reason nil)
     (state/log-loop-start! monitor author)
+    (state/emit! monitor (mevents/loop-started nil (:config @monitor)))
     (step-monitor-loop! monitor author)
+    (state/emit! monitor (mevents/loop-stopped nil (get @monitor :stop-reason :completed)))
     (when logger
       (log/info logger :pr-monitor :loop/stopped
                 {:message "PR monitor loop stopped"
@@ -258,9 +285,9 @@
                                    3600000.0))}))))
 
 (defn stop-monitor-loop
-  "Stop a running monitor loop gracefully."
+  "Stop a running monitor loop gracefully. Records :manual-stop as stop reason."
   [monitor]
-  (swap! monitor assoc :running? false))
+  (swap! monitor assoc :running? false :stop-reason :manual-stop))
 
 (defn monitor-running?
   "Check if the monitor loop is currently running."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -252,9 +252,16 @@
           (stop-when-no-open-prs! monitor logger)
 
           :else
-          (let [prs (:prs (:data pr-result))]
-            (run! #(run-pr-cycle! monitor logger %) prs)
-            (finalize-loop-iteration! monitor (count prs))
+          ;; Count PRs actually processed, short-circuiting if the loop is
+          ;; stopped mid-iteration, so :prs-polled reflects work done rather
+          ;; than the open-PR count returned by the poller.
+          (let [prs       (:prs (:data pr-result))
+                processed (reduce (fn [n pr]
+                                    (if (:running? @monitor)
+                                      (do (run-pr-cycle! monitor logger pr) (inc n))
+                                      (reduced n)))
+                                  0 prs)]
+            (finalize-loop-iteration! monitor processed)
             (continue-loop! monitor author poll-interval-ms)))))))
 
 (defn run-monitor-loop

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
@@ -79,8 +79,8 @@
 
 (defn- make-test-monitor
   "Build a monitor atom directly, bypassing classpath config and disk I/O.
-   Caller supplies extra-config keys to merge; :event-bus is required for
-   emission assertions."
+   Caller supplies extra-config keys to merge; pass an :event-bus (via
+   extra-config) when asserting on emissions — it defaults to nil otherwise."
   ([] (make-test-monitor {}))
   ([extra-config]
    (atom
@@ -150,7 +150,7 @@
                                           (nil? (:pr/id %)))))]
         (is (= n-iters (count iter-events))
             "one heartbeat per iteration")
-        (is (= [1 2 3] (mapv :iteration iter-events))
+        (is (= (vec (range 1 (inc n-iters))) (mapv :iteration iter-events))
             "iteration values are sequential starting at 1")
         (testing "heartbeat fires even when poll-pr-for-new-comments returns zero comments"
           ;; All no-new-comments stubs return 0; the heartbeat must still appear.

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
@@ -18,7 +18,9 @@
 
 (ns ai.miniforge.pr-lifecycle.monitor-loop-test
   (:require
+   [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.pr-lifecycle.monitor-loop :as sut]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]
    [clojure.test :refer [deftest is testing]]))
 
 (deftest actionable-comments-test
@@ -36,3 +38,175 @@
       (is (= 0 (:processed result)))
       (is (true? (:stopped? result)))
       (is (= :time-budget-exhausted (:stop-reason result))))))
+
+;; ---------------------------------------------------------------------------
+;; Loop lifecycle event emission tests
+;; ---------------------------------------------------------------------------
+
+;; A minimal fake PR info that satisfies run-cycle's expectations.
+(def ^:private fake-pr
+  {:pr/number  99
+   :pr/url     "https://github.com/example/repo/pull/99"
+   :pr/title   "Test PR"
+   :pr/branch  "feat/test"
+   :pr/sha     "abc123"
+   :pr/updated-at "2026-06-15T00:00:00Z"})
+
+(defn- ok
+  "Wrap data in a result map that dag/err? treats as success."
+  [data]
+  {:ok? true :data data})
+
+(defn- no-prs
+  "poll-open-prs stub that always returns an empty PR list."
+  [_worktree-path _author]
+  (ok {:prs []}))
+
+(defn- one-pr-then-empty
+  "Returns a poll-open-prs stub that yields [fake-pr] for n-iters calls, then empty."
+  [n-iters]
+  (let [call-count (atom 0)]
+    (fn [_worktree-path _author]
+      (if (< @call-count n-iters)
+        (do (swap! call-count inc)
+            (ok {:prs [fake-pr]}))
+        (ok {:prs []})))))
+
+(defn- no-new-comments
+  "poll-pr-for-new-comments stub: no new comments, empty watermarks."
+  [_worktree-path _pr-number _watermarks _logger]
+  (ok {:new-comments [] :watermarks {}}))
+
+(defn- make-test-monitor
+  "Build a monitor atom directly, bypassing classpath config and disk I/O.
+   Caller supplies extra-config keys to merge; :event-bus is required for
+   emission assertions."
+  ([] (make-test-monitor {}))
+  ([extra-config]
+   (atom
+    {:config    (merge {:poll-interval-ms            0
+                        :event-bus                   nil
+                        :logger                      nil
+                        :worktree-path               "/dev/null"
+                        :self-author                 "bot"
+                        :generate-fn                 nil
+                        :max-fix-attempts-per-comment   3
+                        :max-total-fix-attempts-per-pr 10
+                        :abandon-after-hours           72}
+                       extra-config)
+     :watermarks {}
+     :budgets    {}
+     :running?   false
+     :started-at nil
+     :cycles     0
+     :last-cycle-at nil
+     :evidence   {:comments-received  0
+                  :comments-addressed 0
+                  :fixes-pushed       []
+                  :questions-answered []}})))
+
+(defn- run-with-stubs
+  "Run run-monitor-loop inside with-redefs that replace all I/O-touching poller
+   functions.  poll-open-prs-fn controls which PRs each iteration sees."
+  [monitor poll-open-prs-fn]
+  (with-redefs [poller/poll-open-prs             poll-open-prs-fn
+                poller/poll-pr-for-new-comments  no-new-comments
+                poller/save-watermarks!          (constantly nil)]
+    (sut/run-monitor-loop monitor "bot")))
+
+;; ---------------------------------------------------------------------------
+;; (1) Loop start emission
+
+(deftest loop-started-event-emitted-test
+  (testing "run-monitor-loop emits :pr-monitor/loop-started on entry before polling"
+    (let [bus     (events/create-event-bus)
+          monitor (make-test-monitor {:event-bus bus})]
+      (run-with-stubs monitor no-prs)
+      (let [started-events (filter #(= :pr-monitor/loop-started (:event/type %))
+                                   (:events @bus))]
+        (is (= 1 (count started-events))
+            "exactly one loop-started event")
+        (is (nil? (:pr/id (first started-events)))
+            "loop-level event carries nil :pr/id")
+        (is (map? (:config (first started-events)))
+            "loop-started event carries :config map")
+        (is (contains? (:config (first started-events)) :poll-interval-ms)
+            "config contains :poll-interval-ms")))))
+
+;; ---------------------------------------------------------------------------
+;; (2) Per-iteration heartbeat
+
+(deftest cycle-completed-heartbeat-test
+  (testing "finalize-loop-iteration! emits :pr-monitor/cycle-completed per iteration"
+    (let [n-iters 3
+          bus     (events/create-event-bus)
+          monitor (make-test-monitor {:event-bus bus})]
+      (run-with-stubs monitor (one-pr-then-empty n-iters))
+      ;; Iteration-level cycle-completed events have nil :pr/id (distinct from
+      ;; the per-PR cycle-completed events emitted by run-cycle, which carry the
+      ;; PR number).
+      (let [iter-events (->> (:events @bus)
+                             (filter #(and (= :pr-monitor/cycle-completed (:event/type %))
+                                          (nil? (:pr/id %)))))]
+        (is (= n-iters (count iter-events))
+            "one heartbeat per iteration")
+        (is (= [1 2 3] (mapv :iteration iter-events))
+            "iteration values are sequential starting at 1")
+        (testing "heartbeat fires even when poll-pr-for-new-comments returns zero comments"
+          ;; All no-new-comments stubs return 0; the heartbeat must still appear.
+          (is (every? #(nat-int? (:iteration %)) iter-events)))))))
+
+;; ---------------------------------------------------------------------------
+;; (3) Loop stop emission
+
+(deftest loop-stopped-event-emitted-test
+  (testing "run-monitor-loop emits :pr-monitor/loop-stopped when no open PRs found"
+    (let [bus     (events/create-event-bus)
+          monitor (make-test-monitor {:event-bus bus})]
+      (run-with-stubs monitor no-prs)
+      (let [stopped-events (filter #(= :pr-monitor/loop-stopped (:event/type %))
+                                   (:events @bus))]
+        (is (= 1 (count stopped-events))
+            "exactly one loop-stopped event")
+        (is (nil? (:pr/id (first stopped-events)))
+            "loop-level event carries nil :pr/id")
+        (is (= :no-open-prs (:stop/reason (first stopped-events)))
+            "stop reason is :no-open-prs")))))
+
+;; ---------------------------------------------------------------------------
+;; (4) Manual stop reason (unit-level, no loop needed)
+
+(deftest manual-stop-reason-test
+  (testing "stop-monitor-loop sets :running? false and :stop-reason :manual-stop"
+    (let [monitor (make-test-monitor {})]
+      (swap! monitor assoc :running? true)
+      (sut/stop-monitor-loop monitor)
+      (is (false? (:running? @monitor))
+          ":running? must be false after stop")
+      (is (= :manual-stop (:stop-reason @monitor))
+          "stop reason must be :manual-stop"))))
+
+;; ---------------------------------------------------------------------------
+;; (5) Event ordering
+
+(deftest event-ordering-test
+  (testing "loop-started precedes any cycle-completed; loop-stopped is last"
+    (let [n-iters 2
+          bus     (events/create-event-bus)
+          monitor (make-test-monitor {:event-bus bus})]
+      (run-with-stubs monitor (one-pr-then-empty n-iters))
+      (let [all-types   (mapv :event/type (:events @bus))
+            started-idx (.indexOf all-types :pr-monitor/loop-started)
+            stopped-idx (.indexOf all-types :pr-monitor/loop-stopped)
+            completed-idxs (keep-indexed #(when (= :pr-monitor/cycle-completed %2) %1)
+                                         all-types)]
+        (is (nat-int? started-idx)
+            "loop-started must be present")
+        (is (nat-int? stopped-idx)
+            "loop-stopped must be present")
+        (is (seq completed-idxs)
+            "at least one cycle-completed must be present")
+        (is (< started-idx (apply min completed-idxs))
+            "loop-started appears before the first cycle-completed")
+        (is (= stopped-idx (dec (count all-types)))
+            "loop-stopped is the final event in the bus")))))


### PR DESCRIPTION
## Summary

Consolidated spec-1 (monitor-loop-event-emission). `run-monitor-loop` now emits `:pr-monitor/loop-started` on entry, a per-iteration `cycle-completed` heartbeat, and `loop-stopped` (with reason) on exit — so an operator can distinguish a normally-polling monitor from a stalled one. (The observe phase looked hung precisely because this loop emitted nothing.)

## Provenance

Consolidated from the spec-1 stack (#1189 wiring / #1191 tests), which was stacked on stale pre-#1197/#1198/#1206/#1209 main — the raw diffs would revert those merged fixes. This takes only `monitor_loop.clj` + `monitor_loop_test.clj`, rebased onto current main. #1189/#1191 will be closed as superseded.

## Copilot review (#1189) addressed

- Replaced the "VERIFICATION FINDINGS" narrative block with a concise contract note (keeps the real side-bus caveat).
- `finalize-loop-iteration!` uses the `swap!` return value for `:iteration` rather than a second non-atomic `@monitor` read.
- `run-monitor-loop` clears `:stop-reason` on entry so `loop-stopped` reports this run's reason (nil → `:completed` at exit), not a stale one from a reused atom.
- Emission behavior is covered by `monitor_loop_test` (7 tests / 21 assertions).
- The loop lifecycle events intentionally carry `pr-number` nil (they describe the loop, not a PR); aligning TUI consumers that key on `:pr/id` is a separate follow-up.

## Test plan

- `monitor_loop_test`: 7 tests / 21 assertions — loop-started/cycle/loop-stopped emission, stop-reason handling.
- `bb pre-commit` passes (312 + 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)