### PR TITLE
fix(gate): use tool registry for LSP formatting

### DIFF
--- a/components/gate/deps.edn
+++ b/components/gate/deps.edn
@@ -6,6 +6,7 @@
         ai.miniforge/repo-analyzer {:local/root "../repo-analyzer"}
         ai.miniforge/response {:local/root "../response"}
         ai.miniforge/semantic-analyzer {:local/root "../semantic-analyzer"}
+        ai.miniforge/tool-registry {:local/root "../tool-registry"}
         slingshot/slingshot {:mvn/version "0.12.2"}}
  :aliases
  {:test {:extra-paths ["test"]

--- a/components/gate/src/ai/miniforge/gate/format.clj
+++ b/components/gate/src/ai/miniforge/gate/format.clj
@@ -14,77 +14,130 @@
   (:require
    [ai.miniforge.gate.registry :as registry]
    [ai.miniforge.response.interface :as response]
-   [clojure.edn :as edn]
+   [ai.miniforge.tool-registry.interface :as tool-registry]
    [clojure.java.io :as io]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; LSP config resolution — driven by tools/lsp/*.edn data
-
-(def ^:private lsp-configs-resource-dir "tools/lsp")
-
-(defn- load-format-patterns
-  "Load file patterns from LSP tool configs that support :format capability."
-  []
-  (try
-    (let [dir (io/file (io/resource lsp-configs-resource-dir))]
-      (->> (file-seq dir)
-           (filter #(str/ends-with? (.getName %) ".edn"))
-           (map #(edn/read-string (slurp %)))
-           (filter #(contains? (get-in % [:tool/config :lsp/capabilities] #{}) :format))
-           (mapcat #(get-in % [:tool/config :lsp/file-patterns] []))
-           vec))
-    (catch Exception _ [])))
-
-(def ^:private format-capable-patterns
-  "File patterns that support LSP formatting. Loaded once from classpath."
-  (delay (load-format-patterns)))
+;; LSP config resolution — driven by tool-registry LSP tools
 
 (defn- file-matches-format-pattern?
-  "Check if a file path matches any format-capable LSP pattern."
-  [file-path]
+  "Check if a file path matches a format-capable LSP pattern."
+  [file-path pattern]
   (let [fs   (java.nio.file.FileSystems/getDefault)
         path (java.nio.file.Paths/get (str file-path) (into-array String []))]
-    (some #(.matches (.getPathMatcher fs (str "glob:" %)) path)
-          @format-capable-patterns)))
+    (.matches (.getPathMatcher fs (str "glob:" pattern)) path)))
+
+(defn- create-registry
+  "Create and load the tool registry used by this gate."
+  [worktree-path]
+  (let [registry (tool-registry/create-registry {:project-dir worktree-path})]
+    (tool-registry/load-tools registry)
+    registry))
+
+(defn- format-capable-tools
+  [registry]
+  (tool-registry/find-tools registry {:type :lsp
+                                      :capabilities #{:code/format}
+                                      :enabled true}))
+
+(defn- tool-matches-file?
+  [file-path tool]
+  (some #(file-matches-format-pattern? file-path %)
+        (get-in tool [:tool/config :lsp/file-patterns] [])))
+
+(defn- format-tool-for-file
+  [registry file-path]
+  (first (filter #(tool-matches-file? file-path %)
+                 (format-capable-tools registry))))
 
 (defn- formattable-file?
   "True when a file matches a format-capable LSP tool config."
-  [file-entry]
-  (file-matches-format-pattern? (get file-entry :path "")))
+  [registry file-entry]
+  (boolean (format-tool-for-file registry (get file-entry :path ""))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; File formatting via LSP
 
-(defn- file-extension
-  "Get file extension from path."
-  [path]
-  (when-let [idx (str/last-index-of (str path) ".")]
-    (subs (str path) (inc idx))))
-
-(defn- get-or-create-lsp-manager
-  "Get LSP manager from context, or create one.
-   Uses requiring-resolve to avoid component-to-base dependency."
+(defn- get-or-create-tool-registry
+  "Get an injected tool registry from context, or create one."
   [ctx]
-  (or (get ctx :lsp-manager)
-      ((requiring-resolve 'ai.miniforge.lsp-mcp-bridge.lsp.manager/create-manager)
-       {} (or (get ctx :execution/worktree-path) "."))))
+  (or (get ctx :tool-registry)
+      (create-registry (or (get ctx :execution/worktree-path) "."))))
+
+(defn- registry-context
+  [ctx]
+  (if-let [registry (get ctx :tool-registry)]
+    {:registry registry :owned? false}
+    {:registry (create-registry (or (get ctx :execution/worktree-path) "."))
+     :owned? true}))
+
+(defn- stop-registry-lsps!
+  [registry]
+  (doseq [{:keys [tool-id]} (tool-registry/list-lsp-servers registry)]
+    (tool-registry/stop-lsp registry tool-id)))
+
+(defn- field
+  [m k]
+  (or (get m k) (get m (name k))))
+
+(defn- line-start-offsets
+  [content]
+  (loop [idx 0
+         starts [0]]
+    (if-let [newline-idx (str/index-of content "\n" idx)]
+      (recur (inc newline-idx) (conj starts (inc newline-idx)))
+      starts)))
+
+(defn- position->offset
+  [line-starts content position]
+  (let [line (long (or (field position :line) 0))
+        character (long (or (field position :character) 0))
+        line-start (get line-starts line (count content))]
+    (min (count content) (+ line-start character))))
+
+(defn- text-edit->span
+  [line-starts content edit]
+  (let [range (field edit :range)]
+    {:start (position->offset line-starts content (field range :start))
+     :end (position->offset line-starts content (field range :end))
+     :text (or (field edit :newText) "")}))
+
+(defn- apply-text-edits
+  [content edits]
+  (let [line-starts (line-start-offsets content)
+        spans (->> edits
+                   (map #(text-edit->span line-starts content %))
+                   (sort-by :start >))]
+    (reduce (fn [acc {:keys [start end text]}]
+              (str (subs acc 0 start) text (subs acc end)))
+            content
+            spans)))
+
+(defn- apply-format-result!
+  [file result]
+  (when (:success? result)
+    (let [edits (:result result)]
+      (when (seq edits)
+        (let [content (slurp file)]
+          (spit file (apply-text-edits content edits))))
+      true)))
 
 (defn- format-single-file
   "Format a single file using LSP. Returns {:formatted? bool :path string}."
-  [manager file-path worktree-path]
+  [registry file-path worktree-path]
   (try
     (let [full-path (str worktree-path "/" file-path)
           uri       (str "file://" full-path)
-          ext       (file-extension file-path)]
-      (if (.exists (io/file full-path))
-        (do
-          ((requiring-resolve 'ai.miniforge.lsp-mcp-bridge.lsp.manager/start-server)
-           manager {:language ext})
-          (when-let [server (get @(:servers manager) ext)]
-            ((requiring-resolve 'ai.miniforge.lsp-mcp-bridge.lsp.client/format-document)
-             server uri {}))
-          {:formatted? true :path file-path})
+          tool      (format-tool-for-file registry file-path)]
+      (if (and tool (.exists (io/file full-path)))
+        (if-let [client (tool-registry/get-lsp-client registry (:tool/id tool))]
+          {:formatted? (boolean
+                        (apply-format-result!
+                         (io/file full-path)
+                         (tool-registry/format-document client uri {})))
+           :path file-path}
+          {:formatted? false :path file-path})
         {:formatted? false :path file-path}))
     (catch Exception _
       {:formatted? false :path file-path})))
@@ -97,8 +150,10 @@
 
    Returns the canonical `response/success` shape; the gate machinery's
    `passed?` predicate recognizes it via `response/success?`."
-  [artifact _ctx]
-  (let [formattable (filterv formattable-file? (get artifact :code/files []))]
+  [artifact ctx]
+  (let [registry (get-or-create-tool-registry ctx)
+        formattable (filterv #(formattable-file? registry %)
+                             (get artifact :code/files []))]
     (response/success {:formattable-files (mapv :path formattable)
                        :message (str (count formattable)
                                      " file(s) support LSP formatting")})))
@@ -107,11 +162,16 @@
   "Format files via LSP. Returns the canonical `response/success` shape."
   [artifact _errors ctx]
   (let [worktree    (or (get ctx :execution/worktree-path) ".")
-        manager     (get-or-create-lsp-manager ctx)
-        formattable (filterv formattable-file? (get artifact :code/files []))
-        results     (mapv #(format-single-file manager (:path %) worktree) formattable)
-        formatted   (mapv :path (filter :formatted? results))]
-    (response/success {:artifact artifact :formatted formatted})))
+        {:keys [registry owned?]} (registry-context ctx)]
+    (try
+      (let [formattable (filterv #(formattable-file? registry %)
+                                 (get artifact :code/files []))
+            results     (mapv #(format-single-file registry (:path %) worktree) formattable)
+            formatted   (mapv :path (filter :formatted? results))]
+        (response/success {:artifact artifact :formatted formatted}))
+      (finally
+        (when owned?
+          (stop-registry-lsps! registry))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Gate registration

--- a/components/gate/test/ai/miniforge/gate/format_test.clj
+++ b/components/gate/test/ai/miniforge/gate/format_test.clj
@@ -30,6 +30,8 @@
    [ai.miniforge.gate.format :as format-gate]
    [ai.miniforge.gate.interface :as gate]
    [ai.miniforge.response.interface :as response]
+   [ai.miniforge.tool-registry.interface :as tool-registry]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]))
 
 (deftest check-format-returns-canonical-success
@@ -53,3 +55,31 @@
           result (format-gate/check-format artifact {})]
       (is (response/success? result))
       (is (vector? (get-in result [:output :formattable-files]))))))
+
+(deftest repair-format-applies-lsp-text-edits
+  (testing "repair-format writes successful LSP format edits to disk"
+    (let [dir (java.nio.file.Files/createTempDirectory
+               "format-gate-test" (make-array java.nio.file.attribute.FileAttribute 0))
+          src-dir (io/file (.toFile dir) "src")
+          file (io/file src-dir "foo.clj")
+          registry ::registry
+          tool {:tool/id :lsp/clojure
+                :tool/config {:lsp/file-patterns ["**/*.clj"]}}]
+      (.mkdirs src-dir)
+      (spit file "(defn x []\n  1)\n")
+      (with-redefs [tool-registry/find-tools (fn [_ _] [tool])
+                    tool-registry/get-lsp-client (fn [_ _] ::client)
+                    tool-registry/format-document
+                    (fn [_ _ _]
+                      {:success? true
+                       :result [{:range {:start {:line 0 :character 0}
+                                         :end {:line 1 :character 4}}
+                                 :newText "(defn x []\n  2)"}]})]
+        (let [result (format-gate/repair-format
+                      {:code/files [{:path "src/foo.clj"}]}
+                      []
+                      {:execution/worktree-path (.getPath (.toFile dir))
+                       :tool-registry registry})]
+          (is (response/success? result))
+          (is (= ["src/foo.clj"] (get-in result [:output :formatted])))
+          (is (= "(defn x []\n  2)\n" (slurp file))))))))

--- a/components/tool-registry/src/ai/miniforge/tool_registry/interface.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/interface.clj
@@ -59,6 +59,7 @@
    [ai.miniforge.tool-registry.schema :as schema]
    [ai.miniforge.tool-registry.registry :as registry]
    [ai.miniforge.tool-registry.loader :as loader]
+   [ai.miniforge.tool-registry.lsp.client :as lsp-client]
    [ai.miniforge.tool-registry.lsp.manager :as lsp-manager]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -239,6 +240,11 @@
    Returns LSP client or nil if unavailable."
   [registry tool-id]
   (lsp-manager/get-client registry tool-id))
+
+(defn format-document
+  "Format a document through an LSP client."
+  [client uri options]
+  (lsp-client/format-document client uri options))
 
 (defn list-lsp-servers
   "List all LSP servers with their status.


### PR DESCRIPTION
## Summary
- rewire the format gate to use the tool-registry component for LSP metadata, clients, and formatting
- expose a small tool-registry.interface/format-document wrapper for gate consumers
- remove the format gate's lazy dependency on the lsp-mcp-bridge base

## Validation
- clj-kondo --lint components/gate/src/ai/miniforge/gate/format.clj components/gate/deps.edn components/tool-registry/src/ai/miniforge/tool_registry/interface.clj
- clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.gate.format-test 'ai.miniforge.gate.interface-test) (let [r (clojure.test/run-tests 'ai.miniforge.gate.format-test 'ai.miniforge.gate.interface-test)] (shutdown-agents) (System/exit (+ (:fail r) (:error r))))"
- clojure -M:poly check
- bb pre-commit