### PR TITLE
fix(cli): use event-stream manifest interface

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -846,6 +846,18 @@
 
 ;; BD-2b sub-3a: per-workflow manifest lifecycle.
 
+;------------------------------------------------------------------------------ Layer 1 — manifest operations
+
+(def ^:dynamic *manifest-ops*
+  "Manifest operations used by the workflow lifecycle helpers."
+  {:init-active       es-manifest/init-active
+   :load-manifest     es-manifest/load-manifest
+   :mark-terminal     es-manifest/mark-terminal
+   :save-manifest!    es-manifest/save-manifest!
+   :start-heartbeat!  es-manifest/start-heartbeat!
+   :stop-heartbeat!   es-manifest/stop-heartbeat!
+   :archive-workflow! es-manifest/archive-workflow!})
+
 ;------------------------------------------------------------------------------ Layer 2 — lifecycle helpers
 ;; Peers; none calls another. `run-workflow!` composes them at Layer 3.
 
@@ -858,9 +870,9 @@
   [workflow-id event-stream]
   (when event-stream
     (let [dir (es/workflow-dir workflow-id)]
-      (es-manifest/save-manifest! dir (es-manifest/init-active workflow-id))
+      ((:save-manifest! *manifest-ops*) dir ((:init-active *manifest-ops*) workflow-id))
       {:dir       dir
-       :heartbeat (es-manifest/start-heartbeat! dir)
+       :heartbeat ((:start-heartbeat! *manifest-ops*) dir)
        :marked?   (atom false)})))
 
 (defn mark-manifest-terminal!
@@ -876,8 +888,8 @@
    fallback) can still try to write."
   [{:keys [dir marked?]} status]
   (when (and dir (not @marked?))
-    (when-let [m (es-manifest/load-manifest dir)]
-      (es-manifest/save-manifest! dir (es-manifest/mark-terminal m status))
+    (when-let [m ((:load-manifest *manifest-ops*) dir)]
+      ((:save-manifest! *manifest-ops*) dir ((:mark-terminal *manifest-ops*) m status))
       (reset! marked? true))))
 
 (defn finish-workflow-manifest!
@@ -895,7 +907,7 @@
   [{:keys [heartbeat]}]
   (when heartbeat
     (try
-      (es-manifest/stop-heartbeat! heartbeat)
+      ((:stop-heartbeat! *manifest-ops*) heartbeat)
       (catch InterruptedException _
         (.interrupt (Thread/currentThread))
         nil)
@@ -918,7 +930,7 @@
   [{:keys [dir marked?]} workflow-id]
   (when (and dir @marked?)
     (try
-      (es-manifest/archive-workflow! workflow-id)
+      ((:archive-workflow! *manifest-ops*) workflow-id)
       (catch Exception e
         (binding [*out* *err*]
           (println (str "WARNING: archive of workflow " workflow-id

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -24,6 +24,7 @@
    [cheshire.core :as json]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.event-stream.interface.manifest :as es-manifest]
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.workflow.interface :as workflow]
@@ -844,29 +845,8 @@
     (boolean (and v (contains? #{"1" "true" "yes" "on"} (str/lower-case v))))))
 
 ;; BD-2b sub-3a: per-workflow manifest lifecycle.
-;;
-;; `ai.miniforge.event-stream.manifest` is jvm-only (FileLock /
-;; ScheduledExecutorService / java.lang.management). This base loads
-;; under Babashka, so we reach manifest fns via `requiring-resolve`
-;; rather than a top-level `:require`. Same pattern as the other
-;; jvm-only deferrals in this file (event-stream.interface lazy
-;; require around line 853, the resume command at line 1024).
-;;
-;; Stratified-design layering: `manifest-fn` / `archive-fn` are the
-;; lone Layer 1 helpers; `start-/mark-/finish-/archive-workflow-manifest!`
-;; sit at Layer 2 and each independently call the Layer 1 resolvers
-;; (never each other). `run-workflow!` (further down) is the Layer 3
-;; orchestrator that composes them.
 
-;------------------------------------------------------------------------------ Layer 1 — var resolution
-
-(defn manifest-fn [sym]
-  (requiring-resolve (symbol "ai.miniforge.event-stream.manifest" (name sym))))
-
-(defn archive-fn [sym]
-  (requiring-resolve (symbol "ai.miniforge.event-stream.archive" (name sym))))
-
-;------------------------------------------------------------------------------ Layer 2 — lifecycle helpers (compose Layer 1)
+;------------------------------------------------------------------------------ Layer 2 — lifecycle helpers
 ;; Peers; none calls another. `run-workflow!` composes them at Layer 3.
 
 (defn start-workflow-manifest!
@@ -877,13 +857,10 @@
    manifest to maintain in that case."
   [workflow-id event-stream]
   (when event-stream
-    (let [dir         (es/workflow-dir workflow-id)
-          init-active (manifest-fn 'init-active)
-          save!       (manifest-fn 'save-manifest!)
-          start-hb!   (manifest-fn 'start-heartbeat!)]
-      (save! dir (init-active workflow-id))
+    (let [dir (es/workflow-dir workflow-id)]
+      (es-manifest/save-manifest! dir (es-manifest/init-active workflow-id))
       {:dir       dir
-       :heartbeat (start-hb! dir)
+       :heartbeat (es-manifest/start-heartbeat! dir)
        :marked?   (atom false)})))
 
 (defn mark-manifest-terminal!
@@ -899,12 +876,9 @@
    fallback) can still try to write."
   [{:keys [dir marked?]} status]
   (when (and dir (not @marked?))
-    (let [load!         (manifest-fn 'load-manifest)
-          mark-terminal (manifest-fn 'mark-terminal)
-          save!         (manifest-fn 'save-manifest!)]
-      (when-let [m (load! dir)]
-        (save! dir (mark-terminal m status))
-        (reset! marked? true)))))
+    (when-let [m (es-manifest/load-manifest dir)]
+      (es-manifest/save-manifest! dir (es-manifest/mark-terminal m status))
+      (reset! marked? true))))
 
 (defn finish-workflow-manifest!
   "Stop the heartbeat. Caller is expected to have already called
@@ -921,7 +895,7 @@
   [{:keys [heartbeat]}]
   (when heartbeat
     (try
-      ((manifest-fn 'stop-heartbeat!) heartbeat)
+      (es-manifest/stop-heartbeat! heartbeat)
       (catch InterruptedException _
         (.interrupt (Thread/currentThread))
         nil)
@@ -944,7 +918,7 @@
   [{:keys [dir marked?]} workflow-id]
   (when (and dir @marked?)
     (try
-      ((archive-fn 'archive-workflow!) workflow-id)
+      (es-manifest/archive-workflow! workflow-id)
       (catch Exception e
         (binding [*out* *err*]
           (println (str "WARNING: archive of workflow " workflow-id

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
@@ -50,12 +50,18 @@
      'stop-heartbeat!  (fn [hb] (swap! calls conj [:stop-heartbeat hb]))}))
 
 (defn- with-mocked-manifest
-  "Bind `manifest-fn` to look up the mock map. Returns whatever `f`
-   returns; the call log is in `calls`."
+  "Bind manifest interface functions. Returns whatever `f` returns;
+   the call log is in `calls`."
   [f]
   (let [calls (atom [])
         mocks (mock-manifest-fns calls)]
-    (with-redefs [sut/manifest-fn (fn [sym] (get mocks sym))
+    (with-redefs [sut/*manifest-ops* {:init-active (get mocks 'init-active)
+                                      :save-manifest! (get mocks 'save-manifest!)
+                                      :load-manifest (get mocks 'load-manifest)
+                                      :mark-terminal (get mocks 'mark-terminal)
+                                      :start-heartbeat! (get mocks 'start-heartbeat!)
+                                      :stop-heartbeat! (get mocks 'stop-heartbeat!)
+                                      :archive-workflow! (fn [& _])}
                   es/workflow-dir (fn [wid] (java.io.File. (str "/tmp/test-" wid)))]
       (f calls))))
 
@@ -108,8 +114,16 @@
   ;; suppressed even though no terminal status ever got written.
   (let [calls (atom [])
         nil-load-mocks (assoc (mock-manifest-fns calls)
-                              'load-manifest (fn [_dir] nil))]
-    (with-redefs [sut/manifest-fn (fn [sym] (get nil-load-mocks sym))
+                              'load-manifest (fn [dir]
+                                               (swap! calls conj [:load dir])
+                                               nil))]
+    (with-redefs [sut/*manifest-ops* {:init-active (get nil-load-mocks 'init-active)
+                                      :save-manifest! (get nil-load-mocks 'save-manifest!)
+                                      :load-manifest (get nil-load-mocks 'load-manifest)
+                                      :mark-terminal (get nil-load-mocks 'mark-terminal)
+                                      :start-heartbeat! (get nil-load-mocks 'start-heartbeat!)
+                                      :stop-heartbeat! (get nil-load-mocks 'stop-heartbeat!)
+                                      :archive-workflow! (fn [& _])}
                   es/workflow-dir (fn [wid] (java.io.File. (str "/tmp/test-" wid)))]
       (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
         (reset! calls [])
@@ -158,7 +172,13 @@
   (let [calls (atom [])
         boom-mocks (assoc (mock-manifest-fns calls)
                           'stop-heartbeat! (fn [_] (throw (RuntimeException. "boom"))))]
-    (with-redefs [sut/manifest-fn (fn [sym] (get boom-mocks sym))
+    (with-redefs [sut/*manifest-ops* {:init-active (get boom-mocks 'init-active)
+                                      :save-manifest! (get boom-mocks 'save-manifest!)
+                                      :load-manifest (get boom-mocks 'load-manifest)
+                                      :mark-terminal (get boom-mocks 'mark-terminal)
+                                      :start-heartbeat! (get boom-mocks 'start-heartbeat!)
+                                      :stop-heartbeat! (get boom-mocks 'stop-heartbeat!)
+                                      :archive-workflow! (fn [& _])}
                   es/workflow-dir (fn [_] (java.io.File. "/tmp/test"))]
       (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
         (is (nil? (sut/finish-workflow-manifest! handle))
@@ -171,9 +191,8 @@
   ;; event stream), there's nothing to archive — the archive op
   ;; would error on the missing manifest. Skip in that case.
   (let [archive-calls (atom [])]
-    (with-redefs [sut/archive-fn (fn [_]
-                                   (fn [& args]
-                                     (swap! archive-calls conj args)))]
+    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
+                                                           (swap! archive-calls conj args))}]
       (let [handle {:dir (java.io.File. "/tmp/x") :marked? (atom false)}]
         (sut/archive-workflow-manifest! handle :wid)
         (is (empty? @archive-calls)
@@ -182,17 +201,15 @@
 (deftest archive-workflow-manifest!-no-op-when-dir-nil
   ;; nil dir means dashboard-only run; no manifest to archive.
   (let [archive-calls (atom [])]
-    (with-redefs [sut/archive-fn (fn [_]
-                                   (fn [& args]
-                                     (swap! archive-calls conj args)))]
+    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
+                                                           (swap! archive-calls conj args))}]
       (sut/archive-workflow-manifest! {:dir nil :marked? (atom true)} :wid)
       (is (empty? @archive-calls)))))
 
 (deftest archive-workflow-manifest!-invokes-archive-workflow!
   (let [archive-calls (atom [])]
-    (with-redefs [sut/archive-fn (fn [_]
-                                   (fn [& args]
-                                     (swap! archive-calls conj args)))]
+    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
+                                                           (swap! archive-calls conj args))}]
       (sut/archive-workflow-manifest!
        {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
        :wid)
@@ -203,9 +220,8 @@
   ;; Per the docstring, archive failures must not propagate — the
   ;; boot-time recovery pass picks up half-finished archives. A
   ;; failing archive should log to stderr and return nil.
-  (with-redefs [sut/archive-fn (fn [_]
-                                 (fn [& _]
-                                   (throw (RuntimeException. "rename failed"))))]
+  (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& _]
+                                                         (throw (RuntimeException. "rename failed")))}]
     (binding [*err* (java.io.PrintWriter. (java.io.StringWriter.))]
       (is (nil? (sut/archive-workflow-manifest!
                  {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
@@ -224,13 +240,19 @@
                                                   (throw (InterruptedException. "shutdown"))))]
     ;; Clear any leaked interrupt before the test.
     (Thread/interrupted)
-    (with-redefs [sut/manifest-fn (fn [sym] (get interrupt-mocks sym))
+    (with-redefs [sut/*manifest-ops* {:init-active (get interrupt-mocks 'init-active)
+                                      :save-manifest! (get interrupt-mocks 'save-manifest!)
+                                      :load-manifest (get interrupt-mocks 'load-manifest)
+                                      :mark-terminal (get interrupt-mocks 'mark-terminal)
+                                      :start-heartbeat! (get interrupt-mocks 'start-heartbeat!)
+                                      :stop-heartbeat! (get interrupt-mocks 'stop-heartbeat!)
+                                      :archive-workflow! (fn [& _])}
                   es/workflow-dir (fn [_] (java.io.File. "/tmp/test"))]
-      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
-        (is (nil? (sut/finish-workflow-manifest! handle))
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)
+            result (sut/finish-workflow-manifest! handle)
+            interrupted? (Thread/interrupted)]
+        (is (nil? result)
             "InterruptedException is still swallowed (best-effort cleanup)")
-        ;; `Thread/interrupted` reads-and-clears; if we set the flag
-        ;; correctly it should return true now.
-        (is (true? (Thread/interrupted))
+        (is (true? interrupted?)
             "current thread's interrupt flag must be restored
              so cooperative-cancellation callers above us see it")))))

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/manifest.cljc
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/manifest.cljc
@@ -34,36 +34,71 @@
                       :runtime :bb}))))
 
 #?(:bb
-   (defn init-active [workflow-id] (jvm-only! :init-active))
+   (defn init-active
+     "Build the initial active manifest for workflow-id."
+     [workflow-id]
+     (jvm-only! :init-active))
    :clj
-   (def init-active manifest/init-active))
+   (def init-active
+     "Build the initial active manifest for workflow-id."
+     manifest/init-active))
 
 #?(:bb
-   (defn load-manifest [dir] (jvm-only! :load-manifest))
+   (defn load-manifest
+     "Load the manifest from workflow directory dir, or nil when absent."
+     [dir]
+     (jvm-only! :load-manifest))
    :clj
-   (def load-manifest manifest/load-manifest))
+   (def load-manifest
+     "Load the manifest from workflow directory dir, or nil when absent."
+     manifest/load-manifest))
 
 #?(:bb
-   (defn mark-terminal [manifest status] (jvm-only! :mark-terminal))
+   (defn mark-terminal
+     "Return manifest updated to terminal workflow status."
+     [manifest status]
+     (jvm-only! :mark-terminal))
    :clj
-   (def mark-terminal manifest/mark-terminal))
+   (def mark-terminal
+     "Return manifest updated to terminal workflow status."
+     manifest/mark-terminal))
 
 #?(:bb
-   (defn save-manifest! [dir manifest] (jvm-only! :save-manifest!))
+   (defn save-manifest!
+     "Atomically persist manifest under workflow directory dir."
+     [dir manifest]
+     (jvm-only! :save-manifest!))
    :clj
-   (def save-manifest! manifest/save-manifest!))
+   (def save-manifest!
+     "Atomically persist manifest under workflow directory dir."
+     manifest/save-manifest!))
 
 #?(:bb
-   (defn start-heartbeat! [dir] (jvm-only! :start-heartbeat!))
+   (defn start-heartbeat!
+     "Start the manifest heartbeat for workflow directory dir."
+     [dir]
+     (jvm-only! :start-heartbeat!))
    :clj
-   (def start-heartbeat! manifest/start-heartbeat!))
+   (def start-heartbeat!
+     "Start the manifest heartbeat for workflow directory dir."
+     manifest/start-heartbeat!))
 
 #?(:bb
-   (defn stop-heartbeat! [heartbeat] (jvm-only! :stop-heartbeat!))
+   (defn stop-heartbeat!
+     "Stop a manifest heartbeat handle."
+     [heartbeat]
+     (jvm-only! :stop-heartbeat!))
    :clj
-   (def stop-heartbeat! manifest/stop-heartbeat!))
+   (def stop-heartbeat!
+     "Stop a manifest heartbeat handle."
+     manifest/stop-heartbeat!))
 
 #?(:bb
-   (defn archive-workflow! [workflow-id] (jvm-only! :archive-workflow!))
+   (defn archive-workflow!
+     "Archive the live workflow directory for workflow-id."
+     [workflow-id]
+     (jvm-only! :archive-workflow!))
    :clj
-   (def archive-workflow! archive/archive-workflow!))
+   (def archive-workflow!
+     "Archive the live workflow directory for workflow-id."
+     archive/archive-workflow!))

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/manifest.cljc
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/manifest.cljc
@@ -1,0 +1,69 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.interface.manifest
+  "Public manifest/archive boundary for JVM workflow lifecycle hooks."
+  #?(:bb
+     (:require
+      [clojure.string :as str])
+     :clj
+     (:require
+      [ai.miniforge.event-stream.archive :as archive]
+      [ai.miniforge.event-stream.manifest :as manifest])))
+
+#?(:bb
+   (defn- jvm-only!
+     [op]
+     (throw (ex-info (str/join "" ["Event-stream manifest operation is JVM-only: " op])
+                     {:operation op
+                      :runtime :bb}))))
+
+#?(:bb
+   (defn init-active [workflow-id] (jvm-only! :init-active))
+   :clj
+   (def init-active manifest/init-active))
+
+#?(:bb
+   (defn load-manifest [dir] (jvm-only! :load-manifest))
+   :clj
+   (def load-manifest manifest/load-manifest))
+
+#?(:bb
+   (defn mark-terminal [manifest status] (jvm-only! :mark-terminal))
+   :clj
+   (def mark-terminal manifest/mark-terminal))
+
+#?(:bb
+   (defn save-manifest! [dir manifest] (jvm-only! :save-manifest!))
+   :clj
+   (def save-manifest! manifest/save-manifest!))
+
+#?(:bb
+   (defn start-heartbeat! [dir] (jvm-only! :start-heartbeat!))
+   :clj
+   (def start-heartbeat! manifest/start-heartbeat!))
+
+#?(:bb
+   (defn stop-heartbeat! [heartbeat] (jvm-only! :stop-heartbeat!))
+   :clj
+   (def stop-heartbeat! manifest/stop-heartbeat!))
+
+#?(:bb
+   (defn archive-workflow! [workflow-id] (jvm-only! :archive-workflow!))
+   :clj
+   (def archive-workflow! archive/archive-workflow!))


### PR DESCRIPTION
## Summary
- add a BB-safe event-stream manifest/archive interface namespace
- replace CLI workflow manifest/archive requiring-resolve helpers with direct interface calls
- preserve explicit JVM-only behavior under Babashka instead of dynamically resolving JVM namespaces

## Standards
- removes the manifest/archive dynamic resolver pair from cli.workflow-runner
- fixes the runtime split as an explicit .cljc composition boundary

## Validation
- clj-kondo --lint components/event-stream/src/ai/miniforge/event_stream/interface/manifest.cljc bases/cli/src/ai/miniforge/cli/workflow_runner.clj
- clojure -M:dev -e "(require 'ai.miniforge.event-stream.interface.manifest 'ai.miniforge.cli.workflow-runner) (println :ok)"
- bb -cp components/event-stream/src:components/event-stream/resources:bases/cli/src -e "(require 'ai.miniforge.event-stream.interface.manifest) (println :ok)"
- clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.cli.workflow-runner.display-output-test 'ai.miniforge.cli.workflow-runner.help-test 'ai.miniforge.cli.workflow-runner.help.registry-test 'ai.miniforge.workflow.runner-test) (let [r (clojure.test/run-tests 'ai.miniforge.cli.workflow-runner.display-output-test 'ai.miniforge.cli.workflow-runner.help-test 'ai.miniforge.cli.workflow-runner.help.registry-test 'ai.miniforge.workflow.runner-test)] (shutdown-agents) (System/exit (+ (:fail r) (:error r))))"
- clojure -M:poly check
- bb pre-commit