### PR TITLE
fix(cli): use workflow resume interface

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.workflow.interface :as workflow]
+   [ai.miniforge.workflow.interface.resume :as workflow-resume]
    [ai.miniforge.artifact.interface :as artifact]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.cli.messages :as messages]
@@ -1184,9 +1185,7 @@
    - opts: Same opts as run-workflow-from-spec!"
   [workflow-id-str spec {:keys [quiet] :or {quiet false} :as opts}]
   (let [resume-ctx (try
-                     (let [resume-fn (requiring-resolve
-                                      'ai.miniforge.workflow.dag-resilience/resume-context)]
-                       (resume-fn workflow-id-str))
+                     (workflow-resume/resume-context workflow-id-str)
                      (catch Exception e
                        (when-not quiet
                          (println (display/colorize :red

--- a/components/workflow/src/ai/miniforge/workflow/interface/resume.cljc
+++ b/components/workflow/src/ai/miniforge/workflow/interface/resume.cljc
@@ -1,0 +1,41 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.interface.resume
+  "Public workflow resume boundary."
+  #?(:bb
+     (:require
+      [clojure.string :as str])
+     :clj
+     (:require
+      [ai.miniforge.workflow.dag-resilience :as dag-resilience])))
+
+#?(:bb
+   (defn resume-context
+     "Load resume context for workflow-id from checkpointed DAG state."
+     ([workflow-id]
+      (resume-context workflow-id {}))
+     ([workflow-id opts]
+      (throw (ex-info (str/join "" ["Workflow DAG resume is JVM-only: " workflow-id])
+                      {:workflow-id workflow-id
+                       :opts opts
+                       :runtime :bb}))))
+   :clj
+   (def resume-context
+     "Load resume context for workflow-id from checkpointed DAG state."
+     dag-resilience/resume-context))


### PR DESCRIPTION
## Summary
- add a BB-safe workflow resume interface namespace
- replace cli.workflow-runner's dag-resilience requiring-resolve with a direct interface call
- keep Babashka behavior explicit with a JVM-only resume error from the interface boundary

## Standards
- removes the final requiring-resolve from cli.workflow-runner
- keeps implementation namespaces behind workflow.interface.*

## Validation
- clj-kondo --lint components/workflow/src/ai/miniforge/workflow/interface/resume.cljc bases/cli/src/ai/miniforge/cli/workflow_runner.clj
- clojure -M:dev -e "(require 'ai.miniforge.workflow.interface.resume 'ai.miniforge.cli.workflow-runner) (println :ok)"
- bb -cp components/workflow/src:bases/cli/src -e "(require 'ai.miniforge.workflow.interface.resume) (println :ok)"
- clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.cli.main.commands.resume-test 'ai.miniforge.cli.workflow-runner.display-output-test 'ai.miniforge.cli.workflow-runner.help-test 'ai.miniforge.cli.workflow-runner.help.registry-test 'ai.miniforge.workflow.dag-resilience-resume-test) (let [r (clojure.test/run-tests 'ai.miniforge.cli.main.commands.resume-test 'ai.miniforge.cli.workflow-runner.display-output-test 'ai.miniforge.cli.workflow-runner.help-test 'ai.miniforge.cli.workflow-runner.help.registry-test 'ai.miniforge.workflow.dag-resilience-resume-test)] (shutdown-agents) (System/exit (+ (:fail r) (:error r))))"
- clojure -M:poly check
- bb pre-commit