### PR TITLE
fix(phase): use workflow DAG PR interface

### DIFF
--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -10,7 +10,8 @@
         ai.miniforge/repo-index {:local/root "../repo-index"}
         ai.miniforge/context-pack {:local/root "../context-pack"}
         ai.miniforge/response {:local/root "../response"}
-        ai.miniforge/release-executor {:local/root "../release-executor"}}
+        ai.miniforge/release-executor {:local/root "../release-executor"}
+        ai.miniforge/workflow {:local/root "../workflow"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {babashka/process {:mvn/version "0.5.22"}}}}}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/pr_monitor.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/pr_monitor.clj
@@ -25,7 +25,8 @@
    Agent: none (orchestration only)
    Default gates: none"
   (:require [ai.miniforge.phase.interface :as phase]
-            [ai.miniforge.response.interface :as response]))
+            [ai.miniforge.response.interface :as response]
+            [ai.miniforge.workflow.interface.dag-prs :as dag-prs]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
@@ -60,11 +61,7 @@
                                                          :pr-monitor/reason "No PRs from DAG"})))
 
       ;; Assemble train and monitor
-      (let [;; Resolve at runtime to avoid circular deps
-            create-train (requiring-resolve 'ai.miniforge.workflow.dag-train/create-train-from-dag-result)
-            monitor-dag-prs (requiring-resolve 'ai.miniforge.workflow.dag-monitor/monitor-dag-prs)
-
-            plan-tasks (get-in ctx [:execution/phase-results :plan :artifacts 0 :plan/tasks]
+      (let [plan-tasks (get-in ctx [:execution/phase-results :plan :artifacts 0 :plan/tasks]
                                [])
             dag-result (get-in ctx [:execution/dag-result])
             logger (get-in ctx [:execution/logger])
@@ -72,16 +69,18 @@
                               (get-in ctx [:worktree-path]))
 
             ;; Build train from DAG result
-            train-state (create-train (assoc dag-result :pr-infos pr-infos)
-                                       plan-tasks
-                                       :logger logger)
+            train-state (dag-prs/create-train-from-dag-result
+                         (assoc dag-result :pr-infos pr-infos)
+                         plan-tasks
+                         :logger logger)
 
             ;; Monitor all PRs
-            monitor-result (monitor-dag-prs train-state pr-infos
-                                             {:worktree-path worktree-path
-                                              :logger logger
-                                              :generate-fn (get-in ctx [:execution/generate-fn])
-                                              :event-bus (get-in ctx [:execution/event-bus])})
+            monitor-result (dag-prs/monitor-dag-prs
+                            train-state pr-infos
+                            {:worktree-path worktree-path
+                             :logger logger
+                             :generate-fn (get-in ctx [:execution/generate-fn])
+                             :event-bus (get-in ctx [:execution/event-bus])})
 
             result-data {:pr-monitor/status (if (:success? monitor-result) :completed :failed)
                          :pr-monitor/merged-prs (:merged-prs monitor-result [])

--- a/components/workflow/src/ai/miniforge/workflow/interface/dag_prs.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/dag_prs.clj
@@ -1,0 +1,31 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.interface.dag-prs
+  "Public boundary for DAG-created PR train assembly and monitoring."
+  (:require
+   [ai.miniforge.workflow.dag-monitor :as dag-monitor]
+   [ai.miniforge.workflow.dag-train :as dag-train]))
+
+(def create-train-from-dag-result
+  "Create a PR train from DAG execution results and plan-task topology."
+  dag-train/create-train-from-dag-result)
+
+(def monitor-dag-prs
+  "Monitor DAG-created pull requests through CI, review, and merge."
+  dag-monitor/monitor-dag-prs)


### PR DESCRIPTION
## Summary
- add a workflow public boundary for DAG PR train assembly and monitoring
- wire phase-software-factory PR monitoring through that interface instead of runtime requiring-resolve
- make the phase-software-factory dependency on workflow explicit

## Validation
- clj-kondo --lint components/workflow/src/ai/miniforge/workflow/interface/dag_prs.clj components/phase-software-factory/src/ai/miniforge/phase_software_factory/pr_monitor.clj
- clojure -M:poly check
- clojure -M:test -e "(require 'clojure.test 'ai.miniforge.workflow.dag-monitor-test 'ai.miniforge.phase-software-factory.pr-monitor 'ai.miniforge.workflow.interface.dag-prs) (clojure.test/run-tests 'ai.miniforge.workflow.dag-monitor-test)"
- bb pre-commit