### PR TITLE
fix(cli): inject TUI launcher composition

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -80,16 +80,23 @@
    [ai.miniforge.lsp-mcp-bridge.tasks :as lsp-tasks]
    [slingshot.slingshot :refer [try+]]))
 
-;; TUI components loaded conditionally (only in JVM/jlink bundled runtime)
-(def tui-available?
+;; TUI components loaded conditionally (only in JVM/jlink bundled runtime).
+;; This is an optional composition seam: miniforge-core includes the CLI
+;; without bundling the JVM TUI component.
+(def tui-launcher
   (try
     (require '[ai.miniforge.event-stream.interface :as es])
     (require '[ai.miniforge.tui-views.interface :as tui])
-    true
-    (catch Exception _ false)))
+    (some-> (find-ns 'ai.miniforge.tui-views.interface)
+            (ns-resolve 'start-standalone-tui!))
+    (catch Throwable _ nil)))
+
+(def tui-available?
+  (some? tui-launcher))
 
 ;; Propagate TUI availability to monitoring commands
 (alter-var-root #'cmd-monitoring/*tui-available?* (constantly tui-available?))
+(alter-var-root #'cmd-monitoring/*start-standalone-tui!* (constantly tui-launcher))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants and pure helpers

--- a/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
@@ -118,14 +118,18 @@
                                          {:error (ex-message e)}))
         (exit! 1)))))
 
-;; TUI availability check (set at load time by parent ns)
+;; TUI availability and launcher are composed by the parent CLI namespace.
 (def ^:dynamic *tui-available?* false)
+
+(def ^:dynamic *start-standalone-tui!*
+  "Injected JVM TUI launcher. Nil when the TUI component is not on the classpath."
+  nil)
 
 (defn tui-cmd
   "Start terminal UI for workflow monitoring.
    Launches standalone TUI that tail-follows app event files."
   [opts]
-  (if-not *tui-available?*
+  (if-not (and *tui-available?* *start-standalone-tui!*)
     (do
       (display/print-error (messages/t :tui/not-available))
       (println)
@@ -148,13 +152,12 @@
       (display/print-info (messages/t :tui/help-hint))
       (println)
       (try
-        (let [start-standalone! (requiring-resolve 'ai.miniforge.tui-views.interface/start-standalone-tui!)]
-          ;; Start standalone TUI (blocks until quit)
-          (start-standalone! opts)
-          ;; Force immediate JVM exit — Clojure's agent thread pool
-          ;; keeps the process alive for ~60s otherwise
-          (shutdown-agents)
-          (exit! 0))
+        ;; Start standalone TUI (blocks until quit)
+        (*start-standalone-tui!* opts)
+        ;; Force immediate JVM exit — Clojure's agent thread pool
+        ;; keeps the process alive for ~60s otherwise
+        (shutdown-agents)
+        (exit! 0)
         (catch Exception e
           (display/print-error (messages/t :tui/start-failed
                                            {:error (.getMessage e)}))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/tui.clj
@@ -19,9 +19,7 @@
 (ns ai.miniforge.cli.main.commands.tui
   "TUI command — launch standalone TUI monitor."
   (:require
-   [ai.miniforge.cli.app-config :as app-config]
-   [ai.miniforge.cli.main.display :as display]
-   [ai.miniforge.cli.messages :as messages]))
+   [ai.miniforge.cli.main.commands.monitoring :as monitoring]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; TUI command
@@ -30,7 +28,4 @@
   "Launch standalone TUI that monitors workflow event files.
    Tail-follows app event files for live workflow state."
   [opts]
-  (display/print-info (messages/t :tui/starting))
-  (display/print-info (messages/t :tui/watching {:events-dir (app-config/events-dir)}))
-  (let [start-tui! (requiring-resolve 'ai.miniforge.tui-views.interface/start-standalone-tui!)]
-    (start-tui! opts)))
+  (monitoring/tui-cmd opts))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/monitoring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/monitoring_test.clj
@@ -56,3 +56,50 @@
           (is (.contains output "TUI-REQUIRES-JVM"))
           (is (.contains output "TUI-INSTALL"))
           (is (.contains output "TUI-USE-WEB")))))))
+
+(deftest tui-cmd-missing-launcher-uses-unavailable-path-test
+  (testing "TUI is unavailable when the composed launcher is missing"
+    (binding [sut/*tui-available?* true
+              sut/*start-standalone-tui!* nil]
+      (with-redefs [messages/t (fn
+                                 ([k]
+                                  (case k
+                                    :tui/not-available "TUI-NOT-AVAILABLE"
+                                    :tui/requires-jvm "TUI-REQUIRES-JVM"
+                                    :tui/install-package "TUI-INSTALL"
+                                    :tui/use-web "TUI-USE-WEB"
+                                    (str "UNEXPECTED:" k)))
+                                 ([k params]
+                                  (case k
+                                    :tui/no-standalone-package (str "NO-STANDALONE:" (:command params))
+                                    (str "UNEXPECTED:" k))))
+                    display/print-error println
+                    app-config/tui-package (constantly "engine-tui")
+                    app-config/command-string identity
+                    sut/exit! (fn [code] (throw (exit-ex code)))]
+        (let [output (with-out-str
+                       (try
+                         (sut/tui-cmd {})
+                         (catch clojure.lang.ExceptionInfo e
+                           (is (= 1 (:code (ex-data e)))))))]
+          (is (.contains output "TUI-NOT-AVAILABLE"))
+          (is (.contains output "TUI-REQUIRES-JVM")))))))
+
+(deftest tui-cmd-uses-injected-launcher-test
+  (testing "TUI startup uses the launcher composed by cli.main"
+    (let [started (atom nil)
+          shut-down? (atom false)
+          exit-code (atom nil)]
+      (binding [sut/*tui-available?* true
+                sut/*start-standalone-tui!* (fn [opts]
+                                              (reset! started opts))]
+        (with-redefs [messages/t (fn
+                                   ([k] (name k))
+                                   ([k params] (str (name k) params)))
+                      display/print-info (fn [& _] nil)
+                      clojure.core/shutdown-agents (fn [] (reset! shut-down? true))
+                      sut/exit! (fn [code] (reset! exit-code code))]
+          (sut/tui-cmd {:events-dir "/tmp/events"}))
+        (is (= {:events-dir "/tmp/events"} @started))
+        (is @shut-down?)
+        (is (= 0 @exit-code))))))


### PR DESCRIPTION
## Summary
- replace TUI command runtime symbol resolution with an injected launcher composed by cli.main
- keep the CLI optional TUI classpath seam explicit for miniforge-core without pulling JVM TUI code into command namespaces
- delegate the older standalone TUI command namespace to the monitored TUI command path
- add regression coverage for unavailable and injected launcher paths

## Validation
- clj-kondo on changed CLI source and test namespaces
- clojure -M:poly check
- focused CLI monitoring command test via clojure -M:dev:test
- bb pre-commit

## Notes
- A broad diagnostic run with bb test:since-stable:subset project:miniforge still hits existing ai.miniforge.loop.outer-test FSM errors unrelated to this CLI/TUI change.
