### PR TITLE
fix(cli): compose monitoring launchers explicitly

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -117,16 +117,49 @@
 (register-artifact-providers!)
 (register-policy-pack-providers!)
 
+(defn- optional-web-launcher
+  "Compose the dashboard command when the product includes web-dashboard."
+  []
+  (when-let [start! (optional-var 'ai.miniforge.web-dashboard.interface 'start!)]
+    (fn [{:keys [port]}]
+      (let [event-stream (es/create-event-stream)
+            create-pr-manager (optional-var 'ai.miniforge.pr-train.interface
+                                            'create-manager)
+            create-repo-manager (optional-var 'ai.miniforge.repo-dag.interface
+                                              'create-manager)
+            pr-train-manager (when create-pr-manager
+                               (try
+                                 (create-pr-manager)
+                                 (catch Exception e
+                                   (println (messages/t :web/pr-train-warning
+                                                        {:error (.getMessage e)}))
+                                   nil)))
+            repo-dag-manager (when create-repo-manager
+                               (try
+                                 (create-repo-manager)
+                                 (catch Exception e
+                                   (println (messages/t :web/repo-dag-warning
+                                                        {:error (.getMessage e)}))
+                                   nil)))]
+        (start! {:port port
+                 :event-stream event-stream
+                 :pr-train-manager pr-train-manager
+                 :repo-dag-manager repo-dag-manager})))))
+
+(def web-launcher
+  (optional-web-launcher))
+
+(def web-available?
+  (some? web-launcher))
+
+(alter-var-root #'cmd-monitoring/*web-available?* (constantly web-available?))
+(alter-var-root #'cmd-monitoring/*start-web-dashboard!* (constantly web-launcher))
+
 ;; TUI components loaded conditionally (only in JVM/jlink bundled runtime).
 ;; This is an optional composition seam: miniforge-core includes the CLI
 ;; without bundling the JVM TUI component.
 (def tui-launcher
-  (try
-    (require '[ai.miniforge.event-stream.interface :as es])
-    (require '[ai.miniforge.tui-views.interface :as tui])
-    (some-> (find-ns 'ai.miniforge.tui-views.interface)
-            (ns-resolve 'start-standalone-tui!))
-    (catch Throwable _ nil)))
+  (optional-var 'ai.miniforge.tui-views.interface 'start-standalone-tui!))
 
 (def tui-available?
   (some? tui-launcher))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
@@ -22,9 +22,9 @@
    [babashka.process :as process]
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
-   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.config :as config]
    [ai.miniforge.cli.main.display :as display]
-   [ai.miniforge.cli.config :as config]))
+   [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Web dashboard command
@@ -33,6 +33,12 @@
   [code]
   (System/exit code))
 
+(def ^:dynamic *web-available?* false)
+
+(def ^:dynamic *start-web-dashboard!*
+  "Injected JVM dashboard launcher. Nil when the dashboard component is not on the classpath."
+  nil)
+
 (defn web-cmd
   "Start web dashboard for workflow monitoring."
   [opts]
@@ -40,50 +46,15 @@
         port (or port
                  (get-in (config/load-config) [:dashboard :port])
                  7878)]
-    (try
-      ;; Conditionally require web-dashboard (may not be on classpath in Babashka)
-      (require '[ai.miniforge.web-dashboard.interface :as dashboard])
-      (require '[ai.miniforge.event-stream.interface :as es])
-
-      (let [dashboard-ns (find-ns 'ai.miniforge.web-dashboard.interface)
-            es-ns (find-ns 'ai.miniforge.event-stream.interface)]
-        (when-not (and dashboard-ns es-ns)
-          (display/print-error (messages/t :web/not-available))
-          (println (messages/t :web/requires-jvm))
-          (exit! 1))
-
-        (let [start! (ns-resolve dashboard-ns 'start!)
-              create-stream (ns-resolve es-ns 'create-event-stream)
-              event-stream (create-stream)
-
-              ;; Create PR train manager
-              pr-train-manager (try
-                                 (require '[ai.miniforge.pr-train.interface :as pr-train])
-                                 (when-let [pr-ns (find-ns 'ai.miniforge.pr-train.interface)]
-                                   (when-let [create-fn (ns-resolve pr-ns 'create-manager)]
-                                     (create-fn)))
-                                 (catch Exception e
-                                   (println (messages/t :web/pr-train-warning
-                                                        {:error (.getMessage e)}))
-                                   nil))
-
-              ;; Create repo DAG manager
-              repo-dag-manager (try
-                                 (require '[ai.miniforge.repo-dag.interface :as repo-dag])
-                                 (when-let [dag-ns (find-ns 'ai.miniforge.repo-dag.interface)]
-                                   (when-let [create-fn (ns-resolve dag-ns 'create-manager)]
-                                     (create-fn)))
-                                 (catch Exception e
-                                   (println (messages/t :web/repo-dag-warning
-                                                        {:error (.getMessage e)}))
-                                   nil))
-
-              url (str "http://localhost:" port)]
+    (if-not (and *web-available?* *start-web-dashboard!*)
+      (do
+        (display/print-error (messages/t :web/not-available))
+        (println (messages/t :web/requires-jvm))
+        (exit! 1))
+      (try
+        (let [url (str "http://localhost:" port)]
           (display/print-info (messages/t :web/starting {:port port}))
-          (start! {:port port
-                   :event-stream event-stream
-                   :pr-train-manager pr-train-manager
-                   :repo-dag-manager repo-dag-manager})
+          (*start-web-dashboard!* {:port port})
           (println)
           (println (str "  " url))
           (println)
@@ -102,21 +73,21 @@
               (try
                 (process/sh "open" url)
                 (catch Exception _e nil))
-              @(promise)))))  ; Block until interrupted
-      (catch java.net.BindException _e
-        (display/print-error (messages/t :web/port-in-use {:port port}))
-        (println)
-        (println (messages/t :web/solutions))
-        (println (messages/t :web/use-different-port
-                             {:command (app-config/command-string "web --port"
-                                                                  (str (inc port)))}))
-        (println (messages/t :web/kill-port-header {:port port}))
-        (println (messages/t :web/kill-port-command {:port port}))
-        (exit! 1))
-      (catch Exception e
-        (display/print-error (messages/t :web/start-failed
-                                         {:error (ex-message e)}))
-        (exit! 1)))))
+              @(promise))))  ; Block until interrupted
+        (catch java.net.BindException _e
+          (display/print-error (messages/t :web/port-in-use {:port port}))
+          (println)
+          (println (messages/t :web/solutions))
+          (println (messages/t :web/use-different-port
+                               {:command (app-config/command-string "web --port"
+                                                                    (str (inc port)))}))
+          (println (messages/t :web/kill-port-header {:port port}))
+          (println (messages/t :web/kill-port-command {:port port}))
+          (exit! 1))
+        (catch Exception e
+          (display/print-error (messages/t :web/start-failed
+                                           {:error (ex-message e)}))
+          (exit! 1))))))
 
 ;; TUI availability and launcher are composed by the parent CLI namespace.
 (def ^:dynamic *tui-available?* false)

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -983,10 +983,7 @@
           es (or event-stream
                  (when-not dashboard-url
                    (try
-                     (require '[ai.miniforge.event-stream.interface :as es])
-                     (when-let [es-ns (find-ns 'ai.miniforge.event-stream.interface)]
-                       (when-let [create-fn (ns-resolve es-ns 'create-event-stream)]
-                         (create-fn)))
+                     (es/create-event-stream)
                      (catch Exception _ nil))))]
       (display/print-workflow-header workflow-id version quiet)
       (let [workflow-input (context/resolve-input opts)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/monitoring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/monitoring_test.clj
@@ -20,6 +20,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.config :as config]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.main.commands.monitoring :as sut]
    [ai.miniforge.cli.main.display :as display]))
@@ -27,6 +28,47 @@
 (defn- exit-ex
   [code]
   (ex-info "exit" {:code code}))
+
+(deftest web-cmd-unavailable-uses-message-catalog-test
+  (testing "Web dashboard is unavailable when the composed launcher is missing"
+    (binding [sut/*web-available?* false
+              sut/*start-web-dashboard!* nil]
+      (with-redefs [config/load-config (constantly {})
+                    messages/t (fn
+                                 ([k]
+                                  (case k
+                                    :web/not-available "WEB-NOT-AVAILABLE"
+                                    :web/requires-jvm "WEB-REQUIRES-JVM"
+                                    (str "UNEXPECTED:" k)))
+                                 ([k params] (str "UNEXPECTED:" k params)))
+                    display/print-error println
+                    sut/exit! (fn [code] (throw (exit-ex code)))]
+        (let [output (with-out-str
+                       (try
+                         (sut/web-cmd {})
+                         (catch clojure.lang.ExceptionInfo e
+                           (is (= 1 (:code (ex-data e)))))))]
+          (is (.contains output "WEB-NOT-AVAILABLE"))
+          (is (.contains output "WEB-REQUIRES-JVM")))))))
+
+(deftest web-cmd-uses-injected-launcher-test
+  (testing "Web startup uses the launcher composed by cli.main"
+    (let [started (atom nil)
+          exit-code (atom nil)]
+      (binding [sut/*web-available?* true
+                sut/*start-web-dashboard!* (fn [opts]
+                                             (reset! started opts)
+                                             (throw (ex-info "stop" {})))]
+        (with-redefs [config/load-config (constantly {:dashboard {:port 9191}})
+                      messages/t (fn
+                                   ([k] (name k))
+                                   ([k params] (str (name k) params)))
+                      display/print-info (fn [& _] nil)
+                      display/print-error (fn [& _] nil)
+                      sut/exit! (fn [code] (reset! exit-code code))]
+          (sut/web-cmd {}))
+        (is (= {:port 9191} @started))
+        (is (= 1 @exit-code))))))
 
 (deftest tui-cmd-unavailable-uses-message-catalog-test
   (testing "TUI unavailable output reads user-facing copy from the message catalog"


### PR DESCRIPTION
## Summary

- move web dashboard startup behind the same explicit CLI composition boundary used by TUI startup
- compose the web launcher in `cli.main` when the dashboard component is present, while keeping shared CLI command code free of dashboard dependencies
- replace the remaining CLI workflow event-stream dynamic resolver with the existing direct event-stream interface call
- add focused monitoring command tests for unavailable and injected launcher paths

## Validation

- `clj-kondo --lint bases/cli/src/ai/miniforge/cli/main.clj bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj bases/cli/src/ai/miniforge/cli/workflow_runner.clj bases/cli/test/ai/miniforge/cli/main/commands/monitoring_test.clj`
- `clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.cli.main.commands.monitoring-test 'ai.miniforge.cli.main.commands.shared-test 'ai.miniforge.cli.main) (clojure.test/run-tests 'ai.miniforge.cli.main.commands.monitoring-test 'ai.miniforge.cli.main.commands.shared-test)"`
- `clojure -M:poly check`
- `bb pre-commit`
