### PR TITLE
fix(dashboard): call event stream interface directly

### DIFF
--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/websocket.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/websocket.clj
@@ -18,6 +18,7 @@
    [cheshire.core :as json]
    [clojure.string :as str]
    [org.httpkit.server :as http]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.web-dashboard.state :as state])
   (:import
    [java.time Instant]
@@ -126,16 +127,13 @@
   (when event-stream
     (let [subscriber-id (keyword (str "ws-" (hash ch)))]
       (try
-        (let [es-ns (find-ns 'ai.miniforge.event-stream.interface)]
-          (when es-ns
-            (let [subscribe! (ns-resolve es-ns 'subscribe!)]
-              (subscribe! event-stream subscriber-id
-                          (fn [event]
-                            (try
-                              (http/send! ch (json/generate-string
-                                              (ws-event-envelope event)))
-                              (catch Exception e
-                                (println "Error sending event to WebSocket:" (ex-message e)))))))))
+        (es/subscribe! event-stream subscriber-id
+                       (fn [event]
+                         (try
+                           (http/send! ch (json/generate-string
+                                           (ws-event-envelope event)))
+                           (catch Exception e
+                             (println "Error sending event to WebSocket:" (ex-message e))))))
         (catch Exception e
           (println "Error subscribing to event stream:" (ex-message e)))))))
 
@@ -145,10 +143,7 @@
   (when event-stream
     (let [subscriber-id (keyword (str "ws-" (hash ch)))]
       (try
-        (let [es-ns (find-ns 'ai.miniforge.event-stream.interface)]
-          (when es-ns
-            (let [unsubscribe! (ns-resolve es-ns 'unsubscribe!)]
-              (unsubscribe! event-stream subscriber-id))))
+        (es/unsubscribe! event-stream subscriber-id)
         (catch Exception e
           (println "Error unsubscribing from event stream:" (ex-message e)))))))
 
@@ -191,12 +186,9 @@
     (let [event (json/parse-string data true)
           normalized-event (normalize-workflow-event event)]
       ;; Publish event to dashboard's event stream
-      (when-let [es (:event-stream @state)]
+      (when-let [event-stream (:event-stream @state)]
         (try
-          (let [es-ns (find-ns 'ai.miniforge.event-stream.interface)]
-            (when es-ns
-              (when-let [publish! (ns-resolve es-ns 'publish!)]
-                (publish! es normalized-event))))
+          (es/publish! event-stream normalized-event)
           (catch Exception e
             (println "Error publishing workflow event:" (ex-message e))))))
     (catch Exception e

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/workflows.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/workflows.clj
@@ -16,6 +16,7 @@
   "Workflow state from live and historical event streams."
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.event-stream.interface :as es]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.web-dashboard.watcher :as watcher]))
@@ -342,22 +343,12 @@
              :dependency-severity (dependency-severity dependency-issues)
              :failure-attribution (first dependency-issues)))))
 
-(def resolved-get-events
-  "Cached reference to event-stream get-events fn."
-  (delay
-    (try
-      (require 'ai.miniforge.event-stream.interface)
-      (ns-resolve (find-ns 'ai.miniforge.event-stream.interface) 'get-events)
-      (catch Exception _ nil))))
-
 (defn live-stream-events
   "Read all currently buffered live events from the in-memory event stream."
   [state]
   (try
     (if-let [stream (:event-stream @state)]
-      (if-let [get-events-fn @resolved-get-events]
-        (get-events-fn stream)
-        [])
+      (es/get-events stream)
       [])
     (catch Exception e
       (println "Error reading live workflow events:" (ex-message e))


### PR DESCRIPTION
## Summary

- replace web-dashboard WebSocket event-stream `find-ns`/`ns-resolve` calls with direct event-stream interface calls
- replace live workflow event `get-events` resolver cache with the direct event-stream interface
- keep PR-train/repo-DAG dynamic manager calls out of this wave for a separate composition pass

## Validation

- `clj-kondo --lint components/web-dashboard/src/ai/miniforge/web_dashboard/server/websocket.clj components/web-dashboard/src/ai/miniforge/web_dashboard/state/workflows.clj`
- `clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.web-dashboard.state.workflows-test) (clojure.test/run-tests 'ai.miniforge.web-dashboard.state.workflows-test)"`
- `clojure -M:dev:test -e "(require 'ai.miniforge.web-dashboard.server.websocket)"`
- `clojure -M:poly check`
- `bb pre-commit`
