### PR TITLE
review(prompt): add recurring-defect checklist to the reviewer

### DIFF
--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -99,10 +99,13 @@ You must output a structured review as a Clojure map:
 6. **Recurring miniforge defects** (flag these explicitly — static tools miss them):
    - **Present-nil map access**: `(get m :k default)` and `(:k m default)` return
      the default only when `:k` is ABSENT. If a writer stored `:k` with value
-     `nil`, they return `nil`, not the default — and downstream arithmetic
-     (`(+ ... x)`, `(fnil + 0) x`) then NPEs with no message. Flag get/keyword-
-     with-default on an optional numeric key (`:tokens`, `:cost-usd`, durations,
-     counts) that feeds arithmetic; prefer `(or (:k m) default)`, or normalize
+     `nil`, they return `nil`, not the default — and downstream arithmetic then
+     NPEs with no message. The classic case is feeding that nil as the SECOND
+     arg of a `fnil`-guarded accumulate: `(update-in m [:k] (fnil + 0) x)` —
+     `(fnil + 0)` only replaces a nil FIRST arg (the accumulator), so a nil `x`
+     still hits `(+ acc nil)` and throws. Flag get/keyword-with-default on an
+     optional numeric key (`:tokens`, `:cost-usd`, durations, counts) whose
+     value then feeds arithmetic; prefer `(or (:k m) default)`, or normalize
      present-nil away at the writer.
    - **`with-redefs` binding names**: the binding-vector NAMES must be plain
      symbols, never var-quotes — `(with-redefs [#'ns/f g] ...)` is a compile

--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -96,6 +96,26 @@ You must output a structured review as a Clojure map:
    - Input validation at boundaries
    - Safe handling of user-provided data
 
+6. **Recurring miniforge defects** (flag these explicitly — static tools miss them):
+   - **Present-nil map access**: `(get m :k default)` and `(:k m default)` return
+     the default only when `:k` is ABSENT. If a writer stored `:k` with value
+     `nil`, they return `nil`, not the default — and downstream arithmetic
+     (`(+ ... x)`, `(fnil + 0) x`) then NPEs with no message. Flag get/keyword-
+     with-default on an optional numeric key (`:tokens`, `:cost-usd`, durations,
+     counts) that feeds arithmetic; prefer `(or (:k m) default)`, or normalize
+     present-nil away at the writer.
+   - **`with-redefs` binding names**: the binding-vector NAMES must be plain
+     symbols, never var-quotes — `(with-redefs [#'ns/f g] ...)` is a compile
+     error (`Cons cannot be cast to Symbol`). `#'` is fine as a binding VALUE
+     or to CALL a private fn. Flag any `#'` in a `with-redefs` name slot.
+   - **Cross-namespace private access**: a test (or any caller) referencing
+     another namespace's private var must use `#'ns/private` — `(ns/private …)`
+     is a compile error (`var: … is not public`).
+   - **Record-before-signal**: when one thread interrupts/kills another, any
+     state the interrupted thread reads afterward must be written BEFORE the
+     kill, or the reader can observe it unset (read race). Flag kill/interrupt
+     calls that precede the state write they're supposed to make visible.
+
 ## Severity Levels
 
 - **:blocking** — Must be fixed before approval. Logic errors, security issues, data loss risks.


### PR DESCRIPTION
## Why

Part 2 of the verify/review hardening. After the gate fixes, static tooling now covers the mechanical classes — compile errors (#1220 full `:all` suite, #1223 verify exit-code) and unused vars (clj-kondo, already mapped to a blocking lint violation). What's left uncovered are **judgment-requiring** patterns no static tool can flag, and they're exactly the ones that slipped past review this cycle. An LLM reviewer *can* catch these — it just needs to be told to look.

## What

Adds a "Recurring miniforge defects" item to the reviewer's Review Criteria:

- **Present-nil map access** feeding arithmetic — `(get m :k default)` returns a *stored* nil, not the default → message-less NPE. (The cost-usd implement-leave crash, #1197.)
- **Var-quote in a `with-redefs` binding name** — compile error. (3× this cycle.)
- **Cross-namespace private access without `#'`** — compile error. (stream-recovery test.)
- **Record-before-signal** ordering in interrupt/kill paths — read race. (The watchdog stall-state bug, #1220.)

The reviewer already gets the standards addendum + `:policy-review` gate; this broadens the semantic criteria it applies. EDN validated; `bb pre-commit` passes.

## Note

Static *pack detectors* for these were considered and rejected: the `#'`/private/compile classes are now deterministically caught by the compile gates (a regex would also false-positive on `#'` in value position), and present-nil-then-arithmetic isn't reliably statically detectable. The LLM checklist is the right tool for the judgment cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)