### PR TITLE
fix(bb): add repo-analyzer to the miniforge run classpath

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -684,6 +684,12 @@
                  "components/connector-retry/resources"
                  "components/connector-linter/src"
                  "components/connector-linter/resources"
+                 ;; gate/pre_verify_lint requires repo-analyzer.interface
+                 ;; directly (#1170/#1212); without these the bb `miniforge run`
+                 ;; classpath can't load the gate and the dogfood CLI fails to
+                 ;; start. CI doesn't run `bb miniforge run`, so it went unseen.
+                 "components/repo-analyzer/src"
+                 "components/repo-analyzer/resources"
                  "components/semantic-analyzer/src"
                  "components/semantic-analyzer/resources"
                  "components/failure-classifier/src"


### PR DESCRIPTION
## Why

`bb miniforge run` (the dogfood / local CLI entrypoint) fails at startup:

```
Could not locate ai/miniforge/repo_analyzer/interface.clj on classpath
  at components/gate/src/ai/miniforge/gate/pre_verify_lint.clj:14
```

`gate/pre_verify_lint` now statically requires `ai.miniforge.repo-analyzer.interface` (#1170/#1212 replaced a `requiring-resolve` with a direct require), but the `miniforge` bb task's explicit `:extra-paths` was never updated to include repo-analyzer. The gate loads fine under the JVM `deps.edn` (gate's deps list repo-analyzer), but the bb classpath is a separate hand-maintained path list — so the dogfood CLI broke.

CI never runs `bb miniforge run`, so this regression was invisible — the same class of gap as the verify/full-suite work: the bb/dogfood path isn't exercised by CI.

## What

Add `components/repo-analyzer/src` + `/resources` to the `miniforge` task's `:extra-paths`, next to the other `pre_verify_lint` deps (connector-linter).

## Test plan

- `bb miniforge --help` loads cleanly (was throwing the FileNotFoundException).
- Verified by relaunching a dogfood run, which now starts (was failing at gate load).
- `bb pre-commit` passes.

Follow-up worth considering: a CI smoke step that runs `bb miniforge --help` (or a tiny `bb miniforge run`) would catch bb-classpath regressions like this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)