### PR TITLE
fix(workflow): send websocket events directly

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -28,7 +28,8 @@
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.self-healing.interface :as self-healing]
    [ai.miniforge.workflow.messages :as messages]
-   [cheshire.core :as json]))
+   [cheshire.core :as json]
+   [org.httpkit.server :as http]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Core event dispatch
@@ -37,11 +38,8 @@
   "Send event JSON to a WebSocket connection."
   [event-stream event]
   (try
-    (require '[org.httpkit.client :as http])
-    (when-let [http-ns (find-ns 'org.httpkit.client)]
-      (when-let [ws (:websocket event-stream)]
-        (when-let [send-fn (ns-resolve http-ns 'send!)]
-          (send-fn ws (json/generate-string event)))))
+    (when-let [ws (:websocket event-stream)]
+      (http/send! ws (json/generate-string event)))
     (catch Exception e
       (println (messages/t :warn/websocket-send {:error (ex-message e)})))))
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -21,10 +21,12 @@
    Verifies that workflow-run/* entity fields are merged into lifecycle events
    so the Rust StateManager can deserialize WorkflowRun projections."
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.runner-events :as events]
-   [ai.miniforge.event-stream.interface :as event-stream]))
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [org.httpkit.server :as http]))
 
 ;------------------------------------------------------------------------------ Helpers
 
@@ -156,6 +158,22 @@
 (deftest publish-phase-started-nil-stream-is-noop-test
   (testing "nil event-stream does not throw"
     (is (nil? (events/publish-phase-started! nil (test-context) :plan)))))
+
+(deftest publish-event-websocket-stream-sends-json-test
+  (testing "WebSocket event streams send serialized events to the channel"
+    (let [sent (atom nil)
+          ch (Object.)
+          event {:event/type :workflow/phase-started
+                 :workflow/id (random-uuid)}]
+      (with-redefs [http/send! (fn [channel payload]
+                                 (reset! sent {:channel channel
+                                               :payload payload})
+                                 true)]
+        (events/publish-event! {:websocket ch} event))
+      (is (= ch (:channel @sent)))
+      (is (= {:event/type "workflow/phase-started"
+              :workflow/id (str (:workflow/id event))}
+             (json/parse-string (:payload @sent) true))))))
 
 (deftest start-phase-heartbeat-websocket-stream-is-noop-test
   (testing "heartbeats require a durable stream because the scheduler derefs it"


### PR DESCRIPTION
## Summary

- replace workflow WebSocket event sending `require`/`find-ns`/`ns-resolve` with a direct http-kit server `send!` call
- correct the namespace from `org.httpkit.client` to `org.httpkit.server`, which is where `send!` is defined
- keep the existing exception boundary for failed WebSocket sends

## Validation

- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/runner_events.clj`
- `clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.workflow.runner-events-test 'ai.miniforge.workflow.runner-events) (clojure.test/run-tests 'ai.miniforge.workflow.runner-events-test)"`
- `clojure -M:poly check`
- `bb pre-commit`
