### PR TITLE
fix(agent): budget the reviewer prompt against the model context window

### DIFF
--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -30,6 +30,18 @@
   :max-total-ms                600000
   :min-activity-interval-ms    3000}
 
+ ;; Headroom reserved below the model's context window when deciding whether
+ ;; to shed the reviewer's inlined artifact file bodies to a manifest
+ ;; (N12 §5). The shed/bail estimate covers only miniforge's assembled
+ ;; prompt (system + standards addendum + user); the agent CLI adds its own
+ ;; baseline on top (its system prompt, tool schemas, host plugins/skills)
+ ;; that we can't measure. This reserve fires the shed before that
+ ;; unmeasured baseline pushes the true total over the window. Matches the
+ ;; planner reserve; the reviewer overflowed at 237k input tokens on an
+ ;; aggregated DAG integration-task review (full file contents + the ~38k
+ ;; standards pack) and the CLI hard-errored 'Prompt is too long'.
+ :prompt/context-window-reserve-tokens 50000
+
  :prompt/system
  "You are a Code Review Agent for an autonomous software development team.
 

--- a/components/agent/src/ai/miniforge/agent/context_budget.clj
+++ b/components/agent/src/ai/miniforge/agent/context_budget.clj
@@ -1,0 +1,89 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.context-budget
+  "Shared N12 §5 context-window budgeting for agent prompt assembly.
+
+   A role assembles its user-prompt with eagerly-inlined bodies — the
+   planner's in-scope files, the reviewer's artifact-under-review. When
+   that prompt would overflow the model's context window, the inlined
+   bodies are shed to a manifest (paths + size): the bodies stay reachable
+   via the MCP context cache (`context_read`, which reads through to the
+   worktree/source-root on a miss), so the agent keeps a query surface,
+   and only if the shed form still overflows do we mark an irreducible
+   overflow so the caller can bail pre-flight rather than pay for a request
+   the model will reject.
+
+   This namespace holds the role-agnostic ladder. Each role supplies its
+   full/shed prompt builders and its sheddable-unit count via
+   `assemble-within-budget`; the planner and reviewer each wrap it with a
+   role-specific signature (and tests) over this core."
+  (:require [ai.miniforge.llm.interface :as llm]))
+
+(defn assemble-within-budget
+  "Assemble a user-prompt within `model`'s context window (N12 §5).
+
+   Options map:
+   - `:effective-system` — the system prompt as it will be sent (including
+     any standards addendum). Counted toward the estimate; never trimmed
+     here — shedding the inlined bodies is preferred, and an irreducible
+     overflow bails rather than silently dropping system content.
+   - `:model` — backend model-id string. A nil/uncatalogued window means
+     the budget is unknown, so nothing is ever shed (files stay inlined).
+   - `:reserve` — headroom kept below the real window for the agent CLI's
+     own unmeasured baseline (its system prompt, tool schemas, host
+     plugins/skills). The shed/bail decision fires against
+     `effective-window = window - reserve`. Clamped to at most half the
+     window so a misconfigured reserve >= window can't zero the effective
+     window and make every prompt look over-budget; `:reserve-clamped?`
+     flags that.
+   - `:build-full` — 0-arg fn returning the user-prompt with bodies inlined.
+   - `:build-shed` — 0-arg fn returning the user-prompt with bodies shed to
+     a manifest. Only called when the full prompt is over budget and there
+     is something to shed.
+   - `:shed-count` — number of sheddable units (e.g. inlined file bodies).
+     Zero means nothing to shed, so an over-budget prompt is irreducibly
+     over.
+
+   Returns {:user-prompt :shed? :over-after-shed? :window :reserve
+            :effective-window :reserve-clamped? :est-full :est-final
+            :file-count}; `:over-after-shed?` marks an irreducible overflow."
+  [{:keys [effective-system model reserve build-full build-shed shed-count]}]
+  (let [window      (llm/context-window-for-model-id model)
+        eff-reserve (when window (min reserve (quot window 2)))
+        clamped?    (boolean (and window (> reserve eff-reserve)))
+        effective   (when window (- window eff-reserve))
+        est         (fn [user] (:estimated-input-tokens
+                                (llm/prompt-size-telemetry effective-system user)))
+        full        (build-full)
+        est-full    (est full)
+        base        {:window window :reserve reserve :effective-window effective
+                     :reserve-clamped? clamped?
+                     :est-full est-full :file-count shed-count}]
+    (cond
+      (or (nil? effective) (< est-full effective))
+      (merge base {:user-prompt full :shed? false :over-after-shed? false :est-final est-full})
+
+      (zero? shed-count)                 ; nothing left to shed — irreducibly over
+      (merge base {:user-prompt full :shed? false :over-after-shed? true :est-final est-full})
+
+      :else
+      (let [shed     (build-shed)
+            est-shed (est shed)]
+        (merge base {:user-prompt shed :shed? true
+                     :over-after-shed? (>= est-shed effective) :est-final est-shed})))))

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -22,6 +22,7 @@
   (:require
    [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.budget :as budget]
+   [ai.miniforge.agent.context-budget :as context-budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.result-boundary :as result-boundary]
@@ -213,31 +214,20 @@
    The shed/bail fire against `effective-window = window - reserve`. The
    reserve is clamped to at most half the window so a reserve >= window
    (misconfig, or a tiny-window model) can't zero the effective window and
-   make every prompt look over-budget; `:reserve-clamped?` flags that."
+   make every prompt look over-budget; `:reserve-clamped?` flags that.
+
+   Thin role wrapper over `context-budget/assemble-within-budget`: supplies
+   the planner's full/shed prompt builders and its sheddable-unit count
+   (the eagerly-inlined existing files)."
   [spec-text existing-files effective-system model reserve]
-  (let [window     (llm/context-window-for-model-id model)
-        eff-reserve (when window (min reserve (quot window 2)))
-        clamped?   (boolean (and window (> reserve eff-reserve)))
-        effective  (when window (- window eff-reserve))
-        est        (fn [user] (:estimated-input-tokens
-                               (llm/prompt-size-telemetry effective-system user)))
-        full       (build-user-prompt spec-text existing-files)
-        est-full   (est full)
-        base       {:window window :reserve reserve :effective-window effective
-                    :reserve-clamped? clamped?
-                    :est-full est-full :file-count (count existing-files)}]
-    (cond
-      (or (nil? effective) (< est-full effective))
-      (merge base {:user-prompt full :shed? false :over-after-shed? false :est-final est-full})
-
-      (empty? existing-files)            ; nothing left to shed — irreducibly over
-      (merge base {:user-prompt full :shed? false :over-after-shed? true :est-final est-full})
-
-      :else
-      (let [shed (build-user-prompt spec-text existing-files format-existing-files-manifest)
-            est-shed (est shed)]
-        (merge base {:user-prompt shed :shed? true
-                     :over-after-shed? (>= est-shed effective) :est-final est-shed})))))
+  (context-budget/assemble-within-budget
+   {:effective-system effective-system
+    :model            model
+    :reserve          reserve
+    :build-full       #(build-user-prompt spec-text existing-files)
+    :build-shed       #(build-user-prompt spec-text existing-files
+                                          format-existing-files-manifest)
+    :shed-count       (count existing-files)}))
 
 (defn- emit-prompt-size!
   "Emit an :agent/prompt-size workflow event recording the planner's

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -23,6 +23,7 @@
   (:require
    [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.budget :as budget]
+   [ai.miniforge.agent.context-budget :as context-budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.reviewer.artifact :as artifact]
@@ -33,6 +34,7 @@
    [ai.miniforge.agent.reviewer.scope :as scope]
    [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.loop.interface :as loop]))
@@ -85,6 +87,63 @@
    Bash → off entirely. With cached reads it can check reachability (callers,
    related files) without native exploration or modifying anything."
   ["Read" "Grep" "Glob" "LS" "Agent" "Bash" "Write" "Edit" "MultiEdit"])
+
+(def ^:private default-context-window-reserve-tokens
+  "Fallback when reviewer.edn omits :prompt/context-window-reserve-tokens.
+   Headroom kept below the model's context window for the agent CLI's own
+   unmeasured baseline (system prompt, tool schemas, host plugins/skills).
+   Matches the planner default; authority is the EDN."
+  50000)
+
+(defn- assemble-review-within-budget
+  "Reviewer-side N12 §5 budgeting — parallels the planner's
+   `assemble-within-budget`. The artifact-under-review's eagerly-inlined
+   file bodies are the unbounded contributor: an aggregated DAG integration
+   task's full file contents + the reviewer's exploration + the standards
+   addendum overflowed the 200k window → the CLI hard-errored 'Prompt is too
+   long' and the review phase died. When the assembled prompt would
+   overflow, shed those bodies to a manifest the reviewer fetches on demand
+   via `context_read` (read-only session, native Read/Grep disallowed; the
+   context server reads through to the worktree on a cache miss). The
+   standards addendum lives in `effective-system` and is counted toward the
+   estimate but never trimmed here — bailing pre-flight is preferred to
+   silently dropping enforcement rules. Delegates the ladder to
+   `context-budget/assemble-within-budget`."
+  [input effective-system model reserve]
+  (let [artifact (or (:task/artifact input) input)]
+    (context-budget/assemble-within-budget
+     {:effective-system effective-system
+      :model            model
+      :reserve          reserve
+      :build-full       #(reviewer-prompts/build-review-prompt input)
+      :build-shed       #(reviewer-prompts/build-review-prompt
+                          input reviewer-prompts/format-artifact-manifest)
+      :shed-count       (count (:code/files artifact))})))
+
+(defn- emit-prompt-size!
+  "Emit an :agent/prompt-size workflow event recording the reviewer's
+   pre-flight budget (N12 §3) so estimate-vs-window is visible/queryable.
+   Mirrors the planner emitter. Safe no-op without an event stream."
+  [context budget]
+  (when-let [stream (or (:event-stream context) (:execution/event-stream context))]
+    (when-let [wf-id (or (:execution/id context) (:workflow/id context))]
+      (try
+        (es/publish!
+         stream
+         (-> (es/create-envelope stream :agent/prompt-size wf-id
+                                 (str "reviewer prompt ~" (:est-full budget)
+                                      " est tokens / window " (:window budget)
+                                      (when (:shed? budget) " (shed to manifest)")))
+             (assoc :agent/id :reviewer
+                    :prompt/estimated-input-tokens (:est-full budget)
+                    :prompt/context-window (:window budget)
+                    :prompt/reserve (:reserve budget)
+                    :prompt/reserve-clamped? (:reserve-clamped? budget)
+                    :prompt/effective-window (:effective-window budget)
+                    :prompt/shed? (:shed? budget)
+                    :prompt/estimated-after-shed (:est-final budget)
+                    :prompt/file-count (:file-count budget))))
+        (catch Exception _ nil)))))
 
 (defn- invoke-reviewer-session
   "Read-only session body for the reviewer: force the MCP-read tools, build the
@@ -163,8 +222,7 @@
 
           (if llm-client
             ;; LLM + gates review
-            (let [user-prompt (reviewer-prompts/build-review-prompt input)
-                  monitor (reviewer-prompts/create-reviewer-progress-monitor)
+            (let [monitor (reviewer-prompts/create-reviewer-progress-monitor)
                   max-turns (get @reviewer-prompts/reviewer-prompt-data
                                  :prompt/max-turns
                                  reviewer-prompts/default-reviewer-max-turns)
@@ -175,6 +233,44 @@
                   ;; (legacy callers / no rules apply to :review).
                   effective-system (str @reviewer-prompts/reviewer-system-prompt
                                         (get input :task/behavior-addendum ""))
+                  ;; N12 §5: assemble the user-prompt within the model's
+                  ;; context window, shedding the artifact's inlined file
+                  ;; bodies to a context_read-able manifest before the prompt
+                  ;; overflows. Without this the reviewer balloons past 200k
+                  ;; on aggregated DAG integration tasks (full file contents +
+                  ;; standards addendum) → CLI 'Prompt is too long' kills the
+                  ;; review phase.
+                  prompt-budget (assemble-review-within-budget
+                                 input effective-system (:model review-config)
+                                 (get @reviewer-prompts/reviewer-prompt-data
+                                      :prompt/context-window-reserve-tokens
+                                      default-context-window-reserve-tokens))
+                  user-prompt (:user-prompt prompt-budget)
+                  _ (emit-prompt-size! context prompt-budget)
+                  _ (when (:shed? prompt-budget)
+                      (log/info logger :reviewer :reviewer/context-shed
+                                {:data {:file-count (:file-count prompt-budget)
+                                        :window (:window prompt-budget)
+                                        :estimated-tokens-before (:est-full prompt-budget)
+                                        :estimated-tokens-after (:est-final prompt-budget)}}))
+                  ;; Irreducible overflow: the prompt exceeds the window even
+                  ;; with the artifact shed to a manifest (only reachable on a
+                  ;; tiny-window model — production 200k windows fit the shed
+                  ;; form). Skip the doomed LLM call, but STILL run the
+                  ;; deterministic policy gates below and return an infra
+                  ;; failure. The compiled policy gates are the trust boundary
+                  ;; and MUST always apply; the LLM's semantic pass is the only
+                  ;; thing dropped here, and a 'prompt too long' error must
+                  ;; never be synthesized into a false :rejected. N12 §5.4-5.5.
+                  context-overflow? (:over-after-shed? prompt-budget)
+                  overflow-message (when context-overflow?
+                                     (str "Reviewer prompt ~" (:est-final prompt-budget)
+                                          " est tokens exceeds the model context window "
+                                          (:window prompt-budget)
+                                          (if (:shed? prompt-budget)
+                                            " even after shedding the artifact's file bodies to a manifest"
+                                            " and has no inlined file bodies to shed")
+                                          "; LLM semantic review skipped, deterministic gates still applied"))
                   base-opts (cond-> {:system effective-system
                                      :max-turns max-turns}
                               monitor (assoc :progress-monitor monitor))
@@ -189,19 +285,29 @@
                   ;; product) and returns the LLM result directly. The
                   ;; enumeration-retry below keeps base-opts — it re-asks over
                   ;; the same content and needs no tools/cache.
-                  response (artifact-session/with-readonly-session
-                            context
-                            #(invoke-reviewer-session % llm-client user-prompt on-chunk
-                                                      base-opts budget-usd max-turns))
-                  normalized (result-boundary/normalize-llm-result
-                              {:response response
-                               :parse-response llm-response/parse-review-response})
+                  ;; Skip the LLM call entirely on irreducible overflow — the
+                  ;; synthesized error `normalized` below routes to the
+                  ;; context-overflow infra exit; the gates still run.
+                  response (when-not context-overflow?
+                             (artifact-session/with-readonly-session
+                              context
+                              #(invoke-reviewer-session % llm-client user-prompt on-chunk
+                                                        base-opts budget-usd max-turns)))
+                  normalized (if context-overflow?
+                               {:llm-error {:message overflow-message
+                                            :data {:context-overflow true
+                                                   :estimated-tokens (:est-final prompt-budget)
+                                                   :context-window (:window prompt-budget)}}
+                                :content nil :parsed-content nil :tokens 0 :cost-usd nil}
+                               (result-boundary/normalize-llm-result
+                                {:response response
+                                 :parse-response llm-response/parse-review-response}))
                   content (:content normalized)
                   tokens (:tokens normalized)
                   cost-usd (:cost-usd normalized)]
 
               (log/info logger :reviewer :reviewer/llm-called
-                        {:data {:success (llm/success? response)
+                        {:data {:success (boolean (and response (llm/success? response)))
                                 :tokens tokens
                                 :streaming? (boolean on-chunk)}})
 
@@ -244,7 +350,7 @@
                     ;; `recovered-review` below; these are already normalized,
                     ;; not literally "raw".
                     initial-llm-decision (cond
-                                           backend-timeout? nil
+                                           (or backend-timeout? context-overflow?) nil
                                            parse-failed? :rejected
                                            llm-review (issues/normalize-llm-decision (:review/decision llm-review)))
                     ;; Resolve the task's scope once; partitioning happens
@@ -347,7 +453,7 @@
                     ;; pathology the 2026-06-05 dogfood revealed.
                     all-blocking (cond-> (into (vec (:blocking-issues gate-result))
                                                (issues/llm-issues->blocking-strings llm-issues))
-                                   (and parse-failed? (not backend-timeout?))
+                                   (and parse-failed? (not backend-timeout?) (not context-overflow?))
                                    (conj parse-failure-message)
                                    timeout-only-review?
                                    (conj timeout-failure-message))
@@ -373,10 +479,17 @@
 
                     duration (- (System/currentTimeMillis) start-time)]
 
-                (if backend-timeout?
+                (cond
+                  context-overflow?
+                  (artifact/context-overflow-error-result
+                   logger normalized gate-result counts duration overflow-message)
+
+                  backend-timeout?
                   (artifact/timeout-only-error-result
                    logger normalized llm-review gate-result counts duration tokens cost-usd
                    timeout-failure-message)
+
+                  :else
                   (do
                     ;; Observability — when the deterministic gates flip
                     ;; the LLM's verdict, the operator needs to know

--- a/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
@@ -225,6 +225,42 @@
               :tokens tokens}
        cost-usd (assoc :cost-usd cost-usd)))))
 
+(defn context-overflow-error-result
+  "Reviewer exit when the assembled prompt exceeds the model's context window
+   even after shedding the artifact's inlined file bodies to a manifest
+   (N12 §5). Sibling of `timeout-only-error-result`: the LLM never produced a
+   verdict, so this reports an INFRA failure (code `:reviewer/context-overflow`)
+   rather than a bogus code-review rejection — but it still reports the
+   DETERMINISTIC gate outcome. The compiled policy gates are Miniforge's trust
+   boundary and run regardless of prompt size; only the LLM's semantic pass is
+   skipped here, so policy enforcement is never dropped."
+  [logger normalized gate-result counts duration overflow-message]
+  (log/warn logger :reviewer :reviewer/context-overflow
+            {:data {:gate-decision (:decision gate-result)
+                    :gates-passed (:passed counts)
+                    :gates-failed (:failed counts)
+                    :duration-ms duration}})
+  (leave-review logger {:review/decision (:decision gate-result)
+                        :duration-ms duration
+                        :gates-passed (:passed counts)
+                        :gates-failed (:failed counts)
+                        :llm? true
+                        :status :error
+                        :error-code :reviewer/context-overflow})
+  (assoc
+   (result-boundary/error-response
+    normalized
+    overflow-message
+    {:data (merge (or (some-> normalized :llm-error :data) {})
+                  {:code :reviewer/context-overflow})})
+   :metrics
+   {:decision (:decision gate-result)
+    :gates-passed (:passed counts)
+    :gates-failed (:failed counts)
+    :gates-total (:total counts)
+    :duration-ms duration
+    :tokens 0}))
+
 ;------------------------------------------------------------------------------ Layer 4
 ;; Public-API accessors
 ;;

--- a/components/agent/src/ai/miniforge/agent/reviewer/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/prompts.clj
@@ -92,45 +92,74 @@
     :else
     (pr-str artifact)))
 
+(defn format-artifact-manifest
+  "Compact manifest of the artifact-under-review for the shed path (N12 §6):
+   each file's path, action, and size — not its inlined body. The reviewer
+   runs read-only with native Read/Grep disallowed, so it fetches any file
+   on demand via `context_read`, which reads through to the worktree on a
+   cache miss. Mirrors the planner's `format-existing-files-manifest`.
+
+   Only `:code/files` artifacts carry sheddable bodies; plain-string / other
+   shapes have nothing to shed and fall back to the full rendering (the
+   budget ladder treats those as a zero sheddable-unit count, so this
+   fallback is never reached on the shed branch — it just keeps the
+   formatter total over every artifact shape)."
+  [artifact]
+  (if (:code/files artifact)
+    (str "_File bodies omitted to fit the context window — fetch any on "
+         "demand with `context_read`:_\n"
+         (str/join "\n"
+                   (map (fn [{:keys [path content action]}]
+                          (str "- " path " (" (name (or action :unknown)) ")"
+                               (when content (str " (" (count content) " chars)"))))
+                        (:code/files artifact))))
+    (format-artifact-for-review artifact)))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; User-prompt assembly
 
 (defn build-review-prompt
-  "Construct the user prompt for LLM review from task data."
-  [input]
-  (let [artifact (or (:task/artifact input) input)
-        description (or (:task/description input) "")
-        title (or (:task/title input) "")
-        intent (or (:task/intent input) "")
-        constraints (or (:task/constraints input) "")
-        tests (:task/tests input)
-        review-scope (scope/effective-review-scope input)
-        artifact-text (format-artifact-for-review artifact)]
-    (str "Review the following code implementation.\n\n"
-         (when-not (str/blank? title)
-           (str "## Task: " title "\n\n"))
-         (when-not (str/blank? description)
-           (str "## Description\n\n" description "\n\n"))
-         (when (and intent (not (str/blank? (str intent))))
-           (str "## Intent\n\n" (if (string? intent) intent (pr-str intent)) "\n\n"))
-         (when review-scope
-           (str "## Scope\n\n"
-                "Findings inside these paths/prefixes are in-scope; report them in\n"
-                "`:review/issues` with the appropriate severity\n"
-                "(`:blocking` / `:warning` / `:nit`). Normal severity rules apply —\n"
-                "only `:blocking` issues actually block the verdict.\n\n"
-                "Findings outside the scope are out-of-scope — report them in\n"
-                "`:review/out-of-scope-observations`, NOT in `:review/issues`.\n\n"
-                (str/join "\n" (map #(str "- " %) review-scope))
-                "\n\n"))
-         (when (and constraints (not (str/blank? (str constraints))))
-           (str "## Constraints\n\n" (if (string? constraints) constraints (pr-str constraints)) "\n\n"))
-         "## Code to Review\n\n"
-         artifact-text
-         (when tests
-           (str "\n\n## Test Results\n\n"
-                (if (string? tests) tests (pr-str tests))))
-         "\n\nOutput your review as a Clojure map inside a ```clojure code block.")))
+  "Construct the user prompt for LLM review from task data.
+
+   `artifact-fmt` selects how the artifact-under-review is rendered: full
+   bodies by default (`format-artifact-for-review`), or a compact manifest
+   (`format-artifact-manifest`) on the N12 §5 shed path when the full prompt
+   would overflow the model's context window."
+  ([input] (build-review-prompt input format-artifact-for-review))
+  ([input artifact-fmt]
+   (let [artifact (or (:task/artifact input) input)
+         description (or (:task/description input) "")
+         title (or (:task/title input) "")
+         intent (or (:task/intent input) "")
+         constraints (or (:task/constraints input) "")
+         tests (:task/tests input)
+         review-scope (scope/effective-review-scope input)
+         artifact-text (artifact-fmt artifact)]
+     (str "Review the following code implementation.\n\n"
+          (when-not (str/blank? title)
+            (str "## Task: " title "\n\n"))
+          (when-not (str/blank? description)
+            (str "## Description\n\n" description "\n\n"))
+          (when (and intent (not (str/blank? (str intent))))
+            (str "## Intent\n\n" (if (string? intent) intent (pr-str intent)) "\n\n"))
+          (when review-scope
+            (str "## Scope\n\n"
+                 "Findings inside these paths/prefixes are in-scope; report them in\n"
+                 "`:review/issues` with the appropriate severity\n"
+                 "(`:blocking` / `:warning` / `:nit`). Normal severity rules apply —\n"
+                 "only `:blocking` issues actually block the verdict.\n\n"
+                 "Findings outside the scope are out-of-scope — report them in\n"
+                 "`:review/out-of-scope-observations`, NOT in `:review/issues`.\n\n"
+                 (str/join "\n" (map #(str "- " %) review-scope))
+                 "\n\n"))
+          (when (and constraints (not (str/blank? (str constraints))))
+            (str "## Constraints\n\n" (if (string? constraints) constraints (pr-str constraints)) "\n\n"))
+          "## Code to Review\n\n"
+          artifact-text
+          (when tests
+            (str "\n\n## Test Results\n\n"
+                 (if (string? tests) tests (pr-str tests))))
+          "\n\nOutput your review as a Clojure map inside a ```clojure code block."))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Enumeration retry

--- a/components/agent/src/ai/miniforge/agent/reviewer/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/prompts.clj
@@ -93,7 +93,7 @@
     (pr-str artifact)))
 
 (defn format-artifact-manifest
-  "Compact manifest of the artifact-under-review for the shed path (N12 §6):
+  "Compact manifest of the artifact-under-review for the shed path (N12 §5):
    each file's path, action, and size — not its inlined body. The reviewer
    runs read-only with native Read/Grep disallowed, so it fetches any file
    on demand via `context_read`, which reads through to the worktree on a

--- a/components/agent/test/ai/miniforge/agent/context_budget_test.clj
+++ b/components/agent/test/ai/miniforge/agent/context_budget_test.clj
@@ -1,0 +1,110 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.context-budget-test
+  "Tests for the shared N12 §5 context-window budgeting ladder. The planner
+   and reviewer each wrap this with role-specific prompt builders; here it is
+   exercised directly with synthetic builders so the ladder's behavior is
+   pinned independent of either role's prompt shape.
+
+   `codellama-34b` is a 16384-token-window catalog entry (the same one the
+   planner budget test uses); deriving thresholds from the returned window
+   keeps the asserts off hard-coded sizes."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.agent.context-budget :as cb]))
+
+(defn- assemble [m]
+  (cb/assemble-within-budget
+   (merge {:effective-system "system"
+           :reserve 0
+           :build-full (constantly "FULL")
+           :build-shed (constantly "SHED")
+           :shed-count 1}
+          m)))
+
+(deftest assemble-within-budget-test
+  (testing "uncatalogued model (nil window) → never sheds, full prompt kept"
+    (let [r (assemble {:model "no-such-model"})]
+      (is (nil? (:window r)))
+      (is (false? (:shed? r)))
+      (is (false? (:over-after-shed? r)))
+      (is (= "FULL" (:user-prompt r)))))
+
+  (testing "a small prompt under the window is not shed"
+    (let [r (assemble {:model "codellama-34b"})]
+      (is (false? (:shed? r)))
+      (is (= "FULL" (:user-prompt r)))
+      (is (= (:est-full r) (:est-final r)))))
+
+  (testing "a full prompt over the window sheds to the shed builder's output"
+    (let [big (apply str (repeat 300000 \x))
+          r (assemble {:model "codellama-34b"
+                       :build-full (constantly big)
+                       :build-shed (constantly "manifest")})]
+      (is (true? (:shed? r)))
+      (is (false? (:over-after-shed? r)))
+      (is (= "manifest" (:user-prompt r)))
+      (is (< (:est-final r) (:est-full r)))))
+
+  (testing "shed-count 0 → nothing to shed → irreducible overflow, full kept"
+    (let [big (apply str (repeat 300000 \x))
+          r (assemble {:model "codellama-34b"
+                       :build-full (constantly big)
+                       :shed-count 0})]
+      (is (false? (:shed? r)))
+      (is (true? (:over-after-shed? r)))
+      (is (= big (:user-prompt r)))))
+
+  (testing "the shed form is still over the window → shed? true AND over-after-shed? true"
+    (let [big (apply str (repeat 300000 \x))
+          r (assemble {:model "codellama-34b"
+                       :build-full (constantly big)
+                       :build-shed (constantly big)})]
+      (is (true? (:shed? r)))
+      (is (true? (:over-after-shed? r)))))
+
+  (testing "the reserve drops the effective window and fires the shed earlier"
+    (let [content    (apply str (repeat 50000 \x))
+          no-reserve (assemble {:model "codellama-34b"
+                                :build-full (constantly content)
+                                :build-shed (constantly "m")})
+          window     (:window no-reserve)
+          est        (:est-full no-reserve)
+          ;; a reserve that drops the effective window just below the estimate,
+          ;; kept under window/2 so it isn't clamped
+          reserve    (+ (- window est) 1000)
+          reserved   (assemble {:model "codellama-34b"
+                                :reserve reserve
+                                :build-full (constantly content)
+                                :build-shed (constantly "m")})]
+      (is (false? (:shed? no-reserve)) "fits the full window with no reserve")
+      (is (true? (:shed? reserved)) "reserve pushes it past the effective window")
+      (is (false? (:reserve-clamped? reserved)))
+      (is (= (- window reserve) (:effective-window reserved)))))
+
+  (testing "a reserve >= window is clamped so it can't zero the effective window"
+    (let [r (assemble {:model "codellama-34b" :reserve 999999
+                       :build-full (constantly "tiny")})]
+      (is (true? (:reserve-clamped? r)))
+      (is (pos? (:effective-window r)) "effective window is never zeroed")
+      (is (false? (:shed? r)) "a trivial prompt still fits")
+      (is (false? (:over-after-shed? r)))))
+
+  (testing ":file-count echoes the supplied shed-count"
+    (is (= 7 (:file-count (assemble {:model "codellama-34b" :shed-count 7}))))))

--- a/components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj
@@ -24,7 +24,8 @@
    accessors used by phase-software-factory."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.agent.reviewer.artifact :as artifact]))
+   [ai.miniforge.agent.reviewer.artifact :as artifact]
+   [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Factories
 
@@ -270,3 +271,37 @@
     ;; Callers may pass a nil review artifact when a previous phase failed
     ;; to produce output.  The predicate must return false, not throw.
     (is (not (artifact/rejection-warnings-only? nil)))))
+
+;------------------------------------------------------------------------------ context-overflow-error-result (N12 §5)
+
+(deftest context-overflow-error-result-test
+  (let [logger (log/create-logger {:min-level :error :output (fn [_])})
+        msg (str "Reviewer prompt ~250000 est tokens exceeds the model context "
+                 "window 200000; LLM semantic review skipped, deterministic "
+                 "gates still applied")
+        ;; Mirror the producer: reviewer.clj synthesizes the normalized
+        ;; :llm-error :message AS the overflow message, so error-response
+        ;; surfaces it verbatim (it prefers :llm-error :message over the
+        ;; default arg).
+        normalized {:llm-error {:message msg :data {:context-overflow true}}}]
+    (testing "reports an INFRA failure, never a synthesized code-review rejection"
+      (let [result (artifact/context-overflow-error-result
+                     logger normalized
+                     {:decision :approved :blocking-issues [] :warnings []}
+                     {:passed 4 :failed 0 :total 4} 1234 msg)]
+        (is (= :error (:status result)))
+        (is (= :reviewer/context-overflow (get-in result [:error :data :code])))
+        (is (re-find #"deterministic gates still applied" (get-in result [:error :message])))
+        (testing "still reports the deterministic gate outcome (policy gates applied)"
+          (is (= :approved (get-in result [:metrics :decision])))
+          (is (= 4 (get-in result [:metrics :gates-passed])))
+          (is (= 0 (get-in result [:metrics :gates-failed])))
+          (is (= 4 (get-in result [:metrics :gates-total]))))))
+
+    (testing "a gate-blocking verdict survives the overflow exit — overflow never auto-approves a policy violation"
+      (let [blocked (artifact/context-overflow-error-result
+                      logger normalized
+                      {:decision :rejected :blocking-issues ["secret committed"] :warnings []}
+                      {:passed 3 :failed 1 :total 4} 99 msg)]
+        (is (= :rejected (get-in blocked [:metrics :decision])))
+        (is (= 1 (get-in blocked [:metrics :gates-failed])))))))

--- a/components/agent/test/ai/miniforge/agent/reviewer/prompts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/prompts_test.clj
@@ -50,6 +50,50 @@
   (testing "other shapes round-trip via pr-str"
     (is (= "{:k 1}" (reviewer-prompts/format-artifact-for-review {:k 1})))))
 
+;------------------------------------------------------------------------------ format-artifact-manifest (N12 §5 shed path)
+
+(deftest format-artifact-manifest-test
+  (testing "CodeArtifact renders each file as path + action + size, omitting the body"
+    (let [out (reviewer-prompts/format-artifact-manifest
+                {:code/files [{:path "src/a.clj" :content "(def x 1)" :action :create}
+                              {:path "src/b.clj" :content "(def y 2)" :action :modify}]})]
+      (is (re-find #"src/a\.clj \(create\) \(9 chars\)" out))
+      (is (re-find #"src/b\.clj \(modify\) \(9 chars\)" out))
+      ;; the inlined body is gone — only the manifest line remains
+      (is (not (re-find #"\(def x 1\)" out)))
+      (is (not (re-find #"```" out)))
+      ;; and the reviewer is told how to fetch a body on demand
+      (is (re-find #"context_read" out))))
+
+  (testing "missing :action defaults to :unknown"
+    (is (re-find #"\(unknown\)"
+                 (reviewer-prompts/format-artifact-manifest
+                   {:code/files [{:path "p" :content "c"}]}))))
+
+  (testing "non-CodeArtifact shapes have nothing to shed → full rendering"
+    (is (= "literal" (reviewer-prompts/format-artifact-manifest "literal")))
+    (is (= "{:k 1}" (reviewer-prompts/format-artifact-manifest {:k 1})))))
+
+;------------------------------------------------------------------------------ build-review-prompt — manifest artifact formatter
+
+(deftest build-review-prompt-manifest-arity-test
+  (let [input {:task/title "T"
+               :task/scope ["src"]
+               :task/artifact {:code/files [{:path "src/a.clj"
+                                             :content "(def x 1)"
+                                             :action :modify}]}}]
+    (testing "default arity inlines the file body"
+      (let [prompt (reviewer-prompts/build-review-prompt input)]
+        (is (re-find #"\(def x 1\)" prompt))))
+
+    (testing "manifest arity sheds the body but keeps the path + context_read hint"
+      (let [prompt (reviewer-prompts/build-review-prompt
+                     input reviewer-prompts/format-artifact-manifest)]
+        (is (re-find #"## Code to Review" prompt))
+        (is (re-find #"src/a\.clj" prompt))
+        (is (re-find #"context_read" prompt))
+        (is (not (re-find #"\(def x 1\)" prompt)))))))
+
 ;------------------------------------------------------------------------------ build-review-prompt — section rendering
 
 (deftest build-review-prompt-renders-scope-section-test

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.agent.reviewer-test
   "Tests for the reviewer agent."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.reviewer :as reviewer]
@@ -974,3 +975,93 @@
             cache. Pinned so any change is deliberate."
     (is (= #{"Read" "Grep" "Glob" "LS" "Agent" "Bash" "Write" "Edit" "MultiEdit"}
            (set @#'reviewer/reviewer-disallowed-tools)))))
+
+;------------------------------------------------------------------------------ Context-budget shedding (N12 §5)
+
+(def ^:private assemble-review-within-budget #'reviewer/assemble-review-within-budget)
+
+(defn- code-artifact
+  "n files, each `chars` bytes of body — the inlined contributor the reviewer
+   sheds when the prompt would overflow."
+  [n chars]
+  {:code/files (vec (for [i (range n)]
+                      {:path (str "src/f" i ".clj")
+                       :action :modify
+                       :content (apply str (repeat chars \x))}))})
+
+(defn- review-input [artifact]
+  {:task/title "T" :task/scope ["src"] :task/artifact artifact})
+
+(deftest assemble-review-within-budget-test
+  (testing "uncatalogued model (nil window) → never sheds, full bodies inlined"
+    (let [r (assemble-review-within-budget (review-input (code-artifact 1 100))
+                                           "system" "no-such-model" 0)]
+      (is (false? (:shed? r)))
+      (is (false? (:over-after-shed? r)))
+      (is (str/includes? (:user-prompt r) (apply str (repeat 100 \x))))))
+
+  (testing "a small artifact under the window is not shed"
+    (let [r (assemble-review-within-budget (review-input (code-artifact 1 100))
+                                           "system" "codellama-34b" 0)]
+      (is (false? (:shed? r)))
+      (is (str/includes? (:user-prompt r) (apply str (repeat 100 \x))))))
+
+  (testing "an artifact that blows the window sheds bodies to a manifest: the
+            path + the context_read hint stay, the inlined body drops, the
+            prompt now fits, and the file-count is reported"
+    (let [r (assemble-review-within-budget (review-input (code-artifact 1 300000))
+                                           "system" "codellama-34b" 0)]
+      (is (true? (:shed? r)))
+      (is (false? (:over-after-shed? r)))
+      (is (= 1 (:file-count r)))
+      (is (< (:est-final r) (:est-full r)))
+      (is (str/includes? (:user-prompt r) "src/f0.clj"))
+      (is (str/includes? (:user-prompt r) "context_read"))
+      (is (not (str/includes? (:user-prompt r) (apply str (repeat 5000 \x)))))))
+
+  (testing "the reserve fires the shed earlier — a prompt that fits the full
+            window sheds once the reserve drops the effective window below it"
+    (let [input      (review-input (code-artifact 1 50000))
+          no-reserve (assemble-review-within-budget input "system" "codellama-34b" 0)
+          window     (:window no-reserve)
+          est        (:est-full no-reserve)
+          reserve    (+ (- window est) 1000)
+          reserved   (assemble-review-within-budget input "system" "codellama-34b" reserve)]
+      (is (false? (:shed? no-reserve)) "fits the full window with no reserve")
+      (is (true? (:shed? reserved)) "reserve pushes it past the effective window")
+      (is (false? (:reserve-clamped? reserved)))
+      (is (= (- window reserve) (:effective-window reserved)))))
+
+  (testing "no inlined file bodies (empty :code/files) + a huge description →
+            irreducible overflow, no shed"
+    (let [r (assemble-review-within-budget
+             {:task/title "T" :task/scope ["src"]
+              :task/description (apply str (repeat 300000 \y))
+              :task/artifact {:code/files []}}
+             "system" "codellama-34b" 0)]
+      (is (false? (:shed? r)))
+      (is (true? (:over-after-shed? r))))))
+
+(deftest test-reviewer-context-overflow-applies-gates-without-llm
+  (testing "irreducible context overflow skips the doomed LLM call but STILL
+            runs the deterministic policy gates and returns an infra failure,
+            never a synthesized rejection — policy enforcement is never dropped
+            (the trust boundary)"
+    (let [llm-called? (atom false)]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                    ;; Force overflow regardless of the real catalog window.
+                    llm/context-window-for-model-id (fn [_] 100)
+                    llm/chat (fn [_ _ _] (reset! llm-called? true)
+                               (mock-llm-response valid-review-content))
+                    llm/chat-stream (fn [_ _ _ _] (reset! llm-called? true)
+                                      (mock-llm-response valid-review-content))]
+        (let [reviewer (reviewer/create-reviewer
+                        {:llm-backend ::mock-backend
+                         :gates [(passing-gate :policy-check)]})
+              result (core/invoke reviewer {} sample-artifact)]
+          (is (false? @llm-called?) "the doomed LLM call is skipped")
+          (is (= :error (:status result)) "returns an infra failure, not a review verdict")
+          (is (= :reviewer/context-overflow (get-in result [:error :data :code])))
+          (is (= 1 (get-in result [:metrics :gates-passed]))
+              "the deterministic policy gate still ran")
+          (is (= 0 (get-in result [:metrics :tokens]))))))))


### PR DESCRIPTION
## Problem

The reviewer had no context budgeting. On an aggregated DAG integration task it inlined the full file contents of every artifact file plus the ~38k standards pack into a single prompt; the input reached 237k tokens, exceeded the model's ~200k window, and the Claude CLI hard-errored `Prompt is too long` — killing the review phase. This is the recurring blocker behind the dogfood's review failures.

The planner already got model-aware budgeting (#1091 `context-window-for-model-id` + headroom reserve + eager file shedding). The reviewer never did.

## Fix

Mirror the planner's N12 §5 ladder for the reviewer:

- Derive the window from the model id, reserve headroom for the agent CLI's unmeasured baseline (system prompt, tool schemas, host plugins) — 50k, matching the planner.
- When the assembled prompt would overflow, shed the artifact's inlined file bodies to a manifest (paths + size). The reviewer runs read-only with native Read/Grep disallowed, so it fetches any shed file on demand via `context_read`, which reads through to the worktree on a cache miss (`context_cache.clj`) — the bodies stay reachable, the prompt fits.
- The standards addendum is counted toward the estimate but **never trimmed** — review quality is unchanged.

The role-agnostic ladder is extracted into `ai.miniforge.agent.context-budget`, shared by the planner and reviewer. The planner's `assemble-within-budget` becomes a thin wrapper (signature + existing tests intact).

## Trust boundary: every defined policy is still applied

On an *irreducible* overflow (only reachable on a tiny-window model — production 200k windows fit the shed form), the reviewer skips the doomed LLM call but **still runs the deterministic policy gates** and returns an infra failure (`:reviewer/context-overflow`) — never a synthesized "prompt too long" rejection. The compiled policy gates are the hard enforcement layer and run regardless of prompt size; only the LLM's semantic pass is dropped. A too-big task fails closed rather than auto-approving.

This was a bug in the first cut of this change (an earlier draft threw before the gates ran, which would have skipped policy enforcement on overflow). The gate-preserving path is now covered by tests.

## Tests

- `context_budget_test` — the shared ladder (fits / sheds / irreducible-overflow / reserve / clamp).
- `reviewer/prompts_test` — `format-artifact-manifest` + the manifest arity of `build-review-prompt`.
- `reviewer_test` — `assemble-review-within-budget` ladder, and an end-to-end test proving overflow skips the LLM yet still runs the gates and returns the infra failure.
- `reviewer/artifact_test` — `context-overflow-error-result` reports the gate outcome (incl. a gate-blocking verdict surviving the overflow exit) and never auto-approves.
- Planner tests unchanged and green.

Full pre-commit gate passed locally: poly:check, clj-kondo, precommit smoke (314 tests / 1185 assertions), graalvm (6 / 517) — 0 failures.

## Follow-up (separate waves)

The artifact shed is all-or-nothing (full → manifest), mirroring the planner; a partial largest-file-first shed is a later refinement if manifest-only review proves too blind on real runs. Compacting the ~38k standards addendum for review (drop verbose `:rule/knowledge-content`, keep `:rule/agent-behavior`) was explicitly scoped out here to avoid changing what the reviewer enforces against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)