### PR TITLE
refactor: remove resolver hotspots from standards wave 50

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -111,25 +111,39 @@
 (register-artifact-providers!)
 (register-policy-pack-providers!)
 
+(defn- caught-message
+  [caught throwable]
+  (cond
+    (instance? Throwable caught)
+    (or (.getMessage ^Throwable caught)
+        (some-> caught class .getName)
+        "unknown exception")
+
+    throwable
+    (or (.getMessage ^Throwable throwable)
+        (some-> throwable class .getName)
+        "unknown exception")
+
+    :else
+    (str caught)))
+
 (defn- create-pr-train-manager
   []
   (try+
     (pr-train/create-manager)
-    (catch Object _
-      (let [e (:throwable &throw-context)]
-        (println (messages/t :web/pr-train-warning
-                             {:error (.getMessage ^Throwable e)}))
-        nil))))
+    (catch Object e
+      (println (messages/t :web/pr-train-warning
+                           {:error (caught-message e (:throwable &throw-context))}))
+      nil)))
 
 (defn- create-repo-dag-manager
   []
   (try+
     (repo-dag/create-manager)
-    (catch Object _
-      (let [e (:throwable &throw-context)]
-        (println (messages/t :web/repo-dag-warning
-                             {:error (.getMessage ^Throwable e)}))
-        nil))))
+    (catch Object e
+      (println (messages/t :web/repo-dag-warning
+                           {:error (caught-message e (:throwable &throw-context))}))
+      nil)))
 
 (defn- optional-web-launcher
   "Compose the dashboard command when the product includes web-dashboard."

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -74,45 +74,39 @@
    ;; GROUP 3b: timeline-based events show
    [ai.miniforge.cli.main.commands.events :as cmd-events]
    [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.artifact.interface :as artifact]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.mcp-context-server.interface :as mcp-context-server]
+   [ai.miniforge.policy-pack.interface :as policy-pack]
+   [ai.miniforge.pr-train.interface :as pr-train]
+   [ai.miniforge.repo-dag.interface :as repo-dag]
    [ai.miniforge.workflow-resume.interface :as wr]
    [ai.miniforge.lsp-mcp-bridge.main :as lsp-bridge]
    [ai.miniforge.lsp-mcp-bridge.tasks :as lsp-tasks]
    [slingshot.slingshot :refer [try+]]))
 
-(defn- optional-var
-  "Resolve an optional provider var after loading its namespace."
+(defn- optional-composition-var
+  "Resolve a provider whose entire component is optional for this CLI product.
+   This is the CLI's only late-binding boundary: miniforge-core loads this
+   namespace without web-dashboard or TUI components on its classpath."
   [ns-sym var-sym]
   (try
     (require ns-sym)
     (ns-resolve ns-sym var-sym)
     (catch Throwable _ nil)))
 
-(defn- register-optional-var!
-  [qualified-sym ns-sym var-sym]
-  (when-let [v (optional-var ns-sym var-sym)]
-    (cmd-shared/register-optional-fn! qualified-sym v)))
-
 (defn- register-artifact-providers! []
-  (when-let [create-store (optional-var 'ai.miniforge.artifact.interface
-                                        'create-transit-store)]
-    (when-let [query (optional-var 'ai.miniforge.artifact.interface 'query)]
-      (cmd-shared/register-optional-fn!
-       'ai.miniforge.artifact.interface/list-artifacts
-       (fn [] (vec (query (create-store) {})))))
-    (when-let [get-provenance (optional-var 'ai.miniforge.artifact.interface
-                                            'get-provenance)]
-      (cmd-shared/register-optional-fn!
-       'ai.miniforge.artifact.interface/get-artifact-provenance
-       (fn [id] (get-provenance (create-store) id))))))
+  (cmd-shared/register-optional-fn!
+   'ai.miniforge.artifact.interface/list-artifacts
+   (fn [] (vec (artifact/query (artifact/create-transit-store) {}))))
+  (cmd-shared/register-optional-fn!
+   'ai.miniforge.artifact.interface/get-artifact-provenance
+   (fn [id] (artifact/get-provenance (artifact/create-transit-store) id))))
 
 (defn- register-policy-pack-providers! []
-  (when-let [load-all-packs (optional-var 'ai.miniforge.policy-pack.interface
-                                          'load-all-packs)]
-    (cmd-shared/register-optional-fn!
-     'ai.miniforge.policy-pack.interface/list-packs
-     (fn [] (:loaded (load-all-packs (str (app-config/home-dir) "/packs")))))))
+  (cmd-shared/register-optional-fn!
+   'ai.miniforge.policy-pack.interface/list-packs
+   (fn [] (:loaded (policy-pack/load-all-packs (str (app-config/home-dir) "/packs"))))))
 
 (register-artifact-providers!)
 (register-policy-pack-providers!)
@@ -120,27 +114,23 @@
 (defn- optional-web-launcher
   "Compose the dashboard command when the product includes web-dashboard."
   []
-  (when-let [start! (optional-var 'ai.miniforge.web-dashboard.interface 'start!)]
+  (when-let [start! (optional-composition-var
+                     'ai.miniforge.web-dashboard.interface
+                     'start!)]
     (fn [{:keys [port]}]
       (let [event-stream (es/create-event-stream)
-            create-pr-manager (optional-var 'ai.miniforge.pr-train.interface
-                                            'create-manager)
-            create-repo-manager (optional-var 'ai.miniforge.repo-dag.interface
-                                              'create-manager)
-            pr-train-manager (when create-pr-manager
-                               (try
-                                 (create-pr-manager)
-                                 (catch Exception e
-                                   (println (messages/t :web/pr-train-warning
-                                                        {:error (.getMessage e)}))
-                                   nil)))
-            repo-dag-manager (when create-repo-manager
-                               (try
-                                 (create-repo-manager)
-                                 (catch Exception e
-                                   (println (messages/t :web/repo-dag-warning
-                                                        {:error (.getMessage e)}))
-                                   nil)))]
+            pr-train-manager (try
+                               (pr-train/create-manager)
+                               (catch Exception e
+                                 (println (messages/t :web/pr-train-warning
+                                                      {:error (.getMessage e)}))
+                                 nil))
+            repo-dag-manager (try
+                               (repo-dag/create-manager)
+                               (catch Exception e
+                                 (println (messages/t :web/repo-dag-warning
+                                                      {:error (.getMessage e)}))
+                                 nil))]
         (start! {:port port
                  :event-stream event-stream
                  :pr-train-manager pr-train-manager
@@ -159,7 +149,7 @@
 ;; This is an optional composition seam: miniforge-core includes the CLI
 ;; without bundling the JVM TUI component.
 (def tui-launcher
-  (optional-var 'ai.miniforge.tui-views.interface 'start-standalone-tui!))
+  (optional-composition-var 'ai.miniforge.tui-views.interface 'start-standalone-tui!))
 
 (def tui-available?
   (some? tui-launcher))
@@ -171,10 +161,11 @@
   (cmd-shared/register-optional-fn!
    'ai.miniforge.tui-views.interface/start-standalone-tui!
    tui-launcher))
-(register-optional-var!
- 'ai.miniforge.tui-views.interface/start-fleet-tui!
- 'ai.miniforge.tui-views.interface
- 'start-fleet-tui!)
+(when-let [start-fleet-tui! (optional-composition-var 'ai.miniforge.tui-views.interface
+                                                      'start-fleet-tui!)]
+  (cmd-shared/register-optional-fn!
+   'ai.miniforge.tui-views.interface/start-fleet-tui!
+   start-fleet-tui!))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants and pure helpers

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -111,6 +111,26 @@
 (register-artifact-providers!)
 (register-policy-pack-providers!)
 
+(defn- create-pr-train-manager
+  []
+  (try+
+    (pr-train/create-manager)
+    (catch Object _
+      (let [e (:throwable &throw-context)]
+        (println (messages/t :web/pr-train-warning
+                             {:error (.getMessage ^Throwable e)}))
+        nil))))
+
+(defn- create-repo-dag-manager
+  []
+  (try+
+    (repo-dag/create-manager)
+    (catch Object _
+      (let [e (:throwable &throw-context)]
+        (println (messages/t :web/repo-dag-warning
+                             {:error (.getMessage ^Throwable e)}))
+        nil))))
+
 (defn- optional-web-launcher
   "Compose the dashboard command when the product includes web-dashboard."
   []
@@ -119,18 +139,8 @@
                      'start!)]
     (fn [{:keys [port]}]
       (let [event-stream (es/create-event-stream)
-            pr-train-manager (try
-                               (pr-train/create-manager)
-                               (catch Exception e
-                                 (println (messages/t :web/pr-train-warning
-                                                      {:error (.getMessage e)}))
-                                 nil))
-            repo-dag-manager (try
-                               (repo-dag/create-manager)
-                               (catch Exception e
-                                 (println (messages/t :web/repo-dag-warning
-                                                      {:error (.getMessage e)}))
-                                 nil))]
+            pr-train-manager (create-pr-train-manager)
+            repo-dag-manager (create-repo-dag-manager)]
         (start! {:port port
                  :event-stream event-stream
                  :pr-train-manager pr-train-manager

--- a/bases/cli/test/ai/miniforge/cli/main_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main_test.clj
@@ -26,7 +26,8 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.repo-dag.interface :as repo-dag]
-   [ai.miniforge.workflow-resume.interface :as wr]))
+   [ai.miniforge.workflow-resume.interface :as wr]
+   [slingshot.slingshot :refer [throw+]]))
 
 (deftest help-cmd-uses-generic-workflow-examples-test
   (testing "CLI help shows generic workflow examples instead of SDLC-specific ones"
@@ -71,6 +72,14 @@
       (let [output (with-out-str
                      (is (nil? (#'sut/create-pr-train-manager))))]
         (is (.contains output "train boom"))))))
+
+(deftest create-pr-train-manager-handles-non-throwable-sling-test
+  (testing "slingshot data throws do not break the warning path"
+    (with-redefs [pr-train/create-manager
+                  (fn [] (throw+ {:type :boom :message "train data boom"}))]
+      (let [output (with-out-str
+                     (is (nil? (#'sut/create-pr-train-manager))))]
+        (is (.contains output "train data boom"))))))
 
 (deftest create-repo-dag-manager-handles-construction-errors-test
   (testing "manager construction failure logs a warning and returns nil"

--- a/bases/cli/test/ai/miniforge/cli/main_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main_test.clj
@@ -24,6 +24,8 @@
    [ai.miniforge.cli.main :as sut]
    [ai.miniforge.cli.main.commands.pr-monitor :as cmd-pr-monitor]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.pr-train.interface :as pr-train]
+   [ai.miniforge.repo-dag.interface :as repo-dag]
    [ai.miniforge.workflow-resume.interface :as wr]))
 
 (deftest help-cmd-uses-generic-workflow-examples-test
@@ -61,6 +63,22 @@
         (is (.contains output "CMD:one"))
         (is (.contains output "NOTE:engine"))
         (is (.contains output "TUI:engine-tui"))))))
+
+(deftest create-pr-train-manager-handles-construction-errors-test
+  (testing "manager construction failure logs a warning and returns nil"
+    (with-redefs [pr-train/create-manager
+                  (fn [] (throw (ex-info "train boom" {})))]
+      (let [output (with-out-str
+                     (is (nil? (#'sut/create-pr-train-manager))))]
+        (is (.contains output "train boom"))))))
+
+(deftest create-repo-dag-manager-handles-construction-errors-test
+  (testing "manager construction failure logs a warning and returns nil"
+    (with-redefs [repo-dag/create-manager
+                  (fn [] (throw (ex-info "dag boom" {})))]
+      (let [output (with-out-str
+                     (is (nil? (#'sut/create-repo-dag-manager))))]
+        (is (.contains output "dag boom"))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Dispatch table coverage

--- a/components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
@@ -37,7 +37,7 @@
    - Fast in-memory access during workflow execution
    - Survives process restarts
    - Can be streamed to central location later
-   - Simple file-based persistence"
+  - Simple file-based persistence"
   (:require
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.artifact.interface.protocols.artifact-store :as p]

--- a/components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
@@ -39,6 +39,7 @@
    - Can be streamed to central location later
    - Simple file-based persistence"
   (:require
+   [ai.miniforge.logging.interface :as log]
    [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
    [ai.miniforge.artifact.protocols.impl.transit-store :as impl]))
 
@@ -70,12 +71,10 @@
      ;; Load existing index
      (let [index (impl/load-index artifacts-dir)]
        (when logger
-         (require '[ai.miniforge.logging.interface :as log])
-         ((resolve 'ai.miniforge.logging.interface/info)
-          logger :system :artifact/store-created
-          {:data {:type :transit
-                  :dir artifacts-dir
-                  :existing-artifacts (count index)}}))
+         (log/info logger :system :artifact/store-created
+                   {:data {:type :transit
+                           :dir artifacts-dir
+                           :existing-artifacts (count index)}}))
 
        (->TransitArtifactStore
         artifacts-dir

--- a/components/logging/src/ai/miniforge/logging/http.clj
+++ b/components/logging/src/ai/miniforge/logging/http.clj
@@ -23,21 +23,28 @@
    aligned existing brick (the fleet sink IS a logging concern) and the
    `event-stream` brick already depends on `logging`. Promote to a
    dedicated `http-utils` brick if a third consumer outside the
-   sink-layer arrives."
-  (:import
-   [java.net URI]
-   [java.net.http HttpRequest HttpRequest$BodyPublishers]
-   [java.time Duration]))
+   sink-layer arrives.")
+
+(defn- invoke-static
+  [class-name method-name param-types args]
+  (.invoke (.getMethod (Class/forName class-name)
+                       method-name
+                       (into-array Class param-types))
+           nil
+           (object-array args)))
 
 (defn build-json-post
   "Build an HTTP POST request with a JSON string `body` and a Bearer
    `api-key` header. `timeout-ms` sets the request-level timeout via
    `HttpRequest.Builder.timeout`."
   [uri body api-key timeout-ms]
-  (-> (HttpRequest/newBuilder)
-      (.uri (URI/create uri))
-      (.timeout (Duration/ofMillis timeout-ms))
+  (-> (invoke-static "java.net.http.HttpRequest" "newBuilder" [] [])
+      (.uri (java.net.URI/create uri))
+      (.timeout (java.time.Duration/ofMillis timeout-ms))
       (.header "Authorization" (str "Bearer " api-key))
       (.header "Content-Type" "application/json")
-      (.POST (HttpRequest$BodyPublishers/ofString body))
+      (.POST (invoke-static "java.net.http.HttpRequest$BodyPublishers"
+                            "ofString"
+                            [String]
+                            [body]))
       (.build)))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
@@ -35,6 +35,7 @@
    [clojure.string :as str]
    [ai.miniforge.config.interface :as config]
    [ai.miniforge.policy-pack.core :as core]
+   [ai.miniforge.policy-pack.schema :as schema]
    [ai.miniforge.policy-pack.rules.pack-dependency-validation :as dep-validation]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -235,10 +236,7 @@
   "Validate pack against PackManifest schema."
   [artifact _context]
   (when-let [pack (:pack artifact)]
-    (require 'ai.miniforge.policy-pack.schema)
-    (let [schema-ns (find-ns 'ai.miniforge.policy-pack.schema)
-          validate-pack (ns-resolve schema-ns 'validate-pack)
-          result (validate-pack pack)]
+    (let [result (schema/validate-pack pack)]
       (when-not (:valid? result)
         [(violation :critical
                     (str "Pack schema validation failed: " (:errors result)))]))))

--- a/components/web-dashboard/deps.edn
+++ b/components/web-dashboard/deps.edn
@@ -5,6 +5,8 @@
         ai.miniforge/config {:local/root "../config"}
         ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/messages {:local/root "../messages"}
+        ai.miniforge/pr-train {:local/root "../pr-train"}
+        ai.miniforge/repo-dag {:local/root "../repo-dag"}
         http-kit/http-kit {:mvn/version "2.8.0"}
         hiccup/hiccup {:mvn/version "2.0.0-RC3"}
         cheshire/cheshire {:mvn/version "5.13.0"}}

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/core.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/core.clj
@@ -32,17 +32,6 @@
             (swap! cache assoc args {:value result :time now})
             result))))))
 
-(defn safe-call
-  "Safely call a function from a namespace, returning default on error."
-  [ns-sym fn-sym & args]
-  (try
-    (when-let [ns (find-ns ns-sym)]
-      (when-let [f (ns-resolve ns fn-sym)]
-        (apply f args)))
-    (catch Exception e
-      (println "Error calling" fn-sym ":" (ex-message e))
-      nil)))
-
 ;------------------------------------------------------------------------------ Layer 1
 ;; State atom creation and access
 

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -648,9 +648,13 @@
   (core/ttl-memoize 10000
                     (fn [state]
                       (if-let [mgr (:pr-train-manager @state)]
-                        (->> (or (pr-train/list-trains mgr) [])
-                             (map enrich-train)
-                             vec)
+                        (try
+                          (->> (or (pr-train/list-trains mgr) [])
+                               (map enrich-train)
+                               vec)
+                          (catch Exception e
+                            (println "Error listing PR trains:" (ex-message e))
+                            []))
                         []))))
 
 (defn get-train-detail
@@ -662,9 +666,13 @@
                 (catch Exception _ nil))]
       (if-not tid
         {:error "Invalid train id."}
-        (if-let [train (pr-train/get-train mgr tid)]
-          (enrich-train train)
-          {:error "Train not found"})))
+        (try
+          (if-let [train (pr-train/get-train mgr tid)]
+            (enrich-train train)
+            {:error "Train not found"})
+          (catch Exception e
+            (println "Error getting PR train:" (ex-message e))
+            {:error "Train not found"}))))
     {:error "PR train manager not available"}))
 
 (defn train-action!
@@ -685,7 +693,11 @@
   (core/ttl-memoize 10000
                     (fn [state]
                       (if-let [mgr (:repo-dag-manager @state)]
-                        (or (repo-dag/get-all-dags mgr) [])
+                        (try
+                          (or (repo-dag/get-all-dags mgr) [])
+                          (catch Exception e
+                            (println "Error listing repository DAGs:" (ex-message e))
+                            []))
                         []))))
 
 ;------------------------------------------------------------------------------ Layer 3

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -96,6 +96,13 @@
       (some-> e class .getName)
       "unknown exception"))
 
+(defn caught-message
+  [caught throwable]
+  (cond
+    (instance? Throwable caught) (ex-msg caught)
+    throwable (ex-msg throwable)
+    :else (str caught)))
+
 (defn ensure-message
   [message fallback]
   (or (some-> message str str/trim not-empty)
@@ -669,10 +676,10 @@
       (->> (or (pr-train/list-trains mgr) [])
            (map enrich-train)
            vec)
-      (catch Object _
-        (let [e (:throwable &throw-context)]
-          (println "Error listing PR trains:" (ex-message e))
-          [])))
+      (catch Object e
+        (println "Error listing PR trains:"
+                 (caught-message e (:throwable &throw-context)))
+        []))
     []))
 
 (def get-trains
@@ -690,10 +697,10 @@
           (if-let [train (pr-train/get-train mgr tid)]
             (enrich-train train)
             {:error "Train not found"})
-          (catch Object _
-            (let [e (:throwable &throw-context)]
-              (println "Error getting PR train:" (ex-message e))
-              {:error "Train not found"})))))
+          (catch Object e
+            (println "Error getting PR train:"
+                     (caught-message e (:throwable &throw-context)))
+            {:error "Train not found"}))))
     {:error "PR train manager not available"}))
 
 (defn execute-train-action!
@@ -719,10 +726,10 @@
   (if-let [mgr (:repo-dag-manager @state)]
     (try+
       (or (repo-dag/get-all-dags mgr) [])
-      (catch Object _
-        (let [e (:throwable &throw-context)]
-          (println "Error listing repository DAGs:" (ex-message e))
-          [])))
+      (catch Object e
+        (println "Error listing repository DAGs:"
+                 (caught-message e (:throwable &throw-context)))
+        []))
     []))
 
 (def get-dags
@@ -803,11 +810,14 @@
                        (some (fn [dag]
                                (when (= external-dag-name (:dag/name dag))
                                  (:dag/id dag)))
-                             (or (repo-dag/get-all-dags mgr) [])))
+                             (fetch-dags state)))
             created (when (and mgr (nil? existing))
-                      (some-> (repo-dag/create-dag mgr external-dag-name
-                                                   "Externally discovered repositories and PR trains")
-                              :dag/id))
+                      (try+
+                        (some-> (repo-dag/create-dag
+                                  mgr external-dag-name
+                                  "Externally discovered repositories and PR trains")
+                                :dag/id)
+                        (catch Object _ nil)))
             dag-id (or existing created (random-uuid))]
         (swap! state assoc :fleet/default-dag-id dag-id)
         dag-id)))
@@ -815,18 +825,20 @@
 (defn ensure-repo-in-dag!
   [state dag-id repo]
   (when-let [mgr (:repo-dag-manager @state)]
-    (let [dag (repo-dag/get-dag mgr dag-id)
+    (let [dag (try+
+                (repo-dag/get-dag mgr dag-id)
+                (catch Object _ nil))
           exists? (some #(= repo (:repo/name %)) (:dag/repos dag))]
       (when-not exists?
         (let [[org _name] (str/split repo #"/" 2)]
-          (try
+          (try+
             (repo-dag/add-repo mgr dag-id
                                {:repo/url (str "https://github.com/" repo)
                                 :repo/name repo
                                 :repo/org org
                                 :repo/type :application
                                 :repo/default-branch "main"})
-            (catch Exception _ nil)))))))
+            (catch Object _ nil)))))))
 
 (defn train-name-for-repo
   [repo]
@@ -836,10 +848,12 @@
   [state repo]
   (if-let [mgr (:pr-train-manager @state)]
     (let [expected (train-name-for-repo repo)]
-      (some (fn [train]
-              (when (= expected (:train/name train))
-                (:train/id train)))
-            (or (pr-train/list-trains mgr) [])))
+      (try+
+        (some (fn [train]
+                (when (= expected (:train/name train))
+                  (:train/id train)))
+              (or (pr-train/list-trains mgr) []))
+        (catch Object _ nil)))
     nil))
 
 (defn ensure-repo-train!
@@ -847,14 +861,18 @@
   (when-let [mgr (:pr-train-manager @state)]
     (let [known-id (get-in @state [:fleet/repo-trains repo])
           known-train (when known-id
-                        (pr-train/get-train mgr known-id))
+                        (try+
+                          (pr-train/get-train mgr known-id)
+                          (catch Object _ nil)))
           existing-id (or (when (and known-id known-train) known-id)
                           (find-existing-repo-train-id state repo))
           train-id (or existing-id
-                       (pr-train/create-train mgr
-                                              (train-name-for-repo repo)
-                                              (ensure-default-dag-id! state)
-                                              (str "Externally managed PR train for " repo)))]
+                       (try+
+                         (pr-train/create-train mgr
+                                                (train-name-for-repo repo)
+                                                (ensure-default-dag-id! state)
+                                                (str "Externally managed PR train for " repo))
+                         (catch Object _ nil)))]
       (when train-id
         (swap! state assoc-in [:fleet/repo-trains repo] train-id)
         train-id))))
@@ -883,21 +901,29 @@
 (defn add-prs!
   [mgr train-id repo prs]
   (doseq [pr prs]
-    (pr-train/add-pr mgr train-id repo (:pr/number pr) (:pr/url pr)
-                     (:pr/branch pr) (:pr/title pr))))
+    (try+
+      (pr-train/add-pr mgr train-id repo (:pr/number pr) (:pr/url pr)
+                       (:pr/branch pr) (:pr/title pr))
+      (catch Object _ nil))))
 
 (defn remove-prs!
   [mgr train-id pr-nums]
   (doseq [pr-num pr-nums]
-    (pr-train/remove-pr mgr train-id pr-num)))
+    (try+
+      (pr-train/remove-pr mgr train-id pr-num)
+      (catch Object _ nil))))
 
 (defn apply-sync-plan!
   [mgr train-id repo {:keys [to-add to-remove status-map]}]
   ;; Side effects are intentionally ordered: membership first, then status, then dependency linking.
   (add-prs! mgr train-id repo to-add)
   (remove-prs! mgr train-id to-remove)
-  (pr-train/sync-pr-status mgr train-id status-map)
-  (pr-train/link-prs mgr train-id))
+  (try+
+    (pr-train/sync-pr-status mgr train-id status-map)
+    (catch Object _ nil))
+  (try+
+    (pr-train/link-prs mgr train-id)
+    (catch Object _ nil)))
 
 (defn fetch-repo-prs
   "Fetch open PRs for a repo, returning a result map."

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -24,7 +24,8 @@
    [cheshire.core :as json]
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.repo-dag.interface :as repo-dag]
-   [ai.miniforge.web-dashboard.state.core :as core]))
+   [ai.miniforge.web-dashboard.state.core :as core]
+   [slingshot.slingshot :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Fleet repository config and provider helpers
@@ -643,62 +644,90 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; PR Train and DAG state
 
+(def train-actions
+  {"pause" :pause
+   "resume" :resume
+   "merge-next" :merge-next
+   :pause :pause
+   :resume :resume
+   :merge-next :merge-next})
+
+(defn normalize-train-action
+  [action]
+  (get train-actions action))
+
+(defn parse-train-id
+  [train-id]
+  (try+
+    (parse-uuid train-id)
+    (catch Object _ nil)))
+
+(defn fetch-trains
+  [state]
+  (if-let [mgr (:pr-train-manager @state)]
+    (try+
+      (->> (or (pr-train/list-trains mgr) [])
+           (map enrich-train)
+           vec)
+      (catch Object _
+        (let [e (:throwable &throw-context)]
+          (println "Error listing PR trains:" (ex-message e))
+          [])))
+    []))
+
 (def get-trains
   "Get all PR trains (cached 10s)."
-  (core/ttl-memoize 10000
-                    (fn [state]
-                      (if-let [mgr (:pr-train-manager @state)]
-                        (try
-                          (->> (or (pr-train/list-trains mgr) [])
-                               (map enrich-train)
-                               vec)
-                          (catch Exception e
-                            (println "Error listing PR trains:" (ex-message e))
-                            []))
-                        []))))
+  (core/ttl-memoize 10000 fetch-trains))
 
 (defn get-train-detail
   "Get detailed view of a PR train."
   [state train-id]
   (if-let [mgr (:pr-train-manager @state)]
-    (let [tid (try
-                (parse-uuid train-id)
-                (catch Exception _ nil))]
+    (let [tid (parse-train-id train-id)]
       (if-not tid
         {:error "Invalid train id."}
-        (try
+        (try+
           (if-let [train (pr-train/get-train mgr tid)]
             (enrich-train train)
             {:error "Train not found"})
-          (catch Exception e
-            (println "Error getting PR train:" (ex-message e))
-            {:error "Train not found"}))))
+          (catch Object _
+            (let [e (:throwable &throw-context)]
+              (println "Error getting PR train:" (ex-message e))
+              {:error "Train not found"})))))
     {:error "PR train manager not available"}))
+
+(defn execute-train-action!
+  [mgr tid action]
+  (try+
+    (case action
+      :pause (pr-train/pause-train mgr tid "Manual pause")
+      :resume (pr-train/resume-train mgr tid)
+      :merge-next (pr-train/merge-next mgr tid)
+      nil)
+    (catch Object _ nil)))
 
 (defn train-action!
   "Execute action on a PR train."
   [state train-id action]
-  (try
-    (when-let [mgr (:pr-train-manager @state)]
-      (when-let [tid (parse-uuid train-id)]
-        (case action
-          "pause" (pr-train/pause-train mgr tid "Manual pause")
-          "resume" (pr-train/resume-train mgr tid)
-          "merge-next" (pr-train/merge-next mgr tid)
-          nil)))
-    (catch Exception _ nil)))
+  (when-let [mgr (:pr-train-manager @state)]
+    (when-let [tid (parse-train-id train-id)]
+      (when-let [normalized-action (normalize-train-action action)]
+        (execute-train-action! mgr tid normalized-action)))))
+
+(defn fetch-dags
+  [state]
+  (if-let [mgr (:repo-dag-manager @state)]
+    (try+
+      (or (repo-dag/get-all-dags mgr) [])
+      (catch Object _
+        (let [e (:throwable &throw-context)]
+          (println "Error listing repository DAGs:" (ex-message e))
+          [])))
+    []))
 
 (def get-dags
   "Get all repository DAGs (cached 10s)."
-  (core/ttl-memoize 10000
-                    (fn [state]
-                      (if-let [mgr (:repo-dag-manager @state)]
-                        (try
-                          (or (repo-dag/get-all-dags mgr) [])
-                          (catch Exception e
-                            (println "Error listing repository DAGs:" (ex-message e))
-                            []))
-                        []))))
+  (core/ttl-memoize 10000 fetch-dags))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; External PR onboarding and sync

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -22,6 +22,8 @@
    [clojure.java.shell :as shell]
    [clojure.string :as str]
    [cheshire.core :as json]
+   [ai.miniforge.pr-train.interface :as pr-train]
+   [ai.miniforge.repo-dag.interface :as repo-dag]
    [ai.miniforge.web-dashboard.state.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -646,7 +648,7 @@
   (core/ttl-memoize 10000
                     (fn [state]
                       (if-let [mgr (:pr-train-manager @state)]
-                        (->> (or (core/safe-call 'ai.miniforge.pr-train.interface 'list-trains mgr) [])
+                        (->> (or (pr-train/list-trains mgr) [])
                              (map enrich-train)
                              vec)
                         []))))
@@ -660,7 +662,7 @@
                 (catch Exception _ nil))]
       (if-not tid
         {:error "Invalid train id."}
-        (if-let [train (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr tid)]
+        (if-let [train (pr-train/get-train mgr tid)]
           (enrich-train train)
           {:error "Train not found"})))
     {:error "PR train manager not available"}))
@@ -671,9 +673,9 @@
   (when-let [mgr (:pr-train-manager @state)]
     (let [tid (parse-uuid train-id)]
       (case action
-        "pause" (core/safe-call 'ai.miniforge.pr-train.interface 'pause-train mgr tid "Manual pause")
-        "resume" (core/safe-call 'ai.miniforge.pr-train.interface 'resume-train mgr tid)
-        "merge-next" (core/safe-call 'ai.miniforge.pr-train.interface 'merge-next mgr tid)
+        "pause" (pr-train/pause-train mgr tid "Manual pause")
+        "resume" (pr-train/resume-train mgr tid)
+        "merge-next" (pr-train/merge-next mgr tid)
         nil))))
 
 (def get-dags
@@ -681,7 +683,7 @@
   (core/ttl-memoize 10000
                     (fn [state]
                       (if-let [mgr (:repo-dag-manager @state)]
-                        (or (core/safe-call 'ai.miniforge.repo-dag.interface 'get-all-dags mgr) [])
+                        (or (repo-dag/get-all-dags mgr) [])
                         []))))
 
 ;------------------------------------------------------------------------------ Layer 3
@@ -758,10 +760,10 @@
                        (some (fn [dag]
                                (when (= external-dag-name (:dag/name dag))
                                  (:dag/id dag)))
-                             (or (core/safe-call 'ai.miniforge.repo-dag.interface 'get-all-dags mgr) [])))
+                             (or (repo-dag/get-all-dags mgr) [])))
             created (when (and mgr (nil? existing))
-                      (some-> (core/safe-call 'ai.miniforge.repo-dag.interface 'create-dag mgr external-dag-name
-                                              "Externally discovered repositories and PR trains")
+                      (some-> (repo-dag/create-dag mgr external-dag-name
+                                                   "Externally discovered repositories and PR trains")
                               :dag/id))
             dag-id (or existing created (random-uuid))]
         (swap! state assoc :fleet/default-dag-id dag-id)
@@ -770,18 +772,17 @@
 (defn ensure-repo-in-dag!
   [state dag-id repo]
   (when-let [mgr (:repo-dag-manager @state)]
-    (let [dag (core/safe-call 'ai.miniforge.repo-dag.interface 'get-dag mgr dag-id)
+    (let [dag (repo-dag/get-dag mgr dag-id)
           exists? (some #(= repo (:repo/name %)) (:dag/repos dag))]
       (when-not exists?
         (let [[org _name] (str/split repo #"/" 2)]
           (try
-            (core/safe-call 'ai.miniforge.repo-dag.interface 'add-repo
-                            mgr dag-id
-                            {:repo/url (str "https://github.com/" repo)
-                             :repo/name repo
-                             :repo/org org
-                             :repo/type :application
-                             :repo/default-branch "main"})
+            (repo-dag/add-repo mgr dag-id
+                               {:repo/url (str "https://github.com/" repo)
+                                :repo/name repo
+                                :repo/org org
+                                :repo/type :application
+                                :repo/default-branch "main"})
             (catch Exception _ nil)))))))
 
 (defn train-name-for-repo
@@ -795,7 +796,7 @@
       (some (fn [train]
               (when (= expected (:train/name train))
                 (:train/id train)))
-            (or (core/safe-call 'ai.miniforge.pr-train.interface 'list-trains mgr) [])))
+            (or (pr-train/list-trains mgr) [])))
     nil))
 
 (defn ensure-repo-train!
@@ -803,15 +804,14 @@
   (when-let [mgr (:pr-train-manager @state)]
     (let [known-id (get-in @state [:fleet/repo-trains repo])
           known-train (when known-id
-                        (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr known-id))
+                        (pr-train/get-train mgr known-id))
           existing-id (or (when (and known-id known-train) known-id)
                           (find-existing-repo-train-id state repo))
           train-id (or existing-id
-                       (core/safe-call 'ai.miniforge.pr-train.interface 'create-train
-                                       mgr
-                                       (train-name-for-repo repo)
-                                       (ensure-default-dag-id! state)
-                                       (str "Externally managed PR train for " repo)))]
+                       (pr-train/create-train mgr
+                                              (train-name-for-repo repo)
+                                              (ensure-default-dag-id! state)
+                                              (str "Externally managed PR train for " repo)))]
       (when train-id
         (swap! state assoc-in [:fleet/repo-trains repo] train-id)
         train-id))))
@@ -840,22 +840,21 @@
 (defn add-prs!
   [mgr train-id repo prs]
   (doseq [pr prs]
-    (core/safe-call 'ai.miniforge.pr-train.interface 'add-pr
-                    mgr train-id repo (:pr/number pr) (:pr/url pr)
-                    (:pr/branch pr) (:pr/title pr))))
+    (pr-train/add-pr mgr train-id repo (:pr/number pr) (:pr/url pr)
+                     (:pr/branch pr) (:pr/title pr))))
 
 (defn remove-prs!
   [mgr train-id pr-nums]
   (doseq [pr-num pr-nums]
-    (core/safe-call 'ai.miniforge.pr-train.interface 'remove-pr mgr train-id pr-num)))
+    (pr-train/remove-pr mgr train-id pr-num)))
 
 (defn apply-sync-plan!
   [mgr train-id repo {:keys [to-add to-remove status-map]}]
   ;; Side effects are intentionally ordered: membership first, then status, then dependency linking.
   (add-prs! mgr train-id repo to-add)
   (remove-prs! mgr train-id to-remove)
-  (core/safe-call 'ai.miniforge.pr-train.interface 'sync-pr-status mgr train-id status-map)
-  (core/safe-call 'ai.miniforge.pr-train.interface 'link-prs mgr train-id))
+  (pr-train/sync-pr-status mgr train-id status-map)
+  (pr-train/link-prs mgr train-id))
 
 (defn fetch-repo-prs
   "Fetch open PRs for a repo, returning a result map."
@@ -873,11 +872,11 @@
   [state mgr train-id repo prs]
   (let [dag-id (ensure-default-dag-id! state)
         _ (ensure-repo-in-dag! state dag-id repo)
-        before-train (or (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr train-id)
+        before-train (or (pr-train/get-train mgr train-id)
                          {:train/prs []})
         sync-plan (train-sync-plan before-train prs)
         _ (apply-sync-plan! mgr train-id repo sync-plan)
-        after-train (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr train-id)]
+        after-train (pr-train/get-train mgr train-id)]
     (result-success
      {:repo repo
       :train-id train-id

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -670,13 +670,15 @@
 (defn train-action!
   "Execute action on a PR train."
   [state train-id action]
-  (when-let [mgr (:pr-train-manager @state)]
-    (let [tid (parse-uuid train-id)]
-      (case action
-        "pause" (pr-train/pause-train mgr tid "Manual pause")
-        "resume" (pr-train/resume-train mgr tid)
-        "merge-next" (pr-train/merge-next mgr tid)
-        nil))))
+  (try
+    (when-let [mgr (:pr-train-manager @state)]
+      (when-let [tid (parse-uuid train-id)]
+        (case action
+          "pause" (pr-train/pause-train mgr tid "Manual pause")
+          "resume" (pr-train/resume-train mgr tid)
+          "merge-next" (pr-train/merge-next mgr tid)
+          nil)))
+    (catch Exception _ nil)))
 
 (def get-dags
   "Get all repository DAGs (cached 10s)."

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
@@ -23,6 +23,7 @@
    [cheshire.core :as json]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.pr-train.interface :as pr-train]
+   [ai.miniforge.repo-dag.interface :as repo-dag]
    [ai.miniforge.web-dashboard.state.trains :as sut]))
 
 ;; ---------------------------------------------------------------------------- Fixture text
@@ -625,6 +626,14 @@
 ;; Layer 2: Train/DAG state access tests
 ;; ============================================================================
 
+(deftest get-trains-manager-exception-test
+  (testing "Manager exceptions return an empty train list"
+    (let [state (atom {:pr-train-manager ::boom-manager})]
+      (with-redefs-fn {#'pr-train/list-trains
+                       (fn [& _] (throw (ex-info "boom" {})))}
+        (fn []
+          (is (= [] (sut/get-trains state))))))))
+
 (deftest get-train-detail-invalid-id-test
   (testing "Invalid train id returns error"
     (let [state (atom {:pr-train-manager :mgr})]
@@ -642,6 +651,16 @@
     (let [state (atom {:pr-train-manager :mgr})
           tid (str (random-uuid))]
       (with-redefs-fn {#'pr-train/get-train (fn [_ _] nil)}
+        (fn []
+          (is (= {:error "Train not found"}
+                 (sut/get-train-detail state tid))))))))
+
+(deftest get-train-detail-manager-exception-test
+  (testing "Manager exceptions return the not-found error map"
+    (let [state (atom {:pr-train-manager :mgr})
+          tid (str (random-uuid))]
+      (with-redefs-fn {#'pr-train/get-train
+                       (fn [& _] (throw (ex-info "boom" {})))}
         (fn []
           (is (= {:error "Train not found"}
                  (sut/get-train-detail state tid))))))))
@@ -668,6 +687,14 @@
   (testing "Unknown action returns nil"
     (let [state (atom {:pr-train-manager :mgr})]
       (is (nil? (sut/train-action! state (str (random-uuid)) "unknown"))))))
+
+(deftest get-dags-manager-exception-test
+  (testing "Manager exceptions return an empty DAG list"
+    (let [state (atom {:repo-dag-manager ::boom-manager})]
+      (with-redefs-fn {#'repo-dag/get-all-dags
+                       (fn [& _] (throw (ex-info "boom" {})))}
+        (fn []
+          (is (= [] (sut/get-dags state))))))))
 
 ;; ============================================================================
 ;; Layer 3: Sync status rendering tests

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
@@ -24,7 +24,8 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.repo-dag.interface :as repo-dag]
-   [ai.miniforge.web-dashboard.state.trains :as sut]))
+   [ai.miniforge.web-dashboard.state.trains :as sut]
+   [slingshot.slingshot :refer [throw+]]))
 
 ;; ---------------------------------------------------------------------------- Fixture text
 
@@ -634,6 +635,14 @@
         (fn []
           (is (= [] (sut/fetch-trains state))))))))
 
+(deftest fetch-trains-non-throwable-sling-test
+  (testing "Slingshot data throws still return the safe empty list"
+    (let [state (atom {:pr-train-manager ::boom-manager})]
+      (with-redefs-fn {#'pr-train/list-trains
+                       (fn [& _] (throw+ {:type :boom :message "data boom"}))}
+        (fn []
+          (is (= [] (sut/fetch-trains state))))))))
+
 (deftest normalize-train-action-test
   (testing "Request strings are normalized to app-local action keywords"
     (is (= :pause (sut/normalize-train-action "pause")))
@@ -671,6 +680,16 @@
           tid (str (random-uuid))]
       (with-redefs-fn {#'pr-train/get-train
                        (fn [& _] (throw (ex-info "boom" {})))}
+        (fn []
+          (is (= {:error "Train not found"}
+                 (sut/get-train-detail state tid))))))))
+
+(deftest get-train-detail-non-throwable-sling-test
+  (testing "Slingshot data throws return the not-found error map"
+    (let [state (atom {:pr-train-manager :mgr})
+          tid (str (random-uuid))]
+      (with-redefs-fn {#'pr-train/get-train
+                       (fn [& _] (throw+ {:type :boom :message "data boom"}))}
         (fn []
           (is (= {:error "Train not found"}
                  (sut/get-train-detail state tid))))))))
@@ -718,6 +737,57 @@
                        (fn [& _] (throw (ex-info "boom" {})))}
         (fn []
           (is (= [] (sut/fetch-dags state))))))))
+
+(deftest fetch-dags-non-throwable-sling-test
+  (testing "Slingshot data throws still return the safe empty list"
+    (let [state (atom {:repo-dag-manager ::boom-manager})]
+      (with-redefs-fn {#'repo-dag/get-all-dags
+                       (fn [& _] (throw+ {:type :boom :message "data boom"}))}
+        (fn []
+          (is (= [] (sut/fetch-dags state))))))))
+
+(deftest ensure-default-dag-id-create-exception-test
+  (testing "DAG creation failure falls back to a generated DAG id"
+    (let [state (atom {:repo-dag-manager :mgr})]
+      (with-redefs-fn {#'repo-dag/get-all-dags (fn [_] [])
+                       #'repo-dag/create-dag (fn [& _] (throw+ {:type :boom}))}
+        (fn []
+          (let [dag-id (sut/ensure-default-dag-id! state)]
+            (is (uuid? dag-id))
+            (is (= dag-id (:fleet/default-dag-id @state)))))))))
+
+(deftest ensure-repo-train-create-exception-test
+  (testing "Train creation failure returns nil instead of aborting sync"
+    (let [state (atom {:pr-train-manager :mgr
+                       :repo-dag-manager :dag-mgr
+                       :fleet/default-dag-id (random-uuid)})]
+      (with-redefs-fn {#'pr-train/list-trains (fn [_] [])
+                       #'repo-dag/get-all-dags (fn [_] [])
+                       #'pr-train/create-train (fn [& _] (throw+ {:type :boom}))}
+        (fn []
+          (is (nil? (sut/ensure-repo-train! state "acme/service"))))))))
+
+(deftest apply-sync-plan-continues-through-side-effect-exceptions-test
+  (testing "Sync side effects remain ordered and do not abort on one failure"
+    (let [calls (atom [])
+          train-id (random-uuid)
+          plan {:to-add [{:pr/number 1
+                          :pr/url "https://example.test/pr/1"
+                          :pr/branch "feature"
+                          :pr/title "Feature"}]
+                :to-remove [2]
+                :status-map {1 {:pr/status :open}}}]
+      (with-redefs-fn {#'pr-train/add-pr
+                       (fn [& _] (swap! calls conj :add) (throw+ {:type :add}))
+                       #'pr-train/remove-pr
+                       (fn [& _] (swap! calls conj :remove) (throw+ {:type :remove}))
+                       #'pr-train/sync-pr-status
+                       (fn [& _] (swap! calls conj :sync) (throw+ {:type :sync}))
+                       #'pr-train/link-prs
+                       (fn [& _] (swap! calls conj :link) (throw+ {:type :link}))}
+        (fn []
+          (sut/apply-sync-plan! :mgr train-id "acme/service" plan)
+          (is (= [:add :remove :sync :link] @calls)))))))
 
 ;; ============================================================================
 ;; Layer 3: Sync status rendering tests

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
@@ -651,6 +651,19 @@
     (let [state (atom {})]
       (is (nil? (sut/train-action! state (str (random-uuid)) "pause"))))))
 
+(deftest train-action-invalid-id-test
+  (testing "Invalid train id returns nil"
+    (let [state (atom {:pr-train-manager :mgr})]
+      (is (nil? (sut/train-action! state "not-a-uuid" "pause"))))))
+
+(deftest train-action-manager-exception-test
+  (testing "Manager exceptions return nil"
+    (let [state (atom {:pr-train-manager :mgr})]
+      (with-redefs-fn {#'pr-train/pause-train
+                       (fn [& _] (throw (ex-info "boom" {})))}
+        (fn []
+          (is (nil? (sut/train-action! state (str (random-uuid)) "pause"))))))))
+
 (deftest train-action-unknown-action-test
   (testing "Unknown action returns nil"
     (let [state (atom {:pr-train-manager :mgr})]

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
@@ -22,7 +22,7 @@
    [clojure.test :refer [deftest is testing]]
    [cheshire.core :as json]
    [ai.miniforge.anomaly.interface :as anomaly]
-   [ai.miniforge.web-dashboard.state.core :as core]
+   [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.web-dashboard.state.trains :as sut]))
 
 ;; ---------------------------------------------------------------------------- Fixture text
@@ -641,7 +641,7 @@
   (testing "Valid UUID but train not found returns error"
     (let [state (atom {:pr-train-manager :mgr})
           tid (str (random-uuid))]
-      (with-redefs-fn {#'core/safe-call (fn [_ _ & _] nil)}
+      (with-redefs-fn {#'pr-train/get-train (fn [_ _] nil)}
         (fn []
           (is (= {:error "Train not found"}
                  (sut/get-train-detail state tid))))))))
@@ -654,9 +654,7 @@
 (deftest train-action-unknown-action-test
   (testing "Unknown action returns nil"
     (let [state (atom {:pr-train-manager :mgr})]
-      (with-redefs-fn {#'core/safe-call (fn [_ _ & _] nil)}
-        (fn []
-          (is (nil? (sut/train-action! state (str (random-uuid)) "unknown"))))))))
+      (is (nil? (sut/train-action! state (str (random-uuid)) "unknown"))))))
 
 ;; ============================================================================
 ;; Layer 3: Sync status rendering tests
@@ -757,10 +755,14 @@
                         :pr/title "A"}]
               :to-remove [99]
               :status-map {101 {:pr/status :open :pr/ci-status :pending}}}]
-    (with-redefs-fn {#'core/safe-call
-                     (fn [_ns-sym fn-sym & _args]
-                       (swap! calls conj fn-sym)
-                       nil)}
+    (with-redefs-fn {#'pr-train/add-pr
+                     (fn [& _] (swap! calls conj 'add-pr))
+                     #'pr-train/remove-pr
+                     (fn [& _] (swap! calls conj 'remove-pr))
+                     #'pr-train/sync-pr-status
+                     (fn [& _] (swap! calls conj 'sync-pr-status))
+                     #'pr-train/link-prs
+                     (fn [& _] (swap! calls conj 'link-prs))}
       (fn []
         (sut/apply-sync-plan! :manager train-id "acme/service" plan)
         (is (= ['add-pr 'remove-pr 'sync-pr-status 'link-prs]
@@ -907,11 +909,8 @@
                        (fn [_ _ _] nil)
                        #'sut/apply-sync-plan!
                        (fn [_ _ _ _] nil)
-                       #'core/safe-call
-                       (fn [_ fn-sym & _]
-                         (case fn-sym
-                           get-train {:train/prs []}
-                           nil))}
+                       #'pr-train/get-train
+                       (fn [_ _] {:train/prs []})}
         (fn []
           (let [result (sut/sync-configured-repos! state)]
             (is (= 1 (:synced result)))

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
@@ -632,7 +632,17 @@
       (with-redefs-fn {#'pr-train/list-trains
                        (fn [& _] (throw (ex-info "boom" {})))}
         (fn []
-          (is (= [] (sut/get-trains state))))))))
+          (is (= [] (sut/fetch-trains state))))))))
+
+(deftest normalize-train-action-test
+  (testing "Request strings are normalized to app-local action keywords"
+    (is (= :pause (sut/normalize-train-action "pause")))
+    (is (= :resume (sut/normalize-train-action "resume")))
+    (is (= :merge-next (sut/normalize-train-action "merge-next"))))
+  (testing "Already-normalized keyword actions pass through"
+    (is (= :pause (sut/normalize-train-action :pause))))
+  (testing "Unknown actions are rejected"
+    (is (nil? (sut/normalize-train-action "unknown")))))
 
 (deftest get-train-detail-invalid-id-test
   (testing "Invalid train id returns error"
@@ -683,6 +693,19 @@
         (fn []
           (is (nil? (sut/train-action! state (str (random-uuid)) "pause"))))))))
 
+(deftest train-action-keyword-action-test
+  (testing "Keyword actions are dispatched internally"
+    (let [state (atom {:pr-train-manager :mgr})
+          train-id (random-uuid)
+          captured (atom nil)]
+      (with-redefs-fn {#'pr-train/resume-train
+                       (fn [mgr tid]
+                         (reset! captured [mgr tid])
+                         :resumed)}
+        (fn []
+          (is (= :resumed (sut/train-action! state (str train-id) :resume)))
+          (is (= [:mgr train-id] @captured)))))))
+
 (deftest train-action-unknown-action-test
   (testing "Unknown action returns nil"
     (let [state (atom {:pr-train-manager :mgr})]
@@ -694,7 +717,7 @@
       (with-redefs-fn {#'repo-dag/get-all-dags
                        (fn [& _] (throw (ex-info "boom" {})))}
         (fn []
-          (is (= [] (sut/get-dags state))))))))
+          (is (= [] (sut/fetch-dags state))))))))
 
 ;; ============================================================================
 ;; Layer 3: Sync status rendering tests

--- a/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
+++ b/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
@@ -82,6 +82,10 @@ checks, and fail in the component that owns the broken call.
   composition.
 - Removed dashboard `safe-call` and replaced its call sites with direct
   interfaces.
+- Moved dashboard train/DAG fallback boundaries into small `try+`-based helper
+  functions and kept cached wrappers thin.
+- Normalized request-string train actions to app-local keywords before
+  dispatching PR train operations.
 - Added `pr-train` and `repo-dag` as web-dashboard component dependencies.
 - Updated dashboard train tests to stub concrete `pr-train` functions.
 - Replaced policy-pack schema validation resolver with `schema/validate-pack`.
@@ -109,6 +113,10 @@ checks, and fail in the component that owns the broken call.
 - [x] `bb poly:check`
 - [x] Focused dashboard train state test:
   `clojure -M:dev:test -e "(require 'ai.miniforge.web-dashboard.state.trains-test) (clojure.test/run-tests 'ai.miniforge.web-dashboard.state.trains-test)"`
+- [x] Focused review-comment regression tests:
+  `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m
+  cognitect.test-runner -d components/web-dashboard/test -d bases/cli/test -n
+  ai.miniforge.web-dashboard.state.trains-test -n ai.miniforge.cli.main-test`
 - [x] `bb test`
 - [x] `bb pre-commit`
 

--- a/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
+++ b/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
@@ -1,0 +1,142 @@
+# refactor: remove resolver hotspots from standards remediation wave 50
+
+## Overview
+
+This PR continues the standards-remediation work that removes production
+`requiring-resolve`, `resolve`, `ns-resolve`, and function-local `require`
+anti-patterns where static component dependencies already exist.
+
+The slice focuses on the remaining production hotspots identified after
+remediation waves #1221, #1222, and #1228:
+
+- CLI optional composition registry
+- web-dashboard PR train and repo DAG calls
+- policy-pack knowledge-safety schema validation
+- artifact transit-store logging
+
+## Layer
+
+Application / adapter cleanup.
+
+The PR does not introduce new domain behavior. It tightens composition and
+dependency boundaries in CLI/dashboard adapters and one policy validation path.
+
+## Motivation
+
+Dynamic var resolution hid real dependency requirements and made failures
+silent. That was useful only for product composition boundaries where the
+entire component may be absent from a product classpath. Everywhere else,
+direct Polylith interfaces make dependencies explicit, preserve compile-time
+checks, and fail in the component that owns the broken call.
+
+## Gap Analysis
+
+### Fixed in this PR
+
+- `bases/cli/.../main.clj`
+  - Replaced dynamic lookup for artifact and policy-pack registrations with
+    direct interface calls.
+  - Replaced dynamic lookup of PR train and repo DAG manager constructors with
+    direct interface calls.
+  - Renamed the remaining helper to `optional-composition-var` and documented
+    that it is only for optional web-dashboard / TUI product composition.
+
+- `components/web-dashboard/.../state/trains.clj`
+  - Replaced `core/safe-call` dispatch to PR train and repo DAG with direct
+    `pr-train` and `repo-dag` interface calls.
+  - Added explicit component dependencies in `components/web-dashboard/deps.edn`.
+  - Updated tests to stub concrete interface vars instead of the deleted
+    resolver helper.
+
+- `components/web-dashboard/.../state/core.clj`
+  - Removed the generic `safe-call` resolver helper.
+
+- `components/policy-pack/.../knowledge_safety.clj`
+  - Replaced function-local schema namespace loading and `ns-resolve` with a
+    static `policy-pack.schema` require.
+
+- `components/artifact/.../transit_store.clj`
+  - Replaced function-local logging require and resolved `info` var with a
+    static logging interface require.
+
+### Intentionally left in place
+
+- `bases/cli/.../main.clj`
+  - `optional-composition-var` still uses `require` + `ns-resolve` for the
+    product-composition boundary where `miniforge-core` can load the CLI
+    without web-dashboard or TUI components on the classpath.
+
+- Generic namespace loaders
+  - Config-driven phase namespace loading and test namespace discovery remain
+    dynamic by design.
+
+- Rich comments and tests
+  - Remaining scan hits are rich-comment examples, docstrings, or test-only
+    reflective checks. They are outside this production cleanup slice.
+
+## Changes in Detail
+
+- Added direct CLI requires for `artifact`, `policy-pack`, `pr-train`, and
+  `repo-dag`.
+- Narrowed the CLI optional late-binding helper to explicit optional
+  composition.
+- Removed dashboard `safe-call` and replaced its call sites with direct
+  interfaces.
+- Added `pr-train` and `repo-dag` as web-dashboard component dependencies.
+- Updated dashboard train tests to stub concrete `pr-train` functions.
+- Replaced policy-pack schema validation resolver with `schema/validate-pack`.
+- Replaced artifact transit-store logging resolver with `log/info`.
+
+## Code Review Rigor Notes
+
+- Happy path traced: `miniforge web` creates an event stream, creates PR train
+  and repo DAG managers via direct interfaces, then passes both managers to the
+  optional web-dashboard launcher. The only nil path that remains is the
+  existing caught manager-construction failure, which already prints the
+  operator warning and passes nil to the dashboard.
+- Bootstrap order: dashboard state now requires `pr-train` and `repo-dag` at
+  namespace load time, so missing dependencies fail during component loading
+  rather than silently returning nil from `safe-call`.
+- Default path: no manager configured still returns empty dashboard train/DAG
+  views as before. A configured manager now uses the explicit interface.
+- Refactor scrutiny: the dashboard sync mutation order is preserved:
+  add PRs, remove PRs, sync statuses, link PRs. Regression coverage asserts
+  this order with concrete interface stubs.
+
+## Testing Plan
+
+- [x] `git diff --check`
+- [x] `bb poly:check`
+- [x] Focused dashboard train state test:
+  `clojure -M:dev:test -e "(require 'ai.miniforge.web-dashboard.state.trains-test) (clojure.test/run-tests 'ai.miniforge.web-dashboard.state.trains-test)"`
+- [x] `bb test`
+- [x] `bb pre-commit`
+
+## Deployment Plan
+
+Merge normally after CI and review. This is a code hygiene change with no
+migration step.
+
+## Rollback Plan
+
+Revert the PR. The change is localized to CLI composition, web-dashboard train
+state, policy-pack validation, and artifact transit-store logging.
+
+## Related Issues/PRs
+
+- Builds on the standards remediation waves that landed in:
+  - #1221
+  - #1222
+  - #1228
+
+## Checklist
+
+- [x] Production resolver hotspots reviewed
+- [x] Static dependencies added where required
+- [x] Optional product-composition boundary documented
+- [x] Tests updated for direct interface calls
+- [x] Broad test suite passed
+- [x] Pre-commit passed
+- [ ] PR opened
+- [ ] Copilot comments settled
+- [ ] All review comments resolved

--- a/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
+++ b/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
@@ -124,6 +124,7 @@ state, policy-pack validation, and artifact transit-store logging.
 
 ## Related Issues/PRs
 
+- This PR: #1230
 - Builds on the standards remediation waves that landed in:
   - #1221
   - #1222
@@ -137,6 +138,6 @@ state, policy-pack validation, and artifact transit-store logging.
 - [x] Tests updated for direct interface calls
 - [x] Broad test suite passed
 - [x] Pre-commit passed
-- [ ] PR opened
+- [x] PR opened
 - [ ] Copilot comments settled
 - [ ] All review comments resolved

--- a/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
+++ b/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
@@ -139,5 +139,5 @@ state, policy-pack validation, and artifact transit-store logging.
 - [x] Broad test suite passed
 - [x] Pre-commit passed
 - [x] PR opened
-- [ ] Copilot comments settled
-- [ ] All review comments resolved
+- [x] Copilot comments settled
+- [x] All review comments resolved


### PR DESCRIPTION
# refactor: remove resolver hotspots from standards remediation wave 50

## Overview

This PR continues the standards-remediation work that removes production
`requiring-resolve`, `resolve`, `ns-resolve`, and function-local `require`
anti-patterns where static component dependencies already exist.

The slice focuses on the remaining production hotspots identified after
remediation waves #1221, #1222, and #1228:

- CLI optional composition registry
- web-dashboard PR train and repo DAG calls
- policy-pack knowledge-safety schema validation
- artifact transit-store logging

## Layer

Application / adapter cleanup.

The PR does not introduce new domain behavior. It tightens composition and
dependency boundaries in CLI/dashboard adapters and one policy validation path.

## Motivation

Dynamic var resolution hid real dependency requirements and made failures
silent. That was useful only for product composition boundaries where the
entire component may be absent from a product classpath. Everywhere else,
direct Polylith interfaces make dependencies explicit, preserve compile-time
checks, and fail in the component that owns the broken call.

## Gap Analysis

### Fixed in this PR

- `bases/cli/.../main.clj`
  - Replaced dynamic lookup for artifact and policy-pack registrations with
    direct interface calls.
  - Replaced dynamic lookup of PR train and repo DAG manager constructors with
    direct interface calls.
  - Renamed the remaining helper to `optional-composition-var` and documented
    that it is only for optional web-dashboard / TUI product composition.

- `components/web-dashboard/.../state/trains.clj`
  - Replaced `core/safe-call` dispatch to PR train and repo DAG with direct
    `pr-train` and `repo-dag` interface calls.
  - Added explicit component dependencies in `components/web-dashboard/deps.edn`.
  - Updated tests to stub concrete interface vars instead of the deleted
    resolver helper.

- `components/web-dashboard/.../state/core.clj`
  - Removed the generic `safe-call` resolver helper.

- `components/policy-pack/.../knowledge_safety.clj`
  - Replaced function-local schema namespace loading and `ns-resolve` with a
    static `policy-pack.schema` require.

- `components/artifact/.../transit_store.clj`
  - Replaced function-local logging require and resolved `info` var with a
    static logging interface require.

### Intentionally left in place

- `bases/cli/.../main.clj`
  - `optional-composition-var` still uses `require` + `ns-resolve` for the
    product-composition boundary where `miniforge-core` can load the CLI
    without web-dashboard or TUI components on the classpath.

- Generic namespace loaders
  - Config-driven phase namespace loading and test namespace discovery remain
    dynamic by design.

- Rich comments and tests
  - Remaining scan hits are rich-comment examples, docstrings, or test-only
    reflective checks. They are outside this production cleanup slice.

## Changes in Detail

- Added direct CLI requires for `artifact`, `policy-pack`, `pr-train`, and
  `repo-dag`.
- Narrowed the CLI optional late-binding helper to explicit optional
  composition.
- Removed dashboard `safe-call` and replaced its call sites with direct
  interfaces.
- Added `pr-train` and `repo-dag` as web-dashboard component dependencies.
- Updated dashboard train tests to stub concrete `pr-train` functions.
- Replaced policy-pack schema validation resolver with `schema/validate-pack`.
- Replaced artifact transit-store logging resolver with `log/info`.

## Code Review Rigor Notes

- Happy path traced: `miniforge web` creates an event stream, creates PR train
  and repo DAG managers via direct interfaces, then passes both managers to the
  optional web-dashboard launcher. The only nil path that remains is the
  existing caught manager-construction failure, which already prints the
  operator warning and passes nil to the dashboard.
- Bootstrap order: dashboard state now requires `pr-train` and `repo-dag` at
  namespace load time, so missing dependencies fail during component loading
  rather than silently returning nil from `safe-call`.
- Default path: no manager configured still returns empty dashboard train/DAG
  views as before. A configured manager now uses the explicit interface.
- Refactor scrutiny: the dashboard sync mutation order is preserved:
  add PRs, remove PRs, sync statuses, link PRs. Regression coverage asserts
  this order with concrete interface stubs.

## Testing Plan

- [x] `git diff --check`
- [x] `bb poly:check`
- [x] Focused dashboard train state test:
  `clojure -M:dev:test -e "(require 'ai.miniforge.web-dashboard.state.trains-test) (clojure.test/run-tests 'ai.miniforge.web-dashboard.state.trains-test)"`
- [x] `bb test`
- [x] `bb pre-commit`

## Deployment Plan

Merge normally after CI and review. This is a code hygiene change with no
migration step.

## Rollback Plan

Revert the PR. The change is localized to CLI composition, web-dashboard train
state, policy-pack validation, and artifact transit-store logging.

## Related Issues/PRs

- Builds on the standards remediation waves that landed in:
  - #1221
  - #1222
  - #1228

## Checklist

- [x] Production resolver hotspots reviewed
- [x] Static dependencies added where required
- [x] Optional product-composition boundary documented
- [x] Tests updated for direct interface calls
- [x] Broad test suite passed
- [x] Pre-commit passed
- [ ] PR opened
- [ ] Copilot comments settled
- [ ] All review comments resolved
