### PR TITLE
Fix reviewer policy session splitting

### DIFF
--- a/components/agent/deps.edn
+++ b/components/agent/deps.edn
@@ -14,7 +14,8 @@
         ai.miniforge/self-healing {:local/root "../self-healing"}
         ai.miniforge/llm {:local/root "../llm"}
         ai.miniforge/progress-detector {:local/root "../progress-detector"}
-        slingshot/slingshot {:mvn/version "0.12.2"}}
+        slingshot/slingshot {:mvn/version "0.12.2"}
+        selmer/selmer {:mvn/version "1.13.1"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -223,6 +223,45 @@ artifact.**
 
 Output your review as a Clojure map inside a ```clojure code block."
 
+ :prompt/user-template
+ "Review the following code implementation.
+
+{% if has_title %}## Task: {{title|safe}}
+
+{% endif %}{% if has_description %}## Description
+
+{{description|safe}}
+
+{% endif %}{% if has_intent %}## Intent
+
+{{intent|safe}}
+
+{% endif %}{% if review_scope %}## Scope
+
+Findings inside these paths/prefixes are in-scope; report them in
+`:review/issues` with the appropriate severity
+(`:blocking` / `:warning` / `:nit`). Normal severity rules apply —
+only `:blocking` issues actually block the verdict.
+
+Findings outside the scope are out-of-scope — report them in
+`:review/out-of-scope-observations`, NOT in `:review/issues`.
+
+{% for path in review_scope %}- {{path|safe}}
+{% endfor %}
+{% endif %}{% if has_constraints %}## Constraints
+
+{{constraints|safe}}
+
+{% endif %}## Code to Review
+
+{{artifact_text|safe}}{% if has_tests %}
+
+## Test Results
+
+{{tests|safe}}{% endif %}
+
+Output your review as a Clojure map inside a ```clojure code block."
+
  ;; Bounded enumeration-retry turn — used by the review-output validator when a
  ;; :rejected / :changes-requested decision lands WITHOUT any :blocking items
  ;; in :review/issues. A rejection without enumerated blockers can't tell the

--- a/components/agent/src/ai/miniforge/agent/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/prompts.clj
@@ -24,7 +24,8 @@
    [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [selmer.parser :as selmer]))
+   [selmer.parser :as selmer]
+   [selmer.util :as selmer-util]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Prompt loading
@@ -128,11 +129,13 @@
 (defn render-template
   "Render a Selmer template with the given substitutions.
 
-   Prompt resources use Selmer syntax (`{{key}}`, `{% if key %}`,
-   `{% for item in items %}`), with the `safe` filter applied in prompt
-   templates for code or markdown values that must not be HTML-escaped."
+   Prompt resources use Selmer syntax (`{{key}}`, `{% if key %}`, and
+   `{% for item in items %}`). Substitution is intentionally raw by default
+   because these templates target LLM prompts, not HTML, and historical
+   callers pass code, markdown, diffs, and EDN that must not be escaped."
   [template substitutions]
-  (selmer/render (or template "") (template-context substitutions)))
+  (selmer-util/without-escaping
+    (selmer/render (or template "") (template-context substitutions))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/prompts.clj
@@ -24,7 +24,7 @@
    [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.string :as str]))
+   [selmer.parser :as selmer]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Prompt loading
@@ -114,15 +114,25 @@
   (when-let [config (get prompt-data monitor-key)]
     (llm/create-progress-monitor config)))
 
+(defn- template-context
+  "Normalize keyword-heavy Clojure maps into Selmer's string-key context.
+   Nil still renders as the empty string, matching the historical prompt
+   renderer, while false remains false so `{% if %}` branches behave."
+  [substitutions]
+  (into {}
+        (map (fn [[k v]]
+               [(if (keyword? k) (name k) (str k))
+                (if (nil? v) "" v)]))
+        substitutions))
+
 (defn render-template
-  "Render a `{{key}}`-style template with the given substitutions. Each entry
-   `{kw v}` replaces the literal string \"{{kw}}\" with `v` (nil renders as the
-   empty string). Single source of truth for the agents' prompt templating."
+  "Render a Selmer template with the given substitutions.
+
+   Prompt resources use Selmer syntax (`{{key}}`, `{% if key %}`,
+   `{% for item in items %}`), with the `safe` filter applied in prompt
+   templates for code or markdown values that must not be HTML-escaped."
   [template substitutions]
-  (reduce-kv (fn [text k v]
-               (str/replace text (str "{{" (name k) "}}") (or v "")))
-             (or template "")
-             substitutions))
+  (selmer/render (or template "") (template-context substitutions)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -228,19 +228,21 @@
 (defn- combine-parsed-reviews
   [reviews]
   (let [multiple? (> (count reviews) 1)
-        summaries (keep :review/summary reviews)]
+        summaries (seq (keep :review/summary reviews))]
     (cond-> {:review/decision (strongest-review-decision reviews)
              :review/issues (vec (mapcat #(get % :review/issues []) reviews))
              :review/out-of-scope-observations
              (vec (mapcat #(get % :review/out-of-scope-observations []) reviews))
              :review/strengths (vec (mapcat #(get % :review/strengths []) reviews))
              :review/summary (if multiple?
-                               (str "Split reviewer sessions:\n"
-                                    (str/join "\n"
-                                              (map-indexed
-                                               (fn [idx summary]
-                                                 (str "- Session " (inc idx) ": " summary))
-                                               summaries)))
+                               (if summaries
+                                 (str "Split reviewer sessions:\n"
+                                      (str/join "\n"
+                                                (map-indexed
+                                                 (fn [idx summary]
+                                                   (str "- Session " (inc idx) ": " summary))
+                                                 summaries)))
+                                 "Split reviewer sessions completed.")
                                (or (first summaries) "Review completed."))}
       (not multiple?) (assoc :review/summary (or (first summaries)
                                                  "Review completed.")))))

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -37,7 +37,8 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
-   [ai.miniforge.loop.interface :as loop]))
+   [ai.miniforge.loop.interface :as loop]
+   [clojure.string :as str]))
 
 ;; Schemas (GateFeedback, ReviewIssue, ReviewArtifact) moved to
 ;; ai.miniforge.agent.reviewer.issues (PR-C decomposition).
@@ -120,6 +121,173 @@
                           input reviewer-prompts/format-artifact-manifest)
       :shed-count       (count (:code/files artifact))})))
 
+(defn- estimated-input-tokens
+  [system user-prompt]
+  (:estimated-input-tokens (llm/prompt-size-telemetry system user-prompt)))
+
+(defn- fits-effective-window?
+  [system user-prompt effective-window]
+  (or (nil? effective-window)
+      (< (estimated-input-tokens system user-prompt) effective-window)))
+
+(defn- addendum-units
+  "Split a policy/knowledge addendum at natural markdown paragraph
+   boundaries. The greedy packer below preserves these units whenever
+   possible and only falls back to character chunks for a single oversized
+   paragraph."
+  [addendum]
+  (->> (str/split (or addendum "") #"\n{2,}")
+       (remove str/blank?)
+       vec))
+
+(defn- max-fitting-prefix-length
+  [base-system text user-prompt effective-window]
+  (loop [lo 1
+         hi (count text)
+         best 0]
+    (if (> lo hi)
+      best
+      (let [mid (quot (+ lo hi) 2)
+            prefix (subs text 0 mid)]
+        (if (fits-effective-window? (str base-system prefix) user-prompt effective-window)
+          (recur (inc mid) hi mid)
+          (recur lo (dec mid) best))))))
+
+(defn- split-oversized-addendum-unit
+  [base-system unit user-prompt effective-window]
+  (loop [remaining unit
+         chunks []]
+    (cond
+      (str/blank? remaining)
+      chunks
+
+      (fits-effective-window? (str base-system remaining) user-prompt effective-window)
+      (conj chunks remaining)
+
+      :else
+      (let [n (max-fitting-prefix-length base-system remaining user-prompt effective-window)]
+        (when (pos? n)
+          (recur (subs remaining n)
+                 (conj chunks (subs remaining 0 n))))))))
+
+(defn- split-addendum-into-fitting-chunks
+  "Return addendum chunks that each fit with the base system and user prompt,
+   or nil when even the base system plus user prompt is over budget."
+  [base-system addendum user-prompt effective-window]
+  (when (and (not (str/blank? addendum))
+             (fits-effective-window? base-system user-prompt effective-window))
+    (loop [remaining (addendum-units addendum)
+           current ""
+           chunks []]
+      (if (empty? remaining)
+        (cond-> chunks
+          (not (str/blank? current)) (conj current))
+        (let [unit (first remaining)
+              more (rest remaining)
+              candidate (if (str/blank? current)
+                          unit
+                          (str current "\n\n" unit))]
+          (cond
+            (fits-effective-window? (str base-system candidate) user-prompt effective-window)
+            (recur more candidate chunks)
+
+            (not (str/blank? current))
+            (recur remaining "" (conj chunks current))
+
+            :else
+            (when-let [oversized-chunks
+                       (seq (split-oversized-addendum-unit
+                             base-system unit user-prompt effective-window))]
+              (recur more "" (into chunks oversized-chunks)))))))))
+
+(defn- review-session-systems
+  "Resolve the system prompts to use for the review. Most reviews use one
+   system prompt. If the compiled policy/knowledge addendum pushes the shed
+   prompt over budget, split that addendum across multiple LLM sessions so
+   every compiled rule is still applied."
+  [base-system behavior-addendum user-prompt prompt-budget]
+  (if-not (:over-after-shed? prompt-budget)
+    [(str base-system behavior-addendum)]
+    (when-let [chunks (seq (split-addendum-into-fitting-chunks
+                            base-system behavior-addendum user-prompt
+                            (:effective-window prompt-budget)))]
+      (mapv #(str base-system %) chunks))))
+
+(def ^:private review-decision-rank
+  {:approved 0
+   :conditionally-approved 1
+   :changes-requested 2
+   :rejected 3})
+
+(defn- strongest-review-decision
+  [reviews]
+  (->> reviews
+       (map #(issues/normalize-llm-decision (:review/decision %)))
+       (apply max-key #(get review-decision-rank % 0))))
+
+(defn- combine-parsed-reviews
+  [reviews]
+  (let [multiple? (> (count reviews) 1)
+        summaries (keep :review/summary reviews)]
+    (cond-> {:review/decision (strongest-review-decision reviews)
+             :review/issues (vec (mapcat #(get % :review/issues []) reviews))
+             :review/out-of-scope-observations
+             (vec (mapcat #(get % :review/out-of-scope-observations []) reviews))
+             :review/strengths (vec (mapcat #(get % :review/strengths []) reviews))
+             :review/summary (if multiple?
+                               (str "Split reviewer sessions:\n"
+                                    (str/join "\n"
+                                              (map-indexed
+                                               (fn [idx summary]
+                                                 (str "- Session " (inc idx) ": " summary))
+                                               summaries)))
+                               (or (first summaries) "Review completed."))}
+      (not multiple?) (assoc :review/summary (or (first summaries)
+                                                 "Review completed.")))))
+
+(defn- aggregate-cost-usd
+  [normalized-results]
+  (when-let [costs (seq (keep :cost-usd normalized-results))]
+    (reduce + 0M costs)))
+
+(defn- combined-review-content
+  [review]
+  (str "```clojure\n" (pr-str review) "\n```"))
+
+(defn- combine-normalized-review-results
+  "Combine split reviewer calls into one normalized result. Any split session
+   that fails to parse or times out keeps the combined result failed; only an
+   all-parseable set is merged into a ReviewArtifact."
+  [normalized-results]
+  (let [tokens (reduce + 0 (map #(or (:tokens %) 0) normalized-results))
+        cost-usd (aggregate-cost-usd normalized-results)
+        joined-content (str/join "\n\n--- split reviewer session ---\n\n"
+                                 (map :content normalized-results))
+        failed (first (remove :parsed-content normalized-results))]
+    (if failed
+      (assoc failed
+             :content joined-content
+             :tokens tokens
+             :cost-usd cost-usd
+             :response (cond-> (assoc (or (:response failed) {})
+                                      :tokens tokens)
+                         cost-usd (assoc :cost-usd cost-usd)))
+      (let [review (combine-parsed-reviews (mapv :parsed-content normalized-results))
+            content (combined-review-content review)
+            response (cond-> {:success true
+                              :success? true
+                              :content content
+                              :tokens tokens}
+                       cost-usd (assoc :cost-usd cost-usd))]
+        {:response response
+         :content content
+         :response-success? true
+         :llm-error nil
+         :parsed-content review
+         :tokens tokens
+         :cost-usd cost-usd
+         :usable? true}))))
+
 (defn- emit-prompt-size!
   "Emit an :agent/prompt-size workflow event recording the reviewer's
    pre-flight budget (N12 §3) so estimate-vs-window is visible/queryable.
@@ -162,6 +330,69 @@
     (if on-chunk
       (llm/chat-stream llm-client user-prompt on-chunk opts)
       (llm/chat llm-client user-prompt opts))))
+
+(defn- invoke-reviewer-with-system
+  [context llm-client user-prompt on-chunk system-prompt monitor
+   budget-usd max-turns]
+  (let [base-opts (cond-> {:system system-prompt
+                           :max-turns max-turns}
+                    monitor (assoc :progress-monitor monitor))]
+    (artifact-session/with-readonly-session
+     context
+     #(invoke-reviewer-session % llm-client user-prompt on-chunk
+                               base-opts budget-usd max-turns))))
+
+(defn- invoke-reviewer-sessions
+  [context llm-client user-prompt on-chunk systems monitor budget-usd max-turns]
+  (let [responses (mapv #(invoke-reviewer-with-system
+                          context llm-client user-prompt on-chunk %
+                          monitor budget-usd max-turns)
+                        systems)]
+    (if (= 1 (count responses))
+      (result-boundary/normalize-llm-result
+       {:response (first responses)
+        :parse-response llm-response/parse-review-response})
+      (combine-normalized-review-results
+       (mapv #(result-boundary/normalize-llm-result
+               {:response %
+                :parse-response llm-response/parse-review-response})
+             responses)))))
+
+(defn- invoke-enumeration-retry-session
+  [llm-client retry-prompt on-chunk system-prompt monitor]
+  (let [retry-opts (cond-> {:system system-prompt
+                            :max-turns
+                            (get @reviewer-prompts/reviewer-prompt-data
+                                 :prompt/enumeration-retry-max-turns
+                                 6)}
+                     monitor (assoc :progress-monitor monitor))]
+    (if on-chunk
+      (llm/chat-stream llm-client retry-prompt on-chunk retry-opts)
+      (llm/chat llm-client retry-prompt retry-opts))))
+
+(defn- recover-review-enumeration-across-sessions
+  [llm-client systems monitor on-chunk user-prompt prior-content]
+  (if (= 1 (count systems))
+    (llm-response/recover-review-enumeration
+     llm-client
+     (cond-> {:system (first systems)
+              :max-turns (get @reviewer-prompts/reviewer-prompt-data
+                              :prompt/max-turns
+                              reviewer-prompts/default-reviewer-max-turns)}
+       monitor (assoc :progress-monitor monitor))
+     on-chunk user-prompt prior-content)
+    (let [retry-prompt (reviewer-prompts/enumeration-retry-prompt
+                        user-prompt prior-content)
+          normalized (combine-normalized-review-results
+                      (mapv #(result-boundary/normalize-llm-result
+                              {:response (invoke-enumeration-retry-session
+                                          llm-client retry-prompt on-chunk %
+                                          monitor)
+                               :parse-response llm-response/parse-review-response})
+                            systems))
+          re-review (:parsed-content normalized)]
+      (when (and re-review (llm-response/well-formed-recovery? re-review))
+        re-review))))
 
 (defn create-reviewer
   "Create a Reviewer agent with optional configuration overrides.
@@ -231,8 +462,9 @@
                   ;; reviewer sees the rules it should be checking
                   ;; against. Empty string when no addendum is present
                   ;; (legacy callers / no rules apply to :review).
-                  effective-system (str @reviewer-prompts/reviewer-system-prompt
-                                        (get input :task/behavior-addendum ""))
+                  base-system @reviewer-prompts/reviewer-system-prompt
+                  behavior-addendum (get input :task/behavior-addendum "")
+                  effective-system (str base-system behavior-addendum)
                   ;; N12 §5: assemble the user-prompt within the model's
                   ;; context window, shedding the artifact's inlined file
                   ;; bodies to a context_read-able manifest before the prompt
@@ -253,27 +485,30 @@
                                         :window (:window prompt-budget)
                                         :estimated-tokens-before (:est-full prompt-budget)
                                         :estimated-tokens-after (:est-final prompt-budget)}}))
-                  ;; Irreducible overflow: the prompt exceeds the window even
-                  ;; with the artifact shed to a manifest (only reachable on a
-                  ;; tiny-window model — production 200k windows fit the shed
-                  ;; form). Skip the doomed LLM call, but STILL run the
-                  ;; deterministic policy gates below and return an infra
-                  ;; failure. The compiled policy gates are the trust boundary
-                  ;; and MUST always apply; the LLM's semantic pass is the only
-                  ;; thing dropped here, and a 'prompt too long' error must
-                  ;; never be synthesized into a false :rejected. N12 §5.4-5.5.
-                  context-overflow? (:over-after-shed? prompt-budget)
+                  session-systems (review-session-systems
+                                   base-system behavior-addendum
+                                   user-prompt prompt-budget)
+                  split-session? (> (count session-systems) 1)
+                  _ (when split-session?
+                      (log/info logger :reviewer :reviewer/context-split
+                                {:data {:session-count (count session-systems)
+                                        :window (:window prompt-budget)
+                                        :estimated-tokens-before (:est-full prompt-budget)
+                                        :estimated-tokens-after (:est-final prompt-budget)}}))
+                  ;; Irreducible overflow: even the base reviewer prompt plus
+                  ;; the shed user prompt exceeds the window, or there is no
+                  ;; compiled addendum to split. Compiled policy addenda are
+                  ;; never dropped; when they are the over-budget contributor,
+                  ;; `session-systems` contains one LLM session per chunk.
+                  context-overflow? (empty? session-systems)
                   overflow-message (when context-overflow?
                                      (str "Reviewer prompt ~" (:est-final prompt-budget)
                                           " est tokens exceeds the model context window "
                                           (:window prompt-budget)
                                           (if (:shed? prompt-budget)
-                                            " even after shedding the artifact's file bodies to a manifest"
+                                            " even after shedding the artifact's file bodies to a manifest and splitting policy addenda was not possible"
                                             " and has no inlined file bodies to shed")
-                                          "; LLM semantic review skipped, deterministic gates still applied"))
-                  base-opts (cond-> {:system effective-system
-                                     :max-turns max-turns}
-                              monitor (assoc :progress-monitor monitor))
+                                          "; deterministic gates still applied"))
                   budget-usd (budget/resolve-cost-budget-usd :reviewer review-config context)
                   ;; Run the main review inside a read-only artifact session so
                   ;; the reviewer reads through the MCP context cache
@@ -283,25 +518,19 @@
                   ;; the cache without modifying anything. with-readonly-session
                   ;; skips artifact promotion/WARN (the reviewer has no work
                   ;; product) and returns the LLM result directly. The
-                  ;; enumeration-retry below keeps base-opts — it re-asks over
-                  ;; the same content and needs no tools/cache.
-                  ;; Skip the LLM call entirely on irreducible overflow — the
-                  ;; synthesized error `normalized` below routes to the
-                  ;; context-overflow infra exit; the gates still run.
-                  response (when-not context-overflow?
-                             (artifact-session/with-readonly-session
-                              context
-                              #(invoke-reviewer-session % llm-client user-prompt on-chunk
-                                                        base-opts budget-usd max-turns)))
+                  ;; enumeration-retry below re-asks over the same content and
+                  ;; needs no tools/cache, but still uses the same split
+                  ;; systems so every compiled policy chunk is applied.
                   normalized (if context-overflow?
                                {:llm-error {:message overflow-message
                                             :data {:context-overflow true
                                                    :estimated-tokens (:est-final prompt-budget)
                                                    :context-window (:window prompt-budget)}}
                                 :content nil :parsed-content nil :tokens 0 :cost-usd nil}
-                               (result-boundary/normalize-llm-result
-                                {:response response
-                                 :parse-response llm-response/parse-review-response}))
+                               (invoke-reviewer-sessions
+                                context llm-client user-prompt on-chunk
+                                session-systems monitor budget-usd max-turns))
+                  response (:response normalized)
                   content (:content normalized)
                   tokens (:tokens normalized)
                   cost-usd (:cost-usd normalized)]
@@ -395,8 +624,8 @@
                                                  {:data {:initial-decision    initial-llm-decision
                                                          :initial-issue-count (count initial-llm-issues)
                                                          :gate-blocking-count (count (:blocking-issues gate-result))}})
-                                       (llm-response/recover-review-enumeration
-                                        llm-client base-opts on-chunk
+                                       (recover-review-enumeration-across-sessions
+                                        llm-client session-systems monitor on-chunk
                                         user-prompt content))
                     ;; When recovery succeeds, the first call's parse failure
                     ;; no longer represents the agent's verdict — clearing

--- a/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/artifact.clj
@@ -227,13 +227,12 @@
 
 (defn context-overflow-error-result
   "Reviewer exit when the assembled prompt exceeds the model's context window
-   even after shedding the artifact's inlined file bodies to a manifest
-   (N12 §5). Sibling of `timeout-only-error-result`: the LLM never produced a
+   after every faithful reduction has been tried: artifact bodies shed to a
+   manifest and compiled policy/knowledge addenda split across multiple LLM
+   sessions. Sibling of `timeout-only-error-result`: the LLM never produced a
    verdict, so this reports an INFRA failure (code `:reviewer/context-overflow`)
    rather than a bogus code-review rejection — but it still reports the
-   DETERMINISTIC gate outcome. The compiled policy gates are Miniforge's trust
-   boundary and run regardless of prompt size; only the LLM's semantic pass is
-   skipped here, so policy enforcement is never dropped."
+   deterministic gate outcome."
   [logger normalized gate-result counts duration overflow-message]
   (log/warn logger :reviewer :reviewer/context-overflow
             {:data {:gate-decision (:decision gate-result)

--- a/components/agent/src/ai/miniforge/agent/reviewer/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/prompts.clj
@@ -135,31 +135,21 @@
          tests (:task/tests input)
          review-scope (scope/effective-review-scope input)
          artifact-text (artifact-fmt artifact)]
-     (str "Review the following code implementation.\n\n"
-          (when-not (str/blank? title)
-            (str "## Task: " title "\n\n"))
-          (when-not (str/blank? description)
-            (str "## Description\n\n" description "\n\n"))
-          (when (and intent (not (str/blank? (str intent))))
-            (str "## Intent\n\n" (if (string? intent) intent (pr-str intent)) "\n\n"))
-          (when review-scope
-            (str "## Scope\n\n"
-                 "Findings inside these paths/prefixes are in-scope; report them in\n"
-                 "`:review/issues` with the appropriate severity\n"
-                 "(`:blocking` / `:warning` / `:nit`). Normal severity rules apply —\n"
-                 "only `:blocking` issues actually block the verdict.\n\n"
-                 "Findings outside the scope are out-of-scope — report them in\n"
-                 "`:review/out-of-scope-observations`, NOT in `:review/issues`.\n\n"
-                 (str/join "\n" (map #(str "- " %) review-scope))
-                 "\n\n"))
-          (when (and constraints (not (str/blank? (str constraints))))
-            (str "## Constraints\n\n" (if (string? constraints) constraints (pr-str constraints)) "\n\n"))
-          "## Code to Review\n\n"
-          artifact-text
-          (when tests
-            (str "\n\n## Test Results\n\n"
-                 (if (string? tests) tests (pr-str tests))))
-          "\n\nOutput your review as a Clojure map inside a ```clojure code block."))))
+     (prompts/render-template
+      (get @reviewer-prompt-data :prompt/user-template)
+      {"title" title
+       "has_title" (not (str/blank? title))
+       "description" description
+       "has_description" (not (str/blank? description))
+       "intent" (if (string? intent) intent (pr-str intent))
+       "has_intent" (not (str/blank? (str intent)))
+       "review_scope" review-scope
+       "constraints" (if (string? constraints) constraints (pr-str constraints))
+       "has_constraints" (not (str/blank? (str constraints)))
+       "artifact_text" artifact-text
+       "has_tests" (some? tests)
+       "tests" (when (some? tests)
+                 (if (string? tests) tests (pr-str tests)))}))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Enumeration retry

--- a/components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/artifact_test.clj
@@ -277,7 +277,7 @@
 (deftest context-overflow-error-result-test
   (let [logger (log/create-logger {:min-level :error :output (fn [_])})
         msg (str "Reviewer prompt ~250000 est tokens exceeds the model context "
-                 "window 200000; LLM semantic review skipped, deterministic "
+                 "window 200000; deterministic "
                  "gates still applied")
         ;; Mirror the producer: reviewer.clj synthesizes the normalized
         ;; :llm-error :message AS the overflow message, so error-response

--- a/components/agent/test/ai/miniforge/agent/reviewer/prompts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/prompts_test.clj
@@ -25,6 +25,7 @@
    the `## Scope` boundary, and the required-scope contract."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.reviewer.prompts :as reviewer-prompts]))
 
 ;------------------------------------------------------------------------------ format-artifact-for-review
@@ -75,6 +76,12 @@
     (is (= "{:k 1}" (reviewer-prompts/format-artifact-manifest {:k 1})))))
 
 ;------------------------------------------------------------------------------ build-review-prompt — manifest artifact formatter
+
+(deftest render-template-preserves-raw-prompt-content-test
+  (testing "Selmer prompt rendering does not HTML-escape code, diffs, markdown, or EDN"
+    (is (= "Review <src/a.clj> && {:ok? true}"
+           (prompts/render-template "Review {{content}}"
+                                    {:content "<src/a.clj> && {:ok? true}"})))))
 
 (deftest build-review-prompt-manifest-arity-test
   (let [input {:task/title "T"

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -1078,3 +1078,39 @@
           (is (= (* 2 (count @captured-systems))
                  (get-in result [:metrics :tokens]))
               "token accounting sums every split LLM session"))))))
+
+(deftest test-reviewer-split-session-summary-fallback
+  (testing "split reviews without per-session summaries still produce a useful summary"
+    (let [combine #'reviewer/combine-parsed-reviews
+          result (combine [{:review/decision :approved
+                            :review/issues []}
+                           {:review/decision :changes-requested
+                            :review/issues []}])]
+      (is (= :changes-requested (:review/decision result)))
+      (is (= "Split reviewer sessions completed."
+             (:review/summary result))))))
+
+(deftest test-reviewer-irreducible-context-overflow-applies-gates-without-llm
+  (testing "irreducible context overflow skips the doomed LLM call but still
+            runs deterministic policy gates"
+    (let [llm-called? (atom false)]
+      (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
+                    llm/context-window-for-model-id (fn [_] 100)
+                    llm/chat (fn [_ _ _]
+                               (reset! llm-called? true)
+                               (mock-llm-response valid-review-content))
+                    llm/chat-stream (fn [_ _ _ _]
+                                      (reset! llm-called? true)
+                                      (mock-llm-response valid-review-content))]
+        (let [reviewer (reviewer/create-reviewer
+                        {:llm-backend ::mock-backend
+                         :gates [(passing-gate :policy-check)]})
+              result (core/invoke reviewer {} sample-artifact)]
+          (is (false? @llm-called?) "the doomed LLM call is skipped")
+          (is (= :error (:status result))
+              "returns an infra failure, not a review verdict")
+          (is (= :reviewer/context-overflow
+                 (get-in result [:error :data :code])))
+          (is (= 1 (get-in result [:metrics :gates-passed]))
+              "the deterministic policy gate still ran")
+          (is (= 0 (get-in result [:metrics :tokens]))))))))

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -84,15 +84,6 @@
 (def ^:private valid-review-content
   (test-t :reviewer-test/valid-review-content))
 
-(def ^:private malformed-review-issue-content
-  (test-t :reviewer-test/malformed-review-issue-content))
-
-(def ^:private approved-with-nil-line-content
-  (test-t :reviewer-test/approved-with-nil-line-content))
-
-(def ^:private approved-with-nil-optional-fields-content
-  (test-t :reviewer-test/approved-with-nil-optional-fields-content))
-
 ;------------------------------------------------------------------------------ Test fixtures
 
 (defn passing-gate
@@ -1042,26 +1033,48 @@
       (is (false? (:shed? r)))
       (is (true? (:over-after-shed? r))))))
 
-(deftest test-reviewer-context-overflow-applies-gates-without-llm
-  (testing "irreducible context overflow skips the doomed LLM call but STILL
-            runs the deterministic policy gates and returns an infra failure,
-            never a synthesized rejection — policy enforcement is never dropped
-            (the trust boundary)"
-    (let [llm-called? (atom false)]
+(deftest test-reviewer-context-overflow-splits-policy-addendum-across-llm-sessions
+  (testing "an over-budget compiled policy addendum is split across multiple
+            LLM sessions instead of silently skipping semantic policy review"
+    (let [captured-systems (atom [])
+          addendum "\n\n## Policy Rules — Required Behaviors\n\n1. RULE-1: check public API boundaries.\n\n2. RULE-2: check prompt templating.\n\n3. RULE-3: check faithful standards application."]
       (with-redefs [model/resolve-llm-client-for-role (fn [_role client] client)
-                    ;; Force overflow regardless of the real catalog window.
-                    llm/context-window-for-model-id (fn [_] 100)
-                    llm/chat (fn [_ _ _] (reset! llm-called? true)
-                               (mock-llm-response valid-review-content))
-                    llm/chat-stream (fn [_ _ _ _] (reset! llm-called? true)
-                                      (mock-llm-response valid-review-content))]
+                    ;; Reserve clamps to 100; all three rules overflow
+                    ;; together, while the base prompt and any one rule fit.
+                    llm/context-window-for-model-id (fn [_] 200)
+                    llm/prompt-size-telemetry
+                    (fn [system user-prompt]
+                      {:estimated-input-tokens
+                       (+ 40
+                          (* 30 (count (re-seq #"RULE-" system)))
+                          (if (str/includes? user-prompt "_File bodies omitted")
+                            5
+                            80))})
+                    llm/chat (fn [_ _ opts]
+                               (swap! captured-systems conj (:system opts))
+                               (mock-llm-response valid-review-content
+                                                  :tokens 2))
+                    llm/chat-stream (fn [_ _ _ opts]
+                                      (swap! captured-systems conj (:system opts))
+                                      (mock-llm-response valid-review-content
+                                                         :tokens 2))
+                    llm/success? :success?
+                    llm/get-content :content]
         (let [reviewer (reviewer/create-reviewer
                         {:llm-backend ::mock-backend
                          :gates [(passing-gate :policy-check)]})
-              result (core/invoke reviewer {} sample-artifact)]
-          (is (false? @llm-called?) "the doomed LLM call is skipped")
-          (is (= :error (:status result)) "returns an infra failure, not a review verdict")
-          (is (= :reviewer/context-overflow (get-in result [:error :data :code])))
+              input (assoc (review-input (code-artifact 1 5000))
+                           :task/behavior-addendum addendum)
+              result (core/invoke reviewer {} input)]
+          (is (= :success (:status result)))
+          (is (< 1 (count @captured-systems))
+              "policy application must be split into multiple LLM sessions")
+          (doseq [rule ["RULE-1" "RULE-2" "RULE-3"]]
+            (is (= 1 (count (filter #(str/includes? % rule)
+                                    @captured-systems)))
+                (str rule " should be applied by exactly one split session")))
           (is (= 1 (get-in result [:metrics :gates-passed]))
-              "the deterministic policy gate still ran")
-          (is (= 0 (get-in result [:metrics :tokens]))))))))
+              "deterministic gates still run alongside split LLM review")
+          (is (= (* 2 (count @captured-systems))
+                 (get-in result [:metrics :tokens]))
+              "token accounting sums every split LLM session"))))))

--- a/docs/pull-requests/2026-06-19-fix-reviewer-policy-session-splitting.md
+++ b/docs/pull-requests/2026-06-19-fix-reviewer-policy-session-splitting.md
@@ -1,0 +1,56 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix Reviewer Policy Session Splitting
+
+## Overview
+
+Ensure reviewer context-window pressure never silently degrades compiled policy
+application. When one reviewer prompt cannot fit the model context window, the
+reviewer must split policy application across multiple LLM sessions rather than
+skip the LLM review and rely only on mechanical gates. Move reviewer user
+prompt assembly out of ad hoc string composition and into a Selmer-backed
+resource template.
+
+## Motivation
+
+PR #1229 made reviewer prompt construction context-aware, but its irreducible
+overflow path can skip the reviewer LLM call. That is not acceptable for
+compiled policy: every compiled policy must be faithfully applied, whether the
+enforcement is mechanical or LLM-mediated.
+
+## Changes in Detail
+
+- Add reviewer prompt chunking/session splitting for over-budget review inputs.
+- Preserve mandatory LLM policy application instead of degrading to a
+  mechanical-only overflow result.
+- Render reviewer user prompts through Selmer templates in `reviewer.edn`.
+- Add focused regression coverage for the split-review path.
+
+## Testing Plan
+
+- Focused reviewer tests for context splitting and reviewer prompt rendering.
+- Focused Clojure lint for touched reviewer files.
+- `bb pre-commit` before commit.
+- GitHub CI after PR creation.
+
+## Deployment Plan
+
+Normal merge after review and CI. No runtime migration required.
+
+## Related Issues/PRs
+
+- Follows #1229.
+
+## Checklist
+
+- [x] Inspect reviewer budget and prompt assembly path.
+- [x] Implement LLM session splitting for over-budget reviewer inputs.
+- [x] Move reviewer user prompt assembly to Selmer templates.
+- [x] Add regression tests.
+- [x] Run focused tests.
+- [x] Run `bb pre-commit`.
+- [ ] Open PR and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Fix Reviewer Policy Session Splitting

## Overview

Ensure reviewer context-window pressure never silently degrades compiled policy
application. When one reviewer prompt cannot fit the model context window, the
reviewer must split policy application across multiple LLM sessions rather than
skip the LLM review and rely only on mechanical gates. Move reviewer user
prompt assembly out of ad hoc string composition and into a Selmer-backed
resource template.

## Motivation

PR #1229 made reviewer prompt construction context-aware, but its irreducible
overflow path can skip the reviewer LLM call. That is not acceptable for
compiled policy: every compiled policy must be faithfully applied, whether the
enforcement is mechanical or LLM-mediated.

## Changes in Detail

- Add reviewer prompt chunking/session splitting for over-budget review inputs.
- Preserve mandatory LLM policy application instead of degrading to a
  mechanical-only overflow result.
- Render reviewer user prompts through Selmer templates in `reviewer.edn`.
- Add focused regression coverage for the split-review path.

## Testing Plan

- Focused reviewer tests for context splitting and reviewer prompt rendering.
- Focused Clojure lint for touched reviewer files.
- `bb pre-commit` before commit.
- GitHub CI after PR creation.

## Deployment Plan

Normal merge after review and CI. No runtime migration required.

## Related Issues/PRs

- Follows #1229.

## Checklist

- [x] Inspect reviewer budget and prompt assembly path.
- [x] Implement LLM session splitting for over-budget reviewer inputs.
- [x] Move reviewer user prompt assembly to Selmer templates.
- [x] Add regression tests.
- [x] Run focused tests.
- [x] Run `bb pre-commit`.
- [ ] Open PR and resolve review comments.
