### PR TITLE
Fix CLI artifact and policy command composition

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -74,10 +74,8 @@
    ;; GROUP 3b: timeline-based events show
    [ai.miniforge.cli.main.commands.events :as cmd-events]
    [ai.miniforge.agent.interface :as agent]
-   [ai.miniforge.artifact.interface :as artifact]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.mcp-context-server.interface :as mcp-context-server]
-   [ai.miniforge.policy-pack.interface :as policy-pack]
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.repo-dag.interface :as repo-dag]
    [ai.miniforge.workflow-resume.interface :as wr]
@@ -94,22 +92,6 @@
     (require ns-sym)
     (ns-resolve ns-sym var-sym)
     (catch Throwable _ nil)))
-
-(defn- register-artifact-providers! []
-  (cmd-shared/register-optional-fn!
-   'ai.miniforge.artifact.interface/list-artifacts
-   (fn [] (vec (artifact/query (artifact/create-transit-store) {}))))
-  (cmd-shared/register-optional-fn!
-   'ai.miniforge.artifact.interface/get-artifact-provenance
-   (fn [id] (artifact/get-provenance (artifact/create-transit-store) id))))
-
-(defn- register-policy-pack-providers! []
-  (cmd-shared/register-optional-fn!
-   'ai.miniforge.policy-pack.interface/list-packs
-   (fn [] (:loaded (policy-pack/load-all-packs (str (app-config/home-dir) "/packs"))))))
-
-(register-artifact-providers!)
-(register-policy-pack-providers!)
 
 (defn- caught-message
   [caught throwable]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds.clj
@@ -20,7 +20,7 @@
   "Artifact commands: list, provenance.
 
    Uses ai.miniforge.artifact.interface directly, falling back to filesystem
-   scanning of the configured artifacts directory when the store is empty."
+   scanning of the configured artifacts directory when the store cannot be queried."
   (:require
    [ai.miniforge.artifact.interface :as artifact]
    [clojure.java.io :as io]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds.clj
@@ -19,9 +19,10 @@
 (ns ai.miniforge.cli.main.commands.artifact-cmds
   "Artifact commands: list, provenance.
 
-   Delegates to ai.miniforge.artifact.interface when available.
-   Falls back to filesystem scanning of the configured artifacts directory."
+   Uses ai.miniforge.artifact.interface directly, falling back to filesystem
+   scanning of the configured artifacts directory when the store is empty."
   (:require
+   [ai.miniforge.artifact.interface :as artifact]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
@@ -44,6 +45,19 @@
            (take shared/max-artifacts-display)
            vec)
       [])))
+
+(defn- create-artifact-store []
+  (artifact/create-transit-store {:dir (app-config/home-dir)}))
+
+(defn- list-component-artifacts []
+  (try
+    (vec (artifact/query (create-artifact-store) {}))
+    (catch Exception _ nil)))
+
+(defn- get-component-provenance [id]
+  (try
+    (artifact/get-provenance (create-artifact-store) id)
+    (catch Exception _ nil)))
 
 (defn format-file-size
   "Format a byte count into a human-readable size string."
@@ -91,7 +105,7 @@
   (println (display/style (messages/t :artifact/header) :foreground :cyan :bold true))
   (println (messages/t :artifact/directory {:dir (artifacts-dir)}))
   (println)
-  (let [component-result (shared/try-resolve-fn 'ai.miniforge.artifact.interface/list-artifacts)]
+  (let [component-result (list-component-artifacts)]
     (cond
       component-result
       (if (seq component-result)
@@ -123,8 +137,7 @@
   (let [{:keys [id]} opts]
     (if-not id
       (shared/usage-error! :artifact/provenance-usage "artifact provenance <id>")
-      (let [provenance (shared/try-resolve-fn
-                        'ai.miniforge.artifact.interface/get-artifact-provenance id)]
+      (let [provenance (get-component-provenance id)]
         (if provenance
           (display-provenance id provenance)
           ;; Fallback: look for artifact file in artifacts dir

--- a/bases/cli/src/ai/miniforge/cli/main/commands/policy.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/policy.clj
@@ -19,10 +19,10 @@
 (ns ai.miniforge.cli.main.commands.policy
   "Policy pack commands: list, show, install.
 
-   Delegates to ai.miniforge.policy-pack.interface when available.
-   Falls back to classpath resource scanning for list/show when the
-   component is not loaded (Babashka-safe)."
+   Uses ai.miniforge.policy-pack.interface directly, with classpath resource
+   scanning as a fallback for built-in packs."
   (:require
+   [ai.miniforge.policy-pack.interface :as policy-pack]
    [babashka.fs :as fs]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -63,6 +63,18 @@
   []
   ["foundations-1.0.0" "miniforge-standards"])
 
+(defn- component-packs []
+  (try
+    (:loaded (policy-pack/load-all-packs (packs-dir)))
+    (catch Exception _ nil)))
+
+(defn- load-installed-pack [pack-id]
+  (let [result (try
+                 (policy-pack/load-pack (str (packs-dir) "/" pack-id ".pack.edn"))
+                 (catch Exception _ nil))]
+    (when (:success? result)
+      (:pack result))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Command implementations
 
@@ -74,8 +86,8 @@
   (println)
   (println (display/style (messages/t :policy/header) :foreground :cyan :bold true))
   (println)
-  ;; Try the component interface first
-  (let [component-packs (shared/try-resolve-fn 'ai.miniforge.policy-pack.interface/list-packs)]
+  ;; Try the component interface first.
+  (let [component-packs (component-packs)]
     (cond
       component-packs
       (if (seq component-packs)
@@ -119,7 +131,7 @@
       (shared/usage-error! :policy/show-usage "policy show <pack-id>")
       (let [pack (or (load-pack-from-resource pack-id)
                      (load-pack-from-path (str (packs-dir) "/" pack-id ".pack.edn"))
-                     (shared/try-resolve-fn 'ai.miniforge.policy-pack.interface/load-pack pack-id))]
+                     (load-installed-pack pack-id))]
         (if-not pack
           (do (display/print-error
                (messages/t :policy/not-found

--- a/bases/cli/src/ai/miniforge/cli/main/commands/policy.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/policy.clj
@@ -87,11 +87,11 @@
   (println (display/style (messages/t :policy/header) :foreground :cyan :bold true))
   (println)
   ;; Try the component interface first.
-  (let [component-packs (component-packs)]
+  (let [loaded-packs (component-packs)]
     (cond
-      component-packs
-      (if (seq component-packs)
-        (doseq [pack component-packs]
+      loaded-packs
+      (if (seq loaded-packs)
+        (doseq [pack loaded-packs]
           (println (str "  " (display/style (str (get pack :pack/id pack)) :foreground :bold)
                         (when-let [v (:pack/version pack)] (str " v" v))
                         (when-let [d (:pack/description pack)] (str "  —  " d)))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/artifact_cmds_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/artifact_cmds_test.clj
@@ -56,14 +56,14 @@
 
 (deftest artifact-list-cmd-no-component-empty-dir-test
   (testing "list command shows 'no artifacts' when dir is empty"
-    (with-redefs [shared/try-resolve-fn (constantly nil)
+    (with-redefs [sut/list-component-artifacts (constantly nil)
                   app-config/artifacts-dir (constantly "/tmp/nonexistent-artifacts")]
       (let [output (with-out-str (sut/artifact-list-cmd {}))]
         (is (re-find #"(?i)no artifacts" output))))))
 
 (deftest artifact-list-cmd-component-result-test
   (testing "list command displays component results when available"
-    (with-redefs [shared/try-resolve-fn
+    (with-redefs [sut/list-component-artifacts
                   (constantly [{:artifact/id "art-1"
                                 :artifact/type :code
                                 :artifact/workflow-id "wf-1"}])
@@ -81,7 +81,7 @@
 (deftest artifact-provenance-cmd-with-provenance-test
   (testing "provenance command displays provenance data"
     (let [prov (make-provenance)]
-      (with-redefs [shared/try-resolve-fn (constantly prov)
+      (with-redefs [sut/get-component-provenance (constantly prov)
                     app-config/artifacts-dir (constantly "/tmp/test")]
         (let [output (with-out-str (sut/artifact-provenance-cmd {:id "art-1"}))]
           (is (.contains output "wf-123"))
@@ -90,7 +90,7 @@
 (deftest artifact-provenance-cmd-not-found-test
   (testing "provenance command shows error when artifact not found"
     (let [exited? (atom false)]
-      (with-redefs [shared/try-resolve-fn (constantly nil)
+      (with-redefs [sut/get-component-provenance (constantly nil)
                     app-config/artifacts-dir (constantly "/tmp/nonexistent")
                     shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/artifact-provenance-cmd {:id "missing"}))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/policy_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/policy_test.clj
@@ -56,14 +56,14 @@
 
 (deftest policy-list-cmd-no-component-empty-dir-test
   (testing "list command shows 'no packs' when no packs available"
-    (with-redefs [shared/try-resolve-fn (constantly nil)
+    (with-redefs [sut/component-packs (constantly nil)
                   app-config/home-dir (constantly *tmp-dir*)]
       (let [output (with-out-str (sut/policy-list-cmd {}))]
         (is (re-find #"(?i)no installed" output))))))
 
 (deftest policy-list-cmd-component-results-test
   (testing "list command displays component results when available"
-    (with-redefs [shared/try-resolve-fn
+    (with-redefs [sut/component-packs
                   (constantly [{:pack/id "foundations-1.0.0"
                                 :pack/version "1.0.0"
                                 :pack/description "Core rules"}])]
@@ -80,7 +80,7 @@
 (deftest policy-show-cmd-not-found-test
   (testing "show command reports not found for unknown pack"
     (let [exited? (atom false)]
-      (with-redefs [shared/try-resolve-fn (constantly nil)
+      (with-redefs [sut/load-installed-pack (constantly nil)
                     app-config/home-dir (constantly *tmp-dir*)
                     shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/policy-show-cmd {:pack-id "nonexistent"}))

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md
@@ -64,9 +64,11 @@ fallback behavior while making the dependency boundary explicit.
 - [x] `git diff --check`
 - [x] Focused Clojure lint for touched CLI source and tests.
 - [x] Focused CLI command tests:
-  `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m
-  cognitect.test-runner -d bases/cli/test -n ai.miniforge.cli.main.commands.artifact-cmds-test -n
-  ai.miniforge.cli.main.commands.policy-test -n ai.miniforge.cli.main-test`
+
+  ```bash
+  clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m cognitect.test-runner -d bases/cli/test -n ai.miniforge.cli.main.commands.artifact-cmds-test -n ai.miniforge.cli.main.commands.policy-test -n ai.miniforge.cli.main-test
+  ```
+
 - [x] `bb pre-commit`
 
 ## Deployment Plan

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md
@@ -1,0 +1,98 @@
+# Fix CLI Artifact And Policy Command Composition
+
+## Overview
+
+This PR continues the standards-remediation work after the broad resolver
+cleanup waves by removing symbol-provider indirection from CLI artifact and
+policy commands where the components are always present on the product
+classpath.
+
+## Layer
+
+CLI adapter cleanup.
+
+The PR does not change artifact or policy domain behavior. It tightens CLI
+composition so command namespaces call concrete Polylith interfaces directly.
+
+## Motivation
+
+The CLI optional function registry was still carrying artifact and policy-pack
+entries that no longer represent optional product composition. Keeping those
+paths behind symbol lookups hides dependency requirements and makes broken
+interface calls fail silently. Direct interface calls preserve the existing
+fallback behavior while making the dependency boundary explicit.
+
+## Gap Analysis
+
+### Fixed in this PR
+
+- `bases/cli/.../commands/artifact_cmds.clj`
+  - Replaced `shared/try-resolve-fn` artifact listing with direct
+    `artifact/query` through a configured transit store.
+  - Replaced dynamic artifact provenance lookup with direct
+    `artifact/get-provenance`.
+  - Preserved the existing filesystem fallback paths.
+
+- `bases/cli/.../commands/policy.clj`
+  - Replaced `shared/try-resolve-fn` policy listing with direct
+    `policy-pack/load-all-packs`.
+  - Replaced dynamic installed-pack lookup with direct `policy-pack/load-pack`.
+  - Preserved resource and filesystem fallback behavior.
+
+- `bases/cli/.../main.clj`
+  - Removed artifact and policy-pack provider registration from the optional
+    CLI composition registry.
+
+### Intentionally left in place
+
+- `bases/cli/.../main.clj`
+  - `optional-composition-var` remains the explicit product-composition
+    boundary for optional web-dashboard / TUI classpath loading.
+
+- `bases/cli/.../commands/fleet.clj`
+  - TUI launch resolution still crosses the optional TUI product boundary.
+
+- `bases/cli/.../commands/etl.clj`
+  - ETL repository analysis still needs a separate product-boundary decision.
+
+- `bases/cli/.../commands/evidence.clj`
+  - Evidence command dynamic lookups need a separate manager/persistence design
+    review rather than a mechanical replacement.
+
+## Testing Plan
+
+- [x] `git diff --check`
+- [x] Focused Clojure lint for touched CLI source and tests.
+- [x] Focused CLI command tests:
+  `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m
+  cognitect.test-runner -d bases/cli/test -n ai.miniforge.cli.main.commands.artifact-cmds-test -n
+  ai.miniforge.cli.main.commands.policy-test -n ai.miniforge.cli.main-test`
+- [x] `bb pre-commit`
+
+## Deployment Plan
+
+Merge normally after CI and review. No migration step is required.
+
+## Rollback Plan
+
+Revert the PR. The change is localized to CLI artifact and policy command
+composition.
+
+## Related Issues/PRs
+
+- Builds on the standards remediation waves that landed in:
+  - #1221
+  - #1222
+  - #1228
+  - #1230
+
+## Checklist
+
+- [x] Production resolver hotspots reviewed
+- [x] Static CLI dependencies used where required
+- [x] Optional product-composition boundaries left explicit
+- [x] Focused tests passed
+- [x] Pre-commit passed
+- [ ] PR opened
+- [ ] Copilot comments settled
+- [ ] All review comments resolved


### PR DESCRIPTION
# Fix CLI Artifact And Policy Command Composition

## Overview

This PR continues the standards-remediation work after the broad resolver
cleanup waves by removing symbol-provider indirection from CLI artifact and
policy commands where the components are always present on the product
classpath.

## Layer

CLI adapter cleanup.

The PR does not change artifact or policy domain behavior. It tightens CLI
composition so command namespaces call concrete Polylith interfaces directly.

## Motivation

The CLI optional function registry was still carrying artifact and policy-pack
entries that no longer represent optional product composition. Keeping those
paths behind symbol lookups hides dependency requirements and makes broken
interface calls fail silently. Direct interface calls preserve the existing
fallback behavior while making the dependency boundary explicit.

## Gap Analysis

### Fixed in this PR

- `bases/cli/.../commands/artifact_cmds.clj`
  - Replaced `shared/try-resolve-fn` artifact listing with direct
    `artifact/query` through a configured transit store.
  - Replaced dynamic artifact provenance lookup with direct
    `artifact/get-provenance`.
  - Preserved the existing filesystem fallback paths.

- `bases/cli/.../commands/policy.clj`
  - Replaced `shared/try-resolve-fn` policy listing with direct
    `policy-pack/load-all-packs`.
  - Replaced dynamic installed-pack lookup with direct `policy-pack/load-pack`.
  - Preserved resource and filesystem fallback behavior.

- `bases/cli/.../main.clj`
  - Removed artifact and policy-pack provider registration from the optional
    CLI composition registry.

### Intentionally left in place

- `bases/cli/.../main.clj`
  - `optional-composition-var` remains the explicit product-composition
    boundary for optional web-dashboard / TUI classpath loading.

- `bases/cli/.../commands/fleet.clj`
  - TUI launch resolution still crosses the optional TUI product boundary.

- `bases/cli/.../commands/etl.clj`
  - ETL repository analysis still needs a separate product-boundary decision.

- `bases/cli/.../commands/evidence.clj`
  - Evidence command dynamic lookups need a separate manager/persistence design
    review rather than a mechanical replacement.

## Testing Plan

- [x] `git diff --check`
- [x] Focused Clojure lint for touched CLI source and tests.
- [x] Focused CLI command tests:
  `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m
  cognitect.test-runner -d bases/cli/test -n ai.miniforge.cli.main.commands.artifact-cmds-test -n
  ai.miniforge.cli.main.commands.policy-test -n ai.miniforge.cli.main-test`
- [x] `bb pre-commit`

## Deployment Plan

Merge normally after CI and review. No migration step is required.

## Rollback Plan

Revert the PR. The change is localized to CLI artifact and policy command
composition.

## Related Issues/PRs

- Builds on the standards remediation waves that landed in:
  - #1221
  - #1222
  - #1228
  - #1230

## Checklist

- [x] Production resolver hotspots reviewed
- [x] Static CLI dependencies used where required
- [x] Optional product-composition boundaries left explicit
- [x] Focused tests passed
- [x] Pre-commit passed
- [ ] PR opened
- [ ] Copilot comments settled
- [ ] All review comments resolved
