### PR TITLE
Fix policy-pack custom detector registration

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -30,7 +30,7 @@
    - :ast-analysis - Structural pattern matching via tree-sitter CLI
    - :state-comparison - Drift detection via clojure.data/diff
    - :capability - Mechanical tool-gate check via the capability registry
-   - :custom - Custom detection function (resolvable :custom-fn), else routed
+   - :custom - Registered custom detection function (:custom-fn), else routed
      to the LLM-as-judge semantic detector"
   (:require
    [ai.miniforge.policy-pack.ast :as ast]
@@ -324,13 +324,43 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Custom detection
 
+(defonce ^{:private true
+           :doc "Explicit extension registry for custom policy detectors.
+
+Keys are the symbols stored under `:rule/detection :custom-fn`; values are
+2-arity detector functions. This keeps pack manifests data-driven without
+depending on ambient namespace loading or raw var resolution."}
+  custom-fn-registry
+  (atom {}))
+
+(defn register-custom-fn!
+  "Register `f` as the detector implementation for `custom-fn-sym`.
+
+   Custom policy detectors are an explicit extension point. Callers that own a
+   detector namespace should register the symbol they place in policy-pack EDN
+   before compiling or applying packs."
+  [custom-fn-sym f]
+  (when-not (symbol? custom-fn-sym)
+    (throw (ex-info "Custom detector key must be a symbol"
+                    {:custom-fn custom-fn-sym})))
+  (when-not (fn? f)
+    (throw (ex-info "Custom detector value must be a function"
+                    {:custom-fn custom-fn-sym})))
+  (swap! custom-fn-registry assoc custom-fn-sym f)
+  f)
+
+(defn unregister-custom-fn!
+  "Remove a registered custom detector. Intended for tests and reload hygiene."
+  [custom-fn-sym]
+  (swap! custom-fn-registry dissoc custom-fn-sym)
+  nil)
+
 (defn- resolve-custom-fn
-  "Resolve a `:custom` rule's `:custom-fn` symbol to a var, or nil. Never
-   throws — an unresolvable symbol is the no-op case routed to the judge."
+  "Look up a `:custom` rule's `:custom-fn` symbol in the explicit registry.
+   Missing registrations are the no-op case routed to the judge."
   [rule]
   (when-let [custom-fn-sym (get-in rule [:rule/detection :custom-fn])]
-    (try (resolve custom-fn-sym)
-         (catch Exception _ nil))))
+    (get @custom-fn-registry custom-fn-sym)))
 
 (defn- run-resolved-custom
   "Run an already-resolved custom fn against `artifact`/`context`, adapting
@@ -352,7 +382,7 @@
 (defn detect-custom
   "Detect violations using a custom function.
 
-   The custom function is specified by symbol in :custom-fn and must:
+   The custom function is specified by registered symbol in :custom-fn and must:
    - Accept [artifact context]
    - Return violation map or nil
 
@@ -368,7 +398,7 @@
     (run-resolved-custom f rule artifact context)))
 
 (defn custom-fn-resolvable?
-  "True when a `:custom` rule names a `:custom-fn` symbol that resolves to a var.
+  "True when a `:custom` rule names a registered `:custom-fn` symbol.
 
    A `:custom` rule with no resolvable `:custom-fn` is the no-op case the
    compiled standards pack is full of (PR #979): such rules route to the

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -333,6 +333,27 @@ depending on ambient namespace loading or raw var resolution."}
   custom-fn-registry
   (atom {}))
 
+(defn- declared-method?
+  [method-name arity f]
+  (some (fn [^java.lang.reflect.Method method]
+          (and (= method-name (.getName method))
+               (= arity (count (.getParameterTypes method)))))
+        (.getDeclaredMethods (class f))))
+
+(defn- variadic-accepts-arity?
+  [arity f]
+  (when (declared-method? "getRequiredArity" 0 f)
+    (try
+      (<= (.getRequiredArity f) arity)
+      (catch Throwable _ false))))
+
+(defn- detector-predicate?
+  "True when `f` is a custom detector predicate with a supported 2-arity shape."
+  [f]
+  (and (fn? f)
+       (or (declared-method? "invoke" 2 f)
+           (variadic-accepts-arity? 2 f))))
+
 (defn register-custom-fn!
   "Register `f` as the detector implementation for `custom-fn-sym`.
 
@@ -343,9 +364,10 @@ depending on ambient namespace loading or raw var resolution."}
   (when-not (symbol? custom-fn-sym)
     (throw (ex-info "Custom detector key must be a symbol"
                     {:custom-fn custom-fn-sym})))
-  (when-not (fn? f)
-    (throw (ex-info "Custom detector value must be a function"
-                    {:custom-fn custom-fn-sym})))
+  (when-not (detector-predicate? f)
+    (throw (ex-info "Custom detector value must be a two-arity predicate function"
+                    {:custom-fn custom-fn-sym
+                     :value-type (some-> f class .getName)})))
   (swap! custom-fn-registry assoc custom-fn-sym f)
   f)
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -30,7 +30,7 @@
    [ai.miniforge.policy-pack.interface.intent :as intent]
    [ai.miniforge.policy-pack.interface.mapping :as mapping]
    [ai.miniforge.policy-pack.interface.prompt-template :as prompt-template]
-   [ai.miniforge.policy-pack.interface.taxonomy :as taxonomy]
+   [ai.miniforge.policy-pack.detection :as detection]
    [ai.miniforge.policy-pack.mdc-compiler :as mdc-compiler]
    [ai.miniforge.policy-pack.software-factory :as software-factory]))
 
@@ -225,6 +225,17 @@
    judge throws, or nil when clean or when the semantic wiring is absent from
    context."
   checking/detect-semantic)
+
+(def register-custom-fn!
+  "Register a custom policy detector implementation for a `:custom-fn` symbol.
+   Explicit registration replaces ambient var resolution for custom detector
+   extension points."
+  detection/register-custom-fn!)
+
+(def unregister-custom-fn!
+  "Remove a custom policy detector registration. Intended for tests and reload
+   hygiene."
+  detection/unregister-custom-fn!)
 
 (def check-rules
   "Check multiple rules against one artifact.

--- a/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
@@ -269,14 +269,33 @@
          (map (fn [w] (violation :minor (:message w) :raw w))
               (:warnings result)))))))
 
+(defn- first-violation-detector
+  "Adapt legacy knowledge-safety detectors to the custom-detector contract.
+
+   The public helpers in this namespace return a sequence of violations for
+   direct callers. `detect-custom` expects one violation map or nil, so registered
+   detector functions expose the first violation only."
+  [detector]
+  (fn [artifact context]
+    (let [result (detector artifact context)]
+      (cond
+        (map? result) result
+        (seqable? result) (first (seq result))
+        :else nil))))
+
 (def ^:private custom-detectors
-  {'ai.miniforge.policy-pack.knowledge-safety/check-trust-labels check-trust-labels
-   'ai.miniforge.policy-pack.knowledge-safety/check-instruction-authority check-instruction-authority
-   'ai.miniforge.policy-pack.knowledge-safety/check-agent-source check-agent-source
-   'ai.miniforge.policy-pack.knowledge-safety/validate-pack-schema validate-pack-schema
-   'ai.miniforge.policy-pack.knowledge-safety/check-pack-root check-pack-root
+  {'ai.miniforge.policy-pack.knowledge-safety/check-trust-labels
+   (first-violation-detector check-trust-labels)
+   'ai.miniforge.policy-pack.knowledge-safety/check-instruction-authority
+   (first-violation-detector check-instruction-authority)
+   'ai.miniforge.policy-pack.knowledge-safety/check-agent-source
+   (first-violation-detector check-agent-source)
+   'ai.miniforge.policy-pack.knowledge-safety/validate-pack-schema
+   (first-violation-detector validate-pack-schema)
+   'ai.miniforge.policy-pack.knowledge-safety/check-pack-root
+   (first-violation-detector check-pack-root)
    'ai.miniforge.policy-pack.knowledge-safety/validate-pack-dependencies-wrapper
-   validate-pack-dependencies-wrapper})
+   (first-violation-detector validate-pack-dependencies-wrapper)})
 
 #_{:clj-kondo/ignore [:unused-private-var]}
 (def ^:private registered-custom-detectors?

--- a/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
@@ -279,7 +279,7 @@
    validate-pack-dependencies-wrapper})
 
 #_{:clj-kondo/ignore [:unused-private-var]}
-(defonce ^:private registered-custom-detectors?
+(def ^:private registered-custom-detectors?
   (do
     (doseq [[custom-fn-sym f] custom-detectors]
       (detection/register-custom-fn! custom-fn-sym f))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
@@ -35,6 +35,7 @@
    [clojure.string :as str]
    [ai.miniforge.config.interface :as config]
    [ai.miniforge.policy-pack.core :as core]
+   [ai.miniforge.policy-pack.detection :as detection]
    [ai.miniforge.policy-pack.schema :as schema]
    [ai.miniforge.policy-pack.rules.pack-dependency-validation :as dep-validation]))
 
@@ -267,6 +268,22 @@
               (:violations result))
          (map (fn [w] (violation :minor (:message w) :raw w))
               (:warnings result)))))))
+
+(def ^:private custom-detectors
+  {'ai.miniforge.policy-pack.knowledge-safety/check-trust-labels check-trust-labels
+   'ai.miniforge.policy-pack.knowledge-safety/check-instruction-authority check-instruction-authority
+   'ai.miniforge.policy-pack.knowledge-safety/check-agent-source check-agent-source
+   'ai.miniforge.policy-pack.knowledge-safety/validate-pack-schema validate-pack-schema
+   'ai.miniforge.policy-pack.knowledge-safety/check-pack-root check-pack-root
+   'ai.miniforge.policy-pack.knowledge-safety/validate-pack-dependencies-wrapper
+   validate-pack-dependencies-wrapper})
+
+#_{:clj-kondo/ignore [:unused-private-var]}
+(defonce ^:private registered-custom-detectors?
+  (do
+    (doseq [[custom-fn-sym f] custom-detectors]
+      (detection/register-custom-fn! custom-fn-sym f))
+    true))
 
 ;------------------------------------------------------------------------------ Pack Assembly
 

--- a/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
@@ -25,17 +25,21 @@
    [ai.miniforge.policy-pack.detection :as detection]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.test :refer [deftest is testing]]))
+   [clojure.test :refer [deftest is testing use-fixtures]]))
 
 (defn- a-resolvable-custom-fn [_artifact _context] nil)
 
-#_{:clj-kondo/ignore [:unused-private-var]}
-(def ^:private registered-test-custom-fn?
-  (do
-    (detection/register-custom-fn!
-     'ai.miniforge.policy-pack.compiler-test/a-resolvable-custom-fn
-     a-resolvable-custom-fn)
-    true))
+(def ^:private resolvable-custom-fn-sym
+  'ai.miniforge.policy-pack.compiler-test/a-resolvable-custom-fn)
+
+(use-fixtures
+  :once
+  (fn [run-tests]
+    (detection/register-custom-fn! resolvable-custom-fn-sym a-resolvable-custom-fn)
+    (try
+      (run-tests)
+      (finally
+        (detection/unregister-custom-fn! resolvable-custom-fn-sym)))))
 
 (defn- noop-check [_artifact _context] nil)
 
@@ -79,7 +83,7 @@
            (sut/resolve-detector
             {:rule/detection
              {:type :custom
-              :custom-fn 'ai.miniforge.policy-pack.compiler-test/a-resolvable-custom-fn}}))))
+              :custom-fn resolvable-custom-fn-sym}}))))
   (testing "a :custom rule with no :custom-fn binds to :semantic (always available)"
     (is (= :semantic (sut/resolve-detector {:rule/detection {:type :custom}}))))
   (testing "a :custom rule with an unresolvable :custom-fn binds to :semantic"

--- a/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
@@ -30,7 +30,7 @@
 (defn- a-resolvable-custom-fn [_artifact _context] nil)
 
 #_{:clj-kondo/ignore [:unused-private-var]}
-(defonce ^:private registered-test-custom-fn?
+(def ^:private registered-test-custom-fn?
   (do
     (detection/register-custom-fn!
      'ai.miniforge.policy-pack.compiler-test/a-resolvable-custom-fn

--- a/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
@@ -22,11 +22,20 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.policy-pack.capability :as capability]
    [ai.miniforge.policy-pack.compiler :as sut]
+   [ai.miniforge.policy-pack.detection :as detection]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]))
 
 (defn- a-resolvable-custom-fn [_artifact _context] nil)
+
+#_{:clj-kondo/ignore [:unused-private-var]}
+(defonce ^:private registered-test-custom-fn?
+  (do
+    (detection/register-custom-fn!
+     'ai.miniforge.policy-pack.compiler-test/a-resolvable-custom-fn
+     a-resolvable-custom-fn)
+    true))
 
 (defn- noop-check [_artifact _context] nil)
 

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -20,7 +20,7 @@
   "Tests for the policy-pack detection logic."
   (:require
    [clojure.string]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.policy-pack.capability :as capability]
    [ai.miniforge.policy-pack.detection :as detection]))
 
@@ -304,19 +304,23 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Semantic (LLM-as-judge) detection tests
 
+(def ^:private resolvable-custom-fn-sym
+  'ai.miniforge.policy-pack.detection-test/a-resolvable-custom-fn)
+
 (defn a-resolvable-custom-fn
   "A real custom detection fn used to prove resolvable :custom-fn rules stay
    on the deterministic detect-custom path (not routed to the judge)."
   [_artifact _context]
   {:matches ["custom-hit"]})
 
-#_{:clj-kondo/ignore [:unused-private-var]}
-(def ^:private registered-test-custom-fn?
-  (do
-    (detection/register-custom-fn!
-     'ai.miniforge.policy-pack.detection-test/a-resolvable-custom-fn
-     a-resolvable-custom-fn)
-    true))
+(use-fixtures
+  :once
+  (fn [run-tests]
+    (detection/register-custom-fn! resolvable-custom-fn-sym a-resolvable-custom-fn)
+    (try
+      (run-tests)
+      (finally
+        (detection/unregister-custom-fn! resolvable-custom-fn-sym)))))
 
 (deftest register-custom-fn-validates-detector-predicate-test
   (testing "custom detector registration rejects non-functions"
@@ -340,7 +344,7 @@
     (is (detection/custom-fn-resolvable?
          {:rule/detection
           {:type :custom
-           :custom-fn 'ai.miniforge.policy-pack.detection-test/a-resolvable-custom-fn}})))
+           :custom-fn resolvable-custom-fn-sym}})))
   (testing "a :custom rule with no :custom-fn is not resolvable"
     (is (not (detection/custom-fn-resolvable? {:rule/detection {:type :custom}}))))
   (testing "a :custom rule with an unresolvable :custom-fn is not resolvable"
@@ -400,7 +404,7 @@
     (let [rule   {:rule/id :resolvable
                   :rule/detection
                   {:type :custom
-                   :custom-fn 'ai.miniforge.policy-pack.detection-test/a-resolvable-custom-fn}}
+                   :custom-fn resolvable-custom-fn-sym}}
           ;; If this routed to the judge it would NPE on a nil analyze-fn /
           ;; return nil; detect-custom must produce the custom-tagged violation.
           result (detection/detect-violation rule {} {})]

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -310,6 +310,14 @@
   [_artifact _context]
   {:matches ["custom-hit"]})
 
+#_{:clj-kondo/ignore [:unused-private-var]}
+(defonce ^:private registered-test-custom-fn?
+  (do
+    (detection/register-custom-fn!
+     'ai.miniforge.policy-pack.detection-test/a-resolvable-custom-fn
+     a-resolvable-custom-fn)
+    true))
+
 (deftest custom-fn-resolvable-test
   (testing "a :custom rule with a resolvable :custom-fn is resolvable"
     (is (detection/custom-fn-resolvable?

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -318,6 +318,23 @@
      a-resolvable-custom-fn)
     true))
 
+(deftest register-custom-fn-validates-detector-predicate-test
+  (testing "custom detector registration rejects non-functions"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"two-arity predicate function"
+         (detection/register-custom-fn! 'test/not-a-detector {:not :a-fn}))))
+  (testing "custom detector registration rejects functions without artifact/context arity"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"two-arity predicate function"
+         (detection/register-custom-fn! 'test/wrong-arity (fn [_artifact] nil)))))
+  (testing "custom detector registration accepts a two-arity detector"
+    (let [detector (fn [_artifact _context] nil)]
+      (is (identical? detector
+                      (detection/register-custom-fn! 'test/two-arity detector)))
+      (detection/unregister-custom-fn! 'test/two-arity))))
+
 (deftest custom-fn-resolvable-test
   (testing "a :custom rule with a resolvable :custom-fn is resolvable"
     (is (detection/custom-fn-resolvable?

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -311,7 +311,7 @@
   {:matches ["custom-hit"]})
 
 #_{:clj-kondo/ignore [:unused-private-var]}
-(defonce ^:private registered-test-custom-fn?
+(def ^:private registered-test-custom-fn?
   (do
     (detection/register-custom-fn!
      'ai.miniforge.policy-pack.detection-test/a-resolvable-custom-fn

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave52.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave52.md
@@ -1,0 +1,81 @@
+# Fix Policy Pack Custom Detector Registration
+
+## Overview
+
+This PR removes production `resolve` use from policy-pack custom detector
+binding. Custom detector symbols remain data in policy-pack manifests, but they
+now bind through an explicit registry instead of ambient namespace state.
+
+## Layer
+
+Policy-pack extension boundary cleanup.
+
+## Motivation
+
+Policy compilation must not silently depend on whether a namespace happened to
+be loaded before `resolve` runs. A compiled policy rule either binds to an
+explicit detector mechanism or routes to the semantic detector. This PR keeps
+that behavior while making the custom detector extension point deliberate and
+testable.
+
+## Changes in Detail
+
+- Added `register-custom-fn!` / `unregister-custom-fn!` to
+  `policy_pack.detection`.
+- Replaced raw `resolve` for `:custom-fn` with lookup in the explicit custom
+  detector registry.
+- Exported custom detector registration through `policy-pack.interface`.
+- Registered the built-in knowledge-safety custom detector functions at
+  namespace load.
+- Updated policy-pack tests to register their test custom detector symbols
+  explicitly.
+
+## Gap Analysis
+
+### Fixed in this PR
+
+- `components/policy-pack/.../detection.clj`
+  - Removed production raw `resolve` from custom detector binding.
+
+### Intentionally left in place
+
+- Semantic detector injection still remains context-driven. That is the
+  existing dependency-cycle boundary between policy-pack and semantic-analyzer.
+- Rich-comment examples and test-only reflective assertions are outside this
+  production cleanup slice.
+
+## Testing Plan
+
+- [x] `git diff --check`
+- [x] Focused Clojure lint for touched policy-pack source and tests.
+- [x] Focused policy-pack tests:
+
+  ```bash
+  clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m cognitect.test-runner -d components/policy-pack/test -n ai.miniforge.policy-pack.knowledge-safety-test -n ai.miniforge.policy-pack.detection-test -n ai.miniforge.policy-pack.compiler-test
+  ```
+
+- [x] `bb pre-commit`
+
+## Deployment Plan
+
+Merge normally after CI and review. Custom detector owners should register
+their detector symbols through `policy-pack.interface/register-custom-fn!`.
+
+## Rollback Plan
+
+Revert the PR. The change is localized to policy-pack custom detector binding.
+
+## Related Issues/PRs
+
+- Builds on the standards remediation series through #1232.
+
+## Checklist
+
+- [x] Production raw resolver reviewed
+- [x] Extension boundary made explicit
+- [x] Built-in custom detectors registered
+- [x] Focused tests passed
+- [x] Pre-commit passed
+- [ ] PR opened
+- [ ] Copilot comments settled
+- [ ] All review comments resolved


### PR DESCRIPTION
# Fix Policy Pack Custom Detector Registration

## Overview

This PR removes production `resolve` use from policy-pack custom detector
binding. Custom detector symbols remain data in policy-pack manifests, but they
now bind through an explicit registry instead of ambient namespace state.

## Layer

Policy-pack extension boundary cleanup.

## Motivation

Policy compilation must not silently depend on whether a namespace happened to
be loaded before `resolve` runs. A compiled policy rule either binds to an
explicit detector mechanism or routes to the semantic detector. This PR keeps
that behavior while making the custom detector extension point deliberate and
testable.

## Changes in Detail

- Added `register-custom-fn!` / `unregister-custom-fn!` to
  `policy_pack.detection`.
- Replaced raw `resolve` for `:custom-fn` with lookup in the explicit custom
  detector registry.
- Exported custom detector registration through `policy-pack.interface`.
- Registered the built-in knowledge-safety custom detector functions at
  namespace load.
- Updated policy-pack tests to register their test custom detector symbols
  explicitly.

## Gap Analysis

### Fixed in this PR

- `components/policy-pack/.../detection.clj`
  - Removed production raw `resolve` from custom detector binding.

### Intentionally left in place

- Semantic detector injection still remains context-driven. That is the
  existing dependency-cycle boundary between policy-pack and semantic-analyzer.
- Rich-comment examples and test-only reflective assertions are outside this
  production cleanup slice.

## Testing Plan

- [x] `git diff --check`
- [x] Focused Clojure lint for touched policy-pack source and tests.
- [x] Focused policy-pack tests:

  ```bash
  clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m cognitect.test-runner -d components/policy-pack/test -n ai.miniforge.policy-pack.knowledge-safety-test -n ai.miniforge.policy-pack.detection-test -n ai.miniforge.policy-pack.compiler-test
  ```

- [x] `bb pre-commit`

## Deployment Plan

Merge normally after CI and review. Custom detector owners should register
their detector symbols through `policy-pack.interface/register-custom-fn!`.

## Rollback Plan

Revert the PR. The change is localized to policy-pack custom detector binding.

## Related Issues/PRs

- Builds on the standards remediation series through #1232.

## Checklist

- [x] Production raw resolver reviewed
- [x] Extension boundary made explicit
- [x] Built-in custom detectors registered
- [x] Focused tests passed
- [x] Pre-commit passed
- [ ] PR opened
- [ ] Copilot comments settled
- [ ] All review comments resolved
