### PR TITLE
Fix CLI ETL repo direct analysis

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -393,7 +393,7 @@
   :etl/output-path "  Output: {path}"
   :etl/failed "ETL failed: {error}"
   :etl/clone-failed "Clone failed: {error}"
-  :etl/analysis-complete "Repository analysis complete (ETL fallback)."
+  :etl/analysis-complete "Repository analysis complete."
   :etl/technologies "  Technologies: {value}"
   :etl/git-host "  Git host:     {value}"
   :etl/packs "  Packs:        {value}"

--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -397,7 +397,7 @@
   :etl/technologies "  Technologies: {value}"
   :etl/git-host "  Git host:     {value}"
   :etl/packs "  Packs:        {value}"
-  :etl/install-note "Install the etl-pipe component for full ETL support."
+  :etl/install-note "Use etl run with a Data Foundry pack for full pipeline execution."
   :etl/analysis-failed "Analysis failed: {error}"
 
   ;; ── Evidence ──────────────────────────────────────────────────────────

--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
@@ -27,9 +27,9 @@
      - `etl list <search-path>`        — discover pipeline EDN files.
      - `etl validate <pack> --env …`   — load + resolve without running.
 
-   The `etl repo` command delegates to `ai.miniforge.etl-pipe.interface`
-   when available. The `etl run|list|validate` commands shell out to
-   `ai.miniforge.etl.main` on the JVM."
+   The `etl repo` command clones the repository and runs the direct
+   repo-analyzer interface. The `etl run|list|validate` commands shell
+   out to `ai.miniforge.etl.main` on the JVM."
   (:require
    [babashka.fs :as fs]
    [babashka.process :as process]
@@ -181,10 +181,10 @@
         1)))
 
 ;------------------------------------------------------------------------------ Layer 3
-;; Fallback analysis (etl repo)
+;; Repository analysis (etl repo)
 
-(defn- etl-repo-fallback
-  "Clone repo and run repo-analyzer as ETL fallback."
+(defn- analyze-repo-url!
+  "Clone repo and run repo-analyzer against the temporary checkout."
   [url]
   (let [clone-result (git-clone-temp url)]
     (if (schema/failed? clone-result)
@@ -224,21 +224,7 @@
             (shared/exit! 1))
         (do
           (display/print-info (messages/t :etl/running {:url url}))
-          (let [result (shared/try-resolve-fn 'ai.miniforge.etl-pipe.interface/etl-repo url opts)]
-            (cond
-              (and result (schema/succeeded? result))
-              (do
-                (display/print-success (messages/t :etl/complete))
-                (when-let [artifacts (:artifacts result)]
-                  (println (messages/t :etl/artifacts-produced {:count (count artifacts)})))
-                (when-let [path (:output-path result)]
-                  (println (messages/t :etl/output-path {:path path}))))
-
-              (and result (schema/failed? result))
-              (display/print-error (messages/t :etl/failed {:error (get result :error "unknown error")}))
-
-              :else
-              (etl-repo-fallback url))))))))
+          (analyze-repo-url! url))))))
 
 (defn etl-run-cmd
   "Execute a Data Foundry ETL pack.

--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
@@ -188,7 +188,9 @@
   [url]
   (let [clone-result (git-clone-temp url)]
     (if (schema/failed? clone-result)
-      (display/print-error (messages/t :etl/clone-failed {:error (:error clone-result)}))
+      (do
+        (display/print-error (messages/t :etl/clone-failed {:error (:error clone-result)}))
+        1)
       (let [repo-path (:path clone-result)]
         (try
           (let [analysis (repo-analyzer/analyze-repo repo-path)]
@@ -197,9 +199,11 @@
             (println (messages/t :etl/git-host {:value (get analysis :git-host "unknown")}))
             (println (messages/t :etl/packs {:value (pr-str (:packs analysis))}))
             (println)
-            (println (display/style (messages/t :etl/install-note) :foreground :yellow)))
+            (println (display/style (messages/t :etl/install-note) :foreground :yellow))
+            0)
           (catch Exception e
-            (display/print-error (messages/t :etl/analysis-failed {:error (ex-message e)})))
+            (display/print-error (messages/t :etl/analysis-failed {:error (ex-message e)}))
+            1)
           (finally
             (try (fs/delete-tree repo-path)
                  (catch Exception _ nil))))))))
@@ -224,7 +228,9 @@
             (shared/exit! 1))
         (do
           (display/print-info (messages/t :etl/running {:url url}))
-          (analyze-repo-url! url))))))
+          (let [exit-code (analyze-repo-url! url)]
+            (when (pos? exit-code)
+              (shared/exit! exit-code))))))))
 
 (defn etl-run-cmd
   "Execute a Data Foundry ETL pack.

--- a/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
@@ -19,6 +19,8 @@
 (ns ai.miniforge.cli.main.commands.etl-test
   "Unit tests for ETL CLI commands."
   (:require
+   [ai.miniforge.repo-analyzer.interface :as repo-analyzer]
+   [ai.miniforge.schema.interface :as schema]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.cli.main.commands.etl :as sut]
    [ai.miniforge.cli.main.commands.shared :as shared]))
@@ -66,3 +68,31 @@
       (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/etl-repo-cmd {:url "bad-url"}))
         (is @exited?)))))
+
+(deftest etl-repo-cmd-analyzes-repo-directly-test
+  (testing "valid repo URLs use the direct repo-analyzer interface"
+    (let [repo-dir (.toFile
+                    (java.nio.file.Files/createTempDirectory
+                     "etl-repo-test"
+                     (make-array java.nio.file.attribute.FileAttribute 0)))
+          calls (atom [])]
+      (.deleteOnExit repo-dir)
+      (with-redefs-fn {#'sut/git-clone-temp
+                       (fn [url]
+                         (swap! calls conj [:clone url])
+                         (schema/success :path (.getAbsolutePath repo-dir)))
+                       #'repo-analyzer/analyze-repo
+                       (fn [repo-path]
+                         (swap! calls conj [:analyze repo-path])
+                         {:technologies [:clojure]
+                          :git-host "github"
+                          :packs [:foundations]})
+                       #'shared/try-resolve-fn
+                       (fn [& _]
+                         (throw (ex-info "optional provider should not be used" {})))}
+        (fn []
+          (with-out-str
+            (sut/etl-repo-cmd {:url "https://github.com/example/repo"}))
+          (is (= [[:clone "https://github.com/example/repo"]
+                  [:analyze (.getAbsolutePath repo-dir)]]
+                 @calls)))))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
@@ -87,12 +87,51 @@
                          {:technologies [:clojure]
                           :git-host "github"
                           :packs [:foundations]})
-                       #'shared/try-resolve-fn
-                       (fn [& _]
-                         (throw (ex-info "optional provider should not be used" {})))}
+                    #'shared/try-resolve-fn
+                    (fn [& _]
+                      (throw (ex-info "optional provider should not be used" {})))
+                    #'shared/exit!
+                    (fn [code]
+                      (throw (ex-info "unexpected exit" {:code code})))}
         (fn []
           (with-out-str
             (sut/etl-repo-cmd {:url "https://github.com/example/repo"}))
           (is (= [[:clone "https://github.com/example/repo"]
                   [:analyze (.getAbsolutePath repo-dir)]]
                  @calls)))))))
+
+(deftest etl-repo-cmd-exits-on-clone-failure-test
+  (testing "clone failures become a non-zero command exit"
+    (let [exit-code (atom nil)]
+      (with-redefs-fn {#'sut/git-clone-temp
+                       (fn [_url]
+                         (schema/failure :path "clone failed"))
+                       #'shared/exit!
+                       (fn [code]
+                         (reset! exit-code code))}
+        (fn []
+          (with-out-str
+            (sut/etl-repo-cmd {:url "https://github.com/example/repo"}))
+          (is (= 1 @exit-code)))))))
+
+(deftest etl-repo-cmd-exits-on-analysis-failure-test
+  (testing "repo-analyzer failures become a non-zero command exit"
+    (let [repo-dir (.toFile
+                    (java.nio.file.Files/createTempDirectory
+                     "etl-repo-test"
+                     (make-array java.nio.file.attribute.FileAttribute 0)))
+          exit-code (atom nil)]
+      (.deleteOnExit repo-dir)
+      (with-redefs-fn {#'sut/git-clone-temp
+                       (fn [_url]
+                         (schema/success :path (.getAbsolutePath repo-dir)))
+                       #'repo-analyzer/analyze-repo
+                       (fn [_repo-path]
+                         (throw (ex-info "analysis failed" {})))
+                       #'shared/exit!
+                       (fn [code]
+                         (reset! exit-code code))}
+        (fn []
+          (with-out-str
+            (sut/etl-repo-cmd {:url "https://github.com/example/repo"}))
+          (is (= 1 @exit-code)))))))

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave53.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave53.md
@@ -1,0 +1,74 @@
+# Fix CLI ETL Repo Direct Analysis
+
+## Overview
+
+This PR removes the dead optional `etl-pipe` provider lookup from `mf etl repo`.
+The command now calls the direct `repo-analyzer` interface path that was already
+required by the namespace.
+
+## Layer
+
+CLI command composition cleanup.
+
+## Motivation
+
+`mf etl repo` previously attempted to call
+`ai.miniforge.etl-pipe.interface/etl-repo` through the optional CLI provider
+registry. That component is not present in the workspace, so the command always
+silently degraded to the fallback path. The fallback is the real implementation
+available in this product slice, so the command should name it directly.
+
+## Changes in Detail
+
+- Replaced the optional `etl-pipe` lookup with a direct `repo-analyzer` command
+  path.
+- Renamed the private fallback helper to describe the actual repository
+  analysis behavior.
+- Updated the user-facing ETL note so it does not tell users to install a
+  nonexistent component.
+- Added a regression test that fails if `etl repo` touches the optional
+  provider registry for valid repo URLs.
+
+## Gap Analysis
+
+### Fixed in this PR
+
+- `bases/cli/.../commands/etl.clj`
+  - Removed dead optional provider lookup for `etl-pipe`.
+
+### Intentionally left in place
+
+- The CLI optional provider registry still exists for true product composition
+  boundaries such as TUI availability.
+- Other CLI optional provider removals are handled in separate remediation PRs
+  to keep review scope small.
+
+## Testing Plan
+
+- [x] `clj-kondo --lint bases/cli/src/ai/miniforge/cli/main/commands/etl.clj bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj`
+- [x] `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}'
+  -M:dev:test -m cognitect.test-runner -d bases/cli/test -n ai.miniforge.cli.main.commands.etl-test`
+- [x] `git diff --check`
+- [x] `bb pre-commit`
+
+## Deployment Plan
+
+Merge normally after CI and review. No migration is required.
+
+## Rollback Plan
+
+Revert the PR.
+
+## Related Issues/PRs
+
+- Continues the standards remediation series after #1233.
+
+## Checklist
+
+- [x] Dead optional provider removed
+- [x] Direct interface path covered by tests
+- [x] Focused tests passed
+- [x] Pre-commit passed
+- [ ] PR opened
+- [ ] Copilot comments settled
+- [ ] All review comments resolved


### PR DESCRIPTION
# Fix CLI ETL Repo Direct Analysis

## Overview

This PR removes the dead optional `etl-pipe` provider lookup from `mf etl repo`.
The command now calls the direct `repo-analyzer` interface path that was already
required by the namespace.

## Layer

CLI command composition cleanup.

## Motivation

`mf etl repo` previously attempted to call
`ai.miniforge.etl-pipe.interface/etl-repo` through the optional CLI provider
registry. That component is not present in the workspace, so the command always
silently degraded to the fallback path. The fallback is the real implementation
available in this product slice, so the command should name it directly.

## Changes in Detail

- Replaced the optional `etl-pipe` lookup with a direct `repo-analyzer` command
  path.
- Renamed the private fallback helper to describe the actual repository
  analysis behavior.
- Updated the user-facing ETL note so it does not tell users to install a
  nonexistent component.
- Added a regression test that fails if `etl repo` touches the optional
  provider registry for valid repo URLs.

## Gap Analysis

### Fixed in this PR

- `bases/cli/.../commands/etl.clj`
  - Removed dead optional provider lookup for `etl-pipe`.

### Intentionally left in place

- The CLI optional provider registry still exists for true product composition
  boundaries such as TUI availability.
- Other CLI optional provider removals are handled in separate remediation PRs
  to keep review scope small.

## Testing Plan

- [x] `clj-kondo --lint bases/cli/src/ai/miniforge/cli/main/commands/etl.clj bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj`
- [x] `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}'
  -M:dev:test -m cognitect.test-runner -d bases/cli/test -n ai.miniforge.cli.main.commands.etl-test`
- [x] `git diff --check`
- [x] `bb pre-commit`

## Deployment Plan

Merge normally after CI and review. No migration is required.

## Rollback Plan

Revert the PR.

## Related Issues/PRs

- Continues the standards remediation series after #1233.

## Checklist

- [x] Dead optional provider removed
- [x] Direct interface path covered by tests
- [x] Focused tests passed
- [x] Pre-commit passed
- [ ] PR opened
- [ ] Copilot comments settled
- [ ] All review comments resolved
