### PR TITLE
fix(pipeline-runner): preserve exception type and cause chain in stage failure results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ work/dogfood-session-*.edn
 work/*-local.spec.edn
 work/*-wip.edn
 .miniforge/
+.worktrees/

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -29,6 +29,20 @@
      {:started-at   (or started-at now)
       :completed-at now})))
 
+(defn- exception-context
+  "Build structured exception metadata for failed stage results."
+  [^Throwable e]
+  (let [causes (->> (iterate ex-cause e)
+                    rest
+                    (take-while some?)
+                    (mapv (fn [^Throwable cause]
+                            {:error-message (ex-message cause)
+                             :error-type    (.getName (class cause))})))]
+    {:error-message (ex-message e)
+     :error-type    (.getName (class e))
+     :error-cause   (:error-message (first causes))
+     :error-causes  causes}))
+
 (def ^:private auth-keys
   "Keys that belong to auth config, extracted from stage config."
   #{:auth/method :auth/credential-id :auth/credential-scope
@@ -112,10 +126,7 @@
           (catch Exception e
             (when-let [h @handle]
               (try (conn/close connector h) (catch Exception _)))
-            (stage-result id name :failed
-                          {:error-message (ex-message e)
-                           :error-type    (.getName (class e))
-                           :error-cause   (some-> (ex-cause e) ex-message)})))))))
+            (stage-result id name :failed (exception-context e))))))))
 
 (defn- execute-publish-stage
   "Execute a publish stage using the connector's publish method."
@@ -137,10 +148,7 @@
           (catch Exception e
             (when-let [h @handle]
               (try (conn/close connector h) (catch Exception _)))
-            (stage-result id name :failed
-                          {:error-message (ex-message e)
-                           :error-type    (.getName (class e))
-                           :error-cause   (some-> (ex-cause e) ex-message)})))))))
+            (stage-result id name :failed (exception-context e))))))))
 
 (defn- execute-transform-stage
   "Execute a non-connector stage (normalize, transform, aggregate, etc.).
@@ -157,10 +165,7 @@
           (stage-result id name :completed
                         (assoc (timestamps) :records result-records)))
         (catch Exception e
-          (stage-result id name :failed
-                        {:error-message (ex-message e)
-                         :error-type    (.getName (class e))
-                         :error-cause   (some-> (ex-cause e) ex-message)})))
+          (stage-result id name :failed (exception-context e))))
       (stage-result id name :completed
                     (assoc (timestamps) :records input-records)))))
 

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -29,20 +29,37 @@
      {:started-at   (or started-at now)
       :completed-at now})))
 
+(def ^:private max-exception-causes
+  "Maximum number of nested exception causes preserved in stage failure results."
+  16)
+
 (defn- exception-context
   "Build structured exception metadata for failed stage results."
   [^Throwable e]
-  (let [causes (->> (iterate ex-cause e)
-                    rest
-                    (take-while some?)
-                    (take 10)
-                    (mapv (fn [^Throwable cause]
-                            {:error-message (ex-message cause)
-                             :error-type    (.getName (class cause))})))]
-    {:error-message (ex-message e)
-     :error-type    (.getName (class e))
-     :error-cause   (:error-message (first causes))
-     :error-causes  causes}))
+  (let [bounded-causes (->> (iterate ex-cause e)
+                            rest
+                            (take-while some?)
+                            (take (inc max-exception-causes))
+                            vec)
+        truncated?     (> (count bounded-causes) max-exception-causes)
+        causes         (->> bounded-causes
+                            (take max-exception-causes)
+                            (mapv (fn [^Throwable cause]
+                                    {:error-message (ex-message cause)
+                                     :error-type    (.getName (class cause))})))]
+    (cond-> {:error-message (ex-message e)
+             :error-type    (.getName (class e))
+             :error-cause   (:error-message (first causes))
+             :error-causes  causes}
+      truncated? (assoc :error-causes-truncated? true))))
+
+(defn- close-handle!
+  "Best-effort connector cleanup; close failures must not mask stage outcomes."
+  [connector handle]
+  (when handle
+    (try
+      (conn/close connector handle)
+      (catch Exception _ nil))))
 
 (def ^:private auth-keys
   "Keys that belong to auth config, extracted from stage config."
@@ -126,8 +143,7 @@
           (catch Exception e
             (stage-result id name :failed (exception-context e)))
           (finally
-            (when-let [h @handle]
-              (try (conn/close connector h) (catch Exception _)))))))))
+            (close-handle! connector @handle)))))))
 
 (defn- execute-publish-stage
   "Execute a publish stage using the connector's publish method."
@@ -148,8 +164,7 @@
           (catch Exception e
             (stage-result id name :failed (exception-context e)))
           (finally
-            (when-let [h @handle]
-              (try (conn/close connector h) (catch Exception _)))))))))
+            (close-handle! connector @handle)))))))
 
 (defn- execute-transform-stage
   "Execute a non-connector stage (normalize, transform, aggregate, etc.).

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -35,6 +35,7 @@
   (let [causes (->> (iterate ex-cause e)
                     rest
                     (take-while some?)
+                    (take 10)
                     (mapv (fn [^Throwable cause]
                             {:error-message (ex-message cause)
                              :error-type    (.getName (class cause))})))]
@@ -117,16 +118,16 @@
                                        (cond-> {:extract/batch-size (get config :connector/page-size
                                                                          (:connector/page-size default-config))}
                                          cursor (assoc :extract/cursor cursor)))]
-              (conn/close connector @handle)
               (stage-result id name :completed
                             (merge (timestamps (get context :started-at))
                                    {:schema-name schema
                                     :records (:records result)
                                     :cursor (:extract/cursor result)}))))
           (catch Exception e
+            (stage-result id name :failed (exception-context e)))
+          (finally
             (when-let [h @handle]
-              (try (conn/close connector h) (catch Exception _)))
-            (stage-result id name :failed (exception-context e))))))))
+              (try (conn/close connector h) (catch Exception _)))))))))
 
 (defn- execute-publish-stage
   "Execute a publish stage using the connector's publish method."
@@ -143,12 +144,12 @@
                           {:publish/mode     (get config :publish-mode
                                                  (:publish/default-mode default-config))
                            :publish/datasets (:publish/datasets context)})
-            (conn/close connector @handle)
             (stage-result id name :completed {:completed-at (Instant/now)}))
           (catch Exception e
+            (stage-result id name :failed (exception-context e)))
+          (finally
             (when-let [h @handle]
-              (try (conn/close connector h) (catch Exception _)))
-            (stage-result id name :failed (exception-context e))))))))
+              (try (conn/close connector h) (catch Exception _)))))))))
 
 (defn- execute-transform-stage
   "Execute a non-connector stage (normalize, transform, aggregate, etc.).

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -89,30 +89,33 @@
     (if (nil? connector)
       (stage-result id name :failed
                     {:error-message (msg/t :run/connector-not-found {:ref connector-ref})})
-      (try
-        (let [auth   (or (extract-auth config) (get context :auth {}))
-              schema (resolve-schema-name config name)
-              cursor (prior-cursor {:stage/id id
-                                    :stage/name name
-                                    :stage/connector-ref connector-ref
-                                    :stage/config config}
-                                   context)
-              handle (:connection/handle (conn/connect connector (or config {}) auth))
-              result (conn/extract connector handle schema
-                                   (cond-> {:extract/batch-size (get config :connector/page-size
-                                                                     (:connector/page-size default-config))}
-                                     cursor (assoc :extract/cursor cursor)))]
-          (conn/close connector handle)
-          (stage-result id name :completed
-                        (merge (timestamps (get context :started-at))
-                               {:schema-name schema
-                                :records (:records result)
-                                :cursor (:extract/cursor result)})))
-        (catch Exception e
-          (stage-result id name :failed
-                        {:error-message (ex-message e)
-                         :error-type    (.getName (class e))
-                         :error-cause   (some-> (ex-cause e) ex-message)}))))))
+      (let [handle (atom nil)]
+        (try
+          (let [auth   (or (extract-auth config) (get context :auth {}))
+                schema (resolve-schema-name config name)
+                cursor (prior-cursor {:stage/id id
+                                      :stage/name name
+                                      :stage/connector-ref connector-ref
+                                      :stage/config config}
+                                     context)]
+            (reset! handle (:connection/handle (conn/connect connector (or config {}) auth)))
+            (let [result (conn/extract connector @handle schema
+                                       (cond-> {:extract/batch-size (get config :connector/page-size
+                                                                         (:connector/page-size default-config))}
+                                         cursor (assoc :extract/cursor cursor)))]
+              (conn/close connector @handle)
+              (stage-result id name :completed
+                            (merge (timestamps (get context :started-at))
+                                   {:schema-name schema
+                                    :records (:records result)
+                                    :cursor (:extract/cursor result)}))))
+          (catch Exception e
+            (when-let [h @handle]
+              (try (conn/close connector h) (catch Exception _)))
+            (stage-result id name :failed
+                          {:error-message (ex-message e)
+                           :error-type    (.getName (class e))
+                           :error-cause   (some-> (ex-cause e) ex-message)})))))))
 
 (defn- execute-publish-stage
   "Execute a publish stage using the connector's publish method."
@@ -121,20 +124,23 @@
     (if (nil? connector)
       (stage-result id name :failed
                     {:error-message (msg/t :run/connector-not-found {:ref connector-ref})})
-      (try
-        (let [auth   (or (extract-auth config) (:auth context {}))
-              handle (:connection/handle (conn/connect connector (or config {}) auth))
-              result (conn/publish connector handle name input-records
-                                   {:publish/mode     (get config :publish-mode
-                                                          (:publish/default-mode default-config))
-                                    :publish/datasets (:publish/datasets context)})]
-          (conn/close connector handle)
-          (stage-result id name :completed {:completed-at (Instant/now)}))
-        (catch Exception e
-          (stage-result id name :failed
-                        {:error-message (ex-message e)
-                         :error-type    (.getName (class e))
-                         :error-cause   (some-> (ex-cause e) ex-message)}))))))
+      (let [handle (atom nil)]
+        (try
+          (let [auth (or (extract-auth config) (:auth context {}))]
+            (reset! handle (:connection/handle (conn/connect connector (or config {}) auth)))
+            (conn/publish connector @handle name input-records
+                          {:publish/mode     (get config :publish-mode
+                                                 (:publish/default-mode default-config))
+                           :publish/datasets (:publish/datasets context)})
+            (conn/close connector @handle)
+            (stage-result id name :completed {:completed-at (Instant/now)}))
+          (catch Exception e
+            (when-let [h @handle]
+              (try (conn/close connector h) (catch Exception _)))
+            (stage-result id name :failed
+                          {:error-message (ex-message e)
+                           :error-type    (.getName (class e))
+                           :error-cause   (some-> (ex-cause e) ex-message)})))))))
 
 (defn- execute-transform-stage
   "Execute a non-connector stage (normalize, transform, aggregate, etc.).

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -109,7 +109,10 @@
                                 :records (:records result)
                                 :cursor (:extract/cursor result)})))
         (catch Exception e
-          (stage-result id name :failed {:error-message (.getMessage e)}))))))
+          (stage-result id name :failed
+                        {:error-message (ex-message e)
+                         :error-type    (.getName (class e))
+                         :error-cause   (some-> (ex-cause e) ex-message)}))))))
 
 (defn- execute-publish-stage
   "Execute a publish stage using the connector's publish method."
@@ -128,7 +131,10 @@
           (conn/close connector handle)
           (stage-result id name :completed {:completed-at (Instant/now)}))
         (catch Exception e
-          (stage-result id name :failed {:error-message (.getMessage e)}))))))
+          (stage-result id name :failed
+                        {:error-message (ex-message e)
+                         :error-type    (.getName (class e))
+                         :error-cause   (some-> (ex-cause e) ex-message)}))))))
 
 (defn- execute-transform-stage
   "Execute a non-connector stage (normalize, transform, aggregate, etc.).
@@ -145,7 +151,10 @@
           (stage-result id name :completed
                         (assoc (timestamps) :records result-records)))
         (catch Exception e
-          (stage-result id name :failed {:error-message (.getMessage e)})))
+          (stage-result id name :failed
+                        {:error-message (ex-message e)
+                         :error-type    (.getName (class e))
+                         :error-cause   (some-> (ex-cause e) ex-message)})))
       (stage-result id name :completed
                     (assoc (timestamps) :records input-records)))))
 

--- a/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
+++ b/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
@@ -427,6 +427,56 @@
                  :error-type    "clojure.lang.ExceptionInfo"}]
                (:error-causes failed)))))))
 
+(deftest execute-pipeline-ingest-close-failure-does-not-mask-primary-error-test
+  (testing "Ingest cleanup closes once and preserves the primary extract failure"
+    (let [close-count (atom 0)
+          connector   (reify
+                        conn/Connector
+                        (connect [_ _ _]
+                          {:connection/handle "ingest-handle"
+                           :connector/status :connected})
+                        (close [_ _]
+                          (swap! close-count inc)
+                          (throw (ex-info "Close failed" {})))
+                        conn/SourceConnector
+                        (discover [_ _ _] {:schemas []})
+                        (extract [_ _ _ _]
+                          (throw (ex-info "Extract failed" {}
+                                          (ex-info "Network root" {}))))
+                        (checkpoint [_ _ _ _] {}))
+          result      (runner/execute-pipeline test-pipeline {conn-src connector} {})
+          failed      (first (get-in result [:pipeline-run :pipeline-run/stage-runs]))]
+      (is (not (:success? result)))
+      (is (= 1 @close-count))
+      (is (= "Extract failed" (:error-message failed)))
+      (is (= "Network root" (:error-cause failed))))))
+
+(deftest execute-pipeline-publish-close-failure-does-not-mask-primary-error-test
+  (testing "Publish cleanup closes once and preserves the primary publish failure"
+    (let [close-count (atom 0)
+          mock-source (->MockSourceConnector nil)
+          sink        (reify
+                        conn/Connector
+                        (connect [_ _ _]
+                          {:connection/handle "publish-handle"
+                           :connector/status :connected})
+                        (close [_ _]
+                          (swap! close-count inc)
+                          (throw (ex-info "Close failed" {})))
+                        conn/SinkConnector
+                        (publish [_ _ _ _ _]
+                          (throw (ex-info "Publish failed" {}
+                                          (ex-info "Sink root" {})))))
+          result      (runner/execute-pipeline
+                       three-stage-pipeline
+                       {conn-src mock-source conn-sink sink}
+                       {})
+          failed      (last (get-in result [:pipeline-run :pipeline-run/stage-runs]))]
+      (is (not (:success? result)))
+      (is (= 1 @close-count))
+      (is (= "Publish failed" (:error-message failed)))
+      (is (= "Sink root" (:error-cause failed))))))
+
 (deftest execute-pipeline-transform-exception-test
   (testing "Pipeline preserves structured exception context for transform failures"
     (let [transform-stage-id (java.util.UUID/randomUUID)

--- a/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
+++ b/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
@@ -415,10 +415,13 @@
           result (runner/execute-pipeline test-pipeline {conn-src failing-conn} {})]
       (is (not (:success? result)))
       (is (= :failed (get-in result [:pipeline-run :pipeline-run/status])))
-      ;; First stage should be failed
-      (let [stage-runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
-        (is (= :failed (:status (first stage-runs))))
-        (is (some? (:error-message (first stage-runs))))))))
+      ;; First stage should be failed with structured exception context
+      (let [stage-runs (get-in result [:pipeline-run :pipeline-run/stage-runs])
+            failed     (first stage-runs)]
+        (is (= :failed (:status failed)))
+        (is (= "Connection refused" (:error-message failed)))
+        (is (= "clojure.lang.ExceptionInfo" (:error-type failed)))
+        (is (nil? (:error-cause failed)))))))
 
 (deftest execute-pipeline-stops-on-failure-test
   (testing "Pipeline stops executing after first stage failure"

--- a/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
+++ b/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
@@ -86,7 +86,8 @@
   conn/SourceConnector
   (discover [_ handle opts] {:schemas []})
   (extract [_ handle schema-name opts]
-    (throw (ex-info "Connection refused" {:cause :network})))
+    (throw (ex-info "Connection refused" {:cause :network}
+                    (ex-info "Socket closed" {:cause :socket}))))
   (checkpoint [_ handle connector-id cursor-state] {}))
 
 (defrecord InspectableSourceConnector [calls extract-fn]
@@ -421,7 +422,49 @@
         (is (= :failed (:status failed)))
         (is (= "Connection refused" (:error-message failed)))
         (is (= "clojure.lang.ExceptionInfo" (:error-type failed)))
-        (is (nil? (:error-cause failed)))))))
+        (is (= "Socket closed" (:error-cause failed)))
+        (is (= [{:error-message "Socket closed"
+                 :error-type    "clojure.lang.ExceptionInfo"}]
+               (:error-causes failed)))))))
+
+(deftest execute-pipeline-transform-exception-test
+  (testing "Pipeline preserves structured exception context for transform failures"
+    (let [transform-stage-id (java.util.UUID/randomUUID)
+          root-cause         (ex-info "Bad input" {:cause :bad-input})
+          transform-pipeline {:pipeline/id (java.util.UUID/randomUUID)
+                              :pipeline/name "Transform Failure Pipeline"
+                              :pipeline/version "1.0.0"
+                              :pipeline/stages
+                              [{:stage/id transform-stage-id
+                                :stage/name "Transform"
+                                :stage/family :transform
+                                :stage/input-datasets [ds-a]
+                                :stage/output-datasets [ds-b]
+                                :stage/dependencies []
+                                :stage/config {:stage/transform
+                                               {:transform/type :explode}}}]
+                              :pipeline/mode :full-refresh
+                              :pipeline/input-datasets [ds-a]
+                              :pipeline/output-datasets [ds-b]
+                              :pipeline/created-at (java.time.Instant/now)
+                              :pipeline/updated-at (java.time.Instant/now)}
+          result             (runner/execute-pipeline
+                              transform-pipeline
+                              {}
+                              {:transforms
+                               {:explode
+                                (fn [_records _config]
+                                  (throw (ex-info "Transform failed" {} root-cause)))}})
+          failed             (first (get-in result [:pipeline-run :pipeline-run/stage-runs]))]
+      (is (not (:success? result)))
+      (is (= :failed (get-in result [:pipeline-run :pipeline-run/status])))
+      (is (= :failed (:status failed)))
+      (is (= "Transform failed" (:error-message failed)))
+      (is (= "clojure.lang.ExceptionInfo" (:error-type failed)))
+      (is (= "Bad input" (:error-cause failed)))
+      (is (= [{:error-message "Bad input"
+               :error-type    "clojure.lang.ExceptionInfo"}]
+             (:error-causes failed))))))
 
 (deftest execute-pipeline-stops-on-failure-test
   (testing "Pipeline stops executing after first stage failure"


### PR DESCRIPTION
## Problem

`execute-ingest-stage`, `execute-publish-stage`, and `execute-transform-stage` previously recorded only an exception message in the stage failure result:

```clojure
(catch Exception e
  (stage-result id name :failed {:error-message (.getMessage e)}))
```

In production, when a multi-stage pipeline run fails, operators need enough structured context to distinguish connector IO failures, auth failures, transform bugs, and wrapped exceptions without guessing from a single message string.

## Fix

Stage failure results now include structured exception metadata:

```clojure
{:error-message "..."
 :error-type    "..."
 :error-cause   "..."
 :error-causes  [{:error-message "..."
                  :error-type    "..."}]}
```

The full nested cause chain is captured up to a bounded limit. If that limit is exceeded, the payload includes `:error-causes-truncated? true` so failure results remain bounded.

`ex-message` is used rather than `.getMessage` because it is nil-safe and idiomatic since Clojure 1.10.

## Connector Cleanup

Ingest and publish stages now close connector handles from a single best-effort cleanup path after connect succeeds. Cleanup runs for both success and failure outcomes, and close failures are suppressed so they do not mask the primary extract/publish result or exception context.

## Scope

- Structured exception metadata for ingest, publish, and transform failures.
- Bounded nested cause-chain capture.
- Best-effort connector handle cleanup for ingest and publish stages.
- Regression coverage for connector exceptions, transform exceptions, and close failures that must not mask primary failures.

## Checklist

- [x] Stage failures include `:error-message`, `:error-type`, `:error-cause`, and `:error-causes`
- [x] Cause-chain capture is bounded
- [x] Connector handles are closed once from cleanup paths
- [x] Close failures do not mask primary stage outcomes
- [x] No new dependencies
- [x] `git diff --check` clean
