### PR TITLE
feat: typed handoff acts (phase outcomes, meta-loop halt, PR-monitor decision)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
@@ -114,12 +114,16 @@
                                                             {:phase phase}))
       :workflow/phase-completed (let [outcome (or (:phase/outcome event) :completed)
                                       color   (case outcome
-                                                :failure :red
-                                                :skipped :yellow
+                                                :failure    :red
+                                                :blocked    :red
+                                                :skipped    :yellow
+                                                :redirected :yellow
                                                 :green)
                                       symbol  (case outcome
-                                                :failure "✗"
-                                                :skipped "○"
+                                                :failure    "✗"
+                                                :blocked    "⊘"
+                                                :skipped    "○"
+                                                :redirected "↻"
                                                 "✓")]
                                   (str (colorize color (messages/t :workflow-runner/phase-completed
                                                                    {:symbol symbol

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -523,6 +523,7 @@
         (cond->
           (:duration-ms result) (assoc :phase/duration-ms (:duration-ms result))
           (:review-decision result) (assoc :phase/review-decision (:review-decision result))
+          (:phase/blocked-reason result) (assoc :phase/blocked-reason (:phase/blocked-reason result))
           (:artifacts result) (assoc :phase/artifacts (:artifacts result))
           (:error result) (assoc :phase/error (:error result))
           request (assoc :phase/transition-request request)
@@ -1003,6 +1004,23 @@
         (:meta-eval? opts) (assoc :supervision/meta-eval? true)
         (:confidence opts) (assoc :supervision/confidence (:confidence opts))
         (:phase opts)      (assoc :workflow/phase (:phase opts)))))
+
+(defn meta-loop-halt-requested
+  "Emit when a meta-agent signals the meta-loop must halt the workflow.
+
+   The REFUSE act for meta-supervision: makes the halt first-class on the stream
+   rather than only a value in the coordinator result. `reason-code` is a
+   RefusalReason keyword; `opts` may carry :detail (the halting agent's free-text
+   message) and :phase (current workflow phase)."
+  [stream workflow-id halting-agent reason-code & [opts]]
+  (-> (create-envelope stream :meta-loop/halt-requested workflow-id
+                       (str "Meta-loop halt requested by " (name halting-agent)
+                            ": " (name reason-code)))
+      (assoc :halt/halting-agent halting-agent
+             :halt/reason-code reason-code)
+      (cond->
+        (:detail opts) (assoc :halt/detail (:detail opts))
+        (:phase opts)  (assoc :workflow/phase (:phase opts)))))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Control plane events

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -398,6 +398,13 @@
    :supervision/meta-eval?, :supervision/confidence, :workflow/phase."
   events/tool-use-evaluated)
 
+;; Meta-loop supervision events
+(def meta-loop-halt-requested
+  "Build and return a :meta-loop/halt-requested event envelope map recording a
+   meta-agent's REFUSE: :halt/halting-agent and :halt/reason-code (RefusalReason);
+   optional opts add :halt/detail and :workflow/phase."
+  events/meta-loop-halt-requested)
+
 ;; Control plane events
 (def cp-agent-registered
   "Build and return a :control-plane/agent-registered event envelope map

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -211,6 +211,12 @@
    message-type as :message/type."
   core/inter-agent-message-received)
 
+(def meta-loop-halt-requested
+  "Build and return a :meta-loop/halt-requested event envelope map recording a
+   meta-agent's REFUSE: :halt/halting-agent and :halt/reason-code (RefusalReason);
+   optional opts add :halt/detail and :workflow/phase."
+  core/meta-loop-halt-requested)
+
 (def listener-attached
   "Build and return a :listener/attached event envelope map for a
    listener id; optional listener-type and capability as :listener/type

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -61,7 +61,9 @@
    - :budget-exhausted    — the token or time budget is exhausted
    - :policy-block        — a policy pack forbids proceeding
 
-   Consumers MUST tolerate unknown values for forward compatibility."
+   Closed: the schema validates against exactly this set, so a typo or a
+   not-yet-added reason fails fast. Producers are all first-party, so catching
+   those beats wire forward-compat. Extending it is a deliberate spec change."
   [:enum :no-progress :quality-gate :conflict :missing-input :ambiguous-intent
    :precondition-failed :resource-unavailable :budget-exhausted :policy-block])
 

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -43,6 +43,28 @@
    [:transition/type keyword?]
    [:transition/target keyword?]])
 
+(def RefusalReason
+  "Closed vocabulary for why an agent or phase refuses to proceed.
+
+   One vocabulary shared by every refusal act on the stream — phase
+   `:blocked` outcomes (PhaseCompleted) and meta-loop halts
+   (MetaLoopHaltRequested) — so a refusal carries the same machine-readable
+   cause wherever it originates, rather than only free text in `:message`.
+
+   - :no-progress         — work stalled; no forward movement (progress monitor)
+   - :quality-gate        — a quality threshold is unmet (e.g. test coverage)
+   - :conflict            — an irreconcilable conflict was detected (e.g. merge)
+   - :missing-input       — a required upstream artifact or spec is absent
+   - :ambiguous-intent    — intent/spec underspecified; needs human resolution
+   - :precondition-failed — a declared precondition or gate is not satisfied
+   - :resource-unavailable— runtime, dependency, or executor is unavailable
+   - :budget-exhausted    — the token or time budget is exhausted
+   - :policy-block        — a policy pack forbids proceeding
+
+   Consumers MUST tolerate unknown values for forward compatibility."
+  [:enum :no-progress :quality-gate :conflict :missing-input :ambiguous-intent
+   :precondition-failed :resource-unavailable :budget-exhausted :policy-block])
+
 ;; ----------------------------------------------------------------------------
 ;; Decision-14 identity quartet (added for miniforge-fleet's Phase E.1
 ;; planning prerequisite #10). Defined ONCE here as a vector of Malli
@@ -152,7 +174,15 @@
     [:workflow/id uuid?]
     [:workflow/phase keyword?]
     [:phase/duration-ms {:optional true} int?]
-    [:phase/outcome {:optional true} [:enum :success :failure :skipped]]
+    ;; `:phase/outcome` is the typed-act surface for a phase boundary on the
+    ;; observed layer (stream + evidence). The internal phase-result `:status`
+    ;; stays a 2-valued control flag for the FSM; this enum carries the full act.
+    ;; INFORM → :success/:failure/:skipped; REFUSE → :blocked (+ :phase/blocked-reason);
+    ;; REQUEST(redirect) → :redirected (+ :phase/transition-request).
+    [:phase/outcome {:optional true}
+     [:enum :success :failure :skipped :blocked :redirected]]
+    ;; Machine-readable cause, present when :phase/outcome is :blocked.
+    [:phase/blocked-reason {:optional true} RefusalReason]
     ;; Review verdict, present only for the review phase. Carried so resume can
     ;; reconstruct a blocked review from events alone — the event is a writer of
     ;; this datum, one canonical location, no lossy reconstruction.
@@ -685,6 +715,9 @@
    ;; the other supervisory snapshots; default `:internal` matches the
    ;; sibling `:supervisory/*-upserted` family.
    :supervisory/automation-edge-upserted :internal
+   ;; Meta-loop halt is a supervision signal — :internal, matching the
+   ;; agent/supervisory families.
+   :meta-loop/halt-requested :internal
    :control-action/requested :confidential
    :control-action/executed  :confidential
    :annotation/created       :internal
@@ -1134,6 +1167,81 @@
     [:index/previous-coverage [:and number? [:>= 0] [:<= 1]]]
     [:index/coverage [:and number? [:>= 0] [:<= 1]]]
     [:index/changed-files {:optional true} [:and int? [:>= 0]]]
+    [:message string?]]))
+
+;; ----------------------------------------------------------------------------
+;; Typed handoff acts
+;;
+;; Inter-agent messages and meta-loop halts are handoff points between agents
+;; and phases. Each is an explicit, typed act on the stream rather than an
+;; implicit signal reconstructed from status flags: INFORM (message) and REFUSE
+;; (halt). Field values stay domain-native; the act lineage is documented, not
+;; imported as a generic performative vocabulary. (The PR-monitor's classify→act
+;; decision is the third such act, but the PR-monitor runs on its own decoupled
+;; event bus — see `pr-lifecycle/monitor-events` `:pr-monitor/decision-recorded`
+;; — so its typed act lives there, not on this stream.)
+
+(def AgentMessageSent
+  "Schema for `:agent/message-sent` event (N3 §3.7).
+
+   Emitted by `core/inter-agent-message-sent` when one agent sends a message to
+   another. `:message/type` is an open keyword — known values `:clarification-request`,
+   `:clarification-response`, `:inform`, `:ack`; consumers MUST tolerate others."
+  (with-identity
+   [:map
+    [:event/type [:= :agent/message-sent]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:from-agent/id keyword?]
+    [:from-agent/instance-id {:optional true} uuid?]
+    [:to-agent/id keyword?]
+    [:message/type {:optional true} keyword?]
+    [:message/content {:optional true} string?]
+    [:message string?]]))
+
+(def AgentMessageReceived
+  "Schema for `:agent/message-received` event (N3 §3.7).
+
+   Emitted by `core/inter-agent-message-received`. See AgentMessageSent for the
+   `:message/type` vocabulary note."
+  (with-identity
+   [:map
+    [:event/type [:= :agent/message-received]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:from-agent/id keyword?]
+    [:from-agent/instance-id {:optional true} uuid?]
+    [:to-agent/id keyword?]
+    [:message/type {:optional true} keyword?]
+    [:message/content {:optional true} string?]
+    [:message string?]]))
+
+(def MetaLoopHaltRequested
+  "Schema for `:meta-loop/halt-requested` event.
+
+   The REFUSE act for the meta-loop: a meta-agent (progress monitor, test-quality,
+   conflict detector) has signalled that the workflow must stop. Previously the
+   halt lived only in the coordinator's return value and the runner's error map;
+   this event makes the refusal first-class on the stream with a machine-readable
+   cause (`:halt/reason-code`) alongside the halting agent and its free-text detail."
+  (with-identity
+   [:map
+    [:event/type [:= :meta-loop/halt-requested]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase {:optional true} keyword?]
+    [:halt/halting-agent keyword?]
+    [:halt/reason-code RefusalReason]
+    [:halt/detail {:optional true} string?]
     [:message string?]]))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/event-stream/test/ai/miniforge/event_stream/typed_acts_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/typed_acts_schema_test.clj
@@ -1,0 +1,68 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.typed-acts-schema-test
+  "Schemas for the typed handoff acts: widened phase outcomes, the meta-loop
+   REFUSE, and inter-agent messages."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.event-stream.schema :as schema]
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as m]))
+
+(defn- stream [] (es/create-event-stream {:sinks []}))
+
+(deftest phase-completed-accepts-blocked-and-redirected-test
+  (testing "the widened :phase/outcome enum admits :blocked with a reason and :redirected"
+    (let [s          (stream)
+          wid        (random-uuid)
+          blocked    (es/phase-completed s wid :plan
+                                         {:outcome :blocked
+                                          :phase/blocked-reason :missing-input
+                                          :duration-ms 1})
+          redirected (es/phase-completed s wid :review
+                                         {:outcome :redirected :duration-ms 1})]
+      (is (= :blocked (:phase/outcome blocked)))
+      (is (= :missing-input (:phase/blocked-reason blocked)))
+      (is (m/validate schema/PhaseCompleted blocked))
+      (is (= :redirected (:phase/outcome redirected)))
+      (is (m/validate schema/PhaseCompleted redirected)))))
+
+(deftest meta-loop-halt-requested-is-valid-test
+  (testing "meta-loop-halt-requested builds a schema-valid REFUSE event"
+    (let [ev (es/meta-loop-halt-requested (stream) (random-uuid)
+                                          :conflict-detector :conflict
+                                          {:detail "merge conflict" :phase :implement})]
+      (is (= :meta-loop/halt-requested (:event/type ev)))
+      (is (= :conflict (:halt/reason-code ev)))
+      (is (= :conflict-detector (:halt/halting-agent ev)))
+      (is (m/validate schema/MetaLoopHaltRequested ev)))))
+
+(deftest inter-agent-messages-are-valid-test
+  (testing "inter-agent message constructors satisfy the now-defined schemas"
+    (let [s    (stream)
+          wid  (random-uuid)
+          sent (es/inter-agent-message-sent s wid :implementer :planner :clarification-request)
+          recv (es/inter-agent-message-received s wid :planner :implementer :clarification-response)]
+      (is (m/validate schema/AgentMessageSent sent))
+      (is (m/validate schema/AgentMessageReceived recv)))))
+
+(deftest refusal-reason-is-closed-test
+  (testing "RefusalReason admits the shared vocabulary and rejects unknowns"
+    (is (m/validate schema/RefusalReason :budget-exhausted))
+    (is (not (m/validate schema/RefusalReason :totally-made-up)))))

--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -154,6 +154,14 @@
   "True when a phase result requests a redirect transition."
   phase-result/redirect-requested?)
 
+(def blocked?
+  "True when a phase result carries a refusal reason (a blocked outcome)."
+  phase-result/blocked?)
+
+(def blocked-reason
+  "Return the RefusalReason keyword for a blocked phase result, if any."
+  phase-result/blocked-reason)
+
 (def create-streaming-callback
   "Create a phase-scoped streaming callback when an event stream is available."
   telemetry/create-streaming-callback)
@@ -224,6 +232,10 @@
 (def error
   "Build an error environment-model phase result."
   phase-result/error)
+
+(def blocked
+  "Build a blocked (refused) phase result tagged with a RefusalReason cause."
+  phase-result/blocked)
 
 (def skipped
   "Build a skipped-phase result for phases that short-circuit."

--- a/components/phase/src/ai/miniforge/phase/phase_result.clj
+++ b/components/phase/src/ai/miniforge/phase/phase_result.clj
@@ -44,6 +44,19 @@
   [result]
   (= :error (:status result)))
 
+(defn blocked?
+  "True when a phase result carries a refusal reason (a blocked outcome).
+
+   A block is an error result tagged with a machine-readable cause; it halts
+   the phase like any error but the cause surfaces as :phase/outcome :blocked."
+  [result]
+  (contains? result :phase/blocked-reason))
+
+(defn blocked-reason
+  "Return the RefusalReason keyword for a blocked phase result, if any."
+  [result]
+  (:phase/blocked-reason result))
+
 (def ^:private transition-request-key
   :phase/transition-request)
 
@@ -131,6 +144,17 @@
    :summary        summary
    :error          {:message error-message}
    :metrics        metrics})
+
+(defn blocked
+  "Build a blocked (refused) phase result — the phase cannot proceed.
+
+   `reason` is a RefusalReason keyword (see event-stream schema) recording the
+   machine-readable cause. A block reuses the error result shape so existing
+   non-success handling halts the phase; the cause travels to the event as
+   :phase/outcome :blocked with :phase/blocked-reason."
+  [environment-id summary reason metrics]
+  (assoc (error environment-id summary summary metrics)
+         :phase/blocked-reason reason))
 
 (defn exception-error
   "Build a [:phase :error] map from an unhandled exception.

--- a/components/phase/test/ai/miniforge/phase/phase_result_test.clj
+++ b/components/phase/test/ai/miniforge/phase/phase_result_test.clj
@@ -1,0 +1,37 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.phase-result-test
+  (:require
+   [ai.miniforge.phase.phase-result :as pr]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest blocked-builds-refusal-result-test
+  (testing "blocked tags an error-shaped result with a RefusalReason cause"
+    (let [result (pr/blocked "env-7" "spec missing" :missing-input
+                             {:tokens 0 :duration-ms 5})]
+      (is (pr/blocked? result))
+      (is (= :missing-input (pr/blocked-reason result)))
+      (is (= :error (:status result)) "block reuses the error halt path")
+      (is (= "env-7" (:environment-id result))))))
+
+(deftest blocked?-false-for-plain-results-test
+  (testing "non-blocked results carry no refusal reason"
+    (is (not (pr/blocked? (pr/success "env-1" "done"))))
+    (is (not (pr/blocked? (pr/error "env-1" "boom" "boom" {}))))
+    (is (nil? (pr/blocked-reason (pr/success "env-1" "done"))))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_events.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_events.clj
@@ -30,6 +30,7 @@
   #{:pr-monitor/poll-completed       ; Poll cycle completed
     :pr-monitor/comment-received     ; New comment detected
     :pr-monitor/comment-classified   ; Comment classified into category
+    :pr-monitor/decision-recorded    ; Classify→act decision (fix/answer/approve/skip)
     :pr-monitor/fix-started          ; Fix cycle initiated for change-request
     :pr-monitor/fix-pushed           ; Fix committed and pushed
     :pr-monitor/reply-posted         ; Reply comment posted to PR
@@ -64,6 +65,18 @@
                        {:pr/id pr-number
                         :comment comment-data
                         :classification classification}))
+
+(defn decision-recorded
+  "Create a decision-recorded event: the typed classify→act decision for a
+   comment. `action` is the chosen verb (:fix :answer :approve :skip), recorded
+   as one act with provenance back to the comment and its classification."
+  [pr-number comment-id action category confidence]
+  (events/create-event :pr-monitor/decision-recorded
+                       {:pr/id pr-number
+                        :comment/id comment-id
+                        :decision/action action
+                        :decision/category category
+                        :decision/confidence confidence}))
 
 (defn fix-started
   "Create a fix-started event."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_handlers.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_handlers.clj
@@ -34,6 +34,20 @@
   [result]
   (true? (:success? result)))
 
+(def ^:private category->action
+  "The PR-monitor's action verb for each classified-comment category. The
+   closed vocabulary the classify→act decision records."
+  {:change-request :fix
+   :question       :answer
+   :approval       :approve
+   :bot-comment    :skip
+   :noise          :skip})
+
+(defn- decision-action
+  "Action verb for a classified comment's category; unknown categories → :skip."
+  [category]
+  (get category->action category :skip))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Comment handlers
 
@@ -200,13 +214,21 @@
 ;; Routing
 
 (defn route-comment
-  "Route a classified comment to the appropriate handler."
+  "Route a classified comment to the appropriate handler, recording the typed
+   classify→act decision first so the choice is one explicit act with provenance
+   rather than an inference from which handler ran."
   [monitor pr-info classified]
-  (case (:category classified)
-    :change-request (handle-change-request monitor pr-info classified)
-    :question (handle-question monitor pr-info classified)
-    :bot-comment (handle-bot-comment monitor pr-info classified)
-    :approval (handle-approval monitor pr-info classified)
-    :noise {:success? true :type :noise-skipped}
-    {:success? true :type :unknown-skipped :category (:category classified)}))
+  (let [category   (:category classified)
+        comment-id (get-in classified [:comment :comment/id])]
+    (state/emit! monitor
+                 (mevents/decision-recorded (:pr/number pr-info) comment-id
+                                            (decision-action category)
+                                            category (:confidence classified)))
+    (case category
+      :change-request (handle-change-request monitor pr-info classified)
+      :question (handle-question monitor pr-info classified)
+      :bot-comment (handle-bot-comment monitor pr-info classified)
+      :approval (handle-approval monitor pr-info classified)
+      :noise {:success? true :type :noise-skipped}
+      {:success? true :type :unknown-skipped :category category})))
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_handlers_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_handlers_test.clj
@@ -1,0 +1,49 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-handlers-test
+  (:require
+   [ai.miniforge.pr-lifecycle.monitor-handlers :as handlers]
+   [ai.miniforge.pr-lifecycle.monitor-state :as state]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest decision-action-maps-categories-test
+  (testing "each comment category maps to the PR-monitor's action verb"
+    (is (= :fix     (#'handlers/decision-action :change-request)))
+    (is (= :answer  (#'handlers/decision-action :question)))
+    (is (= :approve (#'handlers/decision-action :approval)))
+    (is (= :skip    (#'handlers/decision-action :bot-comment)))
+    (is (= :skip    (#'handlers/decision-action :noise)))
+    (is (= :skip    (#'handlers/decision-action :anything-unrecognised)))))
+
+(deftest route-comment-records-typed-decision-test
+  (testing "route-comment emits one :pr-monitor/decision-recorded act with provenance"
+    (let [emitted (atom [])]
+      (with-redefs [state/emit! (fn [_ ev] (swap! emitted conj ev))
+                    handlers/handle-question (fn [_ _ _] {:success? true :type :answered})]
+        (handlers/route-comment (atom {:config {}})
+                                {:pr/number 7}
+                                {:category :question :confidence :high
+                                 :comment {:comment/id 99}}))
+      (let [d (first @emitted)]
+        (is (= :pr-monitor/decision-recorded (:event/type d)))
+        (is (= :answer (:decision/action d)))
+        (is (= :question (:decision/category d)))
+        (is (= :high (:decision/confidence d)))
+        (is (= 99 (:comment/id d)))
+        (is (= 7 (:pr/id d)))))))

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
@@ -174,10 +174,12 @@
 (defn phase-status
   [outcome]
   (case outcome
-    :failure :failed
-    :failed  :failed
-    :skipped :skipped
-    :success :success
+    :failure    :failed
+    :failed     :failed
+    :blocked    :failed
+    :skipped    :skipped
+    :success    :success
+    :redirected :success
     :running))
 
 (defn update-phase-entry

--- a/components/workflow/src/ai/miniforge/workflow/monitoring.clj
+++ b/components/workflow/src/ai/miniforge/workflow/monitoring.clj
@@ -154,7 +154,10 @@
    Best-effort: a telemetry failure must not mask the halt itself."
   [ctx halt-data]
   (when-let [stream (resolve-event-stream ctx)]
-    (let [halting-agent (get halt-data :supervisor :supervisor)
+    ;; Guard a nil halting agent (key present, value nil): without it,
+    ;; (name halting-agent) in the constructor throws and the catch below
+    ;; silently drops the halt event.
+    (let [halting-agent (if-some [a (:supervisor halt-data)] a :supervision)
           reason-code   (halt-reason-code halt-data)]
       (try
         (es/publish! stream

--- a/components/workflow/src/ai/miniforge/workflow/monitoring.clj
+++ b/components/workflow/src/ai/miniforge/workflow/monitoring.clj
@@ -22,6 +22,7 @@
    Provides functions for building workflow state, checking health via the
    live supervision runtime, and handling halt conditions."
   (:require [ai.miniforge.agent.interface.supervision :as supervision]
+            [ai.miniforge.event-stream.interface :as es]
             [ai.miniforge.workflow.messages :as messages]
             [ai.miniforge.response.interface :as response]))
 
@@ -123,10 +124,53 @@
    :reason (:reason halt-data)
    :checks (:checks halt-data)})
 
+;;----------------------------------------------------------------------------- Halt emission
+;; Meta-loop halt as a typed REFUSE on the event stream (N3)
+
+(def ^:private halt-reason-codes
+  "Default RefusalReason for each meta-agent that can halt the workflow.
+   A halting agent's health-check :data may override via :halt/reason-code."
+  {:progress-monitor  :no-progress
+   :test-quality      :quality-gate
+   :conflict-detector :conflict})
+
+(defn- halt-reason-code
+  "RefusalReason for a halt: the halting agent's explicit code when supplied,
+   else the per-agent default, else :no-progress."
+  [halt-data]
+  (or (get-in halt-data [:data :halt/reason-code])
+      (get halt-reason-codes (:supervisor halt-data) :no-progress)))
+
+(defn- resolve-event-stream
+  "Find the event stream on the execution context, across the keys the runner
+   and dashboard use to carry it."
+  [ctx]
+  (or (:event-stream ctx)
+      (:execution/event-stream ctx)
+      (get-in ctx [:execution/opts :event-stream])))
+
+(defn- emit-halt-requested!
+  "Publish the typed REFUSE for a meta-loop halt when a stream is present.
+   Best-effort: a telemetry failure must not mask the halt itself."
+  [ctx halt-data]
+  (when-let [stream (resolve-event-stream ctx)]
+    (let [halting-agent (get halt-data :supervisor :supervisor)
+          reason-code   (halt-reason-code halt-data)]
+      (try
+        (es/publish! stream
+                     (es/meta-loop-halt-requested
+                      stream (:execution/id ctx) halting-agent reason-code
+                      {:detail (:reason halt-data)
+                       :phase  (:execution/current-phase ctx)}))
+        (catch Exception _ nil)))))
+
 (defn handle-supervision-halt
-  "Handle supervision halt signal by transitioning workflow to failed state."
+  "Handle supervision halt signal by transitioning workflow to failed state.
+   Emits a :meta-loop/halt-requested REFUSE before transitioning so the refusal
+   is first-class on the stream, not only an error map in the response chain."
   [ctx supervision-result transition-to-failed-fn]
   (let [halt-data (supervision-halt-data supervision-result)]
+    (emit-halt-requested! ctx halt-data)
     (-> ctx
         (update :execution/errors conj
                 (supervision-halt-error halt-data))

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -106,6 +106,18 @@
     (or (contains? inner-failure-statuses (get-in result [:result :status]))
         (false? (get-in result [:result :success?])))))
 
+(defn- phase-outcome
+  "Typed act for a completed phase boundary on the observed layer.
+   A refusal (:blocked) and an outright failure are dominant; a successful phase
+   that asks the pipeline elsewhere is :redirected; otherwise :success. The
+   internal phase-result :status stays the 2-valued control flag for the FSM."
+  [result succeeded?]
+  (cond
+    (phase/blocked? result)            :blocked
+    (not succeeded?)                   :failure
+    (phase/redirect-requested? result) :redirected
+    :else                              :success))
+
 (defn- build-phase-event-data
   "Build event data map for a phase completion event.
 
@@ -135,7 +147,8 @@
   [result]
   (let [succeeded? (and (get result :success? (phase/succeeded-or-done? result))
                         (not (inner-result-failed? result)))
-        outcome    (if succeeded? :success :failure)
+        outcome    (phase-outcome result succeeded?)
+        blocked-reason (phase/blocked-reason result)
         duration-ms (get result :duration-ms
                       (get-in result [:phase/metrics :duration-ms]
                         (get-in result [:metrics :duration-ms])))
@@ -180,6 +193,7 @@
                                 tool-call-count       (assoc :tool-call-count tool-call-count))))]
     (cond-> {:outcome outcome :duration-ms duration-ms}
       error-info              (assoc :error error-info)
+      blocked-reason          (assoc :phase/blocked-reason blocked-reason)
       review-decision         (assoc :review-decision review-decision)
       transition-request      (assoc :phase/transition-request transition-request)
       tokens                  (assoc :tokens tokens)

--- a/components/workflow/test/ai/miniforge/workflow/monitoring_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/monitoring_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.workflow.monitoring-test
   (:require
    [ai.miniforge.agent.interface.supervision :as supervision]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.monitoring :as monitoring]
    [clojure.test :refer [deftest is testing]]))
@@ -91,3 +92,35 @@
               :checks [{:status :halt
                         :data {:elapsed-ms 120000}}]}
              (response/last-response (:execution/response-chain result)))))))
+
+(deftest handle-supervision-halt-emits-typed-refuse-test
+  (testing "handle-supervision-halt publishes a :meta-loop/halt-requested REFUSE"
+    (let [captured (atom nil)
+          stream   (es/create-event-stream {:sinks []})
+          ctx      {:execution/id (random-uuid)
+                    :execution/current-phase :implement
+                    :execution/opts {:event-stream stream}
+                    :execution/errors []
+                    :execution/response-chain (response/create :workflow)}
+          supervision-result {:halt-reason "merge conflict"
+                              :halting-agent :conflict-detector
+                              :checks [{:status :halt :data {}}]}]
+      (with-redefs [es/publish! (fn [_ ev] (reset! captured ev) ev)]
+        (monitoring/handle-supervision-halt ctx supervision-result identity))
+      (is (= :meta-loop/halt-requested (:event/type @captured)))
+      (is (= :conflict-detector (:halt/halting-agent @captured)))
+      (is (= :conflict (:halt/reason-code @captured)))
+      (is (= "merge conflict" (:halt/detail @captured)))
+      (is (= :implement (:workflow/phase @captured))))))
+
+(deftest halt-reason-code-resolution-test
+  (testing "reason-code uses the per-agent default, or an explicit override"
+    (is (= :no-progress  (#'monitoring/halt-reason-code {:supervisor :progress-monitor})))
+    (is (= :quality-gate (#'monitoring/halt-reason-code {:supervisor :test-quality})))
+    (is (= :conflict     (#'monitoring/halt-reason-code {:supervisor :conflict-detector})))
+    (is (= :budget-exhausted
+           (#'monitoring/halt-reason-code {:supervisor :anything
+                                           :data {:halt/reason-code :budget-exhausted}}))
+        "an agent-supplied reason-code overrides the default")
+    (is (= :no-progress (#'monitoring/halt-reason-code {:supervisor :unknown-agent}))
+        "unknown agents fall back to :no-progress")))

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -278,3 +278,28 @@
         (is (nil? (:final-message-preview meta)))
         (is (nil? (:turn-count meta)))
         (is (nil? (:tool-call-count meta)))))))
+
+(deftest phase-completed-blocked-carries-refusal-test
+  (testing "a blocked phase result emits :phase/outcome :blocked with its reason"
+    (let [stream (create-stream)
+          ctx    (test-context)
+          result (phase/blocked "env-1" "spec missing" :missing-input
+                                {:tokens 0 :duration-ms 0})]
+      (events/publish-phase-completed! stream ctx :plan result)
+      (let [event (first-event stream)]
+        (is (some? event) "event must be published — stream must be non-empty")
+        (is (= :blocked (:phase/outcome event)))
+        (is (= :missing-input (:phase/blocked-reason event)))))))
+
+(deftest phase-completed-redirected-names-the-act-test
+  (testing "a successful phase requesting a redirect emits :phase/outcome :redirected"
+    (let [stream (create-stream)
+          ctx    (test-context)
+          result (-> {:status :completed :success? true
+                      :result {:status :success :output {}
+                               :metrics {:tokens 0 :duration-ms 0}}}
+                     (phase/request-redirect :plan))]
+      (events/publish-phase-completed! stream ctx :review result)
+      (let [event (first-event stream)]
+        (is (some? event) "event must be published — stream must be non-empty")
+        (is (= :redirected (:phase/outcome event)))))))

--- a/docs/pull-requests/2026-06-19-chris-typed-phase-acts.md
+++ b/docs/pull-requests/2026-06-19-chris-typed-phase-acts.md
@@ -1,0 +1,142 @@
+# feat: typed handoff acts for phase outputs, meta-loop halts, and PR-monitor decisions
+
+## Overview
+
+Makes three inter-agent handoff points explicit, typed acts instead of signals
+reconstructed from status flags or FSM transitions:
+
+1. **Phase outputs** — `:phase/outcome` gains `:blocked` (a refusal with a
+   machine-readable cause) and `:redirected` (a request to the pipeline).
+2. **Meta-loop halts** — a new `:meta-loop/halt-requested` event puts a
+   meta-agent's halt on the event stream as a typed refusal with a reason code.
+3. **PR-monitor decisions** — a new `:pr-monitor/decision-recorded` bus event
+   records the classify→act choice (`:fix`/`:answer`/`:approve`/`:skip`) as one
+   act with provenance, at the single routing point.
+
+A single closed `RefusalReason` vocabulary is shared by phase `:blocked` and
+meta-loop halts. It also closes a pre-existing gap: the `:agent/message-sent` /
+`:agent/message-received` constructors had no schema; both are now defined.
+
+## Motivation
+
+A review of miniforge against the Symbol Grounding Framework ontology found that
+the SDLC handoffs are implicit speech acts. The one borrowed idea was to name
+them — not by importing a generic performative vocabulary (FIPA/AFP) as field
+values, but by extending miniforge's own closed, domain-tuned enums. The review
+phase already emitted a typed `:phase/review-decision`; the gap was uneven
+coverage of the *refusal* and *decision* acts, which were the least legible:
+
+- A meta-agent halt lived only in the coordinator's return value and the
+  runner's error map — never on the stream, so absent from observability and
+  evidence.
+- The PR-monitor's chosen action was spread across fine-grained bus events
+  (`fix-started`, `question-answered`, …) with no single decision act.
+- A phase that cannot proceed had no first-class outcome distinct from a crash.
+
+## Changes in Detail
+
+### Event-stream contract (`components/event-stream`)
+
+- `RefusalReason` — closed enum shared by refusal acts; consumers tolerate
+  unknown values (forward-compat).
+- `PhaseCompleted` — `:phase/outcome` enum widened with `:blocked` / `:redirected`;
+  added optional `:phase/blocked-reason` (a `RefusalReason`).
+- `AgentMessageSent` / `AgentMessageReceived` — new schemas for the existing
+  constructors (gap close); fields match the code (`:message/type`,
+  `:message/content`, optional `:from-agent/instance-id`).
+- `MetaLoopHaltRequested` — new `:meta-loop/halt-requested` schema, constructor,
+  interface exports, and privacy registration (`:internal`).
+
+### Phase outputs (`components/phase`, `components/workflow`)
+
+- `phase-result/blocked` factory (reuses the error halt path, tags the cause) +
+  `blocked?` / `blocked-reason` predicates, exported through the phase interface.
+- `runner-events` derives `:phase/outcome` via a new `phase-outcome` helper
+  (refusal and failure dominate; a successful redirect is `:redirected`) and
+  carries `:phase/blocked-reason` onto the event.
+
+### Meta-loop halt (`components/workflow`)
+
+- `monitoring/handle-supervision-halt` emits `:meta-loop/halt-requested` before
+  transitioning. Reason code resolves from the halting agent's explicit
+  `:halt/reason-code`, else a per-agent default, else `:no-progress`. Emission
+  is best-effort — a telemetry failure cannot mask the halt.
+
+### PR-monitor decision (`components/pr-lifecycle`)
+
+- `monitor-events/decision-recorded` constructor + `:pr-monitor/decision-recorded`
+  event type. `monitor-handlers/route-comment` emits it once at the routing
+  point, with a pure `category->action` map.
+
+### Outcome consumers (`bases/cli`, `components/tui-views`)
+
+- `workflow-runner/display` renders `:blocked` (red ⊘) and `:redirected`
+  (yellow ↻) distinctly, instead of falling through to the green-check default.
+- `tui-views/persistence/phase-status` maps `:blocked` → `:failed` and
+  `:redirected` → `:success` (nearest existing TUI status), instead of the
+  `:running` default.
+
+### Specs
+
+- N3 §3.1 phase-completed outcome list; §3.7 field-name correction to match code;
+  new §3.7b documenting `:meta-loop/halt-requested` and the `RefusalReason` set.
+- N6 §2.3 note: a phase's typed outcome (incl. `:blocked` + reason) is recoverable
+  from the linked phase-completed event via `:phase/event-stream-range`.
+
+## Architecture Changes
+
+- **`:phase/outcome` is the typed-act surface; `:status` is unchanged.** The
+  internal phase-result `:status` stays a two-valued control flag for the FSM
+  (read by many leave-handlers); the full act vocabulary lives on the observed
+  layer only. This avoids destabilizing control flow.
+- **PR-monitor decision is a bus event, not a stream event.** The PR-monitor
+  runs on its own in-process bus (`monitor-state/emit!`), decoupled from the
+  observability event-stream by design. The decision act lives where the
+  monitor's other typed events live. Surfacing it into evidence bundles would
+  require a pr-lifecycle→event-stream bridge — out of scope here, noted as the
+  follow-on.
+
+## Testing Plan
+
+- New: `phase-result-test`, `typed-acts-schema-test`, `monitor-handlers-test`;
+  added cases to `runner-events-test` and `monitoring-test`.
+- Coverage: `blocked` factory shape; `:blocked`/`:redirected` outcomes through
+  the public `publish-phase-completed!` path; all new events validate against
+  their Malli schemas; `RefusalReason` rejects unknowns; halt emission +
+  reason-code resolution (default + override); `route-comment` records one
+  decision with provenance; `decision-action` category mapping.
+- Verified: `clj-kondo` clean; affected tests green (107 assertions);
+  `clojure -M:poly check` OK.
+
+## Deployment Plan
+
+Product is unreleased — no compatibility shims. The widened enum and new event
+types are additive; existing producers and consumers are unaffected. No data
+migration.
+
+## PR Layering
+
+This spans the event-stream contract plus three emitters. The pieces are not
+independently meaningful (an enum value with no producer is dead; a producer
+referencing an undefined value fails validation), so it lands as one cohesive
+change rather than the four-PR DAG the <400-line guideline would otherwise
+suggest. If a split is preferred: PR1 = event-stream contract + specs; PR2 =
+phase outputs; PR3 = meta-loop halt; PR4 = PR-monitor decision.
+
+## Related
+
+- Specs: N3 (event stream), N6 (evidence & provenance)
+- Source: SGF/MiniForge ontology review (typed-act recommendation)
+
+## Checklist
+
+- [x] `RefusalReason` + widened `PhaseCompleted` schema
+- [x] Inter-agent message schemas (gap close)
+- [x] `MetaLoopHaltRequested` schema + constructor + interface exports
+- [x] `phase-result/blocked` + predicates + runner outcome wiring
+- [x] Meta-loop halt emission with reason-code resolution
+- [x] PR-monitor `decision-recorded` bus event + routing emit
+- [x] N3 / N6 spec updates
+- [x] Tests for all five areas
+- [x] clj-kondo clean, affected tests green, `poly check` OK
+- [ ] Push and open PR (awaiting approval)

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -137,11 +137,19 @@ Implementations MUST emit these event types:
  :workflow/phase :implement
 
  :phase/duration-ms long
- :phase/outcome :success         ; :success, :failure, :skipped
+ :phase/outcome :success         ; :success :failure :skipped :blocked :redirected
+ :phase/blocked-reason keyword   ; OPTIONAL: RefusalReason, present when :blocked
  :phase/artifacts [uuid ...]     ; Artifacts produced
 
  :message "Implementation phase completed"}
 ```
+
+`:phase/outcome` is the typed act of a phase boundary on the observed layer.
+`:success` / `:failure` / `:skipped` INFORM; `:blocked` is a REFUSE carrying a
+machine-readable `:phase/blocked-reason` (a RefusalReason — see
+`§3.7b meta-loop/halt-requested`); `:redirected` is a REQUEST to the pipeline,
+detailed by `:phase/transition-request`. The internal phase-result `:status`
+stays a two-valued control flag; this field carries the full act vocabulary.
 
 #### workflow/completed
 
@@ -345,8 +353,8 @@ All subagent events MUST include `parent-agent/id` and `parent-agent/instance-id
  :to-agent/id :planner
  :workflow/id uuid
 
- :message-type :clarification-request
- :message-content string
+ :message/type :clarification-request   ; open keyword; consumers tolerate unknowns
+ :message/content string
 
  :message "Asking Planner: Should we create new security group?"}
 ```
@@ -359,10 +367,39 @@ All subagent events MUST include `parent-agent/id` and `parent-agent/instance-id
  :to-agent/id :implementer
  :workflow/id uuid
 
- :message-type :clarification-response
- :message-content string
+ :message/type :clarification-response
+ :message/content string
 
  :message "Planner response: Reuse existing security group sg-prod-rds"}
+```
+
+### 3.7b Meta-Loop Halt
+
+The REFUSE act for meta-supervision. A meta-agent (progress monitor,
+test-quality, conflict detector) can stop the workflow; this event makes that
+refusal first-class on the stream with a machine-readable cause, rather than
+leaving it only in the coordinator's return value and the runner's error map.
+
+`:halt/reason-code` is a **RefusalReason** — the closed vocabulary shared with
+`:phase/blocked-reason`:
+
+`:no-progress :quality-gate :conflict :missing-input :ambiguous-intent
+:precondition-failed :resource-unavailable :budget-exhausted :policy-block`
+
+Consumers MUST tolerate unknown RefusalReason values for forward compatibility.
+
+#### meta-loop/halt-requested
+
+```clojure
+{:event/type :meta-loop/halt-requested
+ :workflow/id uuid
+ :workflow/phase :implement              ; OPTIONAL: phase active at halt
+
+ :halt/halting-agent :conflict-detector  ; meta-agent that refused
+ :halt/reason-code :conflict             ; RefusalReason
+ :halt/detail string                     ; OPTIONAL: free-text from the agent
+
+ :message "Meta-loop halt requested by conflict-detector: conflict"}
 ```
 
 ### 3.8 Milestone Events

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -349,12 +349,12 @@ All subagent events MUST include `parent-agent/id` and `parent-agent/instance-id
 ```clojure
 {:event/type :agent/message-sent
  :from-agent/id :implementer
- :from-agent/instance-id uuid
+ :from-agent/instance-id uuid           ; OPTIONAL
  :to-agent/id :planner
  :workflow/id uuid
 
- :message/type :clarification-request   ; open keyword; consumers tolerate unknowns
- :message/content string
+ :message/type :clarification-request   ; OPTIONAL; open keyword, consumers tolerate unknowns
+ :message/content string                ; OPTIONAL
 
  :message "Asking Planner: Should we create new security group?"}
 ```
@@ -367,8 +367,8 @@ All subagent events MUST include `parent-agent/id` and `parent-agent/instance-id
  :to-agent/id :implementer
  :workflow/id uuid
 
- :message/type :clarification-response
- :message/content string
+ :message/type :clarification-response   ; OPTIONAL; open keyword, consumers tolerate unknowns
+ :message/content string                 ; OPTIONAL
 
  :message "Planner response: Reuse existing security group sg-prod-rds"}
 ```
@@ -386,7 +386,8 @@ leaving it only in the coordinator's return value and the runner's error map.
 `:no-progress :quality-gate :conflict :missing-input :ambiguous-intent
 :precondition-failed :resource-unavailable :budget-exhausted :policy-block`
 
-Consumers MUST tolerate unknown RefusalReason values for forward compatibility.
+The vocabulary is closed: the schema validates `:halt/reason-code` against exactly
+this set. Adding a reason is a deliberate spec change, not an open extension point.
 
 #### meta-loop/halt-requested
 

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -142,6 +142,11 @@ Each workflow phase MUST produce phase evidence:
  :phase/event-stream-range {:start-seq long :end-seq long}}  ; Link to events
 ```
 
+A phase's typed outcome — including a `:blocked` refusal and its
+`:phase/blocked-reason` (RefusalReason) — is carried on the linked
+`:workflow/phase-completed` event (N3 §3.1), so refusals are recoverable from
+the audit trail via `:phase/event-stream-range` without a separate field here.
+
 ### 2.4 Semantic Validation Evidence
 
 ```clojure


### PR DESCRIPTION
## Overview

Makes three SDLC handoff points explicit, typed acts instead of signals reconstructed from status flags or FSM transitions — the one idea borrowed from the SGF/MiniForge ontology review (typed acts), implemented by extending miniforge's own closed enums rather than importing a generic performative vocabulary.

1. **Phase outputs** — `:phase/outcome` gains `:blocked` (refusal + machine-readable cause) and `:redirected` (request to the pipeline).
2. **Meta-loop halt** — new `:meta-loop/halt-requested` event: a meta-agent halt is now first-class on the stream, not just a value in the coordinator result.
3. **PR-monitor decision** — new `:pr-monitor/decision-recorded` bus event recording the classify→act choice (`:fix`/`:answer`/`:approve`/`:skip`) with provenance, at the single routing point.

A shared closed `RefusalReason` enum backs both phase `:blocked` and meta-loop halts. Also closes a pre-existing gap: the `:agent/message-sent` / `:agent/message-received` constructors had no schema; both are now defined.

## Design notes

- **`:status` not collapsed.** It stays the 2-valued FSM control flag (read by many leave-handlers); `:phase/outcome` carries the act vocabulary on the observed layer only.
- **PR-monitor decision is a bus event, not a stream event.** The monitor runs on its own bus, decoupled from the observability stream by design. Surfacing it into evidence bundles needs a pr-lifecycle→event-stream bridge — flagged as follow-on.

## Layering

Four commits, one per stratum (contract → phase → meta-loop → pr-monitor), each under the 200-line commit budget. Kept as one PR because the pieces are not independently mergeable in isolation (an emitter referencing an undefined enum value fails; the enum with no emitter is dead). Meaningful change 340 lines, under the 400 PR limit.

## Verification

clj-kondo clean; affected tests green; `clojure -M:poly check` OK; full pre-commit hook (poly check, lint, fmt, smoke, GraalVM) passed on every commit.

Full detail: `docs/pull-requests/2026-06-19-chris-typed-phase-acts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
