### PR TITLE
Compile policy-pack rules into executable checks

### DIFF
--- a/components/gate/src/ai/miniforge/gate/capabilities.clj
+++ b/components/gate/src/ai/miniforge/gate/capabilities.clj
@@ -27,10 +27,10 @@
    calling `policy-pack/register-capability!`. No requiring-resolve is used:
    the gate checks are reached through ordinary requires.
 
-   Capabilities registered (each wraps the EXISTING tool gate, not a
-   reimplementation):
+   Capabilities registered:
    - :lint       -> gate :lint       (clj-kondo lint gate)
-   - :format     -> gate :format     (cljfmt / LSP format gate)
+   - :format     -> pure format-drift check requiring explicit formatted
+                    content or an injected check function
    - :syntax     -> gate :syntax     (reader/syntax gate)
    - :no-secrets -> gate :no-secrets (policy no-secrets gate)
 
@@ -126,6 +126,53 @@
   [artifact context]
   (run-gate-capability :no-secrets :no-secrets artifact context))
 
+(defn- artifact-content
+  [artifact]
+  (cond
+    (contains? artifact :artifact/content) (get artifact :artifact/content)
+    (contains? artifact :content)          (get artifact :content)
+    :else                                  ""))
+
+(defn- expected-formatted-content
+  [artifact]
+  (or (get artifact :artifact/formatted-content)
+      (get artifact :formatted-content)))
+
+(defn- format-drift-violation
+  [artifact message]
+  {:type          :capability
+   :capability    :format
+   :artifact-path (or (:artifact/path artifact) (:path artifact))
+   :message       message})
+
+(defn- injected-format-result
+  [artifact context]
+  (when-let [check-fn (:format-check-fn context)]
+    (check-fn artifact context)))
+
+(defn- artifact-format-result
+  [artifact]
+  (when-let [formatted (expected-formatted-content artifact)]
+    {:passed? (= formatted (artifact-content artifact))
+     :errors  [{:message "Artifact content is not formatted"}]}))
+
+(defn check-format
+  "Format capability — performs a pure formatting check.
+
+   The existing :format gate repairs via LSP and intentionally reports pass for
+   check-only mode. Policy enforcement needs a check that cannot silently pass,
+   so this capability accepts either an injected pure `:format-check-fn` in the
+   context or an artifact-provided `:artifact/formatted-content` expectation.
+   Without either, the capability returns a violation naming the missing check
+   contract."
+  [artifact context]
+  (let [result (or (injected-format-result artifact context)
+                   (artifact-format-result artifact))]
+    (if result
+      (gate-result->violation :format result artifact)
+      (format-drift-violation artifact
+                              "Format capability requires :format-check-fn or :artifact/formatted-content"))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Injection
 
@@ -133,15 +180,14 @@
   "Capability keyword -> {:meta {...} :check fn} for the mechanical tool
    gates. Injected into the policy-pack registry by
    `register-mechanical-capabilities!`."
-  ;; NOTE: :format is intentionally NOT registered. The :format gate's check
-  ;; "always passes — formatting is repair" (gate/format.clj), so a rule using
-  ;; :format would never produce a violation — a silent no-op, exactly what the
-  ;; policy-gate compiler exists to eliminate. Register :format only once a
-  ;; failing format-CHECK gate (e.g. `cljfmt check`) exists. (Follow-up.)
   {:lint       {:meta  {:tool :clj-kondo
                         :class :deterministic
                         :description "Lint Clojure code via the clj-kondo gate"}
                 :check check-lint}
+   :format     {:meta  {:tool :formatter
+                        :class :deterministic
+                        :description "Detect formatting drift through a pure format check"}
+                :check check-format}
    :syntax     {:meta  {:tool :reader
                         :class :deterministic
                         :description "Parse code via the reader/syntax gate"}

--- a/components/gate/test/ai/miniforge/gate/capabilities_test.clj
+++ b/components/gate/test/ai/miniforge/gate/capabilities_test.clj
@@ -26,14 +26,11 @@
 (deftest register-mechanical-capabilities-test
   (testing "registers the failing mechanical gates as capabilities"
     (let [available (sut/register-mechanical-capabilities!)]
-      (doseq [capability-kw [:lint :syntax :no-secrets]]
+      (doseq [capability-kw [:lint :format :syntax :no-secrets]]
         (is (contains? available capability-kw))
         (is (policy-pack/capability-available? capability-kw)
             (str capability-kw " should be registered"))
-        (is (fn? (:check (policy-pack/get-capability capability-kw)))))
-      (testing ":format is intentionally NOT registered — its gate never fails"
-        (is (not (contains? available :format)))
-        (is (not (policy-pack/capability-available? :format)))))))
+        (is (fn? (:check (policy-pack/get-capability capability-kw))))))))
 
 (deftest no-secrets-capability-surfaces-violation-test
   (testing "a hardcoded secret surfaces as a capability violation"
@@ -62,6 +59,38 @@
       (is (some? result))
       (is (= :capability (:type result)))
       (is (= :syntax (:capability result))))))
+
+(deftest format-capability-surfaces-format-drift-test
+  (testing "unformatted content surfaces as a deterministic format violation"
+    (sut/register-mechanical-capabilities!)
+    (let [check    (:check (policy-pack/get-capability :format))
+          artifact {:artifact/content           "(defn x []\n42)"
+                    :artifact/formatted-content "(defn x []\n  42)"
+                    :artifact/path              "core.clj"}
+          result   (check artifact {})]
+      (is (some? result))
+      (is (= :capability (:type result)))
+      (is (= :format (:capability result))))))
+
+(deftest format-capability-clean-test
+  (testing "formatted content yields nil"
+    (sut/register-mechanical-capabilities!)
+    (let [check    (:check (policy-pack/get-capability :format))
+          artifact {:artifact/content           "(defn x []\n  42)"
+                    :artifact/formatted-content "(defn x []\n  42)"
+                    :artifact/path              "core.clj"}]
+      (is (nil? (check artifact {}))))))
+
+(deftest format-capability-missing-check-fails-loud-test
+  (testing "format capability never silently passes without a check contract"
+    (sut/register-mechanical-capabilities!)
+    (let [check    (:check (policy-pack/get-capability :format))
+          artifact {:artifact/content "(defn x [] 42)"
+                    :artifact/path    "core.clj"}
+          result   (check artifact {})]
+      (is (some? result))
+      (is (= :format (:capability result)))
+      (is (re-find #"requires" (:message result))))))
 
 (deftest registration-idempotent-test
   (testing "repeated registration is safe and stays stable"

--- a/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
@@ -107,6 +107,11 @@
   (or (get artifacts :code/files)
       (get artifacts :files)))
 
+(defn- code-files-present?
+  [artifacts]
+  (or (contains? artifacts :code/files)
+      (contains? artifacts :files)))
+
 (defn- file-entry->artifact
   [file-entry]
   (let [path    (or (get file-entry :artifact/path)
@@ -122,7 +127,7 @@
   [artifacts]
   (cond
     (sequential? artifacts) (mapv file-entry->artifact artifacts)
-    (seq (code-files artifacts)) (mapv file-entry->artifact (code-files artifacts))
+    (code-files-present? artifacts) (mapv file-entry->artifact (code-files artifacts))
     (map? artifacts) [(file-entry->artifact artifacts)]
     :else []))
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
@@ -89,8 +89,173 @@
       :else
       :none)))
 
+(defn- detector-class
+  [detector]
+  (if (= :semantic detector)
+    :heuristic
+    :deterministic))
+
+(defn- rule-metadata
+  [rule detector]
+  {:rule/id       (:rule/id rule)
+   :rule/severity (:rule/severity rule)
+   :detector      detector
+   :class         (detector-class detector)})
+
+(defn- code-files
+  [artifacts]
+  (or (get artifacts :code/files)
+      (get artifacts :files)))
+
+(defn- file-entry->artifact
+  [file-entry]
+  (let [path    (or (get file-entry :artifact/path)
+                    (get file-entry :path))
+        content (or (get file-entry :artifact/content)
+                    (get file-entry :content))]
+    (cond-> file-entry
+      path    (assoc :artifact/path path)
+      content (assoc :artifact/content content))))
+
+(defn- normalize-artifacts
+  "Normalize N4 check input into artifact maps that existing detectors accept."
+  [artifacts]
+  (cond
+    (sequential? artifacts) (mapv file-entry->artifact artifacts)
+    (seq (code-files artifacts)) (mapv file-entry->artifact (code-files artifacts))
+    (map? artifacts) [(file-entry->artifact artifacts)]
+    :else []))
+
+(defn- artifact-inputs
+  [detector artifacts]
+  (let [normalized (normalize-artifacts artifacts)]
+    (if (and (= :semantic detector) (seq normalized))
+      [(first normalized)]
+      normalized)))
+
+(defn- semantic-context-ready?
+  [context]
+  (and (fn? (:semantic-analyze-fn context))
+       (some? (:llm-client context))
+       (fn? (:complete-fn context))))
+
+(defn- violation-with-rule
+  [rule violation]
+  (assoc violation
+         :rule-id  (or (:rule-id violation) (:rule/id rule))
+         :severity (or (:severity violation) (:rule/severity rule))))
+
+(defn- detect-rule-violations
+  [rule detector artifacts context]
+  (->> (artifact-inputs detector artifacts)
+       (keep #(detection/detect-violation rule % context))
+       (mapv #(violation-with-rule rule %))))
+
+(defn- exception-violation
+  [rule detector e]
+  {:type     :check-error
+   :rule-id  (:rule/id rule)
+   :severity (:rule/severity rule)
+   :detector detector
+   :error    (ex-message e)
+   :message  (str "Policy check failed: " (ex-message e))})
+
+(defn- missing-semantic-wiring-violation
+  [rule]
+  {:type     :semantic-error
+   :rule-id  (:rule/id rule)
+   :severity (:rule/severity rule)
+   :message  "Semantic policy check requires :semantic-analyze-fn, :llm-client, and :complete-fn"})
+
+(defn- check-result
+  [rule detector violations]
+  {:passed?    (empty? violations)
+   :violations violations
+   :metadata   (rule-metadata rule detector)})
+
+(defn- compile-check-fn
+  [rule detector]
+  (fn [artifacts context]
+    (try
+      (if (and (= :semantic detector)
+               (not (semantic-context-ready? context)))
+        (check-result rule detector [(missing-semantic-wiring-violation rule)])
+        (check-result rule detector
+                      (detect-rule-violations rule detector artifacts context)))
+      (catch Exception e
+        (check-result rule detector [(exception-violation rule detector e)])))))
+
+(defn compile-rule-check
+  "Compile one enabled rule into an executable N4 check entry.
+
+   Returns:
+     {:rule rule
+      :detector <mechanism>
+      :check-fn (fn [artifacts context] -> {:passed? bool
+                                            :violations [...]
+                                            :metadata {...}})}
+
+   Returns an :invalid-input anomaly when the rule cannot bind to any
+   mechanism. Disabled rules are not compiled."
+  [rule]
+  (let [detector (resolve-detector rule)]
+    (cond
+      (not (rule-enabled? rule))
+      (anomaly/anomaly :invalid-input
+                       "Disabled rules are not compiled into checks"
+                       {:rule/id (:rule/id rule)})
+
+      (= :none detector)
+      (anomaly/anomaly :invalid-input
+                       "Enabled policy rule binds to no detection mechanism"
+                       {:rule/id (:rule/id rule)})
+
+      :else
+      {:rule     rule
+       :detector detector
+       :check-fn (compile-check-fn rule detector)})))
+
+(defn- anomaly-rule-id
+  [a]
+  (get-in a [:anomaly/data :rule/id]))
+
+(defn- compiled-entry-detector
+  [entry]
+  (:detector entry))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pack-level validation
+
+(defn compile-pack-checks
+  "Compile every enabled rule in `pack` into executable check entries.
+
+   Returns:
+     {:ok true
+      :rule-count n
+      :detector-counts {...}
+      :compiled-rules [{:rule ... :detector ... :check-fn fn} ...]}
+
+   Returns an :invalid-input anomaly when pack shape is malformed or any
+   enabled rule is unbindable."
+  [pack]
+  (if-not (sequential? (:pack/rules pack))
+    (anomaly/anomaly :invalid-input
+                     "Policy pack :pack/rules must be a sequential collection of rules"
+                     {:pack-rules-type (some-> (:pack/rules pack) type str)})
+    (let [enabled    (filter rule-enabled? (:pack/rules pack))
+          compiled   (mapv compile-rule-check enabled)
+          anomalies  (filter anomaly/anomaly? compiled)
+          unbindable (mapv anomaly-rule-id anomalies)]
+      (if (seq anomalies)
+        (anomaly/anomaly :invalid-input
+                         (str "Policy pack has " (count anomalies)
+                              " enabled rule(s) that bind to no detection mechanism")
+                         {:unbindable-rule-ids unbindable
+                          :rule-count          (count enabled)})
+        {:ok              true
+         :rule-count      (count enabled)
+         :detector-counts (frequencies (map compiled-entry-detector compiled))
+         :compiled-rules  compiled}))))
 
 (defn compile-pack
   "Validate that every ENABLED rule in `pack` binds to a detection mechanism.
@@ -106,30 +271,10 @@
    enabled rules resolve to `:none`; its `:anomaly/data` names
    `:unbindable-rule-ids` so the failure is actionable and fails loud."
   [pack]
-  (if-not (sequential? (:pack/rules pack))
-    ;; A validator must fail loud on a malformed pack shape, not treat a
-    ;; missing/garbage :pack/rules as an empty (vacuously-valid) rule list.
-    (anomaly/anomaly :invalid-input
-                     "Policy pack :pack/rules must be a sequential collection of rules"
-                     {:pack-rules-type (some-> (:pack/rules pack) type str)})
-    (let [enabled    (filter rule-enabled? (:pack/rules pack))
-          resolved   (map (fn [rule]
-                            {:rule/id  (:rule/id rule)
-                             :detector (resolve-detector rule)})
-                          enabled)
-          unbindable (->> resolved
-                          (filter #(= :none (:detector %)))
-                          (map :rule/id)
-                          vec)]
-      (if (seq unbindable)
-        (anomaly/anomaly :invalid-input
-                         (str "Policy pack has " (count unbindable)
-                              " enabled rule(s) that bind to no detection mechanism")
-                         {:unbindable-rule-ids unbindable
-                          :rule-count          (count enabled)})
-        {:ok              true
-         :rule-count      (count enabled)
-         :detector-counts (frequencies (map :detector resolved))}))))
+  (let [result (compile-pack-checks pack)]
+    (if (anomaly/anomaly? result)
+      result
+      (dissoc result :compiled-rules))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -295,6 +295,19 @@
    :rule/enabled? to false; a missing flag means enabled."
   checking/rule-enabled?)
 
+(def compile-rule-check
+  "Compile one enabled rule into an executable N4 check entry.
+   (compile-rule-check rule) returns {:rule :detector :check-fn}, or an
+   :invalid-input anomaly when the rule cannot bind to a detector."
+  checking/compile-rule-check)
+
+(def compile-pack-checks
+  "Compile every enabled rule in a pack into executable N4 check entries.
+   (compile-pack-checks pack) returns {:ok true :rule-count :detector-counts
+   :compiled-rules [...]}, or an :invalid-input anomaly naming unbindable
+   rule ids."
+  checking/compile-pack-checks)
+
 (def compile-pack
   "Validate that every enabled rule in a pack binds to a detection mechanism.
    (compile-pack pack) returns {:ok true :rule-count int :detector-counts {...}}

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/checking.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/checking.clj
@@ -113,6 +113,19 @@
    :rule/enabled? to false; a missing flag means enabled."
   compiler/rule-enabled?)
 
+(def compile-rule-check
+  "Compile one enabled rule into an executable N4 check entry.
+   (compile-rule-check rule) returns {:rule :detector :check-fn}, or an
+   :invalid-input anomaly when the rule cannot bind to a detector."
+  compiler/compile-rule-check)
+
+(def compile-pack-checks
+  "Compile every enabled rule in a pack into executable N4 check entries.
+   (compile-pack-checks pack) returns {:ok true :rule-count :detector-counts
+   :compiled-rules [...]}, or an :invalid-input anomaly naming unbindable
+   rule ids."
+  compiler/compile-pack-checks)
+
 (def compile-pack
   "Validate that every enabled rule in a pack binds to a detection mechanism.
    (compile-pack pack) returns {:ok true :rule-count int :detector-counts {...}}

--- a/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
@@ -50,6 +50,12 @@
      :capability ::compile-lint
      :message "lint failed"}))
 
+(defn- always-violating-capability-check
+  [_artifact _context]
+  {:type :capability
+   :capability ::empty-files
+   :message "capability should not run without artifacts"})
+
 (defn- semantic-violation-analyze
   [_llm-client _complete-fn _repo-path rule]
   {:rule/id (:rule/id rule)
@@ -205,6 +211,23 @@
       (is (= :capability (:detector compiled)))
       (is (false? (:passed? result)))
       (is (= :critical (get-in result [:violations 0 :severity]))))))
+
+(deftest compile-rule-check-empty-files-capability-test
+  (testing "explicit empty file collections do not run capability checks on the envelope"
+    (capability/register-capability!
+     ::empty-files
+     {:meta {:tool :stub}
+      :check always-violating-capability-check})
+    (let [rule     {:rule/id :empty-files
+                    :rule/severity :critical
+                    :rule/detection {:type :capability
+                                     :capability ::empty-files}}
+          compiled (sut/compile-rule-check rule)]
+      (doseq [artifacts [{:code/files []}
+                         {:files []}]]
+        (let [result ((:check-fn compiled) artifacts {})]
+          (is (true? (:passed? result)))
+          (is (= [] (:violations result))))))))
 
 (deftest compile-rule-check-semantic-test
   (testing "a custom heuristic rule with no custom fn compiles to semantic check"

--- a/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
@@ -43,6 +43,22 @@
 
 (defn- noop-check [_artifact _context] nil)
 
+(defn- compile-lint-check
+  [artifact _context]
+  (when (= "bad.clj" (:artifact/path artifact))
+    {:type :capability
+     :capability ::compile-lint
+     :message "lint failed"}))
+
+(defn- semantic-violation-analyze
+  [_llm-client _complete-fn _repo-path rule]
+  {:rule/id (:rule/id rule)
+   :status :failed
+   :violations [{:path "src/core.clj"
+                 :message "semantic issue"}]})
+
+(defn- noop-complete [_request] nil)
+
 (def ^:private pack-rel-path
   "components/phase/resources/packs/miniforge-standards.pack.edn")
 
@@ -137,6 +153,123 @@
       (let [result (sut/compile-pack bad)]
         (is (anomaly/anomaly? result) (str "expected anomaly for " (pr-str bad)))
         (is (= :invalid-input (:anomaly/type result)))))))
+
+;------------------------------------------------------------------------------ executable check-fn compiler
+
+(deftest compile-rule-check-content-violation-test
+  (testing "a content-scan rule compiles to an N4 check-fn that reports violations"
+    (let [rule     {:rule/id :no-duplicate-ns
+                    :rule/severity :major
+                    :rule/detection {:type :content-scan
+                                     :pattern "duplicate namespace"}
+                    :rule/enforcement {:message "Duplicate namespace"}}
+          compiled (sut/compile-rule-check rule)
+          check-fn (:check-fn compiled)
+          result   (check-fn {:code/files [{:path "src/core.clj"
+                                            :content "duplicate namespace"}]}
+                             {})]
+      (is (= :content-scan (:detector compiled)))
+      (is (false? (:passed? result)))
+      (is (= :no-duplicate-ns (get-in result [:metadata :rule/id])))
+      (is (= :major (get-in result [:violations 0 :severity])))
+      (is (= :no-duplicate-ns (get-in result [:violations 0 :rule-id]))))))
+
+(deftest compile-rule-check-content-clean-test
+  (testing "a clean artifact returns :passed? true and no violations"
+    (let [rule     {:rule/id :no-duplicate-ns
+                    :rule/severity :major
+                    :rule/detection {:type :content-scan
+                                     :pattern "duplicate namespace"}}
+          compiled (sut/compile-rule-check rule)
+          result   ((:check-fn compiled)
+                    {:code/files [{:path "src/core.clj"
+                                   :content "clean namespace"}]}
+                    {})]
+      (is (true? (:passed? result)))
+      (is (= [] (:violations result))))))
+
+(deftest compile-rule-check-capability-test
+  (testing "a capability rule binds to the registered capability check"
+    (capability/register-capability!
+     ::compile-lint
+     {:meta {:tool :stub}
+      :check compile-lint-check})
+    (let [rule     {:rule/id :lint
+                    :rule/severity :critical
+                    :rule/detection {:type :capability
+                                     :capability ::compile-lint}}
+          compiled (sut/compile-rule-check rule)
+          result   ((:check-fn compiled)
+                    {:code/files [{:path "bad.clj" :content "(def x 1)"}]}
+                    {})]
+      (is (= :capability (:detector compiled)))
+      (is (false? (:passed? result)))
+      (is (= :critical (get-in result [:violations 0 :severity]))))))
+
+(deftest compile-rule-check-semantic-test
+  (testing "a custom heuristic rule with no custom fn compiles to semantic check"
+    (let [rule       {:rule/id :heuristic-review
+                      :rule/severity :minor
+                      :rule/detection {:type :custom}
+                      :rule/enforcement {:message "Heuristic review failed"}}
+          context    {:semantic-analyze-fn semantic-violation-analyze
+                      :llm-client ::llm
+                      :complete-fn noop-complete}
+          compiled   (sut/compile-rule-check rule)
+          result     ((:check-fn compiled)
+                      {:code/files [{:path "src/core.clj" :content "x"}]}
+                      context)]
+      (is (= :semantic (:detector compiled)))
+      (is (= :heuristic (get-in result [:metadata :class])))
+      (is (false? (:passed? result)))
+      (is (= :semantic (get-in result [:violations 0 :type]))))))
+
+(deftest compile-rule-check-semantic-missing-wiring-fails-test
+  (testing "compiled semantic checks fail loud instead of silently passing"
+    (let [rule     {:rule/id :heuristic-review
+                    :rule/severity :minor
+                    :rule/detection {:type :custom}}
+          compiled (sut/compile-rule-check rule)
+          result   ((:check-fn compiled)
+                    {:code/files [{:path "src/core.clj" :content "x"}]}
+                    {})]
+      (is (false? (:passed? result)))
+      (is (= :semantic-error (get-in result [:violations 0 :type])))
+      (is (= :heuristic-review (get-in result [:violations 0 :rule-id]))))))
+
+(deftest compile-rule-check-unbindable-anomaly-test
+  (testing "an unbindable enabled rule fails before check execution"
+    (let [result (sut/compile-rule-check
+                  {:rule/id :missing
+                   :rule/detection {:type :unknown}})]
+      (is (anomaly/anomaly? result))
+      (is (= :missing (get-in result [:anomaly/data :rule/id]))))))
+
+(deftest compile-pack-checks-returns-executable-entries-test
+  (testing "compile-pack-checks returns one executable entry per enabled rule"
+    (let [pack   {:pack/rules [{:rule/id :a
+                                :rule/detection {:type :content-scan :pattern "A"}}
+                               {:rule/id :b
+                                :rule/enabled? false
+                                :rule/detection {:type :unknown}}]}
+          result (sut/compile-pack-checks pack)]
+      (is (:ok result))
+      (is (= 1 (:rule-count result)))
+      (is (= 1 (count (:compiled-rules result))))
+      (is (fn? (get-in result [:compiled-rules 0 :check-fn]))))))
+
+(deftest compiled-mechanical-check-pure-test
+  (testing "a deterministic compiled check returns equal results for identical inputs"
+    (let [rule     {:rule/id :no-token
+                    :rule/severity :major
+                    :rule/detection {:type :content-scan
+                                     :pattern "TOKEN"}}
+          compiled (sut/compile-rule-check rule)
+          artifacts {:code/files [{:path "src/core.clj"
+                                   :content "TOKEN"}]}
+          first-result ((:check-fn compiled) artifacts {})
+          second-result ((:check-fn compiled) artifacts {})]
+      (is (= first-result second-result)))))
 
 ;------------------------------------------------------------------------------ compile-pack — REAL shipped pack (headline acceptance criterion)
 

--- a/docs/pull-requests/2026-06-20-chris-policy-gate-compiler.md
+++ b/docs/pull-requests/2026-06-20-chris-policy-gate-compiler.md
@@ -1,0 +1,65 @@
+# feat: compile policy-pack rules into executable checks
+
+## Overview
+
+This PR adds the policy-pack compiler layer that turns enabled rules into
+executable N4-style check functions. It is the foundation for later phase
+wiring: no enabled rule should silently disappear because it lacks a detector.
+
+## Layer
+
+Domain / application compiler foundation.
+
+## Motivation
+
+The standards pack can compile rule data today, but many enabled rules do not
+bind to executable checks. That leaves policy as prompt guidance rather than an
+enforced contract. The compiler must either produce a check function or fail
+loudly with the rule id and missing binding reason.
+
+## Changes in Detail
+
+- Add a rule-to-check compiler in `policy-pack`.
+- Bind pattern/content rules to deterministic artifact content scanning across
+  N4 artifact collections.
+- Bind mechanical rules through explicit policy capabilities.
+- Bind heuristic custom rules to an injectable semantic checker and fail loud
+  when judge wiring is absent.
+- Preserve rule severity on produced violations.
+- Register `:format` as a fail-loud mechanical capability that requires an
+  injected pure formatter check or expected formatted content.
+- Add regression coverage for successful compilation, clean/violating
+  artifacts, capability binding, semantic binding, and unbindable rules.
+
+## Testing Plan
+
+- [x] Focused lint for touched Clojure files
+- [x] Focused policy-pack/gate compiler tests
+- [x] Broader policy-pack and gate tests
+- [x] `git diff --check`
+- [x] `bb pre-commit`
+
+## Deployment Plan
+
+Merge normally after CI and review. This is additive compiler functionality; the
+follow-up PR wires compiled checks into verify/review execution.
+
+## Rollback Plan
+
+Revert the PR. Existing policy-pack callers continue using their current paths
+until the follow-up phase wiring lands.
+
+## Related Issues/PRs
+
+- Spec: `work/policy-gate-compiler.spec.edn`
+- Follow-up: `work/policy-gate-phase-wiring-and-evidence.spec.edn`
+
+## Checklist
+
+- [x] Enabled rules compile to concrete check functions or explicit errors
+- [x] Capability rules are represented as policy bindings
+- [x] Semantic fallback is explicit and injectable
+- [x] Tests cover pass, fail, capability, semantic, and unbindable paths
+- [ ] PR opened
+- [ ] Copilot comments settled
+- [ ] All review comments resolved


### PR DESCRIPTION
# feat: compile policy-pack rules into executable checks

## Overview

This PR adds the policy-pack compiler layer that turns enabled rules into
executable N4-style check functions. It is the foundation for later phase
wiring: no enabled rule should silently disappear because it lacks a detector.

## Layer

Domain / application compiler foundation.

## Motivation

The standards pack can compile rule data today, but many enabled rules do not
bind to executable checks. That leaves policy as prompt guidance rather than an
enforced contract. The compiler must either produce a check function or fail
loudly with the rule id and missing binding reason.

## Changes in Detail

- Add a rule-to-check compiler in `policy-pack`.
- Bind pattern/content rules to deterministic artifact content scanning across
  N4 artifact collections.
- Bind mechanical rules through explicit policy capabilities.
- Bind heuristic custom rules to an injectable semantic checker and fail loud
  when judge wiring is absent.
- Preserve rule severity on produced violations.
- Register `:format` as a fail-loud mechanical capability that requires an
  injected pure formatter check or expected formatted content.
- Add regression coverage for successful compilation, clean/violating
  artifacts, capability binding, semantic binding, and unbindable rules.

## Testing Plan

- [x] Focused lint for touched Clojure files
- [x] Focused policy-pack/gate compiler tests
- [x] Broader policy-pack and gate tests
- [x] `git diff --check`
- [x] `bb pre-commit`

## Deployment Plan

Merge normally after CI and review. This is additive compiler functionality; the
follow-up PR wires compiled checks into verify/review execution.

## Rollback Plan

Revert the PR. Existing policy-pack callers continue using their current paths
until the follow-up phase wiring lands.

## Related Issues/PRs

- Spec: `work/policy-gate-compiler.spec.edn`
- Follow-up: `work/policy-gate-phase-wiring-and-evidence.spec.edn`

## Checklist

- [x] Enabled rules compile to concrete check functions or explicit errors
- [x] Capability rules are represented as policy bindings
- [x] Semantic fallback is explicit and injectable
- [x] Tests cover pass, fail, capability, semantic, and unbindable paths
- [ ] PR opened
- [ ] Copilot comments settled
- [ ] All review comments resolved
