### PR TITLE
Wire phase policy gates to compiled checks

### DIFF
--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -43,7 +43,11 @@
   :policy-pack/repair-required
   "Policy violations require redirect to :implement phase — no in-place repair"
 
-  ;; Policy-pack gate — exception caught during check-artifact evaluation.
+  ;; Policy-pack gate — exception caught during policy evaluation.
   ;; {message} is the ex-message of the caught exception.
   :policy-pack/check-error
-  "Policy check failed: {message}"}}
+  "Policy check failed: {message}"
+
+  ;; Policy-pack gate — pack compilation failed before evaluation.
+  :policy-pack/compile-error
+  "Policy pack compilation failed: {message}"}}

--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -56,7 +56,8 @@
    [ai.miniforge.policy-pack.interface :as policy-pack]
    [ai.miniforge.semantic-analyzer.interface :as semantic]
    [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pack source
@@ -130,10 +131,26 @@
   [ctx]
   (get-in ctx [:execution/phase-results :implement :artifact]))
 
+(defn- path-inside-worktree?
+  [worktree file]
+  (let [root-path (str (.getPath worktree) java.io.File/separator)
+        file-path (.getPath file)]
+    (or (= file-path (.getPath worktree))
+        (str/starts-with? file-path root-path))))
+
+(defn- safe-worktree-file
+  [worktree-path file-path]
+  (let [worktree (.getCanonicalFile (io/file worktree-path))
+        file     (.getCanonicalFile (io/file worktree file-path))]
+    (when (path-inside-worktree? worktree file)
+      file)))
+
 (defn- code-file-entry
   [worktree-path file-path action]
-  (let [file    (io/file worktree-path file-path)
-        content (when (.exists file) (slurp file))]
+  (let [file    (safe-worktree-file worktree-path file-path)
+        content (cond
+                  (= :delete action) ""
+                  (and file (.isFile file)) (slurp file))]
     (cond-> {:path file-path}
       content (assoc :content content)
       action  (assoc :action action))))
@@ -142,10 +159,11 @@
   [artifact worktree-path]
   (when-let [paths (seq (:code/file-paths artifact))]
     (let [actions (get artifact :code/file-actions [])
-          files   (mapv code-file-entry
-                        (repeat worktree-path)
-                        paths
-                        actions)]
+          files   (mapv (fn [idx path]
+                          (code-file-entry worktree-path path
+                                           (or (nth actions idx nil) :modify)))
+                        (range)
+                        paths)]
       (assoc artifact :code/files files))))
 
 (defn- policy-artifact
@@ -187,6 +205,7 @@
 (defn- compile-anomaly-result
   [anomaly]
   {:passed?  false
+   :compiled? false
    :blocking [{:code    :policy-pack/compile-failed
                :message (msg/t :policy-pack/compile-error
                                {:message (compile-anomaly-message anomaly)})
@@ -271,6 +290,7 @@
             warnings   (policy-pack/warning-violations violations)
             audits     (audit-violations violations)]
         {:passed?          (empty? blocking)
+         :compiled?        true
          :violations       violations
          :blocking         (mapv policy-pack/violation->error blocking)
          :require-approval (mapv policy-pack/violation->error approvals)
@@ -366,9 +386,10 @@
       (let [artifact (policy-artifact artifact ctx)
             context  (-> ctx with-semantic-wiring (assoc :phase phase))
             result   (compiled-check-result packs phase artifact context)]
-        (emit-rule-evidence! ctx phase
-                             (classify-rules packs phase artifact context
-                                             (:violations result)))
+        (when (:compiled? result)
+          (emit-rule-evidence! ctx phase
+                               (classify-rules packs phase artifact context
+                                               (:violations result))))
         {:passed?  (:passed? result)
          :errors   (vec (:blocking result))
          :warnings (vec (concat (:require-approval result)

--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -29,9 +29,9 @@
 
    Registered as two phase-baked gates, `:policy-verify` and `:policy-review`,
    so the generic `apply-gate-validation` path runs the right rule subset per
-   phase. The whole evaluation delegates to
-   `policy-pack/check-artifact`, which already does phase filtering,
-   detection, and severity/enforcement classification — this gate adds no
+   phase. The whole evaluation delegates to compiled policy checks from
+   `policy-pack/compile-pack-checks`, preserving phase/applicability
+   filtering and severity/enforcement classification — this gate adds no
    parallel enforcement channel (N4 reuse constraint).
 
    Pack source: `ctx :policy-packs` when provided (tests / repo packs), else
@@ -40,16 +40,17 @@
    Semantic seam: when the run carries an `:llm-client` and `:complete-fn` in
    ctx, this gate INJECTS `semantic-analyzer/analyze-rule` under
    `:semantic-analyze-fn` so heuristic (`:custom` rules with no resolvable
-   `:custom-fn`) reach the LLM judge. Absent that wiring such rules no-op
-   gracefully (see `policy-pack.detection/detect-semantic`) — they default to
-   non-blocking enforcement, so a run is never hard-blocked on a
-   non-deterministic judge by default.
+   `:custom-fn`) reach the LLM judge. With compiled checks, missing semantic
+   wiring is reported as a policy violation; the pack's enforcement action
+   controls whether that violation blocks, requires approval, warns, or audits.
 
    Fail-safe: a check that throws is converted to a failed gate by
    `gate.interface/check-gate` (mirrors the reviewer fix in #977) — never a
    silent pass."
   (:require
    [ai.miniforge.event-stream.interface :as event-stream]
+   ;; Registers mechanical capability checks before compiled pack evaluation.
+   [ai.miniforge.gate.capabilities]
    [ai.miniforge.gate.messages :as msg]
    [ai.miniforge.gate.registry :as registry]
    [ai.miniforge.policy-pack.interface :as policy-pack]
@@ -101,8 +102,8 @@
   "Inject the LLM-judge seam when the run carries an `:llm-client` and
    `:complete-fn` but no explicit `:semantic-analyze-fn`. Also normalizes the
    repo path the judge scans (`:repo-path`, falling back to the execution
-   worktree). When the LLM seam is absent, leaves ctx untouched — semantic
-   rules then no-op in detection."
+   worktree). When the LLM seam is absent, leaves ctx untouched so compiled
+   semantic checks can fail loud according to pack enforcement."
   [ctx]
   (let [ctx (assoc ctx :repo-path (or (:repo-path ctx)
                                       (:execution/worktree-path ctx)
@@ -118,8 +119,163 @@
   {:type :no-policy-packs
    :message (msg/t :policy-pack/no-policy-packs)})
 
+(defn- artifact-has-code?
+  [artifact]
+  (and (map? artifact)
+       (or (seq (:code/files artifact))
+           (contains? artifact :artifact/content)
+           (contains? artifact :content))))
+
+(defn- implement-artifact
+  [ctx]
+  (get-in ctx [:execution/phase-results :implement :artifact]))
+
+(defn- code-file-entry
+  [worktree-path file-path action]
+  (let [file    (io/file worktree-path file-path)
+        content (when (.exists file) (slurp file))]
+    (cond-> {:path file-path}
+      content (assoc :content content)
+      action  (assoc :action action))))
+
+(defn- rehydrate-code-files
+  [artifact worktree-path]
+  (when-let [paths (seq (:code/file-paths artifact))]
+    (let [actions (get artifact :code/file-actions [])
+          files   (mapv code-file-entry
+                        (repeat worktree-path)
+                        paths
+                        actions)]
+      (assoc artifact :code/files files))))
+
+(defn- policy-artifact
+  "Resolve the artifact that pack-derived policy should evaluate.
+
+   Verify emits test metadata and review emits a verdict, but policy rules
+   target the code-under-review. Prefer an explicit code artifact when present;
+   otherwise use the implement phase artifact, rehydrating paths-only metadata
+   from the execution worktree when available."
+  [artifact ctx]
+  (let [impl-artifact (implement-artifact ctx)
+        worktree-path (:execution/worktree-path ctx)]
+    (cond
+      (artifact-has-code? artifact)
+      artifact
+
+      (and worktree-path (seq (:code/file-paths impl-artifact)))
+      (rehydrate-code-files impl-artifact worktree-path)
+
+      (artifact-has-code? impl-artifact)
+      impl-artifact
+
+      :else
+      artifact)))
+
 ;------------------------------------------------------------------------------ Layer 1.5
-;; Per-rule application evidence
+;; Compiled policy evaluation and per-rule application evidence
+
+(defn- compile-anomaly?
+  [result]
+  (contains? result :anomaly/type))
+
+(defn- compile-anomaly-message
+  [anomaly]
+  (or (:anomaly/message anomaly)
+      (:message anomaly)
+      (name (:anomaly/type anomaly))))
+
+(defn- compile-anomaly-result
+  [anomaly]
+  {:passed?  false
+   :blocking [{:code    :policy-pack/compile-failed
+               :message (msg/t :policy-pack/compile-error
+                               {:message (compile-anomaly-message anomaly)})
+               :data    (:anomaly/data anomaly)}]
+   :warnings []})
+
+(defn- compile-pack-results
+  [packs]
+  (mapv policy-pack/compile-pack-checks packs))
+
+(defn- compiled-rules
+  [compile-results]
+  (mapcat :compiled-rules compile-results))
+
+(defn- phase-compiled-rule?
+  [phase compiled]
+  (policy-pack/rule-applies-to-phase? (:rule compiled) phase))
+
+(defn- phase-compiled-rules
+  [compile-results phase]
+  (filterv #(phase-compiled-rule? phase %) (compiled-rules compile-results)))
+
+(defn- file-entry->artifact
+  [file-entry]
+  (let [path    (or (:artifact/path file-entry) (:path file-entry))
+        content (or (:artifact/content file-entry) (:content file-entry))]
+    (cond-> file-entry
+      path    (assoc :artifact/path path)
+      content (assoc :artifact/content content))))
+
+(defn- artifact-inputs
+  [artifact]
+  (if-let [files (seq (:code/files artifact))]
+    (mapv file-entry->artifact files)
+    [(file-entry->artifact artifact)]))
+
+(defn- rule-applicable-to-artifact?
+  [rule phase context artifact]
+  (seq (policy-pack/filter-applicable-rules
+        [rule]
+        (assoc context :phase phase :artifact artifact))))
+
+(defn- applicable-artifacts
+  [rule phase artifact context]
+  (filterv #(rule-applicable-to-artifact? rule phase context %)
+           (artifact-inputs artifact)))
+
+(defn- violation-entry
+  [compiled violation]
+  {:rule (:rule compiled)
+   :violation violation
+   :timestamp (java.time.Instant/now)})
+
+(defn- run-compiled-rule
+  [artifact context compiled]
+  (let [rule   (:rule compiled)
+        phase  (:phase context)
+        inputs (applicable-artifacts rule phase artifact context)
+        result ((:check-fn compiled) inputs context)]
+    (mapv #(violation-entry compiled %) (:violations result))))
+
+(defn- run-compiled-rules
+  [compiled-rules artifact context]
+  (mapcat #(run-compiled-rule artifact context %) compiled-rules))
+
+(defn- audit-violations
+  [violations]
+  (filter #(= :audit (get-in % [:rule :rule/enforcement :action]))
+          violations))
+
+(defn- compiled-check-result
+  [packs phase artifact context]
+  (let [compile-results (compile-pack-results packs)]
+    (if-let [anomaly (first (filter compile-anomaly? compile-results))]
+      (compile-anomaly-result anomaly)
+      (let [violations (vec (run-compiled-rules
+                             (phase-compiled-rules compile-results phase)
+                             artifact
+                             context))
+            blocking   (policy-pack/blocking-violations violations)
+            approvals  (policy-pack/approval-required-violations violations)
+            warnings   (policy-pack/warning-violations violations)
+            audits     (audit-violations violations)]
+        {:passed?          (empty? blocking)
+         :violations       violations
+         :blocking         (mapv policy-pack/violation->error blocking)
+         :require-approval (mapv policy-pack/violation->error approvals)
+         :warnings         (mapv policy-pack/violation->warning warnings)
+         :audits           (mapv policy-pack/violation->warning audits)}))))
 
 (defn- violation-summary
   "Non-sensitive summary of a violation for an evidence event. Drops :matches
@@ -134,16 +290,16 @@
 
 (defn- classify-rules
   "Per-rule evidence: classify every enabled rule across `packs` for `phase`.
-   `violations` are the {:rule :violation} maps from `check-artifact`.
+   `violations` are the {:rule :violation} maps from compiled check results.
 
      :skipped-by-phase — the rule's :applies-to {:phases} excludes `phase`
      :not-applicable   — phase matches but file-glob/task-type excludes it
      :failed           — considered and violated (carries a violation summary)
      :passed           — considered and clean
 
-   Rules are resolved first (same as `check-artifact`), so override-by-id is
-   honored: evidence is 1:1 with the rules actually evaluated and reports the
-   effective merged :severity/:enforcement, not pre-merge values.
+   Rules are resolved first, so override-by-id is honored: evidence is 1:1
+   with the rules actually evaluated and reports the effective merged
+   :severity/:enforcement, not pre-merge values.
 
    Emitting all four statuses (not just failures) makes the applied policy set
    for a run reconstructable from the event log."
@@ -151,8 +307,9 @@
   (let [enabled        (filterv policy-pack/rule-enabled?
                                 (policy-pack/resolve-rules (mapcat :pack/rules packs)))
         considered-ids (set (map :rule/id
-                                 (policy-pack/filter-applicable-rules
-                                  enabled (assoc context :phase phase :artifact artifact))))
+                                 (filter #(seq (applicable-artifacts
+                                                % phase artifact context))
+                                         enabled)))
         violated       (into {} (map (fn [{:keys [rule violation]}]
                                        [(:rule/id rule) violation]))
                              violations)]
@@ -194,8 +351,8 @@
   "Evaluate the pack against `artifact` for `phase`.
 
    Selects the enabled rules whose `:applies-to {:phases}` includes `phase`
-   (via `policy-pack/check-artifact`'s context filtering), runs their
-   detection, and maps the result to a gate result:
+   (via compiled check phase filtering), runs their executable checks, and
+   maps the result to a gate result:
      :errors   — blocking (`:hard-halt`) violations as gate errors
      :warnings — require-approval / warn / audit violations (record-only here)
      :passed?  — true iff no blocking violations
@@ -206,8 +363,9 @@
   (let [packs (packs-for-gate ctx)]
     (if (empty? packs)
       {:passed? true :warnings [(no-policy-packs-warning)]}
-      (let [context (-> ctx with-semantic-wiring (assoc :phase phase))
-            result  (policy-pack/check-artifact packs artifact context)]
+      (let [artifact (policy-artifact artifact ctx)
+            context  (-> ctx with-semantic-wiring (assoc :phase phase))
+            result   (compiled-check-result packs phase artifact context)]
         (emit-rule-evidence! ctx phase
                              (classify-rules packs phase artifact context
                                              (:violations result)))

--- a/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
@@ -23,6 +23,7 @@
    [ai.miniforge.gate.interface :as gate]
    [ai.miniforge.gate.policy-pack :as sut]
    [ai.miniforge.gate.registry :as registry]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Factories
@@ -72,6 +73,19 @@
                  :content "(def x \"FORBIDDEN\")"
                  :action :modify}]})
 
+(defn- temp-dir
+  []
+  (.toFile (java.nio.file.Files/createTempDirectory
+            "policy-gate"
+            (make-array java.nio.file.attribute.FileAttribute 0))))
+
+(defn- write-worktree-file!
+  [worktree path content]
+  (let [file (io/file worktree path)]
+    (.mkdirs (.getParentFile file))
+    (spit file content)
+    file))
+
 ;------------------------------------------------------------------------------ No packs
 
 (deftest no-packs-passes-with-warning-test
@@ -98,6 +112,20 @@
           result (sut/check-policy-verify dirty-artifact ctx)]
       (is (not (:passed? result)))
       (is (= :policy-pack/compile-failed (-> result :errors first :code))))))
+
+(deftest compile-failure-does-not-emit-rule-applied-events-test
+  (testing "no per-rule applied evidence is emitted when pack compilation fails"
+    (let [stream      (event-stream/create-event-stream {:sinks []})
+          captured    (atom [])
+          _           (event-stream/subscribe! stream :collector #(swap! captured conj %))
+          broken-rule (assoc (content-scan-rule :phases #{:verify})
+                             :rule/detection {:type :not-a-detector})
+          ctx         (assoc (ctx-with [(pack broken-rule)])
+                             :event-stream stream
+                             :workflow/id "wf-compile-failed")
+          result      (sut/check-policy-verify dirty-artifact ctx)]
+      (is (not (:passed? result)))
+      (is (empty? (filter #(= :gate/rule-applied (:event/type %)) @captured))))))
 
 (deftest clean-artifact-passes-test
   (testing "a clean artifact yields zero violations and passes"
@@ -133,6 +161,46 @@
           result (sut/check-policy-verify {:status :success :summary "tests passed"} ctx)]
       (is (not (:passed? result)))
       (is (= :test/forbidden (-> result :errors first :code))))))
+
+(deftest path-only-implement-artifact-defaults-missing-actions-test
+  (testing "path-only artifacts rehydrate files even when actions are omitted"
+    (let [worktree (temp-dir)
+          _        (write-worktree-file! worktree "src/core.clj"
+                                         "(def x \"FORBIDDEN\")")
+          ctx      (-> (ctx-with-implement-artifact
+                        [(pack (content-scan-rule :phases #{:verify}))]
+                        {:code/file-paths ["src/core.clj"]})
+                       (assoc :execution/worktree-path (.getPath worktree)))
+          result   (sut/check-policy-verify {:status :success} ctx)]
+      (is (not (:passed? result)))
+      (is (= :test/forbidden (-> result :errors first :code))))))
+
+(deftest path-only-implement-artifact-does-not-read-outside-worktree-test
+  (testing "rehydration does not follow path traversal outside the worktree"
+    (let [root     (temp-dir)
+          worktree (io/file root "worktree")
+          secret   (io/file root "secret.clj")
+          _        (.mkdirs worktree)
+          _        (spit secret "(def x \"FORBIDDEN\")")
+          ctx      (-> (ctx-with-implement-artifact
+                        [(pack (content-scan-rule :phases #{:verify}))]
+                        {:code/file-paths ["../secret.clj"]})
+                       (assoc :execution/worktree-path (.getPath worktree)))
+          result   (sut/check-policy-verify {:status :success} ctx)]
+      (is (:passed? result)))))
+
+(deftest path-only-delete-action-rehydrates-empty-content-test
+  (testing "deleted files do not rehydrate old worktree content"
+    (let [worktree (temp-dir)
+          _        (write-worktree-file! worktree "src/core.clj"
+                                         "(def x \"FORBIDDEN\")")
+          ctx      (-> (ctx-with-implement-artifact
+                        [(pack (content-scan-rule :phases #{:verify}))]
+                        {:code/file-paths   ["src/core.clj"]
+                         :code/file-actions [:delete]})
+                       (assoc :execution/worktree-path (.getPath worktree)))
+          result   (sut/check-policy-verify {:status :success} ctx)]
+      (is (:passed? result)))))
 
 ;------------------------------------------------------------------------------ Severity / enforcement routing
 

--- a/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
@@ -55,11 +55,22 @@
   [packs]
   {:policy-packs packs})
 
+(defn- ctx-with-implement-artifact
+  [packs artifact]
+  (assoc-in (ctx-with packs)
+            [:execution/phase-results :implement :artifact]
+            artifact))
+
 (def ^:private dirty-artifact
   {:artifact/content "(def x \"FORBIDDEN\")" :artifact/path "core.clj"})
 
 (def ^:private clean-artifact
   {:artifact/content "(def x 42)" :artifact/path "core.clj"})
+
+(def ^:private dirty-code-artifact
+  {:code/files [{:path "src/core.clj"
+                 :content "(def x \"FORBIDDEN\")"
+                 :action :modify}]})
 
 ;------------------------------------------------------------------------------ No packs
 
@@ -79,6 +90,15 @@
       (is (seq (:errors result)))
       (is (= :test/forbidden (-> result :errors first :code))))))
 
+(deftest compile-failure-fails-with-error-test
+  (testing "an unbindable compiled rule fails closed with a gate error"
+    (let [rule   (assoc (content-scan-rule :phases #{:verify})
+                        :rule/detection {:type :not-a-detector})
+          ctx    (ctx-with [(pack rule)])
+          result (sut/check-policy-verify dirty-artifact ctx)]
+      (is (not (:passed? result)))
+      (is (= :policy-pack/compile-failed (-> result :errors first :code))))))
+
 (deftest clean-artifact-passes-test
   (testing "a clean artifact yields zero violations and passes"
     (let [ctx    (ctx-with [(pack (content-scan-rule :phases #{:verify}))])
@@ -95,6 +115,24 @@
           "review-only rule must not gate verify")
       (is (not (:passed? (sut/check-policy-review dirty-artifact ctx)))
           "review-only rule must gate review"))))
+
+(deftest review-policy-uses-implement-artifact-test
+  (testing "review policy evaluates code under review, not the review verdict artifact"
+    (let [ctx    (ctx-with-implement-artifact
+                  [(pack (content-scan-rule :phases #{:review}))]
+                  dirty-code-artifact)
+          result (sut/check-policy-review {:review/decision :approved} ctx)]
+      (is (not (:passed? result)))
+      (is (= :test/forbidden (-> result :errors first :code))))))
+
+(deftest verify-policy-uses-implement-artifact-test
+  (testing "verify policy evaluates code under review when verify output is metadata-only"
+    (let [ctx    (ctx-with-implement-artifact
+                  [(pack (content-scan-rule :phases #{:verify}))]
+                  dirty-code-artifact)
+          result (sut/check-policy-verify {:status :success :summary "tests passed"} ctx)]
+      (is (not (:passed? result)))
+      (is (= :test/forbidden (-> result :errors first :code))))))
 
 ;------------------------------------------------------------------------------ Severity / enforcement routing
 

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -292,3 +292,40 @@
   (testing "no gates configured → unchanged (nothing to validate)"
     (let [pr {:result {}}]
       (is (= pr (exec/apply-gate-validation {:config {:gates []}} pr {}))))))
+
+(defn- policy-rule
+  []
+  {:rule/id          :test/forbidden
+   :rule/enabled?    true
+   :rule/severity    :critical
+   :rule/applies-to  {:phases #{:review}}
+   :rule/detection   {:type :content-scan :pattern "FORBIDDEN"}
+   :rule/enforcement {:action :hard-halt :message "Forbidden content"}})
+
+(defn- policy-pack
+  []
+  {:pack/id    "test-pack"
+   :pack/name  "Test Pack"
+   :pack/rules [(policy-rule)]})
+
+(defn- implement-code-artifact
+  []
+  {:code/files [{:path "src/core.clj"
+                 :content "(def x \"FORBIDDEN\")"
+                 :action :modify}]})
+
+(defn- policy-review-context
+  []
+  {:policy-packs [(policy-pack)]
+   :execution/phase-results
+   {:implement {:artifact (implement-code-artifact)}}})
+
+(deftest apply-gate-validation-policy-review-uses-implement-artifact
+  (testing "policy-review runs through the normal gate path against implemented code"
+    (let [phase-result {:result {:output {:review/decision :approved}}}
+          out          (exec/apply-gate-validation
+                        {:config {:gates [:policy-review]}}
+                        phase-result
+                        (policy-review-context))]
+      (is (= :failed (:phase/status out)))
+      (is (= :policy-review (get-in out [:phase/gate-errors 0 :gate]))))))

--- a/docs/pull-requests/2026-06-20-chris-policy-gate-phase-wiring.md
+++ b/docs/pull-requests/2026-06-20-chris-policy-gate-phase-wiring.md
@@ -1,0 +1,49 @@
+# fix: Policy Gate Phase Wiring
+
+## Overview
+
+Wire phase policy gates to evaluate the implemented code artifact through compiled policy checks when verify or review
+phase outputs are not code artifacts.
+
+## Motivation
+
+`policy-verify` and `policy-review` are present in phase defaults, but the generic gate runner passes the phase output
+to every gate. Verify outputs test metadata and review outputs a review verdict, so pack-derived content rules can
+silently miss the code under review.
+
+## Changes in Detail
+
+- Add policy-gate artifact resolution from `:execution/phase-results :implement :artifact`.
+- Preserve current behavior when the phase artifact already contains code.
+- Run policy packs through `compile-pack-checks`, including fail-loud semantic and compile-error handling.
+- Require built-in gate capabilities before compiled pack evaluation so mechanical checks are registered without relying
+  on caller load order.
+- Add regression coverage for direct policy-gate checks and the generic workflow gate path.
+
+## Testing Plan
+
+- `clj-kondo --lint components/gate/src/ai/miniforge/gate/policy_pack.clj
+  components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+  components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj`
+- `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m
+  cognitect.test-runner -d components/gate/test -d components/workflow/test -n ai.miniforge.gate.policy-pack-test -n
+  ai.miniforge.workflow.phase-transitions-test`
+- `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m
+  cognitect.test-runner -d components/gate/test -d components/workflow/test`
+- `bb pre-commit`
+
+## Deployment Plan
+
+Merge after CI and review comments are resolved. No migration required.
+
+## Related Issues/PRs
+
+- Depends on #1237.
+- Covers `work/policy-gate-phase-wiring-and-evidence.spec.edn`.
+
+## Checklist
+
+- [x] Code artifact is used for verify/review policy gates.
+- [x] Existing review verdict gates still validate review output.
+- [x] Policy gate failures remain on the existing gate execution path.
+- [ ] CI and review comments are resolved.


### PR DESCRIPTION
# fix: Policy Gate Phase Wiring

## Overview

Wire phase policy gates to evaluate the implemented code artifact through compiled policy checks when verify or review
phase outputs are not code artifacts.

## Motivation

`policy-verify` and `policy-review` are present in phase defaults, but the generic gate runner passes the phase output
to every gate. Verify outputs test metadata and review outputs a review verdict, so pack-derived content rules can
silently miss the code under review.

## Changes in Detail

- Add policy-gate artifact resolution from `:execution/phase-results :implement :artifact`.
- Preserve current behavior when the phase artifact already contains code.
- Run policy packs through `compile-pack-checks`, including fail-loud semantic and compile-error handling.
- Require built-in gate capabilities before compiled pack evaluation so mechanical checks are registered without relying
  on caller load order.
- Add regression coverage for direct policy-gate checks and the generic workflow gate path.

## Testing Plan

- `clj-kondo --lint components/gate/src/ai/miniforge/gate/policy_pack.clj
  components/gate/test/ai/miniforge/gate/policy_pack_test.clj
  components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj`
- `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m
  cognitect.test-runner -d components/gate/test -d components/workflow/test -n ai.miniforge.gate.policy-pack-test -n
  ai.miniforge.workflow.phase-transitions-test`
- `clojure -Sdeps '{:deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}' -M:dev:test -m
  cognitect.test-runner -d components/gate/test -d components/workflow/test`
- `bb pre-commit`

## Deployment Plan

Merge after CI and review comments are resolved. No migration required.

## Related Issues/PRs

- Depends on #1237.
- Covers `work/policy-gate-phase-wiring-and-evidence.spec.edn`.

## Checklist

- [x] Code artifact is used for verify/review policy gates.
- [x] Existing review verdict gates still validate review output.
- [x] Policy gate failures remain on the existing gate execution path.
- [ ] CI and review comments are resolved.
