### PR TITLE
Use stable-derived tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,22 +155,6 @@ jobs:
           restore-keys: |
             clojure-${{ runner.os }}-
 
-      # scripts/test-since-stable.bb shells out to the standalone `poly`
-      # CLI. setup-clojure does not install it, and ubuntu-latest does not
-      # carry it either, so we drop the polylith uberjar onto PATH with a
-      # tiny java -jar wrapper. Pinned version mirrors deps.edn :poly alias.
-      - name: Install polylith CLI
-        run: |
-          POLY_VERSION="0.2.21"
-          sudo curl -sSL -o /usr/local/lib/poly.jar \
-            "https://github.com/polyfy/polylith/releases/download/v${POLY_VERSION}/poly-${POLY_VERSION}.jar"
-          sudo tee /usr/local/bin/poly >/dev/null <<'EOF'
-          #!/bin/sh
-          exec java -jar /usr/local/lib/poly.jar "$@"
-          EOF
-          sudo chmod +x /usr/local/bin/poly
-          poly --help >/dev/null && echo "poly installed at $(command -v poly)"
-
       # Pull requests use stable-derived changed-and-affected scope. Main
       # pushes keep the full suite as the stable-tag authority. GitHub
       # Actions' default Linux shell is `bash -e {0}` — no pipefail; without

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        # Full history + tags so Polylith can resolve the stable baseline. The
-        # Test job runs the full `:all` suite (scope-independent), but a shallow
-        # no-tag clone left poly's incremental scope undefined elsewhere and
-        # silently under-tested.
+        # Full history + tags so Polylith can resolve the stable baseline for
+        # PR-scoped tests. When no stable tag is present, `bb test` falls back
+        # to a full Polylith test sweep rather than failing or under-testing.
         with:
           fetch-depth: 0
 
@@ -156,9 +155,9 @@ jobs:
           restore-keys: |
             clojure-${{ runner.os }}-
 
-      # scripts/test-changed-bricks.bb shells out to the standalone `poly`
+      # scripts/test-since-stable.bb shells out to the standalone `poly`
       # CLI. setup-clojure does not install it, and ubuntu-latest does not
-      # carry it either — so we drop the polylith uberjar onto PATH with a
+      # carry it either, so we drop the polylith uberjar onto PATH with a
       # tiny java -jar wrapper. Pinned version mirrors deps.edn :poly alias.
       - name: Install polylith CLI
         run: |
@@ -172,17 +171,20 @@ jobs:
           sudo chmod +x /usr/local/bin/poly
           poly --help >/dev/null && echo "poly installed at $(command -v poly)"
 
-      # GitHub Actions' default Linux shell is `bash -e {0}` — no pipefail.
-      # Without `set -o pipefail`, `bb test:all 2>&1 | tee` reports the exit
-      # code of `tee` (always 0), masking test failures and turning the
-      # job green even when nothing ran. This caused poly-missing failures
-      # to silently pass for an unknown stretch of time before being
-      # surfaced by the Windows fidelity work.
+      # Pull requests use stable-derived changed-and-affected scope. Main
+      # pushes keep the full suite as the stable-tag authority. GitHub
+      # Actions' default Linux shell is `bash -e {0}` — no pipefail; without
+      # `set -o pipefail`, `bb ... | tee` reports the exit code of `tee`
+      # instead of the test command.
       - name: Run tests
         run: |
           set -o pipefail
           echo "::group::Running Tests"
-          bb test:all 2>&1 | tee test-output.log
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            bb test 2>&1 | tee test-output.log
+          else
+            bb test:all 2>&1 | tee test-output.log
+          fi
           echo "::endgroup::"
 
       - name: Upload test logs

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -328,6 +328,7 @@ $ git commit -m "feat: add new feature"
 - Pre-commit hooks are not suggestions
 - Structural workspace checks are part of pre-commit and CI: `bb poly:check`
 - `poly check` failures are blocking architecture regressions, not optional warnings
+- Pull requests use stable-derived changed-and-affected tests in CI; `main` remains the full-suite stable anchor
 - If check is broken, fix the check, don't disable it
 - "Just this once" becomes "just every time"
 - CI time is expensive - catch issues locally
@@ -601,14 +602,17 @@ These guidelines are enforced through:
 1. **Pre-commit Hooks**
    - Linting (clj-kondo)
    - Formatting (cljfmt for Clojure, markdownlint for docs)
-   - Tests (full suite via `poly test`)
+   - Structural checks (`bb poly:check`)
+   - Curated smoke tests and GraalVM/Babashka compatibility checks
 
 2. **Code Review**
    - Reviewers will flag violations
    - PRs may be rejected if guidelines ignored
 
 3. **CI Validation**
-   - GitHub Actions run same checks
+   - Pull requests run stable-derived changed-and-affected tests via `bb test`
+   - `main` branch pushes run the full suite via `bb test:all`
+   - If no stable tag is available, the PR test path falls back to a full Polylith sweep
    - Cannot merge with failing checks
 
 4. **Documentation**

--- a/docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md
+++ b/docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md
@@ -16,6 +16,7 @@ relative to the latest stable tag and falls back to a full sweep if no stable ta
 - Update the Linux CI Test job to run `bb test` for pull requests.
 - Keep `bb test:all` for `main` branch pushes.
 - Preserve the existing full-history checkout so stable tags are available to Polylith.
+- Remove the obsolete Linux standalone `poly` CLI install; the test runner uses `clojure -M:poly`.
 - Update development guidance to describe structural checks, pre-commit smoke tests, PR scoped tests, and main full
   tests accurately.
 

--- a/docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md
+++ b/docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md
@@ -1,0 +1,45 @@
+# fix: Polylith CI Change Scope
+
+## Overview
+
+Run stable-derived changed-and-affected tests on pull requests while preserving full-suite testing on `main`.
+
+## Motivation
+
+`bb test` already delegates to `scripts/test-since-stable.bb`, which asks Polylith for changed-or-affected projects
+relative to the latest stable tag and falls back to a full sweep if no stable tag is available. CI still calls
+`bb test:all` on every PR, so it is not using the change-derived test scope described by
+`work/polylith-workflow-gates-and-scope.spec.edn`.
+
+## Changes in Detail
+
+- Update the Linux CI Test job to run `bb test` for pull requests.
+- Keep `bb test:all` for `main` branch pushes.
+- Preserve the existing full-history checkout so stable tags are available to Polylith.
+- Update development guidance to describe structural checks, pre-commit smoke tests, PR scoped tests, and main full
+  tests accurately.
+
+## Testing Plan
+
+- Validated workflow YAML and task references by inspection.
+- `bb pre-commit`
+- `bb test`
+
+`actionlint` is not installed locally; GitHub Actions remains the workflow-specific syntax check.
+
+## Deployment Plan
+
+Merge after CI and review comments are resolved. The next PR should cover the `bases/lsp-mcp-bridge` boundary audit
+from the same work spec.
+
+## Related Issues/PRs
+
+- Covers Group 2 of `work/polylith-workflow-gates-and-scope.spec.edn`.
+- Builds on the existing `bb test` / `scripts/test-since-stable.bb` stable-derived runner.
+
+## Checklist
+
+- [x] Pull requests use stable-derived changed-and-affected test scope.
+- [x] Main branch pushes still run the full suite.
+- [x] Documentation matches the current validation model.
+- [ ] CI and review comments are resolved.


### PR DESCRIPTION
# fix: Polylith CI Change Scope

## Overview

Run stable-derived changed-and-affected tests on pull requests while preserving full-suite testing on `main`.

## Motivation

`bb test` already delegates to `scripts/test-since-stable.bb`, which asks Polylith for changed-or-affected projects
relative to the latest stable tag and falls back to a full sweep if no stable tag is available. CI still calls
`bb test:all` on every PR, so it is not using the change-derived test scope described by
`work/polylith-workflow-gates-and-scope.spec.edn`.

## Changes in Detail

- Update the Linux CI Test job to run `bb test` for pull requests.
- Keep `bb test:all` for `main` branch pushes.
- Preserve the existing full-history checkout so stable tags are available to Polylith.
- Update development guidance to describe structural checks, pre-commit smoke tests, PR scoped tests, and main full
  tests accurately.

## Testing Plan

- Validated workflow YAML and task references by inspection.
- `bb pre-commit`
- `bb test`

`actionlint` is not installed locally; GitHub Actions remains the workflow-specific syntax check.

## Deployment Plan

Merge after CI and review comments are resolved. The next PR should cover the `bases/lsp-mcp-bridge` boundary audit
from the same work spec.

## Related Issues/PRs

- Covers Group 2 of `work/polylith-workflow-gates-and-scope.spec.edn`.
- Builds on the existing `bb test` / `scripts/test-since-stable.bb` stable-derived runner.

## Checklist

- [x] Pull requests use stable-derived changed-and-affected test scope.
- [x] Main branch pushes still run the full suite.
- [x] Documentation matches the current validation model.
- [ ] CI and review comments are resolved.
