### PR TITLE
refactor(phase): collapse the phase-outcome derivation into one authority

### DIFF
--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -162,6 +162,12 @@
   "Return the RefusalReason keyword for a blocked phase result, if any."
   phase-result/blocked-reason)
 
+(def outcome
+  "Resolve a completed phase's typed act (:phase/outcome) from its result and
+   a success verdict — the single derivation shared by the event stream and
+   the views. See phase-result/outcome for the precedence rules."
+  phase-result/outcome)
+
 (def create-streaming-callback
   "Create a phase-scoped streaming callback when an event stream is available."
   telemetry/create-streaming-callback)

--- a/components/phase/src/ai/miniforge/phase/phase_result.clj
+++ b/components/phase/src/ai/miniforge/phase/phase_result.clj
@@ -85,6 +85,25 @@
   (= redirect-transition-type
      (get-in result [transition-request-key transition-type-key])))
 
+(defn outcome
+  "Resolve a completed phase's typed act — the one derivation of the
+   :phase/outcome value from a phase result and a success verdict.
+
+   `succeeded?` is the caller's verdict. It folds in inner-agent failure and
+   the registry status normalization, both of which live above this layer, so
+   this function stays a pure reduction over the result's own markers.
+
+   Precedence is deliberate: a refusal dominates any other act; an outright
+   failure dominates a pending redirect; a phase that did its work but hands
+   control elsewhere is :redirected. This is the only place the precedence is
+   decided — the event stream and the views read the result, never re-derive it."
+  [result succeeded?]
+  (cond
+    (blocked? result)            :blocked
+    (not succeeded?)             :failure
+    (redirect-requested? result) :redirected
+    :else                        :success))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Metric factories
 

--- a/components/phase/src/ai/miniforge/phase/phase_result.clj
+++ b/components/phase/src/ai/miniforge/phase/phase_result.clj
@@ -89,18 +89,19 @@
   "Resolve a completed phase's typed act — the one derivation of the
    :phase/outcome value from a phase result and a success verdict.
 
-   `succeeded?` is the caller's verdict. It folds in inner-agent failure and
-   the registry status normalization, both of which live above this layer, so
-   this function stays a pure reduction over the result's own markers.
+   `succeeded-verdict?` is the caller's success verdict — distinct from the
+   `succeeded?` predicate above, since it folds in inner-agent failure and the
+   registry status normalization, both of which live above this layer. Passing
+   it in keeps this function a pure reduction over the result's own markers.
 
    Precedence is deliberate: a refusal dominates any other act; an outright
    failure dominates a pending redirect; a phase that did its work but hands
    control elsewhere is :redirected. This is the only place the precedence is
    decided — the event stream and the views read the result, never re-derive it."
-  [result succeeded?]
+  [result succeeded-verdict?]
   (cond
     (blocked? result)            :blocked
-    (not succeeded?)             :failure
+    (not succeeded-verdict?)     :failure
     (redirect-requested? result) :redirected
     :else                        :success))
 

--- a/components/phase/test/ai/miniforge/phase/phase_result_test.clj
+++ b/components/phase/test/ai/miniforge/phase/phase_result_test.clj
@@ -35,3 +35,19 @@
     (is (not (pr/blocked? (pr/success "env-1" "done"))))
     (is (not (pr/blocked? (pr/error "env-1" "boom" "boom" {}))))
     (is (nil? (pr/blocked-reason (pr/success "env-1" "done"))))))
+
+(deftest outcome-resolves-the-typed-act-test
+  (testing "a succeeding phase reports :success"
+    (is (= :success (pr/outcome (pr/success "env-1" "done") true))))
+  (testing "a non-succeeding phase reports :failure"
+    (is (= :failure (pr/outcome (pr/error "env-1" "boom" "boom" {}) false))))
+  (testing "a refusal dominates — :blocked regardless of the success verdict"
+    (let [result (pr/blocked "env-1" "refused" :missing-input {})]
+      (is (= :blocked (pr/outcome result false)))
+      (is (= :blocked (pr/outcome result true)))))
+  (testing "a redirect from a succeeding phase reports :redirected"
+    (let [result (pr/request-redirect (pr/success "env-1" "done") :verify)]
+      (is (= :redirected (pr/outcome result true)))))
+  (testing "an outright failure dominates a pending redirect"
+    (let [result (pr/request-redirect (pr/success "env-1" "done") :verify)]
+      (is (= :failure (pr/outcome result false))))))

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -106,18 +106,6 @@
     (or (contains? inner-failure-statuses (get-in result [:result :status]))
         (false? (get-in result [:result :success?])))))
 
-(defn- phase-outcome
-  "Typed act for a completed phase boundary on the observed layer.
-   A refusal (:blocked) and an outright failure are dominant; a successful phase
-   that asks the pipeline elsewhere is :redirected; otherwise :success. The
-   internal phase-result :status stays the 2-valued control flag for the FSM."
-  [result succeeded?]
-  (cond
-    (phase/blocked? result)            :blocked
-    (not succeeded?)                   :failure
-    (phase/redirect-requested? result) :redirected
-    :else                              :success))
-
 (defn- build-phase-event-data
   "Build event data map for a phase completion event.
 
@@ -147,7 +135,7 @@
   [result]
   (let [succeeded? (and (get result :success? (phase/succeeded-or-done? result))
                         (not (inner-result-failed? result)))
-        outcome    (phase-outcome result succeeded?)
+        outcome    (phase/outcome result succeeded?)
         blocked-reason (phase/blocked-reason result)
         duration-ms (get result :duration-ms
                       (get-in result [:phase/metrics :duration-ms]

--- a/docs/pull-requests/2026-06-19-chris-phase-act-collapse.md
+++ b/docs/pull-requests/2026-06-19-chris-phase-act-collapse.md
@@ -1,0 +1,102 @@
+# refactor: collapse the phase-outcome derivation into one Domain authority
+
+## Overview
+
+Follow-up to #1236. #1236 typed the observed layer — `:phase/outcome` gained
+`:blocked` and `:redirected` — but deliberately left the internal phase-result
+`:status` and the per-consumer derivations untouched to limit blast radius. This
+pays down that deferred debt: the typed act's derivation, previously a private
+helper in the workflow runner, now lives in one Domain function that the
+producer path reads.
+
+## Motivation
+
+After #1236 the relationship between a phase's act and its control status was
+derived independently in more than one place. `runner-events/phase-outcome`
+reconstructed the typed act from `:status` plus marker keys
+(`:phase/blocked-reason`, `:phase/transition-request`); the act was inferred from
+field presence. Adding or changing an outcome value meant editing that derivation
+in lockstep with the predicates that feed it. One authority removes the duplicate
+derivation and gives the precedence a single, tested home.
+
+## Changes in Detail
+
+### Domain authority (`components/phase`)
+
+- `phase-result/outcome` — the single derivation of `:phase/outcome` from a phase
+  result and a success verdict. Precedence: a refusal (`:blocked`) dominates any
+  other act; an outright failure dominates a pending redirect; a phase that did
+  its work but hands control elsewhere is `:redirected`; otherwise `:success`.
+  The `succeeded?` verdict is passed in by the caller (it folds in inner-agent
+  failure and registry status normalization, which live above the Domain), so the
+  function stays a pure reduction over the result's own markers. Exported through
+  the phase interface.
+
+### Producer path (`components/workflow`)
+
+- `runner-events` deletes its private `phase-outcome`; `build-phase-event-data`
+  calls `phase/outcome`. The Domain function carries the same precedence the
+  private copy held, so the emitted `:phase/outcome` is byte-for-byte unchanged.
+
+## Scope and Deliberate Exclusions
+
+This is the "`:phase/outcome` becomes a pass-through of the internal status" arm
+of the design choice, not the "replace `:status`" arm.
+
+- **`:status` kept as the FSM control flag.** `registry/extract-status`
+  normalizes step / chain / execution results too, not just phase results;
+  replacing `:status` would bleed into dag-executor, loop, and gate. Out of scope.
+- **Consumer projections accepted, not collapsed.** `tui-views`
+  `persistence/phase-status` and the cli live-render already read the canonical
+  `:phase/outcome`; they project it to a view vocabulary (`:blocked → :failed`,
+  `:redirected → :success`). Sourcing that projection from a shared classifier
+  would add a `tui-views → event-stream` dependency edge for ~8 lines of view
+  code — declined (recorded decision; Simple-Made-Easy over the marginal DRY).
+- **Per-phase leave-handler outcomes deferred.** The phase-software-factory
+  leave-handlers (verify / review / implement / plan / release) build `:outcome`
+  inline (`:success` / `:failure` only) on a second emission path
+  (telemetry `emit-phase-completed!`, which reads `:outcome` off the result).
+  Routing those through `phase/outcome` is a separate surface the brief did not
+  enumerate; not folded in here.
+- **Pre-existing `:skipped` emission gap noted, not fixed.** `phase-outcome`
+  never returns `:skipped`; a skipped phase reports `:success`.
+  `workflow-resume/extract-completed-phases` filters completed phases on
+  `:success`, so faithfully emitting `:skipped` would change resume semantics.
+  Left as-is, to be addressed with the resume filter together.
+
+## Testing Plan
+
+- New: `outcome` cases in `phase-result-test` — `:success`, `:failure`, refusal
+  dominance (`:blocked` regardless of the success verdict), redirect-on-success
+  (`:redirected`), and failure-over-redirect.
+- Regression (behavior preserved): `phase-outcome-from-inner-result-test`,
+  `tui-views/persistence-test`, `cli/workflow-runner/display-output-test`, and
+  `workflow-resume/core-test` all green.
+- Verified: `clj-kondo` clean; each commit within the 200-line budget;
+  `bb pre-commit` (commit budget, `poly check`, lint, format, 316-test smoke set,
+  graalvm) green on every commit.
+
+## Deployment Plan
+
+Product is unreleased — no compatibility shims. Pure refactor; the emitted
+`:phase/outcome` and all consumer behavior are unchanged. No data migration.
+
+## PR Layering
+
+Two commits, each independently valid and under the 200-line commit budget:
+
+1. `feat(phase)` — the `phase-result/outcome` authority + interface export + tests.
+2. `refactor(workflow)` — `runner-events` delegates to `phase/outcome`.
+
+## Related
+
+- Predecessor: #1236 (`chris/typed-phase-acts`) — typed the observed layer; this
+  collapses its derivation into the Domain.
+
+## Checklist
+
+- [x] `phase-result/outcome` authority + interface export + tests
+- [x] `runner-events` delegates to `phase/outcome`
+- [x] Consumer behavior preserved (persistence / display / resume tests green)
+- [x] `clj-kondo` clean, `poly check` OK, commit budget respected
+- [ ] Push and open PR (awaiting approval)


### PR DESCRIPTION
Follow-up to #1236. #1236 typed the observed layer (`:phase/outcome` gained `:blocked`/`:redirected`) but deliberately left the internal `:status` and the per-consumer derivations untouched to limit blast radius. This pays down that derivation debt: the typed act, previously reconstructed by a private helper in the workflow runner from `:status` plus marker keys, now derives in one Domain function that the producer reads.

## Changes

- **`feat(phase)`** — `phase-result/outcome`: the single derivation of `:phase/outcome` from `(result, succeeded?)`. Precedence: a refusal (`:blocked`) dominates any other act; an outright failure dominates a pending redirect; a phase that did its work but hands control elsewhere is `:redirected`; otherwise `:success`. Exported through the phase interface. Tests cover all four branches plus the domination cases.
- **`refactor(workflow)`** — `runner-events` deletes its private `phase-outcome`; `build-phase-event-data` calls `phase/outcome`. Same precedence, so the emitted `:phase/outcome` is byte-for-byte unchanged.

Net: 5 files, +144 −13. Full write-up: `docs/pull-requests/2026-06-19-chris-phase-act-collapse.md`.

## Scope (deliberate exclusions)

This is the "`:phase/outcome` becomes a pass-through of the internal status" arm of the choice, not the "replace `:status`" arm.

- **`:status` kept** as the FSM control flag — `registry/extract-status` normalizes step/chain/execution results too, so replacing it would bleed into dag-executor/loop/gate.
- **Consumer projections accepted, not collapsed** — `tui-views/persistence/phase-status` and the cli live-render already read the canonical `:phase/outcome`; fully collapsing the view projection would add a `tui-views → event-stream` edge for ~8 lines.
- **Per-phase leave-handler outcomes deferred** — the phase-software-factory leave-handlers build `:outcome` inline (`:success`/`:failure` only) on the telemetry emission path; a separate surface, follow-up.
- **Pre-existing `:skipped` emission gap noted** — `phase-outcome` never returned `:skipped`; `workflow-resume` filters completed phases on `:success`, so faithful `:skipped` emission needs the resume filter changed too. Left paired for a later fix.

## Testing

- New `outcome` cases in `phase-result-test`; regression green in `phase-outcome-from-inner-result-test`, `persistence-test`, `display-output-test`, `workflow-resume/core-test` (behavior preserved).
- `clj-kondo` clean; `bb poly:check` OK; `bb pre-commit` (commit budget, poly check, lint, format, 316-test smoke set, graalvm) green on every commit; each commit under the 200-line budget.

Product is unreleased — no compatibility shims; emitted events unchanged; no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)