### PR TITLE
chore(cli): clarify optional provider registry

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/evidence.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/evidence.clj
@@ -148,7 +148,7 @@
 (defn- load-bundle-for-show
   "Load a bundle from the component interface or the filesystem."
   [id]
-  (or (shared/try-resolve-fn 'ai.miniforge.evidence-bundle.interface/get-bundle id)
+  (or (shared/call-optional-provider 'ai.miniforge.evidence-bundle.interface/get-bundle id)
       (let [f (io/file (str (evidence-dir) "/" id ".edn"))]
         (when (.exists f) (load-bundle-from-file f)))))
 
@@ -197,7 +197,8 @@
   (println)
   (println (display/style (messages/t :evidence/header) :foreground :cyan :bold true))
   (println)
-  (let [component-result (shared/try-resolve-fn 'ai.miniforge.evidence-bundle.interface/list-bundles)]
+  (let [component-result (shared/call-optional-provider
+                          'ai.miniforge.evidence-bundle.interface/list-bundles)]
     (if component-result
       (display-component-bundles component-result)
       (display-filesystem-bundles)))
@@ -238,7 +239,7 @@
         fmt (or format "edn")]
     (if-not id
       (shared/usage-error! :evidence/export-usage "evidence export <id> <format>")
-      (let [result (shared/try-resolve-fn
+      (let [result (shared/call-optional-provider
                     'ai.miniforge.evidence-bundle.interface/export-bundle id fmt)]
         (if result
           (do

--- a/bases/cli/src/ai/miniforge/cli/main/commands/fleet.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/fleet.clj
@@ -119,8 +119,8 @@
   [opts]
   (display/print-info (messages/t :fleet/watch-starting))
   (display/print-info (messages/t :fleet/watch-events-dir {:dir (app-config/events-dir)}))
-  (let [fleet-tui!  (shared/try-resolve 'ai.miniforge.tui-views.interface/start-fleet-tui!)
-        standalone! (shared/try-resolve 'ai.miniforge.tui-views.interface/start-standalone-tui!)]
+  (let [fleet-tui!  (shared/optional-provider 'ai.miniforge.tui-views.interface/start-fleet-tui!)
+        standalone! (shared/optional-provider 'ai.miniforge.tui-views.interface/start-standalone-tui!)]
     (cond
       fleet-tui!
       (fleet-tui! opts)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
@@ -80,7 +80,7 @@
 (defn optional-provider
   "Look up an explicitly composed optional provider by symbol.
    Returns the registered function, or nil when no provider is available.
-  Does NOT call the function."
+   Does NOT call the function."
   [fn-sym]
   (get optional-functions fn-sym))
 
@@ -99,6 +99,9 @@
   (when-let [f (optional-provider fn-sym)]
     (try
       (apply f args)
+      (catch InterruptedException _
+        (.interrupt (Thread/currentThread))
+        nil)
       (catch Exception _ nil))))
 
 (defn usage-error!

--- a/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
@@ -77,7 +77,7 @@
   (alter-var-root #'optional-functions assoc fn-sym f)
   f)
 
-(defn try-resolve
+(defn optional-provider
   "Look up an explicitly composed optional provider by symbol.
    Returns the registered function, or nil when no provider is available.
   Does NOT call the function."
@@ -92,11 +92,11 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Composes Layer 0.
 
-(defn try-resolve-fn
+(defn call-optional-provider
   "Look up optional provider `fn-sym` and immediately apply it to `args`.
    Returns nil when no provider is registered or the provider fails."
   [fn-sym & args]
-  (when-let [f (try-resolve fn-sym)]
+  (when-let [f (optional-provider fn-sym)]
     (try
       (apply f args)
       (catch Exception _ nil))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
@@ -87,7 +87,7 @@
                          {:technologies [:clojure]
                           :git-host "github"
                           :packs [:foundations]})
-                    #'shared/try-resolve-fn
+                    #'shared/call-optional-provider
                     (fn [& _]
                       (throw (ex-info "optional provider should not be used" {})))
                     #'shared/exit!

--- a/bases/cli/test/ai/miniforge/cli/main/commands/evidence_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/evidence_test.clj
@@ -87,7 +87,7 @@
          overrides))
 
 (defn- make-list-bundle
-  "Factory for the minimal bundle shape returned by the resolver in list output."
+  "Factory for the minimal bundle shape returned by the optional provider in list output."
   [& {:as overrides}]
   (merge {:bundle/id          "b-1"
           :bundle/workflow-id "wf-1"
@@ -112,14 +112,14 @@
 
 (deftest evidence-list-cmd-no-component-empty-dir-test
   (testing "list command shows 'no bundles' when dir is empty"
-    (with-redefs [shared/try-resolve-fn (constantly nil)
+    (with-redefs [shared/call-optional-provider (constantly nil)
                   app-config/home-dir (constantly *tmp-dir*)]
       (let [output (with-out-str (sut/evidence-list-cmd {}))]
         (is (re-find #"(?i)no evidence" output))))))
 
 (deftest evidence-list-cmd-component-results-test
   (testing "list command displays component results when available"
-    (with-redefs [shared/try-resolve-fn
+    (with-redefs [shared/call-optional-provider
                   (constantly [(make-list-bundle)])]
       (let [output (with-out-str (sut/evidence-list-cmd {}))]
         (is (.contains output "b-1"))))))
@@ -134,7 +134,7 @@
 (deftest evidence-show-cmd-not-found-test
   (testing "show command reports not found for unknown bundle"
     (let [exited? (atom false)]
-      (with-redefs [shared/try-resolve-fn (constantly nil)
+      (with-redefs [shared/call-optional-provider (constantly nil)
                     app-config/home-dir (constantly *tmp-dir*)
                     shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/evidence-show-cmd {:id "missing"}))
@@ -145,7 +145,7 @@
     (let [evidence-path (str *tmp-dir* "/evidence")]
       (fs/create-dirs evidence-path)
       (spit (str evidence-path "/test-bundle.edn") (pr-str (make-bundle)))
-      (with-redefs [shared/try-resolve-fn (constantly nil)
+      (with-redefs [shared/call-optional-provider (constantly nil)
                     app-config/home-dir (constantly *tmp-dir*)]
         (let [output (with-out-str (sut/evidence-show-cmd {:id "test-bundle"}))]
           (is (.contains output "wf-1")))))))
@@ -155,7 +155,7 @@
     (let [evidence-path (str *tmp-dir* "/evidence")]
       (fs/create-dirs evidence-path)
       (spit (str evidence-path "/canonical-bundle.edn") (pr-str (make-canonical-bundle)))
-      (with-redefs [shared/try-resolve-fn (constantly nil)
+      (with-redefs [shared/call-optional-provider (constantly nil)
                     app-config/home-dir (constantly *tmp-dir*)]
         (let [output (with-out-str (sut/evidence-show-cmd {:id "canonical-bundle"}))]
           (is (.contains output "wf-2"))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/shared_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/shared_test.clj
@@ -33,4 +33,13 @@
     (with-redefs [sut/optional-functions {'example/failing (fn [] (throw (ex-info "boom" {})))}]
       (is (nil? (sut/optional-provider 'example/missing)))
       (is (nil? (sut/call-optional-provider 'example/missing)))
-      (is (nil? (sut/call-optional-provider 'example/failing))))))
+      (is (nil? (sut/call-optional-provider 'example/failing)))))
+
+  (testing "interrupted providers restore the thread interrupt flag"
+    (with-redefs [sut/optional-functions {'example/interrupted
+                                           (fn []
+                                             (throw (InterruptedException. "stop")))}]
+      (let [result       (sut/call-optional-provider 'example/interrupted)
+            interrupted? (Thread/interrupted)]
+        (is (nil? result))
+        (is interrupted?)))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/shared_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/shared_test.clj
@@ -26,11 +26,11 @@
     (let [provider (fn [x] [:ok x])]
       (with-redefs [sut/optional-functions {}]
         (sut/register-optional-fn! 'example/provider provider)
-        (is (identical? provider (sut/try-resolve 'example/provider)))
-        (is (= [:ok 42] (sut/try-resolve-fn 'example/provider 42))))))
+        (is (identical? provider (sut/optional-provider 'example/provider)))
+        (is (= [:ok 42] (sut/call-optional-provider 'example/provider 42))))))
 
   (testing "missing or failing providers return nil to preserve fallback flow"
     (with-redefs [sut/optional-functions {'example/failing (fn [] (throw (ex-info "boom" {})))}]
-      (is (nil? (sut/try-resolve 'example/missing)))
-      (is (nil? (sut/try-resolve-fn 'example/missing)))
-      (is (nil? (sut/try-resolve-fn 'example/failing))))))
+      (is (nil? (sut/optional-provider 'example/missing)))
+      (is (nil? (sut/call-optional-provider 'example/missing)))
+      (is (nil? (sut/call-optional-provider 'example/failing))))))

--- a/docs/pull-requests/2026-06-20-chris-resolver-hotspots-followup.md
+++ b/docs/pull-requests/2026-06-20-chris-resolver-hotspots-followup.md
@@ -1,0 +1,47 @@
+# chore: clarify CLI optional provider registry
+
+## Overview
+
+This PR removes misleading resolver terminology from the CLI command optional
+provider registry. The code path is an explicit composition registry, not a
+dynamic resolver, so the public helper names now say what the boundary does.
+
+## Motivation
+
+The standards remediation work eliminated broad `requiring-resolve` and
+`ns-resolve` anti-patterns. A follow-up scan still surfaced
+`shared/try-resolve` and `shared/try-resolve-fn` in CLI command code even though
+those helpers only read explicitly registered provider functions. Leaving the
+old names makes future audits noisier and obscures the intentional composition
+boundary.
+
+## Changes in Detail
+
+- Rename `shared/try-resolve` to `shared/optional-provider`.
+- Rename `shared/try-resolve-fn` to `shared/call-optional-provider`.
+- Update fleet and evidence CLI command call sites.
+- Update CLI command tests and test descriptions to use provider terminology.
+
+## Testing Plan
+
+- Run focused CLI command tests for the renamed helpers and call sites.
+- Run `bb pre-commit` before commit.
+- Let pull request CI run the stable-derived test plan.
+
+## Deployment Plan
+
+No special deployment steps. This is an internal CLI helper rename with no
+external command behavior change.
+
+## Related Issues/PRs
+
+- Follows the standards remediation wave that removed production resolver
+  anti-patterns.
+- Related to PRs #1230-#1235 and #1242.
+
+## Checklist
+
+- [x] Keep the change scoped to the CLI optional-provider registry.
+- [x] Preserve explicit composition and fallback behavior.
+- [x] Run local validation.
+- [ ] Open PR and address review comments.


### PR DESCRIPTION
# chore: clarify CLI optional provider registry

## Overview

This PR removes misleading resolver terminology from the CLI command optional
provider registry. The code path is an explicit composition registry, not a
dynamic resolver, so the public helper names now say what the boundary does.

## Motivation

The standards remediation work eliminated broad `requiring-resolve` and
`ns-resolve` anti-patterns. A follow-up scan still surfaced
`shared/try-resolve` and `shared/try-resolve-fn` in CLI command code even though
those helpers only read explicitly registered provider functions. Leaving the
old names makes future audits noisier and obscures the intentional composition
boundary.

## Changes in Detail

- Rename `shared/try-resolve` to `shared/optional-provider`.
- Rename `shared/try-resolve-fn` to `shared/call-optional-provider`.
- Update fleet and evidence CLI command call sites.
- Update CLI command tests and test descriptions to use provider terminology.

## Testing Plan

- Run focused CLI command tests for the renamed helpers and call sites.
- Run `bb pre-commit` before commit.
- Let pull request CI run the stable-derived test plan.

## Deployment Plan

No special deployment steps. This is an internal CLI helper rename with no
external command behavior change.

## Related Issues/PRs

- Follows the standards remediation wave that removed production resolver
  anti-patterns.
- Related to PRs #1230-#1235 and #1242.

## Checklist

- [x] Keep the change scoped to the CLI optional-provider registry.
- [x] Preserve explicit composition and fallback behavior.
- [x] Run local validation.
- [ ] Open PR and address review comments.
