### PR TITLE
feat(gate): wire + scope the semantic policy judge (E1, dormant-but-ready)

### DIFF
--- a/components/gate/deps.edn
+++ b/components/gate/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/connector-linter {:local/root "../connector-linter"}
         ai.miniforge/event-stream {:local/root "../event-stream"}
+        ai.miniforge/llm {:local/root "../llm"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}
         ai.miniforge/repo-analyzer {:local/root "../repo-analyzer"}

--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -40,11 +40,12 @@
    Semantic seam: this gate is the layer that depends on both the policy pack
    and the LLM, so it INJECTS the LLM-judge wiring the policy-pack detector
    needs — `:llm-client` (from the run's `:llm-backend`), `:complete-fn`
-   (`llm/complete`), and `semantic-analyzer/analyze-rule` under
-   `:semantic-analyze-fn` — so heuristic (`:custom` rules with no resolvable
-   `:custom-fn`) reach the LLM judge. With compiled checks, missing semantic
-   wiring is reported as a policy violation; the pack's enforcement action
-   controls whether that violation blocks, requires approval, warns, or audits.
+   (`llm/complete`), and a `:semantic-analyze-fn` that scopes the judge to the
+   run's CHANGED files (not the whole repo) — so heuristic (`:custom` rules with
+   no resolvable `:custom-fn`) reach the LLM judge over exactly the artifact
+   under review. With compiled checks, missing semantic wiring is reported as a
+   policy violation; the pack's enforcement action controls whether that
+   violation blocks, requires approval, warns, or audits.
 
    Cost discipline: the judge runs only for semantic rules the run intends to
    ACT on — `:hard-halt` / `:require-approval`. A semantic rule that only warns
@@ -109,15 +110,39 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Context wiring
 
+(defn- artifact-changed-files
+  "The changed files [{:path :content}] this gate evaluates, taken from the
+   resolved policy artifact (its code files, or a single content artifact).
+   This is the changed-files scope handed to the judge."
+  [artifact]
+  (cond
+    (seq (:code/files artifact))
+    (mapv (fn [f] {:path    (or (:path f) (:artifact/path f))
+                   :content (or (:content f) (:artifact/content f))})
+          (:code/files artifact))
+
+    (or (:artifact/path artifact) (:path artifact))
+    [{:path    (or (:artifact/path artifact) (:path artifact))
+      :content (or (:artifact/content artifact) (:content artifact))}]
+
+    :else []))
+
+(defn- changed-files-analyzer
+  "An `analyze-rule`-shaped fn (repo-path ignored) that scopes the judge to the
+   run's changed files instead of scanning the whole repo."
+  [files]
+  (fn [llm-client complete-fn _repo-path rule]
+    (semantic/analyze-rule-on-files llm-client complete-fn rule files)))
+
 (defn- with-semantic-wiring
   "Inject the LLM-judge seam the policy-pack semantic detector needs. Derives
    `:llm-client` from the run's `:llm-backend` when absent, sets `:complete-fn`
-   to `llm/complete`, and injects `semantic-analyzer/analyze-rule` under
-   `:semantic-analyze-fn`. Also normalizes the repo path the judge scans
-   (`:repo-path`, falling back to the execution worktree). When the run carries
+   to `llm/complete`, and injects a `:semantic-analyze-fn` that scopes the judge
+   to `artifact`'s changed files (not the whole repo). Also normalizes
+   `:repo-path` (falling back to the execution worktree). When the run carries
    no LLM backend, the seam stays unwired so compiled semantic checks fail loud
    according to pack enforcement (fail-closed)."
-  [ctx]
+  [ctx artifact]
   (let [ctx (assoc ctx :repo-path (or (:repo-path ctx)
                                       (:execution/worktree-path ctx)
                                       "."))
@@ -130,7 +155,8 @@
     (if (and (:llm-client ctx)
              (:complete-fn ctx)
              (not (:semantic-analyze-fn ctx)))
-      (assoc ctx :semantic-analyze-fn semantic/analyze-rule)
+      (assoc ctx :semantic-analyze-fn (changed-files-analyzer
+                                       (artifact-changed-files artifact)))
       ctx)))
 
 (defn- no-policy-packs-warning
@@ -420,7 +446,7 @@
     (if (empty? packs)
       {:passed? true :warnings [(no-policy-packs-warning)]}
       (let [artifact (policy-artifact artifact ctx)
-            context  (-> ctx with-semantic-wiring (assoc :phase phase))
+            context  (-> (with-semantic-wiring ctx artifact) (assoc :phase phase))
             result   (compiled-check-result packs phase artifact context)]
         (when (:compiled? result)
           (emit-rule-evidence! ctx phase

--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -37,12 +37,21 @@
    Pack source: `ctx :policy-packs` when provided (tests / repo packs), else
    the classpath-shipped `packs/miniforge-standards.pack.edn`.
 
-   Semantic seam: when the run carries an `:llm-client` and `:complete-fn` in
-   ctx, this gate INJECTS `semantic-analyzer/analyze-rule` under
-   `:semantic-analyze-fn` so heuristic (`:custom` rules with no resolvable
+   Semantic seam: this gate is the layer that depends on both the policy pack
+   and the LLM, so it INJECTS the LLM-judge wiring the policy-pack detector
+   needs — `:llm-client` (from the run's `:llm-backend`), `:complete-fn`
+   (`llm/complete`), and `semantic-analyzer/analyze-rule` under
+   `:semantic-analyze-fn` — so heuristic (`:custom` rules with no resolvable
    `:custom-fn`) reach the LLM judge. With compiled checks, missing semantic
    wiring is reported as a policy violation; the pack's enforcement action
    controls whether that violation blocks, requires approval, warns, or audits.
+
+   Cost discipline: the judge runs only for semantic rules the run intends to
+   ACT on — `:hard-halt` / `:require-approval`. A semantic rule that only warns
+   or audits is guidance (surfaced via behavior injection elsewhere), so the
+   gate does not pay for an LLM call that could only yield a non-blocking
+   finding. Until a semantic rule is classified to an acting action, the seam
+   is wired but dormant.
 
    Fail-safe: a check that throws is converted to a failed gate by
    `gate.interface/check-gate` (mirrors the reviewer fix in #977) — never a
@@ -53,6 +62,7 @@
    [ai.miniforge.gate.capabilities]
    [ai.miniforge.gate.messages :as msg]
    [ai.miniforge.gate.registry :as registry]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.policy-pack.interface :as policy-pack]
    [ai.miniforge.semantic-analyzer.interface :as semantic]
    [clojure.edn :as edn]
@@ -100,15 +110,23 @@
 ;; Context wiring
 
 (defn- with-semantic-wiring
-  "Inject the LLM-judge seam when the run carries an `:llm-client` and
-   `:complete-fn` but no explicit `:semantic-analyze-fn`. Also normalizes the
-   repo path the judge scans (`:repo-path`, falling back to the execution
-   worktree). When the LLM seam is absent, leaves ctx untouched so compiled
-   semantic checks can fail loud according to pack enforcement."
+  "Inject the LLM-judge seam the policy-pack semantic detector needs. Derives
+   `:llm-client` from the run's `:llm-backend` when absent, sets `:complete-fn`
+   to `llm/complete`, and injects `semantic-analyzer/analyze-rule` under
+   `:semantic-analyze-fn`. Also normalizes the repo path the judge scans
+   (`:repo-path`, falling back to the execution worktree). When the run carries
+   no LLM backend, the seam stays unwired so compiled semantic checks fail loud
+   according to pack enforcement (fail-closed)."
   [ctx]
   (let [ctx (assoc ctx :repo-path (or (:repo-path ctx)
                                       (:execution/worktree-path ctx)
-                                      "."))]
+                                      "."))
+        ctx (cond-> ctx
+              (and (not (:llm-client ctx)) (:llm-backend ctx))
+              (assoc :llm-client (:llm-backend ctx))
+
+              (not (:complete-fn ctx))
+              (assoc :complete-fn llm/complete))]
     (if (and (:llm-client ctx)
              (:complete-fn ctx)
              (not (:semantic-analyze-fn ctx)))
@@ -259,13 +277,31 @@
    :violation violation
    :timestamp (java.time.Instant/now)})
 
+(def ^:private judge-acting-actions
+  "Enforcement actions for which the LLM judge actually runs. A semantic rule
+   that only warns/audits is guidance — surfaced via behavior injection, not
+   evaluated by the judge — so the run never pays for an LLM call that could
+   only produce a non-blocking finding."
+  #{:hard-halt :require-approval})
+
+(defn- semantic-judge-applies?
+  "True unless this is a semantic-detector rule whose enforcement action is
+   non-acting. Non-semantic detectors (content-scan, diff, etc.) always run —
+   they are cheap and deterministic."
+  [compiled]
+  (or (not= :semantic (:detector compiled))
+      (contains? judge-acting-actions
+                 (get-in compiled [:rule :rule/enforcement :action]))))
+
 (defn- run-compiled-rule
   [artifact context compiled]
-  (let [rule   (:rule compiled)
-        phase  (:phase context)
-        inputs (applicable-artifacts rule phase artifact context)
-        result ((:check-fn compiled) inputs context)]
-    (mapv #(violation-entry compiled %) (:violations result))))
+  (if-not (semantic-judge-applies? compiled)
+    []
+    (let [rule   (:rule compiled)
+          phase  (:phase context)
+          inputs (applicable-artifacts rule phase artifact context)
+          result ((:check-fn compiled) inputs context)]
+      (mapv #(violation-entry compiled %) (:violations result)))))
 
 (defn- run-compiled-rules
   [compiled-rules artifact context]

--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -370,6 +370,16 @@
      :artifact-path (:artifact-path violation)
      :match-count   (count (:matches violation))}))
 
+(defn- guidance-only-semantic?
+  "A semantic-detector rule with a non-acting enforcement action — surfaced as
+   guidance (behavior injection), never evaluated by the judge (see
+   `semantic-judge-applies?`). Evidence marks these `:guidance`, not `:passed`,
+   so the event log never claims the judge cleared a rule it skipped."
+  [rule]
+  (and (= :semantic (policy-pack/resolve-detector rule))
+       (not (contains? judge-acting-actions
+                       (get-in rule [:rule/enforcement :action])))))
+
 (defn- classify-rules
   "Per-rule evidence: classify every enabled rule across `packs` for `phase`.
    `violations` are the {:rule :violation} maps from compiled check results.
@@ -377,6 +387,9 @@
      :skipped-by-phase — the rule's :applies-to {:phases} excludes `phase`
      :not-applicable   — phase matches but file-glob/task-type excludes it
      :failed           — considered and violated (carries a violation summary)
+     :guidance         — applicable semantic rule the judge skips (non-acting
+                         action): surfaced as guidance, not gated. NOT `:passed`
+                         — the judge never ran, so evidence must not imply it did
      :passed           — considered and clean
 
    Rules are resolved first, so override-by-id is honored: evidence is 1:1
@@ -401,6 +414,8 @@
                :status      (cond
                               (not (policy-pack/rule-applies-to-phase? rule phase)) :skipped-by-phase
                               (contains? violated id)                               :failed
+                              (and (contains? considered-ids id)
+                                   (guidance-only-semantic? rule))                 :guidance
                               (contains? considered-ids id)                         :passed
                               :else                                                 :not-applicable)
                :severity    (:rule/severity rule)

--- a/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
@@ -349,6 +349,15 @@
               "raw matches must be redacted from evidence")
           (is (= :critical (:severity fail-rec))))))))
 
+(deftest classify-rules-guidance-status-test
+  (testing "an applicable non-acting semantic rule is classified :guidance, not
+            :passed — the judge was skipped, so evidence must not imply it ran"
+    (let [r-guid     (semantic-rule :id :r/guid :phases #{:verify} :action :warn)
+          classified (#'sut/classify-rules [(pack r-guid)] :verify
+                                           dirty-code-artifact {} [])
+          by-id      (into {} (map (juxt :rule-id :status)) classified)]
+      (is (= :guidance (by-id :r/guid))))))
+
 (deftest emits-rule-applied-events-test
   (testing "evaluation publishes one :gate/rule-applied event per enabled rule"
     (let [stream    (event-stream/create-event-stream {:sinks []})

--- a/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
@@ -197,6 +197,25 @@
       (is (not (:passed? result)))
       (is (seq (:errors result))))))
 
+(deftest semantic-judge-scoped-to-changed-files-test
+  (testing "with no explicit analyze-fn, the gate injects a changed-files-scoped
+            judge: the LLM prompt carries the artifact's changed file content,
+            not a whole-repo scan"
+    (let [seen          (atom nil)
+          fake-complete (fn [_client request]
+                          (reset! seen request)
+                          {:content "[{:line 1 :message \"semantic issue\"}]"})
+          ctx           (assoc (ctx-with [(pack (semantic-rule :phases #{:verify}
+                                                              :action :hard-halt))])
+                               :llm-backend ::client
+                               :complete-fn fake-complete)
+          result        (sut/check-policy-verify dirty-code-artifact ctx)]
+      (is (not (:passed? result)))
+      (is (seq (:errors result)))
+      (is (re-find #"FORBIDDEN"
+                   (-> @seen :messages first :content))
+          "judge prompt must contain the changed file's content"))))
+
 ;------------------------------------------------------------------------------ Phase scoping
 
 (deftest phase-scoping-test

--- a/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
@@ -134,6 +134,69 @@
       (is (:passed? result))
       (is (empty? (:errors result))))))
 
+;------------------------------------------------------------------------------ Semantic seam
+
+(defn- semantic-rule
+  "A heuristic `:custom` rule with no `:custom-fn` — resolves to the `:semantic`
+   (LLM-judge) detector. Defaults to an acting (:hard-halt) enforcement action."
+  [& {:keys [id phases action severity]
+      :or   {id :test/semantic phases #{:verify :review}
+             action :hard-halt severity :major}}]
+  {:rule/id          id
+   :rule/enabled?    true
+   :rule/severity    severity
+   :rule/applies-to  {:phases phases}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action action :message (str "rule " id " fired")}})
+
+(defn- recording-analyze-fn
+  "Stands in for `semantic-analyzer/analyze-rule`. Records the args the gate
+   passes (proving the injected wiring) and reports one violation."
+  [recorder]
+  (fn [llm-client complete-fn repo-path rule]
+    (reset! recorder {:llm-client  llm-client
+                      :complete-fn complete-fn
+                      :repo-path   repo-path
+                      :rule-id     (:rule/id rule)})
+    {:rule/id    (:rule/id rule)
+     :status     :failed
+     :violations [{:path "src/core.clj" :message "semantic issue"}]}))
+
+(deftest semantic-acting-rule-runs-judge-and-blocks-test
+  (testing "a :hard-halt semantic rule runs the judge and blocks; the gate
+            derives :llm-client from :llm-backend and sets :complete-fn"
+    (let [rec    (atom nil)
+          ctx    (assoc (ctx-with [(pack (semantic-rule :phases #{:verify}
+                                                        :action :hard-halt))])
+                        :llm-backend ::client
+                        :semantic-analyze-fn (recording-analyze-fn rec))
+          result (sut/check-policy-verify dirty-code-artifact ctx)]
+      (is (not (:passed? result)))
+      (is (seq (:errors result)))
+      (is (= ::client (:llm-client @rec)) ":llm-client derived from :llm-backend")
+      (is (fn? (:complete-fn @rec)) ":complete-fn injected"))))
+
+(deftest semantic-non-acting-rule-skips-judge-test
+  (testing "a :warn semantic rule is guidance — the judge is not invoked and the
+            gate passes (no LLM cost for a finding that could only warn)"
+    (let [rec    (atom nil)
+          ctx    (assoc (ctx-with [(pack (semantic-rule :phases #{:verify}
+                                                        :action :warn))])
+                        :llm-backend ::client
+                        :semantic-analyze-fn (recording-analyze-fn rec))
+          result (sut/check-policy-verify dirty-code-artifact ctx)]
+      (is (:passed? result))
+      (is (nil? @rec) "judge must not run for a non-acting semantic rule"))))
+
+(deftest semantic-acting-rule-without-wiring-fails-closed-test
+  (testing "a :hard-halt semantic rule with no LLM backend fails closed — a
+            missing-wiring violation blocks rather than silently passing"
+    (let [ctx    (ctx-with [(pack (semantic-rule :phases #{:verify}
+                                                 :action :hard-halt))])
+          result (sut/check-policy-verify dirty-code-artifact ctx)]
+      (is (not (:passed? result)))
+      (is (seq (:errors result))))))
+
 ;------------------------------------------------------------------------------ Phase scoping
 
 (deftest phase-scoping-test

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -170,9 +170,11 @@
      :status         :completed}))
 
 (defn- file-under-size-limit?
-  "True when an in-memory file's content is under the byte size limit."
+  "True when an in-memory file's content is under the byte size limit. Uses `<`
+   to match the repo-scan path's `under-size-limit?` (a file exactly at the
+   limit is excluded by both)."
   [content]
-  (<= (count (.getBytes ^String content "UTF-8")) max-file-size-bytes))
+  (< (count (.getBytes ^String content "UTF-8")) max-file-size-bytes))
 
 (defn analyze-rule-on-files
   "Analyze an explicit set of changed files against one rule, instead of
@@ -185,12 +187,12 @@
   [llm-client complete-fn rule files]
   (let [start-ms (System/currentTimeMillis)
         globs    (get-in rule [:rule/applies-to :file-globs] ["**/*"])
-        eligible (->> files
-                      (filter (fn [{:keys [path content]}]
-                                (and (string? path) (string? content)
-                                     (file-under-size-limit? content)
-                                     (file-matches-globs? path globs))))
-                      (take max-files-per-rule))
+        eligible (vec (->> files
+                           (filter (fn [{:keys [path content]}]
+                                     (and (string? path) (string? content)
+                                          (file-under-size-limit? content)
+                                          (file-matches-globs? path globs))))
+                           (take max-files-per-rule)))
         viols    (vec (mapcat (fn [{:keys [path content]}]
                                 (analyze-file llm-client complete-fn rule path content))
                               eligible))

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -169,6 +169,38 @@
      :duration-ms    (- end-ms start-ms)
      :status         :completed}))
 
+(defn- file-under-size-limit?
+  "True when an in-memory file's content is under the byte size limit."
+  [content]
+  (<= (count (.getBytes ^String content "UTF-8")) max-file-size-bytes))
+
+(defn analyze-rule-on-files
+  "Analyze an explicit set of changed files against one rule, instead of
+   scanning the whole repo. `files` is a vector of {:path :content}. Filters to
+   files matching the rule's globs and under the size limit, runs the judge per
+   file, and returns the same result shape as `analyze-rule`.
+
+   This is the changed-files scope: a run gates only the files it touched, and
+   an in-scope file is judged in full (every violation in it must be fixed)."
+  [llm-client complete-fn rule files]
+  (let [start-ms (System/currentTimeMillis)
+        globs    (get-in rule [:rule/applies-to :file-globs] ["**/*"])
+        eligible (->> files
+                      (filter (fn [{:keys [path content]}]
+                                (and (string? path) (string? content)
+                                     (file-under-size-limit? content)
+                                     (file-matches-globs? path globs))))
+                      (take max-files-per-rule))
+        viols    (vec (mapcat (fn [{:keys [path content]}]
+                                (analyze-file llm-client complete-fn rule path content))
+                              eligible))
+        end-ms   (System/currentTimeMillis)]
+    {:rule/id        (get rule :rule/id)
+     :violations     viols
+     :files-analyzed (count eligible)
+     :duration-ms    (- end-ms start-ms)
+     :status         :completed}))
+
 (defn- analyze-rule-with-timeout
   "Run analyze-rule with a timeout. Returns result or timeout marker."
   [llm-client complete-fn repo-path rule timeout-ms]

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
@@ -29,6 +29,14 @@
    :duration-ms int :status keyword}. Selects files via select-files-for-rule."
   core/analyze-rule)
 
+(def analyze-rule-on-files
+  "Analyze one rule against an explicit set of changed files (changed-files
+   scope) instead of scanning the repo.
+   Args: llm-client, complete-fn, rule, files (vector of {:path :content}).
+   Filters by the rule's globs + size limit, judges per file. Returns the same
+   map shape as analyze-rule."
+  core/analyze-rule-on-files)
+
 (def analyze-rules-parallel
   "Analyze many behavioral rules in parallel batches with per-rule timeouts.
    Args: llm-client, complete-fn, repo-path (string), rules (vector of rule

--- a/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
+++ b/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
@@ -215,6 +215,30 @@
       (is (pos? (:files-analyzed result)))
       (is (pos? @call-count)))))
 
+(deftest analyze-rule-on-files-test
+  (testing "judges only the supplied changed files, filters by glob + size"
+    (let [rule    {:rule/id :std/test
+                   :rule/title "Test Rule"
+                   :rule/category "001"
+                   :rule/severity :minor
+                   :rule/knowledge-content "Check it."
+                   :rule/applies-to {:file-globs ["src/*.clj"]}}
+          judged  (atom [])
+          big     (apply str (repeat 60000 "x"))
+          mock    (fn [_client request]
+                    (swap! judged conj (-> request :messages first :content))
+                    {:success true
+                     :content "[{:line 1 :message \"semantic issue\"}]"})
+          files   [{:path "src/core.clj" :content "(def x 1)"}
+                   {:path "docs/readme.md" :content "skip — not a glob match"}
+                   {:path "src/huge.clj" :content big}]
+          result  (sut/analyze-rule-on-files :mock mock rule files)]
+      (is (= 1 (:files-analyzed result)) "only src/core.clj matches glob + size")
+      (is (= 1 (count (:violations result))))
+      (is (= 1 (count @judged)))
+      (is (re-find #"\(def x 1\)" (first @judged))
+          "the judged file's content reached the prompt"))))
+
 (def ^:private base-rule
   {:rule/id :std/test
    :rule/title "Test"


### PR DESCRIPTION
## What

Makes the LLM-as-judge semantic policy gate production-ready — **wired** to the run's LLM and **scoped** to changed files — while keeping it **dormant** until the classification wave turns rules on. The judge has been dead since it was built: it only runs when the gate context carries `:llm-client` **and** `:complete-fn`, and neither was ever set outside tests, so all 54 `:custom`/`:semantic` standards rules silently passed. This is the central hole in the policy trust boundary (`docs/research/policy-enforcement-gap-analysis.md`, #1239).

## How

**1. Wire (`7b49e601`)** — at the gate layer (the one layer depending on both the policy pack and the LLM, per the `detection.clj` design note): `with-semantic-wiring` derives `:llm-client` from the run's `:llm-backend`, sets `:complete-fn` to `llm/complete`, and injects the judge. Adds `gate -> llm` (no cycle; `poly check` green).

**2. Cost discipline (`7b49e601`)** — the judge runs **only** for semantic rules with an acting enforcement action (`:hard-halt` / `:require-approval`). A `:warn`/`:audit` semantic rule is guidance — surfaced via behavior injection, not judged — so a run never pays for an LLM call that could only warn.

**3. Changed-files scope (`f77b401e`)** — new `semantic-analyzer/analyze-rule-on-files` judges exactly the artifact's changed files (filtered by the rule's globs + size), replacing the whole-repo `analyze-rule` scan. An in-scope file is judged in full (every violation must be fixed); untouched files are never flagged.

**Fail-closed preserved:** an acting semantic rule with no LLM backend yields a missing-wiring violation that blocks, never a silent pass.

## Rollout

No shipped semantic rule is acting yet, so this ships the mechanism **dormant but ready** — zero judge calls in production until the next wave flips concrete rules to `:hard-halt`. Safe to land on its own.

## Next waves

1. **Standards-action classification** — flip concrete semantic rules to `:hard-halt` in the `standards/miniforge` submodule, recompile the pack. *This is what turns the judge on* (settle the submodule PR first, then the consuming pin).
2. **Security pack** — defense-in-depth + AI security, hard-halt.
3. (Later) batched + cached judge for cost, per the eval (opus-4.8 batched).

## Tests

Acting rule runs the judge and blocks (asserts derived `:llm-client` / injected `:complete-fn`); non-acting rule skips the judge; acting rule without wiring fails closed; injected judge is scoped to the changed file's content; `analyze-rule-on-files` filters by glob + size. Pre-commit green (317 tests + GraalVM/bb compat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)