### PR TITLE
refactor(orchestrator,operator): externalize default-config to EDN

### DIFF
--- a/components/operator/resources/config/operator/defaults.edn
+++ b/components/operator/resources/config/operator/defaults.edn
@@ -1,0 +1,24 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; Default operator configuration.
+{:signal-retention-ms 86400000 ; 24 hours
+ :pattern-window-ms 3600000    ; 1 hour
+ :min-pattern-occurrences 3
+ :auto-apply-threshold 0.95
+ :shadow-period-ms 3600000}    ; 1 hour shadow mode

--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -25,18 +25,16 @@
    [ai.miniforge.operator.llm-pattern-detector :as llm-pattern-detector]
    [ai.miniforge.workflow.interface :as wf]
    [ai.miniforge.knowledge.interface :as knowledge]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Configuration
 
 (def default-config
   "Default operator configuration."
-  {:signal-retention-ms (* 24 60 60 1000) ; 24 hours
-   :pattern-window-ms (* 60 60 1000)       ; 1 hour
-   :min-pattern-occurrences 3
-   :auto-apply-threshold 0.95
-   :shadow-period-ms (* 60 60 1000)})      ; 1 hour shadow mode
+  (-> (io/resource "config/operator/defaults.edn") slurp edn/read-string))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Signal management

--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -32,9 +32,34 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Configuration
 
+(defn- load-config
+  "Read an EDN config resource, failing fast with a clear ex-info when the
+   resource is absent from the classpath, malformed, not a map, or missing
+   a required key — rather than a low-signal NPE/reader error at load."
+  [path required-keys]
+  (let [url (io/resource path)]
+    (when (nil? url)
+      (throw (ex-info (str "Missing config resource on classpath: " path)
+                      {:config/resource path})))
+    (let [parsed (try
+                   (edn/read-string (slurp url))
+                   (catch Exception e
+                     (throw (ex-info (str "Malformed EDN config resource: " path)
+                                     {:config/resource path} e))))]
+      (when-not (map? parsed)
+        (throw (ex-info (str "Config resource is not a map: " path)
+                        {:config/resource path})))
+      (let [missing (remove #(contains? parsed %) required-keys)]
+        (when (seq missing)
+          (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
+                          {:config/resource path :config/missing-keys (vec missing)})))
+        parsed))))
+
 (def default-config
   "Default operator configuration."
-  (-> (io/resource "config/operator/defaults.edn") slurp edn/read-string))
+  (load-config "config/operator/defaults.edn"
+               [:signal-retention-ms :pattern-window-ms :min-pattern-occurrences
+                :auto-apply-threshold :shadow-period-ms]))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Signal management

--- a/components/orchestrator/resources/config/orchestrator/defaults.edn
+++ b/components/orchestrator/resources/config/orchestrator/defaults.edn
@@ -1,0 +1,26 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; Default control plane configuration.
+{:default-budget {:max-tokens 100000
+                  :max-cost-usd 10.0
+                  :timeout-ms 1800000} ; 30 min
+ :knowledge-injection? true
+ :learning-capture? true
+ :escalation-threshold 3
+ :log-level :info}

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -54,9 +54,33 @@
      :tags [:repair :inner-loop (keyword (name agent-role))]
      :confidence 0.7}))
 
+(defn- load-config
+  "Read an EDN config resource, failing fast with a clear ex-info when the
+   resource is absent from the classpath, malformed, not a map, or missing
+   a required key — rather than a low-signal NPE/reader error at load."
+  [path required-keys]
+  (let [url (io/resource path)]
+    (when (nil? url)
+      (throw (ex-info (str "Missing config resource on classpath: " path)
+                      {:config/resource path})))
+    (let [parsed (try
+                   (edn/read-string (slurp url))
+                   (catch Exception e
+                     (throw (ex-info (str "Malformed EDN config resource: " path)
+                                     {:config/resource path} e))))]
+      (when-not (map? parsed)
+        (throw (ex-info (str "Config resource is not a map: " path)
+                        {:config/resource path})))
+      (let [missing (remove #(contains? parsed %) required-keys)]
+        (when (seq missing)
+          (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
+                          {:config/resource path :config/missing-keys (vec missing)})))
+        parsed))))
+
 (def default-config
   "Default control plane configuration."
-  (-> (io/resource "config/orchestrator/defaults.edn") slurp edn/read-string))
+  (load-config "config/orchestrator/defaults.edn"
+               [:default-budget :escalation-threshold]))
 
 (def task-type->agent-role
   "Mapping of task types to agent roles."

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -32,7 +32,9 @@
    [ai.miniforge.orchestrator.protocol :as proto]
    [ai.miniforge.workflow.interface :as wf]
    [ai.miniforge.knowledge.interface :as knowledge]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Configuration
@@ -54,13 +56,7 @@
 
 (def default-config
   "Default control plane configuration."
-  {:default-budget {:max-tokens 100000
-                    :max-cost-usd 10.0
-                    :timeout-ms (* 30 60 1000)} ; 30 minutes
-   :knowledge-injection? true
-   :learning-capture? true
-   :escalation-threshold 3
-   :log-level :info})
+  (-> (io/resource "config/orchestrator/defaults.edn") slurp edn/read-string))
 
 (def task-type->agent-role
   "Mapping of task types to agent roles."

--- a/docs/pull-requests/2026-06-20-refactor-orchestrator-operator-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-orchestrator-operator-config-edn.md
@@ -1,0 +1,52 @@
+# refactor(orchestrator,operator): externalize default-config to EDN
+
+## Overview
+
+The orchestrator and operator components each held a `default-config` map as a
+code literal in `core.clj`. This change moves that data to EDN resources loaded
+at namespace load via `io/resource` + `edn/read-string`, matching the existing
+pattern in the reliability component. The `default-config` var name and bound
+value are unchanged.
+
+## Motivation
+
+Both maps are operator-tunable policy: token and cost budgets, escalation and
+auto-apply thresholds, signal-retention and pattern windows. Config-as-data
+(Dewey 007) holds that such policy belongs in a data resource, not embedded as
+Clojure literals. The reliability component already loads its defaults from
+`resources/config/reliability/defaults.edn`; these two components now follow the
+same form.
+
+## Changes
+
+- Added `components/orchestrator/resources/config/orchestrator/defaults.edn`
+  with the control-plane defaults (default budget, knowledge-injection and
+  learning-capture flags, escalation threshold, log level).
+- Added `components/operator/resources/config/operator/defaults.edn` with the
+  operator defaults (signal-retention window, pattern window, minimum pattern
+  occurrences, auto-apply threshold, shadow period).
+- `components/orchestrator/src/ai/miniforge/orchestrator/core.clj`: `default-config`
+  now loads from the EDN resource; added `clojure.edn` and `clojure.java.io`
+  requires.
+- `components/operator/src/ai/miniforge/operator/core.clj`: same change for its
+  `default-config`; added the same two requires.
+
+Compile-time arithmetic in the literals was replaced with the computed integer
+in EDN, with a comment showing the breakdown:
+
+- orchestrator `:timeout-ms` `(* 30 60 1000)` -> `1800000` (30 min)
+- operator `:signal-retention-ms` `(* 24 60 60 1000)` -> `86400000` (24 hours)
+- operator `:pattern-window-ms` `(* 60 60 1000)` -> `3600000` (1 hour)
+- operator `:shadow-period-ms` `(* 60 60 1000)` -> `3600000` (1 hour)
+
+Both components already listed `resources` on `:paths` in their `deps.edn`; no
+path changes were required.
+
+## Verification
+
+- `clojure -M:test -m cognitect.test-runner -d test` (orchestrator): 21 tests,
+  79 assertions, 0 failures, 0 errors.
+- Same for operator: 68 tests, 202 assertions, 0 failures, 0 errors.
+- Load-smoke of each `default-config`: every key and computed millisecond value
+  equals the prior literal.
+- `bb poly:check`: OK.


### PR DESCRIPTION
## Overview

The orchestrator and operator components each held a `default-config` map as a code literal in `core.clj`. This change moves that data to EDN resources loaded at namespace load via `io/resource` + `edn/read-string`, matching the existing pattern in the reliability component. The `default-config` var name and bound value are unchanged.

## Motivation

Both maps are operator-tunable policy: token and cost budgets, escalation and auto-apply thresholds, signal-retention and pattern windows. Config-as-data (Dewey 007) holds that such policy belongs in a data resource, not embedded as Clojure literals. The reliability component already loads its defaults from `resources/config/reliability/defaults.edn`; these two components now follow the same form.

## Changes

- Added `components/orchestrator/resources/config/orchestrator/defaults.edn`.
- Added `components/operator/resources/config/operator/defaults.edn`.
- `orchestrator/core.clj` and `operator/core.clj`: `default-config` now loads from the EDN resource; added `clojure.edn` and `clojure.java.io` requires.

Compile-time arithmetic was replaced with the computed integer in EDN, with a breakdown comment:

- orchestrator `:timeout-ms` `(* 30 60 1000)` -> `1800000` (30 min)
- operator `:signal-retention-ms` `(* 24 60 60 1000)` -> `86400000` (24 hours)
- operator `:pattern-window-ms` `(* 60 60 1000)` -> `3600000` (1 hour)
- operator `:shadow-period-ms` `(* 60 60 1000)` -> `3600000` (1 hour)

Both components already listed `resources` on `:paths`; no path changes required.

## Verification

- orchestrator tests: 21 tests, 79 assertions, 0 failures, 0 errors.
- operator tests: 68 tests, 202 assertions, 0 failures, 0 errors.
- Load-smoke of each `default-config`: every key and computed ms value equals the prior literal.
- `bb poly:check`: OK.
- Pre-commit gate (commit-budget, poly:check, lint, fmt:md, 317 smoke tests, graalvm): passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)