### PR TITLE
refactor(cli): externalize default user config to EDN

### DIFF
--- a/bases/cli/resources/config/cli/user-defaults.edn
+++ b/bases/cli/resources/config/cli/user-defaults.edn
@@ -1,0 +1,33 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; Fallback user config applied when no user config file exists.
+;; The :artifacts :dir value is resolved in code from the runtime home dir.
+{:llm {:backend :opencode
+       :model "anthropic/claude-sonnet-4-5"
+       :timeout-ms 300000
+       :line-timeout-ms 60000
+       :max-tokens 4000}
+ :workflow {:max-iterations 50
+            :max-tokens 150000
+            :failure-strategy :retry}
+ :meta-loop {:enabled true
+             :max-convergence-iterations 10
+             :convergence-threshold 0.95}
+ :dashboard {:port 7878
+             :auto-open false}}

--- a/bases/cli/src/ai/miniforge/cli/config.clj
+++ b/bases/cli/src/ai/miniforge/cli/config.clj
@@ -27,7 +27,8 @@
    [babashka.process :as process]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.backends :as backends]
-   [ai.miniforge.cli.messages :as messages]))
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.resource-config :as resource-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Configuration paths and utilities
@@ -35,21 +36,15 @@
 (def default-user-config-path
   (app-config/config-path))
 
+(def default-config-resource
+  "Classpath resource path for the fallback user config."
+  "config/cli/user-defaults.edn")
+
 (def default-config
-  {:llm {:backend :opencode
-         :model "anthropic/claude-sonnet-4-5"
-         :timeout-ms 300000
-         :line-timeout-ms 60000
-         :max-tokens 4000}
-   :workflow {:max-iterations 50
-              :max-tokens 150000
-              :failure-strategy :retry}
-   :artifacts {:dir (app-config/artifacts-dir)}
-   :meta-loop {:enabled true
-               :max-convergence-iterations 10
-               :convergence-threshold 0.95}
-   :dashboard {:port 7878
-               :auto-open false}})
+  ;; Static defaults load from EDN; :artifacts :dir is resolved from the
+  ;; runtime home dir so MINIFORGE_HOME overrides keep working.
+  (assoc (resource-config/merged-resource-config default-config-resource)
+         :artifacts {:dir (app-config/artifacts-dir)}))
 
 (defn style
   "Apply terminal styling using ANSI escape codes."

--- a/bases/cli/src/ai/miniforge/cli/config.clj
+++ b/bases/cli/src/ai/miniforge/cli/config.clj
@@ -42,9 +42,11 @@
 
 (def default-config
   ;; Static defaults load from EDN; :artifacts :dir is resolved from the
-  ;; runtime home dir so MINIFORGE_HOME overrides keep working.
-  (assoc (resource-config/merged-resource-config default-config-resource)
-         :artifacts {:dir (app-config/artifacts-dir)}))
+  ;; runtime home dir so MINIFORGE_HOME overrides keep working. Merge (not
+  ;; assoc) so any :artifacts keys from the loaded EDN survive while the
+  ;; computed :dir still wins.
+  (update (resource-config/merged-resource-config default-config-resource)
+          :artifacts merge {:dir (app-config/artifacts-dir)}))
 
 (defn style
   "Apply terminal styling using ANSI escape codes."

--- a/docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md
@@ -1,0 +1,48 @@
+# refactor(cli): externalize default user config to EDN
+
+## Overview
+
+Moves the fallback user config in `bases/cli/src/ai/miniforge/cli/config.clj`
+out of an in-code literal map and into an EDN resource at
+`bases/cli/resources/config/cli/user-defaults.edn`. The `default-config` var
+keeps its name and now binds to the loaded resource.
+
+## Motivation
+
+`default-config` held operational settings (LLM model name, timeouts, token
+limits, dashboard port, convergence thresholds) as a literal map embedded in
+code. This is config-as-data (Dewey 007): such values belong in EDN resources
+alongside the existing `app.edn` and `backends.edn`, which the same base
+already loads via `resource-config/merged-resource-config`.
+
+## Changes
+
+- Added `bases/cli/resources/config/cli/user-defaults.edn` carrying the static
+  defaults: `:llm`, `:workflow`, `:meta-loop`, and `:dashboard`. Keys and
+  values are copied verbatim from the previous in-code map. The file uses the
+  Apache-2.0 header block.
+- `config.clj` now requires `ai.miniforge.cli.resource-config` and defines
+  `default-config-resource` plus a rewritten `default-config` that loads the
+  EDN through `resource-config/merged-resource-config` (the same loader used
+  for `app.edn` and `backends.edn`).
+- The `:artifacts {:dir ...}` entry stays computed in code. Its value comes
+  from `app-config/artifacts-dir`, which resolves against the runtime home dir
+  (honoring `MINIFORGE_HOME`), so it cannot be frozen into a static literal.
+  `default-config` assoc-es it onto the loaded EDN, preserving the prior value.
+
+No numbers, keywords, or strings were changed. Map equality is order
+independent, so the relocation of `:artifacts` to the end of the map does not
+alter `default-config`.
+
+## Verification
+
+- Load smoke check via the `:dev` classpath: `default-config` equals the
+  original literal map (`(= default-config {...original...})` returns `true`).
+  Spot values: `[:llm :model]` = `"anthropic/claude-sonnet-4-5"`,
+  `[:dashboard :port]` = `7878`, `[:meta-loop :convergence-threshold]` = `0.95`,
+  `[:artifacts :dir]` resolves at runtime.
+- CLI base tests: 287 tests, 1056 assertions. The one failure
+  (`workflow-runner.preflight-test`) is pre-existing on `origin/main` and
+  environmental (it shells out to the local `claude` CLI binary); it does not
+  reference config defaults and is unrelated to this change.
+- `bb poly:check`: `OK`, exit 0.

--- a/docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md
@@ -28,7 +28,7 @@ already loads via `resource-config/merged-resource-config`.
 - The `:artifacts {:dir ...}` entry stays computed in code. Its value comes
   from `app-config/artifacts-dir`, which resolves against the runtime home dir
   (honoring `MINIFORGE_HOME`), so it cannot be frozen into a static literal.
-  `default-config` assoc-es it onto the loaded EDN, preserving the prior value.
+  `default-config` assocs it onto the loaded EDN, preserving the prior value.
 
 No numbers, keywords, or strings were changed. Map equality is order
 independent, so the relocation of `:artifacts` to the end of the map does not


### PR DESCRIPTION
## Overview

Moves the fallback user config in `bases/cli/src/ai/miniforge/cli/config.clj` out of an in-code literal map into a new EDN resource at `bases/cli/resources/config/cli/user-defaults.edn`. The `default-config` var keeps its name and now binds to the loaded resource.

## Motivation

`default-config` held operational settings (LLM model name, timeouts, token limits, dashboard port, convergence thresholds) as a literal map embedded in code. This is config-as-data (Dewey 007). Those values belong in EDN resources alongside the existing `app.edn` and `backends.edn`, which the same base already loads via `resource-config/merged-resource-config`.

## Changes

- Added `bases/cli/resources/config/cli/user-defaults.edn` with the static `:llm`, `:workflow`, `:meta-loop`, and `:dashboard` defaults, copied verbatim. Apache-2.0 header block included.
- `config.clj` requires `ai.miniforge.cli.resource-config` and rewrites `default-config` to load the EDN via `merged-resource-config` (the loader already used for `app.edn`/`backends.edn`).
- `:artifacts {:dir ...}` stays computed in code via `app-config/artifacts-dir`, which resolves against the runtime home dir (honors `MINIFORGE_HOME`) and so cannot be a static literal. It is assoc-ed onto the loaded EDN.

No numbers, keywords, or strings changed. `default-config` is equal to the original literal (map equality is order independent).

## Verification

- Load smoke check: `default-config` equals the original literal map. `[:llm :model]` = `"anthropic/claude-sonnet-4-5"`, `[:dashboard :port]` = `7878`, `[:meta-loop :convergence-threshold]` = `0.95`, `[:artifacts :dir]` resolves at runtime.
- CLI base tests: 287 tests, 1056 assertions. The single failure (`workflow-runner.preflight-test`) is pre-existing on `origin/main` and environmental (shells out to the local `claude` CLI); unrelated to this change.
- Pre-commit gate passed: 317 smoke tests 0 failures, GraalVM-compat 0 failures.
- `bb poly:check`: OK, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)