### PR TITLE
refactor(llm): externalize backend endpoint/model data to EDN

### DIFF
--- a/components/llm/resources/llm/backends.edn
+++ b/components/llm/resources/llm/backends.edn
@@ -1,0 +1,84 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; Pure-data fields of each LLM backend, keyed by backend keyword.
+;; The function-valued fields (:stream-parser, :args-fn) stay in
+;; llm_client.clj and are merged onto these maps at load time. See the
+;; `backends` var there for the merge and for the rationale of each
+;; field (prompt delivery, probe endpoints, credential handling).
+{:claude {:cmd "claude"
+          :streaming? true
+          :description "Claude via Anthropic CLI"
+          :provider "Anthropic"
+          :requires-cli? true
+          ;; Prompt delivery: stdin. The planner path's system-prompt +
+          ;; spec text + existing-files context regularly pushes argv
+          ;; past POSIX ARG_MAX. Claude CLI supports --input-format text
+          ;; to read the user prompt from stdin; we use that instead.
+          :prompt-via :stdin
+          :probe-endpoint "https://api.anthropic.com/"}
+
+ :codex {:cmd "codex"
+         :streaming? true
+         :description "Codex via Codex CLI"
+         :provider "Codex"
+         :requires-cli? true
+         ;; Prompt delivery: stdin. Codex supports `-` as the prompt
+         ;; placeholder; this keeps large synthesis prompts off argv.
+         :prompt-via :stdin
+         :probe-endpoint "https://api.openai.com/"}
+
+ :ollama {:cmd "http"
+          :streaming? true
+          :description "Local models via Ollama"
+          :provider "Ollama"
+          :requires-cli? false
+          :api-endpoint "http://localhost:11434/api/chat"
+          :default-model "codellama"
+          :models ["codellama" "llama2" "mistral"]
+          :probe-endpoint "http://localhost:11434/api/version"}
+
+ :cursor {:cmd "agent"
+          :streaming? false
+          :description "Cursor AI via CLI"
+          :provider "Cursor"
+          :requires-cli? true
+          :prompt-via :argv
+          :probe-endpoint "https://api2.cursor.sh/"}
+
+ :opencode {:cmd "opencode"
+            :streaming? false
+            :description "OpenCode CLI provider wrapper"
+            :provider "OpenCode"
+            :requires-cli? true
+            :prompt-via :argv
+            ;; OpenCode's typical default provider; tunable per-deployment.
+            :probe-endpoint "https://api.anthropic.com/"}
+
+ ;; :echo's :probe-endpoint mirrors the in-code
+ ;; `generic-connectivity-probe-url` ("https://1.1.1.1/"): backends
+ ;; without a provider-controlled endpoint get the generic Cloudflare
+ ;; DNS connectivity URL so the network-monitor still has something to
+ ;; probe.
+ :echo {:cmd "echo"
+        :streaming? false
+        :description "Echo backend for testing"
+        :provider "Test"
+        :requires-cli? false
+        :prompt-via :argv
+        :probe-endpoint "https://1.1.1.1/"}}

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -647,7 +647,7 @@
 (def ^:private backend-data
   (load-backend-data))
 
-;; Function-valued backend fields. The :echo entry is intentionally
+;; Function-valued backend fields. The :ollama entry is intentionally
 ;; absent (it has none); OpenCode loads credentials from its auth
 ;; store, environment, or project .env/config, so Miniforge should not
 ;; read provider-specific keys on that path.

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -632,73 +632,36 @@
 (def ^:private generic-connectivity-probe-url
   "https://1.1.1.1/")
 
+;; Pure-data backend fields (`:cmd`, endpoints, `:default-model`,
+;; `:models`, etc.) live in `llm/backends.edn`; the function-valued
+;; fields (`:stream-parser`, `:args-fn`) stay here because they
+;; reference parser/arg-builder fns defined in this namespace. The two
+;; are merged per backend below to form `backends`.
+(defn- load-backend-data
+  []
+  (if-let [resource (io/resource "llm/backends.edn")]
+    (edn/read-string (slurp resource))
+    (response/throw-anomaly! :anomalies/not-found
+                             "Missing llm/backends.edn resource")))
+
+(def ^:private backend-data
+  (load-backend-data))
+
+;; Function-valued backend fields. The :echo entry is intentionally
+;; absent (it has none); OpenCode loads credentials from its auth
+;; store, environment, or project .env/config, so Miniforge should not
+;; read provider-specific keys on that path.
+(def ^:private backend-fns
+  {:claude {:stream-parser parse-claude-stream-line
+            :args-fn claude-args}
+   :codex {:stream-parser parse-codex-stream-line
+           :args-fn codex-args}
+   :cursor {:args-fn cursor-args}
+   :opencode {:args-fn opencode-args}
+   :echo {:args-fn echo-args}})
+
 (def backends
-  {:claude {:cmd "claude"
-            :streaming? true
-            :description "Claude via Anthropic CLI"
-            :provider "Anthropic"
-            :requires-cli? true
-            :stream-parser parse-claude-stream-line
-            :args-fn claude-args
-            ;; Prompt delivery: stdin. The planner path's system-prompt +
-            ;; spec text + existing-files context regularly pushes argv
-            ;; past POSIX ARG_MAX. Claude CLI supports --input-format text
-            ;; to read the user prompt from stdin; we use that instead.
-            :prompt-via :stdin
-            :probe-endpoint "https://api.anthropic.com/"}
-
-   :codex {:cmd "codex"
-           :streaming? true
-           :description "Codex via Codex CLI"
-           :provider "Codex"
-           :requires-cli? true
-           :stream-parser parse-codex-stream-line
-           :args-fn codex-args
-           ;; Prompt delivery: stdin. Codex supports `-` as the prompt
-           ;; placeholder; this keeps large synthesis prompts off argv.
-           :prompt-via :stdin
-           :probe-endpoint "https://api.openai.com/"}
-
-   :ollama {:cmd "http"
-            :streaming? true
-            :description "Local models via Ollama"
-            :provider "Ollama"
-            :requires-cli? false
-            :api-endpoint "http://localhost:11434/api/chat"
-            :default-model "codellama"
-            :models ["codellama" "llama2" "mistral"]
-            :probe-endpoint "http://localhost:11434/api/version"}
-
-   :cursor {:cmd "agent"
-            :streaming? false
-            :description "Cursor AI via CLI"
-            :provider "Cursor"
-            :requires-cli? true
-            :args-fn cursor-args
-            :prompt-via :argv
-            :probe-endpoint "https://api2.cursor.sh/"}
-
-   :opencode {:cmd "opencode"
-              :streaming? false
-              :description "OpenCode CLI provider wrapper"
-              :provider "OpenCode"
-              :requires-cli? true
-              ;; OpenCode loads credentials from its auth store,
-              ;; environment, or project .env/config. Miniforge should not
-              ;; read provider-specific keys on this path.
-              :args-fn opencode-args
-              :prompt-via :argv
-              ;; OpenCode's typical default provider; tunable per-deployment.
-              :probe-endpoint "https://api.anthropic.com/"}
-
-   :echo {:cmd "echo"
-          :streaming? false
-          :description "Echo backend for testing"
-          :provider "Test"
-          :requires-cli? false
-          :args-fn echo-args
-          :prompt-via :argv
-          :probe-endpoint generic-connectivity-probe-url}})
+  (merge-with merge backend-data backend-fns))
 
 (defn probe-endpoint-for
   "Resolve the network-health probe URL for `backend-key`. Returns the

--- a/docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md
@@ -3,8 +3,10 @@
 ## Overview
 
 Moves the pure-data fields of the `backends` map in the `llm` component
-out of `llm_client.clj` and into a new EDN resource,
-`resources/llm/backends.edn`. The function-valued fields stay in code.
+out of `llm_client.clj` and into a new EDN resource, loaded from the
+classpath as `llm/backends.edn` (on disk at
+`components/llm/resources/llm/backends.edn`). The function-valued fields
+stay in code.
 The runtime value of the `backends` var is unchanged.
 
 ## Motivation

--- a/docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md
@@ -1,0 +1,68 @@
+# refactor(llm): externalize backend endpoint/model data to EDN
+
+## Overview
+
+Moves the pure-data fields of the `backends` map in the `llm` component
+out of `llm_client.clj` and into a new EDN resource,
+`resources/llm/backends.edn`. The function-valued fields stay in code.
+The runtime value of the `backends` var is unchanged.
+
+## Motivation
+
+`components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj`
+defined `(def backends {...})` as a single literal that mixed
+configuration data (command names, probe/API endpoint URLs, default
+model, model list) with code (stream-parser and arg-builder function
+references). The data portion is config-as-data (Dewey 007) and belongs
+in a resource alongside the component's existing EDN configs
+(`model-catalog.edn`, `cost-table.edn`, `client-defaults.edn`).
+
+## Changes
+
+- Added `components/llm/resources/llm/backends.edn` holding the
+  pure-data fields of each backend, keyed by backend keyword:
+  `:cmd`, `:streaming?`, `:description`, `:provider`, `:requires-cli?`,
+  `:prompt-via`, `:probe-endpoint`, and (for `:ollama`)
+  `:api-endpoint`, `:default-model`, `:models`.
+- In `llm_client.clj`, replaced the `backends` literal with:
+  - `load-backend-data` / `backend-data` — reads the EDN resource (same
+    `io/resource` + `edn/read-string` pattern the component already
+    uses for `client-defaults.edn`; throws `:anomalies/not-found` if the
+    resource is missing).
+  - `backend-fns` — the per-backend function-valued fields kept in code.
+  - `backends` — `(merge-with merge backend-data backend-fns)`.
+- The in-code comments explaining prompt delivery, OpenCode credential
+  handling, and the `:echo` probe-endpoint were moved/retained next to
+  the fields they describe.
+
+## What stayed in code, and why
+
+The function-valued fields cannot be expressed as data in EDN; they are
+references to fns defined in this namespace and must stay in Clojure:
+
+- `:claude` and `:codex`: `:stream-parser` (`parse-claude-stream-line` /
+  `parse-codex-stream-line`) and `:args-fn` (`claude-args` /
+  `codex-args`).
+- `:cursor`, `:opencode`, `:echo`: `:args-fn` (`cursor-args` /
+  `opencode-args` / `echo-args`).
+- `:ollama` has no function-valued fields; its entry is fully data.
+
+The `:echo` backend's `:probe-endpoint` was previously the var
+`generic-connectivity-probe-url`, whose value is the string
+`"https://1.1.1.1/"`. The EDN uses that literal string, which equals the
+var's value. `generic-connectivity-probe-url` remains defined in code
+because `probe-endpoint-for` still references it as the fallback for
+backends without an explicit endpoint.
+
+## Verification
+
+- Equivalence smoke against the original literals: for each of the six
+  backends, the data fields (`:cmd`, endpoints, `:default-model`,
+  `:models`, and the other scalars) equal the pre-refactor values; the
+  per-backend key set is unchanged; `:stream-parser` / `:args-fn` are
+  present where they were before and are `fn?`. Result: pass.
+- `llm` component tests via the cognitect test-runner over
+  `components/llm/test`: 164 tests, 942 assertions, 0 failures, 0
+  errors. This includes `args-fn-test`, which exercises the retained
+  `:args-fn` references.
+- `bb poly:check`: OK.


### PR DESCRIPTION
## Overview

Moves the pure-data fields of the `backends` map in the `llm` component out of `llm_client.clj` into a new EDN resource, `components/llm/resources/llm/backends.edn`. The function-valued fields stay in code. The runtime value of `backends` is unchanged.

## Motivation

`backends` mixed config data (command names, probe/API endpoint URLs, default model, model list) with code (stream-parser and arg-builder fn references). The data portion is config-as-data (Dewey 007) and belongs in a resource alongside the component's existing EDN configs (`model-catalog.edn`, `cost-table.edn`, `client-defaults.edn`).

## Changes

- Added `resources/llm/backends.edn` with the pure-data fields per backend: `:cmd`, `:streaming?`, `:description`, `:provider`, `:requires-cli?`, `:prompt-via`, `:probe-endpoint`, and (for `:ollama`) `:api-endpoint`, `:default-model`, `:models`.
- In `llm_client.clj`: `backend-data` loads the EDN (same `io/resource` + `edn/read-string` pattern as `client-defaults.edn`; throws `:anomalies/not-found` if missing); `backend-fns` keeps the per-backend fn fields in code; `backends` is `(merge-with merge backend-data backend-fns)`.

## What stayed in code, and why

Function-valued fields cannot be EDN data — they reference fns in this namespace:
- `:claude` / `:codex`: `:stream-parser` and `:args-fn`.
- `:cursor` / `:opencode` / `:echo`: `:args-fn`.
- `:ollama` has no fn fields; its entry is fully data.

`:echo`'s `:probe-endpoint` was the var `generic-connectivity-probe-url` (value `"https://1.1.1.1/"`); the EDN uses that literal string, which equals the var's value. The var stays in code because `probe-endpoint-for` still uses it as the fallback.

## Verification

- Equivalence smoke vs original literals: all six backends — data fields equal pre-refactor values, per-backend key set unchanged, `:stream-parser`/`:args-fn` present where before and `fn?`. Pass.
- `llm` tests (cognitect runner over `components/llm/test`): 164 tests, 942 assertions, 0 failures, 0 errors (includes `args-fn-test`).
- `bb poly:check`: OK.
- Full pre-commit gate passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)