### PR TITLE
refactor(connector-edgar): make SEC base URLs configurable (parity with sibling connectors)

### DIFF
--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
@@ -102,12 +102,9 @@
 
 ;; -- EDGAR EFTS API --
 
-(def ^:private efts-base "https://efts.sec.gov/LATEST/search-index")
-(def ^:private archives-base "https://www.sec.gov/Archives/edgar/data")
-
 (defn- search-filings
   "Search EDGAR EFTS for filings of a given form type in a date range."
-  [form-type start-date end-date sample-size user-agent]
+  [efts-base form-type start-date end-date sample-size user-agent]
   (let [url (str efts-base
                  "?q=%22" form-type "%22"
                  "&forms=" form-type
@@ -121,7 +118,7 @@
 
 (defn- fetch-filing-xml
   "Fetch a filing's XML document. Tries common filenames."
-  [adsh cik user-agent filenames]
+  [archives-base adsh cik user-agent filenames]
   (let [adsh-path (clojure.string/replace adsh "-" "")
         cik-num   (str (parse-long cik))]
     (some (fn [fname]
@@ -165,12 +162,12 @@
 
 (defn- fetch-filing-transactions
   "Fetch and extract transactions from a single EFTS hit."
-  [hit user-agent filenames transaction-codes]
+  [archives-base hit user-agent filenames transaction-codes]
   (let [src  (:_source hit)
         adsh (:adsh src)
         cik  (first (:ciks src))]
     (when (and adsh cik)
-      (when-let [xml (fetch-filing-xml adsh cik user-agent filenames)]
+      (when-let [xml (fetch-filing-xml archives-base adsh cik user-agent filenames)]
         (extract-form4-transactions xml transaction-codes)))))
 
 (defn- count-by-code
@@ -183,17 +180,19 @@
   [config user-agent]
   (let [{:edgar/keys [start-date sample-size transaction-codes
                       series-id filing-filenames]} config
+        efts-base     (get config :edgar/efts-base-url "https://efts.sec.gov/LATEST/search-index")
+        archives-base (get config :edgar/archives-base-url "https://www.sec.gov/Archives/edgar/data")
         codes   (or transaction-codes #{"P" "S"})
         fnames  (or filing-filenames ["form4.xml" "ownership.xml" "primary_doc.xml"])
         windows (monthly-windows (or start-date "2025-01-01"))]
     (vec
      (for [[start end] windows
-           :let [hits    (or (search-filings "4" start end
+           :let [hits    (or (search-filings efts-base "4" start end
                                              (or sample-size 200)
                                              user-agent)
                              [])
                  sample  (take (or sample-size 200) hits)
-                 txns    (mapcat #(fetch-filing-transactions % user-agent fnames codes) sample)
+                 txns    (mapcat #(fetch-filing-transactions archives-base % user-agent fnames codes) sample)
                  buys    (count-by-code txns "P")
                  sells   (count-by-code txns "S")
                  ratio   (if (pos? sells)

--- a/docs/pull-requests/2026-06-20-refactor-connector-edgar-base-url-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-connector-edgar-base-url-config.md
@@ -1,0 +1,37 @@
+# refactor(connector-edgar): make SEC base URLs configurable
+
+## Overview
+
+The EDGAR connector held its two SEC endpoints as bare top-level `def`s:
+`efts-base` (`https://efts.sec.gov/LATEST/search-index`) and `archives-base`
+(`https://www.sec.gov/Archives/edgar/data`). This change reads both from the
+passed-in connector config, with the prior literals kept as in-code defaults.
+Behavior is unchanged when no override is supplied.
+
+## Motivation
+
+Config-as-data (Dewey 007): endpoint URLs are configuration, not constants.
+Sibling connectors already read their base URL from the config map — for
+example, connector-github reads `(get config :github/base-url "https://api.github.com")`
+in `do-connect`. EDGAR did not, so an operator could not repoint it at a stub
+or mirror for testing or for an alternate host. This brings EDGAR to parity
+with the sibling pattern.
+
+## Changes
+
+- `components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj`
+  - Removed the `efts-base` and `archives-base` top-level `def`s.
+  - `aggregate-buy-sell-ratio` now resolves both URLs from config:
+    `(get config :edgar/efts-base-url "https://efts.sec.gov/LATEST/search-index")`
+    and `(get config :edgar/archives-base-url "https://www.sec.gov/Archives/edgar/data")`.
+  - The resolved URLs are threaded as the leading argument into
+    `search-filings`, `fetch-filing-transactions`, and `fetch-filing-xml`.
+  - The default strings are byte-for-byte the previous literals, so an empty
+    config produces the same URLs as before.
+
+## Verification
+
+- connector-edgar tests in isolation: 12 tests, 36 assertions, 0 failures, 0 errors.
+- Namespace load smoke: `impl` loads; resolving both keys against an empty
+  config returns the unchanged default URLs.
+- `bb poly:check`: OK.


### PR DESCRIPTION
## Overview

Read the EDGAR connector's two SEC endpoints from the passed-in config instead of holding them as bare top-level defs. Prior literals kept as in-code defaults; empty config yields the unchanged URLs.

## Motivation

Config-as-data (Dewey 007): endpoint URLs are configuration, not constants. Sibling connectors already read their base URL from config — connector-github uses `(get config :github/base-url "https://api.github.com")` in `do-connect`. EDGAR did not, so an operator could not repoint it at a stub or mirror. This brings parity.

## Changes

- `components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj`
  - Removed `efts-base` and `archives-base` top-level defs.
  - `aggregate-buy-sell-ratio` resolves `(get config :edgar/efts-base-url "https://efts.sec.gov/LATEST/search-index")` and `(get config :edgar/archives-base-url "https://www.sec.gov/Archives/edgar/data")`.
  - Threaded resolved URLs into `search-filings`, `fetch-filing-transactions`, `fetch-filing-xml`.
  - Default strings are byte-for-byte the previous literals.

## Verification

- connector-edgar tests in isolation: 12 tests, 36 assertions, 0 failures, 0 errors.
- Namespace load smoke: defaults resolve unchanged against an empty config.
- `bb poly:check`: OK.
- Full pre-commit gate (317 tests / 1196 assertions + GraalVM compat 517 assertions): passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)