### PR TITLE
refactor(semantic-analyzer): externalize scan limits to EDN

### DIFF
--- a/components/semantic-analyzer/resources/config/semantic-analyzer/limits.edn
+++ b/components/semantic-analyzer/resources/config/semantic-analyzer/limits.edn
@@ -1,0 +1,23 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; Operational limits for LLM-as-judge semantic analysis (file selection and
+;; per-rule batch analysis). Tuned for CLI-backend latency.
+{:max-file-size-bytes 50000
+ :max-files-per-rule 5
+ :default-rule-timeout-ms 300000}

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -101,15 +101,19 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; File selection and batch analysis
 
-(def ^:private limits-resource "config/semantic-analyzer/limits.edn")
+(defn- load-limits
+  "Read the limits EDN, returning {} if the resource is absent,
+   unreadable, malformed, or not a map — so the call-site literal
+   defaults remain authoritative (fail-open, matching the prior
+   inline-literal behavior)."
+  [path]
+  (try
+    (let [url    (io/resource path)
+          parsed (when url (edn/read-string (slurp url)))]
+      (if (map? parsed) parsed {}))
+    (catch Exception _ {})))
 
-(def ^:private limits
-  "Operational scan limits loaded from classpath."
-  (if-let [url (io/resource limits-resource)]
-    (edn/read-string (slurp url))
-    {:max-file-size-bytes 50000
-     :max-files-per-rule 5
-     :default-rule-timeout-ms 300000}))
+(def ^:private limits (load-limits "config/semantic-analyzer/limits.edn"))
 
 (def ^:private max-file-size-bytes
   "Maximum file size to send to LLM. Files larger than this are skipped."

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -101,14 +101,24 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; File selection and batch analysis
 
+(def ^:private limits-resource "config/semantic-analyzer/limits.edn")
+
+(def ^:private limits
+  "Operational scan limits loaded from classpath."
+  (if-let [url (io/resource limits-resource)]
+    (edn/read-string (slurp url))
+    {:max-file-size-bytes 50000
+     :max-files-per-rule 5
+     :default-rule-timeout-ms 300000}))
+
 (def ^:private max-file-size-bytes
   "Maximum file size to send to LLM. Files larger than this are skipped."
-  50000)
+  (get limits :max-file-size-bytes 50000))
 
 (def ^:private max-files-per-rule
   "Maximum number of files to analyze per rule.
    Kept low to stay within per-rule timeout when using CLI backends."
-  5)
+  (get limits :max-files-per-rule 5))
 
 ;; NOTE: This mirrors compliance-scanner.scan/globs->file-pred.
 ;; Glob matching should be extracted to repo-index component.
@@ -154,7 +164,7 @@
 (def ^:private default-rule-timeout-ms
   "Maximum time to spend analyzing one rule before giving up.
    5 files × ~30s per CLI backend call = ~150s, so 300s gives headroom."
-  300000)
+  (get limits :default-rule-timeout-ms 300000))
 
 (defn analyze-rule
   [llm-client complete-fn repo-path rule]

--- a/docs/pull-requests/2026-06-20-refactor-semantic-analyzer-limits-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-semantic-analyzer-limits-config.md
@@ -1,0 +1,38 @@
+# refactor(semantic-analyzer): externalize scan limits to EDN
+
+## Overview
+
+Moves three operational tuning literals in the `semantic-analyzer`
+component out of source code and into an EDN resource. Behavior is
+unchanged; the values are identical to the prior inline literals.
+
+## Motivation
+
+Config-as-data (Dewey 007) asks that operational tuning values live in
+data rather than as literals embedded in code. The component already
+loads one EDN resource (the judge prompt), so the loader pattern exists
+in-component. The file-selection and per-rule analysis limits were still
+inline `def` literals.
+
+## Changes
+
+- Add `components/semantic-analyzer/resources/config/semantic-analyzer/limits.edn`
+  with one non-namespaced map: `:max-file-size-bytes 50000`,
+  `:max-files-per-rule 5`, `:default-rule-timeout-ms 300000`. Apache-2.0
+  header included.
+- `components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj`:
+  load the resource via `io/resource` + `slurp` + `edn/read-string` into a
+  private `limits` def, mirroring the reliability component's loader. The
+  three constants now read from `limits` with the original literals kept as
+  named fallbacks.
+
+No changes to function signatures or runtime behavior.
+
+## Verification
+
+- Load smoke under the workspace classpath: namespace loads;
+  `max-file-size-bytes` = 50000, `max-files-per-rule` = 5,
+  `default-rule-timeout-ms` = 300000 (identical to originals).
+- `semantic-analyzer` component tests: 13 tests, 55 assertions, 0
+  failures, 0 errors.
+- `bb poly:check`: OK.


### PR DESCRIPTION
## Overview

Moves three operational tuning literals in the `semantic-analyzer` component out of source and into an EDN resource. Behavior unchanged; values identical to the prior inline literals.

## Motivation

Config-as-data (Dewey 007): operational tuning values should live in data, not as literals in code. The component already loads an EDN resource (the judge prompt), so the loader pattern exists in-component. The file-selection and per-rule analysis limits were still inline `def` literals.

## Changes

- Add `components/semantic-analyzer/resources/config/semantic-analyzer/limits.edn` with one non-namespaced map: `:max-file-size-bytes 50000`, `:max-files-per-rule 5`, `:default-rule-timeout-ms 300000` (Apache-2.0 header included).
- `core.clj`: load the resource via `io/resource` + `slurp` + `edn/read-string` into a private `limits` def, mirroring the reliability component's loader. The three constants read from `limits` with the original literals kept as named fallbacks.

No changes to function signatures or runtime behavior.

## Verification

- Load smoke under the workspace classpath: `max-file-size-bytes` = 50000, `max-files-per-rule` = 5, `default-rule-timeout-ms` = 300000 (identical to originals).
- semantic-analyzer component tests: 13 tests, 55 assertions, 0 failures, 0 errors.
- `bb poly:check`: OK.
- Pre-commit gate: 317 tests / 1196 assertions, 0 failures; GraalVM 6 tests / 517 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)