### PR TITLE
refactor(adapter-claude-code): externalize session staleness windows to EDN

### DIFF
--- a/components/adapter-claude-code/resources/config/adapter_claude_code/staleness.edn
+++ b/components/adapter-claude-code/resources/config/adapter_claude_code/staleness.edn
@@ -1,0 +1,24 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; Session staleness windows for the Claude Code control-plane adapter.
+;; Windows are file-modification ages (milliseconds) used to classify a
+;; session as active/running vs idle vs dead.
+{:session-activity-window-ms 300000 ;; 5 min — discovery: session counts as active if its log was modified within this window
+ :running-window-ms 60000           ;; 1 min — poll-status: live PID + session file touched within this window is :running, else :idle
+ :idle-window-ms 300000}            ;; 5 min — poll-status: no live PID but session file touched within this window still reports :running

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/discovery.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/discovery.clj
@@ -28,9 +28,23 @@
    Layer 1: Process liveness detection
    Layer 2: Session extraction"
   (:require
+   [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.control-plane.interface :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Staleness windows (loaded from EDN)
+
+(def ^:private staleness-resource-path
+  "Classpath path to the EDN holding session staleness windows."
+  "config/adapter_claude_code/staleness.edn")
+
+(def staleness-windows
+  "Session staleness windows (milliseconds) loaded from the classpath.
+   Data lives in resources/config/adapter_claude_code/staleness.edn — a
+   missing resource is a packaging error, not a runtime condition."
+  (-> staleness-resource-path io/resource slurp edn/read-string))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Filesystem scanning
@@ -98,9 +112,9 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Session extraction
 
-(def ^:const activity-threshold-ms
+(def activity-threshold-ms
   "Consider a session active if its log was modified within this window."
-  (* 5 60 1000)) ;; 5 minutes
+  (:session-activity-window-ms staleness-windows))
 
 (defn- project-dir->session-info
   "Extract session info from a project directory.

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/discovery.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/discovery.clj
@@ -40,11 +40,35 @@
   "Classpath path to the EDN holding session staleness windows."
   "config/adapter_claude_code/staleness.edn")
 
+(defn- load-config
+  "Read an EDN config resource, failing fast with a clear ex-info when the
+   resource is absent from the classpath, malformed, not a map, or missing
+   a required key — rather than a low-signal NPE/reader error at load."
+  [path required-keys]
+  (let [url (io/resource path)]
+    (when (nil? url)
+      (throw (ex-info (str "Missing config resource on classpath: " path)
+                      {:config/resource path})))
+    (let [parsed (try
+                   (edn/read-string (slurp url))
+                   (catch Exception e
+                     (throw (ex-info (str "Malformed EDN config resource: " path)
+                                     {:config/resource path} e))))]
+      (when-not (map? parsed)
+        (throw (ex-info (str "Config resource is not a map: " path)
+                        {:config/resource path})))
+      (let [missing (remove #(contains? parsed %) required-keys)]
+        (when (seq missing)
+          (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
+                          {:config/resource path :config/missing-keys (vec missing)})))
+        parsed))))
+
 (def staleness-windows
   "Session staleness windows (milliseconds) loaded from the classpath.
    Data lives in resources/config/adapter_claude_code/staleness.edn — a
    missing resource is a packaging error, not a runtime condition."
-  (-> staleness-resource-path io/resource slurp edn/read-string))
+  (load-config staleness-resource-path
+               [:session-activity-window-ms :running-window-ms :idle-window-ms]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Filesystem scanning

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/impl.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/impl.clj
@@ -66,11 +66,15 @@
         session-file (get-in agent-record [:agent/metadata :session-file])]
     (cond
       (and pid (pid-alive? pid))
-      {:status (if (session-file-active-within-ms? session-file (* 60 1000))
+      {:status (if (session-file-active-within-ms?
+                    session-file
+                    (:running-window-ms discovery/staleness-windows))
                  :running
                  :idle)}
 
-      (session-file-active-within-ms? session-file (* 5 60 1000))
+      (session-file-active-within-ms?
+       session-file
+       (:idle-window-ms discovery/staleness-windows))
       {:status :running}
 
       :else

--- a/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/interface_test.clj
+++ b/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/interface_test.clj
@@ -20,6 +20,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [clojure.java.io :as io]
+   [ai.miniforge.adapter-claude-code.discovery :as discovery]
    [ai.miniforge.adapter-claude-code.interface :as sut]
    [ai.miniforge.control-plane-adapter.interface :as proto]))
 
@@ -193,3 +194,32 @@
       ;; or fail depending on the environment; we just assert the shape.
       (is (contains? ret :success?))
       (is (boolean? (:success? ret))))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; load-config — fail-fast config loading
+
+(deftest load-config-throws-on-missing-resource-test
+  (testing "Absent classpath resource raises an ex-info, not an NPE"
+    (let [ex (try
+               (#'discovery/load-config "config/adapter_claude_code/does-not-exist.edn"
+                                        [:k])
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= "config/adapter_claude_code/does-not-exist.edn"
+             (:config/resource (ex-data ex)))))))
+
+(deftest load-config-throws-on-missing-key-test
+  (testing "Present resource missing a required key raises an ex-info"
+    (let [ex (try
+               (#'discovery/load-config "config/adapter_claude_code/staleness.edn"
+                                        [:nope])
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= [:nope] (:config/missing-keys (ex-data ex)))))))
+
+(deftest staleness-windows-loads-test
+  (testing "Valid resource still loads the expected window keys"
+    (is (= #{:session-activity-window-ms :running-window-ms :idle-window-ms}
+           (set (keys discovery/staleness-windows))))))

--- a/docs/pull-requests/2026-06-20-refactor-adapter-claude-code-staleness-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-adapter-claude-code-staleness-config.md
@@ -1,0 +1,44 @@
+# refactor(adapter-claude-code): externalize session staleness windows to EDN
+
+## Overview
+
+Moves the three hardcoded session staleness windows in `adapter-claude-code`
+into a single EDN resource, in line with config-as-data (Dewey 007). Behavior
+is unchanged: the loaded integers equal the previous inline expressions.
+
+## Motivation
+
+Two source files carried staleness windows as inline arithmetic literals:
+
+- `discovery.clj` had `activity-threshold-ms (* 5 60 1000)` — the
+  session-liveness window.
+- `impl.clj`'s `poll-status` had `(* 60 1000)` (running-vs-idle) and
+  `(* 5 60 1000)` (running-vs-dead) inline at the call sites.
+
+These are tuning values, not algorithm constants, so they belong in data. The
+component already loads `tool-profiles.edn` from
+`resources/config/adapter_claude_code/`, so the loading pattern already exists
+here.
+
+## Changes
+
+- New resource `resources/config/adapter_claude_code/staleness.edn` — one
+  non-namespaced map with the three windows as computed integers
+  (`{:session-activity-window-ms 300000 :running-window-ms 60000
+  :idle-window-ms 300000}`), each with a `;; N min` comment. Apache-2.0 header
+  copied verbatim from the existing reliability defaults exemplar.
+- `discovery.clj` loads the map once at namespace load via `io/resource` +
+  `edn/read-string` into `staleness-windows`, and sources
+  `activity-threshold-ms` from `:session-activity-window-ms`.
+- `impl.clj`'s `poll-status` references
+  `(:running-window-ms discovery/staleness-windows)` and
+  `(:idle-window-ms discovery/staleness-windows)` in place of the inline
+  literals.
+
+## Verification
+
+- Load smoke: loaded windows equal the original expressions —
+  `activity-threshold-ms` = `(* 5 60 1000)`, `:running-window-ms` =
+  `(* 60 1000)`, `:idle-window-ms` = `(* 5 60 1000)`.
+- Isolated component tests: 21 tests, 68 assertions, 0 failures, 0 errors.
+- `bb poly:check`: OK.


### PR DESCRIPTION
## Overview

Moves the three hardcoded session staleness windows in `adapter-claude-code` into a single EDN resource, per config-as-data (Dewey 007). Behavior unchanged: the loaded integers equal the previous inline expressions.

## Motivation

`discovery.clj` had `activity-threshold-ms (* 5 60 1000)` (session-liveness window); `impl.clj`'s `poll-status` had `(* 60 1000)` (running-vs-idle) and `(* 5 60 1000)` (running-vs-dead) inline at the call sites. These are tuning values, not algorithm constants. The component already loads `tool-profiles.edn` from `resources/config/adapter_claude_code/`, so the loading pattern exists here.

## Changes

- New resource `resources/config/adapter_claude_code/staleness.edn` — one non-namespaced map (`{:session-activity-window-ms 300000 :running-window-ms 60000 :idle-window-ms 300000}`), computed integers with `;; N min` comments, Apache-2.0 header copied from the reliability defaults exemplar.
- `discovery.clj` loads the map at namespace load via `io/resource` + `edn/read-string` into `staleness-windows`; sources `activity-threshold-ms` from it.
- `impl.clj` references `(:running-window-ms discovery/staleness-windows)` and `(:idle-window-ms discovery/staleness-windows)` in place of the inline literals.

## Verification

- Load smoke: loaded windows equal originals.
- Isolated component tests: 21 tests, 68 assertions, 0 failures, 0 errors.
- `bb poly:check`: OK.
- Full pre-commit gate (317 tests / 1196 assertions + GraalVM compat): passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)