### PR TITLE
refactor(phase-deployment): externalize shell timeouts to EDN

### DIFF
--- a/components/phase-deployment/resources/config/phase-deployment/timeouts.edn
+++ b/components/phase-deployment/resources/config/phase-deployment/timeouts.edn
@@ -1,0 +1,28 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; Deployment shell command timeouts in milliseconds, tuned per environment by
+;; the operator. Keyed per use-site/tool.
+{:exec-default-ms 300000
+ :pulumi-default-ms 900000
+ :pulumi-outputs-ms 30000
+ :kubectl-default-ms 120000
+ :kustomize-build-ms 60000
+ :kustomize-apply-ms 120000
+ :health-check-ms 10000
+ :smoke-test-ms 30000}

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
@@ -21,8 +21,19 @@
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.schema.interface :as schema]
             [cheshire.core :as json]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Timeout configuration
+
+(def ^:private timeouts
+  "Deployment shell command timeouts (ms), loaded from EDN."
+  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
+    (edn/read-string (slurp resource))
+    {}))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Command result schemas + parsing
@@ -81,7 +92,7 @@
 (defn sh-with-timeout
   "Execute a shell command with timeout and structured results."
   [cmd args & {:keys [dir timeout-ms env]
-               :or {timeout-ms 300000}}]
+               :or {timeout-ms (get timeouts :exec-default-ms 300000)}}]
   (let [start-time (System/currentTimeMillis)
         full-cmd   (into [cmd] args)
         cmd-str    (str/join " " full-cmd)

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
@@ -19,21 +19,11 @@
 (ns ai.miniforge.phase-deployment.shell.exec
   "Shared deployment shell execution helpers."
   (:require [ai.miniforge.phase-deployment.messages :as msg]
+            [ai.miniforge.phase-deployment.shell.timeouts :as timeouts]
             [ai.miniforge.schema.interface :as schema]
             [cheshire.core :as json]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Timeout configuration
-
-(def ^:private timeouts
-  "Deployment shell command timeouts (ms), loaded from EDN."
-  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
-    (edn/read-string (slurp resource))
-    {}))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Command result schemas + parsing
@@ -92,7 +82,7 @@
 (defn sh-with-timeout
   "Execute a shell command with timeout and structured results."
   [cmd args & {:keys [dir timeout-ms env]
-               :or {timeout-ms (get timeouts :exec-default-ms 300000)}}]
+               :or {timeout-ms (get timeouts/timeouts :exec-default-ms 300000)}}]
   (let [start-time (System/currentTimeMillis)
         full-cmd   (into [cmd] args)
         cmd-str    (str/join " " full-cmd)

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kubectl.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kubectl.clj
@@ -19,17 +19,7 @@
 (ns ai.miniforge.phase-deployment.shell.kubectl
   "kubectl CLI wrappers for deployment phases."
   (:require [ai.miniforge.phase-deployment.shell.exec :as exec]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Timeout configuration
-
-(def ^:private timeouts
-  "kubectl command timeouts (ms), loaded from EDN."
-  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
-    (edn/read-string (slurp resource))
-    {}))
+            [ai.miniforge.phase-deployment.shell.timeouts :as timeouts]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; kubectl wrappers
@@ -37,7 +27,7 @@
 (defn kubectl!
   "Execute a kubectl command."
   [subcommand & {:keys [namespace context output extra-args timeout-ms]
-                 :or {timeout-ms (get timeouts :kubectl-default-ms 120000)}}]
+                 :or {timeout-ms (get timeouts/timeouts :kubectl-default-ms 120000)}}]
   (let [args (cond-> [subcommand]
                namespace  (into ["--namespace" namespace])
                context    (into ["--context" context])

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kubectl.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kubectl.clj
@@ -18,7 +18,18 @@
 
 (ns ai.miniforge.phase-deployment.shell.kubectl
   "kubectl CLI wrappers for deployment phases."
-  (:require [ai.miniforge.phase-deployment.shell.exec :as exec]))
+  (:require [ai.miniforge.phase-deployment.shell.exec :as exec]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Timeout configuration
+
+(def ^:private timeouts
+  "kubectl command timeouts (ms), loaded from EDN."
+  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
+    (edn/read-string (slurp resource))
+    {}))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; kubectl wrappers
@@ -26,7 +37,7 @@
 (defn kubectl!
   "Execute a kubectl command."
   [subcommand & {:keys [namespace context output extra-args timeout-ms]
-                 :or {timeout-ms 120000}}]
+                 :or {timeout-ms (get timeouts :kubectl-default-ms 120000)}}]
   (let [args (cond-> [subcommand]
                namespace  (into ["--namespace" namespace])
                context    (into ["--context" context])

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
@@ -20,19 +20,9 @@
   "Kustomize CLI wrappers for deployment phases."
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.phase-deployment.shell.exec :as exec]
-            [ai.miniforge.schema.interface :as schema]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io])
+            [ai.miniforge.phase-deployment.shell.timeouts :as timeouts]
+            [ai.miniforge.schema.interface :as schema])
   (:import [java.io File]))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Timeout configuration
-
-(def ^:private timeouts
-  "Kustomize command timeouts (ms), loaded from EDN."
-  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
-    (edn/read-string (slurp resource))
-    {}))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Kustomize wrappers
@@ -51,7 +41,7 @@
   (schema/validate KustomizeApplyResult result))
 
 (defn kustomize-build!
-  [kustomize-dir & {:keys [timeout-ms] :or {timeout-ms (get timeouts :kustomize-build-ms 60000)}}]
+  [kustomize-dir & {:keys [timeout-ms] :or {timeout-ms (get timeouts/timeouts :kustomize-build-ms 60000)}}]
   (exec/sh-with-timeout "kustomize" ["build" kustomize-dir] :timeout-ms timeout-ms))
 
 (defn kustomize-apply!
@@ -75,7 +65,7 @@
                                                 (-> (subvec apply-args 0 1)
                                                     (into ["-f" (.getAbsolutePath tmp-file)])
                                                     (into (subvec apply-args 3)))
-                                                :timeout-ms (get timeouts :kustomize-apply-ms 120000))]
+                                                :timeout-ms (get timeouts/timeouts :kustomize-apply-ms 120000))]
         (try
           (.delete tmp-file)
           (catch Exception _ nil))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
@@ -20,8 +20,19 @@
   "Kustomize CLI wrappers for deployment phases."
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.phase-deployment.shell.exec :as exec]
-            [ai.miniforge.schema.interface :as schema])
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io])
   (:import [java.io File]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Timeout configuration
+
+(def ^:private timeouts
+  "Kustomize command timeouts (ms), loaded from EDN."
+  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
+    (edn/read-string (slurp resource))
+    {}))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Kustomize wrappers
@@ -40,7 +51,7 @@
   (schema/validate KustomizeApplyResult result))
 
 (defn kustomize-build!
-  [kustomize-dir & {:keys [timeout-ms] :or {timeout-ms 60000}}]
+  [kustomize-dir & {:keys [timeout-ms] :or {timeout-ms (get timeouts :kustomize-build-ms 60000)}}]
   (exec/sh-with-timeout "kustomize" ["build" kustomize-dir] :timeout-ms timeout-ms))
 
 (defn kustomize-apply!
@@ -64,7 +75,7 @@
                                                 (-> (subvec apply-args 0 1)
                                                     (into ["-f" (.getAbsolutePath tmp-file)])
                                                     (into (subvec apply-args 3)))
-                                                :timeout-ms 120000)]
+                                                :timeout-ms (get timeouts :kustomize-apply-ms 120000))]
         (try
           (.delete tmp-file)
           (catch Exception _ nil))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/pulumi.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/pulumi.clj
@@ -18,7 +18,18 @@
 
 (ns ai.miniforge.phase-deployment.shell.pulumi
   "Pulumi CLI wrappers for deployment phases."
-  (:require [ai.miniforge.phase-deployment.shell.exec :as exec]))
+  (:require [ai.miniforge.phase-deployment.shell.exec :as exec]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Timeout configuration
+
+(def ^:private timeouts
+  "Pulumi command timeouts (ms), loaded from EDN."
+  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
+    (edn/read-string (slurp resource))
+    {}))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pulumi wrappers
@@ -36,7 +47,7 @@
         result (exec/sh-with-timeout "pulumi"
                                      args
                                      :dir stack-dir
-                                     :timeout-ms (or timeout-ms 900000)
+                                     :timeout-ms (or timeout-ms (get timeouts :pulumi-default-ms 900000))
                                      :env env)]
     (if json?
       (exec/with-parsed-json result)
@@ -68,7 +79,8 @@
   (let [args (cond-> ["stack" "output" "--json"]
                stack (into ["--stack" stack]))]
     (exec/with-parsed-json
-     (exec/sh-with-timeout "pulumi" args :dir stack-dir :timeout-ms 30000))))
+     (exec/sh-with-timeout "pulumi" args :dir stack-dir
+                           :timeout-ms (get timeouts :pulumi-outputs-ms 30000)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/pulumi.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/pulumi.clj
@@ -19,17 +19,7 @@
 (ns ai.miniforge.phase-deployment.shell.pulumi
   "Pulumi CLI wrappers for deployment phases."
   (:require [ai.miniforge.phase-deployment.shell.exec :as exec]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Timeout configuration
-
-(def ^:private timeouts
-  "Pulumi command timeouts (ms), loaded from EDN."
-  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
-    (edn/read-string (slurp resource))
-    {}))
+            [ai.miniforge.phase-deployment.shell.timeouts :as timeouts]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pulumi wrappers
@@ -47,7 +37,7 @@
         result (exec/sh-with-timeout "pulumi"
                                      args
                                      :dir stack-dir
-                                     :timeout-ms (or timeout-ms (get timeouts :pulumi-default-ms 900000))
+                                     :timeout-ms (or timeout-ms (get timeouts/timeouts :pulumi-default-ms 900000))
                                      :env env)]
     (if json?
       (exec/with-parsed-json result)
@@ -80,7 +70,7 @@
                stack (into ["--stack" stack]))]
     (exec/with-parsed-json
      (exec/sh-with-timeout "pulumi" args :dir stack-dir
-                           :timeout-ms (get timeouts :pulumi-outputs-ms 30000)))))
+                           :timeout-ms (get timeouts/timeouts :pulumi-outputs-ms 30000)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/timeouts.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/timeouts.clj
@@ -1,0 +1,50 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-deployment.shell.timeouts
+  "Deployment shell command timeouts (ms), loaded from EDN.
+
+   Load is tolerant: a missing, unreadable, malformed, or non-map resource
+   yields {} so that call-site literal defaults remain authoritative
+   (fail-open). Never throws at namespace load."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Tolerant loader
+
+(defn- load-timeouts
+  "Read the timeouts EDN, returning {} if the resource is absent,
+   unreadable, malformed, or not a map — so call-site literal defaults
+   remain authoritative (fail-open)."
+  [path]
+  (try
+    (let [url    (io/resource path)
+          parsed (when url (edn/read-string (slurp url)))]
+      (if (map? parsed) parsed {}))
+    (catch Exception _ {})))
+
+(def timeouts
+  "Validated timeout map; {} when the EDN resource is unusable."
+  (load-timeouts "config/phase-deployment/timeouts.edn"))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (load-timeouts "config/phase-deployment/timeouts.edn")
+  (load-timeouts "config/phase-deployment/does-not-exist.edn")
+  :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/validate.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/validate.clj
@@ -25,8 +25,19 @@
             [ai.miniforge.phase-deployment.shell :as shell]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.schema.interface :as schema]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.string :as str])
   (:import [java.net HttpURLConnection URL]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Timeout configuration
+
+(def ^:private timeouts
+  "Validation command timeouts (ms), loaded from EDN."
+  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
+    (edn/read-string (slurp resource))
+    {}))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Defaults + schemas
@@ -143,7 +154,7 @@
 
 (defn- http-health-check
   "Execute an HTTP health check against an endpoint."
-  [url & {:keys [timeout-ms] :or {timeout-ms 10000}}]
+  [url & {:keys [timeout-ms] :or {timeout-ms (get timeouts :health-check-ms 10000)}}]
   (let [start (System/currentTimeMillis)]
     (try
       (let [conn (doto ^HttpURLConnection (.openConnection (URL. url))
@@ -183,7 +194,8 @@
   [commands]
   (let [results (mapv (fn [cmd]
                         (let [[bin & args] (str/split cmd #"\s+")
-                              result (shell/sh-with-timeout bin (vec args) :timeout-ms 30000)]
+                              result (shell/sh-with-timeout bin (vec args)
+                                                            :timeout-ms (get timeouts :smoke-test-ms 30000))]
                           (smoke-test-result cmd result)))
                       commands)]
     (batch-result SmokeTestResult results)))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/validate.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/validate.clj
@@ -23,21 +23,11 @@
             [ai.miniforge.phase-deployment.evidence :as evidence]
             [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.phase-deployment.shell :as shell]
+            [ai.miniforge.phase-deployment.shell.timeouts :as timeouts]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.schema.interface :as schema]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]
             [clojure.string :as str])
   (:import [java.net HttpURLConnection URL]))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Timeout configuration
-
-(def ^:private timeouts
-  "Validation command timeouts (ms), loaded from EDN."
-  (if-let [resource (io/resource "config/phase-deployment/timeouts.edn")]
-    (edn/read-string (slurp resource))
-    {}))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Defaults + schemas
@@ -154,7 +144,7 @@
 
 (defn- http-health-check
   "Execute an HTTP health check against an endpoint."
-  [url & {:keys [timeout-ms] :or {timeout-ms (get timeouts :health-check-ms 10000)}}]
+  [url & {:keys [timeout-ms] :or {timeout-ms (get timeouts/timeouts :health-check-ms 10000)}}]
   (let [start (System/currentTimeMillis)]
     (try
       (let [conn (doto ^HttpURLConnection (.openConnection (URL. url))
@@ -195,7 +185,7 @@
   (let [results (mapv (fn [cmd]
                         (let [[bin & args] (str/split cmd #"\s+")
                               result (shell/sh-with-timeout bin (vec args)
-                                                            :timeout-ms (get timeouts :smoke-test-ms 30000))]
+                                                            :timeout-ms (get timeouts/timeouts :smoke-test-ms 30000))]
                           (smoke-test-result cmd result)))
                       commands)]
     (batch-result SmokeTestResult results)))

--- a/docs/pull-requests/2026-06-20-refactor-phase-deployment-timeouts-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-phase-deployment-timeouts-config.md
@@ -1,0 +1,49 @@
+# Externalize phase-deployment shell timeouts to EDN
+
+## Overview
+
+The `phase-deployment` component carried deployment-tool timeout values as bare
+integer literals at each shell call site. This change moves those values into a
+single EDN resource and loads them at namespace load time, leaving the original
+literals in place as in-code fallbacks.
+
+## Motivation
+
+Deployment-tool timeouts (Pulumi, kubectl, kustomize, HTTP health checks, smoke
+tests) are operational values an operator tunes per environment. Holding them as
+data in a resource file, rather than scattered code literals, satisfies the
+config-as-data rule (Dewey 007) and gives one place to read or adjust them.
+
+## Changes
+
+- Add `components/phase-deployment/resources/config/phase-deployment/timeouts.edn`:
+  one non-namespaced map keyed per use-site/tool.
+- In `shell/exec.clj`, `shell/pulumi.clj`, `shell/kubectl.clj`,
+  `shell/kustomize.clj`, and `validate.clj`, add a private `timeouts` def that
+  loads the EDN via `io/resource` + `edn/read-string`, and replace each timeout
+  literal with `(get timeouts :key <literal>)`. The literal remains as the
+  fallback when the resource is absent.
+
+Key-to-literal mapping (values unchanged):
+
+- `:exec-default-ms` 300000 — `sh-with-timeout` default
+- `:pulumi-default-ms` 900000 — `pulumi!` default
+- `:pulumi-outputs-ms` 30000 — `pulumi-outputs!` stack output
+- `:kubectl-default-ms` 120000 — `kubectl!` default
+- `:kustomize-build-ms` 60000 — `kustomize-build!` default
+- `:kustomize-apply-ms` 120000 — kustomize apply via kubectl
+- `:health-check-ms` 10000 — HTTP health check
+- `:smoke-test-ms` 30000 — smoke test command
+
+The `resources` path was already present on the component `deps.edn` `:paths`,
+so no path wiring was needed.
+
+`evidence.clj` content-hash `sha256:` strings are protocol values, not config,
+and were left untouched.
+
+## Verification
+
+- Load smoke test: each loaded EDN value equals its original literal (all eight
+  match).
+- Isolated component tests: 47 tests, 120 assertions, 0 failures, 0 errors.
+- `bb poly:check`: OK.


### PR DESCRIPTION
## Overview

Move `phase-deployment` deployment-tool timeout literals into a single EDN
resource, loaded at namespace load time, with the original literals kept as
in-code fallbacks. Config-as-data (Dewey 007). Behavior-preserving.

## Changes

- Add `components/phase-deployment/resources/config/phase-deployment/timeouts.edn`
  (one non-namespaced map keyed per use-site/tool).
- `shell/exec.clj`, `shell/pulumi.clj`, `shell/kubectl.clj`,
  `shell/kustomize.clj`, `validate.clj`: private `timeouts` def loads the EDN
  via `io/resource` + `edn/read-string`; each literal replaced with
  `(get timeouts :key <literal>)`.

Values unchanged: exec-default 300000, pulumi-default 900000, pulumi-outputs
30000, kubectl-default 120000, kustomize-build 60000, kustomize-apply 120000,
health-check 10000, smoke-test 30000.

`evidence.clj` `sha256:` strings are protocol values, not config; untouched.
`resources` was already on the component `deps.edn` `:paths`.

## Verification

- Load smoke test: all eight loaded values equal their original literals.
- Isolated component tests: 47 tests, 120 assertions, 0 failures, 0 errors.
- `bb poly:check`: OK.
- Full pre-commit gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)