### PR TITLE
feat(phase): complete the phase-outcome authority — emit :skipped, route leave-handlers, fix resume

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -859,9 +859,8 @@
             (assoc-in [:phase :skipped-reason] :already-implemented))]
       ;; Emit phase-completed telemetry with termination reason
       (phase/emit-phase-completed! final-ctx :implement
-        (merge {:outcome     (if (contains? #{:completed :already-implemented} phase-status)
-                               :success
-                               :failure)
+        (merge {:outcome     (phase/outcome result
+                                            (contains? #{:completed :already-implemented} phase-status))
                 :duration-ms duration-ms
                 :tokens      (get metrics :tokens 0)}
                (phase-terminal/derive-termination-reason

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -235,7 +235,7 @@
     ;; Emit phase-completed with the REAL outcome — never a false :success on a
     ;; failure result (that produced the ✓-then-✗ double-emit).
     (phase/emit-phase-completed! updated-ctx :plan
-      (merge {:outcome     (if succeeded-or-done? :success :failure)
+      (merge {:outcome     (phase/outcome result succeeded-or-done?)
               :duration-ms duration-ms
               :tokens      (get metrics :tokens 0)}
              (phase-terminal/derive-termination-reason result nil)))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -547,7 +547,7 @@
                 (assoc-in [:phase :last-error]
                           (get-in result [:error :message] (messages/t :release/phase-failed)))))
       (phase/emit-phase-completed! :release
-        (merge {:outcome     (if (= :completed phase-status) :success :failure)
+        (merge {:outcome     (phase/outcome result (= :completed phase-status))
                 :duration-ms duration-ms
                 :tokens      (:tokens metrics 0)}
                (phase-terminal/derive-termination-reason result nil))))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -434,7 +434,7 @@
     (phase/emit-phase-completed! next-ctx :review
       ;; :outcome from the FINAL (verdict-corrected) status, not phase-status:
       ;; apply-verdict promotes :accept-with-warnings to :completed.
-      (merge {:outcome     (if (= :completed (get-in next-ctx [:phase :status])) :success :failure)
+      (merge {:outcome     (phase/outcome result (= :completed (get-in next-ctx [:phase :status])))
               :duration-ms duration-ms
               :tokens      (:tokens metrics 0)}
              (phase-terminal/derive-termination-reason result nil)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -471,7 +471,7 @@
                    :else
                    updated-ctx)]
     (phase/emit-phase-completed! next-ctx :verify
-      (merge {:outcome     (if (= :completed phase-status) :success :failure)
+      (merge {:outcome     (phase/outcome result (= :completed phase-status))
               :duration-ms duration-ms
               :tokens      (get metrics :tokens 0)}
              (phase-terminal/derive-termination-reason result

--- a/components/phase/src/ai/miniforge/phase/phase_result.clj
+++ b/components/phase/src/ai/miniforge/phase/phase_result.clj
@@ -85,6 +85,16 @@
   (= redirect-transition-type
      (get-in result [transition-request-key transition-type-key])))
 
+(defn skipped?
+  "True when a phase result is a skip — the phase short-circuited because its
+   work was already done. The marker lives on the result's :output. This checks
+   both the bare result (as a leave-handler holds it) and the result nested
+   under :result (as the event builder receives it), so the same predicate
+   answers on either emission path."
+  [result]
+  (boolean (or (get-in result [:output :skipped])
+               (get-in result [:result :output :skipped]))))
+
 (defn outcome
   "Resolve a completed phase's typed act — the one derivation of the
    :phase/outcome value from a phase result and a success verdict.
@@ -95,13 +105,15 @@
    it in keeps this function a pure reduction over the result's own markers.
 
    Precedence is deliberate: a refusal dominates any other act; an outright
-   failure dominates a pending redirect; a phase that did its work but hands
-   control elsewhere is :redirected. This is the only place the precedence is
-   decided — the event stream and the views read the result, never re-derive it."
+   failure dominates the rest; a phase that short-circuited because its work was
+   already done is :skipped; a phase that did its work but hands control
+   elsewhere is :redirected. This is the only place the precedence is decided —
+   the event stream and the views read the result, never re-derive it."
   [result succeeded-verdict?]
   (cond
     (blocked? result)            :blocked
     (not succeeded-verdict?)     :failure
+    (skipped? result)            :skipped
     (redirect-requested? result) :redirected
     :else                        :success))
 

--- a/components/phase/test/ai/miniforge/phase/phase_result_test.clj
+++ b/components/phase/test/ai/miniforge/phase/phase_result_test.clj
@@ -51,3 +51,21 @@
   (testing "an outright failure dominates a pending redirect"
     (let [result (pr/request-redirect (pr/success "env-1" "done") :verify)]
       (is (= :failure (pr/outcome result false))))))
+
+(deftest outcome-skipped-test
+  (testing "a skipped phase reports :skipped"
+    (is (= :skipped (pr/outcome (pr/skipped :already-implemented) true))))
+  (testing "a skip nested under :result (event-builder shape) is detected"
+    (is (= :skipped (pr/outcome {:status :completed
+                                 :result (pr/skipped :already-implemented)}
+                                true))))
+  (testing "an outright failure still dominates a skip-shaped result"
+    (is (= :failure (pr/outcome (pr/skipped :already-implemented) false)))))
+
+(deftest skipped?-predicate-test
+  (testing "true for a bare skip result and for one nested under :result"
+    (is (pr/skipped? (pr/skipped :already-implemented)))
+    (is (pr/skipped? {:result (pr/skipped :already-implemented)})))
+  (testing "false for plain success/error results"
+    (is (not (pr/skipped? (pr/success "env-1" "done"))))
+    (is (not (pr/skipped? (pr/error "env-1" "boom" "boom" {}))))))

--- a/components/workflow-resume/resources/config/workflow-resume/resume.edn
+++ b/components/workflow-resume/resources/config/workflow-resume/resume.edn
@@ -1,6 +1,7 @@
 {:workflow-resume/resume
  {:completed-phase-statuses #{:completed
                               :success
+                              :skipped
                               :succeeded
                               :already-implemented
                               :already-satisfied}

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -105,11 +105,19 @@
     {:completed-task-ids (set (:dag/completed-task-ids pause-event))
      :pause-reason (:dag/pause-reason pause-event)}))
 
+(def completed-outcomes
+  "Phase outcomes that count as completed for resume — the phase finished its
+   work, so resume trims it from the pipeline rather than re-running it.
+   :success did the work; :skipped short-circuited because the work was already
+   done. :failure re-runs (it is excluded); :blocked and :redirected have no
+   producer yet, so they too fall outside this set and would re-run."
+  #{:success :skipped})
+
 (defn extract-completed-phases
   [events]
   (->> events
        (filter #(= :workflow/phase-completed (:event/type %)))
-       (filter #(= :success (:phase/outcome %)))
+       (filter #(contains? completed-outcomes (:phase/outcome %)))
        (mapv :workflow/phase)))
 
 (defn extract-phase-results

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
@@ -83,9 +83,9 @@
   core/extract-dag-pause-info)
 
 (def extract-completed-phases
-  "Phase names (keywords) that completed with `:success` outcome.
-   Arg: a sequence of events. Returns a vector of phase keywords in
-   event order."
+  "Phase names (keywords) that completed — `:success` or `:skipped` outcome
+   (see `core/completed-outcomes`). Arg: a sequence of events. Returns a vector
+   of phase keywords in event order."
   core/extract-completed-phases)
 
 (def extract-phase-results

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -43,15 +43,18 @@
       (is (false? (core/paused? running))))))
 
 (deftest extract-completed-phases-test
-  (testing "only :phase-completed events with :success outcome are collected"
+  (testing ":success and :skipped count as completed; :failure does not"
     (let [events [{:event/type :workflow/started}
                   {:event/type :workflow/phase-completed
                    :workflow/phase :explore :phase/outcome :success}
                   {:event/type :workflow/phase-completed
                    :workflow/phase :plan :phase/outcome :success}
                   {:event/type :workflow/phase-completed
+                   :workflow/phase :release :phase/outcome :skipped}
+                  {:event/type :workflow/phase-completed
                    :workflow/phase :implement :phase/outcome :failure}]]
-      (is (= [:explore :plan] (core/extract-completed-phases events))))))
+      (is (= [:explore :plan :release] (core/extract-completed-phases events))
+          "a :skipped phase is completed (not re-run); a :failure is omitted"))))
 
 (deftest extract-phase-results-test
   (testing "builds {phase → {:outcome :duration-ms :timestamp}}"

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -369,12 +369,17 @@
                        "~:workflow/phase" "~:plan"
                        "~:phase/outcome" "~:success"
                        "~:phase/duration-ms" 456})
+        ;; release skipped; should appear in completed-phases
+        (write-event! wf-dir "20260421T000003Z-r.json"
+                      {"~:event/type" "~:workflow/phase-completed"
+                       "~:workflow/phase" "~:release"
+                       "~:phase/outcome" "~:skipped"})
         ;; implement failed — should NOT appear in completed-phases
-        (write-event! wf-dir "20260421T000003Z-i.json"
+        (write-event! wf-dir "20260421T000004Z-i.json"
                       {"~:event/type" "~:workflow/phase-completed"
                        "~:workflow/phase" "~:implement"
                        "~:phase/outcome" "~:failure"})
-        (write-event! wf-dir "20260421T000004Z-w.json"
+        (write-event! wf-dir "20260421T000005Z-w.json"
                       {"~:event/type" "~:workspace/persisted"
                        "~:workspace/branch" "task-resume"
                        "~:workspace/bundle-path" "/tmp/task-resume.bundle"
@@ -383,8 +388,8 @@
                        "~:workflow/phase" "~:review"})
         (testing "reconstructs context from per-event JSON files"
           (let [ctx (core/reconstruct-context base-dir wf-id)]
-            (is (= [:explore :plan] (:completed-phases ctx)))
-            (is (= 5 (:event-count ctx)))
+            (is (= [:explore :plan :release] (:completed-phases ctx)))
+            (is (= 6 (:event-count ctx)))
             (is (false? (:completed? ctx)))
             (is (false? (:failed? ctx)))
             (is (= wf-id (:workflow-id ctx)))
@@ -392,6 +397,7 @@
                    (:workflow-spec ctx)))
             (is (= 123 (get-in ctx [:phase-results :explore :duration-ms])))
             (is (= :success (get-in ctx [:phase-results :plan :outcome])))
+            (is (= :skipped (get-in ctx [:phase-results :release :outcome])))
             (is (= {:branch "task-resume"
                     :bundle-path "/tmp/task-resume.bundle"
                     :commit-sha "abc123"

--- a/components/workflow/test/ai/miniforge/workflow/phase_outcome_from_inner_result_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_outcome_from_inner_result_test.clj
@@ -80,6 +80,14 @@
         (is (= :failure (:phase/outcome evt)))
         (is (= {:message "boom"} (:phase/error evt)))))))
 
+(deftest skipped-result-reports-skipped
+  (testing "a phase that short-circuited (skip marker on inner :result) → :skipped"
+    (is (= :skipped
+           (:outcome (build {:name :release :status :completed
+                             :result {:status :success
+                                      :output {:skipped true
+                                               :reason :already-implemented}}}))))))
+
 (deftest error-attached-at-phase-error-surfaces-test
   (testing "[:phase :error] is read when nothing higher carries the payload"
     ;; Regression: error-* interceptors that fall through to

--- a/docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md
+++ b/docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md
@@ -1,0 +1,104 @@
+# feat(phase): complete the phase-outcome authority — emit :skipped, route leave-handlers, fix resume
+
+## Overview
+
+Follow-up to #1243, which made `phase/outcome` the single derivation of a
+phase's typed act but left two gaps noted in its PR doc. This closes both:
+
+1. The five phase leave-handlers still built `:outcome` inline rather than
+   reading the authority.
+2. `:skipped` was schema-allowed and consumer-handled but never produced — a
+   skipped phase reported `:success`, and resume filtered on `:success` only.
+
+## Motivation
+
+After #1243 the act derived in one place for the generic event path (Path A,
+`runner-events`), but the per-phase leave-handlers (Path B,
+`emit-phase-completed!`) each still computed `:outcome` as
+`(if <verdict> :success :failure)`. That left the vocabulary split across six
+sites and meant `:skipped` could never surface: release short-circuits with a
+`phase/skipped` result, but its inline emit reported `:success`, and
+`workflow-resume` treated only `:success` as completed.
+
+## Changes in Detail
+
+### `phase/outcome` recognizes skip (`components/phase`)
+
+- New `skipped?` predicate reads the `:output` skip marker on the bare result
+  and on the result nested under `:result`, so it answers on either emission
+  path (leave-handler holds the bare result; the event builder receives it
+  nested). `phase/outcome` gains a `:skipped` branch:
+  refusal > failure > skipped > redirected > success. Kept internal to the
+  component — only `phase/outcome` consumes it.
+
+### Leave-handlers read the authority (`components/phase-software-factory`)
+
+- verify, review, implement, plan, release now call
+  `(phase/outcome result <verdict>)` instead of an inline
+  `(if <verdict> :success :failure)`. Each still computes its own success
+  verdict and passes it in.
+
+### Resume respects `:skipped` (`components/workflow-resume`)
+
+- `extract-completed-phases` filtered on `:success`; it now filters against a
+  named `completed-outcomes` set (`#{:success :skipped}`), so a skipped phase is
+  trimmed from the pipeline on resume instead of re-executed.
+
+## Behavior Change
+
+- A skipped phase (today, only release when there is nothing to release) now
+  reports `:phase/outcome :skipped` on its completion event instead of
+  `:success`. Consumers already render `:skipped` (cli display, tui-views
+  persistence). Resume counts it as completed. No other observable change.
+
+## Scope Notes
+
+- **`:blocked` and `:redirected` have no producers.** `phase/blocked` is called
+  nowhere, and the redirect calls were removed in favor of FSM-verdict handling
+  (see the comments at release.clj, review.clj, verify.clj). Routing the four
+  non-skip leave-handlers is therefore behavior-neutral today; it unifies the
+  vocabulary and means those acts would surface automatically if a phase ever
+  produces them. The dead values are left in the schema and the resume set's
+  exclusion (they would re-run) rather than removed — that is #1243's contract,
+  not this PR's to retract.
+- The `:status` FSM flag is unchanged, consistent with #1243.
+
+## Testing Plan
+
+- New: `phase-result` `outcome-skipped-test` and `skipped?-predicate-test`;
+  a `skipped-result-reports-skipped` case in
+  `phase-outcome-from-inner-result-test` (Path A emits `:skipped`); a `:skipped`
+  case in `workflow-resume` `extract-completed-phases-test`.
+- Regression: the five leave-handler namespaces compile; the smoke set (316
+  tests) is green on every commit; `clj-kondo` clean (two pre-existing
+  `verdicts` unused-private warnings in verify/release are non-fatal and out of
+  scope).
+- Verified: `bb pre-commit` green per commit; `bb poly:check` OK; each commit
+  under the 200-line budget.
+
+## Deployment Plan
+
+Product is unreleased — no compatibility shims. The only behavior change is a
+more accurate outcome on skipped phases, which existing consumers and resume
+already handle. No data migration.
+
+## PR Layering
+
+Three commits, each independently valid and under the budget:
+
+1. `feat(phase)` — `phase/outcome` recognizes skip + tests.
+2. `refactor(phase-software-factory)` — route the five leave-handlers.
+3. `fix(workflow-resume)` — `:skipped` counts as completed + test.
+
+## Related
+
+- Predecessor: #1243 (the phase-outcome authority); this completes its two
+  noted follow-ups.
+
+## Checklist
+
+- [x] `skipped?` + `:skipped` branch in `phase/outcome` + tests
+- [x] Five leave-handlers routed through `phase/outcome`
+- [x] Resume treats `:skipped` as completed + test
+- [x] `clj-kondo` clean, `poly check` OK, commit budget respected
+- [ ] Push and open PR (awaiting approval)

--- a/docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md
+++ b/docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md
@@ -43,6 +43,9 @@ sites and meant `:skipped` could never surface: release short-circuits with a
 - `extract-completed-phases` filtered on `:success`; it now filters against a
   named `completed-outcomes` set (`#{:success :skipped}`), so a skipped phase is
   trimmed from the pipeline on resume instead of re-executed.
+- The resume config's completed status set also includes `:skipped`, so the
+  reconstructed context path trims skipped phases consistently with the
+  extractor path.
 
 ## Behavior Change
 
@@ -68,7 +71,9 @@ sites and meant `:skipped` could never surface: release short-circuits with a
 - New: `phase-result` `outcome-skipped-test` and `skipped?-predicate-test`;
   a `skipped-result-reports-skipped` case in
   `phase-outcome-from-inner-result-test` (Path A emits `:skipped`); a `:skipped`
-  case in `workflow-resume` `extract-completed-phases-test`.
+  case in `workflow-resume` `extract-completed-phases-test`; and a
+  `reconstruct-context` integration case proving skipped phase-completion events
+  are trimmed by the config-backed resume path.
 - Regression: the five leave-handler namespaces compile; the smoke set (316
   tests) is green on every commit; `clj-kondo` clean (two pre-existing
   `verdicts` unused-private warnings in verify/release are non-fatal and out of
@@ -101,4 +106,4 @@ Three commits, each independently valid and under the budget:
 - [x] Five leave-handlers routed through `phase/outcome`
 - [x] Resume treats `:skipped` as completed + test
 - [x] `clj-kondo` clean, `poly check` OK, commit budget respected
-- [ ] Push and open PR (awaiting approval)
+- [x] Push and open PR


### PR DESCRIPTION
Follow-up to #1243, which made `phase/outcome` the single derivation of a phase's typed act but left two gaps. This closes both.

## Changes

- **`feat(phase)`** — `phase/outcome` recognizes the skip act. New `skipped?` predicate (reads the `:output` skip marker on the bare result and the result nested under `:result`, covering both emission shapes); `:skipped` added to the precedence: refusal > failure > skipped > redirected > success. Kept internal to the component.
- **`refactor(phase-software-factory)`** — the five leave-handlers (verify, review, implement, plan, release) now call `(phase/outcome result <verdict>)` instead of an inline `(if <verdict> :success :failure)`. Each still computes its own verdict.
- **`fix(workflow-resume)`** — `extract-completed-phases` filtered on `:success`; now filters against a named `completed-outcomes` set (`#{:success :skipped}`) so a skipped phase is trimmed on resume, not re-run.

Net: 12 files, +168 −16. Full write-up: `docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md`.

## Behavior change

A skipped phase (today, only release when there's nothing to release) now reports `:phase/outcome :skipped` instead of `:success`. Consumers (cli display, tui-views persistence) already render `:skipped`; resume counts it as completed.

## Scope notes

- **`:blocked` and `:redirected` have no producers** — `phase/blocked` is called nowhere, and the redirect calls were removed in favor of FSM-verdict handling (comments at release/review/verify). Routing the four non-skip leave-handlers is therefore behavior-neutral today; it unifies the vocabulary and future-proofs those acts. The dead values stay in the schema (that's #1243's contract) and outside the resume set (they'd re-run).
- `:status` FSM flag unchanged, per #1243.
- Two pre-existing `verdicts` unused-private-var warnings in verify/release are non-fatal and out of scope.

## Testing

- New `:skipped` cases in `phase-result-test`, `phase-outcome-from-inner-result-test` (Path A), and `workflow-resume` `extract-completed-phases-test`; the five leave-handlers compile; smoke set (316 tests) green per commit.
- `clj-kondo` clean (modulo the noted pre-existing warnings); `bb poly:check` OK; each commit under the 200-line budget.

Product is unreleased — no compatibility shims; the only behavior change is a more accurate outcome on skipped phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)