### PR TITLE
refactor(agent): externalize curator/meta-eval/heartbeat tuning to config

### DIFF
--- a/components/agent/resources/config/agent/agent-llm-defaults.edn
+++ b/components/agent/resources/config/agent/agent-llm-defaults.edn
@@ -16,9 +16,16 @@
 ;;   nothing — 32000 is a heuristic unblocker.
 ;; - reviewer/implementer max-tokens are bumped so structured output isn't
 ;;   truncated.
+;;
+;; :curator is not a role in the create-{role} sense; it is the curator's
+;; LLM-enrichment call site, whose tuning previously lived inline. It carries
+;; the same {:temperature :max-tokens} shape as the role entries and reads
+;; its config through the same loader. The meta-evaluator call site has a
+;; different shape (no :temperature) and lives in meta-eval-tuning.edn.
 
 {:planner     {:temperature 0.3 :max-tokens 32000}
  :implementer {:temperature 0.2 :max-tokens 32000}
  :releaser    {:temperature 0.3 :max-tokens 2000}
  :tester      {:temperature 0.2 :max-tokens 6000}
- :reviewer    {:temperature 0.1 :max-tokens 16000}}
+ :reviewer    {:temperature 0.1 :max-tokens 16000}
+ :curator     {:temperature 0.1 :max-tokens 800}}

--- a/components/agent/resources/config/agent/meta-eval-tuning.edn
+++ b/components/agent/resources/config/agent/meta-eval-tuning.edn
@@ -1,0 +1,8 @@
+;; Tuning for the meta-evaluator LLM call (meta_evaluator.clj/evaluate).
+;;
+;; Loaded at namespace load. The meta-evaluator makes a single focused
+;; call (~500 input tokens, ~100 output tokens) to judge tool-use
+;; relevance. Only :max-tokens is set; the call site does not pass a
+;; temperature.
+
+{:max-tokens 150}

--- a/components/agent/resources/config/agent/supervisory-bridge.edn
+++ b/components/agent/resources/config/agent/supervisory-bridge.edn
@@ -1,0 +1,9 @@
+;; Tuning for the supervisory bridge (supervisory_bridge.clj).
+;;
+;; Loaded at namespace load. Each value has a named in-code fallback
+;; constant; this file overrides it when present.
+;;
+;; - :heartbeat-interval-ms — interval between heartbeat events emitted for
+;;   direct in-process agents bridged into the control-plane event family.
+
+{:heartbeat-interval-ms 30000}

--- a/components/agent/src/ai/miniforge/agent/curator.clj
+++ b/components/agent/src/ai/miniforge/agent/curator.clj
@@ -61,6 +61,7 @@
   (:require
    [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.repo-index.interface :as messages]
    [ai.miniforge.response.interface :as response]
@@ -358,9 +359,8 @@
   [llm-client system-prompt user-prompt]
   (try
     (let [result (llm/chat llm-client user-prompt
-                           {:system system-prompt
-                            :temperature 0.1
-                            :max-tokens 800})]
+                           (merge (role-config/agent-llm-default :curator)
+                                  {:system system-prompt}))]
       (when (llm/success? result)
         (parse-llm-response (llm/get-content result))))
     (catch Exception _ nil)))

--- a/components/agent/src/ai/miniforge/agent/meta_evaluator.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_evaluator.clj
@@ -29,11 +29,26 @@
    - Budget: ~500 input tokens, ~100 output tokens per call"
   (:require
    [cheshire.core :as json]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.llm.interface :as llm]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Prompt construction
+;; Tuning config and prompt construction
+
+(def ^:private fallback-eval-tuning
+  "In-code fallback used when config/agent/meta-eval-tuning.edn is absent."
+  {:max-tokens 150})
+
+(def ^:private eval-tuning
+  "Per-call tuning (currently :max-tokens) for the meta-evaluator LLM call.
+   Loaded from config/agent/meta-eval-tuning.edn at ns load, falling back
+   to fallback-eval-tuning."
+  (or (some-> (io/resource "config/agent/meta-eval-tuning.edn")
+              slurp
+              edn/read-string)
+      fallback-eval-tuning))
 
 (def system-prompt
   "You are a tool-use quality evaluator for a software engineering agent.
@@ -118,9 +133,9 @@ Respond with ONLY a JSON object, no other text:
   (try
     (let [llm-client (:llm-client opts)
           prompt (build-eval-prompt context)
-          request {:prompt prompt
-                   :system system-prompt
-                   :max-tokens 150}
+          request (merge eval-tuning
+                         {:prompt prompt
+                          :system system-prompt})
           response (llm/complete llm-client request)]
       (if (:success response)
         (parse-eval-response (:content response))

--- a/components/agent/src/ai/miniforge/agent/meta_evaluator.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_evaluator.clj
@@ -41,14 +41,22 @@
   "In-code fallback used when config/agent/meta-eval-tuning.edn is absent."
   {:max-tokens 150})
 
+(defn- load-config-or
+  "Read an EDN config resource, returning `fallback` if the resource is
+   absent, unreadable, malformed, or not a map — preserving fail-open
+   behavior."
+  [path fallback]
+  (try
+    (let [url    (io/resource path)
+          parsed (when url (edn/read-string (slurp url)))]
+      (if (map? parsed) parsed fallback))
+    (catch Exception _ fallback)))
+
 (def ^:private eval-tuning
   "Per-call tuning (currently :max-tokens) for the meta-evaluator LLM call.
    Loaded from config/agent/meta-eval-tuning.edn at ns load, falling back
    to fallback-eval-tuning."
-  (or (some-> (io/resource "config/agent/meta-eval-tuning.edn")
-              slurp
-              edn/read-string)
-      fallback-eval-tuning))
+  (load-config-or "config/agent/meta-eval-tuning.edn" fallback-eval-tuning))
 
 (def system-prompt
   "You are a tool-use quality evaluator for a software engineering agent.

--- a/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
+++ b/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
@@ -45,14 +45,24 @@
    or omits :heartbeat-interval-ms."
   30000)
 
+(defn- load-config-or
+  "Read an EDN config resource, returning `fallback` if the resource is
+   absent, unreadable, malformed, or not a map — preserving fail-open
+   behavior."
+  [path fallback]
+  (try
+    (let [url    (io/resource path)
+          parsed (when url (edn/read-string (slurp url)))]
+      (if (map? parsed) parsed fallback))
+    (catch Exception _ fallback)))
+
 (def ^:private default-heartbeat-interval-ms
   "Interval between heartbeat events for direct in-process agents. Loaded
    from config/agent/supervisory-bridge.edn at ns load, falling back to
    fallback-heartbeat-interval-ms."
-  (or (some-> (io/resource "config/agent/supervisory-bridge.edn")
-              slurp
-              edn/read-string
-              :heartbeat-interval-ms)
+  (or (:heartbeat-interval-ms
+       (load-config-or "config/agent/supervisory-bridge.edn"
+                       {:heartbeat-interval-ms fallback-heartbeat-interval-ms}))
       fallback-heartbeat-interval-ms))
 
 (def ^:private agent-session-namespace

--- a/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
+++ b/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
@@ -26,7 +26,9 @@
   when a workflow event-stream is present."
   (:require
    [ai.miniforge.agent.core :as core]
-   [ai.miniforge.event-stream.interface :as events])
+   [ai.miniforge.event-stream.interface :as events]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io])
   (:import
    (java.nio ByteBuffer)
    (java.security MessageDigest)
@@ -38,8 +40,20 @@
 (def ^:private direct-agent-vendor
   :miniforge)
 
-(def ^:private default-heartbeat-interval-ms
+(def ^:private fallback-heartbeat-interval-ms
+  "In-code fallback used when config/agent/supervisory-bridge.edn is absent
+   or omits :heartbeat-interval-ms."
   30000)
+
+(def ^:private default-heartbeat-interval-ms
+  "Interval between heartbeat events for direct in-process agents. Loaded
+   from config/agent/supervisory-bridge.edn at ns load, falling back to
+   fallback-heartbeat-interval-ms."
+  (or (some-> (io/resource "config/agent/supervisory-bridge.edn")
+              slurp
+              edn/read-string
+              :heartbeat-interval-ms)
+      fallback-heartbeat-interval-ms))
 
 (def ^:private agent-session-namespace
   (UUID/fromString "4882f381-e57d-582f-95ab-3a9b36e11df8"))

--- a/docs/pull-requests/2026-06-20-refactor-agent-llm-call-tuning-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-agent-llm-call-tuning-config.md
@@ -1,0 +1,57 @@
+# refactor(agent): externalize curator/meta-eval/heartbeat tuning to config
+
+## Overview
+
+Three LLM-call / timing constants in the `agent` component were hard-coded at
+their call sites, escaping the component's existing config-as-data path. This
+change moves them into EDN resources, leaving an in-code fallback for the
+heartbeat and meta-eval cases. Values are unchanged.
+
+## Motivation
+
+Dewey 007 (config-as-data) asks that tunable LLM-call parameters live in
+config, not inline literals. The component already externalizes per-role
+LLM-call tuning in `resources/config/agent/agent-llm-defaults.edn`, loaded by
+`role_config.clj` and consumed by each `create-{role}` factory. The curator
+enrichment call, the meta-evaluator call, and the supervisory-bridge heartbeat
+interval were defined inline and never routed through that path.
+
+## Changes
+
+- `resources/config/agent/agent-llm-defaults.edn`: added a `:curator` entry
+  `{:temperature 0.1 :max-tokens 800}`. Curator carries the same
+  `{:temperature :max-tokens}` shape as the role entries, so it fits the
+  existing role-keyed map and its shape invariant.
+- `src/ai/miniforge/agent/curator.clj`: `try-llm-chat` now reads its tuning via
+  `role-config/agent-llm-default :curator` and merges `{:system ...}` on top,
+  replacing the inline `{:temperature 0.1 :max-tokens 800}`.
+- `resources/config/agent/meta-eval-tuning.edn` (new): `{:max-tokens 150}`. The
+  meta-evaluator call sets no temperature, so it does not fit the role-keyed
+  map's "every entry carries :temperature" invariant (enforced by
+  `agent-llm-defaults-shape-test`). It gets its own sibling EDN instead.
+- `src/ai/miniforge/agent/meta_evaluator.clj`: loads `meta-eval-tuning.edn` at
+  ns load into `eval-tuning`, with `fallback-eval-tuning {:max-tokens 150}` as
+  the in-code fallback. `evaluate` merges `eval-tuning` into the request map,
+  replacing the inline `:max-tokens 150`.
+- `resources/config/agent/supervisory-bridge.edn` (new):
+  `{:heartbeat-interval-ms 30000}`.
+- `src/ai/miniforge/agent/supervisory_bridge.clj`: `default-heartbeat-interval-ms`
+  is now derived from `supervisory-bridge.edn` at ns load, with
+  `fallback-heartbeat-interval-ms 30000` as the named in-code fallback. The
+  downstream reference is unchanged.
+
+All four values are identical to the originals: curator 0.1 / 800, meta-eval
+150, heartbeat 30000.
+
+## Verification
+
+- Load smoke from `components/agent`: `agent-llm-default :curator` →
+  `{:temperature 0.1 :max-tokens 800}`; `eval-tuning` → `{:max-tokens 150}`;
+  `default-heartbeat-interval-ms` → `30000`. All three modified namespaces load.
+- Isolated test runner (`-M:test -m cognitect.test-runner -d test`): 515 tests,
+  2251 assertions, 0 failures, 0 errors.
+- `bb poly:check`: OK.
+
+## Follow-up
+
+None deferred. All three call sites were wired through config.


### PR DESCRIPTION
## Overview

Three LLM-call / timing constants in the `agent` component were hard-coded at their call sites, escaping the component's config-as-data path. This moves them into EDN resources, keeping an in-code fallback for the heartbeat and meta-eval cases. Values unchanged.

## Motivation

Dewey 007 (config-as-data). The component already externalizes per-role LLM-call tuning in `agent-llm-defaults.edn` via `role_config.clj`. The curator enrichment call, the meta-evaluator call, and the supervisory-bridge heartbeat interval were inline literals that escaped that path.

## Changes

- `agent-llm-defaults.edn`: added `:curator {:temperature 0.1 :max-tokens 800}` (same shape as role entries).
- `curator.clj`: `try-llm-chat` reads tuning via `role-config/agent-llm-default :curator`.
- `meta-eval-tuning.edn` (new): `{:max-tokens 150}`. The meta-eval call sets no temperature, so it does not fit the role-keyed map's "every entry carries :temperature" invariant; it gets its own sibling EDN.
- `meta_evaluator.clj`: loads `meta-eval-tuning.edn` into `eval-tuning` with `fallback-eval-tuning {:max-tokens 150}` as fallback; `evaluate` merges it into the request.
- `supervisory-bridge.edn` (new): `{:heartbeat-interval-ms 30000}`.
- `supervisory_bridge.clj`: `default-heartbeat-interval-ms` derived from config at ns load, with `fallback-heartbeat-interval-ms 30000` named in-code fallback.

Values identical to originals: curator 0.1/800, meta-eval 150, heartbeat 30000.

## Verification

- Load smoke: loaded values equal originals at all three call sites.
- Isolated test runner: 515 tests, 2251 assertions, 0 failures, 0 errors.
- `bb poly:check`: OK.
- Full pre-commit gate (commit hook): passed.

## Follow-up

None deferred. All three call sites wired through config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)