### PR TITLE
test: use direct verify private var handles

### DIFF
--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
@@ -43,6 +43,9 @@
 
 ;------------------------------------------------------------------------------ Test Fixtures
 
+(def ^:private run-tests-var
+  #'verify/run-tests!)
+
 (defn create-base-context
   "Base context with executor environment."
   []
@@ -54,20 +57,18 @@
    :execution/phase-results {}})
 
 (defn with-passing-tests [body-fn]
-  (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
-    (with-redefs-fn
-      {run-var (fn [_ & _opts] {:passed? true :test-count 5 :assertion-count 10
-                                :fail-count 0 :error-count 0
-                                :output "Ran 5 tests containing 10 assertions.\n0 failures, 0 errors."})}
-      body-fn)))
+  (with-redefs-fn
+    {run-tests-var (fn [_ & _opts] {:passed? true :test-count 5 :assertion-count 10
+                                    :fail-count 0 :error-count 0
+                                    :output "Ran 5 tests containing 10 assertions.\n0 failures, 0 errors."})}
+    body-fn))
 
 (defn with-failing-tests [body-fn]
-  (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
-    (with-redefs-fn
-      {run-var (fn [_ & _opts] {:passed? false :test-count 3 :assertion-count 6
-                                :fail-count 2 :error-count 1
-                                :output "Ran 3 tests.\n2 failures, 1 error."})}
-      body-fn)))
+  (with-redefs-fn
+    {run-tests-var (fn [_ & _opts] {:passed? false :test-count 3 :assertion-count 6
+                                    :fail-count 2 :error-count 1
+                                    :output "Ran 3 tests.\n2 failures, 1 error."})}
+    body-fn))
 
 ;------------------------------------------------------------------------------ Enter Tests
 
@@ -119,39 +120,37 @@
 
 (deftest verify-handles-test-runner-error-gracefully-test
   (testing "verify phase handles test runner exception as test failure"
-    (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
-      (with-redefs-fn
-        {run-var (fn [_ & _opts] {:passed? false :test-count 0 :fail-count 0 :error-count 1
-                                  :output "bb: command not found"})}
-        (fn []
-          (let [ctx (-> (create-base-context)
-                        (assoc :phase-config {:phase :verify}))
-                interceptor (phase/get-phase-interceptor {:phase :verify})
-                result ((:enter interceptor) ctx)]
-            (is (= :error (get-in result [:phase :result :status]))
-                "Runner error should produce :error result")
-            (is (some? (get-in result [:phase :result :metrics :test-output]))
-                "Test output captured in metrics even on runner error")))))))
+    (with-redefs-fn
+      {run-tests-var (fn [_ & _opts] {:passed? false :test-count 0 :fail-count 0 :error-count 1
+                                      :output "bb: command not found"})}
+      (fn []
+        (let [ctx (-> (create-base-context)
+                      (assoc :phase-config {:phase :verify}))
+              interceptor (phase/get-phase-interceptor {:phase :verify})
+              result ((:enter interceptor) ctx)]
+          (is (= :error (get-in result [:phase :result :status]))
+              "Runner error should produce :error result")
+          (is (some? (get-in result [:phase :result :metrics :test-output]))
+              "Test output captured in metrics even on runner error"))))))
 
 (deftest verify-preserves-unparseable-test-output-test
   (testing "unparseable test output is surfaced as actionable verify feedback"
-    (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
-      (with-redefs-fn
-        {run-var (fn [_ & _opts] {:passed? false
-                                  :test-count 0
-                                  :assertion-count 0
-                                  :fail-count 0
-                                  :error-count 1
-                                  :parse-error? true
-                                  :output "Syntax error compiling at src/example.clj:12:3"})}
-        (fn []
-          (let [ctx (-> (create-base-context)
-                        (assoc :phase-config {:phase :verify}))
-                interceptor (phase/get-phase-interceptor {:phase :verify})
-                result ((:enter interceptor) ctx)
-                message (get-in result [:phase :result :error :message])]
-            (is (str/includes? message (messages/t :verify/output-unparseable)))
-            (is (str/includes? message "Syntax error compiling"))))))))
+    (with-redefs-fn
+      {run-tests-var (fn [_ & _opts] {:passed? false
+                                      :test-count 0
+                                      :assertion-count 0
+                                      :fail-count 0
+                                      :error-count 1
+                                      :parse-error? true
+                                      :output "Syntax error compiling at src/example.clj:12:3"})}
+      (fn []
+        (let [ctx (-> (create-base-context)
+                      (assoc :phase-config {:phase :verify}))
+              interceptor (phase/get-phase-interceptor {:phase :verify})
+              result ((:enter interceptor) ctx)
+              message (get-in result [:phase :result :error :message])]
+          (is (str/includes? message (messages/t :verify/output-unparseable)))
+          (is (str/includes? message "Syntax error compiling")))))))
 
 (deftest parse-test-output-marks-unparseable-output-test
   (testing "the real parser treats unparseable output as one actionable error"
@@ -185,18 +184,17 @@
 
 (deftest verify-bounds-unparseable-output-preview-test
   (testing "long unparseable output is bounded in the verify error message"
-    (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)
-          preview-limit @#'verify/verify-error-preview-limit
+    (let [preview-limit @#'verify/verify-error-preview-limit
           suffix @#'verify/truncated-output-suffix
           output (apply str (repeat (+ preview-limit 50) "x"))]
       (with-redefs-fn
-        {run-var (fn [_ & _opts] {:passed? false
-                                  :test-count 0
-                                  :assertion-count 0
-                                  :fail-count 0
-                                  :error-count 1
-                                  :parse-error? true
-                                  :output output})}
+        {run-tests-var (fn [_ & _opts] {:passed? false
+                                        :test-count 0
+                                        :assertion-count 0
+                                        :fail-count 0
+                                        :error-count 1
+                                        :parse-error? true
+                                        :output output})}
         (fn []
           (let [ctx (-> (create-base-context)
                         (assoc :phase-config {:phase :verify}))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
@@ -31,6 +31,9 @@
 
 ;------------------------------------------------------------------------------ Test fixtures
 
+(def ^:private run-tests-var
+  #'verify/run-tests!)
+
 (def phase-test-config-resource
   "config/phase/test-support-namespaces.edn")
 
@@ -57,21 +60,19 @@
 (defn with-mocked-test-runner
   "Run body-fn with run-tests! mocked to return a passing result."
   [body-fn]
-  (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
-    (with-redefs-fn
-      {run-var (fn [_ & _opts] {:passed? true :test-count 5 :assertion-count 10
-                                :fail-count 0 :error-count 0 :output "Ran 5 tests containing 10 assertions.\n0 failures, 0 errors."})}
-      body-fn)))
+  (with-redefs-fn
+    {run-tests-var (fn [_ & _opts] {:passed? true :test-count 5 :assertion-count 10
+                                    :fail-count 0 :error-count 0 :output "Ran 5 tests containing 10 assertions.\n0 failures, 0 errors."})}
+    body-fn))
 
 (defn with-failing-test-runner
   "Run body-fn with run-tests! mocked to return a failing result."
   [body-fn]
-  (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
-    (with-redefs-fn
-      {run-var (fn [_ & _opts] {:passed? false :test-count 3 :assertion-count 6
-                                :fail-count 2 :error-count 0
-                                :output "Ran 3 tests containing 6 assertions.\n2 failures, 0 errors."})}
-      body-fn)))
+  (with-redefs-fn
+    {run-tests-var (fn [_ & _opts] {:passed? false :test-count 3 :assertion-count 6
+                                    :fail-count 2 :error-count 0
+                                    :output "Ran 3 tests containing 6 assertions.\n2 failures, 0 errors."})}
+    body-fn))
 
 ;------------------------------------------------------------------------------ Layer 0: Defaults tests
 
@@ -147,12 +148,11 @@
 
 (deftest enter-verify-uses-execution-worktree-path-test
   (testing "enter-verify passes :execution/worktree-path to test runner"
-    (let [captured-path (atom nil)
-          run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
+    (let [captured-path (atom nil)]
       (with-redefs-fn
-        {run-var (fn [path & _opts]
-                   (reset! captured-path path)
-                   {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
+        {run-tests-var (fn [path & _opts]
+                         (reset! captured-path path)
+                         {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
         (fn []
           (let [ctx (-> (create-base-context)
                         (assoc :execution/worktree-path "/tmp/my-worktree")
@@ -203,12 +203,11 @@
 
 (deftest enter-verify-propagates-spec-test-timeout-test
   (testing "enter-verify threads :spec/test-timeout-ms from :execution/input into run-tests!"
-    (let [captured-opts (atom nil)
-          run-var       (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
+    (let [captured-opts (atom nil)]
       (with-redefs-fn
-        {run-var (fn [_path & opts]
-                   (reset! captured-opts (apply hash-map opts))
-                   {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
+        {run-tests-var (fn [_path & opts]
+                         (reset! captured-opts (apply hash-map opts))
+                         {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
         (fn []
           (let [ctx (-> (create-base-context)
                         (assoc-in [:execution/input :spec/test-timeout-ms] 12345)
@@ -220,12 +219,11 @@
 
 (deftest enter-verify-uses-default-timeout-when-no-override-test
   (testing "enter-verify falls back to default-test-timeout-ms when neither spec nor config sets one"
-    (let [captured-opts (atom nil)
-          run-var       (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
+    (let [captured-opts (atom nil)]
       (with-redefs-fn
-        {run-var (fn [_path & opts]
-                   (reset! captured-opts (apply hash-map opts))
-                   {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
+        {run-tests-var (fn [_path & opts]
+                         (reset! captured-opts (apply hash-map opts))
+                         {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
         (fn []
           (let [ctx (-> (create-base-context)
                         (assoc :phase-config {:phase :verify}))]
@@ -294,23 +292,22 @@
     ;; If the fragment doesn't survive into the phase result, the dead-code
     ;; detection in leave-verify stays dead and timeouts get treated as
     ;; ordinary test failures (and route back to implement — wasting tokens).
-    (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
-      (with-redefs-fn
-        {run-var (fn [_path & _opts]
-                   {:passed? false :test-count 0 :assertion-count 0
-                    :fail-count 0 :error-count 1
-                    :timed-out? true
-                    :output "Verify test runner timed out after 1000ms (cmd: bb test)"})}
-        (fn []
-          (let [ctx (-> (create-base-context)
-                        (assoc :phase-config {:phase :verify}))
-                ctx-after (verify/enter-verify ctx)
-                result (get-in ctx-after [:phase :result])]
-            (is (= :error (:status result)))
-            (is (str/includes? (str (:summary result)) "timed out")
-                ":summary must carry the `timed out` fragment")
-            (is (str/includes? (str (get-in result [:error :message])) "timed out")
-                ":error :message must carry the fragment — leave-verify branches on this")))))))
+    (with-redefs-fn
+      {run-tests-var (fn [_path & _opts]
+                       {:passed? false :test-count 0 :assertion-count 0
+                        :fail-count 0 :error-count 1
+                        :timed-out? true
+                        :output "Verify test runner timed out after 1000ms (cmd: bb test)"})}
+      (fn []
+        (let [ctx (-> (create-base-context)
+                      (assoc :phase-config {:phase :verify}))
+              ctx-after (verify/enter-verify ctx)
+              result (get-in ctx-after [:phase :result])]
+          (is (= :error (:status result)))
+          (is (str/includes? (str (:summary result)) "timed out")
+              ":summary must carry the `timed out` fragment")
+          (is (str/includes? (str (get-in result [:error :message])) "timed out")
+              ":error :message must carry the fragment — leave-verify branches on this"))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-06-20-chris-verify-test-direct-private-vars.md
+++ b/docs/pull-requests/2026-06-20-chris-verify-test-direct-private-vars.md
@@ -1,0 +1,41 @@
+# test: replace verify test dynamic resolves
+
+## Overview
+
+This PR removes a focused cluster of test-only dynamic `resolve` calls from the
+phase-software-factory verify tests.
+
+## Motivation
+
+After production resolver remediation, the remaining resolver-looking patterns
+are mostly tests that use `resolve`/`ns-resolve` for white-box access. The
+verify test suite repeatedly resolves the same private `run-tests!` var at
+runtime, which is noisier than an explicit test dependency on the private var.
+
+## Changes in Detail
+
+- Replace repeated dynamic `resolve` calls for
+  `ai.miniforge.phase-software-factory.verify/run-tests!`.
+- Keep the test scope limited to the verify suite.
+- Preserve existing test behavior and white-box intent.
+
+## Testing Plan
+
+- Run the touched verify test namespaces.
+- Run `bb pre-commit` before commit.
+- Let pull request CI run the stable-derived test plan.
+
+## Deployment Plan
+
+No deployment steps. This is test-only cleanup.
+
+## Related Issues/PRs
+
+- Follows PR #1252, which classified remaining production function-local
+  `require` boundaries.
+
+## Checklist
+
+- [x] Replace focused dynamic resolves.
+- [x] Run local validation.
+- [ ] Open PR and address review comments.


### PR DESCRIPTION
# test: replace verify test dynamic resolves

## Overview

This PR removes a focused cluster of test-only dynamic `resolve` calls from the
phase-software-factory verify tests.

## Motivation

After production resolver remediation, the remaining resolver-looking patterns
are mostly tests that use `resolve`/`ns-resolve` for white-box access. The
verify test suite repeatedly resolves the same private `run-tests!` var at
runtime, which is noisier than an explicit test dependency on the private var.

## Changes in Detail

- Replace repeated dynamic `resolve` calls for
  `ai.miniforge.phase-software-factory.verify/run-tests!`.
- Keep the test scope limited to the verify suite.
- Preserve existing test behavior and white-box intent.

## Testing Plan

- Run the touched verify test namespaces.
- Run `bb pre-commit` before commit.
- Let pull request CI run the stable-derived test plan.

## Deployment Plan

No deployment steps. This is test-only cleanup.

## Related Issues/PRs

- Follows PR #1252, which classified remaining production function-local
  `require` boundaries.

## Checklist

- [x] Replace focused dynamic resolves.
- [x] Run local validation.
- [ ] Open PR and address review comments.
