### PR TITLE
feat(config): shared config-resource loader in ai.miniforge.config

### DIFF
--- a/components/config/src/ai/miniforge/config/interface.clj
+++ b/components/config/src/ai/miniforge/config/interface.clj
@@ -22,9 +22,26 @@
    [ai.miniforge.config.user :as user]
    [ai.miniforge.config.governance :as governance]
    [ai.miniforge.config.digest :as digest]
-   [ai.miniforge.config.profile :as profile]))
+   [ai.miniforge.config.profile :as profile]
+   [ai.miniforge.config.resource :as resource]))
 
 ;; Re-export public functions
+
+;; Generic classpath EDN config-resource loaders — the one home for the
+;; load-a-component's-config-resource pattern. `load-config-resource`
+;; fails fast (ex-info) on a missing/malformed/non-map resource or a
+;; missing required key; `read-config-resource-or` is fail-open and
+;; returns the supplied fallback on any error.
+(def load-config-resource
+  "Read an EDN config resource from the classpath, failing fast with a
+   clear ex-info on a missing/malformed/non-map resource or a missing
+   required key. Arities: [path] and [path required-keys]."
+  resource/load-config-resource)
+(def read-config-resource-or
+  "Read an EDN config resource, returning `fallback` if the resource is
+   absent, unreadable, malformed, or not a map (fail-open). Args:
+   [path fallback]."
+  resource/read-config-resource-or)
 (def default-user-config-path
   "Default filesystem path string for the user config file
    (`<miniforge-home>/config.edn`). Computed once at load time."

--- a/components/config/src/ai/miniforge/config/resource.clj
+++ b/components/config/src/ai/miniforge/config/resource.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.config.resource
+  "Generic classpath EDN config-resource loading. One home for the
+   load-this-component's-config-resource pattern so components stop
+   hand-rolling their own `(-> (io/resource ...) slurp edn/read-string)`
+   loaders.
+
+   Two variants:
+
+   - `load-config-resource` fails fast with a clear ex-info when the
+     resource is absent, malformed, not a map, or missing a required key.
+     Use it when the values are required (no in-code fallback).
+   - `read-config-resource-or` is fail-open: it returns a caller-supplied
+     fallback on any error. Use it where call sites already carry literal
+     defaults or the component is documented to fail open."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(defn load-config-resource
+  "Read an EDN config resource from the classpath, failing fast with a
+   clear ex-info when the resource is absent, malformed, not a map, or
+   missing a required key. Returns the parsed map.
+
+   `required-keys` (optional) is a collection of keys that must be present
+   at the top level; an empty/absent collection skips the key check."
+  ([path] (load-config-resource path nil))
+  ([path required-keys]
+   (let [url (io/resource path)]
+     (when (nil? url)
+       (throw (ex-info (str "Missing config resource on classpath: " path)
+                       {:config/resource path})))
+     (let [parsed (try
+                    (edn/read-string (slurp url))
+                    (catch Exception e
+                      (throw (ex-info (str "Malformed EDN config resource: " path)
+                                      {:config/resource path}
+                                      e))))]
+       (when-not (map? parsed)
+         (throw (ex-info (str "Config resource is not a map: " path)
+                         {:config/resource path})))
+       (let [missing (remove #(contains? parsed %) required-keys)]
+         (when (seq missing)
+           (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
+                           {:config/resource path :config/missing-keys (vec missing)})))
+         parsed)))))
+
+(defn read-config-resource-or
+  "Read an EDN config resource, returning `fallback` if the resource is
+   absent, unreadable, malformed, or not a map (fail-open)."
+  [path fallback]
+  (try
+    (let [url    (io/resource path)
+          parsed (when url (edn/read-string (slurp url)))]
+      (if (map? parsed) parsed fallback))
+    (catch Exception _ fallback)))

--- a/components/config/src/ai/miniforge/config/resource.clj
+++ b/components/config/src/ai/miniforge/config/resource.clj
@@ -48,7 +48,12 @@
        (throw (ex-info (str "Missing config resource on classpath: " path)
                        {:config/resource path})))
      (let [parsed (try
-                    (edn/read-string (slurp url))
+                    (edn/read-string (slurp url :encoding "UTF-8"))
+                    (catch InterruptedException e
+                      ;; Never swallow cancellation — restore the flag and
+                      ;; propagate rather than wrap it as a parse error.
+                      (.interrupt (Thread/currentThread))
+                      (throw e))
                     (catch Exception e
                       (throw (ex-info (str "Malformed EDN config resource: " path)
                                       {:config/resource path}
@@ -56,18 +61,22 @@
        (when-not (map? parsed)
          (throw (ex-info (str "Config resource is not a map: " path)
                          {:config/resource path})))
-       (let [missing (remove #(contains? parsed %) required-keys)]
+       (let [missing (vec (remove #(contains? parsed %) required-keys))]
          (when (seq missing)
-           (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
-                           {:config/resource path :config/missing-keys (vec missing)})))
+           (throw (ex-info (str "Config resource " path " missing keys: " missing)
+                           {:config/resource path :config/missing-keys missing})))
          parsed)))))
 
 (defn read-config-resource-or
   "Read an EDN config resource, returning `fallback` if the resource is
-   absent, unreadable, malformed, or not a map (fail-open)."
+   absent, unreadable, malformed, or not a map (fail-open). Cancellation
+   (`InterruptedException`) is propagated, not swallowed."
   [path fallback]
   (try
     (let [url    (io/resource path)
-          parsed (when url (edn/read-string (slurp url)))]
+          parsed (when url (edn/read-string (slurp url :encoding "UTF-8")))]
       (if (map? parsed) parsed fallback))
+    (catch InterruptedException e
+      (.interrupt (Thread/currentThread))
+      (throw e))
     (catch Exception _ fallback)))

--- a/components/config/test/ai/miniforge/config/resource_test.clj
+++ b/components/config/test/ai/miniforge/config/resource_test.clj
@@ -24,6 +24,12 @@
 ;; A real map resource shipped by this component, used for the happy path.
 (def ^:private a-real-resource "config/default-user-config-fallback.edn")
 (def ^:private a-missing-resource "config/does-not-exist-xyz.edn")
+;; Test fixtures (under test/resource_test_fixtures/, on the test classpath).
+;; The malformed fixture uses a .txt extension so the EDN linter does not
+;; reject its deliberately invalid content; the loader reads by path, not
+;; extension.
+(def ^:private a-malformed-resource "resource_test_fixtures/malformed-edn.txt")
+(def ^:private a-non-map-resource "resource_test_fixtures/non-map.edn")
 
 (deftest load-config-resource-happy-path
   (testing "returns the parsed map for a resource on the classpath"
@@ -45,9 +51,29 @@
       (is (instance? clojure.lang.ExceptionInfo ex))
       (is (= [:definitely-not-a-key] (:config/missing-keys (ex-data ex)))))))
 
+(deftest load-config-resource-malformed
+  (testing "throws a clear ex-info for malformed EDN"
+    (let [ex (try (resource/load-config-resource a-malformed-resource)
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= a-malformed-resource (:config/resource (ex-data ex)))))))
+
+(deftest load-config-resource-non-map
+  (testing "throws when the EDN parses to a non-map value"
+    (let [ex (try (resource/load-config-resource a-non-map-resource)
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= a-non-map-resource (:config/resource (ex-data ex)))))))
+
 (deftest read-config-resource-or-fail-open
   (testing "returns the fallback for a missing resource"
     (is (= {:fallback true}
            (resource/read-config-resource-or a-missing-resource {:fallback true}))))
+  (testing "returns the fallback for malformed EDN"
+    (is (= {:fallback true}
+           (resource/read-config-resource-or a-malformed-resource {:fallback true}))))
+  (testing "returns the fallback for a non-map value"
+    (is (= {:fallback true}
+           (resource/read-config-resource-or a-non-map-resource {:fallback true}))))
   (testing "returns the parsed map for a present resource"
     (is (map? (resource/read-config-resource-or a-real-resource {:fallback true})))))

--- a/components/config/test/ai/miniforge/config/resource_test.clj
+++ b/components/config/test/ai/miniforge/config/resource_test.clj
@@ -1,0 +1,53 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.config.resource-test
+  (:require
+   [ai.miniforge.config.resource :as resource]
+   [clojure.test :refer [deftest is testing]]))
+
+;; A real map resource shipped by this component, used for the happy path.
+(def ^:private a-real-resource "config/default-user-config-fallback.edn")
+(def ^:private a-missing-resource "config/does-not-exist-xyz.edn")
+
+(deftest load-config-resource-happy-path
+  (testing "returns the parsed map for a resource on the classpath"
+    (is (map? (resource/load-config-resource a-real-resource))))
+  (testing "an empty required-keys set is a no-op"
+    (is (map? (resource/load-config-resource a-real-resource [])))))
+
+(deftest load-config-resource-missing-resource
+  (testing "throws a clear ex-info naming the missing resource"
+    (let [ex (try (resource/load-config-resource a-missing-resource)
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= a-missing-resource (:config/resource (ex-data ex)))))))
+
+(deftest load-config-resource-missing-key
+  (testing "throws when a required key is absent, naming the key"
+    (let [ex (try (resource/load-config-resource a-real-resource [:definitely-not-a-key])
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= [:definitely-not-a-key] (:config/missing-keys (ex-data ex)))))))
+
+(deftest read-config-resource-or-fail-open
+  (testing "returns the fallback for a missing resource"
+    (is (= {:fallback true}
+           (resource/read-config-resource-or a-missing-resource {:fallback true}))))
+  (testing "returns the parsed map for a present resource"
+    (is (map? (resource/read-config-resource-or a-real-resource {:fallback true})))))

--- a/components/config/test/resource_test_fixtures/malformed-edn.txt
+++ b/components/config/test/resource_test_fixtures/malformed-edn.txt
@@ -1,0 +1,1 @@
+{:unbalanced "missing closing brace"

--- a/components/config/test/resource_test_fixtures/non-map.edn
+++ b/components/config/test/resource_test_fixtures/non-map.edn
@@ -1,0 +1,1 @@
+[:this :is :a :vector :not :a :map]

--- a/docs/pull-requests/2026-06-20-feat-config-resource-loader.md
+++ b/docs/pull-requests/2026-06-20-feat-config-resource-loader.md
@@ -1,0 +1,45 @@
+# feat: shared config-resource loader in ai.miniforge.config
+
+## Overview
+
+Adds one home for the "load a component's EDN config resource from the
+classpath" pattern, so components stop hand-rolling their own
+`(-> (io/resource ...) slurp edn/read-string)` loaders. New namespace
+`ai.miniforge.config.resource`, two functions exported from the config
+interface.
+
+## Motivation
+
+The config-as-data work spread a near-identical private `load-config`
+helper across many components. That is the duplication this consolidates.
+The config component already owns config loading (user / repo / merged /
+governance) and has light deps (clojure, fs, aero), so it is the natural
+owner; depending on it introduces no cycles.
+
+## API
+
+- `load-config-resource` — `[path]` / `[path required-keys]`. Fails fast
+  with a clear `ex-info` (carrying `:config/resource`, and
+  `:config/missing-keys` for the key check) when the resource is absent
+  from the classpath, malformed, not a map, or missing a required key.
+  Returns the parsed map. Use where the values are required.
+- `read-config-resource-or` — `[path fallback]`. Fail-open: returns
+  `fallback` on any error (absent / unreadable / malformed / non-map). Use
+  where call sites already carry literal defaults or the component is
+  documented to fail open.
+
+## Follow-up
+
+Subsequent PRs route the existing inline loaders (self-healing,
+orchestrator, operator, task-executor, tool-registry, adapter-claude-code,
+web-dashboard, phase-deployment, semantic-analyzer, agent, llm) through
+these functions and add the `ai.miniforge/config` dependency where it is
+not already present.
+
+## Verification
+
+- `ai.miniforge.config.resource-test`: happy path, missing resource throws
+  with `:config/resource`, missing required key throws with
+  `:config/missing-keys`, fail-open returns the fallback. Config component
+  suite: 32 tests, 130 assertions, 0 failures.
+- `bb poly:check`: OK.


### PR DESCRIPTION
Adds one home for the "load a component's EDN config resource from the classpath" pattern, so components stop hand-rolling their own `(-> (io/resource ...) slurp edn/read-string)` loaders. The config-as-data PRs spread a near-identical private `load-config` helper across many components; this is the consolidation target.

New `ai.miniforge.config.resource`, exported from the config interface:
- `load-config-resource` `[path]` / `[path required-keys]` — fail-fast `ex-info` (`:config/resource`, `:config/missing-keys`) on a missing/malformed/non-map resource or a missing required key. Returns the parsed map.
- `read-config-resource-or` `[path fallback]` — fail-open; returns `fallback` on any error.

The config component has light deps (clojure, fs, aero) so depending on it introduces no cycles.

**Follow-up:** subsequent PRs route the inline loaders (self-healing, orchestrator, operator, task-executor, tool-registry, adapter-claude-code, web-dashboard, phase-deployment, semantic-analyzer, agent, llm) through these and add the `ai.miniforge/config` dep where missing.

Verification:
- `ai.miniforge.config.resource-test` (happy path, missing-resource throw, missing-key throw, fail-open fallback); config suite 32 tests / 130 assertions, 0 failures.
- `bb poly:check`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)