### PR TITLE
fix(event-stream): close TOCTOU race in publish! quiesce/in-flight acquire

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -230,9 +230,9 @@
   "Atomically check the quiesce fence for `event`'s workflow and, if not
    fenced, increment the in-flight counter.
 
-   Uses a decision atom captured inside the `swap!` fn to signal the outcome
-   to the caller without polluting the stream map with temporary keys. The
-   `swap!` fn may be retried by the atom under contention — the decision atom
+   Uses a decision volatile captured inside the `swap!` fn to signal the
+   outcome to the caller without polluting the stream map with temporary keys.
+   The `swap!` fn may be retried by the atom under contention — the volatile
    is reset on each retry so the final value always reflects the last
    successful swap.
 

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -219,18 +219,53 @@
     (log-rejection! (:logger @stream) event)
     (rejection-result event :workflow-quiesced)))
 
+(def ^:private quiesced-sentinel
+  "Sentinel value returned by `with-in-flight` when the event's workflow was
+   quiesced between the caller's fast-path check and the atomic increment,
+   closing the TOCTOU window. Distinct from nil so callers can distinguish
+   'quiesced-during-acquire' from 'no-workflow-id event'."
+  ::quiesced)
+
+(defn- try-acquire-in-flight!
+  "Atomically check the quiesce fence for `event`'s workflow and, if not
+   fenced, increment the in-flight counter.
+
+   Uses a decision atom captured inside the `swap!` fn to signal the outcome
+   to the caller without polluting the stream map with temporary keys. The
+   `swap!` fn may be retried by the atom under contention — the decision atom
+   is reset on each retry so the final value always reflects the last
+   successful swap.
+
+   Returns true when the slot was acquired (in-flight incremented), false
+   when the workflow was quiesced at the moment of the swap."
+  [stream event]
+  (let [wid      (:workflow/id event)
+        acquired (volatile! false)]
+    (swap! stream
+           (fn [s]
+             (if (and wid (contains? (:quiesced-workflows s) wid))
+               (do (vreset! acquired false) s)
+               (do (vreset! acquired true)
+                   (update s :in-flight inc)))))
+    @acquired))
+
 (defn- with-in-flight
   "Run `body-fn` while incrementing the stream's in-flight publish
    counter, decrementing in a finally so an exception still releases the
-   slot. Returns body-fn's result. Cross-cutting concern that lets
-   `quiesce!` / `drain!` observe an at-rest stream when no publishes
-   are mid-flight."
-  [stream body-fn]
-  (swap! stream update :in-flight inc)
-  (try
-    (body-fn)
-    (finally
-      (swap! stream update :in-flight dec))))
+   slot. Returns body-fn's result, or `quiesced-sentinel` when the
+   workflow was fenced at the moment of the atomic acquire.
+
+   The quiesce check and increment are fused into a single `swap!` via
+   `try-acquire-in-flight!`, eliminating the TOCTOU window that existed
+   when the two operations were separate (check in `rejection-if-quiesced`
+   then increment in `swap! update :in-flight inc`)."
+  [stream event body-fn]
+  (if-not (try-acquire-in-flight! stream event)
+    quiesced-sentinel
+    (try
+      (body-fn)
+      (finally
+        (swap! stream update :in-flight dec)))))
 
 (defn- record-event!
   "Append `event` to the in-memory event log."
@@ -301,17 +336,32 @@
    log, fan out to subscribers, log, and return `event`.
 
    In-flight publishes are tracked so `quiesce!` / `drain!` can wait
-   for the stream to settle before reporting at-rest."
+   for the stream to settle before reporting at-rest.
+
+   The quiesce fence is enforced atomically: `with-in-flight` fuses the
+   quiesce-check and the in-flight increment into a single `swap!`,
+   eliminating the TOCTOU window that allowed a publish to slip through
+   after `quiesce!` fenced the workflow."
   [stream event]
+  ;; Fast path: check quiesce before acquiring the in-flight slot so
+  ;; already-quiesced workflows skip the swap! entirely.
   (or (rejection-if-quiesced stream event)
-      (with-in-flight stream
-        (fn []
-          (let [{:keys [sinks subscribers filters logger]} @stream]
-            (deliver-to-sinks! sinks event logger)
-            (record-event! stream event)
-            (deliver-to-subscribers! subscribers filters event logger)
-            (log-published! logger event)
-            event)))))
+      (let [result (with-in-flight stream event
+                     (fn []
+                       (let [{:keys [sinks subscribers filters logger]} @stream]
+                         (deliver-to-sinks! sinks event logger)
+                         (record-event! stream event)
+                         (deliver-to-subscribers! subscribers filters event logger)
+                         (log-published! logger event)
+                         event)))]
+        ;; with-in-flight returns quiesced-sentinel when the workflow was
+        ;; fenced during the atomic acquire (the TOCTOU window). Convert
+        ;; to the canonical rejection shape so callers see a consistent
+        ;; {:rejected? true ...} map regardless of which path triggered it.
+        (if (= result quiesced-sentinel)
+          (do (log-rejection! (:logger @stream) event)
+              (rejection-result event :workflow-quiesced))
+          result))))
 
 (defn subscribe!
   ([stream subscriber-id callback]

--- a/components/event-stream/test/ai/miniforge/event_stream/publish_helpers_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/publish_helpers_test.clj
@@ -26,11 +26,13 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.event-stream.core :as core]))
 
-(def ^:private workflow-quiesced?     #'core/workflow-quiesced?)
-(def ^:private rejection-result       #'core/rejection-result)
-(def ^:private rejection-if-quiesced  #'core/rejection-if-quiesced)
-(def ^:private with-in-flight         #'core/with-in-flight)
-(def ^:private record-event!          #'core/record-event!)
+(def ^:private workflow-quiesced?       #'core/workflow-quiesced?)
+(def ^:private rejection-result         #'core/rejection-result)
+(def ^:private rejection-if-quiesced    #'core/rejection-if-quiesced)
+(def ^:private try-acquire-in-flight!   #'core/try-acquire-in-flight!)
+(def ^:private with-in-flight           #'core/with-in-flight)
+(def ^:private quiesced-sentinel        #'core/quiesced-sentinel)
+(def ^:private record-event!            #'core/record-event!)
 (def ^:private deliver-to-sink!       #'core/deliver-to-sink!)
 (def ^:private deliver-to-sinks!      #'core/deliver-to-sinks!)
 (def ^:private deliver-to-subscriber! #'core/deliver-to-subscriber!)
@@ -79,12 +81,32 @@
     (is (true? (:rejected? result)))
     (is (= :workflow-quiesced (:reason result)))))
 
+;------------------------------------------------------------------------------ try-acquire-in-flight!
+
+(deftest try-acquire-in-flight!-acquires-when-not-quiesced
+  (let [wid    (random-uuid)
+        stream (atom {:in-flight 0 :quiesced-workflows #{}})
+        event  (evt :test/event wid)]
+    (is (true? (try-acquire-in-flight! stream event))
+        "returns true when the workflow is not fenced")
+    (is (= 1 (:in-flight @stream))
+        ":in-flight is incremented on acquire")))
+
+(deftest try-acquire-in-flight!-rejects-when-quiesced
+  (let [wid    (random-uuid)
+        stream (atom {:in-flight 0 :quiesced-workflows #{wid}})
+        event  (evt :test/event wid)]
+    (is (false? (try-acquire-in-flight! stream event))
+        "returns false when the workflow is already fenced")
+    (is (= 0 (:in-flight @stream))
+        ":in-flight is NOT incremented when fenced — the TOCTOU window is closed")))
+
 ;------------------------------------------------------------------------------ with-in-flight
 
 (deftest with-in-flight-increments-and-decrements-around-body
-  (let [stream (atom {:in-flight 0})
+  (let [stream   (atom {:in-flight 0})
         observed (atom nil)]
-    (with-in-flight stream
+    (with-in-flight stream (evt)
       (fn []
         (reset! observed (:in-flight @stream))
         :body-result))
@@ -94,13 +116,26 @@
 (deftest with-in-flight-decrements-on-body-exception
   (let [stream (atom {:in-flight 0})]
     (is (thrown? Exception
-                 (with-in-flight stream (fn [] (throw (RuntimeException. "boom"))))))
+                 (with-in-flight stream (evt) (fn [] (throw (RuntimeException. "boom"))))))
     (is (= 0 (:in-flight @stream))
         "decrement runs in finally so a body exception doesn't leak the slot")))
 
 (deftest with-in-flight-returns-body-value
   (let [stream (atom {:in-flight 0})]
-    (is (= :result (with-in-flight stream (constantly :result))))))
+    (is (= :result (with-in-flight stream (evt) (constantly :result))))))
+
+(deftest with-in-flight-returns-quiesced-sentinel-when-fenced
+  ;; Pins the TOCTOU fix at the unit level: with-in-flight bypasses
+  ;; body-fn and returns the sentinel when try-acquire-in-flight! finds
+  ;; the workflow already fenced in its atomic swap!.
+  (let [wid    (random-uuid)
+        stream (atom {:in-flight 0 :quiesced-workflows #{wid}})
+        event  (evt :test/event wid)
+        result (with-in-flight stream event (fn [] :should-not-reach))]
+    (is (= result @quiesced-sentinel)
+        "returns quiesced-sentinel when the atomic acquire is denied")
+    (is (= 0 (:in-flight @stream))
+        ":in-flight must not be incremented when fenced")))
 
 ;------------------------------------------------------------------------------ record-event!
 

--- a/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
@@ -220,30 +220,37 @@
       (is (true? (:ok? result))
           "in-flight counter must release even when the sink throws"))))
 
+(def ^:private with-in-flight-var  #'core/with-in-flight)
+(def ^:private quiesced-sentinel-var #'core/quiesced-sentinel)
+
 (deftest publish-rejected-when-quiesced-during-atomic-acquire
-  ;; Pin the TOCTOU fix: a publish that passes the fast-path rejection check
-  ;; but races with quiesce! on the in-flight increment must still be
-  ;; rejected rather than silently reaching the sink.
+  ;; Pin the TOCTOU fix: a publish that clears the fast-path
+  ;; rejection-if-quiesced check (stream not yet quiesced) but then
+  ;; encounters a quiesce during the atomic acquire inside with-in-flight
+  ;; must still be rejected.
   ;;
-  ;; The fix fuses the quiesce-check and the increment into a single swap!
-  ;; inside with-in-flight. This test simulates the scenario by quiescing
-  ;; the workflow directly on the atom (bypassing the fast-path check)
-  ;; immediately before publish! would increment, and asserts that the
-  ;; canonical {:rejected? true :reason :workflow-quiesced} shape is
-  ;; returned and the sink is not reached.
+  ;; We exercise the slow path directly: bypass rejection-if-quiesced by
+  ;; calling with-in-flight on a stream that is already quiesced. This
+  ;; replicates the race window — rejection-if-quiesced would have returned
+  ;; nil (workflow not quiesced at the fast-path instant) but the atomic
+  ;; swap! inside try-acquire-in-flight! observes the fence.
   (let [[sink record] (recording-sink)
-        stream (core/create-event-stream {:sinks [sink]})
-        wid (random-uuid)
-        ;; Quiesce the workflow before any publish so the slow path inside
-        ;; try-acquire-in-flight! fires (fast-path check also guards it,
-        ;; but both paths must yield the same rejection shape).
-        _ (core/quiesce! stream {:workflow-id wid})
-        result (core/publish! stream (workflow-event wid :test/event))]
-    (is (true? (:rejected? result))
-        "quiesced-during-acquire publish must return {:rejected? true}")
-    (is (= :workflow-quiesced (:reason result))
-        "rejection reason must be :workflow-quiesced regardless of which path caught it")
-    (is (= wid (:workflow-id result))
-        "workflow-id must be echoed in the rejection map")
-    (is (= 0 (count @record))
-        "the sink must not be reached when the acquire was rejected")))
+        wid     (random-uuid)
+        event   (workflow-event wid :test/event)
+        ;; Build a stream that is quiesced, simulating the state after a
+        ;; concurrent quiesce! landed between the fast-path check and the swap!.
+        stream  (atom {:in-flight 0
+                       :quiesced-workflows #{wid}
+                       :sinks [sink]
+                       :subscribers {}
+                       :events []
+                       :filters {}
+                       :logger nil})
+        sentinel @quiesced-sentinel-var
+        result  (@with-in-flight-var stream event (fn [] :should-not-reach))]
+    (is (= result sentinel)
+        "with-in-flight returns quiesced-sentinel when the atomic acquire is denied")
+    (is (= 0 (:in-flight @stream))
+        ":in-flight must not be incremented when fenced")
+    (is (empty? @record)
+        "sink must not receive an event when quiesced during atomic acquire")))

--- a/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
@@ -219,3 +219,31 @@
     (let [result (core/drain! stream {:timeout-ms 500})]
       (is (true? (:ok? result))
           "in-flight counter must release even when the sink throws"))))
+
+(deftest publish-rejected-when-quiesced-during-atomic-acquire
+  ;; Pin the TOCTOU fix: a publish that passes the fast-path rejection check
+  ;; but races with quiesce! on the in-flight increment must still be
+  ;; rejected rather than silently reaching the sink.
+  ;;
+  ;; The fix fuses the quiesce-check and the increment into a single swap!
+  ;; inside with-in-flight. This test simulates the scenario by quiescing
+  ;; the workflow directly on the atom (bypassing the fast-path check)
+  ;; immediately before publish! would increment, and asserts that the
+  ;; canonical {:rejected? true :reason :workflow-quiesced} shape is
+  ;; returned and the sink is not reached.
+  (let [[sink record] (recording-sink)
+        stream (core/create-event-stream {:sinks [sink]})
+        wid (random-uuid)
+        ;; Quiesce the workflow before any publish so the slow path inside
+        ;; try-acquire-in-flight! fires (fast-path check also guards it,
+        ;; but both paths must yield the same rejection shape).
+        _ (core/quiesce! stream {:workflow-id wid})
+        result (core/publish! stream (workflow-event wid :test/event))]
+    (is (true? (:rejected? result))
+        "quiesced-during-acquire publish must return {:rejected? true}")
+    (is (= :workflow-quiesced (:reason result))
+        "rejection reason must be :workflow-quiesced regardless of which path caught it")
+    (is (= wid (:workflow-id result))
+        "workflow-id must be echoed in the rejection map")
+    (is (= 0 (count @record))
+        "the sink must not be reached when the acquire was rejected")))


### PR DESCRIPTION
## Summary

- **Bug**: `publish!` checked the quiesce fence and incremented `:in-flight` in two separate operations, leaving a TOCTOU window where a concurrent `quiesce!` call racing between those two steps allowed post-quiesce events to reach sinks and subscribers.
- **Impact**: Under concurrent workflow teardown (the common path for long-running DAG workflows), terminal events (`workflow-completed`, `workflow-failed`) could appear after the quiesce barrier, corrupting the shutdown ordering contract that `drain!` and the file-sink flush rely on. This was the class of race the BD-2a primitives were introduced to close, but the original implementation left the window open.
- **Fix**: Fused the quiesce-check and in-flight increment into a single `swap!` via `try-acquire-in-flight!`. Uses a `volatile!` local (safe across CAS retries) to signal the outcome. `with-in-flight` returns a `quiesced-sentinel` when the workflow was fenced during the acquire. `publish!` converts the sentinel to `{:rejected? true :reason :workflow-quiesced}`.

## Test plan

- [ ] New: `publish-rejected-when-quiesced-during-atomic-acquire` in `quiesce_drain_test.clj` pins the slow-path rejection contract
- [ ] Existing quiesce/drain tests continue to pass (fast-path unchanged)
- [ ] `in-flight-tracking-decrements-on-sink-exception` confirms the finally-block decrement still fires on sink exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G44F2JFefGGSCvAtjmNPyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01G44F2JFefGGSCvAtjmNPyi)_