### PR TITLE
feat(workflow): thread a per-invocation correlation id across ETL chain steps

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -124,7 +124,13 @@
   (let [start-time (System/currentTimeMillis)
         chain-id (:chain/id chain-def)
         steps (:chain/steps chain-def)
-        load-workflow loader/load-workflow]
+        load-workflow loader/load-workflow
+        ;; One correlation id per chain invocation, threaded onto every
+        ;; step's run-pipeline opts so all steps and their lifecycle
+        ;; events share it. Mint-if-absent: a caller may supply one to
+        ;; correlate the whole ETL invocation from outside.
+        correlation-id (or (:workflow-run/correlation-id opts) (random-uuid))
+        step-opts (assoc opts :workflow-run/correlation-id correlation-id)]
     (emit! opts events/chain-started
            chain-id (count steps))
     (loop [remaining steps
@@ -152,7 +158,7 @@
               resolved-input (resolve-bindings input-bindings prev-output chain-input)
               workflow-result (load-workflow workflow-id :latest {:skip-validation? true})
               workflow (:workflow workflow-result)
-              result (runner/run-pipeline workflow resolved-input opts)
+              result (runner/run-pipeline workflow resolved-input step-opts)
               output (:execution/output result)
               step-result {:step/id step-id
                            :step/workflow-id workflow-id

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -125,7 +125,10 @@
    :on-phase-start :on-phase-complete
    :executor :environment-id :sandbox-workdir
    :on-chunk :event-stream :worktree-path
-   :source-root])
+   :source-root
+   ;; Threaded by run-chain so every step of one ETL invocation shares
+   ;; it; lifecycle events read it from the context (see runner-events).
+   :workflow-run/correlation-id])
 
 (defn- passthrough-option-values
   [opts]

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -208,7 +208,10 @@
      :workflow-run/started-at    now
      :workflow-run/updated-at    now
      :workflow-run/trigger-source (get-in context [:execution/opts :trigger-source] :cli)
-     :workflow-run/correlation-id (:execution/id context)}))
+     ;; An inherited id (threaded by run-chain across all steps of one ETL
+     ;; invocation) wins; a standalone run correlates to its own execution.
+     :workflow-run/correlation-id (or (:workflow-run/correlation-id context)
+                                      (:execution/id context))}))
 
 (defn- repo-from-pr-url
   "Extract `owner/repo` from a GitHub-style PR URL.

--- a/components/workflow/test/ai/miniforge/workflow/chain_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_test.clj
@@ -166,3 +166,50 @@
           (is (= 1 @call-count) "step 2 should never execute")
           (is (= :failed (get-in result [:chain/step-results 0 :step/status])))
           (is (nat-int? (:chain/duration-ms result))))))))
+
+(def ^:private two-step-chain
+  {:chain/id :corr-chain
+   :chain/version "1.0.0"
+   :chain/description "Correlation chain"
+   :chain/steps
+   [{:step/id :step-1 :step/workflow-id :workflow-a
+     :step/input-bindings {:task :chain/input.task}}
+    {:step/id :step-2 :step/workflow-id :workflow-b
+     :step/input-bindings {:task :chain/input.task}}]})
+
+(defn- completed-step
+  "A run-pipeline stub result that lets the chain advance."
+  [_workflow _input _opts]
+  {:execution/status :completed
+   :execution/output {:artifacts []
+                      :phase-results {}
+                      :last-phase-result {:success? true}
+                      :status :completed}})
+
+(deftest run-chain-threads-one-correlation-id-to-all-steps-test
+  (testing "every step's run-pipeline opts carry the same minted correlation-id"
+    (let [opts-log (atom [])]
+      (with-redefs [runner/run-pipeline
+                    (fn [workflow input opts]
+                      (swap! opts-log conj opts)
+                      (completed-step workflow input opts))
+                    loader/load-workflow (constantly mock-workflow)]
+        (chain/run-chain two-step-chain {:task "x"} {})
+        (let [ids (map :workflow-run/correlation-id @opts-log)]
+          (is (= 2 (count ids)))
+          (is (every? uuid? ids) "minted as a uuid")
+          (is (apply = ids) "all steps share one correlation-id"))))))
+
+(deftest run-chain-honors-caller-supplied-correlation-id-test
+  (testing "a correlation-id supplied in opts is threaded unchanged, not overwritten"
+    (let [supplied (random-uuid)
+          opts-log (atom [])]
+      (with-redefs [runner/run-pipeline
+                    (fn [workflow input opts]
+                      (swap! opts-log conj opts)
+                      (completed-step workflow input opts))
+                    loader/load-workflow (constantly mock-workflow)]
+        (chain/run-chain two-step-chain {:task "x"}
+                         {:workflow-run/correlation-id supplied})
+        (is (= 2 (count @opts-log)))
+        (is (every? #(= supplied (:workflow-run/correlation-id %)) @opts-log))))))

--- a/components/workflow/test/ai/miniforge/workflow/context_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/context_test.clj
@@ -1,0 +1,41 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.context-test
+  "Tests for execution-context construction."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.context :as context]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Passthrough options
+
+(deftest correlation-id-is-a-passthrough-option-test
+  (testing ":workflow-run/correlation-id is copied from opts onto the context so
+            run-chain's threaded id reaches the lifecycle events"
+    (is (some #{:workflow-run/correlation-id}
+              context/execution-passthrough-option-keys)
+        "registered as a passthrough key")
+    (let [selected (#'context/passthrough-option-values
+                    {:workflow-run/correlation-id :corr
+                     :llm-backend :claude
+                     :not-a-passthrough-key :dropped})]
+      (is (= :corr (:workflow-run/correlation-id selected))
+          "carried through")
+      (is (not (contains? selected :not-a-passthrough-key))
+          "non-passthrough keys are dropped"))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -69,6 +69,24 @@
         (is (inst? (:workflow-run/started-at ev)))
         (is (inst? (:workflow-run/updated-at ev)))))))
 
+(deftest correlation-id-defaults-to-execution-id-test
+  (testing "a standalone run (no inherited id) correlates to its own execution id"
+    (let [stream (create-stream)
+          ctx    (test-context)]
+      (events/publish-workflow-started! stream ctx)
+      (is (= (:execution/id ctx)
+             (:workflow-run/correlation-id (first-event stream)))))))
+
+(deftest correlation-id-honors-inherited-id-test
+  (testing "an inherited :workflow-run/correlation-id wins over the per-run execution id"
+    (let [stream (create-stream)
+          shared (random-uuid)
+          ctx    (assoc (test-context) :workflow-run/correlation-id shared)]
+      (events/publish-workflow-started! stream ctx)
+      (let [ev (first-event stream)]
+        (is (= shared (:workflow-run/correlation-id ev)))
+        (is (not= (:execution/id ctx) (:workflow-run/correlation-id ev)))))))
+
 (deftest publish-workflow-started-timestamps-same-instant-test
   (testing "started-at and updated-at are bound to the same instant"
     (let [stream (create-stream)


### PR DESCRIPTION
## Problem

A chain — one ETL invocation — runs each step through its own `run-pipeline`, and `create-context` mints a fresh random `:execution/id` per call. So the multiple workflows one ETL invocation produces share **no id**, and a consumer tailing the event stream (e.g. a product data plane correlating a run to its progress events) cannot tell which step events belong to the same invocation.

`:workflow-run/correlation-id` already exists on every workflow lifecycle event, but it was wired to the run's own `:execution/id` (`runner-events.clj`), so it correlated nothing across steps. The only chain-spanning identifier was the *static* `:chain/id` (the definition key, identical every invocation).

(For contrast: the spec/DAG side correlates work to a spec via the *content-derived* `:spec/id` the supervisory accumulator reconstructs from `:workflow/spec` — a downstream join, not a threaded id. There was no threaded per-invocation id to reuse; this makes the dormant `:workflow-run/correlation-id` field actually carry one.)

## Change

Make `:workflow-run/correlation-id` inheritable across the steps of one ETL invocation:

- **`chain.clj`** — `run-chain` mints one correlation id per invocation (mint-if-absent, so a caller may supply one via opts to correlate the whole invocation from outside) and threads it onto every step's `run-pipeline` opts.
- **`context.clj`** — `:workflow-run/correlation-id` is added to `execution-passthrough-option-keys`, so it lands on the execution context. `create-context` and the resume path `restore-context` share that helper, so both inherit it.
- **`runner-events.clj`** — the lifecycle-event field becomes `(or inherited-id execution-id)`: a standalone run still self-correlates to its own execution; chain steps share the one inherited id.

`:execution/id` stays per-step (run identity); the correlation id rides alongside it.

**Deferred:** stamping the chain-level envelopes (`chain-started`/`chain-completed` carry `:workflow/id = nil`). The step *pipeline* events carry the shared id, which is what a consumer tails for phase progress, so it isn't needed yet.

## Verification

- New/extended tests: `chain-test` (one id across all steps; a caller-supplied id is threaded unchanged), `runner-events-test` (defaults to execution-id; honors an inherited id), new `context-test` (the passthrough link). The three namespaces: 31 tests / 99 assertions, 0 failures.
- Pre-commit gate green: poly:check, clj-kondo 0/0, pre-commit smoke (317 tests / 1196 assertions), GraalVM/Babashka compat (6 tests / 517 assertions).

## Why

Unblocks a downstream data-plane (Thesium Career) correlating a spawned ETL run to its event-stream progress without racy filesystem inference. Framework-level fix — every ETL tenant benefits.