### PR TITLE
refactor(config): route load-config-resource diagnostics through system-locale catalog

### DIFF
--- a/components/config/deps.edn
+++ b/components/config/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        ai.miniforge/messages {:local/root "../messages"}
         babashka/fs {:mvn/version "0.5.22"}
         aero/aero {:mvn/version "1.1.6"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/config/resources/config/config/messages/system.edn
+++ b/components/config/resources/config/config/messages/system.edn
@@ -1,0 +1,18 @@
+{:config/system
+ {;; Diagnostics raised by config.resource/load-config-resource when a
+  ;; required classpath EDN config resource is absent, malformed, not a map,
+  ;; or missing a required key. Operator-facing (system-locale, not user UI),
+  ;; but routed through the catalog — the system-locale counterpart of a
+  ;; component's user-locale en-US.edn — so the one place to audit or override
+  ;; them is data, not source.
+  :resource/missing
+  "Missing config resource on classpath: {path}"
+
+  :resource/malformed
+  "Malformed EDN config resource: {path}"
+
+  :resource/not-a-map
+  "Config resource is not a map: {path}"
+
+  :resource/missing-keys
+  "Config resource {path} missing keys: {keys}"}}

--- a/components/config/src/ai/miniforge/config/resource.clj
+++ b/components/config/src/ai/miniforge/config/resource.clj
@@ -31,8 +31,16 @@
      fallback on any error. Use it where call sites already carry literal
      defaults or the component is documented to fail open."
   (:require
+   [ai.miniforge.messages.interface :as messages]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
+
+(def ^:private t
+  "System-locale translator for this component. The loader's fail-fast
+   diagnostics are operator-facing (system-locale, not user UI), but routed
+   through the catalog so the one place to audit or override them is data."
+  (messages/create-translator "config/config/messages/system.edn"
+                              :config/system))
 
 (defn load-config-resource
   "Read an EDN config resource from the classpath, failing fast with a
@@ -45,7 +53,7 @@
   ([path required-keys]
    (let [url (io/resource path)]
      (when (nil? url)
-       (throw (ex-info (str "Missing config resource on classpath: " path)
+       (throw (ex-info (t :resource/missing {:path path})
                        {:config/resource path})))
      (let [parsed (try
                     (edn/read-string (slurp url :encoding "UTF-8"))
@@ -55,15 +63,15 @@
                       (.interrupt (Thread/currentThread))
                       (throw e))
                     (catch Exception e
-                      (throw (ex-info (str "Malformed EDN config resource: " path)
+                      (throw (ex-info (t :resource/malformed {:path path})
                                       {:config/resource path}
                                       e))))]
        (when-not (map? parsed)
-         (throw (ex-info (str "Config resource is not a map: " path)
+         (throw (ex-info (t :resource/not-a-map {:path path})
                          {:config/resource path})))
        (let [missing (vec (remove #(contains? parsed %) required-keys))]
          (when (seq missing)
-           (throw (ex-info (str "Config resource " path " missing keys: " missing)
+           (throw (ex-info (t :resource/missing-keys {:path path :keys missing})
                            {:config/resource path :config/missing-keys missing})))
          parsed)))))
 

--- a/docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md
+++ b/docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md
@@ -10,7 +10,7 @@ emits operator-facing (system-locale) messages that are auditable and
 overridable as data — the system-locale counterpart of a component's
 user-locale `en-US.edn`.
 
-Behaviour-preserving: the thrown `ex-info` keeps the same `ex-data`
+Behavior-preserving: the thrown `ex-info` keeps the same `ex-data`
 (`:config/resource`, `:config/missing-keys`) and the same message text; only
 the message source moves from inline strings to the catalog.
 

--- a/docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md
+++ b/docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md
@@ -1,0 +1,46 @@
+# Route config.resource diagnostics through a system-locale catalog
+
+## Overview
+
+`ai.miniforge.config.resource/load-config-resource` is the shared, fail-fast
+classpath-EDN loader ("one home for the load-this-component's-config-resource
+pattern"). Its four fail-fast diagnostics were raw English string literals in
+source. This routes them through a message catalog, so the canonical loader
+emits operator-facing (system-locale) messages that are auditable and
+overridable as data — the system-locale counterpart of a component's
+user-locale `en-US.edn`.
+
+Behaviour-preserving: the thrown `ex-info` keeps the same `ex-data`
+(`:config/resource`, `:config/missing-keys`) and the same message text; only
+the message source moves from inline strings to the catalog.
+
+## Motivation
+
+The system-locale catalog convention already exists (`pr-lifecycle` and
+`phase-software-factory` ship `messages/system.edn`). The canonical config
+loader did not use it, so every caller — `tool-registry`, and any future caller
+such as the `lsp-mcp-bridge` base — got hard-coded English. Putting the strings
+in a catalog gives one place to audit or translate them and keeps the loader,
+not each caller, as the single home for the pattern.
+
+## Changes
+
+- New `components/config/resources/config/config/messages/system.edn`
+  (`:config/system` section) holding the four loader diagnostics.
+- `components/config/src/ai/miniforge/config/resource.clj`: requires
+  `messages.interface`, creates a private system-locale translator, and routes
+  the missing / malformed / not-a-map / missing-keys `ex-info` messages through
+  it. `read-config-resource-or` (fail-open) is unchanged.
+- `components/config/deps.edn`: adds `ai.miniforge/messages` (`messages` has no
+  intra-workspace deps, so no cycle; it is bb-safe).
+
+## Verification
+
+- JVM load smoke: `load-config-resource` returns the parsed map for a present
+  resource; a missing resource throws with the catalog-routed message
+  `Missing config resource on classpath: config/nope.edn` and `:config/resource`
+  in `ex-data`.
+- `config` resource tests: 6 tests, 14 assertions, 0 failures (they assert on
+  `ex-data`, which is unchanged).
+- `bb poly:check`: OK (the pre-existing Warning 205 about the test-fixture
+  `.edn`/`.txt` files is unrelated).


### PR DESCRIPTION
## Overview

`config.resource/load-config-resource` is the shared canonical classpath-EDN loader. Its four fail-fast diagnostics were raw English string literals. This routes them through a component **system-locale** catalog so the canonical loader's operator messages are auditable/overridable as data — the system-locale counterpart of a component's user-locale `en-US.edn`, following the existing `pr-lifecycle` / `phase-software-factory` `system.edn` convention.

Behavior-preserving: same `ex-data` (`:config/resource`, `:config/missing-keys`) and same message text; only the source moves from inline strings to the catalog.

## Why

The system-locale catalog capability already exists, but the canonical config loader didn't use it — so every caller (`tool-registry` today; the `lsp-mcp-bridge` base once it converges onto the loader) got hard-coded English. One catalog = one place to audit or translate.

## Changes

- New `components/config/resources/config/config/messages/system.edn` (`:config/system`).
- `config.resource` requires `messages.interface`, creates a private system-locale translator, routes the missing / malformed / not-a-map / missing-keys messages through it. `read-config-resource-or` unchanged.
- `components/config/deps.edn` gains `ai.miniforge/messages` (no cycle — `messages` has no intra-workspace deps; bb-safe).

## Verification

- JVM load smoke: present resource returns the map; missing resource throws the catalog-routed message + `:config/resource` in `ex-data`.
- `config` resource tests: 6 tests / 14 assertions, 0 failures (assert on `ex-data`, unchanged).
- Full pre-commit gate: `bb poly:check` OK, kondo 0/0, smoke 317 tests, GraalVM/bb compat 517 assertions (config.resource loads under bb with the new require).

🤖 Generated with [Claude Code](https://claude.com/claude-code)