### PR TITLE
fix(reporting): log safe-get exceptions at WARN instead of silently swallowing

### DIFF
--- a/components/reporting/src/ai/miniforge/reporting/core.clj
+++ b/components/reporting/src/ai/miniforge/reporting/core.clj
@@ -29,19 +29,21 @@
 ;; Helper functions
 
 (defn safe-get
-  "Returns nil on error; logs at WARN when a logger is supplied."
-  ([f & args]
-   (try
-     (apply f args)
-     (catch Exception _e nil)))
-  ([logger f & args]
-   (try
-     (apply f args)
-     (catch Exception e
-       (when logger
-         (log/warn logger :reporting :reporting/safe-get-error
-                   {:error (.getMessage e) :fn (str f)}))
-       nil))))
+  "Returns nil on error; logs at WARN when a logger is supplied.
+  Call as (safe-get f arg…) or (safe-get logger f arg…)."
+  [maybe-logger-or-fn & rest]
+  (if (ifn? maybe-logger-or-fn)
+    (try
+      (apply maybe-logger-or-fn rest)
+      (catch Exception _e nil))
+    (let [[f & args] rest]
+      (try
+        (apply f args)
+        (catch Exception e
+          (log/warn maybe-logger-or-fn :reporting :reporting/safe-get-error
+                    {:message (str "safe-get caught: " (.getMessage e))
+                     :data {:fn (str f)}})
+          nil)))))
 
 (defn count-by-status
   "Count workflows by status."

--- a/components/reporting/src/ai/miniforge/reporting/core.clj
+++ b/components/reporting/src/ai/miniforge/reporting/core.clj
@@ -29,12 +29,19 @@
 ;; Helper functions
 
 (defn safe-get
-  "Safely get value from component, returning nil on error."
-  [f & args]
-  (try
-    (apply f args)
-    (catch Exception _e
-      nil)))
+  "Returns nil on error; logs at WARN when a logger is supplied."
+  ([f & args]
+   (try
+     (apply f args)
+     (catch Exception _e nil)))
+  ([logger f & args]
+   (try
+     (apply f args)
+     (catch Exception e
+       (when logger
+         (log/warn logger :reporting :reporting/safe-get-error
+                   {:error (.getMessage e) :fn (str f)}))
+       nil))))
 
 (defn count-by-status
   "Count workflows by status."
@@ -73,8 +80,8 @@
 
 (defn aggregate-workflow-stats
   "Aggregate workflow statistics."
-  [workflow-component]
-  (if-let [all-workflows (safe-get wf/get-state workflow-component :all)]
+  [workflow-component logger]
+  (if-let [all-workflows (safe-get logger wf/get-state workflow-component :all)]
     {:active (count-by-status all-workflows :running)
      :pending (count-by-status all-workflows :pending)
      :completed (count-by-status all-workflows :completed)
@@ -83,8 +90,8 @@
 
 (defn aggregate-resource-metrics
   "Aggregate resource usage metrics."
-  [workflow-component]
-  (if-let [all-workflows (safe-get wf/get-state workflow-component :all)]
+  [workflow-component logger]
+  (if-let [all-workflows (safe-get logger wf/get-state workflow-component :all)]
     (reduce
      (fn [acc wf]
        (let [metrics (:workflow/metrics wf {})]
@@ -96,9 +103,9 @@
 
 (defn aggregate-meta-loop-status
   "Aggregate meta-loop status."
-  [operator-component]
+  [operator-component logger]
   (if operator-component
-    (let [proposals (safe-get op/get-proposals operator-component {:status :proposed})
+    (let [proposals (safe-get logger op/get-proposals operator-component {:status :proposed})
           pending-count (count proposals)]
       {:status (if (> pending-count 0) :active :idle)
        :pending-improvements pending-count})
@@ -107,16 +114,16 @@
 
 (defn collect-alerts
   "Collect system alerts."
-  [workflow-stats operator-component]
+  [workflow-stats operator-component logger]
   (let [alerts []]
     (cond-> alerts
       (> (:failed workflow-stats 0) 0)
       (conj {:type :failed-workflows
              :severity :error
              :message (str (:failed workflow-stats) " failed workflow(s)")})
-      
+
       (and operator-component
-           (> (count (safe-get op/get-proposals operator-component {:status :proposed})) 5))
+           (> (count (safe-get logger op/get-proposals operator-component {:status :proposed})) 5))
       (conj {:type :pending-improvements
              :severity :warning
              :message "Multiple pending improvements awaiting review"}))))
@@ -137,9 +144,9 @@
 
 (defn get-workflow-artifacts
   "Get artifacts for a workflow."
-  [artifact-store workflow-id]
+  [artifact-store workflow-id logger]
   (if artifact-store
-    (let [artifacts (safe-get art/query artifact-store {:workflow-id workflow-id})]
+    (let [artifacts (safe-get logger art/query artifact-store {:workflow-id workflow-id})]
       (mapv (fn [art]
               {:id (:artifact/id art)
                :type (:artifact/type art)
@@ -169,10 +176,10 @@
   proto/ReportingService
 
   (get-system-status [_this]
-    (let [workflow-stats (aggregate-workflow-stats workflow-component)
-          resource-metrics (aggregate-resource-metrics workflow-component)
-          meta-loop-status (aggregate-meta-loop-status operator-component)
-          alerts (collect-alerts workflow-stats operator-component)]
+    (let [workflow-stats (aggregate-workflow-stats workflow-component logger)
+          resource-metrics (aggregate-resource-metrics workflow-component logger)
+          meta-loop-status (aggregate-meta-loop-status operator-component logger)
+          alerts (collect-alerts workflow-stats operator-component logger)]
       {:workflows workflow-stats
        :resources resource-metrics
        :meta-loop meta-loop-status
@@ -183,7 +190,7 @@
           phase-filter (:phase criteria)
           limit (:limit criteria 100)
           all-workflows (if workflow-component
-                          (safe-get wf/get-state workflow-component :all)
+                          (safe-get logger wf/get-state workflow-component :all)
                           [])]
       (->> (or all-workflows [])
            (filter (fn [wf]
@@ -199,7 +206,7 @@
                     :workflow/created-at (:workflow/created-at wf)})))))
 
   (get-workflow-detail [_this workflow-id]
-    (if-let [workflow-state (safe-get wf/get-state workflow-component workflow-id)]
+    (if-let [workflow-state (safe-get logger wf/get-state workflow-component workflow-id)]
       {:header {:id (:workflow/id workflow-state)
                 :status (:workflow/status workflow-state)
                 :phase (:workflow/phase workflow-state)
@@ -209,15 +216,15 @@
        :current-task {:description (:workflow/current-task workflow-state)
                       :agent (:workflow/current-agent workflow-state)
                       :status (:workflow/status workflow-state)}
-       :artifacts (get-workflow-artifacts artifact-store workflow-id)
+       :artifacts (get-workflow-artifacts artifact-store workflow-id logger)
        :logs (get-workflow-logs logger workflow-id)}
       nil))
 
   (get-meta-loop-status [_this]
     (if operator-component
-      (let [signals (safe-get op/get-signals operator-component {:limit 10})
-            pending (safe-get op/get-proposals operator-component {:status :proposed})
-            recent (safe-get op/get-proposals operator-component {:status :applied})]
+      (let [signals (safe-get logger op/get-signals operator-component {:limit 10})
+            pending (safe-get logger op/get-proposals operator-component {:status :proposed})
+            recent (safe-get logger op/get-proposals operator-component {:status :applied})]
         {:signals (or signals [])
          :pending-improvements (or pending [])
          :recent-improvements (take 10 (or recent []))})

--- a/components/reporting/test/ai/miniforge/reporting/core_test.clj
+++ b/components/reporting/test/ai/miniforge/reporting/core_test.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.reporting.core-test
+  "Unit tests for reporting core helpers."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.reporting.core :as core]
+   [ai.miniforge.logging.interface :as log]))
+
+(deftest test-safe-get-returns-value-on-success
+  (testing "safe-get returns the fn result when no exception is thrown"
+    (is (= 42 (core/safe-get (fn [] 42))))
+    (is (= :ok (core/safe-get (constantly :ok))))))
+
+(deftest test-safe-get-returns-nil-on-exception
+  (testing "safe-get without logger returns nil when fn throws"
+    (is (nil? (core/safe-get (fn [] (throw (Exception. "boom"))))))))
+
+(deftest test-safe-get-with-logger-returns-nil-on-exception
+  (testing "safe-get with logger returns nil when fn throws"
+    (let [[logger _] (log/collecting-logger)]
+      (is (nil? (core/safe-get logger (fn [] (throw (Exception. "boom")))))))))
+
+(deftest test-safe-get-with-logger-emits-warn-on-exception
+  (testing "safe-get emits :reporting/safe-get-error at WARN when logger is provided"
+    (let [[logger entries] (log/collecting-logger)]
+      (core/safe-get logger (fn [] (throw (Exception. "boom"))))
+      (is (some #(and (= :reporting/safe-get-error (:log/event %))
+                      (= :warn (:log/level %)))
+                @entries)))))
+
+(deftest test-safe-get-with-logger-returns-value-on-success
+  (testing "safe-get with logger returns value and does not log when fn succeeds"
+    (let [[logger entries] (log/collecting-logger)]
+      (is (= 42 (core/safe-get logger (fn [] 42))))
+      (is (empty? @entries)))))
+
+(deftest test-safe-get-nil-logger-is-safe
+  (testing "safe-get with nil logger behaves like no-logger variant"
+    (is (nil? (core/safe-get nil (fn [] (throw (Exception. "boom"))))))
+    (is (= 42 (core/safe-get nil (fn [] 42))))))


### PR DESCRIPTION
## Problem

`safe-get` in `components/reporting/src/ai/miniforge/reporting/core.clj` catches all exceptions and returns `nil` without logging. Every call site in the `ReportingServiceImpl` then degrades silently to a zero/empty default:

- Failed workflow queries → reports "0 active workflows"
- Failed cost queries → reports $0 / 0 tokens
- Failed operator queries → no system alerts emitted

Operators see a healthy idle system during actual failure cascades — the monitoring layer that should surface problems is itself hiding them.

## Fix

Add a two-arity variant of `safe-get` that accepts an optional logger and logs at `:reporting/safe-get-error` (WARN) before returning `nil`. Thread `logger` through the five aggregation helpers (`aggregate-workflow-stats`, `aggregate-resource-metrics`, `aggregate-meta-loop-status`, `collect-alerts`, `get-workflow-artifacts`) and update all `ReportingServiceImpl` method call sites to pass the record's `logger` field.

The no-logger single-arity variant is retained for backward compatibility. Behavior is unchanged; the only new effect is a WARN log entry when a component call throws.

## Files changed

- `components/reporting/src/ai/miniforge/reporting/core.clj`
  - `safe-get`: new two-arity form with logger
  - 5 aggregation helpers: add `logger` parameter
  - 4 `ReportingServiceImpl` methods: pass `logger` to aggregation calls and direct `safe-get` calls

---
_Generated by [Claude Code](https://claude.ai/code/session_01Njiqq3c9qbyjGXHpVXv2wm)_