### PR TITLE
fix(phase-deployment): pipe kustomize YAML to kubectl via stdin, drop temp file

### DIFF
--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/exec.clj
@@ -80,15 +80,17 @@
 ;; Shell execution + classification
 
 (defn sh-with-timeout
-  "Execute a shell command with timeout and structured results."
-  [cmd args & {:keys [dir timeout-ms env]
+  "Execute a shell command with timeout and structured results.
+   Pass :in STRING to supply the process's stdin (e.g. piping YAML to kubectl)."
+  [cmd args & {:keys [dir timeout-ms env in]
                :or {timeout-ms (get timeouts/timeouts :exec-default-ms 300000)}}]
   (let [start-time (System/currentTimeMillis)
         full-cmd   (into [cmd] args)
         cmd-str    (str/join " " full-cmd)
         sh-args    (cond-> full-cmd
                      dir (into [:dir dir])
-                     env (into [:env (merge (into {} (System/getenv)) env)]))]
+                     env (into [:env (merge (into {} (System/getenv)) env)])
+                     in  (into [:in in]))]
     (try
       (let [future-result (future (apply shell/sh sh-args))
             result        (deref future-result timeout-ms ::timeout)]

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
@@ -21,8 +21,7 @@
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.phase-deployment.shell.exec :as exec]
             [ai.miniforge.phase-deployment.shell.timeouts :as timeouts]
-            [ai.miniforge.schema.interface :as schema])
-  (:import [java.io File]))
+            [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Kustomize wrappers
@@ -59,16 +58,9 @@
                             namespace (into ["--namespace" namespace])
                             context   (into ["--context" context])
                             dry-run?  (conj "--dry-run=client"))
-            tmp-file      (File/createTempFile "kustomize-" ".yaml")
-            _             (spit tmp-file rendered-yaml)
-            apply-result  (exec/sh-with-timeout "kubectl"
-                                                (-> (subvec apply-args 0 1)
-                                                    (into ["-f" (.getAbsolutePath tmp-file)])
-                                                    (into (subvec apply-args 3)))
+            apply-result  (exec/sh-with-timeout "kubectl" apply-args
+                                                :in rendered-yaml
                                                 :timeout-ms (get timeouts/timeouts :kustomize-apply-ms 120000))]
-        (try
-          (.delete tmp-file)
-          (catch Exception _ nil))
         (if (schema/succeeded? apply-result)
           (validate-result!
            (schema/success :rendered-yaml rendered-yaml

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/exec_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/exec_test.clj
@@ -34,7 +34,12 @@
   (testing "returns a structured timeout result"
     (let [result (sut/sh-with-timeout "sleep" ["1"] :timeout-ms 10)]
       (is (false? (:success? result)))
-      (is (= :timeout (:error-type result))))))
+      (is (= :timeout (:error-type result)))))
+
+  (testing "pipes :in string to the subprocess stdin"
+    (let [result (sut/sh-with-timeout "cat" [] :in "hello from stdin")]
+      (is (:success? result))
+      (is (= "hello from stdin" (str/trim (:stdout result)))))))
 
 (deftest classify-error-test
   (testing "classifies retryable and permanent errors"


### PR DESCRIPTION
## Problem

`kustomize-apply!` in `shell/kustomize.clj` built `apply-args` with `-f -` (stdin), then silently discarded that intent by writing rendered YAML to a temp file and swapping in the file path instead.

Two concrete risks:
1. **Race / injection**: between `spit` and `kubectl apply`, an attacker with access to `/tmp` can replace or symlink the file to inject arbitrary pod specs into the cluster.
2. **Secret leakage on disk**: `File/createTempFile` writes deployment manifests (which often contain env-var secrets) to a world-accessible path; the `try/.delete` cleanup could fail silently.

## Fix

Added `:in` support to `sh-with-timeout` in `shell/exec.clj` — `clojure.java.shell/sh` already accepts `:in STRING` for stdin, so this is a two-line change to the destructuring and `cond->` chain. In `kustomize.clj`, removed the `File/createTempFile` / `spit` / `try .delete` block entirely and passed `:in rendered-yaml` with the original `apply-args` (which already carried `-f -`).

## Files changed

| File | Change |
|------|--------|
| `shell/exec.clj` | Add `:in` keyword arg; thread it through `sh-args` via `cond->` |
| `shell/kustomize.clj` | Drop `(:import [java.io File])`, remove temp-file block, pass `:in rendered-yaml` |

## Checklist

- [x] `exec.clj` change is backward-compatible — `:in` is optional, nil is falsy in `cond->`
- [x] Kubernetes manifests no longer touch disk
- [x] `bb` not available in this environment; no runtime test runner executed

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMpV9L8gChJtGbohohmiNA)_