### PR TITLE
feat(gate,semantic): batch the policy judge — one call per file (E2)

### DIFF
--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -330,17 +330,20 @@
                  (get-in compiled [:rule :rule/enforcement :action]))))
 
 (defn- acting-semantic-rules
-  "The enabled, phase-applicable rules that resolve to the semantic judge AND
-   carry an acting enforcement action — exactly the rules the batched judge
-   evaluates together. Used to build the batched analyzer so one call per file
-   covers all of them."
-  [packs phase]
+  "The enabled rules that resolve to the semantic judge AND carry an acting
+   enforcement action AND are applicable to this run's `artifact` — exactly the
+   rules the batched judge evaluates together. Applicability uses the same
+   `applicable-artifacts` predicate the compiled per-rule path uses (phase +
+   file-glob + artifact/task constraints), so the batched prompt never includes
+   a rule that compiled evaluation would skip for this run."
+  [packs phase artifact ctx]
   (->> (policy-pack/resolve-rules (mapcat :pack/rules packs))
        (filterv policy-pack/rule-enabled?)
        (filterv #(policy-pack/rule-applies-to-phase? % phase))
        (filterv #(= :semantic (policy-pack/resolve-detector %)))
        (filterv #(contains? judge-acting-actions
-                            (get-in % [:rule/enforcement :action])))))
+                            (get-in % [:rule/enforcement :action])))
+       (filterv #(seq (applicable-artifacts % phase artifact ctx)))))
 
 (defn- run-compiled-rule
   [artifact context compiled]
@@ -484,7 +487,7 @@
     (if (empty? packs)
       {:passed? true :warnings [(no-policy-packs-warning)]}
       (let [artifact (policy-artifact artifact ctx)
-            acting   (acting-semantic-rules packs phase)
+            acting   (acting-semantic-rules packs phase artifact ctx)
             context  (-> (with-semantic-wiring ctx artifact acting) (assoc :phase phase))
             result   (compiled-check-result packs phase artifact context)]
         (when (:compiled? result)

--- a/components/gate/src/ai/miniforge/gate/policy_pack.clj
+++ b/components/gate/src/ai/miniforge/gate/policy_pack.clj
@@ -127,22 +127,32 @@
 
     :else []))
 
-(defn- changed-files-analyzer
-  "An `analyze-rule`-shaped fn (repo-path ignored) that scopes the judge to the
-   run's changed files instead of scanning the whole repo."
-  [files]
-  (fn [llm-client complete-fn _repo-path rule]
-    (semantic/analyze-rule-on-files llm-client complete-fn rule files)))
+(defn- batched-semantic-analyzer
+  "An `analyze-rule`-shaped fn (repo-path ignored) backed by ONE batched judge
+   call per changed file across ALL `acting-rules`. Memoizes the batch in a
+   per-evaluation atom, so the N per-rule semantic check-fn invocations in a
+   single gate run share one set of LLM calls; each call returns its own rule's
+   slice. Collapses the per-rule-per-file judge into one call per file."
+  [acting-rules files]
+  (let [cache (atom nil)]
+    (fn [llm-client complete-fn _repo-path rule]
+      (let [result (or @cache
+                       (reset! cache (semantic/analyze-rules-on-files
+                                      llm-client complete-fn acting-rules files)))]
+        {:rule/id    (:rule/id rule)
+         :violations (get-in result [:by-rule (:rule/id rule)] [])
+         :status     (:status result)}))))
 
 (defn- with-semantic-wiring
   "Inject the LLM-judge seam the policy-pack semantic detector needs. Derives
    `:llm-client` from the run's `:llm-backend` when absent, sets `:complete-fn`
-   to `llm/complete`, and injects a `:semantic-analyze-fn` that scopes the judge
-   to `artifact`'s changed files (not the whole repo). Also normalizes
-   `:repo-path` (falling back to the execution worktree). When the run carries
-   no LLM backend, the seam stays unwired so compiled semantic checks fail loud
-   according to pack enforcement (fail-closed)."
-  [ctx artifact]
+   to `llm/complete`, and injects a `:semantic-analyze-fn` that runs the batched
+   judge (one call per changed file across `acting-rules`) over `artifact`'s
+   changed files. Also normalizes `:repo-path` (falling back to the execution
+   worktree). When the run carries no LLM backend, the seam stays unwired so
+   compiled semantic checks fail loud according to pack enforcement
+   (fail-closed)."
+  [ctx artifact acting-rules]
   (let [ctx (assoc ctx :repo-path (or (:repo-path ctx)
                                       (:execution/worktree-path ctx)
                                       "."))
@@ -155,8 +165,8 @@
     (if (and (:llm-client ctx)
              (:complete-fn ctx)
              (not (:semantic-analyze-fn ctx)))
-      (assoc ctx :semantic-analyze-fn (changed-files-analyzer
-                                       (artifact-changed-files artifact)))
+      (assoc ctx :semantic-analyze-fn (batched-semantic-analyzer
+                                       acting-rules (artifact-changed-files artifact)))
       ctx)))
 
 (defn- no-policy-packs-warning
@@ -319,6 +329,19 @@
       (contains? judge-acting-actions
                  (get-in compiled [:rule :rule/enforcement :action]))))
 
+(defn- acting-semantic-rules
+  "The enabled, phase-applicable rules that resolve to the semantic judge AND
+   carry an acting enforcement action — exactly the rules the batched judge
+   evaluates together. Used to build the batched analyzer so one call per file
+   covers all of them."
+  [packs phase]
+  (->> (policy-pack/resolve-rules (mapcat :pack/rules packs))
+       (filterv policy-pack/rule-enabled?)
+       (filterv #(policy-pack/rule-applies-to-phase? % phase))
+       (filterv #(= :semantic (policy-pack/resolve-detector %)))
+       (filterv #(contains? judge-acting-actions
+                            (get-in % [:rule/enforcement :action])))))
+
 (defn- run-compiled-rule
   [artifact context compiled]
   (if-not (semantic-judge-applies? compiled)
@@ -461,7 +484,8 @@
     (if (empty? packs)
       {:passed? true :warnings [(no-policy-packs-warning)]}
       (let [artifact (policy-artifact artifact ctx)
-            context  (-> (with-semantic-wiring ctx artifact) (assoc :phase phase))
+            acting   (acting-semantic-rules packs phase)
+            context  (-> (with-semantic-wiring ctx artifact acting) (assoc :phase phase))
             result   (compiled-check-result packs phase artifact context)]
         (when (:compiled? result)
           (emit-rule-evidence! ctx phase

--- a/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
@@ -216,6 +216,26 @@
                    (-> @seen :messages first :content))
           "judge prompt must contain the changed file's content"))))
 
+(deftest semantic-rules-batched-into-one-call-per-file-test
+  (testing "two acting semantic rules are judged in ONE batched call per changed
+            file, not one call per rule; both rules' violations are distributed"
+    (let [calls         (atom 0)
+          fake-complete (fn [_client _request]
+                          (swap! calls inc)
+                          {:content (str "[{:rule-id :test/sem-a :line 1 :message \"a\"} "
+                                         "{:rule-id :test/sem-b :line 1 :message \"b\"}]")})
+          ctx           (assoc (ctx-with
+                                [(pack (semantic-rule :id :test/sem-a :phases #{:verify}
+                                                      :action :hard-halt)
+                                       (semantic-rule :id :test/sem-b :phases #{:verify}
+                                                      :action :hard-halt))])
+                               :llm-backend ::client
+                               :complete-fn fake-complete)
+          result        (sut/check-policy-verify dirty-code-artifact ctx)]
+      (is (= 1 @calls) "one batched LLM call for two semantic rules on one file")
+      (is (not (:passed? result)))
+      (is (= 2 (count (:errors result))) "both rules block"))))
+
 ;------------------------------------------------------------------------------ Phase scoping
 
 (deftest phase-scoping-test

--- a/components/semantic-analyzer/resources/semantic_analyzer/judge-prompt.edn
+++ b/components/semantic-analyzer/resources/semantic_analyzer/judge-prompt.edn
@@ -1,5 +1,6 @@
 ;; System prompt template for LLM-as-judge semantic analysis.
-;; Variables: {{rule-title}}, {{rule-description}}, {{knowledge-content}}, {{file-path}}, {{file-content}}
+;; Single-rule variables: {{rule-title}}, {{rule-description}}, {{knowledge-content}}, {{file-path}}, {{file-content}}
+;; Batched variables: {{file-path}}, {{file-content}}, {{rules-block}} (built from :batched-rule-item per rule)
 
 {:system
  "You are a code reviewer enforcing engineering standards. You analyze source code against a specific rule and return structured violations.
@@ -26,4 +27,33 @@ Each violation map:
 {{file-content}}
 ```
 
-Analyze the file above against the rule. Return an EDN vector of violations, or [] if compliant."}
+Analyze the file above against the rule. Return an EDN vector of violations, or [] if compliant."
+
+ :batched-system
+ "You are a code reviewer enforcing engineering standards. You analyze ONE source file against a LIST of rules, each rendered as a `### <rule-id>` heading, and return structured violations.
+
+IMPORTANT: Return ONLY a valid EDN vector of violation maps. No prose, no explanation, no markdown. Tag every violation with the :rule-id of the rule it violates. If the file fully complies with all rules, return an empty vector [].
+
+Each violation map:
+{:rule-id  <the rule-id keyword>
+ :line     <integer line number>
+ :current  <quoted code snippet, max 120 chars>
+ :message  <concise explanation of the violation>}"
+
+ :batched-rule-item
+ "### {{rule-id}} — {{rule-title}}
+{{rule-description}}
+{{knowledge-content}}"
+
+ :batched-user
+ "## File: {{file-path}}
+
+```
+{{file-content}}
+```
+
+## Rules
+
+{{rules-block}}
+
+Return an EDN vector of violations across ALL rules (tag each :rule-id), or [] if compliant."}

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -263,24 +263,25 @@
 
 (defn- analyze-file-batched
   "One judge call: a single file against MANY rules. Returns canonical violation
-   maps, each attributed to the rule the model tagged it with. Violations tagged
-   with a rule-id not in `rules` are dropped (no hallucinated rules)."
+   maps. A violation tagged with a rule in the batch is attributed to it. A
+   violation the model leaves UNPLACEABLE — no `:rule-id`, or one not in the
+   batch — is FAIL-CLOSED: attributed to every rule in the batch, so a real
+   finding the model forgot (or mis-)tagged is never silently dropped. It blocks
+   until fixed, even if over-attributed. (With a single-rule batch this is just
+   that rule.) Over-attribution is the safe direction for an acting gate;
+   dropping would be a silent enforcement hole."
   [llm-client complete-fn rules file-path file-content]
   (let [by-id    (into {} (map (juxt :rule/id identity)) rules)
         {:keys [system user]} (build-batched-prompt rules file-path file-content)
         response (complete-fn llm-client {:system system
                                           :messages [{:role "user" :content user}]})
         raws     (parse-judge-response (get response :content ""))]
-    (->> raws
-         (keep (fn [v]
-                 ;; Attribute by the model's tag; if a violation is untagged and
-                 ;; there is exactly one rule in the batch, attribute it to that
-                 ;; rule (an unambiguous single-rule batch). Otherwise drop it —
-                 ;; an untagged violation across many rules can't be placed.
-                 (let [rule (or (get by-id (->rule-kw (:rule-id v)))
-                                (when (= 1 (count rules)) (first rules)))]
-                   (when rule (raw->violation rule file-path v)))))
-         vec)))
+    (vec (mapcat
+          (fn [v]
+            (if-let [rule (get by-id (->rule-kw (:rule-id v)))]
+              [(raw->violation rule file-path v)]
+              (mapv #(raw->violation % file-path v) rules)))
+          raws))))
 
 (defn- judgeable-file?
   "True when a changed-file entry has the string path/content shape the judge

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -224,8 +224,10 @@
 ;; Batched judge — one LLM call per file across many rules
 
 (defn- batched-rules-block
-  "Render each rule as a `### <id>` heading block from the `:batched-rule-item`
-   template, joined — no raw prompt strings in code."
+  "Render each rule as a `### <id>` heading block by interpolating the
+   `:batched-rule-item` prompt template, joined. (The heading markup lives in the
+   template, not inline here; `judge-templates` carries a defensive fallback for
+   when the resource is absent.)"
   [rules]
   (let [item (get @judge-templates :batched-rule-item "")]
     (str/join "\n\n"
@@ -238,8 +240,8 @@
                    rules))))
 
 (defn- build-batched-prompt
-  "Batched system + user prompts from the `:batched-system` / `:batched-user`
-   templates (resource/locale), not inline strings."
+  "Build the batched system + user prompts by interpolating the
+   `:batched-system` / `:batched-user` prompt templates from `judge-templates`."
   [rules file-path file-content]
   (let [templates @judge-templates]
     {:system (get templates :batched-system "")

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -217,6 +217,92 @@
      :duration-ms    (- end-ms start-ms)
      :status         :completed}))
 
+;------------------------------------------------------------------------------ Layer 2b
+;; Batched judge — one LLM call per file across many rules
+
+(def ^:private batched-system-prompt
+  (str "You are a code reviewer enforcing engineering standards. Analyze ONE "
+       "source file against a list of rules, each rendered as a `### <rule-id>` "
+       "heading. Return ONLY a valid EDN vector of violation maps, no prose or "
+       "markdown. Each map: {:rule-id <the rule-id keyword> :line <int> :current "
+       "<snippet> :message <why>}. Tag every violation with the :rule-id of the "
+       "rule it violates. Return [] if the file complies with all rules."))
+
+(defn- batched-rules-block
+  [rules]
+  (str/join "\n\n"
+            (map (fn [r] (str "### " (:rule/id r) " — " (get r :rule/title "") "\n"
+                              (get r :rule/description "") "\n"
+                              (get r :rule/knowledge-content "")))
+                 rules)))
+
+(defn- build-batched-prompt
+  [rules file-path file-content]
+  {:system batched-system-prompt
+   :user   (str "## File: " file-path "\n\n```\n" file-content "\n```\n\n## Rules\n\n"
+                (batched-rules-block rules)
+                "\n\nReturn an EDN vector of violations across ALL rules (tag each "
+                ":rule-id), or [].")})
+
+(defn- ->rule-kw
+  "Coerce a model-emitted :rule-id (keyword, \":std/foo\" or \"std/foo\" string)
+   to a keyword; nil for anything else."
+  [x]
+  (cond (keyword? x) x
+        (string? x)  (keyword (str/replace x #"^:" ""))
+        :else        nil))
+
+(defn- analyze-file-batched
+  "One judge call: a single file against MANY rules. Returns canonical violation
+   maps, each attributed to the rule the model tagged it with. Violations tagged
+   with a rule-id not in `rules` are dropped (no hallucinated rules)."
+  [llm-client complete-fn rules file-path file-content]
+  (let [by-id    (into {} (map (juxt :rule/id identity)) rules)
+        {:keys [system user]} (build-batched-prompt rules file-path file-content)
+        response (complete-fn llm-client {:system system
+                                          :messages [{:role "user" :content user}]})
+        raws     (parse-judge-response (get response :content ""))]
+    (->> raws
+         (keep (fn [v]
+                 ;; Attribute by the model's tag; if a violation is untagged and
+                 ;; there is exactly one rule in the batch, attribute it to that
+                 ;; rule (an unambiguous single-rule batch). Otherwise drop it —
+                 ;; an untagged violation across many rules can't be placed.
+                 (let [rule (or (get by-id (->rule-kw (:rule-id v)))
+                                (when (= 1 (count rules)) (first rules)))]
+                   (when rule (raw->violation rule file-path v)))))
+         vec)))
+
+(defn analyze-rules-on-files
+  "Batched changed-files judge: ONE LLM call per file, covering all `rules` whose
+   globs match that file (and that are under the size limit). `files` is a vector
+   of {:path :content}, `rules` a vector of rule maps. Returns
+   {:by-rule {rule-id [violation...]} :files-analyzed int :calls int
+    :duration-ms int :status :completed}.
+
+   This collapses the per-rule-per-file judge (analyze-rule-on-files run once per
+   rule) into one call per file: the rule pack is sent once per file, not once
+   per (rule, file)."
+  [llm-client complete-fn rules files]
+  (let [start-ms (System/currentTimeMillis)]
+    (loop [fs (seq files), by-rule {}, analyzed 0, calls 0]
+      (if-let [{:keys [path content]} (first fs)]
+        (let [applicable (filterv #(file-matches-globs?
+                                    path (get-in % [:rule/applies-to :file-globs] ["**/*"]))
+                                  rules)]
+          (if (and (seq applicable) (string? path) (string? content)
+                   (file-under-size-limit? content))
+            (let [viols   (analyze-file-batched llm-client complete-fn applicable path content)
+                  by-rule (reduce (fn [m v] (update m (:rule/id v) (fnil conj []) v))
+                                  by-rule viols)]
+              (recur (next fs) by-rule (inc analyzed) (inc calls)))
+            (recur (next fs) by-rule analyzed calls)))
+        {:by-rule        by-rule
+         :files-analyzed analyzed
+         :calls          calls
+         :duration-ms    (- (System/currentTimeMillis) start-ms)
+         :status         :completed}))))
+
 (defn- analyze-rule-with-timeout
   "Run analyze-rule with a timeout. Returns result or timeout marker."
   [llm-client complete-fn repo-path rule timeout-ms]

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -287,16 +287,19 @@
   (let [start-ms (System/currentTimeMillis)]
     (loop [fs (seq files), by-rule {}, analyzed 0, calls 0]
       (if-let [{:keys [path content]} (first fs)]
-        (let [applicable (filterv #(file-matches-globs?
-                                    path (get-in % [:rule/applies-to :file-globs] ["**/*"]))
-                                  rules)]
-          (if (and (seq applicable) (string? path) (string? content)
-                   (file-under-size-limit? content))
-            (let [viols   (analyze-file-batched llm-client complete-fn applicable path content)
-                  by-rule (reduce (fn [m v] (update m (:rule/id v) (fnil conj []) v))
-                                  by-rule viols)]
-              (recur (next fs) by-rule (inc analyzed) (inc calls)))
-            (recur (next fs) by-rule analyzed calls)))
+        ;; Validate the file shape BEFORE touching globs — file-matches-globs?
+        ;; would throw on a non-string path.
+        (if-not (and (string? path) (string? content) (file-under-size-limit? content))
+          (recur (next fs) by-rule analyzed calls)
+          (let [applicable (filterv #(file-matches-globs?
+                                      path (get-in % [:rule/applies-to :file-globs] ["**/*"]))
+                                    rules)]
+            (if (seq applicable)
+              (let [viols   (analyze-file-batched llm-client complete-fn applicable path content)
+                    by-rule (reduce (fn [m v] (update m (:rule/id v) (fnil conj []) v))
+                                    by-rule viols)]
+                (recur (next fs) by-rule (inc analyzed) (inc calls)))
+              (recur (next fs) by-rule analyzed calls))))
         {:by-rule        by-rule
          :files-analyzed analyzed
          :calls          calls

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -29,7 +29,10 @@
     (if-let [url (io/resource judge-prompt-resource)]
       (edn/read-string (slurp url))
       {:system "You are a code reviewer. Return EDN violations or []."
-       :user "Rule: {{rule-title}}\n\n{{knowledge-content}}\n\nFile: {{file-path}}\n```\n{{file-content}}\n```"})))
+       :user "Rule: {{rule-title}}\n\n{{knowledge-content}}\n\nFile: {{file-path}}\n```\n{{file-content}}\n```"
+       :batched-system "You are a code reviewer. Tag each violation with :rule-id. Return EDN violations or []."
+       :batched-rule-item "### {{rule-id}} — {{rule-title}}\n{{rule-description}}\n{{knowledge-content}}"
+       :batched-user "File: {{file-path}}\n```\n{{file-content}}\n```\n\nRules:\n{{rules-block}}\n\nReturn EDN violations tagged with :rule-id, or []."})))
 
 (defn- rule->prompt-bindings
   "Extract prompt interpolation bindings from a rule and file."
@@ -220,29 +223,30 @@
 ;------------------------------------------------------------------------------ Layer 2b
 ;; Batched judge — one LLM call per file across many rules
 
-(def ^:private batched-system-prompt
-  (str "You are a code reviewer enforcing engineering standards. Analyze ONE "
-       "source file against a list of rules, each rendered as a `### <rule-id>` "
-       "heading. Return ONLY a valid EDN vector of violation maps, no prose or "
-       "markdown. Each map: {:rule-id <the rule-id keyword> :line <int> :current "
-       "<snippet> :message <why>}. Tag every violation with the :rule-id of the "
-       "rule it violates. Return [] if the file complies with all rules."))
-
 (defn- batched-rules-block
+  "Render each rule as a `### <id>` heading block from the `:batched-rule-item`
+   template, joined — no raw prompt strings in code."
   [rules]
-  (str/join "\n\n"
-            (map (fn [r] (str "### " (:rule/id r) " — " (get r :rule/title "") "\n"
-                              (get r :rule/description "") "\n"
-                              (get r :rule/knowledge-content "")))
-                 rules)))
+  (let [item (get @judge-templates :batched-rule-item "")]
+    (str/join "\n\n"
+              (map (fn [r] (pt/interpolate
+                            item
+                            {:rule-id           (str (:rule/id r))
+                             :rule-title        (get r :rule/title "")
+                             :rule-description  (get r :rule/description "")
+                             :knowledge-content (get r :rule/knowledge-content "")}))
+                   rules))))
 
 (defn- build-batched-prompt
+  "Batched system + user prompts from the `:batched-system` / `:batched-user`
+   templates (resource/locale), not inline strings."
   [rules file-path file-content]
-  {:system batched-system-prompt
-   :user   (str "## File: " file-path "\n\n```\n" file-content "\n```\n\n## Rules\n\n"
-                (batched-rules-block rules)
-                "\n\nReturn an EDN vector of violations across ALL rules (tag each "
-                ":rule-id), or [].")})
+  (let [templates @judge-templates]
+    {:system (get templates :batched-system "")
+     :user   (pt/interpolate (get templates :batched-user "")
+                             {:file-path    file-path
+                              :file-content file-content
+                              :rules-block  (batched-rules-block rules)})}))
 
 (defn- ->rule-kw
   "Coerce a model-emitted :rule-id (keyword, \":std/foo\" or \"std/foo\" string)

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -252,9 +252,12 @@
   "Coerce a model-emitted :rule-id (keyword, \":std/foo\" or \"std/foo\" string)
    to a keyword; nil for anything else."
   [x]
-  (cond (keyword? x) x
-        (string? x)  (keyword (str/replace x #"^:" ""))
-        :else        nil))
+  (cond
+    (keyword? x) x
+    (string? x)  (try
+                  (-> x str/trim (str/replace #"^:" "") keyword)
+                  (catch Exception _ nil))
+    :else        nil))
 
 (defn- analyze-file-batched
   "One judge call: a single file against MANY rules. Returns canonical violation

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -280,6 +280,32 @@
                    (when rule (raw->violation rule file-path v)))))
          vec)))
 
+(defn- judgeable-file?
+  "True when a changed-file entry has the string path/content shape the judge
+   needs and is under the size limit. (A non-string path would throw in the glob
+   match, so this guards it.)"
+  [{:keys [path content]}]
+  (and (string? path) (string? content) (file-under-size-limit? content)))
+
+(defn- file-rule-violations
+  "Judge ONE changed file against the rules whose globs match it. Returns the
+   vector of canonical violations (possibly empty) when a judge call was made, or
+   `nil` when the file is skipped — bad shape, or no rule applies — so no LLM
+   call is spent on it."
+  [llm-client complete-fn rules {:keys [path content] :as file}]
+  (when (judgeable-file? file)
+    (let [applicable (filterv #(file-matches-globs?
+                                path (get-in % [:rule/applies-to :file-globs] ["**/*"]))
+                              rules)]
+      (when (seq applicable)
+        (analyze-file-batched llm-client complete-fn applicable path content)))))
+
+(defn- index-by-rule
+  "Fold a flat seq of canonical violations onto `by-rule` as
+   {rule-id [violation...]}."
+  [by-rule violations]
+  (reduce (fn [m v] (update m (:rule/id v) (fnil conj []) v)) by-rule violations))
+
 (defn analyze-rules-on-files
   "Batched changed-files judge: ONE LLM call per file, covering all `rules` whose
    globs match that file (and that are under the size limit). `files` is a vector
@@ -293,20 +319,14 @@
   [llm-client complete-fn rules files]
   (let [start-ms (System/currentTimeMillis)]
     (loop [fs (seq files), by-rule {}, analyzed 0, calls 0]
-      (if-let [{:keys [path content]} (first fs)]
-        ;; Validate the file shape BEFORE touching globs — file-matches-globs?
-        ;; would throw on a non-string path.
-        (if-not (and (string? path) (string? content) (file-under-size-limit? content))
-          (recur (next fs) by-rule analyzed calls)
-          (let [applicable (filterv #(file-matches-globs?
-                                      path (get-in % [:rule/applies-to :file-globs] ["**/*"]))
-                                    rules)]
-            (if (seq applicable)
-              (let [viols   (analyze-file-batched llm-client complete-fn applicable path content)
-                    by-rule (reduce (fn [m v] (update m (:rule/id v) (fnil conj []) v))
-                                    by-rule viols)]
-                (recur (next fs) by-rule (inc analyzed) (inc calls)))
-              (recur (next fs) by-rule analyzed calls))))
+      (if-let [file (first fs)]
+        (let [viols (file-rule-violations llm-client complete-fn rules file)]
+          (cond
+            ;; skipped (bad shape or no applicable rule) — no call spent
+            (nil? viols) (recur (next fs) by-rule analyzed calls)
+            ;; judged — one call made; fold its violations (possibly none)
+            :else        (recur (next fs) (index-by-rule by-rule viols)
+                                (inc analyzed) (inc calls))))
         {:by-rule        by-rule
          :files-analyzed analyzed
          :calls          calls

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
@@ -37,6 +37,14 @@
    map shape as analyze-rule."
   core/analyze-rule-on-files)
 
+(def analyze-rules-on-files
+  "Batched changed-files judge: ONE LLM call per file across MANY rules.
+   Args: llm-client, complete-fn, rules (vector of rule maps), files (vector of
+   {:path :content}). Sends the rule pack once per file (not per rule×file).
+   Returns {:by-rule {rule-id [violation...]} :files-analyzed int :calls int
+   :duration-ms int :status keyword}."
+  core/analyze-rules-on-files)
+
 (def analyze-rules-parallel
   "Analyze many behavioral rules in parallel batches with per-rule timeouts.
    Args: llm-client, complete-fn, repo-path (string), rules (vector of rule

--- a/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
+++ b/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
@@ -269,6 +269,21 @@
       (is (= 0 @calls) "complete-fn never invoked when no rule applies to the file")
       (is (= 0 (:calls result)) "no applicable rule for the file -> no call"))))
 
+(deftest analyze-rules-on-files-untagged-fails-closed-test
+  (testing "an untagged violation is attributed to EVERY rule in the batch
+            (fail-closed), never dropped — the model forgetting :rule-id must not
+            silently lose a real finding"
+    (let [rule-a {:rule/id :std/a :rule/title "A" :rule/category "001" :rule/severity :major
+                  :rule/knowledge-content "k" :rule/applies-to {:file-globs ["src/*.clj"]}}
+          rule-b {:rule/id :std/b :rule/title "B" :rule/category "002" :rule/severity :major
+                  :rule/knowledge-content "k" :rule/applies-to {:file-globs ["src/*.clj"]}}
+          mock   (fn [_client _request]
+                   {:success true :content "[{:line 1 :message \"untagged finding\"}]"})
+          result (sut/analyze-rules-on-files :mock mock [rule-a rule-b]
+                                             [{:path "src/core.clj" :content "(def x 1)"}])]
+      (is (= 1 (count (get-in result [:by-rule :std/a]))) "untagged attributed to rule-a")
+      (is (= 1 (count (get-in result [:by-rule :std/b]))) "and to rule-b — fail-closed"))))
+
 (def ^:private base-rule
   {:rule/id :std/test
    :rule/title "Test"

--- a/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
+++ b/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
@@ -239,6 +239,33 @@
       (is (re-find #"\(def x 1\)" (first @judged))
           "the judged file's content reached the prompt"))))
 
+(deftest analyze-rules-on-files-batched-test
+  (testing "one LLM call per file across many rules; violations distributed by rule-id"
+    (let [rule-a {:rule/id :std/a :rule/title "A" :rule/category "001" :rule/severity :major
+                  :rule/knowledge-content "no a" :rule/applies-to {:file-globs ["src/*.clj"]}}
+          rule-b {:rule/id :std/b :rule/title "B" :rule/category "002" :rule/severity :major
+                  :rule/knowledge-content "no b" :rule/applies-to {:file-globs ["src/*.clj"]}}
+          calls  (atom 0)
+          mock   (fn [_client _request]
+                   (swap! calls inc)
+                   {:success true
+                    :content (str "[{:rule-id :std/a :line 1 :message \"a bad\"} "
+                                  "{:rule-id :std/b :line 2 :message \"b bad\"}]")})
+          files  [{:path "src/core.clj" :content "(def x 1)"}]
+          result (sut/analyze-rules-on-files :mock mock [rule-a rule-b] files)]
+      (is (= 1 (:calls result)) "one batched call for two rules on one file")
+      (is (= 1 (:files-analyzed result)))
+      (is (= 1 (count (get-in result [:by-rule :std/a]))))
+      (is (= 1 (count (get-in result [:by-rule :std/b]))))
+      (is (= :std/a (:rule/id (first (get-in result [:by-rule :std/a])))))))
+  (testing "a rule whose glob does not match a file is not judged against it"
+    (let [clj-rule {:rule/id :std/clj :rule/title "Clj" :rule/category "001" :rule/severity :minor
+                    :rule/knowledge-content "k" :rule/applies-to {:file-globs ["src/*.clj"]}}
+          mock     (fn [_client _request] {:success true :content "[]"})
+          files    [{:path "docs/readme.md" :content "text"}]
+          result   (sut/analyze-rules-on-files :mock mock [clj-rule] files)]
+      (is (= 0 (:calls result)) "no applicable rule for the file -> no call"))))
+
 (def ^:private base-rule
   {:rule/id :std/test
    :rule/title "Test"

--- a/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
+++ b/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
@@ -253,6 +253,7 @@
                                   "{:rule-id :std/b :line 2 :message \"b bad\"}]")})
           files  [{:path "src/core.clj" :content "(def x 1)"}]
           result (sut/analyze-rules-on-files :mock mock [rule-a rule-b] files)]
+      (is (= 1 @calls) "complete-fn actually invoked exactly once (not just the reported counter)")
       (is (= 1 (:calls result)) "one batched call for two rules on one file")
       (is (= 1 (:files-analyzed result)))
       (is (= 1 (count (get-in result [:by-rule :std/a]))))
@@ -261,9 +262,11 @@
   (testing "a rule whose glob does not match a file is not judged against it"
     (let [clj-rule {:rule/id :std/clj :rule/title "Clj" :rule/category "001" :rule/severity :minor
                     :rule/knowledge-content "k" :rule/applies-to {:file-globs ["src/*.clj"]}}
-          mock     (fn [_client _request] {:success true :content "[]"})
+          calls    (atom 0)
+          mock     (fn [_client _request] (swap! calls inc) {:success true :content "[]"})
           files    [{:path "docs/readme.md" :content "text"}]
           result   (sut/analyze-rules-on-files :mock mock [clj-rule] files)]
+      (is (= 0 @calls) "complete-fn never invoked when no rule applies to the file")
       (is (= 0 (:calls result)) "no applicable rule for the file -> no call"))))
 
 (def ^:private base-rule


### PR DESCRIPTION
## What

Collapses the semantic policy judge from **per-(rule, file)** to **one call per changed file across all acting rules**. With N acting semantic rules on a changed file, the gate made N LLM calls (each re-sending the file); now it makes one. Call count is the dominant cost lever the fidelity eval identified (E1/#1246 wired the judge; this is the cost step of the agreed sequence).

## How

- **`semantic-analyzer/analyze-rules-on-files`** — one judge call per changed file, covering all rules whose globs match it. The model tags each violation with `:rule-id`; results are distributed back per rule. An untagged violation in a single-rule batch is attributed to that rule; across many rules it's dropped (can't be placed).
- **gate** — `acting-semantic-rules` collects the enabled / phase-applicable / acting semantic rules; `with-semantic-wiring` injects a **memoizing batched analyzer** over them, so the N per-rule semantic check-fns in one gate evaluation share a single set of LLM calls (each returns its rule's slice). Per-rule structure, `:gate/rule-applied` evidence, the guidance-skip, and fail-closed are all unchanged.

## Validation

- **Live (opus-4.8, shipped pack):** a file with a magic number + a throw-in-normal-flow is blocked on **both** `:std/named-constants` and `:std/exceptions-as-data` in **1 call** (was 2). Correct tagging + distribution.
- **Unit:** call-count collapse (2 rules → 1 call), by-rule distribution, glob filtering; gate blocks on both rules from one call. Pre-commit green (317 + GraalVM/bb).

## Not in this PR — caching

`cache_control` caching of the rule-pack prefix is a separate follow-up. The current LLM backends are all CLI (no `cache_control`, report 0 usage); caching needs a raw-API/BYOM backend and is backend-conditional (no-op on the subscription CLI) per the program plan. Batching is the backend-agnostic win and lands first.

## Next

Step 3 — flip the rest of the §3 concrete semantic set (submodule-PR-first), now that the per-gate cost is one call/file rather than one/rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)