### PR TITLE
fix(review): include self-healing resources on classpath

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -639,6 +639,7 @@
                  "components/workflow/resources"
                  "components/spec-parser/src"
                  "components/self-healing/src"
+                 "components/self-healing/resources"
                  "components/event-stream/src"
                  "components/event-stream/resources"
                  "components/supervisory-state/src"

--- a/deps.edn
+++ b/deps.edn
@@ -95,6 +95,7 @@
                        "components/web-dashboard/src"
                        "components/web-dashboard/resources"
                        "components/self-healing/src"
+                       "components/self-healing/resources"
                        "components/failure-classifier/src"
                        "components/failure-classifier/resources"
                        "components/reliability/src"

--- a/docs/pull-requests/2026-06-25-review-self-healing-resources-classpath.md
+++ b/docs/pull-requests/2026-06-25-review-self-healing-resources-classpath.md
@@ -1,0 +1,23 @@
+# Wire self-healing resources into review classpaths
+
+## Overview
+
+`bb review` failed before scanning standards violations because loading the
+self-healing component could not resolve
+`config/self-healing/backend-health.edn`. The resource exists in the component,
+but the workspace and Babashka review classpaths included only
+`components/self-healing/src`.
+
+This PR adds `components/self-healing/resources` beside the existing
+self-healing source path in both classpath declarations used by local review.
+
+## Verification
+
+- `bb review` now completes and reports the current standards backlog.
+- The resulting backlog is 308 needs-review violations, all under
+  `005 — Exceptions as Data`.
+
+## Scope
+
+No runtime behavior changes. This only makes the existing self-healing resource
+visible to repo-level review and development classpaths.


### PR DESCRIPTION
# Wire self-healing resources into review classpaths

## Overview

`bb review` failed before scanning standards violations because loading the
self-healing component could not resolve
`config/self-healing/backend-health.edn`. The resource exists in the component,
but the workspace and Babashka review classpaths included only
`components/self-healing/src`.

This PR adds `components/self-healing/resources` beside the existing
self-healing source path in both classpath declarations used by local review.

## Verification

- `bb review` now completes and reports the current standards backlog.
- The resulting backlog is 308 needs-review violations, all under
  `005 — Exceptions as Data`.

## Scope

No runtime behavior changes. This only makes the existing self-healing resource
visible to repo-level review and development classpaths.
