### PR TITLE
Consolidate config resource loaders

### DIFF
--- a/components/operator/deps.edn
+++ b/components/operator/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/messages {:local/root "../messages"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/knowledge {:local/root "../knowledge"}

--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -20,46 +20,23 @@
   "Core operator implementation.
    Manages meta-loop: observe signals, detect patterns, propose improvements."
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.operator.protocol :as proto]
    [ai.miniforge.operator.llm-improvement-generator :as llm-improvement-generator]
    [ai.miniforge.operator.llm-pattern-detector :as llm-pattern-detector]
    [ai.miniforge.workflow.interface :as wf]
    [ai.miniforge.knowledge.interface :as knowledge]
-   [ai.miniforge.logging.interface :as log]
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Configuration
 
-(defn- load-config
-  "Read an EDN config resource, failing fast with a clear ex-info when the
-   resource is absent from the classpath, malformed, not a map, or missing
-   a required key — rather than a low-signal NPE/reader error at load."
-  [path required-keys]
-  (let [url (io/resource path)]
-    (when (nil? url)
-      (throw (ex-info (str "Missing config resource on classpath: " path)
-                      {:config/resource path})))
-    (let [parsed (try
-                   (edn/read-string (slurp url))
-                   (catch Exception e
-                     (throw (ex-info (str "Malformed EDN config resource: " path)
-                                     {:config/resource path} e))))]
-      (when-not (map? parsed)
-        (throw (ex-info (str "Config resource is not a map: " path)
-                        {:config/resource path})))
-      (let [missing (remove #(contains? parsed %) required-keys)]
-        (when (seq missing)
-          (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
-                          {:config/resource path :config/missing-keys (vec missing)})))
-        parsed))))
-
 (def default-config
   "Default operator configuration."
-  (load-config "config/operator/defaults.edn"
-               [:signal-retention-ms :pattern-window-ms :min-pattern-occurrences
-                :auto-apply-threshold :shadow-period-ms]))
+  (config/load-config-resource "config/operator/defaults.edn"
+                               [:signal-retention-ms :pattern-window-ms
+                                :min-pattern-occurrences
+                                :auto-apply-threshold :shadow-period-ms]))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Signal management

--- a/components/orchestrator/deps.edn
+++ b/components/orchestrator/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../schema"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/knowledge {:local/root "../knowledge"}

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -28,13 +28,12 @@
    Workflow execution is delegated to the workflow component.
    Meta-loop management is delegated to the operator component."
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.orchestrator.messages :as messages]
    [ai.miniforge.orchestrator.protocol :as proto]
    [ai.miniforge.workflow.interface :as wf]
    [ai.miniforge.knowledge.interface :as knowledge]
-   [ai.miniforge.logging.interface :as log]
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Configuration
@@ -54,33 +53,10 @@
      :tags [:repair :inner-loop (keyword (name agent-role))]
      :confidence 0.7}))
 
-(defn- load-config
-  "Read an EDN config resource, failing fast with a clear ex-info when the
-   resource is absent from the classpath, malformed, not a map, or missing
-   a required key — rather than a low-signal NPE/reader error at load."
-  [path required-keys]
-  (let [url (io/resource path)]
-    (when (nil? url)
-      (throw (ex-info (str "Missing config resource on classpath: " path)
-                      {:config/resource path})))
-    (let [parsed (try
-                   (edn/read-string (slurp url))
-                   (catch Exception e
-                     (throw (ex-info (str "Malformed EDN config resource: " path)
-                                     {:config/resource path} e))))]
-      (when-not (map? parsed)
-        (throw (ex-info (str "Config resource is not a map: " path)
-                        {:config/resource path})))
-      (let [missing (remove #(contains? parsed %) required-keys)]
-        (when (seq missing)
-          (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
-                          {:config/resource path :config/missing-keys (vec missing)})))
-        parsed))))
-
 (def default-config
   "Default control plane configuration."
-  (load-config "config/orchestrator/defaults.edn"
-               [:default-budget :escalation-threshold]))
+  (config/load-config-resource "config/orchestrator/defaults.edn"
+                               [:default-budget :escalation-threshold]))
 
 (def task-type->agent-role
   "Mapping of task types to agent roles."

--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -20,7 +20,7 @@
   "Backend health tracking and automatic failover.
    Storage: ~/.miniforge/backend_health.edn"
   (:require
-   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.config.interface :as cfg]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
@@ -35,11 +35,11 @@
 ;; sibling stream-recovery / integration namespaces resolve the same
 ;; defaults instead of re-hardcoding them.
 (def config
-  (config/load-config-resource "config/self-healing/backend-health.edn"
-                               [:success-rate-threshold :switch-cooldown-ms
-                                :failure-recency-window-ms
-                                :health-decay-ms :default-backend
-                                :fallback-order]))
+  (cfg/load-config-resource "config/self-healing/backend-health.edn"
+                            [:success-rate-threshold :switch-cooldown-ms
+                             :failure-recency-window-ms
+                             :health-decay-ms :default-backend
+                             :fallback-order]))
 
 (def ^:private default-success-rate-threshold
   "Minimum cumulative success rate (`:successful-calls / :total-calls`)

--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -20,6 +20,7 @@
   "Backend health tracking and automatic failover.
    Storage: ~/.miniforge/backend_health.edn"
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
@@ -33,33 +34,12 @@
 ;; below are the fallback when config is absent. `config` is public so the
 ;; sibling stream-recovery / integration namespaces resolve the same
 ;; defaults instead of re-hardcoding them.
-(defn- load-config
-  "Read an EDN config resource, failing fast with a clear ex-info when the
-   resource is absent from the classpath, malformed, not a map, or missing
-   a required key — rather than a low-signal NPE/reader error at load."
-  [path required-keys]
-  (let [url (io/resource path)]
-    (when (nil? url)
-      (throw (ex-info (str "Missing config resource on classpath: " path)
-                      {:config/resource path})))
-    (let [parsed (try
-                   (edn/read-string (slurp url))
-                   (catch Exception e
-                     (throw (ex-info (str "Malformed EDN config resource: " path)
-                                     {:config/resource path} e))))]
-      (when-not (map? parsed)
-        (throw (ex-info (str "Config resource is not a map: " path)
-                        {:config/resource path})))
-      (let [missing (remove #(contains? parsed %) required-keys)]
-        (when (seq missing)
-          (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
-                          {:config/resource path :config/missing-keys (vec missing)})))
-        parsed))))
-
 (def config
-  (load-config "config/self-healing/backend-health.edn"
-               [:success-rate-threshold :switch-cooldown-ms :failure-recency-window-ms
-                :health-decay-ms :default-backend :fallback-order]))
+  (config/load-config-resource "config/self-healing/backend-health.edn"
+                               [:success-rate-threshold :switch-cooldown-ms
+                                :failure-recency-window-ms
+                                :health-decay-ms :default-backend
+                                :fallback-order]))
 
 (def ^:private default-success-rate-threshold
   "Minimum cumulative success rate (`:successful-calls / :total-calls`)

--- a/components/task-executor/deps.edn
+++ b/components/task-executor/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/dag-executor {:local/root "../dag-executor"}
+ :deps {ai.miniforge/config       {:local/root "../config"}
+        ai.miniforge/dag-executor {:local/root "../dag-executor"}
         ai.miniforge/pr-lifecycle {:local/root "../pr-lifecycle"}
         ai.miniforge/agent        {:local/root "../agent"}
         ai.miniforge/loop         {:local/root "../loop"}

--- a/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
@@ -24,37 +24,14 @@
   - Launches task execution in futures
   - Tracks futures for graceful shutdown
   - Handles task failures and cascading to dependents"
-  (:require [ai.miniforge.task-executor.runner :as runner]
+  (:require [ai.miniforge.config.interface :as config]
+            [ai.miniforge.task-executor.runner :as runner]
             [ai.miniforge.dag-executor.interface :as dag]
-            [ai.miniforge.logging.interface :as log]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]))
-
-(defn- load-config
-  "Read an EDN config resource, failing fast with a clear ex-info when the
-   resource is absent from the classpath, malformed, not a map, or missing
-   a required key — rather than a low-signal NPE at load."
-  [path required-keys]
-  (let [url (io/resource path)]
-    (when (nil? url)
-      (throw (ex-info (str "Missing config resource on classpath: " path)
-                      {:config/resource path})))
-    (let [parsed (try
-                   (edn/read-string (slurp url))
-                   (catch Exception e
-                     (throw (ex-info (str "Malformed EDN config resource: " path)
-                                     {:config/resource path} e))))]
-      (when-not (map? parsed)
-        (throw (ex-info (str "Config resource is not a map: " path) {:config/resource path})))
-      (let [missing (remove #(contains? parsed %) required-keys)]
-        (when (seq missing)
-          (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
-                          {:config/resource path :config/missing-keys (vec missing)})))
-        parsed))))
+            [ai.miniforge.logging.interface :as log]))
 
 (def ^:private defaults
-  (load-config "config/task-executor/defaults.edn"
-               [:max-parallel :scheduler-poll-interval-ms]))
+  (config/load-config-resource "config/task-executor/defaults.edn"
+                               [:max-parallel :scheduler-poll-interval-ms]))
 
 (defn create-run-context
   [run-atom config]

--- a/components/task-executor/src/ai/miniforge/task_executor/runner.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/runner.clj
@@ -25,41 +25,18 @@
   3. PR lifecycle (create → CI → review → merge)
   4. Event bridging (PR events → scheduler events)
   5. Resource cleanup (always in finally block)"
-  (:require [ai.miniforge.task-executor.bridge :as bridge]
+  (:require [ai.miniforge.config.interface :as config]
+            [ai.miniforge.task-executor.bridge :as bridge]
             [ai.miniforge.task-executor.generate :as generate]
             [ai.miniforge.pr-lifecycle.interface :as pr]
             [ai.miniforge.dag-executor.interface :as dag]
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.agent-runtime.interface :as error-classifier]
-            [ai.miniforge.spec-parser.interface :as spec-parser]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]))
-
-(defn- load-config
-  "Read an EDN config resource, failing fast with a clear ex-info when the
-   resource is absent from the classpath, malformed, not a map, or missing
-   a required key — rather than a low-signal NPE at load."
-  [path required-keys]
-  (let [url (io/resource path)]
-    (when (nil? url)
-      (throw (ex-info (str "Missing config resource on classpath: " path)
-                      {:config/resource path})))
-    (let [parsed (try
-                   (edn/read-string (slurp url))
-                   (catch Exception e
-                     (throw (ex-info (str "Malformed EDN config resource: " path)
-                                     {:config/resource path} e))))]
-      (when-not (map? parsed)
-        (throw (ex-info (str "Config resource is not a map: " path) {:config/resource path})))
-      (let [missing (remove #(contains? parsed %) required-keys)]
-        (when (seq missing)
-          (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))
-                          {:config/resource path :config/missing-keys (vec missing)})))
-        parsed))))
+            [ai.miniforge.spec-parser.interface :as spec-parser]))
 
 (def ^:private defaults
-  (load-config "config/task-executor/defaults.edn"
-               [:worktree-acquire-timeout-ms :token-pricing]))
+  (config/load-config-resource "config/task-executor/defaults.edn"
+                               [:worktree-acquire-timeout-ms :token-pricing]))
 
 (defn create-task-context
   [task-id task run-context]

--- a/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
@@ -22,8 +22,9 @@
   Tests that a task flows correctly through: environment acquisition →
   code generation → PR lifecycle → metrics accumulation → cleanup."
   (:require
-   [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.task-executor.runner :as runner]))
+   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.task-executor.runner :as runner]
+   [clojure.test :refer [deftest testing is]]))
 
 ;------------------------------------------------------------------------------ Mock Data
 
@@ -523,5 +524,5 @@
   (testing "missing config resource throws a clear ex-info, not an NPE"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"Missing config resource on classpath"
-         (#'runner/load-config "config/task-executor/does-not-exist.edn"
-                               [:worktree-acquire-timeout-ms])))))
+         (config/load-config-resource "config/task-executor/does-not-exist.edn"
+                                      [:worktree-acquire-timeout-ms])))))

--- a/docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md
+++ b/docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md
@@ -1,0 +1,25 @@
+# Exceptions Config Loader Consolidation
+
+## Summary
+
+Consolidates duplicated fail-fast EDN config resource loaders into the shared
+`ai.miniforge.config.interface/load-config-resource` boundary.
+
+## Changes
+
+- Replaces component-local `load-config` helpers in operator, orchestrator,
+  self-healing backend health, and task-executor namespaces.
+- Adds explicit config component dependencies for the affected components.
+- Updates task-executor runner coverage to assert missing-resource behavior
+  through the shared config loader instead of a private runner helper.
+
+## Verification
+
+- `clojure -M:dev:test -e "(require '[clojure.test :as t] 'ai.miniforge.operator.core-test
+  'ai.miniforge.task-executor.orchestrator-test 'ai.miniforge.task-executor.runner-test
+  'ai.miniforge.self-healing.stream-recovery-test) (let [result (t/run-tests 'ai.miniforge.operator.core-test
+  'ai.miniforge.task-executor.orchestrator-test 'ai.miniforge.task-executor.runner-test
+  'ai.miniforge.self-healing.stream-recovery-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
+  - 93 tests, 198 assertions, 0 failures, 0 errors
+- `bb review`
+  - 288 violations, down from the 308 baseline after PR #1270

--- a/docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md
+++ b/docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md
@@ -15,11 +15,10 @@ Consolidates duplicated fail-fast EDN config resource loaders into the shared
 
 ## Verification
 
-- `clojure -M:dev:test -e "(require '[clojure.test :as t] 'ai.miniforge.operator.core-test
-  'ai.miniforge.task-executor.orchestrator-test 'ai.miniforge.task-executor.runner-test
-  'ai.miniforge.self-healing.stream-recovery-test) (let [result (t/run-tests 'ai.miniforge.operator.core-test
-  'ai.miniforge.task-executor.orchestrator-test 'ai.miniforge.task-executor.runner-test
-  'ai.miniforge.self-healing.stream-recovery-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
-  - 93 tests, 198 assertions, 0 failures, 0 errors
+```bash
+clojure -M:dev:test -e "(require '[clojure.test :as t] 'ai.miniforge.operator.core-test 'ai.miniforge.task-executor.orchestrator-test 'ai.miniforge.task-executor.runner-test 'ai.miniforge.self-healing.stream-recovery-test) (let [result (t/run-tests 'ai.miniforge.operator.core-test 'ai.miniforge.task-executor.orchestrator-test 'ai.miniforge.task-executor.runner-test 'ai.miniforge.self-healing.stream-recovery-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"
+```
+
+- 93 tests, 198 assertions, 0 failures, 0 errors
 - `bb review`
   - 288 violations, down from the 308 baseline after PR #1270


### PR DESCRIPTION
## Summary
- route duplicated EDN config resource loading through ai.miniforge.config.interface/load-config-resource
- add explicit config component dependencies for operator, orchestrator, and task-executor
- update task-executor runner coverage to assert missing-resource behavior through the shared loader

## Verification
- clojure -M:dev:test -e "(require '[clojure.test :as t] 'ai.miniforge.operator.core-test 'ai.miniforge.task-executor.orchestrator-test 'ai.miniforge.task-executor.runner-test 'ai.miniforge.self-healing.stream-recovery-test) (let [result (t/run-tests 'ai.miniforge.operator.core-test 'ai.miniforge.task-executor.orchestrator-test 'ai.miniforge.task-executor.runner-test 'ai.miniforge.self-healing.stream-recovery-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"
- bb review: 288 violations, down from the 308 baseline after PR #1270
- bb pre-commit