### PR TITLE
Refactor fallback config loaders

### DIFF
--- a/components/agent/deps.edn
+++ b/components/agent/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/config {:local/root "../config"}
         ai.miniforge/workspace {:local/root "../workspace"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/tool {:local/root "../tool"}

--- a/components/agent/src/ai/miniforge/agent/meta_evaluator.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_evaluator.clj
@@ -28,11 +28,10 @@
    - Fail-open on timeout/error (never block the inner agent on infra issues)
    - Budget: ~500 input tokens, ~100 output tokens per call"
   (:require
+   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.llm.interface :as llm]
    [cheshire.core :as json]
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
-   [clojure.string :as str]
-   [ai.miniforge.llm.interface :as llm]))
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Tuning config and prompt construction
@@ -41,22 +40,12 @@
   "In-code fallback used when config/agent/meta-eval-tuning.edn is absent."
   {:max-tokens 150})
 
-(defn- load-config-or
-  "Read an EDN config resource, returning `fallback` if the resource is
-   absent, unreadable, malformed, or not a map — preserving fail-open
-   behavior."
-  [path fallback]
-  (try
-    (let [url    (io/resource path)
-          parsed (when url (edn/read-string (slurp url)))]
-      (if (map? parsed) parsed fallback))
-    (catch Exception _ fallback)))
-
 (def ^:private eval-tuning
   "Per-call tuning (currently :max-tokens) for the meta-evaluator LLM call.
    Loaded from config/agent/meta-eval-tuning.edn at ns load, falling back
    to fallback-eval-tuning."
-  (load-config-or "config/agent/meta-eval-tuning.edn" fallback-eval-tuning))
+  (config/read-config-resource-or "config/agent/meta-eval-tuning.edn"
+                                  fallback-eval-tuning))
 
 (def system-prompt
   "You are a tool-use quality evaluator for a software engineering agent.

--- a/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
+++ b/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
@@ -26,9 +26,8 @@
   when a workflow event-stream is present."
   (:require
    [ai.miniforge.agent.core :as core]
-   [ai.miniforge.event-stream.interface :as events]
-   [clojure.edn :as edn]
-   [clojure.java.io :as io])
+   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.event-stream.interface :as events])
   (:import
    (java.nio ByteBuffer)
    (java.security MessageDigest)
@@ -45,24 +44,14 @@
    or omits :heartbeat-interval-ms."
   30000)
 
-(defn- load-config-or
-  "Read an EDN config resource, returning `fallback` if the resource is
-   absent, unreadable, malformed, or not a map — preserving fail-open
-   behavior."
-  [path fallback]
-  (try
-    (let [url    (io/resource path)
-          parsed (when url (edn/read-string (slurp url)))]
-      (if (map? parsed) parsed fallback))
-    (catch Exception _ fallback)))
-
 (def ^:private default-heartbeat-interval-ms
   "Interval between heartbeat events for direct in-process agents. Loaded
    from config/agent/supervisory-bridge.edn at ns load, falling back to
    fallback-heartbeat-interval-ms."
   (or (:heartbeat-interval-ms
-       (load-config-or "config/agent/supervisory-bridge.edn"
-                       {:heartbeat-interval-ms fallback-heartbeat-interval-ms}))
+       (config/read-config-resource-or
+        "config/agent/supervisory-bridge.edn"
+        {:heartbeat-interval-ms fallback-heartbeat-interval-ms}))
       fallback-heartbeat-interval-ms))
 
 (def ^:private agent-session-namespace

--- a/components/event-stream/src/ai/miniforge/event_stream/storage_layout.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/storage_layout.clj
@@ -19,8 +19,7 @@
 (ns ai.miniforge.event-stream.storage-layout
   "Configuration-as-data for the event-stream on-disk storage layout."
   (:require
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [ai.miniforge.config.interface :as config]))
 
 (def ^:private resource-path
   "config/event-stream/storage-layout.edn")
@@ -35,10 +34,7 @@
 
 (defn- load-layout
   []
-  (let [resource (or (io/resource resource-path)
-                     (throw (ex-info "Missing event-stream storage layout resource"
-                                     {:resource resource-path})))
-        layout (edn/read-string (slurp resource))
+  (let [layout (config/load-config-resource resource-path required-keys)
         missing (seq (remove #(string? (get layout %)) required-keys))]
     (when missing
       (throw (ex-info "Invalid event-stream storage layout resource"

--- a/components/semantic-analyzer/deps.edn
+++ b/components/semantic-analyzer/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/policy-pack {:local/root "../policy-pack"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/policy-pack {:local/root "../policy-pack"}
         ai.miniforge/compliance-scanner {:local/root "../compliance-scanner"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -13,6 +13,7 @@
    Layer 2: File selection and batch analysis"
   (:require
    [ai.miniforge.compliance-scanner.interface :as factory]
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.policy-pack.interface :as pt]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -101,19 +102,8 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; File selection and batch analysis
 
-(defn- load-limits
-  "Read the limits EDN, returning {} if the resource is absent,
-   unreadable, malformed, or not a map — so the call-site literal
-   defaults remain authoritative (fail-open, matching the prior
-   inline-literal behavior)."
-  [path]
-  (try
-    (let [url    (io/resource path)
-          parsed (when url (edn/read-string (slurp url)))]
-      (if (map? parsed) parsed {}))
-    (catch Exception _ {})))
-
-(def ^:private limits (load-limits "config/semantic-analyzer/limits.edn"))
+(def ^:private limits
+  (config/read-config-resource-or "config/semantic-analyzer/limits.edn" {}))
 
 (def ^:private max-file-size-bytes
   "Maximum file size to send to LLM. Files larger than this are skipped."

--- a/docs/pull-requests/2026-06-25-chris-exceptions-fallback-loaders.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-fallback-loaders.md
@@ -1,0 +1,67 @@
+# Refactor: Consolidate Fail-Open Config Loaders
+
+## Overview
+
+This PR removes duplicated classpath EDN config-resource parsing from agent and
+semantic analyzer call sites by routing them through the shared
+`ai.miniforge.config.interface/read-config-resource-or` helper. It also moves
+the event-stream storage layout's required resource load onto the shared
+`load-config-resource` boundary.
+
+## Motivation
+
+The standards remediation pass found repeated local implementations of the same
+config-resource pattern:
+
+```clojure
+(try
+  (let [url (io/resource path)
+        parsed (when url (edn/read-string (slurp url)))]
+    (if (map? parsed) parsed fallback))
+  (catch Exception _ fallback))
+```
+
+Those helpers duplicated config parsing policy and made cancellation behavior
+inconsistent across components. The shared config component already owns both
+required-resource and fail-open resource loading, including UTF-8 reads and
+interruption propagation.
+
+## Changes in Detail
+
+- `agent.meta-evaluator` now loads meta-eval tuning through
+  `config/read-config-resource-or`.
+- `agent.supervisory-bridge` now loads heartbeat defaults through
+  `config/read-config-resource-or`.
+- `semantic-analyzer.core` now loads analyzer limits through
+  `config/read-config-resource-or`.
+- `event-stream.storage-layout` now loads the required storage layout resource
+  through `config/load-config-resource`, while preserving the local string-key
+  validation.
+- Added config component dependencies where newly required.
+
+## Testing Plan
+
+- Focused namespace/test run:
+  `clojure -M:dev:test -e "(require ...)"`.
+- Standards review:
+  `bb review`.
+- Full pre-commit before merge:
+  `bb pre-commit`.
+
+## Deployment Plan
+
+No special deployment steps. The resource paths and fallback defaults are
+unchanged.
+
+## Related Issues/PRs
+
+- Continues the exceptions-as-data/config-resource remediation waves after
+  PRs #1271 and #1272.
+
+## Checklist
+
+- [x] Preserve fail-open behavior for optional config resources.
+- [x] Preserve fail-fast behavior for required event-stream storage layout.
+- [x] Confirm focused tests pass.
+- [x] Confirm `bb review` decreases from 280 to 279 violations.
+- [x] Run `bb pre-commit`.


### PR DESCRIPTION
# Refactor: Consolidate Fail-Open Config Loaders

## Overview

This PR removes duplicated classpath EDN config-resource parsing from agent and
semantic analyzer call sites by routing them through the shared
`ai.miniforge.config.interface/read-config-resource-or` helper. It also moves
the event-stream storage layout's required resource load onto the shared
`load-config-resource` boundary.

## Motivation

The standards remediation pass found repeated local implementations of the same
config-resource pattern:

```clojure
(try
  (let [url (io/resource path)
        parsed (when url (edn/read-string (slurp url)))]
    (if (map? parsed) parsed fallback))
  (catch Exception _ fallback))
```

Those helpers duplicated config parsing policy and made cancellation behavior
inconsistent across components. The shared config component already owns both
required-resource and fail-open resource loading, including UTF-8 reads and
interruption propagation.

## Changes in Detail

- `agent.meta-evaluator` now loads meta-eval tuning through
  `config/read-config-resource-or`.
- `agent.supervisory-bridge` now loads heartbeat defaults through
  `config/read-config-resource-or`.
- `semantic-analyzer.core` now loads analyzer limits through
  `config/read-config-resource-or`.
- `event-stream.storage-layout` now loads the required storage layout resource
  through `config/load-config-resource`, while preserving the local string-key
  validation.
- Added config component dependencies where newly required.

## Testing Plan

- Focused namespace/test run:
  `clojure -M:dev:test -e "(require ...)"`.
- Standards review:
  `bb review`.
- Full pre-commit before merge:
  `bb pre-commit`.

## Deployment Plan

No special deployment steps. The resource paths and fallback defaults are
unchanged.

## Related Issues/PRs

- Continues the exceptions-as-data/config-resource remediation waves after
  PRs #1271 and #1272.

## Checklist

- [x] Preserve fail-open behavior for optional config resources.
- [x] Preserve fail-fast behavior for required event-stream storage layout.
- [x] Confirm focused tests pass.
- [x] Confirm `bb review` decreases from 280 to 279 violations.
- [x] Run `bb pre-commit`.
