### PR TITLE
Refactor required config resource context

### DIFF
--- a/components/config/src/ai/miniforge/config/interface.clj
+++ b/components/config/src/ai/miniforge/config/interface.clj
@@ -35,7 +35,8 @@
 (def load-config-resource
   "Read an EDN config resource from the classpath, failing fast with a
    clear ex-info on a missing/malformed/non-map resource or a missing
-   required key. Arities: [path] and [path required-keys]."
+   required key. Arities: [path], [path required-keys], and
+   [path required-keys extra-ex-data]."
   resource/load-config-resource)
 (def read-config-resource-or
   "Read an EDN config resource, returning `fallback` if the resource is

--- a/components/config/src/ai/miniforge/config/resource.clj
+++ b/components/config/src/ai/miniforge/config/resource.clj
@@ -42,19 +42,33 @@
   (messages/create-translator "config/config/messages/system.edn"
                               :config/system))
 
+(defn- extra-ex-data-map
+  [path extra-ex-data]
+  (cond
+    (nil? extra-ex-data) {}
+    (map? extra-ex-data) extra-ex-data
+    :else (throw (ex-info "Config resource extra ex-data must be a map"
+                          {:config/resource path
+                           :config/extra-ex-data extra-ex-data}))))
+
 (defn load-config-resource
   "Read an EDN config resource from the classpath, failing fast with a
    clear ex-info when the resource is absent, malformed, not a map, or
    missing a required key. Returns the parsed map.
 
    `required-keys` (optional) is a collection of keys that must be present
-   at the top level; an empty/absent collection skips the key check."
-  ([path] (load-config-resource path nil))
-  ([path required-keys]
-   (let [url (io/resource path)]
+   at the top level; an empty/absent collection skips the key check.
+   `extra-ex-data` (optional) is merged into thrown ex-data so callers can
+   preserve domain-specific packaging hints while this namespace owns the
+   resource-loading boundary."
+  ([path] (load-config-resource path nil nil))
+  ([path required-keys] (load-config-resource path required-keys nil))
+  ([path required-keys extra-ex-data]
+   (let [ex-data (assoc (extra-ex-data-map path extra-ex-data) :config/resource path)
+         url     (io/resource path)]
      (when (nil? url)
        (throw (ex-info (t :resource/missing {:path path})
-                       {:config/resource path})))
+                       ex-data)))
      (let [parsed (try
                     (edn/read-string (slurp url :encoding "UTF-8"))
                     (catch InterruptedException e
@@ -64,15 +78,15 @@
                       (throw e))
                     (catch Exception e
                       (throw (ex-info (t :resource/malformed {:path path})
-                                      {:config/resource path}
+                                      ex-data
                                       e))))]
        (when-not (map? parsed)
          (throw (ex-info (t :resource/not-a-map {:path path})
-                         {:config/resource path})))
+                         ex-data)))
        (let [missing (vec (remove #(contains? parsed %) required-keys))]
          (when (seq missing)
            (throw (ex-info (t :resource/missing-keys {:path path :keys missing})
-                           {:config/resource path :config/missing-keys missing})))
+                           (assoc ex-data :config/missing-keys missing))))
          parsed)))))
 
 (defn read-config-resource-or

--- a/components/config/test/ai/miniforge/config/resource_test.clj
+++ b/components/config/test/ai/miniforge/config/resource_test.clj
@@ -42,7 +42,25 @@
     (let [ex (try (resource/load-config-resource a-missing-resource)
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (instance? clojure.lang.ExceptionInfo ex))
-      (is (= a-missing-resource (:config/resource (ex-data ex)))))))
+      (is (= a-missing-resource (:config/resource (ex-data ex))))))
+  (testing "preserves caller-supplied diagnostic ex-data"
+    (let [ex (try (resource/load-config-resource
+                   a-missing-resource
+                   nil
+                   {:hint "add the component resources to the classpath"})
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= a-missing-resource (:config/resource (ex-data ex))))
+      (is (= "add the component resources to the classpath"
+             (:hint (ex-data ex)))))))
+
+(deftest load-config-resource-extra-ex-data-contract
+  (testing "throws a clear ex-info when caller-supplied diagnostic ex-data is not a map"
+    (let [ex (try (resource/load-config-resource a-real-resource nil [:hint "bad"])
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= a-real-resource (:config/resource (ex-data ex))))
+      (is (= [:hint "bad"] (:config/extra-ex-data (ex-data ex)))))))
 
 (deftest load-config-resource-missing-key
   (testing "throws when a required key is absent, naming the key"

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_config.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_config.clj
@@ -15,9 +15,8 @@
 (ns ai.miniforge.pr-lifecycle.monitor-config
   "Load shared PR monitor defaults from EDN configuration."
   (:require
-   [ai.miniforge.schema.interface :as schema]
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schemas + config loading
@@ -40,10 +39,11 @@
 
 (defn- load-monitor-config
   []
-  (if-let [res (io/resource "config/pr-monitor/defaults.edn")]
-    (->> res slurp edn/read-string (validate! MonitorConfig))
-    (throw (ex-info "Missing classpath resource: config/pr-monitor/defaults.edn"
-                    {:hint "Add components/pr-lifecycle/resources to your classpath"}))))
+  (->> (config/load-config-resource
+        "config/pr-monitor/defaults.edn"
+        [:pr-monitor/defaults]
+        {:hint "Add components/pr-lifecycle/resources to your classpath"})
+       (validate! MonitorConfig)))
 
 (def ^:private monitor-config
   (delay (load-monitor-config)))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -28,8 +28,7 @@
    This namespace knows nothing about emission, persistence, or threading.
    It is a pure function from an event-stream prefix to an EntityTable."
   (:require
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
+   [ai.miniforge.config.interface :as config]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -553,10 +552,7 @@
    Throws if the resource is missing — the file ships with the component,
    so its absence indicates a packaging bug worth failing fast on."
   []
-  (if-let [r (io/resource task-kanban-mapping-resource)]
-    (edn/read-string (slurp r))
-    (throw (ex-info "supervisory-state: task-kanban mapping resource missing"
-                    {:resource task-kanban-mapping-resource}))))
+  (config/load-config-resource task-kanban-mapping-resource))
 
 (def ^{:doc "Memoized status→column map loaded lazily from
   [[task-kanban-mapping-resource]]. Tests that need to exercise a

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -31,8 +31,6 @@
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
             [babashka.process :as process]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]
             [clojure.string :as str]
             [slingshot.slingshot :refer [try+]]))
 
@@ -70,11 +68,11 @@
 
 (defn- load-observe-phase-config
   []
-  (if-let [res (io/resource "config/workflow/observe-phase.edn")]
-    (->> res slurp edn/read-string (validate! ObservePhaseConfig))
-    (response/throw-anomaly! :anomalies/not-found
-                            "Missing classpath resource: config/workflow/observe-phase.edn"
-                            {:hint "Add components/workflow/resources to your classpath"})))
+  (->> (config/load-config-resource
+        "config/workflow/observe-phase.edn"
+        [:observe/phase-defaults]
+        {:hint "Add components/workflow/resources to your classpath"})
+       (validate! ObservePhaseConfig)))
 
 (defn- load-monitor-defaults
   []

--- a/docs/pull-requests/2026-06-25-chris-exceptions-required-resource-context.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-required-resource-context.md
@@ -1,0 +1,49 @@
+# Refactor: Preserve Context on Required Config Resources
+
+## Overview
+
+This PR extends the shared classpath config-resource loader so callers can
+preserve additional ex-data context, then migrates remaining map-shaped
+required resource loads through that shared boundary.
+
+## Motivation
+
+Earlier resource-loader waves centralized missing/malformed/non-map config
+failures in `ai.miniforge.config`. Some remaining call sites still hand-roll
+`io/resource` + `edn/read-string` only to preserve concrete packaging hints in
+their thrown ex-data. The config loader should own that failure boundary while
+still allowing callers to attach domain-specific diagnostic context.
+
+## Changes in Detail
+
+- Add optional ex-data context to `config.resource/load-config-resource`.
+- Preserve classpath hint data for PR monitor defaults and Observe phase
+  config.
+- Move supervisory-state task Kanban mapping resource loading through the
+  shared required config loader.
+- Remove local EDN/resource parsing requires made obsolete by the migration.
+
+## Testing Plan
+
+- Focused config-resource tests.
+- Focused namespace tests for observe phase, PR monitor defaults, and
+  supervisory-state accumulator.
+- `bb review` to confirm the exceptions-as-data count decreases.
+- `bb pre-commit` before merge.
+
+## Deployment Plan
+
+No special deployment steps. The resource paths, config shapes, and existing
+schema validation behavior are unchanged.
+
+## Related Issues/PRs
+
+- Follows PR #1273, which consolidated fail-open config loaders.
+
+## Checklist
+
+- [x] Preserve missing-resource hint ex-data.
+- [x] Preserve schema validation for migrated resources.
+- [x] Confirm focused tests pass.
+- [x] Confirm `bb review` decreases.
+- [x] Run `bb pre-commit`.


### PR DESCRIPTION
# Refactor: Preserve Context on Required Config Resources

## Overview

This PR extends the shared classpath config-resource loader so callers can
preserve additional ex-data context, then migrates remaining map-shaped
required resource loads through that shared boundary.

## Motivation

Earlier resource-loader waves centralized missing/malformed/non-map config
failures in `ai.miniforge.config`. Some remaining call sites still hand-roll
`io/resource` + `edn/read-string` only to preserve concrete packaging hints in
their thrown ex-data. The config loader should own that failure boundary while
still allowing callers to attach domain-specific diagnostic context.

## Changes in Detail

- Add optional ex-data context to `config.resource/load-config-resource`.
- Preserve classpath hint data for PR monitor defaults and Observe phase
  config.
- Move supervisory-state task Kanban mapping resource loading through the
  shared required config loader.
- Remove local EDN/resource parsing requires made obsolete by the migration.

## Testing Plan

- Focused config-resource tests.
- Focused namespace tests for observe phase, PR monitor defaults, and
  supervisory-state accumulator.
- `bb review` to confirm the exceptions-as-data count decreases.
- `bb pre-commit` before merge.

## Deployment Plan

No special deployment steps. The resource paths, config shapes, and existing
schema validation behavior are unchanged.

## Related Issues/PRs

- Follows PR #1273, which consolidated fail-open config loaders.

## Checklist

- [x] Preserve missing-resource hint ex-data.
- [x] Preserve schema validation for migrated resources.
- [x] Confirm focused tests pass.
- [x] Confirm `bb review` decreases.
- [x] Run `bb pre-commit`.
