### PR TITLE
Fix exceptions scanner boundary namespace classification

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -72,20 +72,38 @@
 
 (def ^:private boundary-segment-patterns
   "Namespace segments that mark a boundary file. A file is a boundary
-   if any of its dotted-segment substrings matches one of these."
-  #{"cli" "boundary" "http" "web" "mcp" "consumer" "listener"})
+   if any of its dotted segments matches one of these."
+  #{"cli" "boundary" "http" "web" "mcp" "consumer" "listener" "listeners"})
+
+(def ^:private boundary-prefix-patterns
+  "Whole namespace prefixes that mark boundary bases whose Polylith name
+   cannot be represented as a standalone dotted segment. Keep this list
+   narrow so component names that merely contain boundary words, such as
+   `bb-data-plane-http`, remain non-boundary."
+  #{"ai.miniforge.mcp-context-server"})
 
 (def ^:private boundary-suffix-patterns
   "Whole-namespace suffixes that mark boundary files."
   #{"main"})
 
 (defn- ns-segments
-  "Split a fully-qualified ns symbol into its dotted segments. Returns []
-   when the value is not a usable ns symbol."
+  "Split a fully-qualified ns symbol or string into its dotted segments.
+   Returns [] when the value is not a usable ns value."
   [ns-sym]
   (if (and ns-sym (or (symbol? ns-sym) (string? ns-sym)))
-    (str/split (name ns-sym) #"\.")
+    (str/split (str ns-sym) #"\.")
     []))
+
+(defn- boundary-prefix?
+  [ns-sym]
+  (let [ns-str (when (and ns-sym (or (symbol? ns-sym) (string? ns-sym)))
+                 (str ns-sym))]
+    (boolean
+     (when ns-str
+       (some (fn [prefix]
+               (or (= ns-str prefix)
+                   (str/starts-with? ns-str (str prefix "."))))
+             boundary-prefix-patterns)))))
 
 (defn boundary-namespace?
   "Return true when the given namespace symbol denotes a boundary file
@@ -101,6 +119,7 @@
         last-seg (last segs)]
     (boolean
      (or (some boundary-segment-patterns segs)
+         (boundary-prefix? ns-sym)
          (when last-seg
            (or (contains? boundary-suffix-patterns last-seg)
                (str/ends-with? last-seg "-main")))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/boundary_exemption_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/boundary_exemption_test.clj
@@ -43,13 +43,20 @@
     (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp.bridge)))
     (is (true? (exc/boundary-namespace? 'ai.miniforge.kafka.consumer)))
     (is (true? (exc/boundary-namespace? 'ai.miniforge.events.listener)))
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.events.listeners)))
     (is (true? (exc/boundary-namespace? 'ai.miniforge.foo.boundary.in)))))
+
+(deftest dashed-mcp-base-is-boundary
+  (testing "the MCP context-server base is an external protocol boundary"
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp-context-server.tools)))
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp-context-server.server)))))
 
 (deftest core-namespaces-are-not-boundaries
   (testing "ordinary component core namespaces are not boundaries"
     (is (false? (exc/boundary-namespace? 'ai.miniforge.agent.planner)))
     (is (false? (exc/boundary-namespace? 'ai.miniforge.workflow.runner)))
-    (is (false? (exc/boundary-namespace? 'ai.miniforge.config.user)))))
+    (is (false? (exc/boundary-namespace? 'ai.miniforge.config.user)))
+    (is (false? (exc/boundary-namespace? 'ai.miniforge.some-mcp-ish.core)))))
 
 (deftest boundary-files-yield-zero-violations
   (testing "throws inside a CLI namespace produce no violations"

--- a/docs/pull-requests/2026-06-25-chris-exceptions-boundary-ns-detection.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-boundary-ns-detection.md
@@ -1,0 +1,52 @@
+# Fix: Classify MCP and Listener Boundary Namespaces
+
+## Overview
+
+This PR fixes exceptions-as-data boundary namespace classification for two
+documented protocol edges that were still reported as violations.
+
+## Motivation
+
+The scanner documents boundary exemptions for namespaces containing segments
+such as `mcp`, `http`, `listener`, `consumer`, and `boundary`. Two real repo
+boundaries did not fit the existing exact-segment catalog:
+
+- `ai.miniforge.mcp-context-server.*` is a base named with a dashed Polylith
+  segment, so `mcp` is not a standalone dotted segment.
+- `ai.miniforge.event-stream.listeners` uses the plural `listeners` segment.
+
+This is scanner precision work, not a weakening of the rule: non-boundary
+production namespaces remain subject to the same exceptions-as-data checks.
+
+## Changes in Detail
+
+- Add `listeners` to the explicit boundary segment catalog.
+- Add a narrow exact-prefix exemption for `ai.miniforge.mcp-context-server`.
+- Preserve the existing rule that boundary markers are not arbitrary
+  substrings of component names.
+- Add regression coverage for the MCP base, plural listeners, and non-boundary
+  dashed names that merely contain boundary words.
+
+## Testing Plan
+
+- Focused exceptions-as-data scanner tests.
+- `bb review` to confirm documented boundary false positives disappear.
+- `bb pre-commit` before merge.
+
+## Deployment Plan
+
+No runtime deployment impact. This changes compliance scanner classification
+only.
+
+## Related Issues/PRs
+
+- Follows PR #1274.
+
+## Checklist
+
+- [x] Preserve non-boundary detection.
+- [x] Preserve component-name substring exclusion.
+- [x] Exempt the MCP context-server base and plural listener boundary.
+- [x] Confirm focused scanner tests pass.
+- [x] Confirm `bb review` decreases.
+- [x] Run `bb pre-commit`.


### PR DESCRIPTION
# Fix: Classify MCP and Listener Boundary Namespaces

## Overview

This PR fixes exceptions-as-data boundary namespace classification for two
documented protocol edges that were still reported as violations.

## Motivation

The scanner documents boundary exemptions for namespaces containing segments
such as `mcp`, `http`, `listener`, `consumer`, and `boundary`. Two real repo
boundaries did not fit the existing exact-segment catalog:

- `ai.miniforge.mcp-context-server.*` is a base named with a dashed Polylith
  segment, so `mcp` is not a standalone dotted segment.
- `ai.miniforge.event-stream.listeners` uses the plural `listeners` segment.

This is scanner precision work, not a weakening of the rule: non-boundary
production namespaces remain subject to the same exceptions-as-data checks.

## Changes in Detail

- Add `listeners` to the explicit boundary segment catalog.
- Add a narrow exact-prefix exemption for `ai.miniforge.mcp-context-server`.
- Preserve the existing rule that boundary markers are not arbitrary
  substrings of component names.
- Add regression coverage for the MCP base, plural listeners, and non-boundary
  dashed names that merely contain boundary words.

## Testing Plan

- Focused exceptions-as-data scanner tests.
- `bb review` to confirm documented boundary false positives disappear.
- `bb pre-commit` before merge.

## Deployment Plan

No runtime deployment impact. This changes compliance scanner classification
only.

## Related Issues/PRs

- Follows PR #1274.

## Checklist

- [x] Preserve non-boundary detection.
- [x] Preserve component-name substring exclusion.
- [x] Exempt the MCP context-server base and plural listener boundary.
- [x] Confirm focused scanner tests pass.
- [x] Confirm `bb review` decreases.
- [x] Run `bb pre-commit`.
