### PR TITLE
Fix exceptions fatal-only review filtering

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
@@ -426,14 +426,22 @@
 
 (defn- run-exceptions-as-data
   "Run the AST-based exceptions-as-data linter against the repo. Returns
-   a vector of Violation maps (already in the canonical scanner shape).
+   a vector of actionable Violation maps when selected, or nil when the
+   rule selector leaves the linter off. Returned rows are already in the
+   canonical scanner shape.
+
+   The raw exceptions-as-data scanner preserves `:fatal-only` records for
+   audit counts, but the top-level compliance review treats only
+   `:cleanup-needed` rows as standards debt. Programmer-error guards are
+   an explicit rule carve-out and should not inflate `bb review` totals.
 
    When `changed-files` is non-nil (incremental mode via `:since`), the
    linter restricts its file walk to the changed set — matching the
    behavior of content rules so `bb review --since` stays fast."
   [repo-path changed-files opts]
   (when (exceptions-as-data-selected? opts)
-    (:violations (exc-data/scan-repo repo-path changed-files))))
+    (filterv #(= :cleanup-needed (:classification %))
+             (:violations (exc-data/scan-repo repo-path changed-files)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Top-level entry point

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
@@ -83,6 +83,21 @@
     (spit f content)
     f))
 
+(defn- run-in-dir!
+  "Run a subprocess in `dir`, clearing inherited Git hook env vars."
+  [dir & cmd]
+  (let [pb       (doto (ProcessBuilder. ^java.util.List (vec cmd))
+                   (.directory dir)
+                   (.inheritIO))
+        env      (.environment pb)
+        git-keys (filterv #(re-find #"^GIT_" %) (keys env))]
+    (doseq [k git-keys] (.remove env k))
+    (let [exit (.waitFor (.start pb))]
+      (when-not (zero? exit)
+        (throw (ex-info "Test subprocess failed"
+                        {:cmd cmd :dir (.getAbsolutePath dir) :exit exit})))
+      exit)))
+
 (deftest scan-repo-detects-210-in-temp-dir
   (testing "scan-repo finds Dewey 210 violations in a synthetic repo"
     (let [tmp-dir (doto (io/file (System/getProperty "java.io.tmpdir")
@@ -93,13 +108,7 @@
         ;; can build an index (scanner uses `git ls-tree HEAD`).
         ;; Clear ALL GIT_* env vars so pre-commit hook env doesn't
         ;; bleed into the child git processes.
-        (let [run! (fn [& cmd]
-                     (let [pb (doto (ProcessBuilder. ^java.util.List (vec cmd))
-                                (.directory tmp-dir))
-                           env (.environment pb)
-                           git-keys (filterv #(re-find #"^GIT_" %) (keys env))]
-                       (doseq [k git-keys] (.remove env k))
-                       (.waitFor (.start pb))))]
+        (let [run! (partial run-in-dir! tmp-dir)]
           (run! "git" "init")
           ;; Disable GPG/SSH signing — 1Password agent blocks in subprocess contexts
           (run! "git" "config" "commit.gpgsign" "false")
@@ -139,6 +148,39 @@
             (is (every? #(pos-int? (:line %)) viols))))
         (finally
           ;; Cleanup
+          (doseq [f (reverse (file-seq tmp-dir))]
+            (.delete f)))))))
+
+(deftest scan-repo-excludes-fatal-only-exceptions-as-data-rows
+  (testing "top-level review output keeps cleanup-needed rows actionable"
+    (let [tmp-dir (doto (io/file (System/getProperty "java.io.tmpdir")
+                                 (str "cs-exc-filter-test-" (System/currentTimeMillis)))
+                    .mkdirs)]
+      (try
+        (let [run! (partial run-in-dir! tmp-dir)]
+          (run! "git" "init")
+          (run! "git" "config" "commit.gpgsign" "false")
+          (run! "git" "-c" "user.email=test@test.com" "-c" "user.name=Test"
+                "commit" "--allow-empty" "-m" "init")
+          (write-temp-file! tmp-dir
+            "components/foo/src/ai/miniforge/foo/core.clj"
+            (str "(ns ai.miniforge.foo.core)\n"
+                 "(defn cleanup-site []\n"
+                 "  (throw (ex-info \"GET failed\" {})))\n"
+                 "(defn fatal-site []\n"
+                 "  (throw (ex-info \"Unknown kind\" {})))\n"))
+          (run! "git" "add" ".")
+          (run! "git" "-c" "user.email=test@test.com" "-c" "user.name=Test"
+                "commit" "-m" "add exceptions"))
+        (let [result (scan/scan-repo (.getAbsolutePath tmp-dir)
+                                     (.getAbsolutePath tmp-dir)
+                                     {:rules :std/exceptions-as-data})
+              viols  (:violations result)]
+          (is (= [:std/exceptions-as-data] (:rules-scanned result)))
+          (is (= 1 (count viols)))
+          (is (= :cleanup-needed (:classification (first viols))))
+          (is (re-find #"GET failed" (:current (first viols)))))
+        (finally
           (doseq [f (reverse (file-seq tmp-dir))]
             (.delete f)))))))
 

--- a/docs/pull-requests/2026-06-25-chris-exceptions-fatal-only-review-filter.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-fatal-only-review-filter.md
@@ -1,0 +1,49 @@
+# Fix: Separate Fatal-Only Exception Notes from Review Violations
+
+## Overview
+
+This PR makes the top-level compliance review honor the
+exceptions-as-data carve-out for programmer-error guards.
+
+## Motivation
+
+The exceptions-as-data scanner already classifies programmer-error guards as
+`:fatal-only`, and the embedded standard describes those rows as
+informational. The top-level `bb review` path still flattened those rows into
+the actionable `:violations` stream, so the review count overstated remaining
+cleanup work.
+
+This is scanner/reporting precision work, not a weakening of the policy:
+runtime failures that should return anomalies remain reported as
+`:cleanup-needed` violations, and the raw exceptions-as-data scan still keeps
+classification counts available for audit.
+
+## Changes in Detail
+
+- Keep `:fatal-only` classification in the exceptions-as-data scanner.
+- Filter `:fatal-only` rows out of the top-level `bb review` violation stream.
+- Preserve `:cleanup-needed` rows as actionable standards violations.
+- Add regression coverage for both the raw scanner behavior and the top-level
+  review behavior.
+
+## Testing Plan
+
+- Focused compliance scanner tests.
+- `bb review` to confirm the actionable count matches `:cleanup-needed`.
+- `bb pre-commit` before merge.
+
+## Deployment Plan
+
+No runtime deployment impact. This changes compliance scanner reporting only.
+
+## Related Issues/PRs
+
+- Follows PR #1275.
+
+## Checklist
+
+- [x] Preserve raw scanner classification counts.
+- [x] Exclude fatal-only rows from top-level actionable review output.
+- [x] Confirm focused scanner tests pass.
+- [x] Confirm `bb review` decreases to cleanup-needed count.
+- [x] Run `bb pre-commit`.


### PR DESCRIPTION
# Fix: Separate Fatal-Only Exception Notes from Review Violations

## Overview

This PR makes the top-level compliance review honor the
exceptions-as-data carve-out for programmer-error guards.

## Motivation

The exceptions-as-data scanner already classifies programmer-error guards as
`:fatal-only`, and the embedded standard describes those rows as
informational. The top-level `bb review` path still flattened those rows into
the actionable `:violations` stream, so the review count overstated remaining
cleanup work.

This is scanner/reporting precision work, not a weakening of the policy:
runtime failures that should return anomalies remain reported as
`:cleanup-needed` violations, and the raw exceptions-as-data scan still keeps
classification counts available for audit.

## Changes in Detail

- Keep `:fatal-only` classification in the exceptions-as-data scanner.
- Filter `:fatal-only` rows out of the top-level `bb review` violation stream.
- Preserve `:cleanup-needed` rows as actionable standards violations.
- Add regression coverage for both the raw scanner behavior and the top-level
  review behavior.

## Testing Plan

- Focused compliance scanner tests.
- `bb review` to confirm the actionable count matches `:cleanup-needed`.
- `bb pre-commit` before merge.

## Deployment Plan

No runtime deployment impact. This changes compliance scanner reporting only.

## Related Issues/PRs

- Follows PR #1275.

## Checklist

- [x] Preserve raw scanner classification counts.
- [x] Exclude fatal-only rows from top-level actionable review output.
- [x] Confirm focused scanner tests pass.
- [x] Confirm `bb review` decreases to cleanup-needed count.
- [x] Run `bb pre-commit`.
