### PR TITLE
Fix data plane HTTP anomaly returns

### DIFF
--- a/components/bb-data-plane-http/deps.edn
+++ b/components/bb-data-plane-http/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps  {org.babashka/http-client {:mvn/version "0.4.22"}
          cheshire/cheshire        {:mvn/version "5.13.0"}
+         ai.miniforge/anomaly     {:local/root "../anomaly"}
          ai.miniforge/bb-out      {:local/root "../bb-out"}
          ai.miniforge/bb-paths    {:local/root "../bb-paths"}
          ai.miniforge/bb-proc     {:local/root "../bb-proc"}}

--- a/components/bb-data-plane-http/src/ai/miniforge/bb_data_plane_http/core.clj
+++ b/components/bb-data-plane-http/src/ai/miniforge/bb_data_plane_http/core.clj
@@ -22,7 +22,8 @@
    Layer 0: pure config resolution + URL/cmd builders.
    Layer 1: lifecycle side effects (build, start, wait-ready, destroy).
    Layer 2: HTTP helpers that take an injectable `:http-fn`."
-  (:require [ai.miniforge.bb-paths.interface :as paths]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.bb-paths.interface :as paths]
             [ai.miniforge.bb-proc.interface :as proc]
             [babashka.http-client :as http]
             [babashka.process :as p]
@@ -92,10 +93,13 @@
           dead?  (and proc-handle (not (p/alive? proc-handle)))]
       (cond
         ready?                    :ready
-        dead?                     (throw (ex-info "Data plane exited during startup" {}))
-        (>= attempt max-attempts) (throw (ex-info "Data plane did not become ready"
-                                                  {:attempts max-attempts
-                                                   :health-url health-url}))
+        dead?                     (anomaly/anomaly :fault
+                                                   "Data plane exited during startup"
+                                                   {:health-url health-url})
+        (>= attempt max-attempts) (anomaly/anomaly :fault
+                                                   "Data plane did not become ready"
+                                                   {:attempts max-attempts
+                                                    :health-url health-url})
         :else                     (do (sleep-fn) (recur (inc attempt)))))))
 
 (defn destroy!
@@ -114,22 +118,36 @@
 
 (defn http-get-json
   [url {:keys [http-fn] :or {http-fn default-http-get}}]
-  (let [resp (http-fn url)]
-    (if (= 200 (:status resp))
-      (json/parse-string (:body resp) true)
-      (throw (ex-info (str "GET " url " failed")
-                      {:status (:status resp) :body (:body resp)})))))
+  (try
+    (let [resp (http-fn url)]
+      (if (= 200 (:status resp))
+        (json/parse-string (:body resp) true)
+        (anomaly/anomaly :fault
+                         (str "GET " url " failed")
+                         {:status (:status resp) :body (:body resp)})))
+    (catch Exception e
+      (anomaly/exception-anomaly :fault
+                                 (str "GET " url " failed")
+                                 {:url url}
+                                 e))))
 
 (defn http-post-json
   [url body-map {:keys [http-fn] :or {http-fn default-http-post}}]
-  (let [resp (http-fn url
-                      {:headers {"Content-Type" "application/json"}
-                       :body    (json/generate-string body-map)
-                       :throw   false})]
-    (if (= 200 (:status resp))
-      (json/parse-string (:body resp) true)
-      (throw (ex-info (str "POST " url " failed")
-                      {:status (:status resp) :body (:body resp)})))))
+  (try
+    (let [resp (http-fn url
+                        {:headers {"Content-Type" "application/json"}
+                         :body    (json/generate-string body-map)
+                         :throw   false})]
+      (if (= 200 (:status resp))
+        (json/parse-string (:body resp) true)
+        (anomaly/anomaly :fault
+                         (str "POST " url " failed")
+                         {:status (:status resp) :body (:body resp)})))
+    (catch Exception e
+      (anomaly/exception-anomaly :fault
+                                 (str "POST " url " failed")
+                                 {:url url}
+                                 e))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/bb-data-plane-http/src/ai/miniforge/bb_data_plane_http/interface.clj
+++ b/components/bb-data-plane-http/src/ai/miniforge/bb_data_plane_http/interface.clj
@@ -66,7 +66,8 @@
 
 (defn wait-ready!
   "Poll `health-url` until it responds (< 500) or attempts exhausted.
-   Throws ex-info on exhaustion or early process death.
+   Returns `:ready` on success or an anomaly on exhaustion or early
+   process death.
    `opts`: `:max-attempts` (60), `:http-fn`, `:sleep-fn` (250 ms),
    `:proc-handle`."
   ([health-url]      (core/wait-ready! health-url {}))
@@ -86,14 +87,14 @@
   ([url opts] (core/http-get-body url opts)))
 
 (defn http-get-json
-  "GET `url`; parse JSON body into keywordized map. Throws ex-info on
-   non-200. `opts`: `:http-fn`."
+  "GET `url`; parse JSON body into keywordized map. Returns an anomaly
+   on non-200. `opts`: `:http-fn`."
   ([url]      (core/http-get-json url {}))
   ([url opts] (core/http-get-json url opts)))
 
 (defn http-post-json
   "POST `url` with `body-map` as JSON. Parse response JSON.
-   Throws ex-info on non-200. `opts`: `:http-fn`."
+   Returns an anomaly on non-200. `opts`: `:http-fn`."
   ([url body-map]      (core/http-post-json url body-map {}))
   ([url body-map opts] (core/http-post-json url body-map opts)))
 

--- a/components/bb-data-plane-http/test/ai/miniforge/bb_data_plane_http/core_test.clj
+++ b/components/bb-data-plane-http/test/ai/miniforge/bb_data_plane_http/core_test.clj
@@ -19,7 +19,9 @@
 (ns ai.miniforge.bb-data-plane-http.core-test
   "Layer 0 + Layer 2 tested here. Layer 1 (process lifecycle) is exercised
    by consumer repos running `bb test:signals:fixtures` or equivalent."
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [babashka.process :as p]
+            [clojure.test :refer [deftest testing is]]
             [ai.miniforge.bb-data-plane-http.core :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -68,11 +70,31 @@
            (sut/http-get-json "http://example"
                               {:http-fn (fn [_] {:status 200 :body "{\"a\":1,\"b\":\"c\"}"})})))))
 
-(deftest test-http-get-json-throws-on-non-200
-  (testing "given 500 response → throws ex-info"
-    (is (thrown? Exception
-                 (sut/http-get-json "http://example"
-                                    {:http-fn (fn [_] {:status 500 :body "err"})})))))
+(deftest test-http-get-json-returns-anomaly-on-non-200
+  (testing "given 500 response → anomaly"
+    (let [result (sut/http-get-json "http://example"
+                                    {:http-fn (fn [_] {:status 500 :body "err"})})]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= {:status 500 :body "err"} (:anomaly/data result))))))
+
+(deftest test-http-get-json-returns-anomaly-on-invalid-json
+  (testing "given 200 response with invalid JSON → anomaly"
+    (let [result (sut/http-get-json "http://example"
+                                    {:http-fn (fn [_] {:status 200 :body "{bad"})})]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= "http://example" (get-in result [:anomaly/data :url])))
+      (is (= "com.fasterxml.jackson.core.JsonParseException"
+             (get-in result [:anomaly/data :anomaly/ex-class]))))))
+
+(deftest test-http-get-json-returns-anomaly-on-transport-error
+  (testing "given http-fn that throws → anomaly"
+    (let [result (sut/http-get-json "http://example"
+                                    {:http-fn (fn [_] (throw (Exception. "offline")))})]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= "offline" (get-in result [:anomaly/data :anomaly/ex-message]))))))
 
 (deftest test-http-post-json-sends-body-and-parses
   (testing "given http-fn capturing args → body serialized, response parsed"
@@ -89,11 +111,31 @@
       (is (= "{\"scenario\":\"live\"}"
              (get-in @captured [:opts :body]))))))
 
-(deftest test-http-post-json-throws-on-non-200
-  (testing "given 400 response → throws ex-info"
-    (is (thrown? Exception
-                 (sut/http-post-json "http://example" {}
-                                     {:http-fn (fn [_ _] {:status 400 :body "bad"})})))))
+(deftest test-http-post-json-returns-anomaly-on-non-200
+  (testing "given 400 response → anomaly"
+    (let [result (sut/http-post-json "http://example" {}
+                                     {:http-fn (fn [_ _] {:status 400 :body "bad"})})]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= {:status 400 :body "bad"} (:anomaly/data result))))))
+
+(deftest test-http-post-json-returns-anomaly-on-invalid-json
+  (testing "given 200 response with invalid JSON → anomaly"
+    (let [result (sut/http-post-json "http://example" {:scenario "live"}
+                                     {:http-fn (fn [_ _] {:status 200 :body "{bad"})})]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= "http://example" (get-in result [:anomaly/data :url])))
+      (is (= "com.fasterxml.jackson.core.JsonParseException"
+             (get-in result [:anomaly/data :anomaly/ex-class]))))))
+
+(deftest test-http-post-json-returns-anomaly-on-transport-error
+  (testing "given http-fn that throws → anomaly"
+    (let [result (sut/http-post-json "http://example" {:scenario "live"}
+                                     {:http-fn (fn [_ _] (throw (Exception. "offline")))})]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= "offline" (get-in result [:anomaly/data :anomaly/ex-message]))))))
 
 ;------------------------------------------------------------------------------ wait-ready!
 ;; Uses injected http + sleep so it's deterministic.
@@ -107,16 +149,26 @@
                              :max-attempts 1})))))
 
 (deftest test-wait-ready-exhausts-attempts
-  (testing "given http-fn that always fails → throws with :attempts"
-    (let [ex (try
-               (sut/wait-ready! "http://example"
-                                {:http-fn (fn [_] (throw (Exception. "nope")))
-                                 :sleep-fn (fn [] nil)
-                                 :max-attempts 3})
-               nil
-               (catch Exception e e))]
-      (is (some? ex))
-      (is (= 3 (:attempts (ex-data ex)))))))
+  (testing "given http-fn that always fails → anomaly with :attempts"
+    (let [result (sut/wait-ready! "http://example"
+                                  {:http-fn (fn [_] (throw (Exception. "nope")))
+                                   :sleep-fn (fn [] nil)
+                                   :max-attempts 3})]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= 3 (get-in result [:anomaly/data :attempts]))))))
+
+(deftest test-wait-ready-reports-process-death
+  (testing "given a dead process handle before readiness → anomaly"
+    (with-redefs [p/alive? (constantly false)]
+      (let [result (sut/wait-ready! "http://example"
+                                    {:http-fn (fn [_] {:status 503})
+                                     :sleep-fn (fn [] nil)
+                                     :max-attempts 3
+                                     :proc-handle ::proc})]
+        (is (anomaly/anomaly? result))
+        (is (= :fault (:anomaly/type result)))
+        (is (= {:health-url "http://example"} (:anomaly/data result)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-06-25-chris-bb-data-plane-http-anomalies.md
+++ b/docs/pull-requests/2026-06-25-chris-bb-data-plane-http-anomalies.md
@@ -1,0 +1,48 @@
+# Fix: Return data-plane HTTP failures as anomalies
+
+## Overview
+
+This PR removes normal-flow exception signaling from the `bb-data-plane-http`
+component. Readiness polling and JSON HTTP helpers should return anomaly data
+for expected process or HTTP failures instead of throwing inside the component.
+
+## Motivation
+
+`bb review` still reports cleanup-needed exceptions-as-data violations. The
+data-plane HTTP component is a small primitive with injected HTTP/process test
+surfaces, making it a focused cleanup wave before larger API migrations such as
+`repo-dag`.
+
+## Changes in Detail
+
+- Convert startup readiness failures into `:fault` anomaly returns.
+- Convert non-200 JSON HTTP responses into `:fault` anomaly returns.
+- Update the public interface docs to describe anomaly results.
+- Update component tests to assert anomaly values instead of thrown exceptions.
+
+## Testing Plan
+
+- Run the focused `bb-data-plane-http` component tests:
+  `clojure -M:dev:test -e "(require 'ai.miniforge.bb-data-plane-http.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.bb-data-plane-http.core-test)"`.
+  Latest result: 17 tests, 38 assertions, 0 failures.
+- Run `bb review` and confirm the component no longer contributes
+  cleanup-needed exception violations.
+- Run `bb pre-commit` before opening the PR.
+
+## Deployment Plan
+
+No special deployment steps. This is a library behavior cleanup with no schema
+or storage migration.
+
+## Related Issues/PRs
+
+- Follows PR #1276, which filtered fatal-only scanner rows from top-level
+  `bb review` output.
+
+## Checklist
+
+- [x] Component implementation updated.
+- [x] Tests updated and focused suite passes.
+- [x] `bb review` count reduced.
+- [x] `bb pre-commit` passes.
+- [ ] PR opened, comments resolved, and CI green.

--- a/projects/bb-utils/deps.edn
+++ b/projects/bb-utils/deps.edn
@@ -9,7 +9,8 @@
 
 {:paths []
 
- :deps {ai.miniforge/bb-paths          {:local/root "../../components/bb-paths"}
+ :deps {ai.miniforge/anomaly           {:local/root "../../components/anomaly"}
+        ai.miniforge/bb-paths          {:local/root "../../components/bb-paths"}
         ai.miniforge/bb-dev-tools      {:local/root "../../components/bb-dev-tools"}
         ai.miniforge/bb-out            {:local/root "../../components/bb-out"}
         ai.miniforge/bb-platform       {:local/root "../../components/bb-platform"}


### PR DESCRIPTION
## Summary
- return canonical anomaly maps from bb-data-plane-http readiness and JSON helper failure paths
- convert JSON parse and transport/generation exceptions with anomaly/exception-anomaly
- add the anomaly component to the bb-data-plane-http and bb-utils dependency surfaces
- update tests and interface docs for anomaly-returning behavior

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.bb-data-plane-http.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.bb-data-plane-http.core-test)" — 17 tests, 38 assertions
- bb review — cleanup-needed violations reduced from 164 to 160; bb-data-plane-http contributes 0
- bb pre-commit — passed