### PR TITLE
Fix R2 pull anomaly returns

### DIFF
--- a/components/bb-r2/deps.edn
+++ b/components/bb-r2/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps  {ai.miniforge/bb-proc {:local/root "../bb-proc"}}
+ :deps  {ai.miniforge/anomaly {:local/root "../anomaly"}
+         ai.miniforge/bb-proc {:local/root "../bb-proc"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/bb-r2/src/ai/miniforge/bb_r2/core.clj
+++ b/components/bb-r2/src/ai/miniforge/bb_r2/core.clj
@@ -21,7 +21,8 @@
 
    Layer 0: pure command-vector builders — no subprocess, testable.
    Layer 1: side-effecting wrappers that invoke the vectors via bb-proc."
-  (:require [ai.miniforge.bb-proc.interface :as proc]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.bb-proc.interface :as proc]
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -52,21 +53,30 @@
 (defn pull!
   [key dest {:keys [worker-dir bucket sh-fn]
              :or   {sh-fn proc/sh}}]
-  (when-not worker-dir
-    (throw (ex-info "bb-r2/pull! requires :worker-dir" {:opts :worker-dir})))
-  (when-not bucket
-    (throw (ex-info "bb-r2/pull! requires :bucket" {:opts :bucket})))
-  (let [result (sh-fn {:dir worker-dir :out :string :err :string}
-                      "npx" "wrangler" "r2" "object" "get"
-                      (str bucket "/" key)
-                      (str "--file=" dest)
-                      "--remote")
-        kind   (classify-wrangler-result result)]
-    (case kind
-      :ok      :ok
-      :missing :missing
-      (throw (ex-info (str "wrangler r2 get failed for " key)
-                      {:exit (:exit result) :err (:err result)})))))
+  (cond
+    (nil? worker-dir)
+    (anomaly/anomaly :invalid-input
+                     "bb-r2/pull! requires :worker-dir"
+                     {:opts :worker-dir})
+
+    (nil? bucket)
+    (anomaly/anomaly :invalid-input
+                     "bb-r2/pull! requires :bucket"
+                     {:opts :bucket})
+
+    :else
+    (let [result (sh-fn {:dir worker-dir :out :string :err :string}
+                        "npx" "wrangler" "r2" "object" "get"
+                        (str bucket "/" key)
+                        (str "--file=" dest)
+                        "--remote")
+          kind   (classify-wrangler-result result)]
+      (case kind
+        :ok      :ok
+        :missing :missing
+        (anomaly/anomaly :fault
+                         (str "wrangler r2 get failed for " key)
+                         {:exit (:exit result) :err (:err result)})))))
 
 (defn upload!
   [bucket src key {:keys [run-fn] :or {run-fn proc/run!} :as opts}]

--- a/components/bb-r2/src/ai/miniforge/bb_r2/interface.clj
+++ b/components/bb-r2/src/ai/miniforge/bb_r2/interface.clj
@@ -27,7 +27,8 @@
 (defn pull!
   "Pull `bucket/key` from R2 via `npx wrangler r2 object get`, writing
    to `dest`. Returns `:ok` on success, `:missing` on a 404-ish wrangler
-   failure, throws on other errors.
+   failure, an `:invalid-input` anomaly when required opts are missing,
+   or a `:fault` anomaly for other wrangler failures.
 
    Required opts: `:worker-dir` (directory where wrangler runs),
    `:bucket`. Optional: `:sh-fn` (defaults to `bb-proc/sh`)."

--- a/components/bb-r2/test/ai/miniforge/bb_r2/core_test.clj
+++ b/components/bb-r2/test/ai/miniforge/bb_r2/core_test.clj
@@ -19,8 +19,9 @@
 (ns ai.miniforge.bb-r2.core-test
   "Pure layer tests: classification + command-vector shape. Side effects
    are exercised by `pull!`/`upload!` via injected `:sh-fn`/`:run-fn` in
-   a single happy-path + missing-key test each."
-  (:require [clojure.test :refer [deftest testing is]]
+   focused success, missing-key, invalid-input, and failure-path tests."
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [clojure.test :refer [deftest testing is]]
             [ai.miniforge.bb-r2.core :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -89,14 +90,28 @@
                                           :err "The specified key does not exist."})})))))
 
 (deftest test-pull-requires-worker-dir
-  (testing "given no :worker-dir → throws with :opts :worker-dir"
-    (is (thrown? Exception
-                 (sut/pull! "k" "/tmp/d" {:bucket "bkt"})))))
+  (testing "given no :worker-dir → invalid-input anomaly"
+    (let [result (sut/pull! "k" "/tmp/d" {:bucket "bkt"})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :worker-dir (get-in result [:anomaly/data :opts]))))))
 
 (deftest test-pull-requires-bucket
-  (testing "given no :bucket → throws with :opts :bucket"
-    (is (thrown? Exception
-                 (sut/pull! "k" "/tmp/d" {:worker-dir "/tmp/w"})))))
+  (testing "given no :bucket → invalid-input anomaly"
+    (let [result (sut/pull! "k" "/tmp/d" {:worker-dir "/tmp/w"})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :bucket (get-in result [:anomaly/data :opts]))))))
+
+(deftest test-pull-wrangler-error-returns-anomaly
+  (testing "given unknown wrangler failure → fault anomaly"
+    (let [result (sut/pull! "k" "/tmp/d"
+                            {:worker-dir "/tmp/w"
+                             :bucket "bkt"
+                             :sh-fn (fn [& _] {:exit 2 :err "auth failed"})})]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= {:exit 2 :err "auth failed"} (:anomaly/data result))))))
 
 (deftest test-upload-invokes-run-fn-and-returns-dest
   (testing "given run-fn → invoked with the built cmd, returns s3 URL"

--- a/docs/pull-requests/2026-06-25-chris-bb-r2-pull-anomalies.md
+++ b/docs/pull-requests/2026-06-25-chris-bb-r2-pull-anomalies.md
@@ -1,0 +1,48 @@
+# Fix: Return R2 pull failures as anomalies
+
+## Overview
+
+This PR converts `bb-r2/pull!` failure branches from thrown exceptions to
+canonical anomaly values. The helper already returns tagged outcomes for
+successful and missing-object cases; this change makes command/config failures
+data-shaped too.
+
+## Motivation
+
+The exceptions-as-data cleanup scan still reports a `bb-r2` normal-flow throw.
+`pull!` is small, has injected process tests, and has no in-repo production
+callers beyond the public pass-through interface, making it a contained
+remediation wave.
+
+## Changes in Detail
+
+- Add the anomaly component to `bb-r2`.
+- Return `:invalid-input` anomalies when required pull options are missing.
+- Return a `:fault` anomaly when `wrangler r2 object get` fails for reasons
+  other than a missing key.
+- Update interface docs and focused tests for the anomaly-returning cases.
+
+## Testing Plan
+
+- Run focused `bb-r2` tests:
+  `clojure -M:dev:test -e "(require 'ai.miniforge.bb-r2.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.bb-r2.core-test)"`.
+  Latest result: 13 tests, 23 assertions, 0 failures.
+- Run `bb review` and confirm `bb-r2` contributes zero cleanup-needed rows.
+  Latest scanner count: 159 cleanup-needed rows.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+No deployment steps. This is a Babashka helper behavior cleanup.
+
+## Related Issues/PRs
+
+- Follows PR #1277.
+
+## Checklist
+
+- [x] Implementation updated.
+- [x] Tests updated and focused suite passes.
+- [x] `bb review` count reduced.
+- [x] `bb pre-commit` passes.
+- [ ] PR opened, comments resolved, CI green, and merged.


### PR DESCRIPTION
## Summary
- return canonical anomalies from bb-r2 pull! invalid-input and wrangler failure branches
- add bb-r2's direct anomaly dependency
- update interface docs and focused tests for anomaly-returning behavior

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.bb-r2.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.bb-r2.core-test)" — 13 tests, 23 assertions
- bb review scanner check — cleanup-needed rows 159; bb-r2 contributes 0
- bb pre-commit — passed