### PR TITLE
Fix pipeline connector registry anomaly

### DIFF
--- a/components/pipeline-config/deps.edn
+++ b/components/pipeline-config/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector    {:local/root "../connector"}
+ :deps {ai.miniforge/anomaly      {:local/root "../anomaly"}
+        ai.miniforge/connector    {:local/root "../connector"}
         ai.miniforge/data-quality {:local/root "../data-quality"}
         ai.miniforge/pipeline     {:local/root "../pipeline"}
-        ai.miniforge/schema          {:local/root "../schema"}}
+        ai.miniforge/schema       {:local/root "../schema"}}
  :aliases {:test {:extra-paths ["test" "test-resources"]
                   :extra-deps {}}}}

--- a/components/pipeline-config/src/ai/miniforge/pipeline_config/connector_registry.clj
+++ b/components/pipeline-config/src/ai/miniforge/pipeline_config/connector_registry.clj
@@ -1,6 +1,7 @@
 (ns ai.miniforge.pipeline-config.connector-registry
   "Atom-backed registry mapping connector type keywords to factory functions."
-  (:require [ai.miniforge.pipeline-config.messages :as msg])
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.pipeline-config.messages :as msg])
   (:import [java.util UUID]))
 
 (defn create-connector-registry
@@ -29,7 +30,9 @@
 (defn instantiate-connectors
   "Given a registry and a map of {symbolic-ref → connector-type-keyword},
    create connector instances with assigned UUIDs.
-   Returns {:connector-refs {symbolic-ref → uuid} :connectors {uuid → instance}}."
+   Returns {:connector-refs {symbolic-ref → uuid} :connectors {uuid → instance}}
+   or an anomaly map with `:anomaly/type :not-found` when a connector type is
+   not registered."
   [registry connector-refs]
   (let [reg @registry]
     (reduce-kv
@@ -40,7 +43,9 @@
            (-> acc
                (assoc-in [:connector-refs ref-name] uuid)
                (assoc-in [:connectors uuid] instance)))
-         (throw (ex-info (msg/t :registry/connector-not-found {:type type-kw})
-                         {:type type-kw :ref ref-name}))))
+         (reduced
+          (anomaly/anomaly :not-found
+                           (msg/t :registry/connector-not-found {:type type-kw})
+                           {:type type-kw :ref ref-name}))))
      {:connector-refs {} :connectors {}}
      connector-refs)))

--- a/components/pipeline-config/src/ai/miniforge/pipeline_config/interface.clj
+++ b/components/pipeline-config/src/ai/miniforge/pipeline_config/interface.clj
@@ -81,7 +81,9 @@
 
 (defn instantiate-connectors
   "Create connector instances from a {symbolic-ref → type-keyword} map.
-   Returns {:connector-refs {ref → uuid} :connectors {uuid → instance}}."
+   Returns {:connector-refs {ref → uuid} :connectors {uuid → instance}},
+   or an anomaly map with `:anomaly/type :not-found` when a connector type is
+   unregistered."
   [registry connector-refs]
   (conn-reg/instantiate-connectors registry connector-refs))
 

--- a/components/pipeline-config/test/ai/miniforge/pipeline_config/interface_test.clj
+++ b/components/pipeline-config/test/ai/miniforge/pipeline_config/interface_test.clj
@@ -216,10 +216,12 @@
           (is (= {:type :mock-connector} inst)))))))
 
 (deftest connector-registry-missing-type-test
-  (testing "instantiate throws for unregistered type"
-    (let [registry (pc/create-connector-registry)]
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (pc/instantiate-connectors registry {:conn/src :unknown}))))))
+  (testing "instantiate returns anomaly for unregistered type"
+    (let [registry (pc/create-connector-registry)
+          result   (pc/instantiate-connectors registry {:conn/src :unknown})]
+      (is (= :not-found (:anomaly/type result)))
+      (is (= {:type :unknown :ref :conn/src}
+             (:anomaly/data result))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Rule registry tests

--- a/docs/pull-requests/2026-06-25-chris-pipeline-config-connector-anomaly.md
+++ b/docs/pull-requests/2026-06-25-chris-pipeline-config-connector-anomaly.md
@@ -1,0 +1,50 @@
+# Fix: Return connector registry misses as anomalies
+
+## Overview
+
+This PR converts the `pipeline-config` connector registry missing-type branch
+from a thrown exception to a canonical anomaly value. Successful connector
+instantiation keeps the existing `{:connector-refs ... :connectors ...}` shape.
+
+## Motivation
+
+The exceptions-as-data cleanup scan reports a normal-flow throw in
+`instantiate-connectors`. Missing connector types are caller-visible lookup
+misses, not process-fatal exceptions, and the component already has focused
+public API tests around that branch.
+
+## Changes in Detail
+
+- Add the anomaly component to `pipeline-config`.
+- Return a `:not-found` anomaly when a symbolic connector ref names an
+  unregistered connector type.
+- Update the public interface docstring to name the anomaly return.
+- Update the connector registry missing-type test to assert anomaly data.
+
+## Testing Plan
+
+- Run focused `pipeline-config` tests.
+  Latest result: 23 tests, 56 assertions, 0 failures.
+- Run the exceptions-as-data scanner and confirm `pipeline-config` contributes
+  zero cleanup-needed rows.
+  Latest scanner count: 158 cleanup-needed rows; `pipeline-config` contributes
+  zero rows.
+- Run `bb pre-commit`.
+  Latest result: all checks passed.
+
+## Deployment Plan
+
+No deployment steps. This is a data-contract cleanup for pipeline config
+registry lookup failures.
+
+## Related Issues/PRs
+
+- Follows PR #1278.
+
+## Checklist
+
+- [x] Implementation updated.
+- [x] Tests updated and focused suite passes.
+- [x] `bb review` count reduced.
+- [x] `bb pre-commit` passes.
+- [ ] PR opened, comments resolved, CI green, and merged.


### PR DESCRIPTION
# Fix: Return connector registry misses as anomalies

## Overview

This PR converts the `pipeline-config` connector registry missing-type branch
from a thrown exception to a canonical anomaly value. Successful connector
instantiation keeps the existing `{:connector-refs ... :connectors ...}` shape.

## Motivation

The exceptions-as-data cleanup scan reports a normal-flow throw in
`instantiate-connectors`. Missing connector types are caller-visible lookup
misses, not process-fatal exceptions, and the component already has focused
public API tests around that branch.

## Changes in Detail

- Add the anomaly component to `pipeline-config`.
- Return a `:not-found` anomaly when a symbolic connector ref names an
  unregistered connector type.
- Update the public interface docstring to name the anomaly return.
- Update the connector registry missing-type test to assert anomaly data.

## Testing Plan

- Run focused `pipeline-config` tests.
  Latest result: 23 tests, 56 assertions, 0 failures.
- Run the exceptions-as-data scanner and confirm `pipeline-config` contributes
  zero cleanup-needed rows.
  Latest scanner count: 158 cleanup-needed rows; `pipeline-config` contributes
  zero rows.
- Run `bb pre-commit`.
  Latest result: all checks passed.

## Deployment Plan

No deployment steps. This is a data-contract cleanup for pipeline config
registry lookup failures.

## Related Issues/PRs

- Follows PR #1278.

## Checklist

- [x] Implementation updated.
- [x] Tests updated and focused suite passes.
- [x] `bb review` count reduced.
- [x] `bb pre-commit` passes.
- [ ] PR opened, comments resolved, CI green, and merged.
