### PR TITLE
Fix control-plane missing agent transition anomaly

### DIFF
--- a/components/control-plane/deps.edn
+++ b/components/control-plane/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/logging {:local/root "../logging"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/response {:local/root "../response"}
         ai.miniforge/decision {:local/root "../decision"}

--- a/components/control-plane/src/ai/miniforge/control_plane/interface.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/interface.clj
@@ -118,7 +118,9 @@
   registry/record-heartbeat!)
 
 (def transition-agent!
-  "Transition an agent to a new status with validation."
+  "Transition an agent to a new status with validation.
+   Returns an updated agent record, or an anomaly map with
+   `:anomaly/type :not-found` when the agent ID is absent."
   registry/transition-agent!)
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/control-plane/src/ai/miniforge/control_plane/registry.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/registry.clj
@@ -28,6 +28,7 @@
    Layer 2: Query operations
    Layer 3: Heartbeat updates"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.control-plane.messages :as messages]
    [ai.miniforge.control-plane.state-machine :as sm]))
 
@@ -191,6 +192,12 @@
 ;------------------------------------------------------------------------------ Layer 3
 ;; Heartbeat updates
 
+(defn- agent-not-found-anomaly
+  [agent-id]
+  (anomaly/anomaly :not-found
+                   (messages/t :registry/agent-not-found)
+                   {:agent/id agent-id}))
+
 (defn record-heartbeat!
   "Record a heartbeat from an agent, updating timestamp and optional fields.
 
@@ -227,15 +234,18 @@
    - agent-id - UUID of the agent
    - new-status - Target status keyword
 
-   Returns: Updated agent record.
+   Returns: Updated agent record, or an anomaly map with
+   `:anomaly/type :not-found` when `agent-id` is absent.
    Throws: ExceptionInfo if transition is invalid."
   [registry agent-id new-status]
   (let [profile (sm/get-profile)
         current-status (get-in @registry [:agents agent-id :agent/status])]
-    (when-not current-status
-      (throw (ex-info (messages/t :registry/agent-not-found) {:agent/id agent-id})))
-    (sm/validate-transition profile current-status new-status)
-    (update-agent! registry agent-id {:agent/status new-status})))
+    (if-not current-status
+      (agent-not-found-anomaly agent-id)
+      (do
+        (sm/validate-transition profile current-status new-status)
+        (or (update-agent! registry agent-id {:agent/status new-status})
+            (agent-not-found-anomaly agent-id))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.control-plane.interface-test
   (:require
    [clojure.test :refer [deftest testing is are]]
+   [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.interface :as cp]))
 
 ;------------------------------------------------------------------------------ State Machine Tests
@@ -129,17 +130,39 @@
         (is (= :running (:agent/status updated)))))))
 
 (deftest transition-agent-test
-  (let [reg (cp/create-registry)
-        agent (cp/register-agent! reg {:agent/vendor :test :agent/name "T"})
-        agent-id (:agent/id agent)]
-    (testing "Valid transition"
+  (testing "Valid transition"
+    (let [reg (cp/create-registry)
+          agent (cp/register-agent! reg {:agent/vendor :test :agent/name "T"})
+          agent-id (:agent/id agent)]
       (cp/transition-agent! reg agent-id :running)
-      (is (= :running (:agent/status (cp/get-agent reg agent-id)))))
+      (is (= :running (:agent/status (cp/get-agent reg agent-id))))))
 
-    (testing "Invalid transition throws"
+  (testing "Invalid transition throws"
+    (let [reg (cp/create-registry)
+          agent (cp/register-agent! reg {:agent/vendor :test :agent/name "T"})
+          agent-id (:agent/id agent)]
+      (cp/transition-agent! reg agent-id :running)
       (cp/transition-agent! reg agent-id :completed)
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid"
-        (cp/transition-agent! reg agent-id :running))))))
+                            (cp/transition-agent! reg agent-id :running)))))
+
+  (testing "Missing agent returns not-found anomaly"
+    (let [reg (cp/create-registry)
+          missing-id (java.util.UUID/randomUUID)
+          result (cp/transition-agent! reg missing-id :running)]
+      (is (= :not-found (:anomaly/type result)))
+      (is (= {:agent/id missing-id}
+             (:anomaly/data result)))))
+
+  (testing "Concurrent removal during transition returns not-found anomaly"
+    (let [reg (cp/create-registry)
+          agent (cp/register-agent! reg {:agent/vendor :test :agent/name "T"})
+          agent-id (:agent/id agent)]
+      (with-redefs [registry/update-agent! (fn [& _] nil)]
+        (let [result (cp/transition-agent! reg agent-id :running)]
+          (is (= :not-found (:anomaly/type result)))
+          (is (= {:agent/id agent-id}
+                 (:anomaly/data result))))))))
 
 (deftest agents-by-status-test
   (let [reg (cp/create-registry)]

--- a/docs/pull-requests/2026-06-25-chris-control-plane-transition-not-found.md
+++ b/docs/pull-requests/2026-06-25-chris-control-plane-transition-not-found.md
@@ -1,0 +1,51 @@
+# Fix: Return missing control-plane agent transitions as anomalies
+
+## Overview
+
+This PR converts the `control-plane` registry lookup miss in
+`transition-agent!` from a thrown exception to a canonical anomaly value.
+Successful transitions and invalid state-machine transitions keep their existing
+behavior.
+
+## Motivation
+
+The exceptions-as-data cleanup scan reports the missing-agent branch in
+`transition-agent!`. A missing agent ID is a caller-visible lookup miss, not a
+process-fatal exception, and can be represented as data without changing valid
+transition behavior.
+
+## Changes in Detail
+
+- Add the anomaly component to `control-plane`.
+- Return an anomaly map with `:anomaly/type :not-found` when
+  `transition-agent!` cannot find the agent ID.
+- Update registry/interface docs for the new missing-agent return contract.
+- Add focused public API coverage for the missing-agent anomaly branch and the
+  concurrent-removal race where `update-agent!` returns nil.
+
+## Testing Plan
+
+- Run focused `control-plane` interface tests.
+  Latest result: 14 tests, 77 assertions, 0 failures.
+- Run the exceptions-as-data scanner and confirm `control-plane/registry`
+  contributes zero cleanup-needed rows.
+  Latest scanner count: 157 cleanup-needed rows; `control-plane/registry`
+  contributes zero rows.
+- Run `bb pre-commit`.
+  Latest result: all checks passed.
+
+## Deployment Plan
+
+No deployment steps. This is a control-plane registry lookup failure cleanup.
+
+## Related Issues/PRs
+
+- Follows PR #1279.
+
+## Checklist
+
+- [x] Implementation updated.
+- [x] Tests updated and focused suite passes.
+- [x] `bb review` count reduced.
+- [x] `bb pre-commit` passes.
+- [ ] PR opened, comments resolved, CI green, and merged.


### PR DESCRIPTION
# Fix: Return missing control-plane agent transitions as anomalies

## Overview

This PR converts the `control-plane` registry lookup miss in
`transition-agent!` from a thrown exception to a canonical anomaly value.
Successful transitions and invalid state-machine transitions keep their existing
behavior.

## Motivation

The exceptions-as-data cleanup scan reports the missing-agent branch in
`transition-agent!`. A missing agent ID is a caller-visible lookup miss, not a
process-fatal exception, and can be represented as data without changing valid
transition behavior.

## Changes in Detail

- Add the anomaly component to `control-plane`.
- Return an anomaly map with `:anomaly/type :not-found` when
  `transition-agent!` cannot find the agent ID.
- Update registry/interface docs for the new missing-agent return contract.
- Add focused public API coverage for the missing-agent anomaly branch.

## Testing Plan

- Run focused `control-plane` interface tests.
  Latest result: 14 tests, 75 assertions, 0 failures.
- Run the exceptions-as-data scanner and confirm `control-plane/registry`
  contributes zero cleanup-needed rows.
  Latest scanner count: 157 cleanup-needed rows; `control-plane/registry`
  contributes zero rows.
- Run `bb pre-commit`.
  Latest result: all checks passed.

## Deployment Plan

No deployment steps. This is a control-plane registry lookup failure cleanup.

## Related Issues/PRs

- Follows PR #1279.

## Checklist

- [x] Implementation updated.
- [x] Tests updated and focused suite passes.
- [x] `bb review` count reduced.
- [x] `bb pre-commit` passes.
- [ ] PR opened, comments resolved, CI green, and merged.
