### PR TITLE
Fix bb-generate-icon source anomaly

### DIFF
--- a/components/bb-generate-icon/deps.edn
+++ b/components/bb-generate-icon/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps  {babashka/fs           {:mvn/version "0.5.22"}
+         ai.miniforge/anomaly  {:local/root "../anomaly"}
          ai.miniforge/bb-out   {:local/root "../bb-out"}
          ai.miniforge/bb-paths {:local/root "../bb-paths"}
          ai.miniforge/bb-proc  {:local/root "../bb-proc"}}

--- a/components/bb-generate-icon/src/ai/miniforge/bb_generate_icon/core.clj
+++ b/components/bb-generate-icon/src/ai/miniforge/bb_generate_icon/core.clj
@@ -24,7 +24,9 @@
    Layer 1: side-effecting steps — placeholder synth, iconset build,
    iconutil invocation.
    Layer 2: `run!` orchestrator."
-  (:require [ai.miniforge.bb-out.interface :as out]
+  (:refer-clojure :exclude [run!])
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.bb-out.interface :as out]
             [ai.miniforge.bb-paths.interface :as paths]
             [ai.miniforge.bb-proc.interface :as proc]
             [babashka.fs :as fs]))
@@ -73,7 +75,8 @@
 
 (defn- resolve-source!
   "Return a usable source PNG. Synthesize a placeholder if the default
-   is missing and a placeholder is configured."
+   is missing and a placeholder is configured. Returns an anomaly map with
+   `:anomaly/type :invalid-input` when no source can be resolved."
   [p override]
   (let [requested (or override (:default-source p))]
     (cond
@@ -88,9 +91,10 @@
           (:path (:placeholder p)))
 
       :else
-      (throw (ex-info (str "No source icon at " requested
-                           " and no placeholder configured.")
-                      {:source requested :cfg p})))))
+      (anomaly/anomaly :invalid-input
+                       (str "No source icon at " requested
+                            " and no placeholder configured.")
+                       {:source requested :cfg p}))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Orchestrator.
@@ -99,13 +103,16 @@
   [cfg args]
   (let [p      (plan cfg)
         source (resolve-source! p (first args))]
-    (fs/create-dirs (:output-dir p))
-    (out/section (str "Creating iconset from " source))
-    (generate-iconset! source (:iconset-dir p) (:sizes p))
-    (out/section "Generating .icns")
-    (proc/run! "iconutil" "-c" "icns" (:iconset-dir p) "-o" (:icns-path p))
-    (fs/delete-tree (:iconset-dir p))
-    (println (str "ICNS_PATH=" (:icns-path p)))))
+    (if (anomaly/anomaly? source)
+      source
+      (do
+        (fs/create-dirs (:output-dir p))
+        (out/section (str "Creating iconset from " source))
+        (generate-iconset! source (:iconset-dir p) (:sizes p))
+        (out/section "Generating .icns")
+        (proc/run! "iconutil" "-c" "icns" (:iconset-dir p) "-o" (:icns-path p))
+        (fs/delete-tree (:iconset-dir p))
+        (println (str "ICNS_PATH=" (:icns-path p)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/bb-generate-icon/src/ai/miniforge/bb_generate_icon/interface.clj
+++ b/components/bb-generate-icon/src/ai/miniforge/bb_generate_icon/interface.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.bb-generate-icon.interface
   "Generate a macOS `.icns` from a source PNG via sips + iconutil.
    Pass-through to `core`."
+  (:refer-clojure :exclude [run!])
   (:require [ai.miniforge.bb-generate-icon.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -41,7 +42,8 @@
                        :swift-file \"dev/generate-placeholder-icon.swift\"}}
    Paths are resolved relative to the repo root. `args` is the bb
    `*command-line-args*` vector; its first element overrides the source
-   PNG path."
+   PNG path. Returns an anomaly map with `:anomaly/type :invalid-input`
+   when no source icon can be resolved."
   ([cfg] (run! cfg nil))
   ([cfg args] (core/run! cfg args)))
 

--- a/components/bb-generate-icon/test/ai/miniforge/bb_generate_icon/core_test.clj
+++ b/components/bb-generate-icon/test/ai/miniforge/bb_generate_icon/core_test.clj
@@ -20,7 +20,8 @@
   "`plan` is exhaustively tested as a pure function. `run!` is
    end-to-end over sips/iconutil/swift — exercised via a consumer's
    `bb generate-icon` invocation rather than duplicated here."
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [babashka.fs :as fs]
+            [clojure.test :refer [deftest testing is]]
             [ai.miniforge.bb-generate-icon.core :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -65,6 +66,32 @@
   (testing "given an absolute path in cfg → used as-is, not re-rooted"
     (let [p (sut/plan (assoc base-cfg :default-source "/abs/source.png"))]
       (is (= "/abs/source.png" (:default-source p))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Source resolution.
+
+(deftest test-resolve-source-returns-existing-source
+  (testing "given an existing source path → returns that path"
+    (let [dir (fs/create-temp-dir {:prefix "bb-generate-icon-test-"})
+          src (str (fs/path dir "source.png"))]
+      (try
+        (spit src "png")
+        (is (= src (@#'sut/resolve-source! {:default-source src} nil)))
+        (finally
+          (fs/delete-tree dir))))))
+
+(deftest test-resolve-source-returns-anomaly-when-missing-without-placeholder
+  (testing "given missing source and no placeholder → returns invalid-input anomaly"
+    (let [dir (fs/create-temp-dir {:prefix "bb-generate-icon-missing-test-"})
+          missing-source (str (fs/path dir "missing-source.png"))
+          p {:default-source missing-source}
+          result (@#'sut/resolve-source! p nil)]
+      (try
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= {:source missing-source :cfg p}
+               (:anomaly/data result)))
+        (finally
+          (fs/delete-tree dir))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-06-26-chris-bb-generate-icon-source-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-bb-generate-icon-source-anomaly.md
@@ -1,0 +1,49 @@
+# Fix: Return icon source misses as anomalies
+
+## Overview
+
+This PR converts the `bb-generate-icon` missing source PNG branch from a thrown
+exception to a canonical anomaly value. Existing icon generation behavior is
+unchanged when the source exists or a placeholder is configured.
+
+## Motivation
+
+The exceptions-as-data cleanup scan reports one normal-flow throw in
+`bb-generate-icon`. A missing source path is invalid input to the helper, not a
+process-fatal exception, and can be represented as data before the side-effecting
+icon generation steps run.
+
+## Changes in Detail
+
+- Add the anomaly component to `bb-generate-icon`.
+- Return an anomaly map with `:anomaly/type :invalid-input` when no source icon
+  exists and no placeholder is configured.
+- Short-circuit `run!` when source resolution returns an anomaly.
+- Add focused coverage for existing source and missing-source resolution.
+
+## Testing Plan
+
+- Run focused `bb-generate-icon` tests.
+  Latest result: 7 tests, 13 assertions, 0 failures.
+- Run the exceptions-as-data scanner and confirm `bb-generate-icon` contributes
+  zero cleanup-needed rows.
+  Latest scanner count: 156 cleanup-needed rows; `bb-generate-icon`
+  contributes zero rows.
+- Run `bb pre-commit`.
+  Latest result: all checks passed.
+
+## Deployment Plan
+
+No deployment steps. This is a Babashka helper input-validation cleanup.
+
+## Related Issues/PRs
+
+- Follows PR #1280.
+
+## Checklist
+
+- [x] Implementation updated.
+- [x] Tests updated and focused suite passes.
+- [x] `bb review` count reduced.
+- [x] `bb pre-commit` passes.
+- [ ] PR opened, comments resolved, CI green, and merged.


### PR DESCRIPTION
# Fix: Return icon source misses as anomalies

## Overview

This PR converts the `bb-generate-icon` missing source PNG branch from a thrown
exception to a canonical anomaly value. Existing icon generation behavior is
unchanged when the source exists or a placeholder is configured.

## Motivation

The exceptions-as-data cleanup scan reports one normal-flow throw in
`bb-generate-icon`. A missing source path is invalid input to the helper, not a
process-fatal exception, and can be represented as data before the side-effecting
icon generation steps run.

## Changes in Detail

- Add the anomaly component to `bb-generate-icon`.
- Return an anomaly map with `:anomaly/type :invalid-input` when no source icon
  exists and no placeholder is configured.
- Short-circuit `run!` when source resolution returns an anomaly.
- Add focused coverage for existing source and missing-source resolution.

## Testing Plan

- Run focused `bb-generate-icon` tests.
  Latest result: 7 tests, 13 assertions, 0 failures.
- Run the exceptions-as-data scanner and confirm `bb-generate-icon` contributes
  zero cleanup-needed rows.
  Latest scanner count: 156 cleanup-needed rows; `bb-generate-icon`
  contributes zero rows.
- Run `bb pre-commit`.
  Latest result: all checks passed.

## Deployment Plan

No deployment steps. This is a Babashka helper input-validation cleanup.

## Related Issues/PRs

- Follows PR #1280.

## Checklist

- [x] Implementation updated.
- [x] Tests updated and focused suite passes.
- [x] `bb review` count reduced.
- [x] `bb pre-commit` passes.
- [ ] PR opened, comments resolved, CI green, and merged.
