### PR TITLE
Fix workflow cost breakdown anomalies

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/cost_breakdown.clj
+++ b/components/workflow/src/ai/miniforge/workflow/cost_breakdown.clj
@@ -61,8 +61,8 @@
    loop (`:task/implement` and `:task/merge-resolution` per spec §3.5).
    Other phases either run a single shot (`:task/release`) or have
    their iteration semantics tracked elsewhere (e.g., `:task/verify`'s
-   retry budget). Adding iteration counts for non-iterating phases is
-   a programming error and `add-phase-cost` rejects it.
+   retry budget). Adding iteration counts for non-iterating phases
+   returns an anomaly so telemetry emitters can keep errors as data.
 
    Granular components are preserved on purpose — rolling them up into
    aggregates loses the placement-of-attention signal that's the whole
@@ -98,8 +98,8 @@
 (def iteration-phase-keys
   "Subset of `phase-keys` whose phases run an iteration loop. Per spec
    §3.5, `:cost/iterations` is keyed only by these. Adding iteration
-   counts for non-iterating phases is a programming error caught by
-   `add-phase-cost` and the schema."
+   counts for non-iterating phases is rejected by `add-phase-cost` and
+   the schema."
   #{:task/implement
     :task/merge-resolution})
 
@@ -173,33 +173,39 @@
    a cross-phase sum isn't (`5 implement iterations + 2 verify
    iterations = 7 of what?`).
 
-   Throws on unknown phase or iterations-on-non-iteration-phase. Both
-   are programming errors at telemetry-emitter sites; failing here
-   surfaces them at the call site rather than at downstream
-   schema-validation time."
+   Returns a canonical `:anomalies/incorrect` anomaly map on unknown
+   phase or iterations-on-non-iteration-phase. Both represent invalid
+   telemetry-emitter input; returning data lets callers fold the failure
+   into response chains rather than catching exceptions."
   [breakdown {:keys [phase tokens iterations duration-ms usd]
               :or   {tokens 0 iterations 0 duration-ms 0 usd 0.0}}]
-  (when-not (contains? phase-keys phase)
-    (response/throw-anomaly! :anomalies/incorrect
-                             (str "Unknown phase " (pr-str phase) " — must be one of "
-                                  (pr-str phase-key-order))
-                             {:phase phase :known phase-key-order}))
-  (when (and (pos? iterations)
-             (not (contains? iteration-phase-keys phase)))
-    (response/throw-anomaly! :anomalies/incorrect
-                             (str "Phase " (pr-str phase) " does not iterate; "
-                                  ":iterations may only be set for "
-                                  (pr-str (sort iteration-phase-keys)))
-                             {:phase phase :iterations iterations
-                              :allowed (sort iteration-phase-keys)}))
-  (-> breakdown
-      (update :cost/total + tokens)
-      (update-in [:cost/breakdown phase] (fnil + 0) tokens)
-      (cond->
-        (pos? iterations)
-        (update-in [:cost/iterations phase] (fnil + 0) iterations))
-      (update :cost/duration-ms + duration-ms)
-      (update :cost/usd + usd)))
+  (cond
+    (not (contains? phase-keys phase))
+    (response/make-anomaly :anomalies/incorrect
+                           (str "Unknown phase " (pr-str phase) " — must be one of "
+                                (pr-str phase-key-order))
+                           {:anomaly/phase phase
+                            :cost/known-phases phase-key-order})
+
+    (and (pos? iterations)
+         (not (contains? iteration-phase-keys phase)))
+    (response/make-anomaly :anomalies/incorrect
+                           (str "Phase " (pr-str phase) " does not iterate; "
+                                ":iterations may only be set for "
+                                (pr-str (sort iteration-phase-keys)))
+                           {:anomaly/phase phase
+                            :cost/iterations iterations
+                            :cost/allowed-iteration-phases (vec (sort iteration-phase-keys))})
+
+    :else
+    (-> breakdown
+        (update :cost/total + tokens)
+        (update-in [:cost/breakdown phase] (fnil + 0) tokens)
+        (cond->
+          (pos? iterations)
+          (update-in [:cost/iterations phase] (fnil + 0) iterations))
+        (update :cost/duration-ms + duration-ms)
+        (update :cost/usd + usd))))
 
 (defn merge-breakdowns
   "Combine two breakdowns. Used at workflow boundaries where two

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/workflow_factory_cost_anomaly_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/workflow_factory_cost_anomaly_test.clj
@@ -18,8 +18,7 @@
 
 (ns ai.miniforge.workflow.anomaly.workflow-factory-cost-anomaly-test
   "Coverage for `agent-factory/create-agent-for-phase` and
-   `cost-breakdown/add-phase-cost` boundary escalation via
-   `response/throw-anomaly!`."
+   `cost-breakdown/add-phase-cost` anomaly contracts."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.workflow.agent-factory :as factory]
             [ai.miniforge.workflow.cost-breakdown :as cost])
@@ -52,33 +51,25 @@
       (is (= :anomalies/unsupported (:anomaly/category (ex-data thrown))))
       (is (= :weird-agent (:agent-type (ex-data thrown)))))))
 
-(deftest cost-add-phase-cost-unknown-phase-throws-anomaly
-  (testing "unknown phase keyword raises :anomalies/incorrect"
-    (let [thrown (try
-                   (cost/add-phase-cost {:cost/total 0 :cost/breakdown {}}
-                                        {:phase :weird-phase :tokens 100})
-                   nil
-                   (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"Unknown phase" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
-      (is (= :weird-phase (:phase (ex-data thrown)))))))
+(deftest cost-add-phase-cost-unknown-phase-returns-anomaly
+  (testing "unknown phase keyword returns :anomalies/incorrect"
+    (let [result (cost/add-phase-cost {:cost/total 0 :cost/breakdown {}}
+                                      {:phase :weird-phase :tokens 100})]
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (re-find #"Unknown phase" (:anomaly/message result)))
+      (is (= :weird-phase (:anomaly/phase result))))))
 
-(deftest cost-add-phase-cost-iterations-on-non-iter-phase-throws-anomaly
-  (testing "iterations > 0 on non-iteration phase raises :anomalies/incorrect"
+(deftest cost-add-phase-cost-iterations-on-non-iter-phase-returns-anomaly
+  (testing "iterations > 0 on non-iteration phase returns :anomalies/incorrect"
     ;; :task/verify is a real phase-key but is NOT in iteration-phase-keys
     ;; (that set is #{:task/implement :task/merge-resolution}). Using a valid
     ;; non-iter phase exercises the "does not iterate" branch rather than
     ;; the unknown-phase branch.
-    (let [thrown (try
-                   (cost/add-phase-cost {:cost/total 0 :cost/breakdown {}}
-                                        {:phase :task/verify
-                                         :tokens 100
-                                         :iterations 3})
-                   nil
-                   (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"does not iterate" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
-      (is (= :task/verify (:phase (ex-data thrown))))
-      (is (= 3 (:iterations (ex-data thrown)))))))
+    (let [result (cost/add-phase-cost {:cost/total 0 :cost/breakdown {}}
+                                      {:phase :task/verify
+                                       :tokens 100
+                                       :iterations 3})]
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (re-find #"does not iterate" (:anomaly/message result)))
+      (is (= :task/verify (:anomaly/phase result)))
+      (is (= 3 (:cost/iterations result))))))

--- a/components/workflow/test/ai/miniforge/workflow/cost_breakdown_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/cost_breakdown_test.clj
@@ -101,14 +101,14 @@
           "release ran but had no iteration-loop counter; map stays empty"))))
 
 (deftest add-phase-cost-rejects-unknown-phase-test
-  (testing "Adding a phase key that isn't in `phase-keys` throws — the
-            error names what was passed and what was acceptable. Catches
-            telemetry-emitter typos at the call site rather than at
-            schema-validation time later."
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"Unknown phase"
-         (cb/add-phase-cost (cb/empty-breakdown)
-                            {:phase :task/imagined :tokens 10})))))
+  (testing "Adding a phase key that isn't in `phase-keys` returns an
+            anomaly naming what was passed and what was acceptable."
+    (let [result (cb/add-phase-cost (cb/empty-breakdown)
+                                    {:phase :task/imagined :tokens 10})]
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (re-find #"Unknown phase" (:anomaly/message result)))
+      (is (= :task/imagined (:anomaly/phase result)))
+      (is (= cb/phase-key-order (:cost/known-phases result))))))
 
 (deftest add-phase-cost-defaults-zero-test
   (testing "Missing keys default to zero. A telemetry emitter that knows
@@ -163,18 +163,21 @@
   (testing "Per spec §3.5, :cost/iterations is keyed only by phases
             that run an iteration loop (`:task/implement`,
             `:task/merge-resolution`). Setting :iterations on any
-            other phase throws — programming-error catch at the
-            telemetry-emitter site rather than letting bogus
-            iteration counts flow into the dashboard."
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"does not iterate"
-         (cb/add-phase-cost (cb/empty-breakdown)
-                            {:phase :task/release :iterations 3}))
-        ":task/release runs once; iterations on it is meaningless")
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"does not iterate"
-         (cb/add-phase-cost (cb/empty-breakdown)
-                            {:phase :task/explore :iterations 1}))))
+            other phase returns an anomaly so bogus iteration counts
+            don't flow into the dashboard."
+    (let [release-result (cb/add-phase-cost (cb/empty-breakdown)
+                                            {:phase :task/release :iterations 3})
+          explore-result (cb/add-phase-cost (cb/empty-breakdown)
+                                            {:phase :task/explore :iterations 1})]
+      (is (= :anomalies/incorrect (:anomaly/category release-result))
+          ":task/release runs once; iterations on it is meaningless")
+      (is (re-find #"does not iterate" (:anomaly/message release-result)))
+      (is (= :task/release (:anomaly/phase release-result)))
+      (is (= 3 (:cost/iterations release-result)))
+      (is (= :anomalies/incorrect (:anomaly/category explore-result)))
+      (is (re-find #"does not iterate" (:anomaly/message explore-result)))
+      (is (= :task/explore (:anomaly/phase explore-result)))
+      (is (= 1 (:cost/iterations explore-result)))))
   (testing "Zero iterations on a non-iterating phase is fine — the
             check fires on positive counts only, so callers passing
             an explicit zero (e.g. uniform call shape from a metrics

--- a/docs/pull-requests/2026-06-26-chris-workflow-cost-breakdown-anomalies.md
+++ b/docs/pull-requests/2026-06-26-chris-workflow-cost-breakdown-anomalies.md
@@ -1,0 +1,51 @@
+# Fix: Return cost breakdown validation failures as anomalies
+
+## Overview
+
+This PR converts `workflow.cost-breakdown/add-phase-cost` validation failures
+from thrown exceptions to canonical anomaly values. Valid phase accumulation is
+unchanged.
+
+## Motivation
+
+The exceptions-as-data cleanup scan reports one throw site in the workflow cost
+breakdown helper. Unknown phases and invalid iteration counts are invalid
+telemetry input and can be represented directly as anomaly data for callers to
+fold into response chains.
+
+## Changes in Detail
+
+- Return `:anomalies/incorrect` anomaly maps for unknown cost phases.
+- Return `:anomalies/incorrect` anomaly maps for positive iteration counts on
+  non-iteration phases.
+- Update focused workflow cost tests to assert returned anomaly data instead
+  of caught exceptions.
+
+## Testing Plan
+
+- Run focused workflow cost breakdown tests.
+  Latest result: 14 tests, 56 assertions, 0 failures.
+- Run focused workflow anomaly tests for the cost contract.
+  Latest result: 4 tests, 27 assertions, 0 failures.
+- Run the exceptions-as-data scanner and confirm `workflow.cost-breakdown`
+  contributes zero cleanup-needed rows.
+  Latest scanner count: 155 cleanup-needed rows; `workflow.cost-breakdown`
+  contributes zero rows.
+- Run `bb pre-commit`.
+  Latest result: all checks passed.
+
+## Deployment Plan
+
+No deployment steps. This is a pure helper validation cleanup.
+
+## Related Issues/PRs
+
+- Follows PR #1281.
+
+## Checklist
+
+- [x] Implementation updated.
+- [x] Tests updated and focused suite passes.
+- [x] `bb review` count reduced.
+- [x] `bb pre-commit` passes.
+- [ ] PR opened, comments resolved, CI green, and merged.


### PR DESCRIPTION
## Summary
- return canonical :anomalies/incorrect maps from workflow cost-breakdown validation failures
- update focused workflow cost tests from thrown exceptions to returned anomaly data
- document the cleanup wave and validation results

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.workflow.cost-breakdown-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.workflow.cost-breakdown-test)"
- clojure -M:dev:test -e "(require 'ai.miniforge.workflow.anomaly.workflow-factory-cost-anomaly-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.workflow.anomaly.workflow-factory-cost-anomaly-test)"
- exceptions-as-data scanner: 155 cleanup-needed rows, workflow.cost-breakdown 0
- bb pre-commit