### PR TITLE
Fix release file path anomalies

### DIFF
--- a/components/release-executor/deps.edn
+++ b/components/release-executor/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/workflow {:local/root "../workflow"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/workflow {:local/root "../workflow"}
         ai.miniforge/artifact {:local/root "../artifact"}
         ai.miniforge/dag-executor {:local/root "../dag-executor"}
         ai.miniforge/logging {:local/root "../logging"}

--- a/components/release-executor/src/ai/miniforge/release_executor/files.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/files.clj
@@ -20,6 +20,7 @@
   "File operations for the release executor.
    Handles writing, deleting, and staging code artifact files."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.release-executor.git :as git]
    [ai.miniforge.release-executor.result :as result]
    [ai.miniforge.logging.interface :as log]
@@ -28,25 +29,52 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; File operation helpers
 
-(defn assert-within-worktree!
-  "Throw ex-info with :type :path-traversal when the resolved file-path escapes
-   the worktree root.  Uses normalized absolute paths so that any combination of
-   '../', symlink components, or redundant separators is collapsed before
-   comparison.
+(defn- existing-ancestor
+  "Return the nearest existing ancestor for `path` after lexical
+   normalization. Used so validation can canonicalize symlinked parents
+   even when the target file itself has not been created yet."
+  [path]
+  (loop [candidate (.normalize (fs/absolutize path))]
+    (cond
+      (nil? candidate) nil
+      (fs/exists? candidate) candidate
+      :else (recur (fs/parent candidate)))))
 
-   This is a programmer-error guard called at the I/O boundary of
-   process-file-action.  It throws rather than returning an anomaly because
-   the surrounding process-file-action methods already catch Exception and
-   convert it into a {:success? false} result."
+(defn- canonical-path
+  "Return a normalized Path with symlinks resolved for every existing
+   ancestor. Missing leaf segments are resolved under the canonicalized
+   nearest ancestor."
+  [path]
+  (let [absolute (.normalize (fs/absolutize path))]
+    (if-let [ancestor (existing-ancestor absolute)]
+      (let [canonical-ancestor (fs/canonicalize ancestor)
+            absolute-ancestor (.normalize (fs/absolutize ancestor))
+            relative-tail (.relativize absolute-ancestor absolute)]
+        (.normalize (.resolve canonical-ancestor relative-tail)))
+      absolute)))
+
+(defn path-traversal-anomaly
+  "Return nil when `file-path` stays inside `worktree-path`, or a
+   canonical anomaly when the resolved path escapes the worktree root.
+   Uses canonical Path comparison so '../', symlink components, and
+   redundant separators are collapsed before comparison."
   [worktree-path file-path]
-  (let [normalized-root (str (fs/normalize (fs/absolutize worktree-path)))
-        normalized-path (str (fs/normalize (fs/absolutize file-path)))]
-    (when-not (fs/starts-with? normalized-path normalized-root)
-      (throw (ex-info "Path traversal rejected: candidate path escapes worktree root"
-                      {:type       :path-traversal
-                       :path       (str file-path)
-                       :root       normalized-root
-                       :normalized normalized-path})))))
+  (let [normalized-root (canonical-path worktree-path)
+        normalized-path (canonical-path file-path)]
+    (when-not (.startsWith normalized-path normalized-root)
+      (anomaly/anomaly :invalid-input
+                       "Path traversal rejected: candidate path escapes worktree root"
+                       {:path       (str file-path)
+                        :root       (str normalized-root)
+                        :normalized (str normalized-path)}))))
+
+(defn- path-validation-failure
+  [action path path-anomaly]
+  {:success? false
+   :action action
+   :path path
+   :error (:anomaly/message path-anomaly)
+   :anomaly path-anomaly})
 
 (defn ensure-parent-dir!
   "Create parent directories for a file path if they don't exist."
@@ -83,11 +111,13 @@
   [worktree-path {:keys [path content]} logger]
   (try
     (let [full-path (fs/path worktree-path path)]
-      (assert-within-worktree! worktree-path full-path)
-      (write-file! full-path content)
-      (when logger
-        (log/debug logger :release-executor :file-created {:data {:path path}}))
-      {:success? true :action :create :path path})
+      (if-let [path-anomaly (path-traversal-anomaly worktree-path full-path)]
+        (path-validation-failure :create path path-anomaly)
+        (do
+          (write-file! full-path content)
+          (when logger
+            (log/debug logger :release-executor :file-created {:data {:path path}}))
+          {:success? true :action :create :path path})))
     (catch Exception e
       (when logger
         (log/error logger :release-executor :file-create-failed
@@ -98,11 +128,13 @@
   [worktree-path {:keys [path content]} logger]
   (try
     (let [full-path (fs/path worktree-path path)]
-      (assert-within-worktree! worktree-path full-path)
-      (write-file! full-path content)
-      (when logger
-        (log/debug logger :release-executor :file-modified {:data {:path path}}))
-      {:success? true :action :modify :path path})
+      (if-let [path-anomaly (path-traversal-anomaly worktree-path full-path)]
+        (path-validation-failure :modify path path-anomaly)
+        (do
+          (write-file! full-path content)
+          (when logger
+            (log/debug logger :release-executor :file-modified {:data {:path path}}))
+          {:success? true :action :modify :path path})))
     (catch Exception e
       (when logger
         (log/error logger :release-executor :file-modify-failed
@@ -113,11 +145,13 @@
   [worktree-path {:keys [path]} logger]
   (try
     (let [full-path (fs/path worktree-path path)
-          _ (assert-within-worktree! worktree-path full-path)
-          deleted? (delete-file! full-path)]
-      (when logger
-        (log/debug logger :release-executor :file-deleted {:data {:path path :existed? deleted?}}))
-      {:success? true :action :delete :path path :deleted? deleted?})
+          path-anomaly (path-traversal-anomaly worktree-path full-path)]
+      (if path-anomaly
+        (path-validation-failure :delete path path-anomaly)
+        (let [deleted? (delete-file! full-path)]
+          (when logger
+            (log/debug logger :release-executor :file-deleted {:data {:path path :existed? deleted?}}))
+          {:success? true :action :delete :path path :deleted? deleted?})))
     (catch Exception e
       (when logger
         (log/error logger :release-executor :file-delete-failed

--- a/components/release-executor/test/ai/miniforge/release_executor/files_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/files_test.clj
@@ -1,0 +1,106 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.release-executor.files-test
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.release-executor.files :as sut]
+   [babashka.fs :as fs]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest process-file-action-create-writes-inside-worktree
+  (testing "valid create actions still write files and return success"
+    (let [worktree (fs/create-temp-dir {:prefix "release-files-create-"})]
+      (try
+        (let [result (sut/process-file-action worktree
+                                              {:action :create
+                                               :path "src/app.clj"
+                                               :content "(ns app)"}
+                                              nil)]
+          (is (= {:success? true :action :create :path "src/app.clj"} result))
+          (is (= "(ns app)" (slurp (str (fs/path worktree "src/app.clj"))))))
+        (finally
+          (fs/delete-tree worktree))))))
+
+(deftest process-file-action-create-rejects-path-traversal-as-data
+  (testing "escaped create paths return a failed result with anomaly data"
+    (let [worktree (fs/create-temp-dir {:prefix "release-files-create-escape-"})]
+      (try
+        (let [result (sut/process-file-action worktree
+                                              {:action :create
+                                               :path "../outside.clj"
+                                               :content "escape"}
+                                              nil)]
+          (is (false? (:success? result)))
+          (is (= :create (:action result)))
+          (is (= "../outside.clj" (:path result)))
+          (is (= "Path traversal rejected: candidate path escapes worktree root"
+                 (:error result)))
+          (is (anomaly/anomaly? (:anomaly result)))
+          (is (= :invalid-input (-> result :anomaly :anomaly/type))))
+        (finally
+          (fs/delete-tree worktree))))))
+
+(deftest process-file-action-create-rejects-symlink-escape-as-data
+  (testing "worktree-local symlinks cannot escape the canonical worktree root"
+    (let [worktree (fs/create-temp-dir {:prefix "release-files-symlink-worktree-"})
+          outside (fs/create-temp-dir {:prefix "release-files-symlink-outside-"})]
+      (try
+        (fs/create-sym-link (fs/path worktree "link") outside)
+        (let [result (sut/process-file-action worktree
+                                              {:action :create
+                                               :path "link/outside.clj"
+                                               :content "escape"}
+                                              nil)]
+          (is (false? (:success? result)))
+          (is (= :create (:action result)))
+          (is (= :invalid-input (-> result :anomaly :anomaly/type)))
+          (is (= (str (fs/path (fs/canonicalize outside) "outside.clj"))
+                 (-> result :anomaly :anomaly/data :normalized))))
+        (finally
+          (fs/delete-tree worktree)
+          (fs/delete-tree outside))))))
+
+(deftest process-file-action-modify-rejects-path-traversal-as-data
+  (testing "escaped modify paths return a failed result with anomaly data"
+    (let [worktree (fs/create-temp-dir {:prefix "release-files-modify-escape-"})]
+      (try
+        (let [result (sut/process-file-action worktree
+                                              {:action :modify
+                                               :path "../outside.clj"
+                                               :content "escape"}
+                                              nil)]
+          (is (false? (:success? result)))
+          (is (= :modify (:action result)))
+          (is (= :invalid-input (-> result :anomaly :anomaly/type))))
+        (finally
+          (fs/delete-tree worktree))))))
+
+(deftest process-file-action-delete-rejects-path-traversal-as-data
+  (testing "escaped delete paths return a failed result with anomaly data"
+    (let [worktree (fs/create-temp-dir {:prefix "release-files-delete-escape-"})]
+      (try
+        (let [result (sut/process-file-action worktree
+                                              {:action :delete
+                                               :path "../outside.clj"}
+                                              nil)]
+          (is (false? (:success? result)))
+          (is (= :delete (:action result)))
+          (is (= :invalid-input (-> result :anomaly :anomaly/type))))
+        (finally
+          (fs/delete-tree worktree))))))

--- a/docs/pull-requests/2026-06-26-chris-release-files-path-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-release-files-path-anomaly.md
@@ -1,0 +1,49 @@
+# Fix: Return release file path traversal as data
+
+## Overview
+
+This PR converts the `release-executor.files` worktree path traversal guard from
+a thrown exception into anomaly data folded into the existing file-operation
+result map.
+
+## Motivation
+
+The exceptions-as-data cleanup scan reports one throw site in
+`release-executor.files`. Escaped artifact paths are invalid input to the file
+operation boundary and can be represented as data while preserving the existing
+`{:success? false :error ...}` result contract for callers.
+
+## Changes in Detail
+
+- Add the anomaly component dependency to `release-executor`.
+- Return `:invalid-input` anomaly maps from escaped worktree path validation.
+- Preserve existing `process-file-action` failure result fields.
+- Add focused coverage for valid creates, escaped create/modify/delete actions,
+  and symlink-based worktree escapes.
+
+## Testing Plan
+
+- Run focused `release-executor.files` tests.
+  Latest result: 5 tests, 18 assertions, 0 failures.
+- Run the exceptions-as-data scanner and confirm `release-executor.files`
+  contributes zero cleanup-needed rows.
+  Latest scanner count: 154 cleanup-needed rows; `release-executor.files`
+  contributes zero rows.
+- Run `bb pre-commit`.
+  Latest result: all checks passed.
+
+## Deployment Plan
+
+No deployment steps. This is a release file-operation validation cleanup.
+
+## Related Issues/PRs
+
+- Follows PR #1283.
+
+## Checklist
+
+- [x] Implementation updated.
+- [x] Tests updated and focused suite passes.
+- [x] `bb review` count reduced.
+- [x] `bb pre-commit` passes.
+- [ ] PR opened, comments resolved, CI green, and merged.


### PR DESCRIPTION
## Summary
- return canonical :invalid-input anomaly data for release file path traversal checks
- preserve process-file-action failure result fields for callers
- add focused release-executor.files tests for valid and escaped paths

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.release-executor.files-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.release-executor.files-test)"
- exceptions-as-data scanner: 154 cleanup-needed rows, release-executor.files 0
- bb pre-commit