### PR TITLE
Fix LSP installer download anomaly

### DIFF
--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/installer.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/installer.clj
@@ -84,13 +84,18 @@
 ;; Download and extraction
 
 (defn download-file
-  "Download a file from a URL to a local path."
+  "Download a file from a URL to a local path.
+   Returns nil on success or a canonical anomaly map on curl failure."
   [url dest-path]
   (binding [*out* *err*]
     (println "Downloading" url "..."))
   (let [result (bp/sh ["curl" "-L" "-o" (str dest-path) "--progress-bar" url])]
     (when-not (zero? (:exit result))
-      (throw (ex-info "Download failed" {:url url :exit (:exit result)})))))
+      (response/make-anomaly :anomalies/fault
+                             "Download failed"
+                             {:lsp-installer/url    url
+                              :lsp-installer/exit   (:exit result)
+                              :lsp-installer/stderr (:err result)}))))
 
 (defn extract-zip
   "Extract a zip archive to a directory."
@@ -158,10 +163,13 @@
             dest-dir (bin-dir)]
         (try
           (fs/create-dirs dest-dir)
-          (download-file url archive-path)
-          (assoc state
-                 :url url :temp-dir temp-dir :archive-path archive-path
-                 :dest-dir dest-dir :binary binary)
+          (if-let [download-anomaly (download-file url archive-path)]
+            (do
+              (fs/delete-tree temp-dir)
+              (assoc state :failure download-anomaly))
+            (assoc state
+                   :url url :temp-dir temp-dir :archive-path archive-path
+                   :dest-dir dest-dir :binary binary))
           (catch Exception e
             (fs/delete-tree temp-dir)
             (fail state (str "Download failed: " (.getMessage e))))))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/installer_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/installer_test.clj
@@ -19,9 +19,11 @@
 (ns ai.miniforge.lsp-mcp-bridge.installer-test
   "Tests for LSP auto-installer (unit tests, no actual downloads)."
   (:require
-   [clojure.test :refer [deftest is testing]]
    [ai.miniforge.lsp-mcp-bridge.installer :as installer]
-   [ai.miniforge.response.interface :as response]))
+   [ai.miniforge.response.interface :as response]
+   [babashka.fs :as fs]
+   [babashka.process :as bp]
+   [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Platform detection
 
@@ -71,3 +73,37 @@
     (let [result (installer/ensure-installed nil :lsp/test ["nonexistent-xyz"])]
       (is (response/anomaly-map? result))
       (is (.contains (:anomaly/message result) "not found")))))
+
+;------------------------------------------------------------------------------ Download failures
+
+(deftest download-file-returns-anomaly-on-curl-failure
+  (testing "curl failure is returned as anomaly data instead of thrown"
+    (with-redefs [bp/sh (fn [_cmd] {:exit 22 :err "not found"})]
+      (let [result (installer/download-file "https://example.test/tool.zip"
+                                            "/tmp/tool.zip")]
+        (is (response/anomaly-map? result))
+        (is (= :anomalies/fault (:anomaly/category result)))
+        (is (= "Download failed" (:anomaly/message result)))
+        (is (= "https://example.test/tool.zip" (:lsp-installer/url result)))
+        (is (= 22 (:lsp-installer/exit result)))
+        (is (= "not found" (:lsp-installer/stderr result)))))))
+
+(deftest install-via-github-propagates-download-anomaly
+  (testing "GitHub installer stops at download anomaly without extraction"
+    (let [bin-dir (fs/create-temp-dir {:prefix "lsp-installer-bin-"})
+          server-entry {:github "example/tool"
+                        :version "v1.0.0"
+                        :binary "tool"
+                        :assets {"test-platform" {:file "tool.zip"
+                                                  :extract :zip}}}]
+      (try
+        (with-redefs [installer/bin-dir (constantly (str bin-dir))
+                      bp/sh (fn [_cmd] {:exit 22 :err "not found"})]
+          (let [result (installer/install-via-github server-entry "test-platform")]
+            (is (response/anomaly-map? result))
+            (is (= :anomalies/fault (:anomaly/category result)))
+            (is (= "Download failed" (:anomaly/message result)))
+            (is (= 22 (:lsp-installer/exit result)))
+            (is (= "not found" (:lsp-installer/stderr result)))))
+        (finally
+          (fs/delete-tree bin-dir))))))

--- a/docs/pull-requests/2026-06-26-chris-lsp-download-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-lsp-download-anomaly.md
@@ -1,0 +1,48 @@
+# Fix: Return LSP download failures as data
+
+## Overview
+
+This PR converts the LSP auto-installer download helper from a thrown exception
+to anomaly data. The GitHub installation pipeline now carries the download
+anomaly directly instead of relying on a throw/catch hop.
+
+## Motivation
+
+The exceptions-as-data cleanup scan reports one throw site in the LSP installer.
+A failed `curl` subprocess is an expected installation failure mode and can be
+represented as an anomaly value in the existing installer result pipeline.
+
+## Changes in Detail
+
+- Return `:anomalies/fault` anomaly maps from `download-file` when `curl`
+  exits non-zero.
+- Have `step-download` propagate the returned anomaly and clean up its temp dir.
+- Add focused unit coverage for direct download failures and GitHub installer
+  propagation without network I/O.
+
+## Testing Plan
+
+- Run focused LSP installer tests.
+  Latest result: 8 tests, 22 assertions, 0 failures.
+- Run the exceptions-as-data scanner and confirm `lsp-mcp-bridge.installer`
+  contributes zero cleanup-needed rows.
+  Latest scanner count: 153 cleanup-needed rows; `lsp-mcp-bridge.installer`
+  contributes zero rows.
+- Run `bb pre-commit`.
+  Latest result: all checks passed.
+
+## Deployment Plan
+
+No deployment steps. This is an installer failure-contract cleanup.
+
+## Related Issues/PRs
+
+- Follows PR #1284.
+
+## Checklist
+
+- [x] Implementation updated.
+- [x] Tests updated and focused suite passes.
+- [x] `bb review` count reduced.
+- [x] `bb pre-commit` passes.
+- [ ] PR opened, comments resolved, CI green, and merged.


### PR DESCRIPTION
## Summary
- return :anomalies/fault data from LSP installer download failures
- propagate download anomalies through the GitHub installer pipeline without throw/catch
- add focused installer tests using mocked subprocess calls

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.lsp-mcp-bridge.installer-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.lsp-mcp-bridge.installer-test)"
- exceptions-as-data scanner: 153 cleanup-needed rows, lsp-mcp-bridge.installer 0
- bb pre-commit