### PR TITLE
Fix self-healing stream recovery anomalies

### DIFF
--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -81,21 +81,26 @@
 
    Arguments:
      backend - Keyword (or anything `clojure.lang.Named`) backend identifier.
-               Must be non-nil; nil/non-Named values throw `ex-info` rather
+               Must be non-nil; nil/non-Named values return an anomaly rather
                than producing a downstream NPE inside execute-resume!'s
                ProcessBuilder.
 
-   Returns: String binary name (defaults to (name backend))"
+   Returns: String binary name (defaults to (name backend)) or anomaly map."
   [backend]
-  (when (nil? backend)
-    (response/throw-anomaly! :anomalies/incorrect
-                             "binary-for: backend must not be nil"
-                             {:backend backend}))
-  (when-not (instance? clojure.lang.Named backend)
-    (response/throw-anomaly! :anomalies/incorrect
-                             "binary-for: backend must be a keyword or symbol"
-                             {:backend backend :type (type backend)}))
-  (get backend-binaries (keyword backend) (name backend)))
+  (cond
+    (nil? backend)
+    (response/make-anomaly :anomalies/incorrect
+                           "binary-for: backend must not be nil"
+                           {:stream-recovery/backend backend})
+
+    (not (instance? clojure.lang.Named backend))
+    (response/make-anomaly :anomalies/incorrect
+                           "binary-for: backend must be a keyword or symbol"
+                           {:stream-recovery/backend backend
+                            :stream-recovery/type    (type backend)})
+
+    :else
+    (get backend-binaries (keyword backend) (name backend))))
 
 (defn build-resume-command
   "Build the full CLI command vector to resume an agent session.
@@ -105,14 +110,18 @@
      session-id - String session identifier to resume
      extra-args - Optional seq of additional CLI arguments
 
-   Returns: Vector of strings, e.g. [\"claude\" \"--resume\" \"<sid>\"]"
+   Returns: Vector of strings, e.g. [\"claude\" \"--resume\" \"<sid>\"],
+   or an anomaly map when backend input is invalid."
   ([backend session-id]
    (build-resume-command backend session-id []))
   ([backend session-id extra-args]
-   (let [backend-kw (keyword backend)
-         flag       (resume-flag-for backend-kw)
-         binary     (binary-for backend-kw)]
-     (into [binary flag (str session-id)] extra-args))))
+   (let [backend-key (if (string? backend) (keyword backend) backend)
+         binary      (binary-for backend-key)]
+     (if (response/anomaly-map? binary)
+       binary
+       (let [backend-kw (keyword backend-key)
+             flag       (resume-flag-for backend-kw)]
+         (into [binary flag (str session-id)] extra-args))))))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; Process management (isolated for testability)
@@ -203,25 +212,33 @@
      {:action :abort,    :reason \"no healthy backends\"}"
   [{:keys [phase-id backend session-id hang-count config allowed-failover-backends]
     :as ctx}]
-  ;; Guard against programmer errors: fail loudly on the watchdog hot-path
-  ;; rather than producing an opaque NPE.
-  (when-not (instance? clojure.lang.IAtom hang-count)
-    (response/throw-anomaly! :anomalies/incorrect
-                             ":hang-count must be an IAtom (e.g. (atom 1))"
-                             {:ctx ctx :type (type hang-count)}))
-  (when (nil? backend)
-    (response/throw-anomaly! :anomalies/incorrect
-                             ":backend is required and must not be nil"
-                             {:ctx ctx}))
-  (let [count       @hang-count
-        backend-kw  (keyword backend)
-        cooldown-ms (get config :backend-switch-cooldown-ms
-                         (:switch-cooldown-ms backend-health/config))
-        threshold   (get config :backend-health-threshold
-                         (:success-rate-threshold backend-health/config))
-        resumable?  (and (string? session-id)
-                         (not (str/blank? session-id)))]
-    (cond
+  ;; Guard against programmer errors on the watchdog hot-path rather than
+  ;; producing an opaque downstream NPE.
+  (or
+   (when-not (instance? clojure.lang.IAtom hang-count)
+     (response/make-anomaly :anomalies/incorrect
+                            ":hang-count must be an IAtom (e.g. (atom 1))"
+                            {:stream-recovery/ctx  ctx
+                             :stream-recovery/type (type hang-count)}))
+   (when (nil? backend)
+     (response/make-anomaly :anomalies/incorrect
+                            ":backend is required and must not be nil"
+                            {:stream-recovery/ctx ctx}))
+   (when-not (or (string? backend)
+                 (instance? clojure.lang.Named backend))
+     (response/make-anomaly :anomalies/incorrect
+                            ":backend must be a keyword, symbol, or string"
+                            {:stream-recovery/ctx  ctx
+                             :stream-recovery/type (type backend)}))
+   (let [count       @hang-count
+         backend-kw  (keyword backend)
+         cooldown-ms (get config :backend-switch-cooldown-ms
+                          (:switch-cooldown-ms backend-health/config))
+         threshold   (get config :backend-health-threshold
+                          (:success-rate-threshold backend-health/config))
+         resumable?  (and (string? session-id)
+                          (not (str/blank? session-id)))]
+     (cond
       ;; First stall — check backend health before committing to a resume attempt
       (= count 1)
       (let [rate (backend-health/get-backend-success-rate backend-kw)]
@@ -284,7 +301,7 @@
            :anomaly?   true}
           {:action   :abort
            :reason   "degenerate hang-count and no resumable session"
-           :anomaly? true})))))
+           :anomaly? true}))))))
 
 ;;------------------------------------------------------------------------------ Layer 4
 ;; Public subprocess restart
@@ -316,15 +333,17 @@
    (execute-resume! backend session-id []))
   ([backend session-id extra-args]
    (let [cmd (build-resume-command backend session-id extra-args)]
-     (try
-       {:process    (start-process! cmd)
-        :backend    (keyword backend)
-        :session-id (str session-id)
-        :command    cmd}
-       (catch java.io.IOException e
-         {:anomaly/category :anomaly.category/fault
-          :anomaly/message  (ex-message e)
-          :cmd              cmd})))))
+     (if (response/anomaly-map? cmd)
+       cmd
+       (try
+         {:process    (start-process! cmd)
+          :backend    (keyword backend)
+          :session-id (str session-id)
+         :command    cmd}
+         (catch java.io.IOException e
+           {:anomaly/category :anomalies/fault
+            :anomaly/message  (ex-message e)
+            :cmd              cmd}))))))
 
 ;;------------------------------------------------------------------------------ Rich comment
 

--- a/components/self-healing/test/ai/miniforge/self_healing/anomaly/stream_recovery_anomaly_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/anomaly/stream_recovery_anomaly_test.clj
@@ -19,56 +19,54 @@
 (ns ai.miniforge.self-healing.anomaly.stream-recovery-anomaly-test
   "Coverage for `stream-recovery/binary-for` and
    `stream-recovery/evaluate-stall-recovery` boundary escalation via
-   `response/throw-anomaly!`. Caller-supplied bad input →
-   `:anomalies/incorrect`."
+   returned anomaly maps. Caller-supplied bad input → `:anomalies/incorrect`."
   (:require [clojure.test :refer [deftest is testing]]
-            [ai.miniforge.self-healing.stream-recovery :as recovery])
-  (:import (clojure.lang ExceptionInfo)))
+            [ai.miniforge.self-healing.stream-recovery :as recovery]))
 
-(deftest binary-for-nil-backend-throws-anomaly
-  (testing "nil backend raises :anomalies/incorrect"
-    (let [thrown (try (#'recovery/binary-for nil) nil (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"backend must not be nil" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+(deftest binary-for-nil-backend-returns-anomaly
+  (testing "nil backend returns :anomalies/incorrect"
+    (let [result (#'recovery/binary-for nil)]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest binary-for-non-named-backend-throws-anomaly
-  (testing "non-keyword non-symbol backend raises :anomalies/incorrect"
-    (let [thrown (try (#'recovery/binary-for "string-backend")
-                      nil
-                      (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"keyword or symbol" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+(deftest binary-for-non-named-backend-returns-anomaly
+  (testing "non-keyword non-symbol backend returns :anomalies/incorrect"
+    (let [result (#'recovery/binary-for "string-backend")]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest evaluate-stall-recovery-non-iatom-hang-count-throws-anomaly
-  (testing "non-IAtom :hang-count raises :anomalies/incorrect"
-    (let [thrown (try
-                   (recovery/evaluate-stall-recovery
-                    {:phase-id :impl
-                     :backend :anthropic
-                     :session-id "sid"
-                     :hang-count 1
-                     :config {}
-                     :allowed-failover-backends []})
-                   nil
-                   (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #":hang-count must be an IAtom" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+(deftest evaluate-stall-recovery-non-iatom-hang-count-returns-anomaly
+  (testing "non-IAtom :hang-count returns :anomalies/incorrect"
+    (let [result (recovery/evaluate-stall-recovery
+                  {:phase-id :impl
+                   :backend :anthropic
+                   :session-id "sid"
+                   :hang-count 1
+                   :config {}
+                   :allowed-failover-backends []})]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest evaluate-stall-recovery-nil-backend-throws-anomaly
-  (testing "nil :backend raises :anomalies/incorrect"
-    (let [thrown (try
-                   (recovery/evaluate-stall-recovery
-                    {:phase-id :impl
-                     :backend nil
-                     :session-id "sid"
-                     :hang-count (atom 1)
-                     :config {}
-                     :allowed-failover-backends []})
-                   nil
-                   (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #":backend is required" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+(deftest evaluate-stall-recovery-nil-backend-returns-anomaly
+  (testing "nil :backend returns :anomalies/incorrect"
+    (let [result (recovery/evaluate-stall-recovery
+                  {:phase-id :impl
+                   :backend nil
+                   :session-id "sid"
+                   :hang-count (atom 1)
+                   :config {}
+                   :allowed-failover-backends []})]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
+
+(deftest evaluate-stall-recovery-invalid-backend-returns-anomaly
+  (testing "non-coercible :backend returns :anomalies/incorrect"
+    (let [result (recovery/evaluate-stall-recovery
+                  {:phase-id :impl
+                   :backend 42
+                   :session-id "sid"
+                   :hang-count (atom 1)
+                   :config {}
+                   :allowed-failover-backends []})]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
+
+(deftest execute-resume-invalid-backend-returns-anomaly
+  (testing "invalid backend returns anomaly before ProcessBuilder startup"
+    (let [result (recovery/execute-resume! 42 "sid")]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))

--- a/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
@@ -87,27 +87,29 @@
 
 ;;------------------------------------------------------------------------------ evaluate-stall-recovery – guard clauses
 
-(deftest evaluate-stall-recovery-nil-backend-throws
-  (testing "nil :backend throws ex-info with clear message"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (sut/evaluate-stall-recovery
+(deftest evaluate-stall-recovery-nil-backend-returns-anomaly
+  (testing "nil :backend returns :anomalies/incorrect"
+    (let [result (sut/evaluate-stall-recovery
                   {:phase-id   :implement
                    :backend    nil
                    :session-id "s"
                    :hang-count (atom 1)
                    :config     {}
-                   :allowed-failover-backends []})))))
+                   :allowed-failover-backends []})]
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (re-find #":backend is required" (:anomaly/message result))))))
 
-(deftest evaluate-stall-recovery-non-atom-hang-count-throws
-  (testing "non-atom :hang-count throws ex-info with clear message"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (sut/evaluate-stall-recovery
+(deftest evaluate-stall-recovery-non-atom-hang-count-returns-anomaly
+  (testing "non-atom :hang-count returns :anomalies/incorrect"
+    (let [result (sut/evaluate-stall-recovery
                   {:phase-id   :implement
                    :backend    :anthropic
                    :session-id "s"
                    :hang-count 2   ; not an atom
                    :config     {}
-                   :allowed-failover-backends []})))))
+                   :allowed-failover-backends []})]
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (re-find #":hang-count must be an IAtom" (:anomaly/message result))))))
 
 ;;------------------------------------------------------------------------------ evaluate-stall-recovery – :resume path
 
@@ -345,7 +347,7 @@
     (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                   (fn [_cmd] (throw (java.io.IOException. "No such file")))]
       (let [result (sut/execute-resume! :anthropic "sess-fail")]
-        (is (= :anomaly.category/fault (:anomaly/category result)))
+        (is (= :anomalies/fault (:anomaly/category result)))
         (is (string? (:anomaly/message result)))
         (is (vector? (:cmd result)))))))
 

--- a/docs/pull-requests/2026-06-26-chris-self-healing-stream-recovery-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-self-healing-stream-recovery-anomaly.md
@@ -1,0 +1,29 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Self-Healing Stream Recovery Anomaly Data
+
+## Summary
+
+Convert self-healing stream recovery invalid-input paths from thrown anomalies
+to returned anomaly maps.
+
+## Changes
+
+- Return `:anomalies/incorrect` maps from backend binary resolution guards.
+- Return `:anomalies/incorrect` maps from `evaluate-stall-recovery` guard
+  clauses for invalid backend or hang-count input.
+- Propagate invalid backend anomalies from `execute-resume!` before process
+  startup.
+- Update stream recovery tests to assert returned anomaly data.
+
+## Validation
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.self-healing.stream-recovery-test
+  'ai.miniforge.self-healing.anomaly.stream-recovery-anomaly-test 'clojure.test) (clojure.test/run-tests
+  'ai.miniforge.self-healing.stream-recovery-test 'ai.miniforge.self-healing.anomaly.stream-recovery-anomaly-test)"`
+- Exceptions-as-data scanner: no `self_healing/stream_recovery` cleanup-needed
+  rows.


### PR DESCRIPTION
## Summary
- return canonical anomaly maps from self-healing stream recovery invalid-input guards
- propagate invalid backend anomalies from resume command construction and execute-resume! before ProcessBuilder startup
- update anomaly coverage to assert returned data instead of caught ExceptionInfo

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.self-healing.stream-recovery-test 'ai.miniforge.self-healing.anomaly.stream-recovery-anomaly-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.self-healing.stream-recovery-test 'ai.miniforge.self-healing.anomaly.stream-recovery-anomaly-test)"
- exceptions-as-data scanner: 152 cleanup-needed rows, self_healing/stream_recovery 0
- bb pre-commit