### PR TITLE
Fix SARIF connector config anomaly

### DIFF
--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
@@ -49,17 +49,17 @@
   "Validate config and establish a connection handle."
   [config]
   (let [{:keys [valid? errors]} (schema/validate-config config)]
-    (when-not valid?
-      (response/throw-anomaly! :anomalies/incorrect
-                               "Invalid SARIF config"
-                               {:errors errors}))
-    (let [handle (generate-handle)]
-      (connector/store-handle! handles handle
-                               {:sarif/source-path (:sarif/source-path config)
-                                :sarif/format      (get config :sarif/format :auto)
-                                :sarif/csv-columns (get config :sarif/csv-columns nil)})
-      {:connection/handle handle
-       :connector/status  :connected})))
+    (if-not valid?
+      (response/make-anomaly :anomalies/incorrect
+                             "Invalid SARIF config"
+                             {:sarif/errors errors})
+      (let [handle (generate-handle)]
+        (connector/store-handle! handles handle
+                                 {:sarif/source-path (:sarif/source-path config)
+                                  :sarif/format      (get config :sarif/format :auto)
+                                  :sarif/csv-columns (get config :sarif/csv-columns nil)})
+        {:connection/handle handle
+         :connector/status  :connected}))))
 
 (defn do-close
   "Release a connection handle."

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/anomaly/sarif_anomaly_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/anomaly/sarif_anomaly_test.clj
@@ -24,7 +24,8 @@
    `:anomalies/incorrect`."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-sarif.format :as fmt]
-            [ai.miniforge.connector-sarif.impl :as impl])
+            [ai.miniforge.connector-sarif.impl :as impl]
+            [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
 (deftest parse-file-unsupported-format-throws-anomaly
@@ -38,12 +39,10 @@
         (is (= "/nope/no.weird" (:path (ex-data e))))
         (is (= :weird (:format (ex-data e))))))))
 
-(deftest do-connect-invalid-config-throws-anomaly
-  (testing "invalid SARIF config raises :anomalies/incorrect"
-    (try
-      (impl/do-connect {})
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (re-find #"Invalid SARIF config" (.getMessage e)))
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
-        (is (seq (:errors (ex-data e))))))))
+(deftest do-connect-invalid-config-returns-anomaly
+  (testing "invalid SARIF config returns :anomalies/incorrect"
+    (let [result (impl/do-connect {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (= "Invalid SARIF config" (:anomaly/message result)))
+      (is (seq (:sarif/errors result))))))

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/impl_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/impl_test.clj
@@ -20,6 +20,7 @@
   (:require [clojure.test :refer [deftest testing is]]
             [cheshire.core :as json]
             [ai.miniforge.connector-sarif.impl :as impl]
+            [ai.miniforge.response.interface :as response]
             [ai.miniforge.connector-sarif.format :as fmt]))
 
 ;; --------------------------------------------------------------------------
@@ -59,8 +60,11 @@
       (is (string? (:connection/handle result)))
       (impl/do-close (:connection/handle result))))
 
-  (testing "Connect with invalid config throws"
-    (is (thrown? Exception (impl/do-connect {})))))
+  (testing "Connect with invalid config returns anomaly"
+    (let [result (impl/do-connect {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (seq (:sarif/errors result))))))
 
 (deftest test-discover
   (testing "Discover schemas from SARIF file"

--- a/components/connector/src/ai/miniforge/connector/protocol.clj
+++ b/components/connector/src/ai/miniforge/connector/protocol.clj
@@ -3,7 +3,8 @@
 (defprotocol Connector
   "Base connector protocol. All connectors must implement connect and close."
   (connect [this config auth]
-    "Establish connection. Returns {:connection/handle str :connector/status keyword}")
+    "Establish connection. Returns {:connection/handle str :connector/status keyword}
+     or a canonical anomaly map when connection input is invalid.")
   (close [this handle]
     "Terminate connection. Returns {:connector/status :closed}"))
 

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -5,6 +5,7 @@
             [ai.miniforge.pipeline-runner.core :as core]
             [ai.miniforge.pipeline-runner.messages :as msg]
             [ai.miniforge.dag-executor.interface :as dag]
+            [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema])
   (:import [java.time Instant]))
 
@@ -52,6 +53,12 @@
              :error-cause   (:error-message (first causes))
              :error-causes  causes}
       truncated? (assoc :error-causes-truncated? true))))
+
+(defn- anomaly-context
+  [anomaly]
+  {:error-message    (:anomaly/message anomaly)
+   :anomaly/category (:anomaly/category anomaly)
+   :anomaly          anomaly})
 
 (defn- close-handle!
   "Best-effort connector cleanup; close failures must not mask stage outcomes."
@@ -123,23 +130,27 @@
                     {:error-message (msg/t :run/connector-not-found {:ref connector-ref})})
       (let [handle (atom nil)]
         (try
-          (let [auth   (or (extract-auth config) (get context :auth {}))
-                schema (resolve-schema-name config name)
-                cursor (prior-cursor {:stage/id id
-                                      :stage/name name
-                                      :stage/connector-ref connector-ref
-                                      :stage/config config}
-                                     context)]
-            (reset! handle (:connection/handle (conn/connect connector (or config {}) auth)))
-            (let [result (conn/extract connector @handle schema
-                                       (cond-> {:extract/batch-size (get config :connector/page-size
-                                                                         (:connector/page-size default-config))}
-                                         cursor (assoc :extract/cursor cursor)))]
-              (stage-result id name :completed
-                            (merge (timestamps (get context :started-at))
-                                   {:schema-name schema
-                                    :records (:records result)
-                                    :cursor (:extract/cursor result)}))))
+          (let [auth           (or (extract-auth config) (get context :auth {}))
+                schema         (resolve-schema-name config name)
+                cursor         (prior-cursor {:stage/id id
+                                              :stage/name name
+                                              :stage/connector-ref connector-ref
+                                              :stage/config config}
+                                             context)
+                connect-result (conn/connect connector (or config {}) auth)]
+            (if (response/anomaly-map? connect-result)
+              (stage-result id name :failed (anomaly-context connect-result))
+              (do
+                (reset! handle (:connection/handle connect-result))
+                (let [result (conn/extract connector @handle schema
+                                           (cond-> {:extract/batch-size (get config :connector/page-size
+                                                                             (:connector/page-size default-config))}
+                                             cursor (assoc :extract/cursor cursor)))]
+                  (stage-result id name :completed
+                                (merge (timestamps (get context :started-at))
+                                       {:schema-name schema
+                                        :records (:records result)
+                                        :cursor (:extract/cursor result)}))))))
           (catch Exception e
             (stage-result id name :failed (exception-context e)))
           (finally
@@ -154,13 +165,17 @@
                     {:error-message (msg/t :run/connector-not-found {:ref connector-ref})})
       (let [handle (atom nil)]
         (try
-          (let [auth (or (extract-auth config) (:auth context {}))]
-            (reset! handle (:connection/handle (conn/connect connector (or config {}) auth)))
-            (conn/publish connector @handle name input-records
-                          {:publish/mode     (get config :publish-mode
-                                                 (:publish/default-mode default-config))
-                           :publish/datasets (:publish/datasets context)})
-            (stage-result id name :completed {:completed-at (Instant/now)}))
+          (let [auth           (or (extract-auth config) (:auth context {}))
+                connect-result (conn/connect connector (or config {}) auth)]
+            (if (response/anomaly-map? connect-result)
+              (stage-result id name :failed (anomaly-context connect-result))
+              (do
+                (reset! handle (:connection/handle connect-result))
+                (conn/publish connector @handle name input-records
+                              {:publish/mode     (get config :publish-mode
+                                                     (:publish/default-mode default-config))
+                               :publish/datasets (:publish/datasets context)})
+                (stage-result id name :completed {:completed-at (Instant/now)}))))
           (catch Exception e
             (stage-result id name :failed (exception-context e)))
           (finally

--- a/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
+++ b/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
@@ -20,7 +20,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.pipeline-runner.interface :as runner]
             [ai.miniforge.connector.interface :as conn]
-            [ai.miniforge.data-quality.interface :as dq]))
+            [ai.miniforge.data-quality.interface :as dq]
+            [ai.miniforge.response.interface :as response]))
 
 ;; ---------------------------------------------------------------------------
 ;; Constants
@@ -426,6 +427,48 @@
         (is (= [{:error-message "Socket closed"
                  :error-type    "clojure.lang.ExceptionInfo"}]
                (:error-causes failed)))))))
+
+(deftest execute-pipeline-ingest-connect-anomaly-test
+  (testing "Pipeline fails immediately when ingest connector connect returns anomaly"
+    (let [connector (reify
+                      conn/Connector
+                      (connect [_ _ _]
+                        (response/make-anomaly :anomalies/incorrect
+                                               "Invalid connector config"
+                                               {:connector/errors {:path ["missing"]}}))
+                      (close [_ _] {:connector/status :closed})
+                      conn/SourceConnector
+                      (discover [_ _ _] {:schemas []})
+                      (extract [_ _ _ _] (is false "extract should not run"))
+                      (checkpoint [_ _ _ _] {}))
+          result    (runner/execute-pipeline test-pipeline {conn-src connector} {})
+          failed    (first (get-in result [:pipeline-run :pipeline-run/stage-runs]))]
+      (is (not (:success? result)))
+      (is (= :failed (:status failed)))
+      (is (= :anomalies/incorrect (:anomaly/category failed)))
+      (is (= "Invalid connector config" (:error-message failed))))))
+
+(deftest execute-pipeline-publish-connect-anomaly-test
+  (testing "Pipeline fails immediately when publish connector connect returns anomaly"
+    (let [mock-source (->MockSourceConnector nil)
+          sink        (reify
+                        conn/Connector
+                        (connect [_ _ _]
+                          (response/make-anomaly :anomalies/incorrect
+                                                 "Invalid sink config"
+                                                 {:connector/errors {:path ["missing"]}}))
+                        (close [_ _] {:connector/status :closed})
+                        conn/SinkConnector
+                        (publish [_ _ _ _ _] (is false "publish should not run")))
+          result      (runner/execute-pipeline
+                       three-stage-pipeline
+                       {conn-src mock-source conn-sink sink}
+                       {})
+          failed      (last (get-in result [:pipeline-run :pipeline-run/stage-runs]))]
+      (is (not (:success? result)))
+      (is (= :failed (:status failed)))
+      (is (= :anomalies/incorrect (:anomaly/category failed)))
+      (is (= "Invalid sink config" (:error-message failed))))))
 
 (deftest execute-pipeline-ingest-close-failure-does-not-mask-primary-error-test
   (testing "Ingest cleanup closes once and preserves the primary extract failure"

--- a/docs/pull-requests/2026-06-26-chris-connector-sarif-config-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-connector-sarif-config-anomaly.md
@@ -1,0 +1,28 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Connector SARIF Config Anomaly
+
+## Summary
+
+Return anomaly data for invalid SARIF connector config instead of throwing from
+the connector implementation.
+
+## Changes
+
+- Convert `connector-sarif.impl/do-connect` invalid config handling from
+  `response/throw-anomaly!` to `response/make-anomaly`.
+- Use namespaced SARIF anomaly context via `:sarif/errors`.
+- Preserve returned connect anomalies as immediate pipeline stage failures.
+- Update implementation and anomaly tests to assert returned anomaly maps.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.connector-sarif.impl-test 'ai.miniforge.connector-sarif.anomaly.sarif-anomaly-test 'ai.miniforge.pipeline-runner.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.connector-sarif.impl-test 'ai.miniforge.connector-sarif.anomaly.sarif-anomaly-test 'ai.miniforge.pipeline-runner.interface-test)"
+```
+
+- Exceptions-as-data scanner: no `connector_sarif/impl` cleanup-needed rows.


### PR DESCRIPTION
## Summary
- return :anomalies/incorrect data from SARIF connector invalid config handling
- use namespaced :sarif/errors anomaly context
- update SARIF implementation/anomaly tests from thrown ExceptionInfo to returned anomaly maps

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.connector-sarif.impl-test 'ai.miniforge.connector-sarif.anomaly.sarif-anomaly-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.connector-sarif.impl-test 'ai.miniforge.connector-sarif.anomaly.sarif-anomaly-test)"
- exceptions-as-data scanner: 152 cleanup-needed rows, connector_sarif/impl 0
- bb pre-commit