### PR TITLE
Fix connector-file extract anomaly

### DIFF
--- a/components/connector-file/src/ai/miniforge/connector_file/impl.clj
+++ b/components/connector-file/src/ai/miniforge/connector_file/impl.clj
@@ -85,20 +85,20 @@
   [handle opts]
   (let [{:file/keys [path format]} (require-handle! handle)
         file (io/file path)]
-    (when-not (.exists file)
-      (response/throw-anomaly! :anomalies/not-found
-                               (msg/t :file/not-found {:path path})
-                               {:path path}))
-    (let [all-records (reader/read-file path format)
-          batch-size  (or (:extract/batch-size opts) (count all-records))
-          offset      (or (get-in opts [:extract/cursor :cursor/value]) 0)
-          batch       (vec (take batch-size (drop offset all-records)))
-          new-offset  (+ offset (count batch))
-          has-more    (< new-offset (count all-records))]
-      (connector/extract-result
-       batch
-       {:cursor/type :offset :cursor/value new-offset}
-       has-more))))
+    (if-not (.exists file)
+      (response/make-anomaly :anomalies/not-found
+                             (msg/t :file/not-found {:path path})
+                             {:path path})
+      (let [all-records (reader/read-file path format)
+            batch-size  (or (:extract/batch-size opts) (count all-records))
+            offset      (or (get-in opts [:extract/cursor :cursor/value]) 0)
+            batch       (vec (take batch-size (drop offset all-records)))
+            new-offset  (+ offset (count batch))
+            has-more    (< new-offset (count all-records))]
+        (connector/extract-result
+         batch
+         {:cursor/type :offset :cursor/value new-offset}
+         has-more)))))
 
 (defn do-checkpoint
   "Persist cursor state (no-op for files, returns committed)."

--- a/components/connector-file/test/ai/miniforge/connector_file/anomaly/file_anomaly_test.clj
+++ b/components/connector-file/test/ai/miniforge/connector_file/anomaly/file_anomaly_test.clj
@@ -18,9 +18,11 @@
 
 (ns ai.miniforge.connector-file.anomaly.file-anomaly-test
   "Coverage for `impl/do-connect` config validation + `impl/do-extract`
-   not-found path. Boundary throws route through `response/throw-anomaly!`."
+   not-found path. Boundary throws route through `response/throw-anomaly!`;
+   normal extract failures return anomaly maps."
   (:require [clojure.test :refer [deftest is testing]]
-            [ai.miniforge.connector-file.impl :as impl])
+            [ai.miniforge.connector-file.impl :as impl]
+            [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
 (deftest do-connect-missing-path-throws-anomaly
@@ -48,12 +50,10 @@
         (is (= :anomalies/unsupported (:anomaly/category (ex-data e))))
         (is (= :weird (:format (ex-data e))))))))
 
-(deftest do-extract-nonexistent-file-throws-anomaly
-  (testing "extract from nonexistent path raises :anomalies/not-found"
-    (let [{:keys [connect/handle]} (impl/do-connect {:file/path "/no/such/file.csv"
-                                                     :file/format :csv})]
-      (try
-        (impl/do-extract handle {})
-        (is false "should have thrown")
-        (catch ExceptionInfo e
-          (is (= :anomalies/not-found (:anomaly/category (ex-data e)))))))))
+(deftest do-extract-nonexistent-file-returns-anomaly
+  (testing "extract from nonexistent path returns :anomalies/not-found"
+    (let [{:keys [connection/handle]} (impl/do-connect {:file/path "/no/such/file.csv"
+                                                        :file/format :csv})
+          result (impl/do-extract handle {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result))))))

--- a/components/connector-file/test/ai/miniforge/connector_file/interface_test.clj
+++ b/components/connector-file/test/ai/miniforge/connector_file/interface_test.clj
@@ -22,7 +22,8 @@
             [cheshire.core :as json]
             [ai.miniforge.connector-file.interface :as file-conn]
             [ai.miniforge.connector-file.impl :as impl]
-            [ai.miniforge.connector.interface :as conn]))
+            [ai.miniforge.connector.interface :as conn]
+            [ai.miniforge.response.interface :as response]))
 
 ;; ---------------------------------------------------------------------------
 ;; Test fixtures — temp directory with sample files
@@ -176,12 +177,14 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest extract-file-not-found-test
-  (testing "Extract fails when file does not exist"
+  (testing "Extract returns anomaly when file does not exist"
     (let [fc (file-conn/create-file-connector)
           handle (:connection/handle
                   (conn/connect fc {:file/path (str test-dir "/nonexistent.csv")
-                                    :file/format :csv} {}))]
-      (is (thrown? Exception (conn/extract fc handle "test" {})))
+                                    :file/format :csv} {}))
+          result (conn/extract fc handle "test" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
       (conn/close fc handle))))
 
 ;; ---------------------------------------------------------------------------

--- a/components/connector/src/ai/miniforge/connector/protocol.clj
+++ b/components/connector/src/ai/miniforge/connector/protocol.clj
@@ -13,7 +13,8 @@
   (discover [this handle opts]
     "Discover available schemas. Returns {:schemas [...] :discover/total-count long}")
   (extract [this handle schema-name opts]
-    "Extract records. Returns {:records [...] :extract/cursor map :extract/has-more bool}")
+    "Extract records. Returns {:records [...] :extract/cursor map :extract/has-more bool}
+     or a canonical anomaly map when extraction input is unavailable or invalid.")
   (checkpoint [this handle connector-id cursor-state]
     "Persist cursor state. Returns {:checkpoint/id uuid :checkpoint/status :committed}"))
 

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -146,11 +146,13 @@
                                            (cond-> {:extract/batch-size (get config :connector/page-size
                                                                              (:connector/page-size default-config))}
                                              cursor (assoc :extract/cursor cursor)))]
-                  (stage-result id name :completed
-                                (merge (timestamps (get context :started-at))
-                                       {:schema-name schema
-                                        :records (:records result)
-                                        :cursor (:extract/cursor result)}))))))
+                  (if (response/anomaly-map? result)
+                    (stage-result id name :failed (anomaly-context result))
+                    (stage-result id name :completed
+                                  (merge (timestamps (get context :started-at))
+                                         {:schema-name schema
+                                          :records (:records result)
+                                          :cursor (:extract/cursor result)})))))))
           (catch Exception e
             (stage-result id name :failed (exception-context e)))
           (finally

--- a/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
+++ b/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
@@ -448,6 +448,28 @@
       (is (= :anomalies/incorrect (:anomaly/category failed)))
       (is (= "Invalid connector config" (:error-message failed))))))
 
+(deftest execute-pipeline-ingest-extract-anomaly-test
+  (testing "Pipeline fails immediately when ingest connector extract returns anomaly"
+    (let [connector (reify
+                      conn/Connector
+                      (connect [_ _ _]
+                        {:connection/handle "extract-handle"
+                         :connector/status :connected})
+                      (close [_ _] {:connector/status :closed})
+                      conn/SourceConnector
+                      (discover [_ _ _] {:schemas []})
+                      (extract [_ _ _ _]
+                        (response/make-anomaly :anomalies/not-found
+                                               "Source file missing"
+                                               {:path "/missing.csv"}))
+                      (checkpoint [_ _ _ _] {}))
+          result    (runner/execute-pipeline test-pipeline {conn-src connector} {})
+          failed    (first (get-in result [:pipeline-run :pipeline-run/stage-runs]))]
+      (is (not (:success? result)))
+      (is (= :failed (:status failed)))
+      (is (= :anomalies/not-found (:anomaly/category failed)))
+      (is (= "Source file missing" (:error-message failed))))))
+
 (deftest execute-pipeline-publish-connect-anomaly-test
   (testing "Pipeline fails immediately when publish connector connect returns anomaly"
     (let [mock-source (->MockSourceConnector nil)

--- a/docs/pull-requests/2026-06-27-chris-connector-file-extract-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-file-extract-anomaly.md
@@ -1,0 +1,24 @@
+# Fix connector-file extract anomaly
+
+## Summary
+
+The exceptions-as-data scan reports one cleanup-needed throw in
+`connector-file` when extracting from a missing source file. Missing input data
+is normal connector failure data, not a boundary exception.
+
+This change:
+
+- returns a canonical `:anomalies/not-found` map from `do-extract` when the
+  source file is unavailable
+- documents that connector `extract` may return anomaly maps
+- teaches pipeline-runner ingest stages to preserve extract anomaly context as
+  the failed stage result
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.connector-file.interface-test 'ai.miniforge.connector-file.anomaly.file-anomaly-test 'ai.miniforge.pipeline-runner.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.connector-file.interface-test 'ai.miniforge.connector-file.anomaly.file-anomaly-test 'ai.miniforge.pipeline-runner.interface-test)"
+```
+
+- Exceptions-as-data scanner: 150 cleanup-needed rows; no
+  `connector_file/impl`, `pipeline_runner`, or `connector/protocol` rows.


### PR DESCRIPTION
## Summary
- Return a canonical :anomalies/not-found map when connector-file extract sees a missing source file.
- Document connector extract anomaly returns.
- Preserve extract anomaly context as an immediate failed ingest stage in pipeline-runner.

## Validation
- clojure -M:dev:test focused connector-file and pipeline-runner tests: 61 tests, 177 assertions, 0 failures/errors
- exceptions-as-data scanner: 150 cleanup-needed rows; no connector_file/impl, pipeline_runner, or connector/protocol rows
- bb pre-commit
