### PR TITLE
Fix connector-github config anomaly

### DIFF
--- a/components/connector-github/src/ai/miniforge/connector_github/impl.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/impl.clj
@@ -195,39 +195,45 @@
   [result]
   (:errors result))
 
-(defn- validate-connect!
-  "Validate config and auth sequentially, throwing on first failure.
-   Auth validation delegates to the shared connector helper, then re-throws
-   with the localized message that interpolates the actual validation errors."
+(defn- validate-connect
+  "Validate config and auth sequentially.
+
+   Returns nil on success. Returns a canonical anomaly map for config
+   failures. Auth validation still delegates to the connector boundary helper
+   and may throw for invalid auth."
   [config auth]
   (let [config-result (gh-schema/validate-config config)]
     (cond
       (gh-schema/invalid? config-result)
       (let [errs (validation-errors config-result)]
-        (response/throw-anomaly! :anomalies/incorrect
-                                 (msg/t :github/config-invalid {:errors errs})
-                                 {:errors errs}))
+        (response/make-anomaly :anomalies/incorrect
+                               (msg/t :github/config-invalid {:errors errs})
+                               {:errors errs}))
 
       (and (nil? (:github/org config)) (nil? (:github/owner config)))
-      (response/throw-anomaly! :anomalies/incorrect
-                               (msg/t :github/owner-or-org-required)
-                               {:config config})
+      (response/make-anomaly :anomalies/incorrect
+                             (msg/t :github/owner-or-org-required)
+                             {:config config})
 
       :else
       (connector/validate-auth-or-throw! auth msg/t :github/auth-invalid))))
 
 ;; -- Lifecycle --
 (defn do-connect
-  "Validate config and auth, register handle. Returns connect-result."
+  "Validate config and auth, register handle.
+
+   Returns a connect-result map on success or a canonical anomaly map when
+   config validation fails."
   [config auth]
-  (validate-connect! config auth)
-  (let [handle       (str (UUID/randomUUID))
-        base-url     (get config :github/base-url "https://api.github.com")
-        auth-headers (if (:auth/method auth) (build-auth-headers auth) {})]
-    (store-handle! handle {:config          (assoc config :github/base-url base-url)
-                           :auth-headers    auth-headers
-                           :last-request-at nil})
-    (connector/connect-result handle)))
+  (if-let [anomaly (validate-connect config auth)]
+    anomaly
+    (let [handle       (str (UUID/randomUUID))
+          base-url     (get config :github/base-url "https://api.github.com")
+          auth-headers (if (:auth/method auth) (build-auth-headers auth) {})]
+      (store-handle! handle {:config          (assoc config :github/base-url base-url)
+                             :auth-headers    auth-headers
+                             :last-request-at nil})
+      (connector/connect-result handle))))
 
 (defn do-close
   "Remove handle state. Returns close-result."

--- a/components/connector-github/test/ai/miniforge/connector_github/anomaly/github_anomaly_test.clj
+++ b/components/connector-github/test/ai/miniforge/connector_github/anomaly/github_anomaly_test.clj
@@ -17,21 +17,20 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.connector-github.anomaly.github-anomaly-test
-  "Coverage for `impl/validate-connect!` and `impl/require-resource!`
-   boundary escalation via `response/throw-anomaly!`."
+  "Coverage for `impl/do-connect` config anomalies and
+   `impl/require-resource!` boundary escalation via `response/throw-anomaly!`."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [ai.miniforge.connector-github.impl :as impl]
-            [ai.miniforge.connector-github.resources :as resources])
+            [ai.miniforge.connector-github.resources :as resources]
+            [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest do-connect-missing-owner-and-org-throws-anomaly
-  (testing "config without :github/owner or :github/org raises :anomalies/incorrect"
-    (try
-      (impl/do-connect {} nil)
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+(deftest do-connect-missing-owner-and-org-returns-anomaly
+  (testing "config without :github/owner or :github/org returns :anomalies/incorrect"
+    (let [result (impl/do-connect {} nil)]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
 (deftest require-resource-unknown-throws-anomaly
   (testing "looking up an unknown resource raises :anomalies/not-found"
@@ -42,14 +41,12 @@
         (is (= :anomalies/not-found (:anomaly/category (ex-data e))))
         (is (= "totally-bogus-resource" (:resource (ex-data e))))))))
 
-(deftest do-connect-invalid-schema-throws-anomaly
-  (testing "malformed config raises :anomalies/incorrect"
-    (try
-      (impl/do-connect {:github/owner 42} nil)
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
-        (is (some? (:errors (ex-data e))))))))
+(deftest do-connect-invalid-schema-returns-anomaly
+  (testing "malformed config returns :anomalies/incorrect"
+    (let [result (impl/do-connect {:github/owner 42} nil)]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (some? (:errors result))))))
 
 (deftest load-resources-missing-edn-throws-anomaly
   (testing "missing resource EDN raises :anomalies/not-found"

--- a/components/connector-github/test/ai/miniforge/connector_github/impl_test.clj
+++ b/components/connector-github/test/ai/miniforge/connector_github/impl_test.clj
@@ -20,8 +20,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-github.impl :as impl]
             [ai.miniforge.connector-github.resources :as resources]
-            [ai.miniforge.connector-http.rate-limit :as rate]
             [ai.miniforge.connector-http.etag :as etag]
+            [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]))
 
 (deftest resource-schemas-test
@@ -96,7 +96,9 @@
 
 (deftest connect-validates-config-test
   (testing "do-connect requires org or owner"
-    (is (thrown? Exception (impl/do-connect {} nil)))))
+    (let [result (impl/do-connect {} nil)]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
 (deftest connect-close-lifecycle-test
   (testing "connect and close work with org"

--- a/docs/pull-requests/2026-06-27-chris-connector-github-config-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-github-config-anomaly.md
@@ -1,0 +1,25 @@
+# Fix connector-github config anomaly
+
+## Summary
+
+The exceptions-as-data scan reports a cleanup-needed throw in
+`connector-github` config validation. Invalid connector configuration is normal
+caller input failure data, not a boundary exception.
+
+This change:
+
+- returns canonical `:anomalies/incorrect` maps from `do-connect` for malformed
+  GitHub config and missing `:github/owner` / `:github/org`
+- preserves existing auth and resource lookup boundary behavior for separate
+  case-by-case remediation
+- relies on pipeline-runner's existing connect anomaly handling to surface the
+  failure as an immediate failed stage
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.connector-github.impl-test 'ai.miniforge.connector-github.anomaly.github-anomaly-test 'ai.miniforge.pipeline-runner.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.connector-github.impl-test 'ai.miniforge.connector-github.anomaly.github-anomaly-test 'ai.miniforge.pipeline-runner.interface-test)"
+```
+
+- Exceptions-as-data scanner: 149 cleanup-needed rows; no
+  `connector_github/impl`, `pipeline_runner`, or `connector/protocol` rows.


### PR DESCRIPTION
## Summary
- Return canonical :anomalies/incorrect maps from connector-github do-connect for malformed config and missing owner/org.
- Leave auth and resource boundary behavior unchanged for separate case-by-case remediation.
- Rely on pipeline-runner connect anomaly handling to surface these as failed stages.

## Validation
- clojure -M:dev:test focused connector-github and pipeline-runner tests: 60 tests, 198 assertions, 0 failures/errors
- exceptions-as-data scanner: 149 cleanup-needed rows; no connector_github/impl, pipeline_runner, or connector/protocol rows
- bb pre-commit via commit hooks
