### PR TITLE
Fix connector-gitlab implementation anomalies

### DIFF
--- a/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
+++ b/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
@@ -143,6 +143,21 @@
             (page-fetch-result all-records
                                (final-cursor resource-def all-records))))))))
 
+(defn- exception->anomaly
+  [^clojure.lang.ExceptionInfo e]
+  (let [data (ex-data e)]
+    (if (response/anomaly-map? data)
+      data
+      (response/make-anomaly :anomalies/fault
+                             (or (ex-message e) "GitLab optional resource fetch failed")
+                             data))))
+
+(defn- optional-fetch-failure
+  [^clojure.lang.ExceptionInfo e]
+  (if (= :permanent (:error-type (ex-data e)))
+    (connector/extract-result [] nil false)
+    (exception->anomaly e)))
+
 (defn- timestamp-value
   [record]
   (or (:updated_at record)
@@ -207,21 +222,25 @@
 ;; Lifecycle and source operations
 
 (defn do-connect
-  "Validate config at boundary, register handle."
+  "Validate config at boundary, register handle.
+
+   Returns a connect-result map on success or a canonical anomaly map when
+   required project config is missing."
   [config auth]
   (let [config (assoc config :gitlab/base-url
                       (get config :gitlab/base-url "https://gitlab.com"))]
-    (when-not (has-project? config)
-      (response/throw-anomaly! :anomalies/incorrect
-                               (msg/t :gitlab/project-required)
-                               {:config config}))
-    (schema/validate! schema/GitLabConfig config)
-    (validate-auth! auth)
-    (let [handle (str (UUID/randomUUID))]
-      (store-handle! handle {:config       config
-                              :auth-headers (resolve-auth-headers auth)
-                              :last-request-at nil})
-      (connector/connect-result handle))))
+    (if-not (has-project? config)
+      (response/make-anomaly :anomalies/incorrect
+                             (msg/t :gitlab/project-required)
+                             {:config config})
+      (do
+        (schema/validate! schema/GitLabConfig config)
+        (validate-auth! auth)
+        (let [handle (str (UUID/randomUUID))]
+          (store-handle! handle {:config       config
+                                 :auth-headers (resolve-auth-headers auth)
+                                 :last-request-at nil})
+          (connector/connect-result handle))))))
 
 (defn do-close [handle]
   (remove-handle! handle)
@@ -247,8 +266,7 @@
         (if (:optional? resource-def)
           (try (fetch)
                (catch clojure.lang.ExceptionInfo e
-                 (when-not (= :permanent (:error-type (ex-data e))) (throw e))
-                 (connector/extract-result [] nil false)))
+                 (optional-fetch-failure e)))
           (fetch))))))
 
 (defn do-checkpoint [cursor-state]

--- a/components/connector-gitlab/test/ai/miniforge/connector_gitlab/anomaly/gitlab_anomaly_test.clj
+++ b/components/connector-gitlab/test/ai/miniforge/connector_gitlab/anomaly/gitlab_anomaly_test.clj
@@ -18,21 +18,20 @@
 
 (ns ai.miniforge.connector-gitlab.anomaly.gitlab-anomaly-test
   "Coverage for `impl/do-connect`, `impl/require-resource!`, and
-   `schema/validate!` boundary escalation via `response/throw-anomaly!`."
+   `schema/validate!` boundary behavior."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [ai.miniforge.connector-gitlab.impl :as impl]
             [ai.miniforge.connector-gitlab.resources :as resources]
-            [ai.miniforge.connector-gitlab.schema :as schema])
+            [ai.miniforge.connector-gitlab.schema :as schema]
+            [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest do-connect-missing-project-throws-anomaly
-  (testing "config without project-id or project-path raises :anomalies/incorrect"
-    (try
-      (impl/do-connect {} nil)
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+(deftest do-connect-missing-project-returns-anomaly
+  (testing "config without project-id or project-path returns :anomalies/incorrect"
+    (let [result (impl/do-connect {} nil)]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
 (deftest require-resource-unknown-throws-anomaly
   (testing "looking up an unknown resource raises :anomalies/not-found"

--- a/components/connector-gitlab/test/ai/miniforge/connector_gitlab/impl_test.clj
+++ b/components/connector-gitlab/test/ai/miniforge/connector_gitlab/impl_test.clj
@@ -17,9 +17,11 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.connector-gitlab.impl-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-gitlab.impl :as impl]
             [ai.miniforge.connector-gitlab.resources :as resources]
+            [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]))
 
 ;;------------------------------------------------------------------------------ Layer 0
@@ -47,8 +49,8 @@
     (let [resource-def (resources/get-resource :merge-requests)
           config {:gitlab/project-path "engrammicai/ixi-services/services/ixi"}
           url (resources/build-url "https://gitlab.com" resource-def config)]
-      (is (clojure.string/includes? url "/api/v4/projects/"))
-      (is (clojure.string/includes? url "/merge_requests"))))
+      (is (str/includes? url "/api/v4/projects/"))
+      (is (str/includes? url "/merge_requests"))))
 
   (testing "builds project URL with project-id"
     (let [resource-def (resources/get-resource :issues)
@@ -112,7 +114,9 @@
 
 (deftest connect-validates-config-test
   (testing "do-connect requires project-id or project-path"
-    (is (thrown? Exception (impl/do-connect {} nil)))))
+    (let [result (impl/do-connect {} nil)]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
 (deftest connect-close-lifecycle-test
   (testing "connect and close with project-path"
@@ -253,6 +257,22 @@
               (is (= {:cursor/type :timestamp-watermark
                       :cursor/value "2026-03-21T10:30:00Z"}
                      (:extract/cursor result))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest extract-optional-transient-failure-returns-anomaly-test
+  (testing "optional resource transient failures return anomaly maps"
+    (let [handle (:connection/handle (impl/do-connect {:gitlab/project-id 1} nil))]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [_url _headers _params]
+             (schema/failure :body "temporarily unavailable" {:error-type :transient}))}
+          (fn []
+            (let [result (impl/do-extract handle "iterations" {})]
+              (is (response/anomaly-map? result))
+              (is (= :anomalies/unavailable (:anomaly/category result)))
+              (is (= :transient (:error-type result))))))
         (finally
           (impl/do-close handle))))))
 

--- a/docs/pull-requests/2026-06-27-chris-connector-gitlab-project-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-gitlab-project-anomaly.md
@@ -1,0 +1,25 @@
+# Fix connector-gitlab project anomaly
+
+## Summary
+
+The exceptions-as-data scan reports cleanup-needed throws in the GitLab
+connector implementation. Missing project config and non-permanent optional
+resource failures are normal connector failure data, not boundary exceptions.
+
+This change:
+
+- returns canonical `:anomalies/incorrect` data from `do-connect` when
+  `:gitlab/project-id` and `:gitlab/project-path` are both absent
+- returns the HTTP failure anomaly for non-permanent optional-resource extract
+  failures instead of rethrowing
+- preserves the existing permanent optional-resource behavior of returning an
+  empty extract result
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.connector-gitlab.impl-test 'ai.miniforge.connector-gitlab.anomaly.gitlab-anomaly-test 'ai.miniforge.pipeline-runner.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.connector-gitlab.impl-test 'ai.miniforge.connector-gitlab.anomaly.gitlab-anomaly-test 'ai.miniforge.pipeline-runner.interface-test)"
+```
+
+- Exceptions-as-data scanner: 149 cleanup-needed rows; no
+  `connector_gitlab/impl`, `pipeline_runner`, or `connector/protocol` rows.


### PR DESCRIPTION
## Summary
- Return canonical :anomalies/incorrect data when connector-gitlab connect lacks project config.
- Return the HTTP failure anomaly for non-permanent optional-resource extract failures instead of rethrowing.
- Preserve permanent optional-resource behavior as an empty extract result.

## Validation
- clojure -M:dev:test focused connector-gitlab and pipeline-runner tests: 58 tests, 186 assertions, 0 failures/errors
- exceptions-as-data scanner: 149 cleanup-needed rows; no connector_gitlab/impl, pipeline_runner, or connector/protocol rows
- bb pre-commit via commit hooks
