### PR TITLE
Fix pipeline output publish anomalies

### DIFF
--- a/components/connector-pipeline-output/src/ai/miniforge/connector_pipeline_output/impl.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/connector_pipeline_output/impl.clj
@@ -36,12 +36,12 @@
 (defn- remove-handle! [handle] (swap! handles dissoc handle))
 
 (defn- require-handle!
-  "Retrieve handle state or throw."
+  "Retrieve handle state or return an anomaly."
   [handle]
   (or (get-handle handle)
-      (response/throw-anomaly! :anomalies/not-found
-                               (msg/t :output/handle-not-found {:handle handle})
-                               {:handle handle})))
+      (response/make-anomaly :anomalies/not-found
+                             (msg/t :output/handle-not-found {:handle handle})
+                             {:handle handle})))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; Lifecycle
@@ -118,9 +118,10 @@
   [handle records opts]
   (let [handle-state (require-handle! handle)
         datasets     (:publish/datasets opts)]
-    (if (and datasets (> (count datasets) 1))
-      (publish-per-dataset! handle-state records datasets opts)
-      (publish-combined! handle-state records opts))))
+    (cond
+      (response/anomaly-map? handle-state) handle-state
+      (and datasets (> (count datasets) 1)) (publish-per-dataset! handle-state records datasets opts)
+      :else (publish-combined! handle-state records opts))))
 
 (comment
   ;; (do-connect {:output/dir "output/test" :output/format :edn})

--- a/components/connector-pipeline-output/test/ai/miniforge/connector_pipeline_output/impl_test.clj
+++ b/components/connector-pipeline-output/test/ai/miniforge/connector_pipeline_output/impl_test.clj
@@ -23,7 +23,8 @@
             [cheshire.core :as json]
             [ai.miniforge.connector-pipeline-output.impl :as impl]
             [ai.miniforge.connector-pipeline-output.schema :as schema]
-            [ai.miniforge.connector-pipeline-output.interface :as iface]))
+            [ai.miniforge.connector-pipeline-output.interface :as iface]
+            [ai.miniforge.response.interface :as response]))
 
 (def ^:private test-dir "target/test-output")
 
@@ -57,6 +58,13 @@
       (is (string? handle))
       (let [close-result (impl/do-close handle)]
         (is (= :closed (:connector/status close-result)))))))
+
+(deftest publish-missing-handle-returns-anomaly
+  (testing "publish returns anomaly data when the output handle is unknown"
+    (let [result (impl/do-publish "missing-output-handle" [{:id 1}] {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "missing-output-handle" (:handle result))))))
 
 (deftest publish-edn-test
   (testing "publish writes manifest.edn and records.edn"

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -173,11 +173,13 @@
               (stage-result id name :failed (anomaly-context connect-result))
               (do
                 (reset! handle (:connection/handle connect-result))
-                (conn/publish connector @handle name input-records
-                              {:publish/mode     (get config :publish-mode
-                                                     (:publish/default-mode default-config))
-                               :publish/datasets (:publish/datasets context)})
-                (stage-result id name :completed {:completed-at (Instant/now)}))))
+                (let [result (conn/publish connector @handle name input-records
+                                           {:publish/mode     (get config :publish-mode
+                                                                  (:publish/default-mode default-config))
+                                            :publish/datasets (:publish/datasets context)})]
+                  (if (response/anomaly-map? result)
+                    (stage-result id name :failed (anomaly-context result))
+                    (stage-result id name :completed {:completed-at (Instant/now)}))))))
           (catch Exception e
             (stage-result id name :failed (exception-context e)))
           (finally

--- a/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
+++ b/components/pipeline-runner/test/ai/miniforge/pipeline_runner/interface_test.clj
@@ -492,6 +492,23 @@
       (is (= :anomalies/incorrect (:anomaly/category failed)))
       (is (= "Invalid sink config" (:error-message failed))))))
 
+(deftest execute-pipeline-publish-anomaly-test
+  (testing "Pipeline fails when publish connector publish returns anomaly"
+    (let [mock-source (->MockSourceConnector nil)
+          sink        (->MockSinkConnector
+                       (response/make-anomaly :anomalies/not-found
+                                              "Output handle missing"
+                                              {:handle "missing-output-handle"}))
+          result      (runner/execute-pipeline
+                       three-stage-pipeline
+                       {conn-src mock-source conn-sink sink}
+                       {})
+          failed      (last (get-in result [:pipeline-run :pipeline-run/stage-runs]))]
+      (is (not (:success? result)))
+      (is (= :failed (:status failed)))
+      (is (= :anomalies/not-found (:anomaly/category failed)))
+      (is (= "Output handle missing" (:error-message failed))))))
+
 (deftest execute-pipeline-ingest-close-failure-does-not-mask-primary-error-test
   (testing "Ingest cleanup closes once and preserves the primary extract failure"
     (let [close-count (atom 0)

--- a/docs/pull-requests/2026-06-27-chris-connector-pipeline-output-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-pipeline-output-anomaly.md
@@ -1,0 +1,21 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Connector Pipeline Output Publish Anomalies
+
+## Summary
+
+- Return `:anomalies/not-found` data when `connector-pipeline-output` publish
+  receives an unknown output handle.
+- Fail pipeline publish stages when sink connectors return anomaly data from
+  `publish`, matching existing connect and extract handling.
+- Add focused regression coverage for direct output publish and pipeline-runner
+  publish anomaly propagation.
+
+## Validation
+
+- `clojure -M:dev:test` focused connector-pipeline-output and pipeline-runner
+  tests.


### PR DESCRIPTION
## Summary
- return :anomalies/not-found data when connector-pipeline-output publish receives an unknown output handle
- fail pipeline publish stages when sink connectors return anomaly data from publish
- add focused direct connector and pipeline-runner regression coverage

## Validation
- clojure -M:dev:test focused connector-pipeline-output and pipeline-runner tests: 56 tests, 198 assertions, 0 failures/errors
- exceptions-as-data scanner: 149 cleanup-needed rows; no connector_pipeline_output/impl or pipeline_runner/run rows
- git commit hook / pre-commit checks passed: Polylith check, lint, Markdown formatting, smoke tests, GraalVM/Babashka compatibility