### PR TITLE
Use data failures for planner DAG readiness

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -73,21 +73,22 @@
   [agent-result]
   (if (not= :success (:status agent-result))
     agent-result
-    (let [output   (:output agent-result)
+    (let [failure-opts (select-keys agent-result [:metrics :tokens :duration-ms])
+          output   (:output agent-result)
           tasks    (:plan/tasks output)
           task-ids (set (keep :task/id tasks))]
       (cond
         ;; Zero tasks → :no-tasks DAG skip → silent monolithic implement fallback
         (empty? tasks)
         (response/error
-         (ex-info
-          (str "Planner produced 0 tasks — DAG orchestrator cannot activate. "
-               "Planner must decompose the spec into a non-empty :plan/tasks vector. "
-               "Use :already-satisfied evidence bundle when the work is truly done.")
-          {:phase     :plan
-           :plan/id   (:plan/id output)
-           :plan/name (:plan/name output)
-           :anomaly   :anomalies.dag/no-tasks}))
+         (str "Planner produced 0 tasks — DAG orchestrator cannot activate. "
+              "Planner must decompose the spec into a non-empty :plan/tasks vector. "
+              "Use :already-satisfied evidence bundle when the work is truly done.")
+         (assoc failure-opts
+                :data {:phase     :plan
+                       :plan/id   (:plan/id output)
+                       :plan/name (:plan/name output)
+                       :anomaly   :anomalies.dag/no-tasks}))
 
         ;; Unknown dep refs → orphan tasks at DAG runtime — fail early
         :else
@@ -97,13 +98,13 @@
                              {:task/id (:task/id t) :unknown-dep dep})]
           (if (seq invalid-deps)
             (response/error
-             (ex-info
-              (str "Plan contains tasks with unknown dependency references. "
-                   "Each :task/dependencies entry must be a :task/id from this plan.")
-              {:phase        :plan
-               :plan/id      (:plan/id output)
-               :invalid-deps (vec invalid-deps)
-               :anomaly      :anomalies.dag/unknown-deps}))
+             (str "Plan contains tasks with unknown dependency references. "
+                  "Each :task/dependencies entry must be a :task/id from this plan.")
+             (assoc failure-opts
+                    :data {:phase        :plan
+                           :plan/id      (:plan/id output)
+                           :invalid-deps (vec invalid-deps)
+                           :anomaly      :anomalies.dag/unknown-deps}))
             agent-result))))))
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/plan_dag_activation_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/plan_dag_activation_test.clj
@@ -70,7 +70,9 @@
           "zero-task plan must fail with :error, not silently trigger :no-tasks DAG skip")
       (is (= :anomalies.dag/no-tasks
              (get-in result [:error :data :anomaly]))
-          "failure must carry :anomalies.dag/no-tasks anomaly for observability"))))
+          "failure must carry :anomalies.dag/no-tasks anomaly for observability")
+      (is (= 100 (get-in result [:metrics :tokens]))
+          "failure must preserve planner invocation metrics"))))
 
 (deftest unknown-dep-refs-fail-explicitly-test
   (testing "Tasks referencing non-existent task IDs fail with :anomalies.dag/unknown-deps"
@@ -87,7 +89,9 @@
           "unknown dep refs must fail — not silently become orphan tasks at runtime")
       (is (= :anomalies.dag/unknown-deps
              (get-in result [:error :data :anomaly]))
-          "failure must carry :anomalies.dag/unknown-deps anomaly"))))
+          "failure must carry :anomalies.dag/unknown-deps anomaly")
+      (is (= 100 (get-in result [:metrics :tokens]))
+          "failure must preserve planner invocation metrics"))))
 
 (deftest valid-deps-pass-through-test
   (testing "Tasks with dependencies pointing to known task IDs pass through"

--- a/docs/pull-requests/2026-06-27-chris-planner-dag-readiness-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-planner-dag-readiness-anomaly.md
@@ -1,0 +1,20 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Planner DAG Readiness Data Failures
+
+## Summary
+
+- Convert planner DAG readiness validation failures from exception-backed
+  responses to data-backed `response/error` values.
+- Preserve the existing `:anomalies.dag/no-tasks` and
+  `:anomalies.dag/unknown-deps` contracts in `[:error :data :anomaly]`.
+
+## Validation
+
+- `clojure -M:dev:test` focused planner DAG activation tests.
+- Exceptions-as-data scanner reports no cleanup row for
+  `phase_software_factory/plan.clj`.


### PR DESCRIPTION
## Summary
- convert planner DAG readiness validation failures from exception-backed responses to data-backed response/error values
- preserve the existing :anomalies.dag/no-tasks and :anomalies.dag/unknown-deps contracts in [:error :data :anomaly]

## Validation
- clojure -M:dev:test focused planner DAG activation tests: 7 tests, 10 assertions, 0 failures/errors
- exceptions-as-data scanner: 148 cleanup-needed rows; no phase_software_factory/plan.clj row
- git commit hook / pre-commit checks passed: Polylith check, lint, Markdown formatting, smoke tests, GraalVM/Babashka compatibility