### PR TITLE
Return anomaly for invalid agent messages

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface/protocols/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/protocols/messaging.clj
@@ -34,7 +34,9 @@
 
   (send-message [this message-data]
     "Send a message to another agent.
-     Returns {:message message-map :event event-map}")
+     Returns {:message message-map :event event-map} on success.
+     Returns an anomaly map with {:message nil :event nil} when message-data
+     fails validation.")
 
   (receive-messages [this]
     "Get all messages received by this agent.

--- a/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
@@ -233,30 +233,32 @@
                         {:from-agent (:agent-id agent-messaging)
                          :from-instance-id (:instance-id agent-messaging)
                          :workflow-id (:workflow-id agent-messaging)}))
-        router (:router agent-messaging)]
+        router (:router agent-messaging)
+        validation (validate-message-impl message)]
     ;; Validate message
-    (let [validation (validate-message-impl message)]
-      (when-not (:valid? validation)
-        (response/throw-anomaly! :anomalies/incorrect
-                                "Invalid message"
-                                {:message message
-                                 :errors (:errors validation)})))
-    ;; Route message and emit events
-    (let [routed-msg   (route-message-impl router message)
-          stream       (:event-stream agent-messaging)
-          workflow-id  (:message/workflow-id routed-msg)
-          from-agent   (:message/from-agent routed-msg)
-          to-agent     (:message/to-agent routed-msg)
-          message-type (:message/type routed-msg)
-          sent-event   (emit-inter-agent-event!
-                         stream workflow-id from-agent to-agent message-type
-                         events/inter-agent-message-sent)]
-      ;; Emit :agent/message-received on behalf of the recipient agent.
-      (emit-inter-agent-event!
-        stream workflow-id from-agent to-agent message-type
-        events/inter-agent-message-received)
-      {:message routed-msg
-       :event sent-event})))
+    (if-not (:valid? validation)
+      (assoc (response/make-anomaly :anomalies/incorrect
+                                    "Invalid message"
+                                    {:message message
+                                     :errors (:errors validation)})
+             :message nil
+             :event nil)
+      ;; Route message and emit events
+      (let [routed-msg   (route-message-impl router message)
+            stream       (:event-stream agent-messaging)
+            workflow-id  (:message/workflow-id routed-msg)
+            from-agent   (:message/from-agent routed-msg)
+            to-agent     (:message/to-agent routed-msg)
+            message-type (:message/type routed-msg)
+            sent-event   (emit-inter-agent-event!
+                           stream workflow-id from-agent to-agent message-type
+                           events/inter-agent-message-sent)]
+        ;; Emit :agent/message-received on behalf of the recipient agent.
+        (emit-inter-agent-event!
+          stream workflow-id from-agent to-agent message-type
+          events/inter-agent-message-received)
+        {:message routed-msg
+         :event sent-event}))))
 
 (defn receive-messages-impl
   "Get all messages received by agent."

--- a/components/agent/test/ai/miniforge/agent/messaging_protocol_test.clj
+++ b/components/agent/test/ai/miniforge/agent/messaging_protocol_test.clj
@@ -20,7 +20,8 @@
   "Tests for AgentMessaging protocol and convenience functions (Layers 4-5)."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.agent.interface :as agent]))
+   [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test Fixtures
@@ -64,6 +65,30 @@
 
       ;; Without an event-stream, event is nil (safe no-op)
       (is (nil? (:event result))))))
+
+(deftest test-send-message-invalid-data-returns-anomaly
+  (testing "Invalid outbound message data returns anomaly and is not routed"
+    (let [router (agent/create-message-router)
+          messaging (agent/create-agent-messaging
+                     :implementer
+                     test-implementer-id
+                     test-workflow-id
+                     router)
+          result (agent/send-message
+                  messaging
+                  {:type :invalid-type
+                   :to-agent :planner
+                   :content "bad message"})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (nil? (:message result)))
+      (is (nil? (:event result)))
+      (is (= [] (agent/receive-messages
+                 (agent/create-agent-messaging
+                  :planner
+                  test-planner-id
+                  test-workflow-id
+                  router)))))))
 
 (deftest test-receive-messages
   (testing "Receive messages sent to agent"

--- a/docs/pull-requests/2026-06-27-chris-agent-messaging-validation-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-agent-messaging-validation-anomaly.md
@@ -1,0 +1,20 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Agent Messaging Validation Anomaly
+
+## Summary
+
+- Return `:anomalies/incorrect` data when outbound inter-agent message
+  validation fails.
+- Keep valid message routing and event emission behavior unchanged.
+- Add protocol coverage that invalid outbound messages are not routed.
+
+## Validation
+
+- `clojure -M:dev:test` focused agent messaging tests.
+- Exceptions-as-data scanner reports no cleanup row for
+  `agent/protocols/impl/messaging.clj`.


### PR DESCRIPTION
## Summary
- return :anomalies/incorrect data when outbound inter-agent message validation fails
- keep valid message routing and event emission behavior unchanged
- add protocol coverage that invalid outbound messages are not routed

## Validation
- clojure -M:dev:test focused agent messaging protocol test: 11 tests, 32 assertions, 0 failures/errors
- clojure -M:dev:test focused agent messaging suite: 29 tests, 90 assertions, 0 failures/errors
- exceptions-as-data scanner: 146 cleanup-needed rows; no agent/protocols/impl/messaging.clj row
- git commit hook / pre-commit checks passed: Polylith check, lint, Markdown formatting, smoke tests, GraalVM/Babashka compatibility