### PR TITLE
Return HTTP connector input anomalies

### DIFF
--- a/components/connector-http/src/ai/miniforge/connector_http/impl.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/impl.clj
@@ -128,12 +128,12 @@
   (let [base-url (:http/base-url config)
         endpoint (:http/endpoint config)]
     (cond
-      (nil? base-url) (response/throw-anomaly! :anomalies/incorrect
-                                               (msg/t :http/base-url-required)
-                                               {:config config})
-      (nil? endpoint) (response/throw-anomaly! :anomalies/incorrect
-                                               (msg/t :http/endpoint-required)
-                                               {:config config})
+      (nil? base-url) (response/make-anomaly :anomalies/incorrect
+                                             (msg/t :http/base-url-required)
+                                             {:config config})
+      (nil? endpoint) (response/make-anomaly :anomalies/incorrect
+                                             (msg/t :http/endpoint-required)
+                                             {:config config})
 
       :else
       (let [handle       (str (UUID/randomUUID))
@@ -155,9 +155,9 @@
   (if-let [{:keys [config]} (get-handle handle)]
     (connector/discover-result [{:schema/name    (:http/endpoint config)
                               :schema/base-url (:http/base-url config)}])
-    (response/throw-anomaly! :anomalies/not-found
-                             (msg/t :http/handle-not-found {:handle handle})
-                             {:handle handle})))
+    (response/make-anomaly :anomalies/not-found
+                           (msg/t :http/handle-not-found {:handle handle})
+                           {:handle handle})))
 
 (defn- fetch-single
   "Fetch one page of records for a single query-params set.
@@ -169,18 +169,18 @@
         query-params (merge base-query-params
                             (build-page-params pagination offset cursor-value batch-size))
         resp         (do-request url headers query-params)]
-    (when-not (:success? resp)
-      (response/throw-anomaly! :anomalies/unavailable
-                               (str (:error resp))
-                               {:error-type (:error-type resp)}))
-    (let [body     (:body resp)
-          records  (extract-records body response-path)
-          has-more (page-has-more? pagination body offset (count records))
-          next-val (next-cursor-value pagination body offset (count records))
-          cursor   (when next-val
-                     {:cursor/type  (get pagination :type :offset)
-                      :cursor/value next-val})]
-      {:records records :cursor cursor :has-more has-more})))
+    (if-not (:success? resp)
+      (response/make-anomaly :anomalies/unavailable
+                             (str (:error resp))
+                             {:error-type (:error-type resp)})
+      (let [body     (:body resp)
+            records  (extract-records body response-path)
+            has-more (page-has-more? pagination body offset (count records))
+            next-val (next-cursor-value pagination body offset (count records))
+            cursor   (when next-val
+                       {:cursor/type  (get pagination :type :offset)
+                        :cursor/value next-val})]
+        {:records records :cursor cursor :has-more has-more}))))
 
 (defn do-extract
   "Fetch records from the HTTP API.
@@ -199,27 +199,33 @@
       (if-let [param-sets (:batch/param-sets config)]
         ;; Batch mode: pmap over param sets, enrich records with param keys
         (letfn [(fetch-and-enrich [params]
-                  (let [{:keys [records]} (fetch-single
-                                           url headers
-                                           (merge base-qp params)
-                                           response-path pagination opts)]
-                    (mapv #(merge % params) records)))]
-          (let [all-records (vec (apply concat
-                                       (pmap fetch-and-enrich param-sets)))]
-            (touch-handle! handle)
-            (connector/extract-result all-records nil false)))
+                  (let [result (fetch-single
+                                url headers
+                                (merge base-qp params)
+                                response-path pagination opts)]
+                    (if (response/anomaly-map? result)
+                      result
+                      (mapv #(merge % params) (:records result)))))]
+          (let [results (doall (pmap fetch-and-enrich param-sets))]
+            (if-let [anomaly (first (filter response/anomaly-map? results))]
+              anomaly
+              (let [all-records (vec (apply concat results))]
+                (touch-handle! handle)
+                (connector/extract-result all-records nil false)))))
 
         ;; Single mode: one fetch with pagination
         (do
           (enforce-rate-limit! handle-state)
-          (let [{:keys [records cursor has-more]}
-                (fetch-single url headers base-qp response-path pagination opts)]
-            (touch-handle! handle)
-            (connector/extract-result records cursor has-more)))))
+          (let [result (fetch-single url headers base-qp response-path pagination opts)]
+            (if (response/anomaly-map? result)
+              result
+              (let [{:keys [records cursor has-more]} result]
+                (touch-handle! handle)
+                (connector/extract-result records cursor has-more)))))))
 
-    (response/throw-anomaly! :anomalies/not-found
-                             (msg/t :http/handle-not-found {:handle handle})
-                             {:handle handle})))
+    (response/make-anomaly :anomalies/not-found
+                           (msg/t :http/handle-not-found {:handle handle})
+                           {:handle handle})))
 
 (defn do-checkpoint [cursor-state]
   (connector/checkpoint-result cursor-state))

--- a/components/connector-http/test/ai/miniforge/connector_http/anomaly/http_anomaly_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/anomaly/http_anomaly_test.clj
@@ -18,48 +18,37 @@
 
 (ns ai.miniforge.connector-http.anomaly.http-anomaly-test
   "Coverage for `impl/do-connect`, `impl/do-discover`, `impl/do-extract`,
-   and `request/throw-on-failure!` boundary escalation via
-   `response/throw-anomaly!`.
+   and `request/throw-on-failure!` anomaly behavior.
 
    Config validation → `:anomalies/incorrect`. Handle not found →
    `:anomalies/not-found`. Request failure → `:anomalies/unavailable`."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-http.impl :as impl]
-            [ai.miniforge.connector-http.request :as request])
+            [ai.miniforge.connector-http.request :as request]
+            [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest do-connect-missing-base-url-throws-anomaly
-  (testing "missing :http/base-url raises :anomalies/incorrect"
-    (try
-      (impl/do-connect {:http/endpoint "/items"} nil)
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+(deftest do-connect-missing-base-url-returns-anomaly
+  (testing "missing :http/base-url returns :anomalies/incorrect"
+    (let [result (impl/do-connect {:http/endpoint "/items"} nil)]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest do-connect-missing-endpoint-throws-anomaly
-  (testing "missing :http/endpoint raises :anomalies/incorrect"
-    (try
-      (impl/do-connect {:http/base-url "https://x"} nil)
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+(deftest do-connect-missing-endpoint-returns-anomaly
+  (testing "missing :http/endpoint returns :anomalies/incorrect"
+    (let [result (impl/do-connect {:http/base-url "https://x"} nil)]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest do-discover-missing-handle-throws-anomaly
-  (testing "discover with bogus handle raises :anomalies/not-found"
-    (try
-      (impl/do-discover "no-such-handle")
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (= :anomalies/not-found (:anomaly/category (ex-data e))))
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest do-discover-missing-handle-returns-anomaly
+  (testing "discover with bogus handle returns :anomalies/not-found"
+    (let [result (impl/do-discover "no-such-handle")]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest do-extract-missing-handle-throws-anomaly
-  (testing "extract with bogus handle raises :anomalies/not-found"
-    (try
-      (impl/do-extract "no-such-handle" {})
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (= :anomalies/not-found (:anomaly/category (ex-data e))))))))
+(deftest do-extract-missing-handle-returns-anomaly
+  (testing "extract with bogus handle returns :anomalies/not-found"
+    (let [result (impl/do-extract "no-such-handle" {})]
+      (is (= :anomalies/not-found (:anomaly/category result))))))
 
 (deftest throw-on-failure-unavailable-anomaly
   (testing "request failure raises :anomalies/unavailable"
@@ -77,8 +66,8 @@
     (let [success {:success? true :body :data}]
       (is (= success (request/throw-on-failure! success))))))
 
-(deftest fetch-single-request-failure-throws-anomaly
-  (testing "do-extract propagates fetch-single request failure as :anomalies/unavailable"
+(deftest fetch-single-request-failure-returns-anomaly
+  (testing "do-extract returns fetch-single request failure as :anomalies/unavailable"
     (let [{:keys [connection/handle]} (impl/do-connect {:http/base-url "https://example.test"
                                                         :http/endpoint "/items"}
                                                        nil)]
@@ -87,11 +76,8 @@
                       {:success? false
                        :error "upstream down"
                        :error-type :transient})]
-        (try
-          (impl/do-extract handle {})
-          (is false "should have thrown")
-          (catch ExceptionInfo e
-            (is (= :anomalies/unavailable (:anomaly/category (ex-data e))))
-            (is (= :transient (:error-type (ex-data e)))))
-          (finally
-            (impl/do-close handle)))))))
+        (let [result (impl/do-extract handle {})]
+          (is (response/anomaly-map? result))
+          (is (= :anomalies/unavailable (:anomaly/category result)))
+          (is (= :transient (:error-type result))))
+        (impl/do-close handle)))))

--- a/components/connector-http/test/ai/miniforge/connector_http/interface_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/interface_test.clj
@@ -48,14 +48,16 @@
         (is (= :closed (:connector/status close-result)))))))
 
 (deftest connect-missing-base-url-test
-  (testing "Connect fails without :http/base-url"
-    (let [hc (http-conn/create-http-connector)]
-      (is (thrown? Exception (conn/connect hc {:http/endpoint "/data"} {}))))))
+  (testing "Connect returns anomaly without :http/base-url"
+    (let [hc (http-conn/create-http-connector)
+          result (conn/connect hc {:http/endpoint "/data"} {})]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
 (deftest connect-missing-endpoint-test
-  (testing "Connect fails without :http/endpoint"
-    (let [hc (http-conn/create-http-connector)]
-      (is (thrown? Exception (conn/connect hc {:http/base-url "https://api.example.com"} {}))))))
+  (testing "Connect returns anomaly without :http/endpoint"
+    (let [hc (http-conn/create-http-connector)
+          result (conn/connect hc {:http/base-url "https://api.example.com"} {})]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Extract with stubbed HTTP (override do-request)
@@ -160,7 +162,7 @@
         (conn/close hc handle)))))
 
 (deftest extract-http-error-test
-  (testing "Extract throws on HTTP 500"
+  (testing "Extract returns anomaly on HTTP 500"
     (with-redefs [impl/do-request
                   (fn [_url _headers _params]
                     {:success? false :error-type :transient
@@ -169,11 +171,13 @@
             handle (:connection/handle
                     (conn/connect hc {:http/base-url "https://api.example.com"
                                       :http/endpoint "/data"} {}))]
-        (is (thrown? Exception (conn/extract hc handle "data" {})))
+        (let [result (conn/extract hc handle "data" {})]
+          (is (= :anomalies/unavailable (:anomaly/category result)))
+          (is (= :transient (:error-type result))))
         (conn/close hc handle)))))
 
 (deftest extract-rate-limited-test
-  (testing "Extract throws on HTTP 429"
+  (testing "Extract returns anomaly on HTTP 429"
     (with-redefs [impl/do-request
                   (fn [_url _headers _params]
                     {:success? false :error-type :rate-limited
@@ -182,8 +186,10 @@
             handle (:connection/handle
                     (conn/connect hc {:http/base-url "https://api.example.com"
                                       :http/endpoint "/data"} {}))]
-        (is (thrown-with-msg? Exception #"Rate limited"
-                              (conn/extract hc handle "data" {})))
+        (let [result (conn/extract hc handle "data" {})]
+          (is (= :anomalies/unavailable (:anomaly/category result)))
+          (is (= :rate-limited (:error-type result)))
+          (is (re-find #"Rate limited" (:anomaly/message result))))
         (conn/close hc handle)))))
 
 ;; ---------------------------------------------------------------------------
@@ -194,12 +200,11 @@
   (testing "Extract with :batch/param-sets fetches all param sets in parallel"
     (let [calls (atom [])]
       (with-redefs [impl/do-request
-                    (fn [_url _headers params]
-                      (swap! calls conj params)
-                      (let [series (get params :series_id)]
-                        {:success? true
-                         :body {:observations [{:date "2026-01-01" :value "1.23"}
-                                               {:date "2026-01-02" :value "4.56"}]}}))]
+                  (fn [_url _headers params]
+                    (swap! calls conj params)
+                    {:success? true
+                     :body {:observations [{:date "2026-01-01" :value "1.23"}
+                                           {:date "2026-01-02" :value "4.56"}]}})]
         (let [hc (http-conn/create-http-connector)
               handle (:connection/handle
                       (conn/connect hc {:http/base-url "https://api.example.com"
@@ -223,7 +228,7 @@
 (deftest batch-extract-enriches-records-test
   (testing "Batch extract merges param-set keys into each record"
     (with-redefs [impl/do-request
-                  (fn [_url _headers params]
+                  (fn [_url _headers _params]
                     {:success? true
                      :body {:data [{:date "2026-01-01" :value "1.0"}]}})]
       (let [hc (http-conn/create-http-connector)
@@ -243,7 +248,7 @@
         (conn/close hc handle)))))
 
 (deftest batch-extract-error-propagates-test
-  (testing "Batch extract propagates errors from individual fetches"
+  (testing "Batch extract returns anomaly from individual fetches"
     (with-redefs [impl/do-request
                   (fn [_url _headers params]
                     (if (= "BAD" (:series_id params))
@@ -256,7 +261,9 @@
                                        :http/response-path [:data]
                                        :batch/param-sets [{:series_id "GOOD"}
                                                           {:series_id "BAD"}]} {}))]
-        (is (thrown? Exception (conn/extract hc handle "data" {})))
+        (let [result (conn/extract hc handle "data" {})]
+          (is (= :anomalies/unavailable (:anomaly/category result)))
+          (is (= :permanent (:error-type result))))
         (conn/close hc handle)))))
 
 ;; ---------------------------------------------------------------------------

--- a/components/connector/src/ai/miniforge/connector/protocol.clj
+++ b/components/connector/src/ai/miniforge/connector/protocol.clj
@@ -11,10 +11,11 @@
 (defprotocol SourceConnector
   "Source connector protocol for data extraction."
   (discover [this handle opts]
-    "Discover available schemas. Returns {:schemas [...] :discover/total-count long}")
+    "Discover available schemas. Returns {:schemas [...] :discover/total-count long}
+     or a canonical anomaly map for unavailable, invalid, or unknown-handle input.")
   (extract [this handle schema-name opts]
     "Extract records. Returns {:records [...] :extract/cursor map :extract/has-more bool}
-     or a canonical anomaly map when extraction input is unavailable or invalid.")
+     or a canonical anomaly map for unavailable, invalid, or unknown-handle input.")
   (checkpoint [this handle connector-id cursor-state]
     "Persist cursor state. Returns {:checkpoint/id uuid :checkpoint/status :committed}"))
 

--- a/docs/pull-requests/2026-06-28-chris-connector-http-input-anomalies.md
+++ b/docs/pull-requests/2026-06-28-chris-connector-http-input-anomalies.md
@@ -1,0 +1,26 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Connector HTTP Input Anomalies
+
+Branch: `chris/connector-http-input-anomalies`
+
+## Summary
+
+- Return canonical anomaly maps from HTTP connector `connect`, `discover`, and
+  `extract` implementation boundaries for invalid input, unknown handles, and
+  upstream request failures.
+- Preserve the explicit `request/throw-on-failure!` compatibility helper for
+  callers that still opt into exception escalation.
+- Document `discover` as an anomaly-capable connector protocol result.
+
+## Validation
+
+- `clojure -M:dev:test` focused HTTP connector tests: 33 tests, 107 assertions,
+  0 failures/errors.
+- Exceptions-as-data scanner drops from 146 to 143 cleanup-needed rows on this
+  branch; only the explicit HTTP request throwing helper remains in
+  `connector_http`.


### PR DESCRIPTION
## Summary
- Return canonical anomaly maps from HTTP connector connect/discover/extract implementation boundaries for invalid input, unknown handles, and upstream request failures.
- Preserve request/throw-on-failure! as the explicit compatibility helper for callers that still opt into exception escalation.
- Document discover as an anomaly-capable connector protocol result.

## Validation
- clojure -M:dev:test focused HTTP connector tests: 33 tests, 107 assertions, 0 failures/errors
- exceptions-as-data scanner: cleanup-needed drops from 146 to 143; only connector_http/request.clj throw-on-failure! remains in connector_http
- bb pre-commit
