### PR TITLE
Return anomaly for invalid execution plans

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/execution_plan.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/execution_plan.clj
@@ -110,16 +110,16 @@
    Arguments:
    - plan-map: Map conforming to ExecutionPlanSchema.
 
-   Returns the validated plan map unchanged if valid.
-   Throws ex-info with :errors key if validation fails."
+   Returns the validated plan map unchanged if valid, or a canonical
+   :anomalies/incorrect map with :errors and :plan when validation fails."
   [plan-map]
   (let [{:keys [valid? errors]} (validate-plan plan-map)]
     (if valid?
       plan-map
-      (response/throw-anomaly! :anomalies/incorrect
-                              "Invalid execution plan"
-                              {:errors errors
-                               :plan   plan-map}))))
+      (response/make-anomaly :anomalies/incorrect
+                             "Invalid execution plan"
+                             {:errors errors
+                              :plan   plan-map}))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -162,6 +162,6 @@
   ;; => good-plan (unchanged)
 
   (create-execution-plan {:image-digest "sha256:abc" :trust-level :unknown})
-  ;; throws ExceptionInfo with :errors
+  ;; => {:anomaly/category :anomalies/incorrect, :errors {...}, :plan {...}, ...}
 
   :leave-this-here)

--- a/components/dag-executor/test/ai/miniforge/dag_executor/execution_plan_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/execution_plan_test.clj
@@ -19,7 +19,8 @@
 (ns ai.miniforge.dag-executor.execution-plan-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.dag-executor.execution-plan :as sut]))
+   [ai.miniforge.dag-executor.execution-plan :as sut]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures and factories
@@ -122,34 +123,23 @@
     (is (false? (:valid? (sut/validate-plan (valid-plan :memory-limit-mb 1.5)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; create-execution-plan — round-trip and throw paths
+;; create-execution-plan — round-trip and anomaly paths
 
 (deftest create-execution-plan-returns-plan-unchanged-test
   (testing "A valid plan is returned unchanged (identity, no normalization)"
     (let [plan (valid-plan)]
       (is (= plan (sut/create-execution-plan plan))))))
 
-(deftest create-execution-plan-throws-anomaly-on-invalid-input-test
-  (testing "create-execution-plan throws ExceptionInfo for invalid input,
-            with an :errors key in the ex-data and an :anomalies/incorrect category"
-    (let [thrown (try
-                   (sut/create-execution-plan {:trust-level :rogue})
-                   ::no-throw
-                   (catch clojure.lang.ExceptionInfo e e))]
-      (is (instance? clojure.lang.ExceptionInfo thrown))
-      (let [data (ex-data thrown)
-            anomaly (or (:anomaly data) data)]
-        (is (some? (:errors data)) "ex-data must carry :errors")
-        ;; throw-anomaly! pattern wraps the data under an anomaly category.
-        (is (or (= :anomalies/incorrect (:anomaly/category anomaly))
-                (= :anomalies/incorrect (:anomaly/category data))))))))
+(deftest create-execution-plan-returns-anomaly-on-invalid-input-test
+  (testing "create-execution-plan returns :anomalies/incorrect for invalid input"
+    (let [result (sut/create-execution-plan {:trust-level :rogue})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (some? (:errors result)) "anomaly must carry :errors"))))
 
-(deftest create-execution-plan-error-includes-original-plan-test
-  (testing "ex-data carries the offending plan map under :plan"
+(deftest create-execution-plan-anomaly-includes-original-plan-test
+  (testing "anomaly carries the offending plan map under :plan"
     (let [bad {:trust-level :rogue :command "wrong"}
-          thrown (try
-                   (sut/create-execution-plan bad)
-                   nil
-                   (catch clojure.lang.ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (= bad (:plan (ex-data thrown)))))))
+          result (sut/create-execution-plan bad)]
+      (is (response/anomaly-map? result))
+      (is (= bad (:plan result))))))

--- a/docs/pull-requests/2026-06-28-chris-execution-plan-validation-anomaly.md
+++ b/docs/pull-requests/2026-06-28-chris-execution-plan-validation-anomaly.md
@@ -1,0 +1,23 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Execution Plan Validation Anomaly
+
+Branch: `chris/execution-plan-validation-anomaly`
+
+## Summary
+
+- Return canonical `:anomalies/incorrect` data from
+  `create-execution-plan` when a plan fails schema validation.
+- Preserve valid execution plan round trips unchanged.
+- Keep validation details and the original offending plan on the anomaly map.
+
+## Validation
+
+- `clojure -M:dev:test` focused execution-plan tests: 15 tests, 28 assertions,
+  0 failures/errors.
+- Exceptions-as-data scanner drops from 143 to 142 cleanup-needed rows; no
+  `execution_plan.clj` cleanup row remains.


### PR DESCRIPTION
## Summary
- Return canonical :anomalies/incorrect data from create-execution-plan when schema validation fails.
- Preserve valid execution plan round trips unchanged.
- Keep validation errors and the offending plan on the anomaly map.

## Validation
- clojure -M:dev:test focused execution-plan tests: 15 tests, 28 assertions, 0 failures/errors
- exceptions-as-data scanner: cleanup-needed drops from 143 to 142; no execution_plan.clj cleanup row remains
- bb pre-commit
