### PR TITLE
Return structured PR monitor failures

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/pr_monitor.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/pr_monitor.clj
@@ -94,8 +94,8 @@
             (assoc-in [:phase :result]
                       (if (:success? monitor-result)
                         (response/success result-data)
-                        (response/failure (ex-info "PR monitoring failed"
-                                                    {:failed-prs (:failed-prs monitor-result)}))))
+                        (response/failure "PR monitoring failed"
+                                          {:data {:failed-prs (:failed-prs monitor-result [])}})))
             (assoc :execution/train train-state))))))
 
 (defn leave-pr-monitor

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/pr_monitor_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/pr_monitor_test.clj
@@ -1,0 +1,58 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase-software-factory.pr-monitor-test
+  (:require
+   [ai.miniforge.phase-software-factory.pr-monitor :as sut]
+   [ai.miniforge.workflow.interface.dag-prs :as dag-prs]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest enter-pr-monitor-returns-structured-failure-data
+  (testing "monitor failure is a response value, not a synthetic exception"
+    (let [failed-prs [{:pr/number 42 :reason :ci-failed}]
+          train-state {:train-id "train-1"}]
+      (with-redefs [dag-prs/create-train-from-dag-result
+                    (fn [_dag-result _plan-tasks & _opts] train-state)
+                    dag-prs/monitor-dag-prs
+                    (fn [_train-state _pr-infos _opts]
+                      {:success? false
+                       :merged-prs []
+                       :failed-prs failed-prs})]
+        (let [result (sut/enter-pr-monitor
+                      {:execution/dag-pr-infos [{:pr/number 42}]
+                       :execution/dag-result {:tasks []}})
+              phase-result (get-in result [:phase :result])]
+          (is (= :failed (get-in result [:phase :status])))
+          (is (= false (:success phase-result)))
+          (is (= "PR monitoring failed" (get-in phase-result [:error :message])))
+          (is (= failed-prs (get-in phase-result [:error :data :failed-prs])))
+          (is (= train-state (:execution/train result))))))))
+
+(deftest enter-pr-monitor-defaults-missing-failed-prs
+  (testing "monitor failure keeps failed-prs as a vector when the monitor omits it"
+    (let [train-state {:train-id "train-1"}]
+      (with-redefs [dag-prs/create-train-from-dag-result
+                    (fn [_dag-result _plan-tasks & _opts] train-state)
+                    dag-prs/monitor-dag-prs
+                    (fn [_train-state _pr-infos _opts]
+                      {:success? false
+                       :merged-prs []})]
+        (let [result (sut/enter-pr-monitor
+                      {:execution/dag-pr-infos [{:pr/number 42}]
+                       :execution/dag-result {:tasks []}})]
+          (is (= [] (get-in result [:phase :result :error :data :failed-prs]))))))))

--- a/docs/pull-requests/2026-06-28-chris-pr-monitor-structured-failure.md
+++ b/docs/pull-requests/2026-06-28-chris-pr-monitor-structured-failure.md
@@ -1,0 +1,34 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# PR Monitor Structured Failure
+
+## Summary
+
+Replace the PR monitor phase's synthetic `ex-info` failure value with the
+existing structured `response/failure` message/data shape.
+
+## Motivation
+
+The PR monitor path already returned failure as data, but constructed that data
+through `ex-info`, keeping the exception cleanup scanner row alive and making a
+non-throwing path look like exception flow.
+
+## Changes
+
+- Return `response/failure` with `"PR monitoring failed"` plus
+  `{:failed-prs ...}` under response error data.
+- Add focused coverage for failed PR monitoring to lock status, message, failed
+  PR payload, and train-state preservation.
+
+## Validation
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.pr-monitor-test 'clojure.test)
+  (clojure.test/run-tests 'ai.miniforge.phase-software-factory.pr-monitor-test)"`
+- `clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r
+  (scanner/scan-exceptions-as-data \".\") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))]
+  (println :cleanup-needed (count cleanup)) (doseq [v (->> cleanup (filter #(clojure.string/includes? (:file %)
+  \"pr_monitor\")) (sort-by :line))] (println (:file v) (:line v))))'`


### PR DESCRIPTION
## Summary
- replace the PR monitor phase's synthetic ex-info failure with structured response/failure data
- preserve failed PR payload under response error data
- add focused coverage for failed PR monitoring

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.pr-monitor-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.phase-software-factory.pr-monitor-test)"
- exceptions-as-data scanner: cleanup-needed drops 142 -> 141, no pr_monitor rows remain
- bb pre-commit