### PR TITLE
Return structured release executor failures

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -423,9 +423,9 @@
                                   {:data {:errors (:errors exec-result)
                                           :metrics (:metrics exec-result)}})
                        (response/failure
-                        (ex-info (messages/t :release/phase-failed)
-                                 {:errors (:errors exec-result)
-                                  :metrics (:metrics exec-result)})))))
+                        (messages/t :release/phase-failed)
+                        {:data {:errors (:errors exec-result)
+                                :metrics (:metrics exec-result)}}))))
                  (catch Exception e
                    ;; The 2026-05-03 dogfood lost the actual exception here —
                    ;; the bare (response/failure e) wraps it but no log line
@@ -451,19 +451,6 @@
         ;; source of truth.
         (cond-> (phase/result-succeeded? result)
           (assoc :workflow/pr-info (response/release-pr-info {:result result}))))))))
-
-(def ^:private verdicts
-  "Phase 3b verdict tag set for release.
-
-     :approved            — PR opened or release artifact persisted;
-                            `:phase/succeed` event
-     :repair-requested    — release failed with `:on-fail` set; FSM
-                            redirects (subject to budget)
-     :release/zero-files  — curator's empty-diff verdict; FSM
-                            terminates because retrying implement
-                            won't change the curator's decision
-     :exhausted           — release failed without `:on-fail` set"
-  #{:approved :repair-requested :release/zero-files :exhausted})
 
 (defn- compute-verdict
   "Pick the verdict that should flow on the phase result.

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -446,7 +446,13 @@
                           (assoc :execution/logger logger)
                           (assoc :phase-config {:phase :release}))
                   interceptor (phase/get-phase-interceptor {:phase :release})]
-              ((:enter interceptor) ctx)
+              (let [result ((:enter interceptor) ctx)
+                    error  (get-in result [:phase :result :error])]
+                (is (= "Release phase failed" (:message error)))
+                (is (= [{:type :gh-auth-failed
+                         :message "gh CLI not authenticated"}]
+                       (get-in error [:data :errors])))
+                (is (= {:files-written 0} (get-in error [:data :metrics]))))
               (is (contains? (entry-events entries) :release/executor-failed)
                   "log/error :release/executor-failed must fire on the :success? false branch — guards the next dogfood post-mortem"))))))))
 

--- a/docs/pull-requests/2026-06-28-chris-release-executor-structured-failure.md
+++ b/docs/pull-requests/2026-06-28-chris-release-executor-structured-failure.md
@@ -1,0 +1,37 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Release Executor Structured Failure
+
+## Summary
+
+Replace the release phase's synthetic `ex-info` wrapper for
+`:success? false` release-executor results with a structured
+`response/failure` message/data value.
+
+## Motivation
+
+The release executor failure branch already returned a failure value, but built
+that value through `ex-info`. That kept the exception cleanup scanner row alive
+and made an exceptions-as-data path look like thrown control flow.
+
+## Changes
+
+- Return `(response/failure (messages/t :release/phase-failed) {:data ...})`
+  for executor failure results.
+- Preserve executor `:errors` and `:metrics` under response error data.
+- Extend release diagnostics coverage to assert the returned failure payload.
+- Remove the unused private `verdicts` documentation var from the touched
+  release namespace.
+
+## Validation
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.release-test 'clojure.test)
+  (clojure.test/run-tests 'ai.miniforge.phase-software-factory.release-test)"`
+- `clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r
+  (scanner/scan-exceptions-as-data \".\") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))]
+  (println :cleanup-needed (count cleanup)) (doseq [v (->> cleanup (filter #(clojure.string/includes? (:file %)
+  \"phase_software_factory/release.clj\")) (sort-by :line))] (println (:file v) (:line v))))'`


### PR DESCRIPTION
## Summary
- replace the release phase's synthetic ex-info wrapper for :success? false executor results with structured response/failure data
- preserve executor errors and metrics under response error data
- extend release diagnostics coverage for the returned failure payload
- remove an unused private release verdicts var surfaced by lint in the touched namespace

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.release-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.phase-software-factory.release-test)" (27 tests, 67 assertions)
- clj-kondo --lint components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
- exceptions-as-data scanner: cleanup-needed drops 141 -> 140; only release zero-files guard remains in release.clj
- bb pre-commit