### PR TITLE
Store task dependency failures as data

### DIFF
--- a/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
@@ -72,8 +72,9 @@
                                         :reason :dependency-failed
                                         :failed-dependency task-id})
       (dag/mark-failed! run-atom dependent-id
-                       (ex-info "Dependency failed"
-                                {:dependency-id task-id})))))
+                        {:message "Dependency failed"
+                         :dependency-id task-id}
+                        logger))))
 
 (defn make-execute-task-fn
   [run-context]
@@ -112,7 +113,7 @@
                                   :error (ex-message e)})
 
                       ;; Mark task as failed and cascade
-                      (dag/mark-failed! run-atom task-id e)
+                      (dag/mark-failed! run-atom task-id e logger)
                       (skip-dependent-tasks! run-atom task-id logger)
 
                       {:ok? false

--- a/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
@@ -107,6 +107,27 @@
          :budget {:tokens 100000
                   :cost-usd 10.0}}))
 
+(deftest skip-dependent-tasks-stores-failure-as-data
+  (testing "dependency cascade records structured failure data, not an exception"
+    (let [tasks {"a" {:task/id "a"
+                      :task/description "root"
+                      :task/dependencies []}
+                 "b" {:task/id "b"
+                      :task/description "dependent"
+                      :task/dependencies ["a"]}}
+          run-atom (dag/create-run-atom
+                    (assoc (-> (dag/create-run-state (random-uuid) tasks)
+                               (assoc-in [:run/tasks "b" :task/status] :running))
+                           :tasks {"a" {:dependencies []}
+                                   "b" {:dependencies ["a"]}}))]
+      (orchestrator/skip-dependent-tasks! run-atom "a" nil)
+      (let [error (get-in @run-atom [:run/tasks "b" :task/error])]
+        (is (= :failed (get-in @run-atom [:run/tasks "b" :task/status])))
+        (is (= {:message "Dependency failed"
+                :dependency-id "a"}
+               error))
+        (is (not (instance? Throwable error)))))))
+
 (defn create-mock-context
   "Create mock execution context."
   [run-atom config execution-tracker]

--- a/docs/pull-requests/2026-06-28-chris-task-dependency-failure-data.md
+++ b/docs/pull-requests/2026-06-28-chris-task-dependency-failure-data.md
@@ -1,0 +1,36 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Task Dependency Failure Data
+
+## Summary
+
+Record dependency-cascade task failures as structured data instead of a
+synthetic `ex-info` value.
+
+## Motivation
+
+When a task failed, the task-executor orchestrator marked dependents failed
+with an `ex-info` object. `dag/mark-failed!` stores opaque error data directly,
+so the exception wrapper was unnecessary and kept an exceptions-as-data scanner
+row alive.
+
+## Changes
+
+- Store dependency-cascade failures as `{:message ..., :dependency-id ...}`.
+- Pass the logger argument to `dag/mark-failed!` in both orchestrator failure
+  paths, fixing the stale three-argument calls.
+- Add focused coverage for the dependent-task error shape.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.task-executor.orchestrator-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.task-executor.orchestrator-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)) (doseq [v (->> cleanup (filter #(clojure.string/includes? (:file %) "task_executor/orchestrator.clj")) (sort-by :line))] (println (:file v) (:line v))))'
+```


### PR DESCRIPTION
## Summary
- Store dependency-cascade task failures as structured data instead of synthetic ex-info values.
- Fix the task orchestrator dag/mark-failed! call sites to pass the logger argument required by the current DAG API.
- Add focused coverage for dependent-task failure payloads.

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.task-executor.orchestrator-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.task-executor.orchestrator-test)"
- Exception-as-data scanner: cleanup-needed count drops 140 -> 139, leaving only the task orchestrator catch/rethrow boundary in this file.
- bb pre-commit