### PR TITLE
Mark adapter config guards as classpath failures

### DIFF
--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/discovery.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/discovery.clj
@@ -49,14 +49,22 @@
     (when (nil? url)
       (throw (ex-info (str "Missing config resource on classpath: " path)
                       {:config/resource path})))
-    (let [parsed (try
-                   (edn/read-string (slurp url))
+    (let [content (slurp url :encoding "UTF-8")
+          parsed (try
+                   (edn/read-string content)
                    (catch Exception e
-                     (throw (ex-info (str "Malformed EDN config resource: " path)
-                                     {:config/resource path} e))))]
+                     (throw (ex-info (str "Invalid classpath config resource; malformed EDN: "
+                                          path)
+                                     {:config/resource path
+                                      :classpath/resource path
+                                      :config/error :malformed-edn}
+                                     e))))]
       (when-not (map? parsed)
-        (throw (ex-info (str "Config resource is not a map: " path)
-                        {:config/resource path})))
+        (throw (ex-info (str "Invalid classpath config resource; expected map: "
+                             path)
+                        {:config/resource path
+                         :classpath/resource path
+                         :config/error :not-a-map})))
       (let [missing (remove #(contains? parsed %) required-keys)]
         (when (seq missing)
           (throw (ex-info (str "Config resource " path " missing keys: " (vec missing))

--- a/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/interface_test.clj
+++ b/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/interface_test.clj
@@ -36,6 +36,13 @@
     (.deleteOnExit dir)
     dir))
 
+(defn- temp-resource-url
+  [contents]
+  (let [file (java.io.File/createTempFile "adapter-config" ".edn")]
+    (.deleteOnExit file)
+    (spit file contents :encoding "UTF-8")
+    (.toURL (.toURI file))))
+
 (defn- write-file!
   "Write content to a file inside dir, creating parents as needed."
   [^java.io.File dir relative-path content]
@@ -218,6 +225,36 @@
                (catch clojure.lang.ExceptionInfo e e))]
       (is (instance? clojure.lang.ExceptionInfo ex))
       (is (= [:nope] (:config/missing-keys (ex-data ex)))))))
+
+(deftest load-config-throws-on-malformed-edn-test
+  (testing "Malformed classpath config carries resource and error data"
+    (let [path "config/adapter_claude_code/malformed-edn.txt"
+          url (temp-resource-url "{:broken")
+          ex (try
+               (with-redefs [io/resource (fn [requested-path]
+                                            (when (= path requested-path) url))]
+                 (#'discovery/load-config path [:k]))
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= path (:config/resource (ex-data ex))))
+      (is (= path (:classpath/resource (ex-data ex))))
+      (is (= :malformed-edn (:config/error (ex-data ex)))))))
+
+(deftest load-config-throws-on-non-map-test
+  (testing "Non-map classpath config carries resource and error data"
+    (let [path "config/adapter_claude_code/non-map.edn"
+          url (temp-resource-url "[:not :a :map]")
+          ex (try
+               (with-redefs [io/resource (fn [requested-path]
+                                            (when (= path requested-path) url))]
+                 (#'discovery/load-config path [:k]))
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= path (:config/resource (ex-data ex))))
+      (is (= path (:classpath/resource (ex-data ex))))
+      (is (= :not-a-map (:config/error (ex-data ex)))))))
 
 (deftest staleness-windows-loads-test
   (testing "Valid resource still loads the expected window keys"

--- a/docs/pull-requests/2026-06-28-chris-adapter-config-classpath-guards.md
+++ b/docs/pull-requests/2026-06-28-chris-adapter-config-classpath-guards.md
@@ -1,0 +1,35 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Adapter Config Classpath Guards
+
+## Summary
+
+Make Claude Code adapter config-shape failures explicit classpath config guards.
+
+## Motivation
+
+`ai.miniforge.adapter-claude-code.discovery/load-config` loads bundled EDN
+resources at namespace startup. Missing resources were already clear classpath
+guards, but malformed EDN and non-map config payloads were still reported as
+generic failures by the exception-as-data scanner. These are packaging/config
+integrity guards, not recoverable runtime errors.
+
+## Changes
+
+- Mark malformed EDN diagnostics as invalid classpath config resources.
+- Mark non-map config diagnostics as invalid classpath config resources.
+- Add `:classpath/resource` and `:config/error` data to those failures.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.adapter-claude-code.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.adapter-claude-code.interface-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
+```


### PR DESCRIPTION
## Summary
- Make Claude Code adapter malformed/non-map config diagnostics explicit classpath config guards.
- Read classpath config resources as UTF-8 before parsing and keep parse wrapping scoped to EDN parsing.
- Add :classpath/resource and :config/error data to those fail-fast config errors, with focused regression tests.

## Validation
- Adapter Claude Code interface tests: 17 tests / 36 assertions, 0 failures.
- Exception-as-data scanner: cleanup-needed drops 136 -> 134; no adapter discovery rows remain cleanup-needed.
- bb pre-commit