### PR TITLE
Mark connector config validation guards invalid

### DIFF
--- a/components/connector-gitlab/src/ai/miniforge/connector_gitlab/schema.clj
+++ b/components/connector-gitlab/src/ai/miniforge/connector_gitlab/schema.clj
@@ -52,6 +52,7 @@
     (response/throw-anomaly! :anomalies/incorrect
                              "GitLab config validation failed"
                              {:errors (me/humanize (m/explain schema value))
+                              :config/error :invalid-config
                               :value value}))
   value)
 

--- a/components/connector-gitlab/test/ai/miniforge/connector_gitlab/anomaly/gitlab_anomaly_test.clj
+++ b/components/connector-gitlab/test/ai/miniforge/connector_gitlab/anomaly/gitlab_anomaly_test.clj
@@ -48,6 +48,7 @@
       (is false "should have thrown")
       (catch ExceptionInfo e
         (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
+        (is (= :invalid-config (:config/error (ex-data e))))
         (is (some? (:errors (ex-data e))))))))
 
 (deftest load-resources-missing-edn-throws-anomaly

--- a/components/connector-jira/src/ai/miniforge/connector_jira/schema.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/schema.clj
@@ -114,6 +114,7 @@
     (response/throw-anomaly! :anomalies/incorrect
                              "Jira config validation failed"
                              {:errors (me/humanize (m/explain schema value))
+                              :config/error :invalid-config
                               :value value}))
   value)
 

--- a/components/connector-jira/test/ai/miniforge/connector_jira/anomaly/jira_anomaly_test.clj
+++ b/components/connector-jira/test/ai/miniforge/connector_jira/anomaly/jira_anomaly_test.clj
@@ -49,6 +49,7 @@
       (is false "should have thrown")
       (catch ExceptionInfo e
         (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
+        (is (= :invalid-config (:config/error (ex-data e))))
         (is (some? (:errors (ex-data e))))))))
 
 (deftest load-resources-missing-edn-throws-anomaly

--- a/docs/pull-requests/2026-06-28-chris-connector-config-invalid-guards.md
+++ b/docs/pull-requests/2026-06-28-chris-connector-config-invalid-guards.md
@@ -1,0 +1,38 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Connector Config Invalid Guards
+
+## Summary
+
+Mark GitLab and Jira connector schema validation failures as invalid config
+guards.
+
+## Motivation
+
+The GitLab and Jira connector `validate!` helpers are config boundary checks.
+They already throw structured anomaly data for invalid connector config, but the
+exception-as-data scanner could not distinguish them from ordinary recoverable
+runtime failures. Adding explicit `:config/error :invalid-config` data preserves
+the existing behavior while making the boundary intent visible.
+
+## Changes
+
+- Add `:config/error :invalid-config` to GitLab connector schema validation
+  failures.
+- Add `:config/error :invalid-config` to Jira connector schema validation
+  failures.
+- Extend the existing anomaly tests to assert the new ex-data key.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.connector-gitlab.anomaly.gitlab-anomaly-test 'ai.miniforge.connector-jira.anomaly.jira-anomaly-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.connector-gitlab.anomaly.gitlab-anomaly-test 'ai.miniforge.connector-jira.anomaly.jira-anomaly-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
+```


### PR DESCRIPTION
## Summary
- Add explicit :config/error :invalid-config data to GitLab connector config validation failures.
- Add explicit :config/error :invalid-config data to Jira connector config validation failures.
- Extend existing anomaly tests for both connector validation boundaries.

## Validation
- GitLab/Jira connector anomaly tests: 8 tests / 15 assertions, 0 failures.
- Exception-as-data scanner: cleanup-needed drops 134 -> 132; no GitLab/Jira schema rows remain cleanup-needed.
- bb pre-commit