### PR TITLE
Mark config resource parse guards invalid

### DIFF
--- a/components/config/src/ai/miniforge/config/resource.clj
+++ b/components/config/src/ai/miniforge/config/resource.clj
@@ -76,13 +76,23 @@
                       ;; propagate rather than wrap it as a parse error.
                       (.interrupt (Thread/currentThread))
                       (throw e))
+                    (catch java.io.IOException e
+                      (throw (ex-info (t :resource/malformed {:path path})
+                                      (assoc ex-data
+                                             :config/error :invalid-config
+                                             :config/invalid-config-reason :unreadable-resource)
+                                      e)))
                     (catch Exception e
                       (throw (ex-info (t :resource/malformed {:path path})
-                                      ex-data
+                                      (assoc ex-data
+                                             :config/error :invalid-config
+                                             :config/invalid-config-reason :malformed-edn)
                                       e))))]
        (when-not (map? parsed)
          (throw (ex-info (t :resource/not-a-map {:path path})
-                         ex-data)))
+                         (assoc ex-data
+                                :config/error :invalid-config
+                                :config/invalid-config-reason :not-a-map))))
        (let [missing (vec (remove #(contains? parsed %) required-keys))]
          (when (seq missing)
            (throw (ex-info (t :resource/missing-keys {:path path :keys missing})

--- a/components/config/test/ai/miniforge/config/resource_test.clj
+++ b/components/config/test/ai/miniforge/config/resource_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.config.resource-test
   (:require
    [ai.miniforge.config.resource :as resource]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]))
 
 ;; A real map resource shipped by this component, used for the happy path.
@@ -74,14 +75,33 @@
     (let [ex (try (resource/load-config-resource a-malformed-resource)
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (instance? clojure.lang.ExceptionInfo ex))
-      (is (= a-malformed-resource (:config/resource (ex-data ex)))))))
+      (is (= a-malformed-resource (:config/resource (ex-data ex))))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :malformed-edn (:config/invalid-config-reason (ex-data ex)))))))
+
+(deftest load-config-resource-unreadable-resource
+  (testing "distinguishes resource read failures from malformed EDN"
+    (let [missing-file-url (java.net.URL.
+                            (str "file:/tmp/miniforge-missing-"
+                                 (random-uuid)
+                                 ".edn"))
+          ex (with-redefs [io/resource (constantly missing-file-url)]
+               (try (resource/load-config-resource a-real-resource)
+                    (catch clojure.lang.ExceptionInfo e e)))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= a-real-resource (:config/resource (ex-data ex))))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :unreadable-resource
+             (:config/invalid-config-reason (ex-data ex)))))))
 
 (deftest load-config-resource-non-map
   (testing "throws when the EDN parses to a non-map value"
     (let [ex (try (resource/load-config-resource a-non-map-resource)
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (instance? clojure.lang.ExceptionInfo ex))
-      (is (= a-non-map-resource (:config/resource (ex-data ex)))))))
+      (is (= a-non-map-resource (:config/resource (ex-data ex))))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :not-a-map (:config/invalid-config-reason (ex-data ex)))))))
 
 (deftest read-config-resource-or-fail-open
   (testing "returns the fallback for a missing resource"

--- a/docs/pull-requests/2026-06-28-chris-config-resource-error-markers.md
+++ b/docs/pull-requests/2026-06-28-chris-config-resource-error-markers.md
@@ -1,0 +1,37 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark Config Resource Parse Guards Invalid
+
+## Summary
+
+Mark malformed EDN and non-map classpath config resources as explicit
+invalid-config failures.
+
+## Motivation
+
+The shared classpath config resource loader already fails fast when required
+config resources are malformed or parse to non-map values. Those are boot-time
+configuration contract failures, not recoverable runtime outcomes. Adding
+explicit invalid-config ex-data makes that intent visible to the standards
+scanner while preserving the precise parse reason for diagnostics.
+
+## Changes
+
+- Add `:config/error :invalid-config` for malformed EDN and non-map resources.
+- Add `:config/invalid-config-reason` to preserve `:malformed-edn` and
+  `:not-a-map`.
+- Extend the existing config resource tests for the new ex-data contract.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.config.resource-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.config.resource-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
+```


### PR DESCRIPTION
## Summary
- mark malformed EDN and non-map classpath config resources as explicit invalid-config failures
- preserve the specific invalid config reason in ex-data
- extend config resource tests for the new data contract

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.config.resource-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.config.resource-test)"
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
- bb pre-commit