### PR TITLE
Mark governance config guards invalid

### DIFF
--- a/components/config/src/ai/miniforge/config/governance.clj
+++ b/components/config/src/ai/miniforge/config/governance.clj
@@ -176,23 +176,27 @@
         (when (not= :trusted trust-level)
           (throw (ex-info "Only :trusted packs can carry config overrides"
                           {:pack-id (:pack/id pack)
-                           :trust-level trust-level})))
+                           :trust-level trust-level
+                           :config/error :invalid-config
+                           :config/invalid-config-reason :untrusted-pack-overrides})))
         (if (= config-key :knowledge-safety)
           ;; Safety check: count patterns before/after, reject if any category shrinks
           (let [before-categories (:injection-patterns base-config)
                 merged (deep-merge base-config overrides)
                 after-categories (:injection-patterns merged)]
             (doseq [[cat-key before-patterns] before-categories]
-              (let [after-patterns (get after-categories cat-key)]
-                (when (and after-patterns
-                           (< (count after-patterns) (count before-patterns)))
+              (let [after-patterns (get after-categories cat-key)
+                    after-count    (count after-patterns)]
+                (when (< after-count (count before-patterns))
                   (throw (ex-info (str "Knowledge-safety pattern category " (name cat-key)
                                        " would shrink from " (count before-patterns)
-                                       " to " (count after-patterns) " patterns. "
+                                       " to " after-count " patterns. "
                                        "Only additive overrides are allowed.")
                                   {:category cat-key
                                    :before-count (count before-patterns)
-                                   :after-count (count after-patterns)})))))
+                                   :after-count after-count
+                                   :config/error :invalid-config
+                                   :config/invalid-config-reason :knowledge-safety-pattern-shrink})))))
             merged)
           ;; Non-safety configs: merge freely
           (deep-merge base-config overrides))))))
@@ -222,7 +226,9 @@
          resource-config (load-resource-config config-key profile)]
      (when-not resource-config
        (throw (ex-info (str "Governance config not found: " (name config-key))
-                       {:config-key config-key})))
+                       {:config-key config-key
+                        :config/error :invalid-config
+                        :config/invalid-config-reason :unknown-governance-config})))
      ;; Digest verification (before any merging)
      (when-not (:skip-digest? opts)
        (let [filename (get config-key->filename config-key)

--- a/components/config/test/ai/miniforge/config/governance_test.clj
+++ b/components/config/test/ai/miniforge/config/governance_test.clj
@@ -109,8 +109,13 @@
 
 (deftest load-governance-config-unknown-key-test
   (testing "throws for unknown config key"
-    (is (thrown? clojure.lang.ExceptionInfo
-                (gov/load-governance-config :nonexistent {:skip-digest? true})))))
+    (let [ex (try (gov/load-governance-config :nonexistent {:skip-digest? true})
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= :nonexistent (:config-key (ex-data ex))))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :unknown-governance-config
+             (:config/invalid-config-reason (ex-data ex)))))))
 
 ;------------------------------------------------------------------------------ Regex Compilation
 
@@ -155,9 +160,15 @@
     (let [base {:merge-threshold 0.85}
           pack {:pack/id "test"
                 :pack/trust-level :untrusted
-                :pack/config-overrides {:readiness {:merge-threshold 0.50}}}]
-      (is (thrown? clojure.lang.ExceptionInfo
-                  (gov/apply-pack-overrides :readiness base pack)))))
+                :pack/config-overrides {:readiness {:merge-threshold 0.50}}}
+          ex (try (gov/apply-pack-overrides :readiness base pack)
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= "test" (:pack-id (ex-data ex))))
+      (is (= :untrusted (:trust-level (ex-data ex))))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :untrusted-pack-overrides
+             (:config/invalid-config-reason (ex-data ex))))))
 
   (testing "returns base config when pack has no overrides for key"
     (let [base {:merge-threshold 0.85}
@@ -185,9 +196,34 @@
                 :pack/trust-level :trusted
                 :pack/config-overrides
                 {:knowledge-safety
-                 {:injection-patterns {:role-hijacking ["a"]}}}}]
-      (is (thrown? clojure.lang.ExceptionInfo
-                  (gov/apply-pack-overrides :knowledge-safety base pack))))))
+                 {:injection-patterns {:role-hijacking ["a"]}}}}
+          ex (try (gov/apply-pack-overrides :knowledge-safety base pack)
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= :role-hijacking (:category (ex-data ex))))
+      (is (= 3 (:before-count (ex-data ex))))
+      (is (= 1 (:after-count (ex-data ex))))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :knowledge-safety-pattern-shrink
+             (:config/invalid-config-reason (ex-data ex))))))
+
+  (testing "rejects knowledge-safety overrides that remove a category"
+    (let [base {:injection-patterns {:role-hijacking ["a" "b"]
+                                     :jailbreak ["d"]}}
+          pack {:pack/id "test"
+                :pack/trust-level :trusted
+                :pack/config-overrides
+                {:knowledge-safety
+                 {:injection-patterns {:role-hijacking nil}}}}
+          ex (try (gov/apply-pack-overrides :knowledge-safety base pack)
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= :role-hijacking (:category (ex-data ex))))
+      (is (= 2 (:before-count (ex-data ex))))
+      (is (= 0 (:after-count (ex-data ex))))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :knowledge-safety-pattern-shrink
+             (:config/invalid-config-reason (ex-data ex)))))))
 
 ;------------------------------------------------------------------------------ Regression: Values Match Original Hardcoded Defaults
 

--- a/docs/pull-requests/2026-06-28-chris-governance-config-error-markers.md
+++ b/docs/pull-requests/2026-06-28-chris-governance-config-error-markers.md
@@ -1,0 +1,37 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark Governance Config Guards Invalid
+
+## Summary
+
+Mark governance config guard failures as explicit invalid-config failures.
+
+## Motivation
+
+Governance pack overrides and governance config lookup are configuration
+contract checks. Untrusted pack overrides, shrinking knowledge-safety patterns,
+and unknown governance config keys should fail fast as invalid configuration
+rather than look like ordinary recoverable runtime exceptions in the standards
+scanner.
+
+## Changes
+
+- Add `:config/error :invalid-config` to untrusted pack override failures.
+- Add `:config/error :invalid-config` to knowledge-safety pattern shrink
+  failures.
+- Add `:config/error :invalid-config` to unknown governance config keys.
+- Preserve precise `:config/invalid-config-reason` values and extend tests.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.config.governance-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.config.governance-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
+```


### PR DESCRIPTION
## Summary
- mark governance config guard failures as explicit invalid-config failures
- preserve precise invalid-config reasons for untrusted overrides, knowledge-safety shrink, and unknown keys
- extend governance config tests for the new data contract

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.config.governance-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.config.governance-test)"
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
- bb pre-commit