### PR TITLE
Mark Excel config guards invalid

### DIFF
--- a/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
@@ -22,11 +22,10 @@
   (:require [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-excel.messages :as msg]
             [ai.miniforge.response.interface :as response]
-            [ai.miniforge.schema.interface :as schema]
             [babashka.http-client :as http])
   (:import [java.io File FileOutputStream]
            [java.util UUID]
-           [org.apache.poi.ss.usermodel WorkbookFactory Cell CellType DateUtil]))
+           [org.apache.poi.ss.usermodel WorkbookFactory Cell DateUtil]))
 
 ;; -- Handle state --
 
@@ -88,7 +87,9 @@
                      records))))))
     (response/throw-anomaly! :anomalies/not-found
                              (msg/t :excel/sheet-not-found {:sheet sheet-name})
-                             {:sheet sheet-name})))
+                             {:sheet sheet-name
+                              :config/error :invalid-config
+                              :config/invalid-config-reason :missing-excel-sheet})))
 
 ;; -- Filtering --
 
@@ -147,13 +148,19 @@
     (cond
       (nil? url)        (response/throw-anomaly! :anomalies/incorrect
                                                  (msg/t :excel/url-required)
-                                                 {:config config})
+                                                 {:config config
+                                                  :config/error :invalid-config
+                                                  :config/invalid-config-reason :missing-excel-url})
       (nil? sheet-name) (response/throw-anomaly! :anomalies/incorrect
                                                  (msg/t :excel/sheet-required)
-                                                 {:config config})
+                                                 {:config config
+                                                  :config/error :invalid-config
+                                                  :config/invalid-config-reason :missing-excel-sheet-name})
       (nil? columns)    (response/throw-anomaly! :anomalies/incorrect
                                                  (msg/t :excel/columns-required)
-                                                 {:config config})
+                                                 {:config config
+                                                  :config/error :invalid-config
+                                                  :config/invalid-config-reason :missing-excel-columns})
       :else
       (let [handle (str (UUID/randomUUID))
             tmp-file (download-to-temp url)

--- a/components/connector-excel/test/ai/miniforge/connector_excel/anomaly/excel_anomaly_test.clj
+++ b/components/connector-excel/test/ai/miniforge/connector_excel/anomaly/excel_anomaly_test.clj
@@ -33,7 +33,10 @@
       (impl/do-connect {:excel/sheet-name "Sheet1" :excel/columns {0 :a}} nil)
       (is false "should have thrown")
       (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
+        (is (= :invalid-config (:config/error (ex-data e))))
+        (is (= :missing-excel-url
+               (:config/invalid-config-reason (ex-data e))))))))
 
 (deftest do-connect-missing-sheet-throws-anomaly
   (testing "missing :excel/sheet-name raises :anomalies/incorrect"
@@ -41,7 +44,10 @@
       (impl/do-connect {:excel/url "http://x/y.xls" :excel/columns {0 :a}} nil)
       (is false "should have thrown")
       (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
+        (is (= :invalid-config (:config/error (ex-data e))))
+        (is (= :missing-excel-sheet-name
+               (:config/invalid-config-reason (ex-data e))))))))
 
 (deftest do-connect-missing-columns-throws-anomaly
   (testing "missing :excel/columns raises :anomalies/incorrect"
@@ -49,7 +55,10 @@
       (impl/do-connect {:excel/url "http://x/y.xls" :excel/sheet-name "Sheet1"} nil)
       (is false "should have thrown")
       (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
+        (is (= :invalid-config (:config/error (ex-data e))))
+        (is (= :missing-excel-columns
+               (:config/invalid-config-reason (ex-data e))))))))
 
 (deftest parse-sheet-missing-sheet-throws-anomaly
   (testing "requesting a sheet absent from the workbook raises :anomalies/not-found"
@@ -61,7 +70,10 @@
           (is false "should have thrown")
           (catch ExceptionInfo e
             (is (= :anomalies/not-found (:anomaly/category (ex-data e))))
-            (is (= "Missing" (:sheet (ex-data e))))))
+            (is (= "Missing" (:sheet (ex-data e))))
+            (is (= :invalid-config (:config/error (ex-data e))))
+            (is (= :missing-excel-sheet
+                   (:config/invalid-config-reason (ex-data e))))))
         (finally
           (.close wb))))))
 

--- a/docs/pull-requests/2026-06-28-chris-excel-config-error-markers.md
+++ b/docs/pull-requests/2026-06-28-chris-excel-config-error-markers.md
@@ -1,0 +1,36 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark Excel Config Guards Invalid
+
+## Summary
+
+Mark Excel connector configuration guard failures as explicit invalid-config
+failures.
+
+## Motivation
+
+Excel connector setup failures such as missing required config fields or a
+configured sheet absent from the workbook are connector configuration contract
+failures. They should carry explicit invalid-config data while preserving the
+existing anomaly categories used by callers.
+
+## Changes
+
+- Add invalid-config ex-data for missing Excel URL, sheet name, and columns.
+- Add invalid-config ex-data when the configured sheet is absent from the
+  workbook.
+- Extend Excel anomaly tests for the new data contract.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.connector-excel.anomaly.excel-anomaly-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.connector-excel.anomaly.excel-anomaly-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
+```


### PR DESCRIPTION
## Summary
- mark Excel connector config guard failures as explicit invalid-config failures
- preserve field-specific invalid-config reasons for missing URL, sheet name, columns, and missing workbook sheet
- extend Excel anomaly tests for the new data contract

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.connector-excel.anomaly.excel-anomaly-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.connector-excel.anomaly.excel-anomaly-test)"
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
- bb pre-commit