### PR TITLE
Mark policy calibration config guard invalid

### DIFF
--- a/components/policy-calibration/src/ai/miniforge/policy_calibration/config.clj
+++ b/components/policy-calibration/src/ai/miniforge/policy_calibration/config.clj
@@ -1,3 +1,21 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 (ns ai.miniforge.policy-calibration.config
   "Calibration configuration as data: read + Malli-validate config.edn."
   (:require [malli.core :as m]
@@ -19,16 +37,52 @@
 
 (def ^:private config-resource "policy-calibration/config.edn")
 
+(defn- invalid-config-ex
+  [message reason data cause]
+  (ex-info message
+           (merge {:classpath/resource config-resource
+                   :config/error :invalid-config
+                   :config/invalid-config-reason reason}
+                  data)
+           cause))
+
 (defn load-config
   "Read and validate the calibration config from the classpath. Throws
-   IllegalArgumentException on a malformed config (a setup/programmer error)."
+   ex-info on malformed config (a setup/programmer error)."
   []
-  (let [cfg (edn/read-string (slurp (io/resource config-resource)))]
-    (when-not (m/validate Config cfg)
-      (throw (IllegalArgumentException.
-              (str "invalid policy-calibration config: "
-                   (pr-str (m/explain Config cfg))))))
-    cfg))
+  (let [resource (io/resource config-resource)]
+    (when-not resource
+      (throw (invalid-config-ex "Missing policy-calibration config resource"
+                                :missing-resource
+                                {}
+                                nil)))
+    (let [cfg (try
+                (edn/read-string (slurp resource :encoding "UTF-8"))
+                (catch java.io.IOException e
+                  (throw (invalid-config-ex "Unreadable policy-calibration config resource"
+                                            :unreadable-resource
+                                            {}
+                                            e)))
+                (catch InterruptedException e
+                  (.interrupt (Thread/currentThread))
+                  (throw e))
+                (catch Exception e
+                  (throw (invalid-config-ex "Malformed policy-calibration config resource"
+                                            :malformed-edn
+                                            {}
+                                            e))))]
+      (when-not (map? cfg)
+        (throw (invalid-config-ex "Policy-calibration config must be a map"
+                                  :not-a-map
+                                  {:value cfg}
+                                  nil)))
+      (when-not (m/validate Config cfg)
+        (throw (invalid-config-ex "Invalid policy-calibration config"
+                                  :schema-validation
+                                  {:errors (m/explain Config cfg)
+                                   :value cfg}
+                                  nil)))
+      cfg)))
 
 (comment
   (load-config)

--- a/components/policy-calibration/test/ai/miniforge/policy_calibration/interface_test.clj
+++ b/components/policy-calibration/test/ai/miniforge/policy_calibration/interface_test.clj
@@ -1,10 +1,92 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 (ns ai.miniforge.policy-calibration.interface-test
-  (:require [ai.miniforge.policy-calibration.interface :as sut]
+  (:require [ai.miniforge.policy-calibration.config :as config]
+            [ai.miniforge.policy-calibration.interface :as sut]
+            [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]))
 
 (def ^:private bar {:max-clean-fp 0 :min-recall 0.8})
 
 (defn- cell-at [cells] (fn [rel t] (get cells [rel t])))
+
+(defn- temp-resource-url
+  [content]
+  (let [f (java.io.File/createTempFile "policy-calibration-config-" ".edn")]
+    (.deleteOnExit f)
+    (spit f content)
+    (.toURL (.toURI f))))
+
+(defn- unreadable-resource-url
+  []
+  (java.net.URL.
+   nil
+   "memory://policy-calibration-config-unreadable"
+   (proxy [java.net.URLStreamHandler] []
+     (openConnection [url]
+       (proxy [java.net.URLConnection] [url]
+         (connect [])
+         (getInputStream []
+           (throw (java.io.IOException. "unreadable"))))))))
+
+(deftest load-config-invalid-resource-test
+  (testing "missing config resource carries invalid-config ex-data"
+    (let [ex (with-redefs [io/resource (constantly nil)]
+               (try (config/load-config)
+                    (catch clojure.lang.ExceptionInfo e e)))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= "policy-calibration/config.edn" (:classpath/resource (ex-data ex))))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :missing-resource (:config/invalid-config-reason (ex-data ex))))))
+
+  (testing "malformed EDN carries invalid-config ex-data"
+    (let [ex (with-redefs [io/resource (constantly (temp-resource-url "{"))]
+               (try (config/load-config)
+                    (catch clojure.lang.ExceptionInfo e e)))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :malformed-edn (:config/invalid-config-reason (ex-data ex))))))
+
+  (testing "unreadable resource carries invalid-config ex-data"
+    (let [ex (with-redefs [io/resource (constantly (unreadable-resource-url))]
+               (try (config/load-config)
+                    (catch clojure.lang.ExceptionInfo e e)))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :unreadable-resource (:config/invalid-config-reason (ex-data ex))))))
+
+  (testing "non-map EDN carries invalid-config ex-data"
+    (let [ex (with-redefs [io/resource (constantly (temp-resource-url "[]"))]
+               (try (config/load-config)
+                    (catch clojure.lang.ExceptionInfo e e)))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :not-a-map (:config/invalid-config-reason (ex-data ex))))))
+
+  (testing "schema-invalid config carries invalid-config ex-data"
+    (let [ex (with-redefs [io/resource (constantly (temp-resource-url "{}"))]
+               (try (config/load-config)
+                    (catch clojure.lang.ExceptionInfo e e)))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (is (= :invalid-config (:config/error (ex-data ex))))
+      (is (= :schema-validation (:config/invalid-config-reason (ex-data ex))))
+      (is (some? (:errors (ex-data ex)))))))
 
 (deftest score-rule-clean-and-violating-test
   (testing "0 false-positives + full recall -> gate-ready"

--- a/docs/pull-requests/2026-06-28-chris-policy-calibration-config-guard.md
+++ b/docs/pull-requests/2026-06-28-chris-policy-calibration-config-guard.md
@@ -1,0 +1,43 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark Policy Calibration Config Guard Invalid
+
+## Summary
+
+Mark policy-calibration config resource failures as explicit invalid-config
+setup failures.
+
+## Motivation
+
+Policy calibration loads a required classpath config resource during setup.
+Missing resources, unreadable resources, malformed EDN, non-map EDN, and
+schema-invalid maps are configuration contract failures. They should carry
+explicit invalid-config data rather than appearing as ordinary recoverable
+runtime exceptions.
+
+## Changes
+
+- Replace the `IllegalArgumentException` schema failure with `ex-info` carrying
+  invalid-config ex-data.
+- Distinguish missing, unreadable, malformed, non-map, and schema-invalid
+  resource states.
+- Add focused regression coverage for each invalid resource path.
+- Add standard Clojure file headers to the touched policy-calibration files.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.policy-calibration.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.policy-calibration.interface-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
+```
+
+```bash
+bb pre-commit
+```


### PR DESCRIPTION
## Summary
- mark policy-calibration config resource failures as explicit invalid-config setup failures
- distinguish missing, unreadable, malformed, non-map, and schema-invalid resource states
- add focused regression coverage and standard headers to touched Clojure files

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.policy-calibration.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.policy-calibration.interface-test)"
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :cleanup-needed (count cleanup)))'
- bb pre-commit