### PR TITLE
Return policy pack registry anomalies

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -118,7 +118,7 @@
 (def register-pack
   "Protocol fn. (register-pack registry pack) registers a pack (or new
    version), keyed by :pack/id and :pack/version. Returns the registered pack;
-   throws an :anomalies/incorrect anomaly when the pack fails schema validation."
+   returns an :invalid-input anomaly map when the pack fails schema validation."
   registry/register-pack)
 
 (def get-pack

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/registry.clj
@@ -37,7 +37,7 @@
 (def register-pack
   "Protocol fn. (register-pack registry pack) registers a pack (or new
    version), keyed by :pack/id and :pack/version. Returns the registered pack;
-   throws an :anomalies/incorrect anomaly when the pack fails schema validation."
+   returns an :invalid-input anomaly map when the pack fails schema validation."
   registry/register-pack)
 
 (def get-pack

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
@@ -23,6 +23,7 @@
    Layer 1: In-memory registry implementation
    Layer 2: Registry constructors"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.policy-pack.crypto :as crypto]
    [ai.miniforge.policy-pack.schema :as schema]
    [ai.miniforge.response.interface :as response]
@@ -40,7 +41,7 @@
   ;; CRUD
   (register-pack [this pack]
     "Register a new pack or new version of existing pack.
-     Returns the registered pack.")
+     Returns the registered pack or an anomaly map on validation failure.")
 
   (get-pack [this pack-id]
     "Get latest version of pack.
@@ -73,7 +74,8 @@
   (export-pack [this pack-id version format]
     "Export pack to specified format.
      Format: :edn, :json, or :directory
-     Returns exported data as string or map.")
+     Returns exported data as string/map, or an anomaly map when the pack
+     is not found.")
 
   ;; Validation
   (validate-pack [this pack]
@@ -199,10 +201,11 @@
               version (:pack/version pack)]
           (swap! state assoc-in [:packs pack-id version] pack)
           pack)
-        (response/throw-anomaly! :anomalies/incorrect
-                                 "Invalid pack schema"
-                                 {:errors errors
-                                  :pack-id (:pack/id pack)}))))
+        (anomaly/sub-anomaly :invalid-input
+                             :anomalies/incorrect
+                             "Invalid pack schema"
+                             {:errors errors
+                              :pack-id (:pack/id pack)}))))
 
   (get-pack [this pack-id]
     (let [versions (get-in @state [:packs pack-id])]
@@ -276,10 +279,11 @@
         (response/throw-anomaly! :anomalies/incorrect
                                  "Unknown export format"
                                  {:format format}))
-      (response/throw-anomaly! :anomalies/not-found
-                               "Pack not found"
-                               {:pack-id pack-id
-                                :version version})))
+      (anomaly/sub-anomaly :not-found
+                           :anomalies/not-found
+                           "Pack not found"
+                           {:pack-id pack-id
+                            :version version})))
 
   (validate-pack [_this pack]
     (schema/validate-pack pack))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/anomaly/registry_anomaly_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/anomaly/registry_anomaly_test.clj
@@ -17,15 +17,12 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.policy-pack.anomaly.registry-anomaly-test
-  "Coverage for `policy-pack/registry` boundary escalation via
-   `response/throw-anomaly!`.
+  "Coverage for `policy-pack/registry` anomaly behavior.
 
-   Pre-cleanup, each site was a raw `(throw (ex-info ...))`. Post-
-   cleanup, throws route through the canonical
-   `response/throw-anomaly!` carrying typed anomaly categories
-   (`:anomalies/incorrect`, `:anomalies/unsupported`,
-   `:anomalies/not-found`)."
+   Validation/not-found failures return anomaly maps. Unsupported and
+   intentionally unimplemented surfaces still throw typed anomalies."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.policy-pack.registry :as registry])
   (:import
@@ -36,25 +33,21 @@
 
 ;------------------------------------------------------------------------------ register-pack — invalid schema
 
-(deftest register-pack-invalid-schema-throws-anomaly
-  (testing "schema-invalid pack raises :anomalies/incorrect"
+(deftest register-pack-invalid-schema-returns-anomaly
+  (testing "schema-invalid pack returns :invalid-input / :anomalies/incorrect"
     (let [reg    (new-registry)
-          thrown (try (registry/register-pack reg {:pack/id :bad-pack}) nil (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"Invalid pack schema" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+          result (registry/register-pack reg {:pack/id :bad-pack})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :anomalies/incorrect (:anomaly/subtype result)))
+      (is (= "Invalid pack schema" (:anomaly/message result))))))
 
 (deftest register-pack-anomaly-carries-pack-id
-  (testing "anomaly ex-data carries :pack-id, :errors, and :anomalies/incorrect category"
-    (let [reg (new-registry)
-          thrown (try
-                   (registry/register-pack reg {:pack/id :bad})
-                   nil
-                   (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (= :bad (:pack-id (ex-data thrown))))
-      (is (contains? (ex-data thrown) :errors))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+  (testing "anomaly data carries :pack-id and schema errors"
+    (let [reg    (new-registry)
+          result (registry/register-pack reg {:pack/id :bad})]
+      (is (= :bad (get-in result [:anomaly/data :pack-id])))
+      (is (contains? (:anomaly/data result) :errors)))))
 
 ;------------------------------------------------------------------------------ import-pack — unsupported source
 
@@ -68,13 +61,14 @@
 
 ;------------------------------------------------------------------------------ export-pack — pack not found
 
-(deftest export-pack-not-found-throws-anomaly
-  (testing "missing pack raises :anomalies/not-found"
+(deftest export-pack-not-found-returns-anomaly
+  (testing "missing pack returns :not-found / :anomalies/not-found"
     (let [reg    (new-registry)
-          thrown (try (registry/export-pack reg :missing "1.0.0" :edn) nil (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"Pack not found" (.getMessage thrown)))
-      (is (= :anomalies/not-found (:anomaly/category (ex-data thrown)))))))
+          result (registry/export-pack reg :missing "1.0.0" :edn)]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= :anomalies/not-found (:anomaly/subtype result)))
+      (is (= {:pack-id :missing :version "1.0.0"} (:anomaly/data result))))))
 
 ;------------------------------------------------------------------------------ export-pack — unsupported / unknown formats
 

--- a/docs/pull-requests/2026-06-28-chris-policy-pack-registry-anomalies.md
+++ b/docs/pull-requests/2026-06-28-chris-policy-pack-registry-anomalies.md
@@ -1,0 +1,43 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Return Policy Pack Registry Anomalies
+
+## Summary
+
+Return anomaly maps for policy-pack registry validation and not-found outcomes.
+
+## Motivation
+
+The in-memory policy-pack registry still escalated ordinary validation and
+lookup failures via `response/throw-anomaly!` inside a non-boundary namespace.
+Those outcomes are data-level registry results, not process-fatal programmer
+guards, and should be represented as anomaly maps so callers can compose them.
+
+## Changes
+
+- Return `:invalid-input` / `:anomalies/incorrect` anomaly data when
+  `register-pack` receives a schema-invalid pack.
+- Return `:not-found` / `:anomalies/not-found` anomaly data when `export-pack`
+  targets a missing pack.
+- Update public registry docs and regression coverage for the returned anomaly
+  shape.
+- Leave unsupported and not-yet-implemented registry surfaces as fatal-only
+  programmer guards.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.policy-pack.anomaly.registry-anomaly-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.policy-pack.anomaly.registry-anomaly-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner]) (quote [clojure.string :as str])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :policy-pack-registry (count (filter #(= "components/policy-pack/src/ai/miniforge/policy_pack/registry.clj" (:file %)) cleanup))))'
+```
+
+```bash
+bb pre-commit
+```


### PR DESCRIPTION
## Summary
- return anomaly maps for policy-pack registry validation failures and missing export targets
- update registry docs/tests for the returned anomaly shape
- leave unsupported/unimplemented registry surfaces as fatal-only programmer guards

## Validation
- clojure -M:dev:test -e '(require (quote [ai.miniforge.policy-pack.anomaly.registry-anomaly-test]) (quote [clojure.test :as t])) (t/run-tests (quote ai.miniforge.policy-pack.anomaly.registry-anomaly-test))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.policy-pack.interface-test]) (quote [ai.miniforge.policy-pack.anomaly.registry-anomaly-test]) (quote [clojure.test :as t])) (t/run-tests (quote ai.miniforge.policy-pack.interface-test) (quote ai.miniforge.policy-pack.anomaly.registry-anomaly-test))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner]) (quote [clojure.string :as str])) (let [r (scanner/scan-exceptions-as-data .) cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r)) policy (filter #(= components/policy-pack/src/ai/miniforge/policy_pack/registry.clj (:file %)) cleanup)] (println :cleanup-needed (count cleanup)) (println :policy-pack-registry (count policy)))'
- bb pre-commit