### PR TITLE
Return tool registry anomalies

### DIFF
--- a/components/tool-registry/src/ai/miniforge/tool_registry/interface.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/interface.clj
@@ -108,8 +108,9 @@
    - registry - ToolRegistry instance
    - tool     - Tool configuration map
 
-   Returns the tool ID on success.
-   Throws if tool config is invalid.
+   Returns the tool ID on success or an anomaly map when tool config is invalid.
+   Throws when :tool/id is not a namespaced keyword, because that is a registry
+   shape invariant.
 
    Example:
      (register! registry {:tool/id :lsp/python
@@ -173,7 +174,8 @@
    - tool-id  - Tool identifier
    - updates  - Map of updates to merge
 
-   Returns updated tool configuration."
+   Returns updated tool configuration or an anomaly map when the tool is missing
+   or the merged configuration is invalid."
   [registry tool-id updates]
   (registry/update-tool registry tool-id updates))
 

--- a/components/tool-registry/src/ai/miniforge/tool_registry/registry.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/registry.clj
@@ -24,6 +24,7 @@
    Layer 2: Query and filter operations
    Layer 3: Status and statistics"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.tool-registry.schema :as schema]
    [ai.miniforge.logging.interface :as log]
@@ -34,12 +35,16 @@
 
 (defprotocol ToolRegistry
   "Protocol for tool registration and lookup."
-  (register-tool [this tool] "Register a tool in the registry.")
+  (register-tool [this tool]
+    "Register a tool in the registry. Returns the tool id or an anomaly map.
+     Throws when :tool/id is not a namespaced keyword, because that is a
+     registry shape invariant.")
   (unregister-tool [this tool-id] "Remove a tool from the registry.")
   (get-tool [this tool-id] "Retrieve a tool by ID.")
   (list-tools [this] "List all registered tools.")
   (find-tools [this query] "Find tools matching query.")
-  (update-tool [this tool-id updates] "Update a tool's configuration.")
+  (update-tool [this tool-id updates]
+    "Update a tool's configuration. Returns the updated tool or an anomaly map.")
   (clear-tools [this] "Remove all tools from the registry."))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -50,23 +55,25 @@
 
   (register-tool [_this tool]
     (let [{:keys [valid? errors]} (schema/validate-tool tool)]
-      (when-not valid?
-        (response/throw-anomaly! :anomalies/incorrect
-                                 "Invalid tool configuration"
-                                 {:tool-id (:tool/id tool)
-                                  :errors errors}))
-      (when-not (schema/valid-tool-id? (:tool/id tool))
-        (response/throw-anomaly! :anomalies/incorrect
-                                 "Tool ID must be a namespaced keyword"
-                                 {:tool-id (:tool/id tool)}))
-      (let [normalized (schema/normalize-tool tool)
-            tool-id (:tool/id normalized)
-            logger (:logger @state)]
-        (swap! (:tools @state) assoc tool-id normalized)
-        (when logger
-          (log/debug logger :system :tool-registry/registered
-                     {:data {:tool-id tool-id}}))
-        tool-id)))
+      (if-not valid?
+        (anomaly/sub-anomaly :invalid-input
+                             :anomalies/incorrect
+                             "Invalid tool configuration"
+                             {:tool-id (:tool/id tool)
+                              :errors errors})
+        (do
+          (when-not (schema/valid-tool-id? (:tool/id tool))
+            (response/throw-anomaly! :anomalies/incorrect
+                                     "Tool ID must be a namespaced keyword"
+                                     {:tool-id (:tool/id tool)}))
+          (let [normalized (schema/normalize-tool tool)
+                tool-id (:tool/id normalized)
+                logger (:logger @state)]
+            (swap! (:tools @state) assoc tool-id normalized)
+            (when logger
+              (log/debug logger :system :tool-registry/registered
+                         {:data {:tool-id tool-id}}))
+            tool-id)))))
 
   (unregister-tool [_this tool-id]
     (let [logger (:logger @state)]
@@ -113,18 +120,28 @@
 
   (update-tool [_this tool-id updates]
     (let [current (get @(:tools @state) tool-id)]
-      (when-not current
-        (response/throw-anomaly! :anomalies/not-found
-                                 "Tool not found"
-                                 {:tool-id tool-id}))
-      (let [updated (merge current updates)
-            {:keys [valid? errors]} (schema/validate-tool updated)]
-        (when-not valid?
-          (response/throw-anomaly! :anomalies/incorrect
+      (if-not current
+        (anomaly/sub-anomaly :not-found
+                             :anomalies/not-found
+                             "Tool not found"
+                             {:tool-id tool-id})
+        (if (and (contains? updates :tool/id)
+                 (not= tool-id (:tool/id updates)))
+          (anomaly/sub-anomaly :invalid-input
+                               :anomalies/incorrect
+                               "Tool ID cannot be changed"
+                               {:tool-id tool-id
+                                :requested-tool-id (:tool/id updates)})
+          (let [updated (merge current updates)
+                {:keys [valid? errors]} (schema/validate-tool updated)]
+            (if-not valid?
+              (anomaly/sub-anomaly :invalid-input
+                                   :anomalies/incorrect
                                    "Invalid update"
-                                   {:tool-id tool-id :errors errors}))
-        (swap! (:tools @state) assoc tool-id updated)
-        updated)))
+                                   {:tool-id tool-id :errors errors})
+              (do
+                (swap! (:tools @state) assoc tool-id updated)
+                updated)))))))
 
   (clear-tools [_this]
     (reset! (:tools @state) {})))

--- a/components/tool-registry/test/ai/miniforge/tool_registry/anomaly/registry_anomaly_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/anomaly/registry_anomaly_test.clj
@@ -17,14 +17,12 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.tool-registry.anomaly.registry-anomaly-test
-  "Coverage for `tool-registry/registry` boundary escalation via
-   `response/throw-anomaly!`.
+  "Coverage for `tool-registry/registry` anomaly behavior.
 
-   Pre-cleanup, each site was a raw `(throw (ex-info ...))`. Post-
-   cleanup, throws route through the canonical
-   `response/throw-anomaly!` carrying typed anomaly categories
-   (`:anomalies/incorrect`, `:anomalies/not-found`)."
+   Validation/not-found failures return anomaly maps. Hard registry shape
+   invariants still throw typed anomalies."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.tool-registry.registry :as registry])
   (:import
@@ -35,25 +33,21 @@
 
 ;------------------------------------------------------------------------------ register-tool — invalid configuration
 
-(deftest register-tool-invalid-config-throws-anomaly
-  (testing "schema-invalid tool raises :anomalies/incorrect"
+(deftest register-tool-invalid-config-returns-anomaly
+  (testing "schema-invalid tool returns :invalid-input / :anomalies/incorrect"
     (let [reg    (new-registry)
-          thrown (try (registry/register-tool reg {}) nil (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"Invalid tool configuration" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+          result (registry/register-tool reg {})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :anomalies/incorrect (:anomaly/subtype result)))
+      (is (= "Invalid tool configuration" (:anomaly/message result))))))
 
 (deftest register-tool-invalid-config-carries-errors
-  (testing "anomaly ex-data carries :tool-id and :errors"
-    (let [reg (new-registry)
-          thrown (try
-                   (registry/register-tool reg {:tool/id :no/such-tool})
-                   nil
-                   (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (= :no/such-tool (:tool-id (ex-data thrown))))
-      (is (contains? (ex-data thrown) :errors))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+  (testing "anomaly data carries :tool-id and schema errors"
+    (let [reg    (new-registry)
+          result (registry/register-tool reg {:tool/id :no/such-tool})]
+      (is (= :no/such-tool (get-in result [:anomaly/data :tool-id])))
+      (is (contains? (:anomaly/data result) :errors)))))
 
 ;------------------------------------------------------------------------------ register-tool — invalid tool id shape
 
@@ -70,21 +64,49 @@
 
 ;------------------------------------------------------------------------------ update-tool — tool not found
 
-(deftest update-tool-not-found-throws-anomaly
-  (testing "missing tool raises :anomalies/not-found"
-    (let [reg (new-registry)]
-      (is (thrown-with-msg?
-           ExceptionInfo
-           #"Tool not found"
-           (registry/update-tool reg :missing/tool {:tool/name "x"}))))))
+(deftest update-tool-not-found-returns-anomaly
+  (testing "missing tool returns :not-found / :anomalies/not-found"
+    (let [reg    (new-registry)
+          result (registry/update-tool reg :missing/tool {:tool/name "x"})]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= :anomalies/not-found (:anomaly/subtype result)))
+      (is (= {:tool-id :missing/tool} (:anomaly/data result))))))
 
 (deftest update-tool-not-found-carries-tool-id
-  (testing "anomaly ex-data carries :tool-id and :anomalies/not-found category"
-    (let [reg (new-registry)
-          thrown (try
-                   (registry/update-tool reg :missing/tool {:tool/name "x"})
-                   nil
-                   (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (= :missing/tool (:tool-id (ex-data thrown))))
-      (is (= :anomalies/not-found (:anomaly/category (ex-data thrown)))))))
+  (testing "anomaly data carries :tool-id"
+    (let [reg    (new-registry)
+          result (registry/update-tool reg :missing/tool {:tool/name "x"})]
+      (is (= :missing/tool (get-in result [:anomaly/data :tool-id]))))))
+
+;------------------------------------------------------------------------------ update-tool — invalid update
+
+(deftest update-tool-invalid-update-returns-anomaly
+  (testing "merged invalid config returns :invalid-input / :anomalies/incorrect"
+    (let [reg  (new-registry)
+          tool {:tool/id :tools/greet
+                :tool/type :function
+                :tool/name "Greet"}]
+      (registry/register-tool reg tool)
+      (let [result (registry/update-tool reg :tools/greet {:tool/type :unknown})]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= :anomalies/incorrect (:anomaly/subtype result)))
+        (is (= :tools/greet (get-in result [:anomaly/data :tool-id])))
+        (is (contains? (:anomaly/data result) :errors))))))
+
+(deftest update-tool-id-change-returns-anomaly
+  (testing "updates cannot change the registry key's tool id"
+    (let [reg  (new-registry)
+          tool {:tool/id :tools/greet
+                :tool/type :function
+                :tool/name "Greet"}]
+      (registry/register-tool reg tool)
+      (let [result (registry/update-tool reg :tools/greet {:tool/id :tools/renamed})]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= :anomalies/incorrect (:anomaly/subtype result)))
+        (is (= "Tool ID cannot be changed" (:anomaly/message result)))
+        (is (= {:tool-id :tools/greet
+                :requested-tool-id :tools/renamed}
+               (:anomaly/data result)))))))

--- a/components/tool-registry/test/ai/miniforge/tool_registry/registry_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/registry_test.clj
@@ -19,8 +19,9 @@
 (ns ai.miniforge.tool-registry.registry-test
   "Tests for tool-registry registry operations."
   (:require
-   [clojure.test :refer [deftest is testing use-fixtures]]
-   [ai.miniforge.tool-registry.registry :as registry]))
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.tool-registry.registry :as registry]
+   [clojure.test :refer [deftest is testing use-fixtures]]))
 
 ;------------------------------------------------------------------------------ Test fixtures
 
@@ -64,11 +65,11 @@
       (is (some? tool))
       (is (= "Test LSP" (:tool/name tool)))))
 
-  (testing "register invalid tool throws"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid tool configuration"
-         (registry/register-tool *registry* {:tool/id :bad}))))
+  (testing "register invalid tool returns anomaly"
+    (let [result (registry/register-tool *registry* {:tool/id :bad})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :anomalies/incorrect (:anomaly/subtype result)))))
 
   (testing "register tool with non-namespaced ID throws"
     (is (thrown-with-msg?
@@ -147,11 +148,19 @@
       (is (= "Test LSP" (:tool/name tool)))
       (is (= :lsp (:tool/type tool)))))
 
-  (testing "update non-existent tool throws"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Tool not found"
-         (registry/update-tool *registry* :nonexistent {:tool/name "New"})))))
+  (testing "update non-existent tool returns anomaly"
+    (let [result (registry/update-tool *registry* :nonexistent {:tool/name "New"})]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= :anomalies/not-found (:anomaly/subtype result)))))
+
+  (testing "update rejects tool id changes"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (let [result (registry/update-tool *registry* :lsp/test
+                                       {:tool/id :lsp/renamed})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :lsp/test (:tool/id (registry/get-tool *registry* :lsp/test)))))))
 
 ;------------------------------------------------------------------------------ Unregister tests
 

--- a/docs/pull-requests/2026-06-28-chris-tool-registry-anomalies.md
+++ b/docs/pull-requests/2026-06-28-chris-tool-registry-anomalies.md
@@ -1,0 +1,46 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Return Tool Registry Anomalies
+
+## Summary
+
+Return anomaly maps for ordinary tool-registry validation and lookup outcomes.
+
+## Motivation
+
+The in-memory tool registry still escalated schema-invalid tool configs,
+missing update targets, and schema-invalid updates via `response/throw-anomaly!`
+inside a non-boundary namespace. These are registry data outcomes and should be
+composable anomaly maps, not thrown control flow.
+
+## Changes
+
+- Return `:invalid-input` / `:anomalies/incorrect` anomaly data for
+  schema-invalid `register-tool` input.
+- Return `:not-found` / `:anomalies/not-found` anomaly data for missing
+  `update-tool` targets.
+- Return `:invalid-input` / `:anomalies/incorrect` anomaly data for invalid
+  merged updates.
+- Reject `:tool/id` changes in `update-tool` so registry keys and stored tool
+  maps cannot diverge.
+- Update public tool-registry docs and regression tests.
+- Leave the non-namespaced tool id shape guard as a fatal-only registry
+  invariant.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.tool-registry.registry-test 'ai.miniforge.tool-registry.anomaly.registry-anomaly-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.tool-registry.registry-test 'ai.miniforge.tool-registry.anomaly.registry-anomaly-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :tool-registry (count (filter #(= "components/tool-registry/src/ai/miniforge/tool_registry/registry.clj" (:file %)) cleanup))))'
+```
+
+```bash
+bb pre-commit
+```


### PR DESCRIPTION
## Summary
- return anomaly maps for schema-invalid tool registration, missing update targets, and invalid merged updates
- update public tool-registry docs and regression tests
- leave the namespaced tool-id shape guard as a fatal-only invariant

## Validation
- clojure -M:dev:test -e '(require (quote [ai.miniforge.tool-registry.registry-test]) (quote [ai.miniforge.tool-registry.anomaly.registry-anomaly-test]) (quote [clojure.test :as t])) (t/run-tests (quote ai.miniforge.tool-registry.registry-test) (quote ai.miniforge.tool-registry.anomaly.registry-anomaly-test))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner]) (quote [clojure.string :as str])) (let [r (scanner/scan-exceptions-as-data .) cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r)) tool (filter #(= components/tool-registry/src/ai/miniforge/tool_registry/registry.clj (:file %)) cleanup)] (println :cleanup-needed (count cleanup)) (println :tool-registry (count tool)))'
- bb pre-commit