### PR TITLE
Mark sink config guards invalid

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -491,7 +491,8 @@
     :else
     (response/throw-anomaly! :anomalies/incorrect
                              "Invalid sink configuration"
-                             {:config sink-config})))
+                             {:config sink-config
+                              :config/error :invalid-config})))
 
 (defn create-sinks-from-config
   "Create sinks from user configuration.

--- a/components/event-stream/test/ai/miniforge/event_stream/anomaly/sinks_anomaly_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/anomaly/sinks_anomaly_test.clj
@@ -82,4 +82,5 @@
                    (catch ExceptionInfo e e))]
       (is (some? thrown))
       (is (= "not-a-sink" (:config (ex-data thrown))))
+      (is (= :invalid-config (:config/error (ex-data thrown))))
       (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -270,7 +270,9 @@
     (multi-sink (map create-sink sink-config))
 
     :else
-    (throw (ex-info "Invalid sink configuration" {:config sink-config}))))
+    (throw (ex-info "Invalid sink configuration"
+                    {:config sink-config
+                     :config/error :invalid-config}))))
 
 (defn create-sinks-from-config
   "Create log sinks from user configuration.

--- a/components/logging/test/ai/miniforge/logging/sinks_test.clj
+++ b/components/logging/test/ai/miniforge/logging/sinks_test.clj
@@ -1,0 +1,34 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.logging.sinks-test
+  (:require
+   [ai.miniforge.logging.sinks :as sinks]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+(deftest create-sink-invalid-config-carries-invalid-config-data
+  (testing "non-map non-vector sink config is an invalid config setup failure"
+    (let [thrown (try
+                   (sinks/create-sink "not-a-sink")
+                   nil
+                   (catch ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (= "not-a-sink" (:config (ex-data thrown))))
+      (is (= :invalid-config (:config/error (ex-data thrown)))))))

--- a/docs/pull-requests/2026-06-28-chris-sink-config-invalid.md
+++ b/docs/pull-requests/2026-06-28-chris-sink-config-invalid.md
@@ -1,0 +1,41 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark Sink Config Guards Invalid
+
+## Summary
+
+Mark event-stream and logging invalid sink configuration guards as explicit
+invalid-config setup failures.
+
+## Motivation
+
+Both sink factories reject non-keyword, non-map, non-vector configuration values
+during sink construction. Those failures are configuration contract violations,
+not ordinary runtime recoverable conditions, so their thrown data should carry
+the same invalid-config marker used by the other config guard cleanups.
+
+## Changes
+
+- Add `:config/error :invalid-config` to event-stream invalid sink config
+  anomalies.
+- Add `:config/error :invalid-config` to logging invalid sink config
+  exceptions.
+- Add regression coverage for both ex-data shapes.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.event-stream.anomaly.sinks-anomaly-test 'ai.miniforge.logging.sinks-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.event-stream.anomaly.sinks-anomaly-test 'ai.miniforge.logging.sinks-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :sink-config (count (filter #(contains? #{"components/event-stream/src/ai/miniforge/event_stream/sinks.clj" "components/logging/src/ai/miniforge/logging/sinks.clj"} (:file %)) cleanup))))'
+```
+
+```bash
+bb pre-commit
+```


### PR DESCRIPTION
## Summary
- mark event-stream invalid sink config anomalies with :config/error :invalid-config
- mark logging invalid sink config exceptions with :config/error :invalid-config
- add regression coverage for both ex-data shapes

## Validation
- clojure -M:dev:test -e '(require (quote [ai.miniforge.event-stream.anomaly.sinks-anomaly-test]) (quote [ai.miniforge.logging.sinks-test]) (quote [clojure.test :as t])) (t/run-tests (quote ai.miniforge.event-stream.anomaly.sinks-anomaly-test) (quote ai.miniforge.logging.sinks-test))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data .) cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r)) files #{components/event-stream/src/ai/miniforge/event_stream/sinks.clj components/logging/src/ai/miniforge/logging/sinks.clj} sink (filter #(contains? files (:file %)) cleanup)] (println :cleanup-needed (count cleanup)) (println :sink-config (count sink)))'
- bb pre-commit