### PR TITLE
Mark agent prompt config guards invalid

### DIFF
--- a/components/agent/src/ai/miniforge/agent/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/prompts.clj
@@ -30,6 +30,14 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Prompt loading
 
+(defn- malformed-prompt-data
+  [agent-type resource-path prompt-data]
+  {:agent-type agent-type
+   :resource-path resource-path
+   :config/error :invalid-config
+   :prompt-data/type (some-> prompt-data type str)
+   :keys (when (map? prompt-data) (keys prompt-data))})
+
 (defn load-prompt
   "Load an agent prompt from the resources directory.
 
@@ -55,16 +63,18 @@
     (if-let [resource (io/resource resource-path)]
       (let [prompt-data (with-open [rdr (io/reader resource)]
                           (edn/read (java.io.PushbackReader. rdr)))]
-        (or (:prompt/system prompt-data)
+        (or (when (map? prompt-data)
+              (:prompt/system prompt-data))
             (response/throw-anomaly! :anomalies/fault
                                     "Prompt data missing :prompt/system key"
-                                    {:agent-type agent-type
-                                     :resource-path resource-path
-                                     :keys (keys prompt-data)})))
+                                    (malformed-prompt-data agent-type
+                                                           resource-path
+                                                           prompt-data))))
       (response/throw-anomaly! :anomalies/fault
                                 "Could not find prompt resource"
                                 {:agent-type agent-type
-                                 :resource-path resource-path}))))
+                                 :resource-path resource-path
+                                 :config/error :invalid-config}))))
 
 (defn load-prompt-data
   "Load full prompt data map from resources.
@@ -90,7 +100,8 @@
       (response/throw-anomaly! :anomalies/fault
                                 "Could not find prompt resource"
                                 {:agent-type agent-type
-                                 :resource-path resource-path}))))
+                                 :resource-path resource-path
+                                 :config/error :invalid-config}))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Progress-monitor factory

--- a/components/agent/test/ai/miniforge/agent/prompts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/prompts_test.clj
@@ -1,0 +1,64 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.prompts-test
+  (:require
+   [ai.miniforge.agent.prompts :as prompts]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [slingshot.slingshot :refer [try+]]))
+
+(defn- fault-anomaly
+  [f]
+  (try+
+    (f)
+    (catch [:anomaly/category :anomalies/fault] m
+      m)))
+
+(deftest missing-prompt-resource-carries-invalid-config-marker
+  (testing "load-prompt reports a missing classpath prompt as invalid config"
+    (with-redefs [io/resource (constantly nil)]
+      (let [anomaly (fault-anomaly #(prompts/load-prompt :missing-agent))]
+        (is (= :anomalies/fault (:anomaly/category anomaly)))
+        (is (= :invalid-config (:config/error anomaly)))
+        (is (= :missing-agent (:agent-type anomaly)))
+        (is (= "prompts/missing-agent.edn" (:resource-path anomaly)))))))
+
+(deftest missing-prompt-data-resource-carries-invalid-config-marker
+  (testing "load-prompt-data reports a missing classpath prompt as invalid config"
+    (with-redefs [io/resource (constantly nil)]
+      (let [anomaly (fault-anomaly #(prompts/load-prompt-data :missing-agent))]
+        (is (= :anomalies/fault (:anomaly/category anomaly)))
+        (is (= :invalid-config (:config/error anomaly)))
+        (is (= :missing-agent (:agent-type anomaly)))
+        (is (= "prompts/missing-agent.edn" (:resource-path anomaly)))))))
+
+(deftest non-map-prompt-data-carries-invalid-config-marker
+  (testing "load-prompt reports malformed prompt EDN without bypassing anomaly data"
+    (let [prompt-file (java.io.File/createTempFile "miniforge-prompt" ".edn")]
+      (.deleteOnExit prompt-file)
+      (spit prompt-file "[]")
+      (with-redefs [io/resource (constantly (.toURL (.toURI prompt-file)))]
+        (let [anomaly (fault-anomaly #(prompts/load-prompt :malformed-agent))]
+          (is (= :anomalies/fault (:anomaly/category anomaly)))
+          (is (= :invalid-config (:config/error anomaly)))
+          (is (= :malformed-agent (:agent-type anomaly)))
+          (is (= "prompts/malformed-agent.edn" (:resource-path anomaly)))
+          (is (= "class clojure.lang.PersistentVector"
+                 (:prompt-data/type anomaly)))
+          (is (nil? (:keys anomaly))))))))

--- a/docs/pull-requests/2026-06-29-chris-agent-prompt-config-invalid.md
+++ b/docs/pull-requests/2026-06-29-chris-agent-prompt-config-invalid.md
@@ -1,0 +1,40 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark Agent Prompt Config Guards Invalid
+
+## Summary
+
+Mark missing or malformed agent prompt resources as explicit invalid-config
+setup failures.
+
+## Motivation
+
+Agent prompts are compiled classpath resources. A missing prompt EDN file, or a
+prompt EDN file without the required `:prompt/system` key, is a packaging or
+configuration contract violation rather than an ordinary runtime not-found
+condition. The thrown anomaly data should carry the same invalid-config marker
+used by the other resource/config guard cleanups.
+
+## Changes
+
+- Add `:config/error :invalid-config` to missing prompt resource anomalies.
+- Add `:config/error :invalid-config` to malformed prompt data anomalies.
+- Add regression coverage for both prompt loader entry points.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.agent.prompts-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.agent.prompts-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :agent-prompts (count (filter #(= "components/agent/src/ai/miniforge/agent/prompts.clj" (:file %)) cleanup))))'
+```
+
+```bash
+bb pre-commit
+```


### PR DESCRIPTION
## Summary
- mark missing prompt classpath resources as invalid-config setup failures
- mark malformed prompt EDN without :prompt/system as invalid-config
- add focused prompt loader regression coverage

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.agent.prompts-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.agent.prompts-test)"\n- scanner: cleanup-needed 117, agent-prompts 0\n- bb pre-commit