### PR TITLE
Mark control-plane profile guard invalid

### DIFF
--- a/components/control-plane/src/ai/miniforge/control_plane/state_machine.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/state_machine.clj
@@ -53,7 +53,8 @@
    (if-let [resource (io/resource path)]
      (edn/read-string (slurp resource))
      (throw (ex-info (messages/t :state-machine/profile-not-found)
-                     {:path path})))))
+                     {:path path
+                      :config/error :invalid-config})))))
 
 (def ^:private profile-cache
   "Cached profile instance."

--- a/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.control-plane.interface-test
   (:require
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest testing is are]]
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.interface :as cp]))
@@ -32,6 +33,21 @@
       (is (contains? (set (:task-statuses profile)) :running))
       (is (contains? (set (:task-statuses profile)) :blocked))
       (is (map? (:valid-transitions profile))))))
+
+(deftest load-profile-missing-resource-carries-invalid-config-marker
+  (testing "Missing classpath state profile is an invalid configuration fault"
+    (let [missing-path "control-plane/state-profiles/missing.edn"
+          resource io/resource]
+      (with-redefs [io/resource (fn [path]
+                                  (when-not (= missing-path path)
+                                    (resource path)))]
+        (let [thrown (try
+                       (cp/load-profile missing-path)
+                       nil
+                       (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown))
+          (is (= missing-path (:path (ex-data thrown))))
+          (is (= :invalid-config (:config/error (ex-data thrown)))))))))
 
 (deftest valid-transition-test
   (let [profile (cp/get-profile)]

--- a/docs/pull-requests/2026-06-29-chris-control-plane-profile-config-invalid.md
+++ b/docs/pull-requests/2026-06-29-chris-control-plane-profile-config-invalid.md
@@ -1,0 +1,38 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark Control-Plane Profile Guard Invalid
+
+## Summary
+
+Mark missing control-plane state profile resources as explicit invalid-config
+setup failures.
+
+## Motivation
+
+The control-plane state machine loads its profile from a compiled classpath EDN
+resource. If that resource is absent, the deploy artifact or configuration is
+invalid; callers should see the same invalid-config marker used by other
+resource/config guard cleanups.
+
+## Changes
+
+- Add `:config/error :invalid-config` to missing state profile exceptions.
+- Add regression coverage for the missing profile resource ex-data.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.control-plane.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.control-plane.interface-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :control-plane (count (filter #(= "components/control-plane/src/ai/miniforge/control_plane/state_machine.clj" (:file %)) cleanup))))'
+```
+
+```bash
+bb pre-commit
+```


### PR DESCRIPTION
## Summary
- mark missing control-plane state profile resources as invalid-config setup failures
- add regression coverage for the missing profile ex-data

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.control-plane.interface-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.control-plane.interface-test)"\n- scanner: cleanup-needed 116, control-plane 1 (remaining row is invalid transition)\n- bb pre-commit