### PR TITLE
Mark workflow resume config guard invalid

### DIFF
--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -185,7 +185,8 @@
     (:workflow-resume/resume (edn/read-string (slurp resource)))
     (response/throw-anomaly! :anomalies/not-found
                              "Workflow resume config resource not found"
-                             {:resource resume-config-resource})))
+                             {:resource resume-config-resource
+                              :config/error :invalid-config})))
 
 (def ^:private resume-config
   (delay (read-resume-config)))

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -24,10 +24,22 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.workflow.interface.checkpoints :as workflow-checkpoints]
    [ai.miniforge.workflow-resume.core :as core]
-   [ai.miniforge.workflow-resume.interface :as wr]))
+   [ai.miniforge.workflow-resume.interface :as wr]
+   [slingshot.slingshot :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure extractors
+
+(deftest missing-resume-config-resource-carries-invalid-config-marker
+  (testing "Missing classpath resume config is an invalid configuration fault"
+    (with-redefs [io/resource (constantly nil)]
+      (let [anomaly (try+
+                      (@#'core/read-resume-config)
+                      (catch [:anomaly/category :anomalies/not-found] m
+                        m))]
+        (is (= :anomalies/not-found (:anomaly/category anomaly)))
+        (is (= "config/workflow-resume/resume.edn" (:resource anomaly)))
+        (is (= :invalid-config (:config/error anomaly)))))))
 
 (deftest reconstructed-status-predicates-test
   (testing "predicates read the reconstructed status flags"

--- a/docs/pull-requests/2026-06-29-chris-workflow-resume-config-invalid.md
+++ b/docs/pull-requests/2026-06-29-chris-workflow-resume-config-invalid.md
@@ -1,0 +1,39 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark Workflow Resume Config Guard Invalid
+
+## Summary
+
+Mark missing workflow-resume config resources as explicit invalid-config setup
+failures.
+
+## Motivation
+
+Workflow resume behavior is driven by a compiled classpath EDN resource. A
+missing `config/workflow-resume/resume.edn` resource is a packaging/configuration
+fault, not an ordinary runtime workflow-not-found condition, so the anomaly data
+should carry the invalid-config marker used by the other config guard cleanups.
+
+## Changes
+
+- Add `:config/error :invalid-config` to the missing resume config resource
+  anomaly.
+- Add regression coverage using `try+` against the thrown anomaly map.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.workflow-resume.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.workflow-resume.core-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :workflow-resume (count (filter #(= "components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj" (:file %)) cleanup))))'
+```
+
+```bash
+bb pre-commit
+```


### PR DESCRIPTION
## Summary
- mark missing workflow-resume config classpath resource as invalid-config
- add try+ regression coverage for the thrown anomaly map

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.workflow-resume.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.workflow-resume.core-test)"\n- scanner: cleanup-needed 115, workflow-resume 2 (remaining rows are runtime not-found paths)\n- bb pre-commit