### PR TITLE
Mark bb-paths repo root guard invalid

### DIFF
--- a/components/bb-paths/src/ai/miniforge/bb_paths/core.clj
+++ b/components/bb-paths/src/ai/miniforge/bb_paths/core.clj
@@ -69,9 +69,11 @@
   "Absolute path to the repo root (nearest `bb.edn` above the cwd).
    Throws ex-info if no `bb.edn` is found walking up from cwd."
   []
-  (or (find-up (fs/cwd) "bb.edn")
-      (throw (ex-info "Could not locate bb.edn from cwd"
-                      {:cwd (str (fs/cwd))}))))
+  (let [cwd (fs/cwd)]
+    (or (find-up cwd "bb.edn")
+        (throw (ex-info "Could not locate bb.edn from cwd"
+                        {:cwd (str cwd)
+                         :config/error :invalid-config})))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Composes Layer 1.

--- a/components/bb-paths/test/ai/miniforge/bb_paths/core_test.clj
+++ b/components/bb-paths/test/ai/miniforge/bb_paths/core_test.clj
@@ -90,6 +90,21 @@
           (is (fs/exists? (str root "/bb.edn")))
           (is (fs/exists? nested)))))))
 
+(deftest test-repo-root-missing-bb-edn-carries-invalid-config-marker
+  (testing "given no bb.edn above cwd → reports invalid configuration"
+    (with-scratch
+      (fn [scratch]
+        (let [nested (sut/ensure-dir! (str scratch "/a/b/c"))]
+          (with-redefs [fs/cwd (constantly (fs/path nested))
+                        ai.miniforge.bb-paths.core/find-up (constantly nil)]
+            (let [thrown (try
+                           (sut/repo-root)
+                           nil
+                           (catch clojure.lang.ExceptionInfo e e))]
+              (is (some? thrown))
+              (is (= nested (:cwd (ex-data thrown))))
+              (is (= :invalid-config (:config/error (ex-data thrown)))))))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (clojure.test/run-tests 'ai.miniforge.bb-paths.core-test)

--- a/docs/pull-requests/2026-06-29-chris-bb-paths-config-invalid.md
+++ b/docs/pull-requests/2026-06-29-chris-bb-paths-config-invalid.md
@@ -1,0 +1,39 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Mark BB Paths Repo Root Guard Invalid
+
+## Summary
+
+Mark the missing `bb.edn` repo-root discovery guard as an explicit
+invalid-config setup failure.
+
+## Motivation
+
+`bb-paths/repo-root` is a local setup boundary: it discovers the workspace root
+by walking up from cwd until it finds `bb.edn`. If no marker exists, the command
+is running outside a Miniforge checkout or in a malformed workspace, so the
+exception data should carry the invalid-config marker used by the other setup
+guard cleanups.
+
+## Changes
+
+- Add `:config/error :invalid-config` to the missing `bb.edn` exception.
+- Add scratch-cwd regression coverage for the ex-data shape.
+
+## Validation
+
+```bash
+clojure -M:dev:test -e "(require 'ai.miniforge.bb-paths.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.bb-paths.core-test)"
+```
+
+```bash
+clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println :bb-paths (count (filter #(= "components/bb-paths/src/ai/miniforge/bb_paths/core.clj" (:file %)) cleanup))))'
+```
+
+```bash
+bb pre-commit
+```


### PR DESCRIPTION
## Summary
- mark missing bb.edn repo-root discovery as invalid-config setup failure
- add scratch-cwd regression coverage for the exception data

## Validation
- clojure -M:dev:test -e "(require 'ai.miniforge.bb-paths.core-test 'clojure.test) (clojure.test/run-tests 'ai.miniforge.bb-paths.core-test)"\n- scanner: cleanup-needed 114, bb-paths 0\n- bb pre-commit