### PR TITLE
Return GitHub connector validation anomalies

### DIFF
--- a/components/connector-github/deps.edn
+++ b/components/connector-github/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector      {:local/root "../connector"}
+ :deps {ai.miniforge/anomaly        {:local/root "../anomaly"}
+        ai.miniforge/connector      {:local/root "../connector"}
         ai.miniforge/connector-auth {:local/root "../connector-auth"}
         ai.miniforge/connector-http {:local/root "../connector-http"}
         ai.miniforge/response       {:local/root "../response"}

--- a/components/connector-github/src/ai/miniforge/connector_github/impl.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/impl.clj
@@ -18,7 +18,8 @@
 
 (ns ai.miniforge.connector-github.impl
   "Implementation functions for the GitHub REST API connector."
-  (:require [ai.miniforge.connector.interface :as connector]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-github.messages :as msg]
             [ai.miniforge.connector-github.resources :as resources]
             [ai.miniforge.connector-github.schema :as gh-schema]
@@ -176,11 +177,11 @@
 
 ;; -- Helpers --
 
-(defn- require-handle!
-  "Retrieve handle state or throw, delegating to the shared helper."
+(defn- require-handle
+  "Retrieve handle state or return an anomaly."
   [handle]
-  (connector/require-handle! handles handle
-                             {:message (msg/t :github/handle-not-found {:handle handle})}))
+  (connector/require-handle handles handle
+                            {:message (msg/t :github/handle-not-found {:handle handle})}))
 
 (defn- require-resource!
   "Look up resource def or throw."
@@ -195,12 +196,17 @@
   [result]
   (:errors result))
 
+(defn- connector-anomaly->response
+  "Convert connector validation anomalies to the response anomaly shape
+   expected by current connector protocol consumers."
+  [category message anomaly]
+  (response/make-anomaly category message (:anomaly/data anomaly)))
+
 (defn- validate-connect
   "Validate config and auth sequentially.
 
-   Returns nil on success. Returns a canonical anomaly map for config
-   failures. Auth validation still delegates to the connector boundary helper
-   and may throw for invalid auth."
+   Returns nil on success. Returns a response anomaly map for config
+   or auth validation failures."
   [config auth]
   (let [config-result (gh-schema/validate-config config)]
     (cond
@@ -216,13 +222,17 @@
                              {:config config})
 
       :else
-      (connector/validate-auth-or-throw! auth msg/t :github/auth-invalid))))
+      (when-let [auth-anomaly (connector/validate-auth auth)]
+        (let [errors (get-in auth-anomaly [:anomaly/data :errors])]
+          (connector-anomaly->response :anomalies/incorrect
+                                       (msg/t :github/auth-invalid {:errors errors})
+                                       auth-anomaly))))))
 
 ;; -- Lifecycle --
 (defn do-connect
   "Validate config and auth, register handle.
 
-   Returns a connect-result map on success or a canonical anomaly map when
+   Returns a connect-result map on success or a response anomaly map when
    config validation fails."
   [config auth]
   (if-let [anomaly (validate-connect config auth)]
@@ -246,24 +256,32 @@
 (defn do-discover
   "Return available resource schemas based on config."
   [handle]
-  (require-handle! handle)
-  (connector/discover-result (resources/resource-schemas)))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (connector-anomaly->response :anomalies/not-found
+                                   (:anomaly/message handle-state)
+                                   handle-state)
+      (connector/discover-result (resources/resource-schemas)))))
 
 (defn do-extract
   "Extract records from a GitHub API resource."
   [handle schema-name opts]
-  (let [handle-state (require-handle! handle)
-        resource-def (require-resource! schema-name)
-        resource-key (keyword schema-name)
-        {:keys [config auth-headers]} handle-state
-        cursor       (:extract/cursor opts)
-        headers      (github-headers auth-headers)]
-    (if (= "reviews" schema-name)
-      (extract-reviews handle config headers cursor opts)
-      (let [url          (resources/build-url (:github/base-url config) resource-def config)
-            query-params (resources/build-query-params resource-def cursor opts)
-            {:keys [records cursor]} (fetch-all-pages handle resource-key resource-def headers url query-params)]
-        (connector/extract-result records cursor false)))))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (connector-anomaly->response :anomalies/not-found
+                                   (:anomaly/message handle-state)
+                                   handle-state)
+      (let [resource-def (require-resource! schema-name)
+            resource-key (keyword schema-name)
+            {:keys [config auth-headers]} handle-state
+            cursor       (:extract/cursor opts)
+            headers      (github-headers auth-headers)]
+        (if (= "reviews" schema-name)
+          (extract-reviews handle config headers cursor opts)
+          (let [url          (resources/build-url (:github/base-url config) resource-def config)
+                query-params (resources/build-query-params resource-def cursor opts)
+                {:keys [records cursor]} (fetch-all-pages handle resource-key resource-def headers url query-params)]
+            (connector/extract-result records cursor false)))))))
 
 (defn do-checkpoint
   "Persist cursor state. Returns checkpoint-result."

--- a/components/connector-github/test/ai/miniforge/connector_github/impl_test.clj
+++ b/components/connector-github/test/ai/miniforge/connector_github/impl_test.clj
@@ -314,35 +314,31 @@
       (is (= "W/\"test-etag\"" (get headers "If-None-Match"))))))
 
 ;;------------------------------------------------------------------------------ Layer 2
-;; Migrated validation helpers — confirm the shared connector helpers
-;; preserve the legacy ex-info shape at the protocol boundary.
+;; Migrated validation helpers — connector boundaries return anomalies.
 
-(deftest discover-throws-on-unknown-handle-test
-  (testing "do-discover throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-discover "no-such-handle")
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest discover-returns-anomaly-on-unknown-handle-test
+  (testing "do-discover returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-discover "no-such-handle")]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-throws-on-unknown-handle-test
-  (testing "do-extract throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-extract "no-such-handle" "issues" {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest extract-returns-anomaly-on-unknown-handle-test
+  (testing "do-extract returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-extract "no-such-handle" "issues" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
 (deftest connect-rejects-malformed-auth-test
-  (testing "do-connect throws ex-info when auth credential-ref is malformed"
-    (try
-      (impl/do-connect {:github/owner "owner" :github/repo "repo"}
-                       {:auth/method :api-key
-                        ;; Missing :auth/credential-id
-                        :auth/scheme :bearer})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (some? (:errors (ex-data e))))))))
+  (testing "do-connect returns an anomaly when auth credential-ref is malformed"
+    (let [result (impl/do-connect {:github/owner "owner" :github/repo "repo"}
+                                  {:auth/method :api-key
+                                   ;; Missing :auth/credential-id
+                                   :auth/scheme :bearer})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (some? (:errors result))))))
 
 (deftest connect-accepts-valid-auth-test
   (testing "do-connect succeeds when auth credential-ref validates"

--- a/docs/pull-requests/2026-06-29-chris-github-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-github-connector-validation-anomalies.md
@@ -1,0 +1,45 @@
+# refactor: return GitHub connector validation anomalies
+
+## Overview
+
+Migrates the GitHub connector away from the shared throwing validation helpers
+for handle lookup and auth validation.
+
+## Motivation
+
+`connector-github` was still translating missing handles and malformed auth
+through shared `!` helpers. Those are ordinary connector protocol failures and
+should remain anomaly values until a true process boundary.
+
+## Base Branch
+
+`main`
+
+## Layer
+
+Connector implementation refactor.
+
+## What Changed
+
+- Adds a direct `ai.miniforge/anomaly` dependency to `connector-github`.
+- Changes the private handle lookup helper to call `connector/require-handle`.
+- Makes `do-discover` and `do-extract` return response-shaped
+  missing-handle anomalies.
+- Makes malformed auth return a localized validation anomaly from
+  `do-connect`.
+- Updates GitHub connector tests from thrown `ExceptionInfo` assertions to
+  returned anomaly assertions.
+
+The returned maps use `response/make-anomaly` so existing connector consumers
+that dispatch with `response/anomaly-map?` continue to treat failures as
+failures.
+
+## Testing
+
+- Focused GitHub connector tests pass.
+- Full `bb pre-commit` pass required before merge.
+
+## Follow-Up
+
+The shared throwing validation helpers remain until the other connector
+implementations are migrated in subsequent slices.


### PR DESCRIPTION
# refactor: return GitHub connector validation anomalies

## Overview

Migrates the GitHub connector away from the shared throwing validation helpers
for handle lookup and auth validation.

## Motivation

`connector-github` was still translating missing handles and malformed auth
through shared `!` helpers. Those are ordinary connector protocol failures and
should remain anomaly values until a true process boundary.

## Base Branch

`main`

## Layer

Connector implementation refactor.

## What Changed

- Adds a direct `ai.miniforge/anomaly` dependency to `connector-github`.
- Changes the private handle lookup helper to call `connector/require-handle`.
- Makes `do-discover` and `do-extract` return missing-handle anomalies.
- Makes malformed auth return a localized validation anomaly from
  `do-connect`.
- Updates GitHub connector tests from thrown `ExceptionInfo` assertions to
  returned anomaly assertions.

## Testing

- Focused GitHub connector tests pass.
- Full `bb pre-commit` pass required before merge.

## Follow-Up

The shared throwing validation helpers remain until the other connector
implementations are migrated in subsequent slices.
