### PR TITLE
Return GitLab connector validation anomalies

### DIFF
--- a/components/connector-gitlab/deps.edn
+++ b/components/connector-gitlab/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector      {:local/root "../connector"}
+ :deps {ai.miniforge/anomaly        {:local/root "../anomaly"}
+        ai.miniforge/connector      {:local/root "../connector"}
         ai.miniforge/connector-auth {:local/root "../connector-auth"}
         ai.miniforge/connector-http {:local/root "../connector-http"}
         ai.miniforge/response       {:local/root "../response"}

--- a/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
+++ b/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
@@ -19,7 +19,8 @@
 (ns ai.miniforge.connector-gitlab.impl
   "Implementation functions for the GitLab REST API connector.
    Small composable functions organized in a stratified DAG."
-  (:require [ai.miniforge.connector.interface :as connector]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-gitlab.messages :as msg]
             [ai.miniforge.connector-gitlab.resources :as resources]
             [ai.miniforge.connector-gitlab.schema :as schema]
@@ -36,11 +37,11 @@
 (defn- remove-handle! [handle] (connector/remove-handle! handles handle))
 (defn- touch-handle! [handle] (connector/touch-handle! handles handle))
 
-(defn- require-handle!
-  "Retrieve handle state or throw, delegating to the shared helper."
+(defn- require-handle
+  "Retrieve handle state or return an anomaly."
   [handle]
-  (connector/require-handle! handles handle
-                             {:message (msg/t :gitlab/handle-not-found {:handle handle})}))
+  (connector/require-handle handles handle
+                            {:message (msg/t :gitlab/handle-not-found {:handle handle})}))
 
 ;; Auth
 
@@ -82,13 +83,22 @@
   [config]
   (some? (or (:gitlab/project-id config) (:gitlab/project-path config))))
 
-(defn- validate-auth!
-  "Validate auth credential reference, throwing on failure with the
-   GitLab-localized message. Delegates to the shared
-   `connector/validate-auth-or-throw!` helper so all the boundary
-   throwers across connector-{jira,gitlab,github} read the same way."
+(defn- validate-auth
+  "Validate auth credential reference, returning a localized response anomaly on failure."
   [auth]
-  (connector/validate-auth-or-throw! auth msg/t :gitlab/auth-invalid))
+  (when-let [auth-anomaly (connector/validate-auth auth)]
+    (let [errors (get-in auth-anomaly [:anomaly/data :errors])]
+      (response/make-anomaly :anomalies/incorrect
+                             (msg/t :gitlab/auth-invalid {:errors errors})
+                             (:anomaly/data auth-anomaly)))))
+
+(defn- handle-anomaly->response
+  "Convert connector handle validation anomalies to the response anomaly shape
+   expected by current connector protocol consumers."
+  [handle-anomaly]
+  (response/make-anomaly :anomalies/not-found
+                         (:anomaly/message handle-anomaly)
+                         (:anomaly/data handle-anomaly)))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; HTTP
@@ -224,8 +234,8 @@
 (defn do-connect
   "Validate config at boundary, register handle.
 
-   Returns a connect-result map on success or a canonical anomaly map when
-   required project config is missing."
+   Returns a connect-result map on success or a response anomaly map when
+   required project config is missing or auth validation fails."
   [config auth]
   (let [config (assoc config :gitlab/base-url
                       (get config :gitlab/base-url "https://gitlab.com"))]
@@ -235,39 +245,44 @@
                              {:config config})
       (do
         (schema/validate! schema/GitLabConfig config)
-        (validate-auth! auth)
-        (let [handle (str (UUID/randomUUID))]
-          (store-handle! handle {:config       config
-                                 :auth-headers (resolve-auth-headers auth)
-                                 :last-request-at nil})
-          (connector/connect-result handle))))))
+        (if-let [auth-anomaly (validate-auth auth)]
+          auth-anomaly
+          (let [handle (str (UUID/randomUUID))]
+            (store-handle! handle {:config       config
+                                   :auth-headers (resolve-auth-headers auth)
+                                   :last-request-at nil})
+            (connector/connect-result handle)))))))
 
 (defn do-close [handle]
   (remove-handle! handle)
   (connector/close-result))
 
 (defn do-discover [handle]
-  (require-handle! handle)
-  (connector/discover-result (resources/resource-schemas)))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (connector/discover-result (resources/resource-schemas)))))
 
 (defn do-extract
   "Extract records from a GitLab API resource."
   [handle schema-name opts]
-  (let [handle-state (require-handle! handle)
-        resource-def (require-resource! schema-name)
-        {:keys [config auth-headers]} handle-state]
-    (if (= "notes" schema-name)
-      (extract-project-notes handle config auth-headers (:extract/cursor opts) opts)
-      (let [url     (resources/build-url (:gitlab/base-url config) resource-def config)
-            params  (resources/build-query-params resource-def (:extract/cursor opts) opts)
-            fetch   (fn [] (let [{:keys [records cursor]}
-                                 (fetch-all-pages handle resource-def url auth-headers params)]
-                             (connector/extract-result records cursor false)))]
-        (if (:optional? resource-def)
-          (try (fetch)
-               (catch clojure.lang.ExceptionInfo e
-                 (optional-fetch-failure e)))
-          (fetch))))))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [resource-def (require-resource! schema-name)
+            {:keys [config auth-headers]} handle-state]
+        (if (= "notes" schema-name)
+          (extract-project-notes handle config auth-headers (:extract/cursor opts) opts)
+          (let [url     (resources/build-url (:gitlab/base-url config) resource-def config)
+                params  (resources/build-query-params resource-def (:extract/cursor opts) opts)
+                fetch   (fn [] (let [{:keys [records cursor]}
+                                     (fetch-all-pages handle resource-def url auth-headers params)]
+                                 (connector/extract-result records cursor false)))]
+            (if (:optional? resource-def)
+              (try (fetch)
+                   (catch clojure.lang.ExceptionInfo e
+                     (optional-fetch-failure e)))
+              (fetch))))))))
 
 (defn do-checkpoint [cursor-state]
   (connector/checkpoint-result cursor-state))

--- a/components/connector-gitlab/test/ai/miniforge/connector_gitlab/impl_test.clj
+++ b/components/connector-gitlab/test/ai/miniforge/connector_gitlab/impl_test.clj
@@ -283,35 +283,31 @@
       (is (= :committed (:checkpoint/status result))))))
 
 ;;------------------------------------------------------------------------------ Layer 6
-;; Migrated validation helpers — confirm the shared connector helpers
-;; preserve the legacy ex-info shape at the protocol boundary.
+;; Migrated validation helpers — connector boundaries return anomalies.
 
-(deftest discover-throws-on-unknown-handle-test
-  (testing "do-discover throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-discover "no-such-handle")
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest discover-returns-anomaly-on-unknown-handle-test
+  (testing "do-discover returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-discover "no-such-handle")]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-throws-on-unknown-handle-test
-  (testing "do-extract throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-extract "no-such-handle" "issues" {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest extract-returns-anomaly-on-unknown-handle-test
+  (testing "do-extract returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-extract "no-such-handle" "issues" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
 (deftest connect-rejects-malformed-auth-test
-  (testing "do-connect throws ex-info when auth credential-ref is malformed"
-    (try
-      (impl/do-connect {:gitlab/project-path "owner/repo"}
-                       {:auth/method :api-key
-                        ;; Missing :auth/credential-id
-                        :auth/scheme :bearer})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (some? (:errors (ex-data e))))))))
+  (testing "do-connect returns an anomaly when auth credential-ref is malformed"
+    (let [result (impl/do-connect {:gitlab/project-path "owner/repo"}
+                                  {:auth/method :api-key
+                                   ;; Missing :auth/credential-id
+                                   :auth/scheme :bearer})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (some? (:errors result))))))
 
 (deftest connect-accepts-valid-auth-test
   (testing "do-connect succeeds when auth credential-ref validates"

--- a/docs/pull-requests/2026-06-29-chris-gitlab-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-gitlab-connector-validation-anomalies.md
@@ -1,0 +1,46 @@
+# refactor: return GitLab connector validation anomalies
+
+## Overview
+
+Migrates the GitLab connector away from shared throwing validation helpers for
+missing handles and malformed auth.
+
+## Motivation
+
+The GitLab connector had already returned an anomaly for missing project config,
+but handle lookup and auth validation still flowed through `ex-info`. Those are
+ordinary connector protocol failures and should remain values until an outer
+process boundary decides how to present them.
+
+## Base Branch
+
+`main`
+
+## Layer
+
+Connector implementation refactor.
+
+## What Changed
+
+- Adds a direct `ai.miniforge/anomaly` dependency to `connector-gitlab`.
+- Changes the private handle lookup helper to call `connector/require-handle`.
+- Makes `do-discover` and `do-extract` return response-shaped
+  missing-handle anomalies.
+- Makes malformed auth return a localized validation anomaly from
+  `do-connect`.
+- Updates GitLab connector tests from thrown `ExceptionInfo` assertions to
+  returned anomaly assertions.
+
+The returned maps use `response/make-anomaly` so existing connector consumers
+that dispatch with `response/anomaly-map?` continue to treat failures as
+failures.
+
+## Testing
+
+- Focused GitLab connector tests pass.
+- Full `bb pre-commit` pass required before merge.
+
+## Follow-Up
+
+The shared throwing validation helpers remain until the remaining connector
+implementations are migrated in subsequent slices.


### PR DESCRIPTION
# refactor: return GitLab connector validation anomalies

## Overview

Migrates the GitLab connector away from shared throwing validation helpers for
missing handles and malformed auth.

## Motivation

The GitLab connector had already returned an anomaly for missing project config,
but handle lookup and auth validation still flowed through `ex-info`. Those are
ordinary connector protocol failures and should remain values until an outer
process boundary decides how to present them.

## Base Branch

`main`

## Layer

Connector implementation refactor.

## What Changed

- Adds a direct `ai.miniforge/anomaly` dependency to `connector-gitlab`.
- Changes the private handle lookup helper to call `connector/require-handle`.
- Makes `do-discover` and `do-extract` return response-shaped
  missing-handle anomalies.
- Makes malformed auth return a localized validation anomaly from
  `do-connect`.
- Updates GitLab connector tests from thrown `ExceptionInfo` assertions to
  returned anomaly assertions.

The returned maps use `response/make-anomaly` so existing connector consumers
that dispatch with `response/anomaly-map?` continue to treat failures as
failures.

## Testing

- Focused GitLab connector tests pass.
- Full `bb pre-commit` pass required before merge.

## Follow-Up

The shared throwing validation helpers remain until the remaining connector
implementations are migrated in subsequent slices.
