### PR TITLE
refactor: return Jira connector validation anomalies

### DIFF
--- a/components/connector-jira/deps.edn
+++ b/components/connector-jira/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector      {:local/root "../connector"}
+ :deps {ai.miniforge/anomaly        {:local/root "../anomaly"}
+        ai.miniforge/connector      {:local/root "../connector"}
         ai.miniforge/connector-auth {:local/root "../connector-auth"}
         ai.miniforge/connector-http {:local/root "../connector-http"}
         ai.miniforge/response       {:local/root "../response"}

--- a/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
@@ -19,7 +19,8 @@
 (ns ai.miniforge.connector-jira.impl
   "Implementation functions for the Jira Cloud REST API connector.
    Small composable functions organized in a stratified DAG."
-  (:require [ai.miniforge.connector.interface :as connector]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-jira.messages :as msg]
             [ai.miniforge.connector-jira.resources :as resources]
             [ai.miniforge.connector-jira.schema :as schema]
@@ -36,11 +37,11 @@
 (defn- remove-handle! [handle] (connector/remove-handle! handles handle))
 (defn- touch-handle! [handle] (connector/touch-handle! handles handle))
 
-(defn- require-handle!
-  "Retrieve handle state or throw, delegating to the shared helper."
+(defn- require-handle
+  "Retrieve handle state or return an anomaly."
   [handle]
-  (connector/require-handle! handles handle
-                             {:message (msg/t :jira/handle-not-found {:handle handle})}))
+  (connector/require-handle handles handle
+                            {:message (msg/t :jira/handle-not-found {:handle handle})}))
 
 ;; Auth — Jira Cloud uses Basic auth (email:api-token)
 
@@ -62,13 +63,22 @@
     (build-auth-headers config auth)
     {}))
 
-(defn- validate-auth!
-  "Validate auth credential reference, throwing on failure with the
-   Jira-localized message. Delegates to the shared
-   `connector/validate-auth-or-throw!` helper so all the boundary
-   throwers across connector-{jira,gitlab,github} read the same way."
+(defn- validate-auth
+  "Validate auth credential reference, returning a localized response anomaly on failure."
   [auth]
-  (connector/validate-auth-or-throw! auth msg/t :jira/auth-invalid))
+  (when-let [auth-anomaly (connector/validate-auth auth)]
+    (let [errors (get-in auth-anomaly [:anomaly/data :errors])]
+      (response/make-anomaly :anomalies/incorrect
+                             (msg/t :jira/auth-invalid {:errors errors})
+                             (:anomaly/data auth-anomaly)))))
+
+(defn- handle-anomaly->response
+  "Convert connector handle validation anomalies to the response anomaly shape
+   expected by current connector protocol consumers."
+  [handle-anomaly]
+  (response/make-anomaly :anomalies/not-found
+                         (:anomaly/message handle-anomaly)
+                         (:anomaly/data handle-anomaly)))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; HTTP — Jira uses offset pagination (startAt + maxResults), not Link headers.
@@ -120,44 +130,50 @@
 (defn do-connect
   "Validate config at boundary, register handle."
   [config auth]
-  (when-not (:jira/site config)
-    (response/throw-anomaly! :anomalies/incorrect
-                             (msg/t :jira/site-required)
-                             {:config config}))
-  (schema/validate! schema/JiraConfig config)
-  (validate-auth! auth)
-  (let [handle (str (UUID/randomUUID))
-        base-url (resources/build-base-url config)]
-    (store-handle! handle {:config       (assoc config :jira/base-url base-url)
-                            :auth-headers (resolve-auth-headers config auth)
-                            :last-request-at nil})
-    (connector/connect-result handle)))
+  (if-not (:jira/site config)
+    (response/make-anomaly :anomalies/incorrect
+                           (msg/t :jira/site-required)
+                           {:config config})
+    (do
+      (schema/validate! schema/JiraConfig config)
+      (if-let [auth-anomaly (validate-auth auth)]
+        auth-anomaly
+        (let [handle (str (UUID/randomUUID))
+              base-url (resources/build-base-url config)]
+          (store-handle! handle {:config       (assoc config :jira/base-url base-url)
+                                 :auth-headers (resolve-auth-headers config auth)
+                                 :last-request-at nil})
+          (connector/connect-result handle))))))
 
 (defn do-close [handle]
   (remove-handle! handle)
   (connector/close-result))
 
 (defn do-discover [handle]
-  (require-handle! handle)
-  (connector/discover-result (resources/resource-schemas)))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (connector/discover-result (resources/resource-schemas)))))
 
 (defn do-extract
   "Extract records from a Jira Cloud API resource.
    Validates records at the API boundary — malformed records from
    the Jira API are filtered out before entering the pipeline."
   [handle schema-name opts]
-  (let [handle-state (require-handle! handle)
-        resource-def (require-resource! schema-name)
-        resource-key (keyword schema-name)
-        {:keys [config auth-headers]} handle-state
-        url          (resources/build-url (:jira/base-url config) resource-def config)
-        params       (resources/build-query-params resource-def (:extract/cursor opts) opts config)
-        response-key (get resource-def :response-key :values)
-        raw-records  (fetch-all-pages handle url auth-headers params response-key)
-        records      (schema/validate-records resource-key raw-records)
-        cursor       (when (= :timestamp-watermark (:cursor-type resource-def))
-                       (http/max-timestamp-cursor timestamp-value records))]
-    (connector/extract-result records cursor false)))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [resource-def (require-resource! schema-name)
+            resource-key (keyword schema-name)
+            {:keys [config auth-headers]} handle-state
+            url          (resources/build-url (:jira/base-url config) resource-def config)
+            params       (resources/build-query-params resource-def (:extract/cursor opts) opts config)
+            response-key (get resource-def :response-key :values)
+            raw-records  (fetch-all-pages handle url auth-headers params response-key)
+            records      (schema/validate-records resource-key raw-records)
+            cursor       (when (= :timestamp-watermark (:cursor-type resource-def))
+                           (http/max-timestamp-cursor timestamp-value records))]
+        (connector/extract-result records cursor false)))))
 
 (defn do-checkpoint [cursor-state]
   (connector/checkpoint-result cursor-state))

--- a/components/connector-jira/test/ai/miniforge/connector_jira/anomaly/jira_anomaly_test.clj
+++ b/components/connector-jira/test/ai/miniforge/connector_jira/anomaly/jira_anomaly_test.clj
@@ -26,13 +26,10 @@
             [ai.miniforge.connector-jira.schema :as schema])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest do-connect-missing-site-throws-anomaly
-  (testing "config without :jira/site raises :anomalies/incorrect"
-    (try
-      (impl/do-connect {} nil)
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
+(deftest do-connect-missing-site-returns-anomaly
+  (testing "config without :jira/site returns :anomalies/incorrect"
+    (let [result (impl/do-connect {} nil)]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
 (deftest require-resource-unknown-throws-anomaly
   (testing "looking up an unknown resource raises :anomalies/not-found"

--- a/components/connector-jira/test/ai/miniforge/connector_jira/impl_test.clj
+++ b/components/connector-jira/test/ai/miniforge/connector_jira/impl_test.clj
@@ -17,10 +17,12 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.connector-jira.impl-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-jira.impl :as impl]
             [ai.miniforge.connector-jira.resources :as resources]
             [ai.miniforge.connector-jira.schema :as jira-schema]
+            [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]))
 
 ;;------------------------------------------------------------------------------ Layer 0
@@ -85,30 +87,30 @@
     (let [resource-def (resources/get-resource :issues)
           params (resources/build-query-params resource-def nil {} {:jira/project-key "PROJ"})]
       (is (= 100 (get params "maxResults")))
-      (is (clojure.string/includes? (get params "jql") "project = PROJ"))
-      (is (clojure.string/includes? (get params "jql") "ORDER BY updated DESC"))
+      (is (str/includes? (get params "jql") "project = PROJ"))
+      (is (str/includes? (get params "jql") "ORDER BY updated DESC"))
       (is (string? (get params "fields")))
-      (is (clojure.string/includes? (get params "fields") "key"))))
+      (is (str/includes? (get params "fields") "key"))))
 
   (testing "issues: includes cursor value in JQL"
     (let [resource-def (resources/get-resource :issues)
           cursor {:cursor/type :timestamp-watermark :cursor/value "2026-01-15 10:00"}
           params (resources/build-query-params resource-def cursor {} {:jira/project-key "PROJ"})]
-      (is (clojure.string/includes? (get params "jql") "updated >= \"2026-01-15 10:00\""))))
+      (is (str/includes? (get params "jql") "updated >= \"2026-01-15 10:00\""))))
 
   (testing "issues: no project clause when project-key is absent; sentinel date used"
     (let [resource-def (resources/get-resource :issues)
           params (resources/build-query-params resource-def nil {} {})]
-      (is (not (clojure.string/includes? (get params "jql") "project")))
-      (is (clojure.string/includes? (get params "jql") "updated >= \"2000-01-01"))
-      (is (clojure.string/includes? (get params "jql") "ORDER BY updated DESC"))))
+      (is (not (str/includes? (get params "jql") "project")))
+      (is (str/includes? (get params "jql") "updated >= \"2000-01-01"))
+      (is (str/includes? (get params "jql") "ORDER BY updated DESC"))))
 
   (testing "issues: no project clause when project-key is unresolved placeholder; sentinel date used"
     (let [resource-def (resources/get-resource :issues)
           params (resources/build-query-params resource-def nil {} {:jira/project-key "${JIRA_PROJECT_KEY}"})]
-      (is (not (clojure.string/includes? (get params "jql") "project")))
-      (is (clojure.string/includes? (get params "jql") "updated >= \"2000-01-01"))
-      (is (clojure.string/includes? (get params "jql") "ORDER BY updated DESC"))))
+      (is (not (str/includes? (get params "jql") "project")))
+      (is (str/includes? (get params "jql") "updated >= \"2000-01-01"))
+      (is (str/includes? (get params "jql") "ORDER BY updated DESC"))))
 
   (testing "non-issues: no JQL"
     (let [resource-def (resources/get-resource :boards)
@@ -121,7 +123,8 @@
 
 (deftest connect-validates-config-test
   (testing "do-connect requires :jira/site"
-    (is (thrown? Exception (impl/do-connect {} nil)))))
+    (let [result (impl/do-connect {} nil)]
+      (is (= :anomalies/incorrect (:anomaly/category result))))))
 
 (deftest connect-close-lifecycle-test
   (testing "connect and close with valid config"
@@ -149,7 +152,7 @@
       (try
         (with-redefs-fn
           {#'impl/do-request
-           (fn [url _headers params]
+           (fn [_url _headers params]
              (swap! calls conj params)
              (let [start-at (get params "startAt" 0)]
                (if (zero? start-at)
@@ -291,35 +294,31 @@
           (impl/do-close handle))))))
 
 ;;------------------------------------------------------------------------------ Layer 6
-;; Migrated validation helpers — confirm the shared connector helpers
-;; preserve the legacy ex-info shape at the protocol boundary.
+;; Migrated validation helpers — connector boundaries return anomalies.
 
-(deftest discover-throws-on-unknown-handle-test
-  (testing "do-discover throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-discover "no-such-handle")
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest discover-returns-anomaly-on-unknown-handle-test
+  (testing "do-discover returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-discover "no-such-handle")]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-throws-on-unknown-handle-test
-  (testing "do-extract throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-extract "no-such-handle" "issues" {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest extract-returns-anomaly-on-unknown-handle-test
+  (testing "do-extract returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-extract "no-such-handle" "issues" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
 (deftest connect-rejects-malformed-auth-test
-  (testing "do-connect throws ex-info when auth credential-ref is malformed"
-    (try
-      (impl/do-connect {:jira/site "mycompany"}
-                       {:auth/method :api-key
-                        ;; Missing :auth/credential-id — connector-auth flags this
-                        :auth/scheme :basic})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (some? (:errors (ex-data e))))))))
+  (testing "do-connect returns an anomaly when auth credential-ref is malformed"
+    (let [result (impl/do-connect {:jira/site "mycompany"}
+                                  {:auth/method :api-key
+                                   ;; Missing :auth/credential-id — connector-auth flags this
+                                   :auth/scheme :basic})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (some? (:errors result))))))
 
 (deftest connect-accepts-valid-auth-test
   (testing "do-connect succeeds when auth credential-ref validates"

--- a/docs/pull-requests/2026-06-29-chris-jira-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-jira-connector-validation-anomalies.md
@@ -1,0 +1,45 @@
+# refactor: return Jira connector validation anomalies
+
+## Overview
+
+Migrates the Jira connector away from shared throwing validation helpers for
+missing handles and malformed auth.
+
+## Motivation
+
+Jira still used throwing validation helpers for connector protocol failures:
+missing handles and malformed auth. Those should be returned anomaly values,
+with exception conversion left to an outer boundary.
+
+## Base Branch
+
+`main`
+
+## Layer
+
+Connector implementation refactor.
+
+## What Changed
+
+- Adds a direct `ai.miniforge/anomaly` dependency to `connector-jira`.
+- Changes the private handle lookup helper to call `connector/require-handle`.
+- Makes `do-discover` and `do-extract` return response-shaped
+  missing-handle anomalies.
+- Makes missing site config and malformed auth return anomaly values from
+  `do-connect`.
+- Updates Jira connector tests from thrown `ExceptionInfo` assertions to
+  returned anomaly assertions.
+
+The returned connector-boundary maps use `response/make-anomaly` so existing
+consumers that dispatch with `response/anomaly-map?` continue to treat failures
+as failures.
+
+## Testing
+
+- Focused Jira connector tests pass.
+- Full `bb pre-commit` pass required before merge.
+
+## Follow-Up
+
+The shared throwing validation helpers remain until the remaining connector
+implementations are migrated in subsequent slices.


### PR DESCRIPTION
# refactor: return Jira connector validation anomalies

## Overview

Migrates the Jira connector away from shared throwing validation helpers for
missing handles and malformed auth.

## Motivation

Jira still used throwing validation helpers for connector protocol failures:
missing handles and malformed auth. Those should be returned anomaly values,
with exception conversion left to an outer boundary.

## Base Branch

`main`

## Layer

Connector implementation refactor.

## What Changed

- Adds a direct `ai.miniforge/anomaly` dependency to `connector-jira`.
- Changes the private handle lookup helper to call `connector/require-handle`.
- Makes `do-discover` and `do-extract` return response-shaped
  missing-handle anomalies.
- Makes missing site config and malformed auth return anomaly values from
  `do-connect`.
- Updates Jira connector tests from thrown `ExceptionInfo` assertions to
  returned anomaly assertions.

The returned connector-boundary maps use `response/make-anomaly` so existing
consumers that dispatch with `response/anomaly-map?` continue to treat failures
as failures.

## Testing

- Focused Jira connector tests pass.
- Full `bb pre-commit` pass required before merge.

## Follow-Up

The shared throwing validation helpers remain until the remaining connector
implementations are migrated in subsequent slices.
