### PR TITLE
refactor: return EDGAR connector handle anomalies

### DIFF
--- a/components/connector-edgar/deps.edn
+++ b/components/connector-edgar/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector       {:local/root "../connector"}
+ :deps {ai.miniforge/anomaly         {:local/root "../anomaly"}
+        ai.miniforge/connector       {:local/root "../connector"}
         ai.miniforge/connector-auth  {:local/root "../connector-auth"}
         ai.miniforge/connector-http  {:local/root "../connector-http"}
         ai.miniforge/connector-retry {:local/root "../connector-retry"}

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
@@ -20,14 +20,15 @@
   "Implementation functions for the EDGAR connector.
    Queries SEC EDGAR EFTS for filings, fetches filing documents,
    and extracts structured data from XML."
-  (:require [ai.miniforge.connector.interface :as connector]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-edgar.messages :as msg]
             [ai.miniforge.connector-http.interface :as http]
             [ai.miniforge.response.interface :as response]
-            [ai.miniforge.schema.interface :as schema]
             [babashka.http-client :as bb-http]
             [cheshire.core :as cheshire]
-            [clojure.data.xml :as xml])
+            [clojure.data.xml :as xml]
+            [clojure.string :as str])
   (:import [java.io ByteArrayInputStream]
            [java.time LocalDate]
            [java.time.format DateTimeFormatter]
@@ -119,7 +120,7 @@
 (defn- fetch-filing-xml
   "Fetch a filing's XML document. Tries common filenames."
   [archives-base adsh cik user-agent filenames]
-  (let [adsh-path (clojure.string/replace adsh "-" "")
+  (let [adsh-path (str/replace adsh "-" "")
         cik-num   (str (parse-long cik))]
     (some (fn [fname]
             (fetch-url (str archives-base "/" cik-num "/" adsh-path "/" fname)
@@ -231,30 +232,44 @@
 
 ;; -- Source --
 
-(defn- require-handle!
-  "Retrieve handle state or throw, delegating to the shared helper."
+(defn- require-handle
+  "Retrieve handle state or return an anomaly."
   [handle]
-  (connector/require-handle! handles handle
-                             {:message (msg/t :edgar/handle-not-found {:handle handle})}))
+  (connector/require-handle handles handle
+                            {:message (msg/t :edgar/handle-not-found {:handle handle})}))
+
+(defn- handle-anomaly->response
+  "Convert connector handle validation anomalies to the response anomaly shape
+   expected by current connector protocol consumers."
+  [handle-anomaly]
+  (response/make-anomaly :anomalies/not-found
+                         (:anomaly/message handle-anomaly)
+                         (:anomaly/data handle-anomaly)))
 
 (defn do-discover [handle]
-  (let [{:keys [config]} (require-handle! handle)]
-    (connector/discover-result [{:schema/name        (:edgar/form-type config)
-                                 :schema/aggregation (:edgar/aggregation config)}])))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [{:keys [config]} handle-state]
+        (connector/discover-result [{:schema/name        (:edgar/form-type config)
+                                     :schema/aggregation (:edgar/aggregation config)}])))))
 
 (defn do-extract
   "Extract aggregated records from EDGAR filings."
   [handle _opts]
-  (let [{:keys [config]} (require-handle! handle)
-        user-agent (:edgar/user-agent config)
-        records    (case (:edgar/aggregation config)
-                     :monthly-buy-sell-ratio
-                     (aggregate-buy-sell-ratio config user-agent)
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [{:keys [config]} handle-state
+            user-agent (:edgar/user-agent config)
+            records    (case (:edgar/aggregation config)
+                         :monthly-buy-sell-ratio
+                         (aggregate-buy-sell-ratio config user-agent)
 
-                     (response/throw-anomaly! :anomalies/unsupported
-                                              (msg/t :edgar/aggregation-unknown {:agg (:edgar/aggregation config)})
-                                              {:aggregation (:edgar/aggregation config)}))]
-    (connector/extract-result records nil false)))
+                         (response/throw-anomaly! :anomalies/unsupported
+                                                  (msg/t :edgar/aggregation-unknown {:agg (:edgar/aggregation config)})
+                                                  {:aggregation (:edgar/aggregation config)}))]
+        (connector/extract-result records nil false)))))
 
 (defn do-checkpoint [cursor-state]
   (connector/checkpoint-result cursor-state))

--- a/components/connector-edgar/test/ai/miniforge/connector_edgar/interface_test.clj
+++ b/components/connector-edgar/test/ai/miniforge/connector_edgar/interface_test.clj
@@ -18,7 +18,8 @@
 
 (ns ai.miniforge.connector-edgar.interface-test
   (:require [clojure.test :refer [deftest is testing]]
-            [ai.miniforge.connector-edgar.impl :as impl]))
+            [ai.miniforge.connector-edgar.impl :as impl]
+            [ai.miniforge.response.interface :as response]))
 
 (deftest connect-validates-config-test
   (testing "do-connect requires form-type, user-agent, aggregation"
@@ -109,21 +110,18 @@
       (impl/do-close handle))))
 
 ;;------------------------------------------------------------------------------ Layer 2
-;; Migrated handle-lookup helper — confirm the shared connector helper
-;; preserves the legacy ex-info shape at the protocol boundary.
+;; Migrated handle-lookup helper — connector boundaries return anomalies.
 
-(deftest discover-throws-on-unknown-handle-test
-  (testing "do-discover throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-discover "no-such-handle")
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest discover-returns-anomaly-on-unknown-handle-test
+  (testing "do-discover returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-discover "no-such-handle")]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-throws-on-unknown-handle-test
-  (testing "do-extract throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-extract "no-such-handle" {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest extract-returns-anomaly-on-unknown-handle-test
+  (testing "do-extract returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-extract "no-such-handle" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))

--- a/docs/pull-requests/2026-06-29-chris-edgar-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-edgar-connector-validation-anomalies.md
@@ -1,0 +1,38 @@
+# refactor: return EDGAR connector handle anomalies
+
+## Overview
+
+Migrates EDGAR connector handle lookup away from the shared throwing validation
+helper.
+
+## Motivation
+
+Missing connector handles are ordinary connector protocol failures. EDGAR now
+returns an anomaly value for that case instead of routing through an
+`ExceptionInfo` throw.
+
+## Base Branch
+
+`main`
+
+## Layer
+
+Connector implementation refactor.
+
+## What Changed
+
+- Adds a direct `ai.miniforge/anomaly` dependency to `connector-edgar`.
+- Changes the private handle lookup helper to call `connector/require-handle`.
+- Makes `do-discover` and `do-extract` return response-shaped
+  missing-handle anomalies.
+- Updates EDGAR connector tests from thrown `ExceptionInfo` assertions to
+  returned anomaly assertions.
+
+The returned maps use `response/make-anomaly` so existing connector consumers
+that dispatch with `response/anomaly-map?` continue to treat failures as
+failures.
+
+## Testing
+
+- Focused EDGAR connector tests pass.
+- Full `bb pre-commit` pass required before merge.


### PR DESCRIPTION
# refactor: return EDGAR connector handle anomalies

## Overview

Migrates EDGAR connector handle lookup away from the shared throwing validation
helper.

## Motivation

Missing connector handles are ordinary connector protocol failures. EDGAR now
returns an anomaly value for that case instead of routing through an
`ExceptionInfo` throw.

## Base Branch

`main`

## Layer

Connector implementation refactor.

## What Changed

- Adds a direct `ai.miniforge/anomaly` dependency to `connector-edgar`.
- Changes the private handle lookup helper to call `connector/require-handle`.
- Makes `do-discover` and `do-extract` return response-shaped
  missing-handle anomalies.
- Updates EDGAR connector tests from thrown `ExceptionInfo` assertions to
  returned anomaly assertions.

The returned maps use `response/make-anomaly` so existing connector consumers
that dispatch with `response/anomaly-map?` continue to treat failures as
failures.

## Testing

- Focused EDGAR connector tests pass.
- Full `bb pre-commit` pass required before merge.
