### PR TITLE
refactor: return Excel connector handle anomalies

### DIFF
--- a/components/connector-excel/deps.edn
+++ b/components/connector-excel/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector       {:local/root "../connector"}
+ :deps {ai.miniforge/anomaly         {:local/root "../anomaly"}
+        ai.miniforge/connector       {:local/root "../connector"}
         ai.miniforge/connector-auth  {:local/root "../connector-auth"}
         ai.miniforge/connector-retry {:local/root "../connector-retry"}
         ai.miniforge/response        {:local/root "../response"}

--- a/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
@@ -19,7 +19,8 @@
 (ns ai.miniforge.connector-excel.impl
   "Implementation functions for the Excel connector.
    Downloads a remote Excel file and extracts records using column mappings."
-  (:require [ai.miniforge.connector.interface :as connector]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-excel.messages :as msg]
             [ai.miniforge.response.interface :as response]
             [babashka.http-client :as http])
@@ -179,29 +180,40 @@
 
 ;; -- Source --
 
-(defn- require-handle!
-  "Retrieve handle state or throw, delegating to the shared helper."
+(defn- require-handle
+  "Retrieve handle state or return an anomaly."
   [handle]
-  (connector/require-handle! handles handle
-                             {:message (msg/t :excel/handle-not-found {:handle handle})}))
+  (connector/require-handle handles handle
+                            {:message (msg/t :excel/handle-not-found {:handle handle})}))
+
+(defn- handle-anomaly->response [handle-anomaly]
+  (response/make-anomaly :anomalies/not-found
+                         (:anomaly/message handle-anomaly)
+                         (:anomaly/data handle-anomaly)))
 
 (defn do-discover [handle]
-  (let [{:keys [config]} (require-handle! handle)]
-    (connector/discover-result [{:schema/name (:excel/sheet-name config)
-                                 :schema/url  (:excel/url config)}])))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [{:keys [config]} handle-state]
+        (connector/discover-result [{:schema/name (:excel/sheet-name config)
+                                     :schema/url  (:excel/url config)}])))))
 
 (defn do-extract
   "Parse the Excel sheet and return records."
   [handle _opts]
-  (let [{:keys [config workbook]} (require-handle! handle)
-        {:excel/keys [sheet-name columns data-start-row series-id]} config
-        filter-fn (when-let [min-val (:excel/min-value config)]
-                    (min-value-filter min-val))
-        records   (parse-sheet workbook sheet-name columns
-                               (or data-start-row 0) filter-fn)
-        date-fmt  (:excel/date-format config)
-        enriched  (mapv (partial normalize-record date-fmt series-id) records)]
-    (connector/extract-result enriched nil false)))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [{:keys [config workbook]} handle-state
+            {:excel/keys [sheet-name columns data-start-row series-id]} config
+            filter-fn (when-let [min-val (:excel/min-value config)]
+                        (min-value-filter min-val))
+            records   (parse-sheet workbook sheet-name columns
+                                   (or data-start-row 0) filter-fn)
+            date-fmt  (:excel/date-format config)
+            enriched  (mapv (partial normalize-record date-fmt series-id) records)]
+        (connector/extract-result enriched nil false)))))
 
 (defn do-checkpoint [cursor-state]
   (connector/checkpoint-result cursor-state))

--- a/components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj
+++ b/components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj
@@ -17,7 +17,8 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.connector-excel.interface-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [ai.miniforge.response.interface :as response]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-excel.impl :as impl]))
 
 (deftest cell-value-nil-test
@@ -126,21 +127,19 @@
     (is (thrown? Exception (impl/do-connect {:excel/url "x" :excel/sheet-name "S"} nil)))))
 
 ;;------------------------------------------------------------------------------ Layer 2
-;; Migrated handle-lookup helper — confirm the shared connector helper
-;; preserves the legacy ex-info shape at the protocol boundary.
+;; Migrated handle-lookup helper — connector boundaries return response
+;; anomalies.
 
-(deftest discover-throws-on-unknown-handle-test
-  (testing "do-discover throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-discover "no-such-handle")
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest discover-returns-anomaly-on-unknown-handle-test
+  (testing "do-discover returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-discover "no-such-handle")]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-throws-on-unknown-handle-test
-  (testing "do-extract throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-extract "no-such-handle" {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest extract-returns-anomaly-on-unknown-handle-test
+  (testing "do-extract returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-extract "no-such-handle" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))

--- a/docs/pull-requests/2026-06-29-chris-excel-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-excel-connector-validation-anomalies.md
@@ -1,0 +1,42 @@
+# refactor: return Excel connector handle anomalies
+
+## Overview
+
+Migrates the Excel connector away from the shared throwing handle lookup helper.
+
+## Motivation
+
+Excel still used a throwing helper for missing connector handles. Connector
+protocol failures should be returned as anomaly values, with exception
+conversion left to an outer boundary.
+
+## Base Branch
+
+`main`
+
+## Layer
+
+Connector implementation refactor.
+
+## What Changed
+
+- Adds a direct `ai.miniforge/anomaly` dependency to `connector-excel`.
+- Changes the private handle lookup helper to call `connector/require-handle`.
+- Makes `do-discover` and `do-extract` return response-shaped missing-handle
+  anomalies.
+- Updates Excel connector tests from thrown `ExceptionInfo` assertions to
+  returned anomaly assertions.
+
+The returned connector-boundary maps use `response/make-anomaly` so existing
+consumers that dispatch with `response/anomaly-map?` continue to treat failures
+as failures.
+
+## Testing
+
+- Focused Excel connector tests pass.
+- Full `bb pre-commit` pass required before merge.
+
+## Follow-Up
+
+The shared throwing validation helpers remain until the remaining connector
+implementations are migrated in subsequent slices.


### PR DESCRIPTION
# refactor: return Excel connector handle anomalies

## Overview

Migrates the Excel connector away from the shared throwing handle lookup helper.

## Motivation

Excel still used a throwing helper for missing connector handles. Connector
protocol failures should be returned as anomaly values, with exception
conversion left to an outer boundary.

## Base Branch

`main`

## Layer

Connector implementation refactor.

## What Changed

- Adds a direct `ai.miniforge/anomaly` dependency to `connector-excel`.
- Changes the private handle lookup helper to call `connector/require-handle`.
- Makes `do-discover` and `do-extract` return response-shaped missing-handle
  anomalies.
- Updates Excel connector tests from thrown `ExceptionInfo` assertions to
  returned anomaly assertions.

The returned connector-boundary maps use `response/make-anomaly` so existing
consumers that dispatch with `response/anomaly-map?` continue to treat failures
as failures.

## Testing

- Focused Excel connector tests pass.
- Full `bb pre-commit` pass required before merge.

## Follow-Up

The shared throwing validation helpers remain until the remaining connector
implementations are migrated in subsequent slices.
