### PR TITLE
refactor: return File connector handle anomalies

### DIFF
--- a/components/connector-file/deps.edn
+++ b/components/connector-file/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector {:local/root "../connector"}
+ :deps {ai.miniforge/anomaly   {:local/root "../anomaly"}
+        ai.miniforge/connector {:local/root "../connector"}
         ai.miniforge/response  {:local/root "../response"}
         org.clojure/data.csv      {:mvn/version "1.1.0"}
         cheshire/cheshire          {:mvn/version "5.13.0"}}

--- a/components/connector-file/src/ai/miniforge/connector_file/impl.clj
+++ b/components/connector-file/src/ai/miniforge/connector_file/impl.clj
@@ -19,7 +19,8 @@
 (ns ai.miniforge.connector-file.impl
   "Implementation functions for the file connector.
    Pure logic separated from protocol wiring."
-  (:require [ai.miniforge.connector.interface :as connector]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-file.reader :as reader]
             [ai.miniforge.connector-file.writer :as writer]
             [ai.miniforge.connector-file.messages :as msg]
@@ -67,38 +68,49 @@
 
 ;; -- Source --
 
-(defn- require-handle!
-  "Retrieve handle state or throw, delegating to the shared helper."
+(defn- require-handle
+  "Retrieve handle state or return an anomaly."
   [handle]
-  (connector/require-handle! handles handle
-                             {:message (msg/t :file/handle-not-found {:handle handle})}))
+  (connector/require-handle handles handle
+                            {:message (msg/t :file/handle-not-found {:handle handle})}))
+
+(defn- handle-anomaly->response [handle-anomaly]
+  (response/make-anomaly :anomalies/not-found
+                         (:anomaly/message handle-anomaly)
+                         (:anomaly/data handle-anomaly)))
 
 (defn do-discover
   "Return schema metadata for the connected file."
   [handle]
-  (let [{:file/keys [path]} (require-handle! handle)]
-    (connector/discover-result [{:schema/name (.getName (io/file path))
-                                 :schema/path path}])))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [{:file/keys [path]} handle-state]
+        (connector/discover-result [{:schema/name (.getName (io/file path))
+                                     :schema/path path}])))))
 
 (defn do-extract
   "Read records from file with offset-based cursor pagination."
   [handle opts]
-  (let [{:file/keys [path format]} (require-handle! handle)
-        file (io/file path)]
-    (if-not (.exists file)
-      (response/make-anomaly :anomalies/not-found
-                             (msg/t :file/not-found {:path path})
-                             {:path path})
-      (let [all-records (reader/read-file path format)
-            batch-size  (or (:extract/batch-size opts) (count all-records))
-            offset      (or (get-in opts [:extract/cursor :cursor/value]) 0)
-            batch       (vec (take batch-size (drop offset all-records)))
-            new-offset  (+ offset (count batch))
-            has-more    (< new-offset (count all-records))]
-        (connector/extract-result
-         batch
-         {:cursor/type :offset :cursor/value new-offset}
-         has-more)))))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [{:file/keys [path format]} handle-state
+            file (io/file path)]
+        (if-not (.exists file)
+          (response/make-anomaly :anomalies/not-found
+                                 (msg/t :file/not-found {:path path})
+                                 {:path path})
+          (let [all-records (reader/read-file path format)
+                batch-size  (or (:extract/batch-size opts) (count all-records))
+                offset      (or (get-in opts [:extract/cursor :cursor/value]) 0)
+                batch       (vec (take batch-size (drop offset all-records)))
+                new-offset  (+ offset (count batch))
+                has-more    (< new-offset (count all-records))]
+            (connector/extract-result
+             batch
+             {:cursor/type :offset :cursor/value new-offset}
+             has-more)))))))
 
 (defn do-checkpoint
   "Persist cursor state (no-op for files, returns committed)."
@@ -110,7 +122,10 @@
 (defn do-publish
   "Write records to file. Returns publish-result map."
   [handle records opts]
-  (let [{:file/keys [path format]} (require-handle! handle)
-        mode    (or (:publish/mode opts) :overwrite)
-        written (writer/write-file path records format mode)]
-    (connector/publish-result written 0)))
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [{:file/keys [path format]} handle-state
+            mode    (or (:publish/mode opts) :overwrite)
+            written (writer/write-file path records format mode)]
+        (connector/publish-result written 0)))))

--- a/components/connector-file/test/ai/miniforge/connector_file/interface_test.clj
+++ b/components/connector-file/test/ai/miniforge/connector_file/interface_test.clj
@@ -17,13 +17,13 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.connector-file.interface-test
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [ai.miniforge.response.interface :as response]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.java.io :as io]
             [cheshire.core :as json]
             [ai.miniforge.connector-file.interface :as file-conn]
             [ai.miniforge.connector-file.impl :as impl]
-            [ai.miniforge.connector.interface :as conn]
-            [ai.miniforge.response.interface :as response]))
+            [ai.miniforge.connector.interface :as conn]))
 
 ;; ---------------------------------------------------------------------------
 ;; Test fixtures — temp directory with sample files
@@ -283,30 +283,27 @@
       (conn/close fc handle))))
 
 ;; ---------------------------------------------------------------------------
-;; Migrated handle-lookup helper — confirm the shared connector helper
-;; preserves the legacy ex-info shape at the protocol boundary.
+;; Migrated handle-lookup helper — connector boundaries return response
+;; anomalies.
 ;; ---------------------------------------------------------------------------
 
-(deftest discover-throws-on-unknown-handle-test
-  (testing "do-discover throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-discover "no-such-handle")
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest discover-returns-anomaly-on-unknown-handle-test
+  (testing "do-discover returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-discover "no-such-handle")]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-throws-on-unknown-handle-test
-  (testing "do-extract throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-extract "no-such-handle" {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest extract-returns-anomaly-on-unknown-handle-test
+  (testing "do-extract returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-extract "no-such-handle" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest publish-throws-on-unknown-handle-test
-  (testing "do-publish throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-publish "no-such-handle" [] {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest publish-returns-anomaly-on-unknown-handle-test
+  (testing "do-publish returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-publish "no-such-handle" [] {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))

--- a/docs/pull-requests/2026-06-29-chris-file-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-file-connector-validation-anomalies.md
@@ -1,0 +1,43 @@
+# refactor: return File connector handle anomalies
+
+## Overview
+
+Migrates File connector handle lookup away from the shared throwing validation
+helper.
+
+## Motivation
+
+Missing connector handles are connector protocol failures. File connector source
+and sink paths should return anomaly values for that case instead of throwing an
+`ExceptionInfo` from a shared helper.
+
+## Base Branch
+
+`main`
+
+## Layer
+
+Connector implementation refactor.
+
+## What Changed
+
+- Adds a direct `ai.miniforge/anomaly` dependency to `connector-file`.
+- Changes the private handle lookup helper to call `connector/require-handle`.
+- Makes `do-discover`, `do-extract`, and `do-publish` return response-shaped
+  missing-handle anomalies.
+- Updates File connector tests from thrown `ExceptionInfo` assertions to
+  returned anomaly assertions.
+
+The returned maps use `response/make-anomaly` so existing connector consumers
+that dispatch with `response/anomaly-map?` continue to treat failures as
+failures.
+
+## Testing
+
+- Focused File connector tests pass.
+- Full `bb pre-commit` pass required before merge.
+
+## Follow-Up
+
+The shared throwing validation helpers remain until the remaining connector
+implementations are migrated in subsequent slices.


### PR DESCRIPTION
# refactor: return File connector handle anomalies

## Overview

Migrates File connector handle lookup away from the shared throwing validation
helper.

## Motivation

Missing connector handles are connector protocol failures. File connector source
and sink paths should return anomaly values for that case instead of throwing an
`ExceptionInfo` from a shared helper.

## Base Branch

`main`

## Layer

Connector implementation refactor.

## What Changed

- Adds a direct `ai.miniforge/anomaly` dependency to `connector-file`.
- Changes the private handle lookup helper to call `connector/require-handle`.
- Makes `do-discover`, `do-extract`, and `do-publish` return response-shaped
  missing-handle anomalies.
- Updates File connector tests from thrown `ExceptionInfo` assertions to
  returned anomaly assertions.

The returned maps use `response/make-anomaly` so existing connector consumers
that dispatch with `response/anomaly-map?` continue to treat failures as
failures.

## Testing

- Focused File connector tests pass.
- Full `bb pre-commit` pass required before merge.

## Follow-Up

The shared throwing validation helpers remain until the remaining connector
implementations are migrated in subsequent slices.
