### PR TITLE
refactor: return SARIF connector handle anomalies

### DIFF
--- a/components/connector-sarif/deps.edn
+++ b/components/connector-sarif/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/coerce {:local/root "../coerce"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/coerce {:local/root "../coerce"}
         ai.miniforge/connector {:local/root "../connector"}
         ai.miniforge/response {:local/root "../response"}
         cheshire/cheshire {:mvn/version "5.12.0"}

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
@@ -18,7 +18,8 @@
 
 (ns ai.miniforge.connector-sarif.impl
   "SARIF connector implementation — connect, discover, extract, checkpoint."
-  (:require [ai.miniforge.connector.interface :as connector]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-sarif.format :as fmt]
             [ai.miniforge.connector-sarif.schema :as schema]
             [ai.miniforge.response.interface :as response]
@@ -31,16 +32,16 @@
 
 (defn- generate-handle [] (str "sarif-" (java.util.UUID/randomUUID)))
 
-(defn- require-handle!
-  "Look up handle state, throw if missing.
-   Delegates to the shared connector helper.
-
-   The `:connector` opt is omitted so the thrown ex-data preserves
-   the historical `{:handle ...}` payload shape; the message already
-   identifies the handle by name."
+(defn- require-handle
+  "Look up handle state or return an anomaly."
   [handle]
-  (connector/require-handle! handles handle
-                             {:message (str "Unknown handle: " handle)}))
+  (connector/require-handle handles handle
+                            {:message (str "Unknown handle: " handle)}))
+
+(defn- handle-anomaly->response [handle-anomaly]
+  (response/make-anomaly :anomalies/not-found
+                         (:anomaly/message handle-anomaly)
+                         (:anomaly/data handle-anomaly)))
 
 ;; --------------------------------------------------------------------------
 ;; Connect / Close
@@ -77,12 +78,45 @@
 (defn do-discover
   "Discover available schemas in the connected source."
   [handle _opts]
-  (let [state       (require-handle! handle)
-        source-path (:sarif/source-path state)
-        scan-files  (fmt/list-scan-files source-path)]
-    (if (empty? scan-files)
-      {:schemas [] :discover/total-count 0}
-      (let [all-violations  (into []
+  (let [state (require-handle handle)]
+    (if (anomaly/anomaly? state)
+      (handle-anomaly->response state)
+      (let [source-path (:sarif/source-path state)
+            scan-files  (fmt/list-scan-files source-path)]
+        (if (empty? scan-files)
+          {:schemas [] :discover/total-count 0}
+          (let [all-violations  (into []
+                                      (mapcat
+                                       (fn [file-path]
+                                         (try
+                                           (fmt/parse-file file-path
+                                                           (:sarif/format state)
+                                                           (:sarif/csv-columns state))
+                                           (catch Exception e
+                                             (println (str "Warning: Failed to parse " file-path ": " (.getMessage e)))
+                                             [])))
+                                       scan-files))
+                violation-count (count all-violations)
+                csv-count       (count (filter #(str/includes? (:violation/id %) "csv:") all-violations))
+                schemas         (if (pos? violation-count)
+                                  [(build-schema-descriptor :sarif-result violation-count)
+                                   (build-schema-descriptor :csv-violation csv-count)]
+                                  [])]
+            {:schemas schemas :discover/total-count (count schemas)}))))))
+
+;; --------------------------------------------------------------------------
+;; Extract
+
+(defn do-extract
+  "Extract records for a given schema."
+  [handle _schema-name opts]
+  (let [state (require-handle handle)]
+    (if (anomaly/anomaly? state)
+      (handle-anomaly->response state)
+      (let [source-path     (:sarif/source-path state)
+            _limit          (get opts :extract/limit 10000)
+            scan-files      (fmt/list-scan-files source-path)
+            all-violations  (into []
                                   (mapcat
                                    (fn [file-path]
                                      (try
@@ -92,39 +126,10 @@
                                        (catch Exception e
                                          (println (str "Warning: Failed to parse " file-path ": " (.getMessage e)))
                                          [])))
-                                   scan-files))
-            violation-count (count all-violations)
-            csv-count       (count (filter #(str/includes? (:violation/id %) "csv:") all-violations))
-            schemas         (if (pos? violation-count)
-                              [(build-schema-descriptor :sarif-result violation-count)
-                               (build-schema-descriptor :csv-violation csv-count)]
-                              [])]
-        {:schemas schemas :discover/total-count (count schemas)}))))
-
-;; --------------------------------------------------------------------------
-;; Extract
-
-(defn do-extract
-  "Extract records for a given schema."
-  [handle _schema-name opts]
-  (let [state           (require-handle! handle)
-        source-path     (:sarif/source-path state)
-        _limit          (get opts :extract/limit 10000)
-        scan-files      (fmt/list-scan-files source-path)
-        all-violations  (into []
-                              (mapcat
-                               (fn [file-path]
-                                 (try
-                                   (fmt/parse-file file-path
-                                                   (:sarif/format state)
-                                                   (:sarif/csv-columns state))
-                                   (catch Exception e
-                                     (println (str "Warning: Failed to parse " file-path ": " (.getMessage e)))
-                                     [])))
-                               scan-files))]
-    {:records      all-violations
-     :extract/cursor   {:extract/offset 0}
-     :extract/has-more false}))
+                                   scan-files))]
+        {:records      all-violations
+         :extract/cursor   {:extract/offset 0}
+         :extract/has-more false}))))
 
 ;; --------------------------------------------------------------------------
 ;; Checkpoint
@@ -132,6 +137,8 @@
 (defn do-checkpoint
   "Persist cursor state for resumable extraction."
   [handle _connector-id _cursor-state]
-  (let [_state (require-handle! handle)]
-    {:checkpoint/id     (java.util.UUID/randomUUID)
-     :checkpoint/status :committed}))
+  (let [state (require-handle handle)]
+    (if (anomaly/anomaly? state)
+      (handle-anomaly->response state)
+      {:checkpoint/id     (java.util.UUID/randomUUID)
+       :checkpoint/status :committed})))

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/impl_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/impl_test.clj
@@ -104,21 +104,26 @@
       (impl/do-close handle))))
 
 ;; --------------------------------------------------------------------------
-;; Migrated handle-lookup helper — confirm the shared connector helper
-;; preserves the legacy ex-info shape at the protocol boundary.
+;; Migrated handle-lookup helper — connector boundaries return response
+;; anomalies.
 
-(deftest discover-throws-on-unknown-handle-test
-  (testing "do-discover throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-discover "no-such-handle" {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest discover-returns-anomaly-on-unknown-handle-test
+  (testing "do-discover returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-discover "no-such-handle" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-throws-on-unknown-handle-test
-  (testing "do-extract throws ex-info with :handle key when handle missing"
-    (try
-      (impl/do-extract "no-such-handle" :sarif-result {})
-      (is false "expected ex-info")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= "no-such-handle" (:handle (ex-data e))))))))
+(deftest extract-returns-anomaly-on-unknown-handle-test
+  (testing "do-extract returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-extract "no-such-handle" :sarif-result {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
+
+(deftest checkpoint-returns-anomaly-on-unknown-handle-test
+  (testing "do-checkpoint returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-checkpoint "no-such-handle" "sarif-conn-1" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))

--- a/docs/pull-requests/2026-06-29-chris-sarif-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-sarif-connector-validation-anomalies.md
@@ -1,0 +1,43 @@
+# refactor: return SARIF connector handle anomalies
+
+## Overview
+
+Migrates SARIF connector handle lookup away from the shared throwing validation
+helper.
+
+## Motivation
+
+Missing connector handles are connector protocol failures. SARIF source and
+checkpoint paths should return anomaly values for that case instead of throwing
+an `ExceptionInfo` from a shared helper.
+
+## Base Branch
+
+`main`
+
+## Layer
+
+Connector implementation refactor.
+
+## What Changed
+
+- Adds a direct `ai.miniforge/anomaly` dependency to `connector-sarif`.
+- Changes the private handle lookup helper to call `connector/require-handle`.
+- Makes `do-discover`, `do-extract`, and `do-checkpoint` return
+  response-shaped missing-handle anomalies.
+- Updates SARIF connector tests from thrown `ExceptionInfo` assertions to
+  returned anomaly assertions.
+
+The returned maps use `response/make-anomaly` so existing connector consumers
+that dispatch with `response/anomaly-map?` continue to treat failures as
+failures.
+
+## Testing
+
+- Focused SARIF connector tests pass.
+- Full `bb pre-commit` pass required before merge.
+
+## Follow-Up
+
+The shared throwing validation helpers remain until the shared connector API is
+cleaned up in a final slice.


### PR DESCRIPTION
# refactor: return SARIF connector handle anomalies

## Overview

Migrates SARIF connector handle lookup away from the shared throwing validation
helper.

## Motivation

Missing connector handles are connector protocol failures. SARIF source and
checkpoint paths should return anomaly values for that case instead of throwing
an `ExceptionInfo` from a shared helper.

## Base Branch

`main`

## Layer

Connector implementation refactor.

## What Changed

- Adds a direct `ai.miniforge/anomaly` dependency to `connector-sarif`.
- Changes the private handle lookup helper to call `connector/require-handle`.
- Makes `do-discover`, `do-extract`, and `do-checkpoint` return
  response-shaped missing-handle anomalies.
- Updates SARIF connector tests from thrown `ExceptionInfo` assertions to
  returned anomaly assertions.

The returned maps use `response/make-anomaly` so existing connector consumers
that dispatch with `response/anomaly-map?` continue to treat failures as
failures.

## Testing

- Focused SARIF connector tests pass.
- Full `bb pre-commit` pass required before merge.

## Follow-Up

The shared throwing validation helpers remain until the shared connector API is
cleaned up in a final slice.
