### PR TITLE
Return pipeline output schema anomalies

### DIFF
--- a/components/connector-pipeline-output/src/ai/miniforge/connector_pipeline_output/impl.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/connector_pipeline_output/impl.clj
@@ -43,6 +43,15 @@
                              (msg/t :output/handle-not-found {:handle handle})
                              {:handle handle})))
 
+(defn- schema-validation-anomaly
+  "Return an anomaly for a failed schema validation result."
+  [value validation]
+  (when-not (:valid? validation)
+    (response/make-anomaly :anomalies/incorrect
+                           "Schema validation failed"
+                           {:errors (:errors validation)
+                            :value  value})))
+
 ;;------------------------------------------------------------------------------ Layer 1
 ;; Lifecycle
 
@@ -51,14 +60,16 @@
   [config]
   (let [config-with-defaults (cond-> config
                                (not (:output/format config))
-                               (assoc :output/format :edn))]
-    (schema/validate! schema/OutputConfig config-with-defaults)
-    (let [handle (str (UUID/randomUUID))]
-      (store-handle! handle {:output/dir           (:output/dir config-with-defaults)
-                              :output/format        (:output/format config-with-defaults)
-                              :output/run-id        (get config :output/run-id (str (UUID/randomUUID)))
-                              :output/pipeline-name (:output/pipeline-name config)})
-      (connector/connect-result handle))))
+                               (assoc :output/format :edn))
+        validation (schema/validate schema/OutputConfig config-with-defaults)]
+    (if-let [anomaly (schema-validation-anomaly config-with-defaults validation)]
+      anomaly
+      (let [handle (str (UUID/randomUUID))]
+        (store-handle! handle {:output/dir           (:output/dir config-with-defaults)
+                               :output/format        (:output/format config-with-defaults)
+                               :output/run-id        (get config :output/run-id (str (UUID/randomUUID)))
+                               :output/pipeline-name (:output/pipeline-name config)})
+        (connector/connect-result handle)))))
 
 (defn do-close [handle]
   (remove-handle! handle)
@@ -81,13 +92,17 @@
 ;; Write helpers
 
 (defn- write-and-validate-manifest!
-  "Build, validate, and write the manifest + JSON Schema."
+  "Build, validate, and write the manifest + JSON Schema, or return an anomaly."
   [handle-state dir run-id schema-name records-file record-count datasets]
   (let [manifest (cond-> (build-manifest handle-state schema-name records-file record-count)
-                   (seq datasets) (assoc :manifest/datasets datasets))]
-    (schema/validate! schema/Manifest (dissoc manifest :manifest/datasets))
-    (fmt/write-manifest dir run-id manifest)
-    (fmt/write-json-schema dir run-id (schema/manifest-json-schema))))
+                   (seq datasets) (assoc :manifest/datasets datasets))
+        manifest-contract (dissoc manifest :manifest/datasets)
+        validation (schema/validate schema/Manifest manifest-contract)]
+    (if-let [anomaly (schema-validation-anomaly manifest-contract validation)]
+      anomaly
+      (do
+        (fmt/write-manifest dir run-id manifest)
+        (fmt/write-json-schema dir run-id (schema/manifest-json-schema))))))
 
 ;;------------------------------------------------------------------------------ Layer 2
 ;; Sink operations
@@ -96,20 +111,24 @@
   "Write all records as a single file."
   [handle-state records opts]
   (let [{:output/keys [dir format run-id]} handle-state
-        records-file (fmt/write-records format dir run-id records)]
-    (write-and-validate-manifest! handle-state dir run-id
-                                   (:publish/schema-name opts) records-file (count records) nil)
-    (connector/publish-result (count records) 0)))
+        records-file (fmt/write-records format dir run-id records)
+        manifest-result (write-and-validate-manifest! handle-state dir run-id
+                                                       (:publish/schema-name opts) records-file (count records) nil)]
+    (if (response/anomaly-map? manifest-result)
+      manifest-result
+      (connector/publish-result (count records) 0))))
 
 (defn- publish-per-dataset!
   "Write separate record files per dataset, plus a combined file."
   [handle-state records datasets opts]
   (let [{:output/keys [dir format run-id]} handle-state
         dataset-files (fmt/write-dataset-records format dir run-id datasets)
-        combined-file (fmt/write-records format dir run-id records)]
-    (write-and-validate-manifest! handle-state dir run-id
-                                   (:publish/schema-name opts) combined-file (count records) dataset-files)
-    (connector/publish-result (count records) 0)))
+        combined-file (fmt/write-records format dir run-id records)
+        manifest-result (write-and-validate-manifest! handle-state dir run-id
+                                                       (:publish/schema-name opts) combined-file (count records) dataset-files)]
+    (if (response/anomaly-map? manifest-result)
+      manifest-result
+      (connector/publish-result (count records) 0))))
 
 (defn do-publish
   "Write records to the pipeline output store.

--- a/components/connector-pipeline-output/src/ai/miniforge/connector_pipeline_output/schema.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/connector_pipeline_output/schema.clj
@@ -20,8 +20,7 @@
   "Malli schemas, validation, and JSON Schema export for the pipeline
    output contract. These schemas define the public API that downstream
    consumers depend on."
-  (:require [ai.miniforge.response.interface :as response]
-            [malli.core :as m]
+  (:require [malli.core :as m]
             [malli.error :as me]
             [malli.json-schema :as json-schema]))
 
@@ -71,16 +70,6 @@
     {:valid? true :errors nil}
     {:valid? false
      :errors (me/humanize (m/explain schema value))}))
-
-(defn validate!
-  "Validate value against schema, throwing on failure."
-  [schema value]
-  (when-not (m/validate schema value)
-    (response/throw-anomaly! :anomalies/incorrect
-                             "Schema validation failed"
-                             {:errors (me/humanize (m/explain schema value))
-                              :value  value}))
-  value)
 
 (defn validate-config
   "Validate a pipeline output config map."

--- a/components/connector-pipeline-output/test/ai/miniforge/connector_pipeline_output/anomaly/pipeline_output_anomaly_test.clj
+++ b/components/connector-pipeline-output/test/ai/miniforge/connector_pipeline_output/anomaly/pipeline_output_anomaly_test.clj
@@ -18,10 +18,10 @@
 
 (ns ai.miniforge.connector-pipeline-output.anomaly.pipeline-output-anomaly-test
   "Coverage for `format/write-records` and
-   `schema/validate!` boundary escalation via `response/throw-anomaly!`.
+   schema validation anomaly-data conversion.
 
-   Unsupported format → `:anomalies/unsupported`; schema validation failure →
-   `:anomalies/incorrect`."
+   Unsupported format -> `:anomalies/unsupported`; schema validation failure
+   returns structured validation errors for boundary conversion."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-pipeline-output.format :as fmt]
             [ai.miniforge.connector-pipeline-output.schema :as schema])
@@ -37,17 +37,14 @@
         (is (= :anomalies/unsupported (:anomaly/category (ex-data e))))
         (is (= :weird (:format (ex-data e))))))))
 
-(deftest validate-bang-schema-failure-throws-anomaly
-  (testing "schema validation failure raises :anomalies/incorrect"
-    (try
-      (schema/validate! schema/OutputConfig {})
-      (is false "should have thrown")
-      (catch ExceptionInfo e
-        (is (re-find #"Schema validation failed" (.getMessage e)))
-        (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
-        (is (some? (:errors (ex-data e))))))))
+(deftest validate-schema-failure-returns-errors
+  (testing "schema validation failure returns structured errors"
+    (let [result (schema/validate schema/OutputConfig {})]
+      (is (false? (:valid? result)))
+      (is (some? (:errors result))))))
 
-(deftest validate-bang-passes-through-on-success
-  (testing "valid value passes through unchanged"
+(deftest validate-schema-success-returns-valid
+  (testing "valid value returns a valid result"
     (let [valid {:output/dir "/tmp/out" :output/format :edn}]
-      (is (= valid (schema/validate! schema/OutputConfig valid))))))
+      (is (= {:valid? true :errors nil}
+             (schema/validate schema/OutputConfig valid))))))

--- a/components/connector-pipeline-output/test/ai/miniforge/connector_pipeline_output/impl_test.clj
+++ b/components/connector-pipeline-output/test/ai/miniforge/connector_pipeline_output/impl_test.clj
@@ -41,14 +41,19 @@
 (use-fixtures :each clean-test-dir)
 
 (deftest connect-requires-dir
-  (testing "connect throws without :output/dir"
-    (is (thrown? Exception (impl/do-connect {})))))
+  (testing "connect returns anomaly data without :output/dir"
+    (let [result (impl/do-connect {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (some? (:errors result))))))
 
 (deftest connect-rejects-unsupported-format
-  (testing "connect throws on unsupported format"
-    (is (thrown? Exception
-                 (impl/do-connect {:output/dir test-dir
-                                   :output/format :xml})))))
+  (testing "connect returns anomaly data on unsupported format"
+    (let [result (impl/do-connect {:output/dir test-dir
+                                   :output/format :xml})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (some? (:errors result))))))
 
 (deftest connect-close-lifecycle
   (testing "connect and close work with defaults"

--- a/docs/pull-requests/2026-06-29-chris-pipeline-output-schema-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-pipeline-output-schema-anomalies.md
@@ -1,0 +1,28 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Pipeline Output Schema Anomalies
+
+## Overview
+
+Convert pipeline-output connector schema validation from throwing anomaly
+exceptions to returning anomaly data at the connector boundary.
+
+## Motivation
+
+Connector boundary validation is caller-visible data validation. Invalid output
+configuration or manifest data should return structured anomaly maps rather than
+raise exceptions that bypass normal connector result handling.
+
+## Testing
+
+- `clojure -M:dev:test -e '(require (quote [clojure.test :as t]) (quote
+  ai.miniforge.connector-pipeline-output.impl-test) (quote
+  ai.miniforge.connector-pipeline-output.anomaly.pipeline-output-anomaly-test)) (let [r (t/run-tests (quote
+  ai.miniforge.connector-pipeline-output.impl-test) (quote
+  ai.miniforge.connector-pipeline-output.anomaly.pipeline-output-anomaly-test))] (when (pos? (+ (:fail r) (:error r)))
+  (System/exit 1)))'`
+- `bb pre-commit`


### PR DESCRIPTION
## Summary
- remove the throwing pipeline-output schema validation helper
- return structured response anomalies for invalid connector config and manifest validation failures
- update pipeline-output tests to assert returned anomaly data

## Testing
- clojure -M:dev:test -e '(require (quote [clojure.test :as t]) (quote ai.miniforge.connector-pipeline-output.impl-test) (quote ai.miniforge.connector-pipeline-output.anomaly.pipeline-output-anomaly-test)) (let [r (t/run-tests (quote ai.miniforge.connector-pipeline-output.impl-test) (quote ai.miniforge.connector-pipeline-output.anomaly.pipeline-output-anomaly-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner]) (quote [clojure.string :as str])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r)) pipeline-output (filter #(str/includes? (:file %) "connector-pipeline-output") cleanup)] (println :cleanup-needed (count cleanup)) (println :pipeline-output (count pipeline-output)) (doseq [v pipeline-output] (println :pipeline-output-row (:file v) (:line v) (:form v))))'
- bb pre-commit