### PR TITLE
Return repo DAG schema alias anomalies

### DIFF
--- a/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
@@ -53,20 +53,11 @@
                       :errors (me/humanize (m/explain schema-def value))})))
 
 (defn validate-schema
-  "Validate a value against a schema, returning the value or throwing.
+  "Validate a value against a schema, returning the value or an anomaly map.
 
-   DEPRECATED: prefer [[validate-schema-anomaly]], which returns an anomaly
-   map rather than throwing. Retained for backward compatibility with
-   existing callers that rely on the ex-info shape."
-  {:deprecated "exceptions-as-data — prefer validate-schema-anomaly"}
+   Kept as a stable alias for [[validate-schema-anomaly]]."
   [schema-def value]
-  (let [result (validate-schema-anomaly schema-def value)]
-    (if (anomaly/anomaly? result)
-      (throw (ex-info "Schema validation failed"
-                      {:schema schema-def
-                       :value value
-                       :errors (get-in result [:anomaly/data :errors])}))
-      result)))
+  (validate-schema-anomaly schema-def value))
 
 (defn- build-repo-node
   "Internal: assemble the repo-node map (no validation). Shared between
@@ -94,9 +85,7 @@
 (defn make-repo-node
   "Create a repo node with layer inference if not specified.
 
-   DEPRECATED: prefer [[make-repo-node-anomaly]], which returns an anomaly
-   map rather than throwing on schema validation failure."
-  {:deprecated "exceptions-as-data — prefer make-repo-node-anomaly"}
+   Returns an anomaly map when schema validation fails."
   [repo-config]
   (validate-schema schema/RepoNode (build-repo-node repo-config)))
 
@@ -123,13 +112,12 @@
 (defn make-repo-edge
   "Create a repo edge with default merge ordering.
 
-   DEPRECATED: prefer [[make-repo-edge-anomaly]]."
-  {:deprecated "exceptions-as-data — prefer make-repo-edge-anomaly"}
+   Returns an anomaly map when schema validation fails."
   [edge-config]
   (validate-schema schema/RepoEdge (build-repo-edge edge-config)))
 
 (defn make-dag
-  "Create a new empty DAG."
+  "Create a new empty DAG, or return an anomaly map if validation fails."
   [id dag-name description]
   (let [dag (cond-> {:dag/id id
                      :dag/name dag-name

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/validate_schema_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/validate_schema_test.clj
@@ -17,9 +17,9 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.repo-dag.anomaly.validate-schema-test
-  "Coverage for `core/validate-schema-anomaly` and its deprecated
-   throwing sibling `core/validate-schema`. Schema rejection is an
-   :invalid-input anomaly; valid values pass through unchanged."
+  "Coverage for `core/validate-schema-anomaly` and its stable alias
+   `core/validate-schema`. Schema rejection is an :invalid-input anomaly;
+   valid values pass through unchanged."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.core :as core]
@@ -65,24 +65,18 @@
       (is (some? (:errors data)))
       (is (map? (:errors data))))))
 
-;------------------------------------------------------------------------------ Throwing-variant compat
+;------------------------------------------------------------------------------ Alias compatibility
 
 (deftest validate-schema-still-returns-on-success
-  (testing "deprecated throwing variant returns the value unchanged"
+  (testing "stable alias returns the value unchanged"
     (is (= valid-repo (core/validate-schema dag/RepoNode valid-repo)))))
 
-(deftest validate-schema-still-throws-ex-info
-  (testing "deprecated throwing variant still throws on bad input"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Schema validation failed"
-          (core/validate-schema dag/RepoNode invalid-repo)))))
-
-(deftest validate-schema-thrown-ex-data-carries-errors
-  (testing "ex-data preserves :schema, :value, and :errors for legacy callers"
-    (try
-      (core/validate-schema dag/RepoNode invalid-repo)
-      (is false "should have thrown")
-      (catch clojure.lang.ExceptionInfo e
-        (let [data (ex-data e)]
-          (is (= dag/RepoNode (:schema data)))
-          (is (= invalid-repo (:value data)))
-          (is (map? (:errors data))))))))
+(deftest validate-schema-returns-anomaly-on-failure
+  (testing "stable alias returns the same anomaly data on bad input"
+    (let [result (core/validate-schema dag/RepoNode invalid-repo)
+          data (:anomaly/data result)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= dag/RepoNode (:schema data)))
+      (is (= invalid-repo (:value data)))
+      (is (map? (:errors data))))))

--- a/docs/pull-requests/2026-06-29-chris-repo-dag-schema-alias-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-repo-dag-schema-alias-anomalies.md
@@ -1,0 +1,25 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Repo DAG Schema Alias Anomalies
+
+## Overview
+
+Convert `repo-dag.core/validate-schema` from a throwing compatibility helper
+into a stable alias for `validate-schema-anomaly`.
+
+## Motivation
+
+Schema rejection is validation data. The repo-dag component already exposes an
+anomaly-returning helper; the legacy alias should preserve that data instead of
+rethrowing it as `ex-info`.
+
+## Testing
+
+- `clojure -M:dev:test -e '(require (quote [clojure.test :as t]) (quote
+  ai.miniforge.repo-dag.anomaly.validate-schema-test)) (let [r (t/run-tests (quote
+  ai.miniforge.repo-dag.anomaly.validate-schema-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
+- `bb pre-commit`


### PR DESCRIPTION
## Summary
- convert repo-dag validate-schema into a data-returning alias for validate-schema-anomaly
- update focused tests to assert anomaly data instead of ex-info compatibility

## Testing
- clojure -M:dev:test -e '(require (quote [clojure.test :as t]) (quote ai.miniforge.repo-dag.anomaly.validate-schema-test)) (let [r (t/run-tests (quote ai.miniforge.repo-dag.anomaly.validate-schema-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner]) (quote [clojure.string :as str])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(and (= :cleanup-needed (:classification %)) (str/includes? (:file %) "components/repo-dag/src/ai/miniforge/repo_dag/core.clj")) (:violations r))] (println :repo-dag (count cleanup)) (doseq [v cleanup] (println (:line v) (:form v))))'
- bb pre-commit