### PR TITLE
Return repo DAG CRUD alias anomalies

### DIFF
--- a/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
@@ -517,19 +517,13 @@
     (add-repo-impl store dag-id repo-config))
 
   (add-repo [this dag-id repo-config]
-    (let [result (add-repo-anomaly this dag-id repo-config)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result)))
+    (add-repo-anomaly this dag-id repo-config))
 
   (remove-repo-anomaly [_this dag-id repo-name]
     (remove-repo-impl store dag-id repo-name))
 
   (remove-repo [this dag-id repo-name]
-    (let [result (remove-repo-anomaly this dag-id repo-name)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result)))
+    (remove-repo-anomaly this dag-id repo-name))
 
   (add-edge-anomaly [_this dag-id from-repo to-repo constraint merge-ordering]
     (add-edge-impl store dag-id from-repo to-repo constraint merge-ordering))

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -157,21 +157,14 @@
    - dag-id: UUID of the DAG
    - repo-config: Map with repo fields (:repo/url, :repo/name, :repo/type required)
 
-   Returns the updated DAG.
-
-   Throws if:
-   - DAG not found
-   - Repo with same name already exists
-
-   DEPRECATED: prefer [[add-repo-anomaly]], which returns an anomaly map
-   instead of throwing. Retained for backward compatibility.
+   Returns the updated DAG, or an anomaly map when the DAG is missing,
+   the repo config is invalid, or the repo already exists.
 
    Example:
      (add-repo mgr dag-id
                {:repo/url \"https://github.com/acme/terraform-modules\"
                 :repo/name \"terraform-modules\"
                 :repo/type :terraform-module})"
-  {:deprecated "exceptions-as-data — prefer add-repo-anomaly"}
   [manager dag-id repo-config]
   (core/add-repo manager dag-id repo-config))
 
@@ -185,7 +178,7 @@
    - `:conflict`      — a repo with the same `:repo/name` already exists
                         in the DAG
 
-   Prefer this over [[add-repo]] in non-boundary code."
+   Kept for callers that prefer the explicit anomaly-returning name."
   [manager dag-id repo-config]
   (core/add-repo-anomaly manager dag-id repo-config))
 
@@ -197,13 +190,8 @@
    - dag-id: UUID of the DAG
    - repo-name: Name of the repo to remove
 
-   Returns the updated DAG.
-   Also removes all edges referencing this repo.
-
-   Throws if DAG not found.
-
-   DEPRECATED: prefer [[remove-repo-anomaly]]."
-  {:deprecated "exceptions-as-data — prefer remove-repo-anomaly"}
+   Returns the updated DAG or a `:not-found` anomaly.
+   Also removes all edges referencing this repo."
   [manager dag-id repo-name]
   (core/remove-repo manager dag-id repo-name))
 

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_repo_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_repo_test.clj
@@ -17,8 +17,8 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.repo-dag.anomaly.add-repo-test
-  "Coverage for `dag/add-repo-anomaly` and its deprecated throwing
-   sibling `dag/add-repo`. Three anomaly classes:
+  "Coverage for `dag/add-repo-anomaly` and its stable alias
+   `dag/add-repo`. Three anomaly classes:
    - `:not-found`     — DAG missing
    - `:invalid-input` — `repo-config` fails schema validation (missing
                         `:repo/type`, malformed `:repo/url`, …)
@@ -66,9 +66,7 @@
 (deftest add-repo-anomaly-invalid-input-on-missing-repo-type
   (testing "repo-config without :repo/type yields :invalid-input anomaly —
             schema rejection short-circuits via make-repo-node-anomaly
-            before the node is appended. Pre-fix this path threw
-            ExceptionInfo via the deprecated throwing validate-schema and
-            silently violated the anomaly-returning contract."
+            before the node is appended."
     (let [d (dag/create-dag *manager* "test-dag")
           bad-config {:repo/url "https://github.com/acme/x"
                       :repo/name "x"} ;; missing :repo/type
@@ -89,16 +87,19 @@
       (is (= :conflict (:anomaly/type result)))
       (is (= "tf" (get-in result [:anomaly/data :repo-name]))))))
 
-;------------------------------------------------------------------------------ Throwing-variant compat
+;------------------------------------------------------------------------------ Alias compatibility
 
-(deftest add-repo-still-throws-on-missing-dag
-  (testing "deprecated throwing variant still throws ex-info on missing DAG"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
-          (dag/add-repo *manager* (random-uuid) repo-config)))))
+(deftest add-repo-returns-anomaly-on-missing-dag
+  (testing "stable alias returns anomaly data on missing DAG"
+    (let [result (dag/add-repo *manager* (random-uuid) repo-config)]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
 
-(deftest add-repo-still-throws-on-duplicate
-  (testing "deprecated throwing variant still throws on duplicate repo"
+(deftest add-repo-returns-anomaly-on-duplicate
+  (testing "stable alias returns anomaly data on duplicate repo"
     (let [d (dag/create-dag *manager* "test-dag")]
       (dag/add-repo *manager* (:dag/id d) repo-config)
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Repo already exists"
-            (dag/add-repo *manager* (:dag/id d) repo-config))))))
+      (let [result (dag/add-repo *manager* (:dag/id d) repo-config)]
+        (is (anomaly/anomaly? result))
+        (is (= :conflict (:anomaly/type result)))
+        (is (= "tf" (get-in result [:anomaly/data :repo-name])))))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_repo_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_repo_test.clj
@@ -17,8 +17,8 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.repo-dag.anomaly.remove-repo-test
-  "Coverage for `dag/remove-repo-anomaly` and its deprecated throwing
-   sibling `dag/remove-repo`. Only failure mode is `:not-found` — DAG missing."
+  "Coverage for `dag/remove-repo-anomaly` and its stable alias
+   `dag/remove-repo`. Only failure mode is `:not-found` — DAG missing."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
@@ -56,9 +56,10 @@
       (is (= :not-found (:anomaly/type result)))
       (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
 
-;------------------------------------------------------------------------------ Throwing-variant compat
+;------------------------------------------------------------------------------ Alias compatibility
 
-(deftest remove-repo-still-throws-on-missing-dag
-  (testing "deprecated throwing variant still throws ex-info on missing DAG"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
-          (dag/remove-repo *manager* (random-uuid) "tf")))))
+(deftest remove-repo-returns-anomaly-on-missing-dag
+  (testing "stable alias returns anomaly data on missing DAG"
+    (let [result (dag/remove-repo *manager* (random-uuid) "tf")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_crud_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_crud_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.repo-dag.dag-crud-test
   "Tests for DAG schema, creation, and CRUD operations (Layers 0-2)."
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
+            [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
 ;------------------------------------------------------------------------------ Fixtures
@@ -101,17 +102,19 @@
       ;; Layer should be inferred as :foundations
       (is (= :foundations (-> updated :dag/repos first :repo/layer)))))
 
-  (testing "throws on duplicate repo name"
+  (testing "returns anomaly data on duplicate repo name"
     (let [d (dag/create-dag *manager* "test-dag")]
       (dag/add-repo *manager* (:dag/id d)
                     {:repo/url "https://github.com/acme/tf-modules"
                      :repo/name "tf-modules"
                      :repo/type :terraform-module})
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Repo already exists"
-            (dag/add-repo *manager* (:dag/id d)
-                          {:repo/url "https://github.com/other/tf-modules"
-                           :repo/name "tf-modules"
-                           :repo/type :terraform-module}))))))
+      (let [result (dag/add-repo *manager* (:dag/id d)
+                                 {:repo/url "https://github.com/other/tf-modules"
+                                  :repo/name "tf-modules"
+                                  :repo/type :terraform-module})]
+        (is (anomaly/anomaly? result))
+        (is (= :conflict (:anomaly/type result)))
+        (is (= "tf-modules" (get-in result [:anomaly/data :repo-name])))))))
 
 (deftest remove-repo-test
   (testing "removes repo from DAG"

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_validation_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_validation_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.repo-dag.dag-validation-test
   "Tests for DAG validation, layers, and edge cases (Layers 7-9)."
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
+            [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
 ;------------------------------------------------------------------------------ Fixtures
@@ -84,10 +85,11 @@
   (testing "operations on nonexistent DAG"
     (let [fake-id (random-uuid)]
       (is (nil? (dag/get-dag *manager* fake-id)))
-      (is (thrown? clojure.lang.ExceptionInfo
-            (dag/add-repo *manager* fake-id
-                          {:repo/url "https://github.com/a" :repo/name "a"
-                           :repo/type :library})))
+      (let [result (dag/add-repo *manager* fake-id
+                                 {:repo/url "https://github.com/a" :repo/name "a"
+                                  :repo/type :library})]
+        (is (anomaly/anomaly? result))
+        (is (= :not-found (:anomaly/type result))))
       (is (thrown? clojure.lang.ExceptionInfo
             (dag/compute-topo-order *manager* fake-id)))))
 

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -832,12 +832,15 @@
       (when-not exists?
         (let [[org _name] (str/split repo #"/" 2)]
           (try+
-            (repo-dag/add-repo mgr dag-id
-                               {:repo/url (str "https://github.com/" repo)
-                                :repo/name repo
-                                :repo/org org
-                                :repo/type :application
-                                :repo/default-branch "main"})
+            (let [result (repo-dag/add-repo-anomaly
+                          mgr dag-id
+                          {:repo/url (str "https://github.com/" repo)
+                           :repo/name repo
+                           :repo/org org
+                           :repo/type :application
+                           :repo/default-branch "main"})]
+              (when-not (anomaly/anomaly? result)
+                result))
             (catch Object _ nil)))))))
 
 (defn train-name-for-repo

--- a/docs/pull-requests/2026-06-29-chris-repo-dag-crud-alias-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-repo-dag-crud-alias-anomalies.md
@@ -1,0 +1,26 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Repo DAG CRUD Alias Anomalies
+
+## Overview
+
+Convert repo-dag `add-repo` and `remove-repo` aliases from throwing wrappers to
+data-returning anomaly aliases.
+
+## Motivation
+
+Repo CRUD failures are already represented by repo-dag anomaly data. The stable
+aliases should preserve that contract instead of rethrowing the anomaly at an
+internal component boundary.
+
+## Testing
+
+- `clojure -M:dev:test -e '(require (quote [clojure.test :as t]) (quote ai.miniforge.repo-dag.dag-crud-test) (quote
+  ai.miniforge.repo-dag.anomaly.add-repo-test) (quote ai.miniforge.repo-dag.anomaly.remove-repo-test)) (let [r
+  (t/run-tests (quote ai.miniforge.repo-dag.dag-crud-test) (quote ai.miniforge.repo-dag.anomaly.add-repo-test) (quote
+  ai.miniforge.repo-dag.anomaly.remove-repo-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
+- `bb pre-commit`


### PR DESCRIPTION
## Summary
- make repo-dag add-repo/remove-repo aliases return anomaly data instead of rethrowing
- update CRUD tests for returned anomaly results
- route dashboard fleet sync through add-repo-anomaly explicitly

## Testing
- clojure -M:dev:test -e '(require (quote [clojure.test :as t]) (quote ai.miniforge.repo-dag.dag-crud-test) (quote ai.miniforge.repo-dag.anomaly.add-repo-test) (quote ai.miniforge.repo-dag.anomaly.remove-repo-test)) (let [r (t/run-tests (quote ai.miniforge.repo-dag.dag-crud-test) (quote ai.miniforge.repo-dag.anomaly.add-repo-test) (quote ai.miniforge.repo-dag.anomaly.remove-repo-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner]) (quote [clojure.string :as str])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(and (= :cleanup-needed (:classification %)) (str/includes? (:file %) "components/repo-dag/src/ai/miniforge/repo_dag/core.clj")) (:violations r))] (println :repo-dag (count cleanup)) (doseq [v cleanup] (println (:line v) (:form v))))'
- bb pre-commit