### PR TITLE
Return repo DAG edge alias anomalies

### DIFF
--- a/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
@@ -529,19 +529,13 @@
     (add-edge-impl store dag-id from-repo to-repo constraint merge-ordering))
 
   (add-edge [this dag-id from-repo to-repo constraint merge-ordering]
-    (let [result (add-edge-anomaly this dag-id from-repo to-repo constraint merge-ordering)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result)))
+    (add-edge-anomaly this dag-id from-repo to-repo constraint merge-ordering))
 
   (remove-edge-anomaly [_this dag-id from-repo to-repo]
     (remove-edge-impl store dag-id from-repo to-repo))
 
   (remove-edge [this dag-id from-repo to-repo]
-    (let [result (remove-edge-anomaly this dag-id from-repo to-repo)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result)))
+    (remove-edge-anomaly this dag-id from-repo to-repo))
 
   (get-dag [_this dag-id]
     (get @store dag-id))

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -214,22 +214,14 @@
    - constraint: Edge constraint type (see edge-constraints)
    - merge-ordering: How PRs should merge (see merge-orderings)
 
-   Returns the updated DAG.
-
-   Throws if:
-   - DAG not found
-   - Either repo not in DAG
-   - Edge would create a cycle
-   - Edge already exists
-   - Self-loop attempted
-
-   DEPRECATED: prefer [[add-edge-anomaly]].
+   Returns the updated DAG, or an anomaly map when the DAG or repos are
+   missing, the edge input is invalid, the edge already exists, or the edge
+   would create a cycle.
 
    Example:
      (add-edge mgr dag-id
                \"terraform-modules\" \"terraform-live\"
                :module-before-live :sequential)"
-  {:deprecated "exceptions-as-data — prefer add-edge-anomaly"}
   [manager dag-id from-repo to-repo constraint merge-ordering]
   (core/add-edge manager dag-id from-repo to-repo constraint merge-ordering))
 
@@ -245,7 +237,7 @@
    - `:conflict`      — edge already exists, or adding the edge would
                         introduce a cycle (`:cycle-nodes` carried in data)
 
-   Prefer this over [[add-edge]] in non-boundary code."
+   Kept for callers that prefer the explicit anomaly-returning name."
   [manager dag-id from-repo to-repo constraint merge-ordering]
   (core/add-edge-anomaly manager dag-id from-repo to-repo constraint merge-ordering))
 
@@ -258,12 +250,7 @@
    - from-repo: Name of the upstream repo
    - to-repo: Name of the downstream repo
 
-   Returns the updated DAG.
-
-   Throws if DAG not found.
-
-   DEPRECATED: prefer [[remove-edge-anomaly]]."
-  {:deprecated "exceptions-as-data — prefer remove-edge-anomaly"}
+   Returns the updated DAG or a `:not-found` anomaly."
   [manager dag-id from-repo to-repo]
   (core/remove-edge manager dag-id from-repo to-repo))
 

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_edge_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_edge_test.clj
@@ -17,8 +17,8 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.repo-dag.anomaly.add-edge-test
-  "Coverage for `dag/add-edge-anomaly` and its deprecated throwing
-   sibling `dag/add-edge`. Seven failure modes:
+  "Coverage for `dag/add-edge-anomaly` and its stable alias
+   `dag/add-edge`. Seven failure modes:
    - `:not-found`     when DAG missing
    - `:not-found`     when from-repo missing
    - `:not-found`     when to-repo missing
@@ -110,9 +110,7 @@
 
 (deftest add-edge-anomaly-invalid-input-on-unknown-constraint
   (testing "unknown :edge/constraint yields :invalid-input anomaly — schema rejection
-            short-circuits via make-repo-edge-anomaly before the edge is appended.
-            Pre-fix this path threw an ExceptionInfo via the deprecated throwing
-            validate-schema and silently violated the anomaly-returning contract."
+            short-circuits via make-repo-edge-anomaly before the edge is appended."
     (let [result (dag/add-edge-anomaly *manager* *dag-id*
                                        "repo-a" "repo-b"
                                        :not-a-real-constraint :sequential)]
@@ -158,24 +156,30 @@
       (is (= :conflict (:anomaly/type result)))
       (is (set? (get-in result [:anomaly/data :cycle-nodes]))))))
 
-;------------------------------------------------------------------------------ Throwing-variant compat
+;------------------------------------------------------------------------------ Alias compatibility
 
-(deftest add-edge-still-throws-on-missing-from-repo
-  (testing "deprecated throwing variant still throws ex-info on missing from-repo"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"From repo not found"
-          (dag/add-edge *manager* *dag-id* "ghost" "repo-b"
-                        :library-before-consumer :sequential)))))
+(deftest add-edge-returns-anomaly-on-missing-from-repo
+  (testing "stable alias returns anomaly data on missing from-repo"
+    (let [result (dag/add-edge *manager* *dag-id* "ghost" "repo-b"
+                               :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= "ghost" (get-in result [:anomaly/data :repo-name]))))))
 
-(deftest add-edge-still-throws-on-self-loop
-  (testing "deprecated throwing variant still throws on self-loop"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Self-loop not allowed"
-          (dag/add-edge *manager* *dag-id* "repo-a" "repo-a"
-                        :library-before-consumer :sequential)))))
+(deftest add-edge-returns-anomaly-on-self-loop
+  (testing "stable alias returns anomaly data on self-loop"
+    (let [result (dag/add-edge *manager* *dag-id* "repo-a" "repo-a"
+                               :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "repo-a" (get-in result [:anomaly/data :repo-name]))))))
 
-(deftest add-edge-still-throws-on-cycle
-  (testing "deprecated throwing variant still throws on cycle introduction"
+(deftest add-edge-returns-anomaly-on-cycle
+  (testing "stable alias returns anomaly data on cycle introduction"
     (dag/add-edge *manager* *dag-id* "repo-a" "repo-b"
                   :library-before-consumer :sequential)
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"create cycle"
-          (dag/add-edge *manager* *dag-id* "repo-b" "repo-a"
-                        :library-before-consumer :sequential)))))
+    (let [result (dag/add-edge *manager* *dag-id* "repo-b" "repo-a"
+                               :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (set? (get-in result [:anomaly/data :cycle-nodes]))))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_edge_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_edge_test.clj
@@ -17,8 +17,8 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.repo-dag.anomaly.remove-edge-test
-  "Coverage for `dag/remove-edge-anomaly` and its deprecated throwing
-   sibling `dag/remove-edge`. Only failure mode is `:not-found` — DAG missing."
+  "Coverage for `dag/remove-edge-anomaly` and its stable alias
+   `dag/remove-edge`. Only failure mode is `:not-found` — DAG missing."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
@@ -60,9 +60,10 @@
       (is (= :not-found (:anomaly/type result)))
       (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
 
-;------------------------------------------------------------------------------ Throwing-variant compat
+;------------------------------------------------------------------------------ Alias compatibility
 
-(deftest remove-edge-still-throws-on-missing-dag
-  (testing "deprecated throwing variant still throws ex-info on missing DAG"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
-          (dag/remove-edge *manager* (random-uuid) "repo-a" "repo-b")))))
+(deftest remove-edge-returns-anomaly-on-missing-dag
+  (testing "stable alias returns anomaly data on missing DAG"
+    (let [result (dag/remove-edge *manager* (random-uuid) "repo-a" "repo-b")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_crud_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_crud_test.clj
@@ -165,27 +165,31 @@
         (is (= :library-before-consumer (:edge/constraint edge)))
         (is (= :sequential (:edge/merge-ordering edge))))))
 
-  (testing "throws on missing from-repo"
+  (testing "returns anomaly data on missing from-repo"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
                           {:repo/url "https://github.com/acme/b"
                            :repo/name "repo-b"
-                           :repo/type :application})]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"From repo not found"
-            (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
-                          :library-before-consumer :sequential)))))
+                           :repo/type :application})
+          result (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
+                               :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= "repo-a" (get-in result [:anomaly/data :repo-name])))))
 
-  (testing "throws on self-loop"
+  (testing "returns anomaly data on self-loop"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
                           {:repo/url "https://github.com/acme/a"
                            :repo/name "repo-a"
-                           :repo/type :library})]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Self-loop not allowed"
-            (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-a"
-                          :library-before-consumer :sequential)))))
+                           :repo/type :library})
+          result (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-a"
+                               :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "repo-a" (get-in result [:anomaly/data :repo-name])))))
 
-  (testing "throws on duplicate edge"
+  (testing "returns anomaly data on duplicate edge"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
                           {:repo/url "https://github.com/acme/a"
@@ -196,10 +200,13 @@
                            :repo/name "repo-b"
                            :repo/type :application})
           _ (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
-                          :library-before-consumer :sequential)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Edge already exists"
-            (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
-                          :library-before-consumer :sequential))))))
+                          :library-before-consumer :sequential)
+          result (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
+                               :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (= "repo-a" (get-in result [:anomaly/data :from])))
+      (is (= "repo-b" (get-in result [:anomaly/data :to]))))))
 
 (deftest remove-edge-test
   (testing "removes edge from DAG"

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_topology_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_topology_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.repo-dag.dag-topology-test
   "Tests for topological sort and cycle detection (Layers 3-4)."
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
+            [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
 ;------------------------------------------------------------------------------ Fixtures
@@ -94,10 +95,12 @@
                           {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
           _ (dag/add-repo *manager* (:dag/id d)
                           {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
-          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Adding edge would create cycle"
-            (dag/add-edge *manager* (:dag/id d) "b" "a"
-                          :library-before-consumer :sequential)))))
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          result (dag/add-edge *manager* (:dag/id d) "b" "a"
+                               :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (= #{"a" "b"} (get-in result [:anomaly/data :cycle-nodes])))))
 
   (testing "detects longer cycle on add-edge"
     (let [d (dag/create-dag *manager* "test-dag")
@@ -108,10 +111,12 @@
           _ (dag/add-repo *manager* (:dag/id d)
                           {:repo/url "https://github.com/c" :repo/name "c" :repo/type :application})
           _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
-          _ (dag/add-edge *manager* (:dag/id d) "b" "c" :library-before-consumer :sequential)]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Adding edge would create cycle"
-            (dag/add-edge *manager* (:dag/id d) "c" "a"
-                          :library-before-consumer :sequential)))))
+          _ (dag/add-edge *manager* (:dag/id d) "b" "c" :library-before-consumer :sequential)
+          result (dag/add-edge *manager* (:dag/id d) "c" "a"
+                               :library-before-consumer :sequential)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (= #{"a" "b" "c"} (get-in result [:anomaly/data :cycle-nodes])))))
 
   (testing "find-cycle-nodes identifies cycle members"
     ;; We can test the pure function directly by creating a dag with a cycle

--- a/docs/pull-requests/2026-06-29-chris-repo-dag-edge-alias-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-repo-dag-edge-alias-anomalies.md
@@ -1,0 +1,27 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Repo DAG Edge Alias Anomalies
+
+## Overview
+
+Convert repo-dag `add-edge` and `remove-edge` aliases from throwing wrappers to
+data-returning anomaly aliases.
+
+## Motivation
+
+Edge validation failures already have structured anomaly results. The stable
+aliases should preserve that data contract instead of rethrowing it inside the
+component.
+
+## Testing
+
+- `clojure -M:dev:test -e '(require (quote [clojure.test :as t]) (quote ai.miniforge.repo-dag.dag-crud-test) (quote
+  ai.miniforge.repo-dag.dag-topology-test) (quote ai.miniforge.repo-dag.anomaly.add-edge-test) (quote
+  ai.miniforge.repo-dag.anomaly.remove-edge-test)) (let [r (t/run-tests (quote ai.miniforge.repo-dag.dag-crud-test)
+  (quote ai.miniforge.repo-dag.dag-topology-test) (quote ai.miniforge.repo-dag.anomaly.add-edge-test) (quote
+  ai.miniforge.repo-dag.anomaly.remove-edge-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
+- `bb pre-commit`


### PR DESCRIPTION
## Summary
- make repo-dag add-edge/remove-edge aliases return anomaly data instead of rethrowing
- update edge and cycle tests for returned anomaly results
- update edge alias docs to match the returned-data contract

## Testing
- clojure -M:dev:test -e '(require (quote [clojure.test :as t]) (quote ai.miniforge.repo-dag.dag-crud-test) (quote ai.miniforge.repo-dag.dag-topology-test) (quote ai.miniforge.repo-dag.anomaly.add-edge-test) (quote ai.miniforge.repo-dag.anomaly.remove-edge-test)) (let [r (t/run-tests (quote ai.miniforge.repo-dag.dag-crud-test) (quote ai.miniforge.repo-dag.dag-topology-test) (quote ai.miniforge.repo-dag.anomaly.add-edge-test) (quote ai.miniforge.repo-dag.anomaly.remove-edge-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner]) (quote [clojure.string :as str])) (let [r (scanner/scan-exceptions-as-data ".") cleanup (filter #(and (= :cleanup-needed (:classification %)) (str/includes? (:file %) "components/repo-dag/src/ai/miniforge/repo_dag/core.clj")) (:violations r))] (println :repo-dag (count cleanup)) (doseq [v cleanup] (println (:line v) (:form v))))'
- bb pre-commit