### PR TITLE
Return repo DAG query alias anomalies

### DIFF
--- a/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
@@ -417,12 +417,6 @@
     (f dag)
     (dag-not-found-anomaly dag-id)))
 
-(defn- anomaly->ex-info
-  "Translate a repo-dag anomaly back into an ex-info for backward-compat
-   throwing wrappers. Preserves the anomaly's `:anomaly/data` as ex-data."
-  [a]
-  (ex-info (:anomaly/message a) (:anomaly/data a)))
-
 ;------------------------------------------------------------------------------ Layer 1
 ;; Protocol definition
 
@@ -466,40 +460,35 @@
     "Retrieve a DAG by ID. Returns nil if not found.")
 
   (compute-topo-order [this dag-id]
-    "Compute topological sort of repos. Returns {:success true :order [...]} or error.")
+    "Compute topological sort of repos. Returns result map or anomaly.")
 
   (compute-topo-order-anomaly [this dag-id]
-    "Anomaly-returning sibling of `compute-topo-order`. Returns the topo
-     result or a `:not-found` anomaly when the DAG is missing.")
+    "Explicit implementation name used by `compute-topo-order`.")
 
   (affected-repos [this dag-id changed-repo]
-    "Given a changed repo, return all downstream repos that may be affected.")
+    "Given a changed repo, return downstream repos or anomaly.")
 
   (affected-repos-anomaly [this dag-id changed-repo]
-    "Anomaly-returning sibling of `affected-repos`. Returns the downstream
-     repo set or a `:not-found` anomaly when the DAG is missing.")
+    "Explicit implementation name used by `affected-repos`.")
 
   (upstream-repos [this dag-id repo-name]
-    "Return all repos that this repo depends on.")
+    "Return all repos that this repo depends on, or anomaly.")
 
   (upstream-repos-anomaly [this dag-id repo-name]
-    "Anomaly-returning sibling of `upstream-repos`. Returns the upstream
-     repo set or a `:not-found` anomaly when the DAG is missing.")
+    "Explicit implementation name used by `upstream-repos`.")
 
   (merge-order [this dag-id pr-set]
-    "Given a set of PRs across repos, return valid merge order.")
+    "Given a set of PRs across repos, return merge order or anomaly.")
 
   (merge-order-anomaly [this dag-id pr-set]
-    "Anomaly-returning sibling of `merge-order`. Returns the merge-order
-     result or a `:not-found` anomaly when the DAG is missing.")
+    "Explicit implementation name used by `merge-order`.")
 
   ;; Validation
   (validate-dag [this dag-id]
-    "Check for cycles, orphans, invalid references. Returns {:valid? bool :errors [...]}.")
+    "Check for cycles, orphans, and invalid references; returns result or anomaly.")
 
   (validate-dag-anomaly [this dag-id]
-    "Anomaly-returning sibling of `validate-dag`. Returns the validation
-     result or a `:not-found` anomaly when the DAG is missing."))
+    "Explicit implementation name used by `validate-dag`."))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; In-memory implementation
@@ -544,46 +533,31 @@
     (with-dag-or-anomaly store dag-id topo-sort))
 
   (compute-topo-order [this dag-id]
-    (let [result (compute-topo-order-anomaly this dag-id)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result)))
+    (compute-topo-order-anomaly this dag-id))
 
   (affected-repos-anomaly [_this dag-id changed-repo]
     (with-dag-or-anomaly store dag-id #(downstream-repos % changed-repo)))
 
   (affected-repos [this dag-id changed-repo]
-    (let [result (affected-repos-anomaly this dag-id changed-repo)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result)))
+    (affected-repos-anomaly this dag-id changed-repo))
 
   (upstream-repos-anomaly [_this dag-id repo-name]
     (with-dag-or-anomaly store dag-id #(upstream-repos-impl % repo-name)))
 
   (upstream-repos [this dag-id repo-name]
-    (let [result (upstream-repos-anomaly this dag-id repo-name)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result)))
+    (upstream-repos-anomaly this dag-id repo-name))
 
   (merge-order-anomaly [_this dag-id pr-set]
     (with-dag-or-anomaly store dag-id #(compute-merge-order % pr-set)))
 
   (merge-order [this dag-id pr-set]
-    (let [result (merge-order-anomaly this dag-id pr-set)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result)))
+    (merge-order-anomaly this dag-id pr-set))
 
   (validate-dag-anomaly [_this dag-id]
     (with-dag-or-anomaly store dag-id validate-dag-impl))
 
   (validate-dag [this dag-id]
-    (let [result (validate-dag-anomaly this dag-id)]
-      (if (anomaly/anomaly? result)
-        (throw (anomaly->ex-info result))
-        result))))
+    (validate-dag-anomaly this dag-id)))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Factory functions

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -275,20 +275,16 @@
    Returns:
    - On success: {:success true :order [repo-names...]}
    - On failure: {:success false :error :cycle-detected :cycle-nodes #{...}}
-
-   Throws ex-info when the DAG does not exist.
-
-   DEPRECATED: prefer [[compute-topo-order-anomaly]].
+   - Missing DAG: `:not-found` anomaly
 
    Example:
      (compute-topo-order mgr dag-id)
      ;; => {:success true :order [\"terraform-modules\" \"terraform-live\" \"k8s\"]}"
-  {:deprecated "exceptions-as-data — prefer compute-topo-order-anomaly"}
   [manager dag-id]
   (core/compute-topo-order manager dag-id))
 
 (defn compute-topo-order-anomaly
-  "Anomaly-returning variant of [[compute-topo-order]].
+  "Explicit implementation name for [[compute-topo-order]].
 
    Returns the topo-sort result map on success, or a `:not-found` anomaly
    when the DAG does not exist."
@@ -303,21 +299,17 @@
    - dag-id: UUID of the DAG
    - changed-repo: Name of the repo that changed
 
-   Returns a set of repo names that are downstream (depend on) the changed repo.
-
-   Throws ex-info when the DAG does not exist.
-
-   DEPRECATED: prefer [[affected-repos-anomaly]].
+   Returns a set of repo names that are downstream (depend on) the changed
+   repo, or a `:not-found` anomaly when the DAG does not exist.
 
    Example:
      (affected-repos mgr dag-id \"terraform-modules\")
      ;; => #{\"terraform-live\" \"k8s-manifests\"}"
-  {:deprecated "exceptions-as-data — prefer affected-repos-anomaly"}
   [manager dag-id changed-repo]
   (core/affected-repos manager dag-id changed-repo))
 
 (defn affected-repos-anomaly
-  "Anomaly-returning variant of [[affected-repos]].
+  "Explicit implementation name for [[affected-repos]].
 
    Returns the set of downstream repo names on success, or a `:not-found`
    anomaly when the DAG does not exist."
@@ -332,21 +324,17 @@
    - dag-id: UUID of the DAG
    - repo-name: Name of the repo to query
 
-   Returns a set of repo names that are upstream (dependencies of) the given repo.
-
-   Throws ex-info when the DAG does not exist.
-
-   DEPRECATED: prefer [[upstream-repos-anomaly]].
+   Returns a set of repo names that are upstream (dependencies of) the given
+   repo, or a `:not-found` anomaly when the DAG does not exist.
 
    Example:
      (upstream-repos mgr dag-id \"k8s-manifests\")
      ;; => #{\"terraform-modules\" \"terraform-live\"}"
-  {:deprecated "exceptions-as-data — prefer upstream-repos-anomaly"}
   [manager dag-id repo-name]
   (core/upstream-repos manager dag-id repo-name))
 
 (defn upstream-repos-anomaly
-  "Anomaly-returning variant of [[upstream-repos]].
+  "Explicit implementation name for [[upstream-repos]].
 
    Returns the set of upstream repo names on success, or a `:not-found`
    anomaly when the DAG does not exist."
@@ -367,19 +355,16 @@
 
    Only considers dependencies between repos in the pr-set.
 
-   Throws ex-info when the DAG does not exist.
-
-   DEPRECATED: prefer [[merge-order-anomaly]].
+   Returns a `:not-found` anomaly when the DAG does not exist.
 
    Example:
      (merge-order mgr dag-id #{\"terraform-modules\" \"terraform-live\"})
      ;; => {:success true :order [\"terraform-modules\" \"terraform-live\"]}"
-  {:deprecated "exceptions-as-data — prefer merge-order-anomaly"}
   [manager dag-id pr-set]
   (core/merge-order manager dag-id pr-set))
 
 (defn merge-order-anomaly
-  "Anomaly-returning variant of [[merge-order]].
+  "Explicit implementation name for [[merge-order]].
 
    Returns the merge-order result map on success, or a `:not-found`
    anomaly when the DAG does not exist."
@@ -406,19 +391,16 @@
    - Edges referencing missing repos
    - Self-loops
 
-   Throws ex-info when the DAG does not exist.
-
-   DEPRECATED: prefer [[validate-dag-anomaly]].
+   Returns a `:not-found` anomaly when the DAG does not exist.
 
    Example:
      (validate-dag mgr dag-id)
      ;; => {:valid? true :errors []}"
-  {:deprecated "exceptions-as-data — prefer validate-dag-anomaly"}
   [manager dag-id]
   (core/validate-dag manager dag-id))
 
 (defn validate-dag-anomaly
-  "Anomaly-returning variant of [[validate-dag]].
+  "Explicit implementation name for [[validate-dag]].
 
    Returns the validation result map on success, or a `:not-found` anomaly
    when the DAG does not exist."

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/queries_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/queries_test.clj
@@ -62,10 +62,11 @@
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest compute-topo-order-still-throws
-  (testing "deprecated throwing variant still throws on missing DAG"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
-          (dag/compute-topo-order *manager* (random-uuid))))))
+(deftest compute-topo-order-alias-not-found
+  (testing "stable alias returns :not-found anomaly"
+    (let [result (dag/compute-topo-order *manager* (random-uuid))]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ affected-repos
 
@@ -81,10 +82,11 @@
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest affected-repos-still-throws
-  (testing "deprecated throwing variant still throws on missing DAG"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
-          (dag/affected-repos *manager* (random-uuid) "repo-a")))))
+(deftest affected-repos-alias-not-found
+  (testing "stable alias returns :not-found anomaly"
+    (let [result (dag/affected-repos *manager* (random-uuid) "repo-a")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ upstream-repos
 
@@ -100,10 +102,11 @@
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest upstream-repos-still-throws
-  (testing "deprecated throwing variant still throws on missing DAG"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
-          (dag/upstream-repos *manager* (random-uuid) "repo-b")))))
+(deftest upstream-repos-alias-not-found
+  (testing "stable alias returns :not-found anomaly"
+    (let [result (dag/upstream-repos *manager* (random-uuid) "repo-b")]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ merge-order
 
@@ -120,10 +123,11 @@
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest merge-order-still-throws
-  (testing "deprecated throwing variant still throws on missing DAG"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
-          (dag/merge-order *manager* (random-uuid) #{"repo-a"})))))
+(deftest merge-order-alias-not-found
+  (testing "stable alias returns :not-found anomaly"
+    (let [result (dag/merge-order *manager* (random-uuid) #{"repo-a"})]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ validate-dag
 
@@ -140,7 +144,8 @@
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest validate-dag-still-throws
-  (testing "deprecated throwing variant still throws on missing DAG"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"DAG not found"
-          (dag/validate-dag *manager* (random-uuid))))))
+(deftest validate-dag-alias-not-found
+  (testing "stable alias returns :not-found anomaly"
+    (let [result (dag/validate-dag *manager* (random-uuid))]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result))))))

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_validation_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_validation_test.clj
@@ -90,8 +90,9 @@
                                   :repo/type :library})]
         (is (anomaly/anomaly? result))
         (is (= :not-found (:anomaly/type result))))
-      (is (thrown? clojure.lang.ExceptionInfo
-            (dag/compute-topo-order *manager* fake-id)))))
+      (let [result (dag/compute-topo-order *manager* fake-id)]
+        (is (anomaly/anomaly? result))
+        (is (= :not-found (:anomaly/type result))))))
 
   (testing "get-all-dags returns all dags"
     (dag/create-dag *manager* "dag-1")

--- a/docs/pull-requests/2026-06-30-chris-repo-dag-query-alias-anomalies.md
+++ b/docs/pull-requests/2026-06-30-chris-repo-dag-query-alias-anomalies.md
@@ -1,0 +1,26 @@
+# Return Repo DAG Query Alias Anomalies
+
+## Summary
+
+The repo-dag read-only query aliases now preserve the exception-as-data
+contract instead of translating missing DAGs back into thrown `ex-info`
+values.
+
+## Changes
+
+- Removed the repo-dag anomaly-to-ex-info compatibility helper.
+- Made `compute-topo-order`, `affected-repos`, `upstream-repos`,
+  `merge-order`, and `validate-dag` delegate directly to their
+  anomaly-returning implementations.
+- Removed deprecated/throwing interface documentation from the stable query
+  aliases.
+- Updated query and edge-case tests to assert returned `:not-found` anomalies
+  from the stable aliases.
+
+## Verification
+
+- `clojure -M:dev:test -e '(require ... repo-dag query namespaces ...) ...'`
+- `clojure -M:dev:test -e '(require ... compliance-scanner ...) ...'`
+
+Scanner result for `components/repo-dag/src/ai/miniforge/repo_dag/core.clj`:
+`0` cleanup-needed rows.


### PR DESCRIPTION
# Return Repo DAG Query Alias Anomalies

## Summary

The repo-dag read-only query aliases now preserve the exception-as-data
contract instead of translating missing DAGs back into thrown `ex-info`
values.

## Changes

- Removed the repo-dag anomaly-to-ex-info compatibility helper.
- Made `compute-topo-order`, `affected-repos`, `upstream-repos`,
  `merge-order`, and `validate-dag` delegate directly to their
  anomaly-returning implementations.
- Removed deprecated/throwing interface documentation from the stable query
  aliases.
- Updated query and edge-case tests to assert returned `:not-found` anomalies
  from the stable aliases.

## Verification

- `clojure -M:dev:test -e '(require ... repo-dag query namespaces ...) ...'`
- `clojure -M:dev:test -e '(require ... compliance-scanner ...) ...'`

Scanner result for `components/repo-dag/src/ai/miniforge/repo_dag/core.clj`:
`0` cleanup-needed rows.
