### PR TITLE
Return PR lifecycle controller anomalies

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -33,7 +33,6 @@
    [ai.miniforge.pr-lifecycle.merge :as merge]
    [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.release-executor.interface :as release]
-   [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [clojure.string :as str]))
@@ -54,10 +53,8 @@
    anomaly when the iteration budget is exhausted. The anomaly's
    `:anomaly/data` carries `:task-id` and `:iterations`.
 
-   This is the canonical, anomaly-returning entry point. The boundary
-   sites `handle-ci-failure!` and `handle-review-feedback!` consume
-   the anomaly and rethrow via `response/throw-anomaly!` with
-   `:anomalies/conflict`."
+   `handle-ci-failure!` and `handle-review-feedback!` return this anomaly
+   after recording failure state and history."
   [task-id current max-iters]
   (if (>= current max-iters)
     (anomaly/anomaly :conflict
@@ -72,9 +69,8 @@
    `:fault` anomaly when the upstream `create-pr!` returns a DAG
    error. The anomaly's `:anomaly/data` carries `:error`.
 
-   This is the canonical, anomaly-returning entry point. The boundary
-   site `run-lifecycle!` consumes the anomaly and rethrows via
-   `response/throw-anomaly!` with `:anomalies/fault`."
+   `run-lifecycle!` consumes this anomaly as data and returns a failed
+   lifecycle status map."
   [pr-result]
   (if (dag/err? pr-result)
     (anomaly/anomaly :fault
@@ -132,15 +128,16 @@
    :auto-resolve-comments (:auto-resolve-comments controller-defaults)
    :branch-name-prefix (:branch-name-prefix controller-defaults)})
 
-(defn- invalid-transition-ex
-  "Create an exception describing an invalid controller status transition."
+(defn- invalid-transition-anomaly
+  "Create an anomaly describing an invalid controller status transition."
   [current-status new-status transition-result]
-  (ex-info (messages/t :controller/invalid-transition)
-           {:from current-status
-            :to new-status
-            :error (controller-fsm/transition-error-code transition-result)
-            :message (controller-fsm/transition-error-message transition-result)
-            :valid-targets (controller-fsm/valid-targets current-status)}))
+  (anomaly/anomaly :conflict
+                   (messages/t :controller/invalid-transition)
+                   {:from current-status
+                    :to new-status
+                    :error (controller-fsm/transition-error-code transition-result)
+                    :message (controller-fsm/transition-error-message transition-result)
+                    :valid-targets (controller-fsm/valid-targets current-status)}))
 
 (defn- result-status
   "Return a normalized status keyword for result payloads."
@@ -161,7 +158,7 @@
       (assoc controller-state
              :status (controller-fsm/transition-state transition-result)
              :updated-at (java.util.Date.))
-      (throw (invalid-transition-ex current-status new-status transition-result)))))
+      (invalid-transition-anomaly current-status new-status transition-result))))
 
 (defn create-controller
   "Create a PR lifecycle controller for a task.
@@ -232,9 +229,11 @@
   (loop []
     (let [current-state @controller
           updated-state (transition-status current-state new-status)]
-      (if (compare-and-set! controller current-state updated-state)
+      (if (anomaly/anomaly? updated-state)
+        updated-state
+        (if (compare-and-set! controller current-state updated-state)
         (:status updated-state)
-        (recur)))))
+          (recur))))))
 
 (defn add-history!
   "Add an event to controller history."
@@ -413,73 +412,69 @@
   [controller ci-logs]
   (let [{task-id :task/id :keys [task pr config event-bus logger generate-fn]} @controller
         {:keys [worktree-path max-fix-iterations]} config
-        current-iterations (:fix-iterations @controller)]
-
-    (let [budget (iter-budget-result task-id current-iterations max-fix-iterations)]
-      (when (anomaly/anomaly? budget)
+        current-iterations (:fix-iterations @controller)
+        budget (iter-budget-result task-id current-iterations max-fix-iterations)]
+    (if (anomaly/anomaly? budget)
+      (do
         (update-status! controller :failed)
         (add-history! controller :max-fix-iterations-exceeded {:iterations current-iterations})
         (when logger
           (log/warn logger :pr-lifecycle :controller/max-iterations
                     {:message (:anomaly/message budget)
                      :data (:anomaly/data budget)}))
-        (response/throw-anomaly! :anomalies/conflict
-                                 (:anomaly/message budget)
-                                 (:anomaly/data budget))))
+        budget)
+      (do
+        (update-status! controller :fixing)
+        (swap! controller update :fix-iterations inc)
+        (add-history! controller :ci-fix-started {:iteration (inc current-iterations)})
 
-    (update-status! controller :fixing)
-    (swap! controller update :fix-iterations inc)
-    (add-history! controller :ci-fix-started {:iteration (inc current-iterations)})
+        (when logger
+          (log/info logger :pr-lifecycle :controller/fixing-ci
+                    {:message (messages/t :controller/fixing-ci)
+                     :data {:task-id task-id :iteration (inc current-iterations)}}))
 
-    (when logger
-      (log/info logger :pr-lifecycle :controller/fixing-ci
-                {:message (messages/t :controller/fixing-ci)
-                 :data {:task-id task-id :iteration (inc current-iterations)}}))
-
-    (let [fix-result (fix/fix-ci-failure
-                      task pr ci-logs generate-fn
-                      {:worktree-path worktree-path
-                       :logger logger
-                       :event-bus event-bus
-                       :dag/id (:dag/id @controller)
-                       :run/id (:run/id @controller)})]
-      (add-history! controller :ci-fix-completed (fix-completion-data fix-result))
-      fix-result)))
+        (let [fix-result (fix/fix-ci-failure
+                          task pr ci-logs generate-fn
+                          {:worktree-path worktree-path
+                           :logger logger
+                           :event-bus event-bus
+                           :dag/id (:dag/id @controller)
+                           :run/id (:run/id @controller)})]
+          (add-history! controller :ci-fix-completed (fix-completion-data fix-result))
+          fix-result)))))
 
 (defn handle-review-feedback!
   "Handle review feedback by running the fix loop."
   [controller review-comments]
   (let [{task-id :task/id :keys [task pr config event-bus logger generate-fn]} @controller
         {:keys [worktree-path max-fix-iterations auto-resolve-comments]} config
-        current-iterations (:fix-iterations @controller)]
-
-    (let [budget (iter-budget-result task-id current-iterations max-fix-iterations)]
-      (when (anomaly/anomaly? budget)
+        current-iterations (:fix-iterations @controller)
+        budget (iter-budget-result task-id current-iterations max-fix-iterations)]
+    (if (anomaly/anomaly? budget)
+      (do
         (update-status! controller :failed)
         (add-history! controller :max-fix-iterations-exceeded {:iterations current-iterations})
-        (response/throw-anomaly! :anomalies/conflict
-                                 (:anomaly/message budget)
-                                 (:anomaly/data budget))))
+        budget)
+      (do
+        (update-status! controller :fixing)
+        (swap! controller update :fix-iterations inc)
+        (add-history! controller :review-fix-started {:iteration (inc current-iterations)})
 
-    (update-status! controller :fixing)
-    (swap! controller update :fix-iterations inc)
-    (add-history! controller :review-fix-started {:iteration (inc current-iterations)})
+        (when logger
+          (log/info logger :pr-lifecycle :controller/fixing-review
+                    {:message (messages/t :controller/fixing-review)
+                     :data {:task-id task-id :comment-count (count review-comments)}}))
 
-    (when logger
-      (log/info logger :pr-lifecycle :controller/fixing-review
-                {:message (messages/t :controller/fixing-review)
-                 :data {:task-id task-id :comment-count (count review-comments)}}))
-
-    (let [fix-result (fix/fix-review-feedback
-                      task pr review-comments generate-fn
-                      {:worktree-path worktree-path
-                       :logger logger
-                       :event-bus event-bus
-                       :dag/id (:dag/id @controller)
-                       :run/id (:run/id @controller)
-                       :auto-resolve-comments auto-resolve-comments})]
-      (add-history! controller :review-fix-completed (fix-completion-data fix-result))
-      fix-result)))
+        (let [fix-result (fix/fix-review-feedback
+                          task pr review-comments generate-fn
+                          {:worktree-path worktree-path
+                           :logger logger
+                           :event-bus event-bus
+                           :dag/id (:dag/id @controller)
+                           :run/id (:run/id @controller)
+                           :auto-resolve-comments auto-resolve-comments})]
+          (add-history! controller :review-fix-completed (fix-completion-data fix-result))
+          fix-result)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Merge
@@ -556,16 +551,18 @@
 
     (try
       ;; Step 1: Create PR if needed
-      (when-not skip-pr-creation?
-        (let [pr-result (create-pr! controller code-artifact)
-              outcome (pr-creation-result pr-result)]
-          (when (anomaly/anomaly? outcome)
-            (response/throw-anomaly! :anomalies/fault
-                                     (:anomaly/message outcome)
-                                     (:anomaly/data outcome)))))
+      (let [creation-outcome (when-not skip-pr-creation?
+                               (pr-creation-result
+                                (create-pr! controller code-artifact)))]
+        (if (anomaly/anomaly? creation-outcome)
+          (do
+            (update-status! controller lifecycle-failed-status)
+            {:status lifecycle-failed-status
+             :error (:anomaly/message creation-outcome)
+             :data (:anomaly/data creation-outcome)})
 
-      ;; Step 2: CI/Review loop
-      (loop []
+          ;; Step 2: CI/Review loop
+          (loop []
         (let [status (:status @controller)]
           (case status
             ;; Start CI monitoring
@@ -659,7 +656,7 @@
             ;; Default
             (do
               (Thread/sleep lifecycle-loop-sleep-ms)
-              (recur)))))
+              (recur)))))))
 
       (catch Exception e
         (let [final-status (if (= lifecycle-failed-status (:status @controller))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -557,7 +557,7 @@
         (if (anomaly/anomaly? creation-outcome)
           (do
             (update-status! controller lifecycle-failed-status)
-            {:status lifecycle-failed-status
+            {:status (:status @controller)
              :error (:anomaly/message creation-outcome)
              :data (:anomaly/data creation-outcome)})
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/iter_budget_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/iter_budget_result_test.clj
@@ -18,18 +18,15 @@
 
 (ns ai.miniforge.pr-lifecycle.anomaly.iter-budget-result-test
   "Coverage for `controller/iter-budget-result` (anomaly-returning) and
-   the throwing boundary at `handle-ci-failure!` / `handle-review-feedback!`.
+   fix-loop boundary behavior in `handle-ci-failure!` /
+   `handle-review-feedback!`.
 
    Iter-budget exhaustion returns a `:conflict` anomaly. The boundary
-   helpers escalate the anomaly to a slingshot `:anomalies/conflict`
-   throw — preserving the legacy thrown-exception contract for
-   external orchestrators that branch on `clojure.lang.ExceptionInfo`."
+   helpers return the anomaly after recording failure state and history."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.anomaly.interface :as anomaly]
-   [ai.miniforge.pr-lifecycle.controller :as controller])
-  (:import
-   (clojure.lang ExceptionInfo)))
+   [ai.miniforge.pr-lifecycle.controller :as controller]))
 
 (def ^:private test-task
   {:task/id (random-uuid)
@@ -67,29 +64,31 @@
       (is (anomaly/anomaly? result))
       (is (= :conflict (:anomaly/type result))))))
 
-;------------------------------------------------------------------------------ Boundary helper escalates via slingshot
+;------------------------------------------------------------------------------ Boundary helper returns anomaly after side effects
 
-(deftest handle-ci-failure-escalates-budget-anomaly
-  (testing "handle-ci-failure! rethrows :conflict anomaly as ExceptionInfo"
+(deftest handle-ci-failure-returns-budget-anomaly
+  (testing "handle-ci-failure! returns :conflict anomaly"
     (let [ctrl (controller/create-controller
                 "dag" "run" "task" test-task
                 :worktree-path "/tmp"
                 :max-fix-iterations 2)]
       (swap! ctrl assoc :fix-iterations 2)
-      (is (thrown-with-msg? ExceptionInfo
-                            #"Max fix iterations exceeded"
-                            (controller/handle-ci-failure! ctrl "logs"))))))
+      (let [result (controller/handle-ci-failure! ctrl "logs")]
+        (is (anomaly/anomaly? result))
+        (is (= :conflict (:anomaly/type result)))
+        (is (= "Max fix iterations exceeded" (:anomaly/message result)))))))
 
-(deftest handle-review-feedback-escalates-budget-anomaly
-  (testing "handle-review-feedback! rethrows :conflict anomaly as ExceptionInfo"
+(deftest handle-review-feedback-returns-budget-anomaly
+  (testing "handle-review-feedback! returns :conflict anomaly"
     (let [ctrl (controller/create-controller
                 "dag" "run" "task" test-task
                 :worktree-path "/tmp"
                 :max-fix-iterations 1)]
       (swap! ctrl assoc :fix-iterations 1)
-      (is (thrown-with-msg? ExceptionInfo
-                            #"Max fix iterations exceeded"
-                            (controller/handle-review-feedback! ctrl [{:body "fix"}]))))))
+      (let [result (controller/handle-review-feedback! ctrl [{:body "fix"}])]
+        (is (anomaly/anomaly? result))
+        (is (= :conflict (:anomaly/type result)))
+        (is (= "Max fix iterations exceeded" (:anomaly/message result)))))))
 
 (deftest boundary-sets-failed-status-on-budget-exhaustion
   (testing "boundary helper transitions controller to :failed before throwing"
@@ -98,9 +97,7 @@
                 :worktree-path "/tmp"
                 :max-fix-iterations 3)]
       (swap! ctrl assoc :fix-iterations 3)
-      (try
-        (controller/handle-ci-failure! ctrl "logs")
-        (catch ExceptionInfo _e nil))
+      (controller/handle-ci-failure! ctrl "logs")
       (is (= :failed (:status @ctrl))))))
 
 (deftest boundary-records-history-on-budget-exhaustion
@@ -110,8 +107,6 @@
                 :worktree-path "/tmp"
                 :max-fix-iterations 2)]
       (swap! ctrl assoc :fix-iterations 2)
-      (try
-        (controller/handle-ci-failure! ctrl "logs")
-        (catch ExceptionInfo _e nil))
+      (controller/handle-ci-failure! ctrl "logs")
       (is (some #(= :max-fix-iterations-exceeded (:type %))
                 (:history @ctrl))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/pr_creation_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/pr_creation_result_test.clj
@@ -20,8 +20,8 @@
   "Coverage for `controller/pr-creation-result` (anomaly-returning).
 
    PR-creation failure (DAG err) returns a `:fault` anomaly. The
-   boundary site `run-lifecycle!` consumes the anomaly and rethrows
-   via `response/throw-anomaly!` with `:anomalies/fault`."
+   boundary site `run-lifecycle!` consumes the anomaly and returns a
+   failed lifecycle status map."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.anomaly.interface :as anomaly]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -25,6 +25,7 @@
    PR creation step functions."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.pr-lifecycle.controller :as controller]
    [ai.miniforge.pr-lifecycle.controller-config :as controller-config]
    [ai.miniforge.pr-lifecycle.merge :as merge]
@@ -86,13 +87,11 @@
      :events events}))
 
 (defn transition-error-data
-  "Return ex-data for an invalid controller status transition."
+  "Return anomaly data for an invalid controller status transition."
   [controller target-status]
-  (try
-    (controller/update-status! controller target-status)
-    nil
-    (catch clojure.lang.ExceptionInfo ex
-      (ex-data ex))))
+  (let [result (controller/update-status! controller target-status)]
+    (when (anomaly/anomaly? result)
+      (:anomaly/data result))))
 
 ;------------------------------------------------------------------------------ Controller Creation
 
@@ -436,29 +435,31 @@
 ;------------------------------------------------------------------------------ Fix Iteration Enforcement
 
 (deftest handle-ci-failure-max-iterations-test
-  (testing "handle-ci-failure! throws when max iterations exceeded"
+  (testing "handle-ci-failure! returns anomaly when max iterations exceeded"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp"
                  :max-fix-iterations 3)]
       ;; Simulate having already used all iterations
       (swap! ctrl assoc :fix-iterations 3)
-      (is (thrown-with-msg?
-            clojure.lang.ExceptionInfo
-            (max-fix-iterations-exceeded-pattern)
-            (controller/handle-ci-failure! ctrl "some ci logs"))))))
+      (let [result (controller/handle-ci-failure! ctrl "some ci logs")]
+        (is (anomaly/anomaly? result))
+        (is (= :conflict (:anomaly/type result)))
+        (is (re-find (max-fix-iterations-exceeded-pattern)
+                     (:anomaly/message result)))))))
 
 (deftest handle-review-feedback-max-iterations-test
-  (testing "handle-review-feedback! throws when max iterations exceeded"
+  (testing "handle-review-feedback! returns anomaly when max iterations exceeded"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp"
                  :max-fix-iterations 2)]
       (swap! ctrl assoc :fix-iterations 2)
-      (is (thrown-with-msg?
-            clojure.lang.ExceptionInfo
-            (max-fix-iterations-exceeded-pattern)
-            (controller/handle-review-feedback! ctrl [{:body "Fix"}]))))))
+      (let [result (controller/handle-review-feedback! ctrl [{:body "Fix"}])]
+        (is (anomaly/anomaly? result))
+        (is (= :conflict (:anomaly/type result)))
+        (is (re-find (max-fix-iterations-exceeded-pattern)
+                     (:anomaly/message result)))))))
 
 (deftest handle-ci-failure-increments-iteration-before-max-test
   (testing "handle-ci-failure! transitions to :fixing and increments counter"
@@ -490,9 +491,7 @@
                  :worktree-path "/tmp"
                  :max-fix-iterations 3)]
       (swap! ctrl assoc :fix-iterations 3)
-      (try
-        (controller/handle-ci-failure! ctrl "logs")
-        (catch clojure.lang.ExceptionInfo _e nil))
+      (controller/handle-ci-failure! ctrl "logs")
       (is (= :failed (:status @ctrl))))))
 
 (deftest handle-ci-failure-records-history-on-max-exceeded-test
@@ -502,21 +501,20 @@
                  :worktree-path "/tmp"
                  :max-fix-iterations 2)]
       (swap! ctrl assoc :fix-iterations 2)
-      (try
-        (controller/handle-ci-failure! ctrl "logs")
-        (catch clojure.lang.ExceptionInfo _e nil))
+      (controller/handle-ci-failure! ctrl "logs")
       (is (some #(= :max-fix-iterations-exceeded (:type %)) (:history @ctrl))))))
 
 (deftest handle-ci-failure-zero-max-iterations-test
-  (testing "handle-ci-failure! immediately throws when max-fix-iterations is 0"
+  (testing "handle-ci-failure! immediately returns anomaly when max-fix-iterations is 0"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp"
-                 :max-fix-iterations 0)]
-      (is (thrown-with-msg?
-            clojure.lang.ExceptionInfo
-            (max-fix-iterations-exceeded-pattern)
-            (controller/handle-ci-failure! ctrl "logs"))))))
+                 :max-fix-iterations 0)
+          result (controller/handle-ci-failure! ctrl "logs")]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (re-find (max-fix-iterations-exceeded-pattern)
+                   (:anomaly/message result))))))
 
 (deftest handle-ci-failure-records-normalized-result-status-test
   (testing "handle-ci-failure! records normalized result status in history"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -665,6 +665,16 @@
           (is (= :failed (:status @ctrl)))
           (is (some #(= :pr-creation-failed (:type %)) (:history @ctrl))))))))
 
+(deftest run-lifecycle-pr-creation-failure-reports-current-status
+  (testing "PR creation anomaly result reports the controller's actual status"
+    (let [ctrl (make-controller)]
+      (with-redefs [release/create-branch! (fn [_path _name]
+                                             (release-failure "git error"))]
+        (let [result (controller/run-lifecycle! ctrl {:code/files []})]
+          (is (= (:status @ctrl) (:status result)))
+          (is (= :failed (:status result)))
+          (is (= "PR creation failed" (:error result))))))))
+
 ;; apply-code-to-files!
 
 (deftest apply-code-to-files-success

--- a/docs/pull-requests/2026-06-30-chris-pr-lifecycle-controller-anomalies.md
+++ b/docs/pull-requests/2026-06-30-chris-pr-lifecycle-controller-anomalies.md
@@ -1,0 +1,27 @@
+# Return PR Lifecycle Controller Anomalies
+
+## Summary
+
+`pr_lifecycle/controller.clj` no longer throws for controller transition,
+fix-loop budget, or PR-creation anomaly paths. Those paths now return anomaly
+data while preserving existing state and history side effects.
+
+## Changes
+
+- Convert invalid controller status transitions from `ex-info` throws to
+  returned `:conflict` anomalies.
+- Make `update-status!` return transition anomalies without mutating controller
+  state.
+- Make CI/review fix-loop budget exhaustion return the existing `:conflict`
+  anomaly after setting `:failed` and recording history.
+- Make `run-lifecycle!` consume PR-creation anomalies as data and return a
+  failed lifecycle status map.
+- Update PR lifecycle tests to assert returned anomaly contracts.
+
+## Verification
+
+- Focused PR lifecycle controller/anomaly tests:
+  63 tests, 164 assertions, 0 failures, 0 errors.
+- Exceptions-as-data scanner:
+  `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj`
+  contributes `0` cleanup-needed rows; repository total is `94`.


### PR DESCRIPTION
# Return PR Lifecycle Controller Anomalies

## Summary

`pr_lifecycle/controller.clj` no longer throws for controller transition,
fix-loop budget, or PR-creation anomaly paths. Those paths now return anomaly
data while preserving existing state and history side effects.

## Changes

- Convert invalid controller status transitions from `ex-info` throws to
  returned `:conflict` anomalies.
- Make `update-status!` return transition anomalies without mutating controller
  state.
- Make CI/review fix-loop budget exhaustion return the existing `:conflict`
  anomaly after setting `:failed` and recording history.
- Make `run-lifecycle!` consume PR-creation anomalies as data and return a
  failed lifecycle status map.
- Update PR lifecycle tests to assert returned anomaly contracts.

## Verification

- Focused PR lifecycle controller/anomaly tests:
  63 tests, 164 assertions, 0 failures, 0 errors.
- Exceptions-as-data scanner:
  `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj`
  contributes `0` cleanup-needed rows; repository total is `94`.
