### PR TITLE
fix(dag-executor): guard copy-file-to/from against path traversal

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -766,35 +766,55 @@
 ;; File Operations
 ;; ============================================================================
 
+(defn- path-inside-worktree?
+  "True when `file` (a canonicalized File) is the worktree root or is nested
+   inside it. Prevents path-traversal escape via `../` segments."
+  [^File worktree ^File file]
+  (let [root-path (str (.getPath worktree) File/separator)
+        file-path (.getPath file)]
+    (or (= file-path (.getPath worktree))
+        (str/starts-with? file-path root-path))))
+
+(defn- safe-worktree-path
+  "Resolve `relative-path` inside `worktree-path` and return the canonical
+   File, or nil if the resolved path would escape the worktree sandbox."
+  [worktree-path relative-path]
+  (let [worktree (.getCanonicalFile (File. ^String worktree-path))
+        file     (.getCanonicalFile (File. worktree ^String relative-path))]
+    (when (path-inside-worktree? worktree file)
+      file)))
+
 (defn copy-file-to
   "Copy a file into the worktree."
   [worktree-path local-path remote-path]
-  (try
-    (let [source (File. ^String local-path)
-          dest-path (str worktree-path "/" remote-path)
-          dest (File. ^String dest-path)]
-      (.mkdirs (.getParentFile dest))
-      (Files/copy (.toPath source)
-                  (.toPath dest)
-                  (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING]))
-      (result/ok {:copied-bytes (.length source)}))
-    (catch Exception e
-      (result/err :copy-failed (.getMessage e)))))
+  (let [dest (safe-worktree-path worktree-path remote-path)]
+    (if-not dest
+      (result/err :path-traversal (str "path escapes worktree sandbox: " remote-path))
+      (try
+        (let [source (File. ^String local-path)]
+          (.mkdirs (.getParentFile dest))
+          (Files/copy (.toPath source)
+                      (.toPath dest)
+                      (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING]))
+          (result/ok {:copied-bytes (.length source)}))
+        (catch Exception e
+          (result/err :copy-failed (.getMessage e)))))))
 
 (defn copy-file-from
   "Copy a file from the worktree."
   [worktree-path remote-path local-path]
-  (try
-    (let [source-path (str worktree-path "/" remote-path)
-          source (File. ^String source-path)
-          dest (File. ^String local-path)]
-      (.mkdirs (.getParentFile dest))
-      (Files/copy (.toPath source)
-                  (.toPath dest)
-                  (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING]))
-      (result/ok {:copied-bytes (.length source)}))
-    (catch Exception e
-      (result/err :copy-failed (.getMessage e)))))
+  (let [source (safe-worktree-path worktree-path remote-path)]
+    (if-not source
+      (result/err :path-traversal (str "path escapes worktree sandbox: " remote-path))
+      (try
+        (let [dest (File. ^String local-path)]
+          (.mkdirs (.getParentFile dest))
+          (Files/copy (.toPath source)
+                      (.toPath dest)
+                      (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING]))
+          (result/ok {:copied-bytes (.length source)}))
+        (catch Exception e
+          (result/err :copy-failed (.getMessage e)))))))
 
 ;; ============================================================================
 ;; Public Utility Functions

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -777,12 +777,15 @@
 
 (defn- safe-worktree-path
   "Resolve `relative-path` inside `worktree-path` and return the canonical
-   File, or nil if the resolved path would escape the worktree sandbox."
+   File, or nil if the resolved path would escape the worktree sandbox or
+   if canonicalization fails (I/O error, invalid path)."
   [worktree-path relative-path]
-  (let [worktree (.getCanonicalFile (File. ^String worktree-path))
-        file     (.getCanonicalFile (File. worktree ^String relative-path))]
-    (when (path-inside-worktree? worktree file)
-      file)))
+  (try
+    (let [worktree (.getCanonicalFile (File. ^String worktree-path))
+          file     (.getCanonicalFile (File. worktree ^String relative-path))]
+      (when (path-inside-worktree? worktree file)
+        file))
+    (catch java.io.IOException _ nil)))
 
 (defn copy-file-to
   "Copy a file into the worktree."

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/worktree_copy_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/worktree_copy_test.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.protocols.worktree-copy-test
+  "Path-traversal guard tests for WorktreeExecutor copy-file-to/from."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.java.io :as io]
+   [ai.miniforge.dag-executor.protocols.impl.worktree :as sut]
+   [ai.miniforge.dag-executor.result :as result]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers
+
+(defn- make-temp-dir!
+  "Create a real temp directory and return its canonical path string."
+  [prefix]
+  (let [dir (java.nio.file.Files/createTempDirectory
+             prefix
+             (into-array java.nio.file.attribute.FileAttribute []))]
+    (.toString (.toRealPath dir (into-array java.nio.file.LinkOption [])))))
+
+(defn- write-temp-file!
+  "Write `content` to `path` (string) and return the path."
+  [path content]
+  (spit path content)
+  path)
+
+(defn- error-code [r] (get-in r [:error :code]))
+
+;------------------------------------------------------------------------------ Layer 1
+;; copy-file-to — traversal guard
+
+(deftest copy-file-to-rejects-dotdot-escape
+  (let [worktree (make-temp-dir! "wt-copy-to-")
+        src-dir  (make-temp-dir! "wt-src-")
+        src-file (write-temp-file! (str src-dir "/payload.txt") "secret")]
+    (testing "../../etc/passwd escapes the worktree root → :path-traversal"
+      (let [r (sut/copy-file-to worktree src-file "../../etc/passwd")]
+        (is (result/err? r))
+        (is (= :path-traversal (error-code r)))))
+    (testing "../ escapes the worktree root → :path-traversal"
+      (let [r (sut/copy-file-to worktree src-file "../escaped.txt")]
+        (is (result/err? r))
+        (is (= :path-traversal (error-code r)))))))
+
+(deftest copy-file-to-allows-nested-path
+  (let [worktree (make-temp-dir! "wt-copy-to-ok-")
+        src-dir  (make-temp-dir! "wt-src-ok-")
+        src-file (write-temp-file! (str src-dir "/hello.txt") "hello")]
+    (testing "a simple nested path inside the worktree succeeds"
+      (let [r (sut/copy-file-to worktree src-file "subdir/hello.txt")]
+        (is (result/ok? r))
+        (is (pos? (:copied-bytes (:data r))))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; copy-file-from — traversal guard
+
+(deftest copy-file-from-rejects-dotdot-escape
+  (let [worktree (make-temp-dir! "wt-copy-from-")
+        dest-dir (make-temp-dir! "wt-dest-")]
+    (testing "../../etc/shadow escapes the worktree root → :path-traversal"
+      (let [r (sut/copy-file-from worktree "../../etc/shadow"
+                                  (str dest-dir "/out.txt"))]
+        (is (result/err? r))
+        (is (= :path-traversal (error-code r)))))
+    (testing "../escaped.txt escapes the worktree root → :path-traversal"
+      (let [r (sut/copy-file-from worktree "../escaped.txt"
+                                  (str dest-dir "/out2.txt"))]
+        (is (result/err? r))
+        (is (= :path-traversal (error-code r)))))))
+
+(deftest copy-file-from-allows-nested-path
+  (let [worktree  (make-temp-dir! "wt-copy-from-ok-")
+        dest-dir  (make-temp-dir! "wt-dest-ok-")
+        _         (io/make-parents (str worktree "/subdir/result.txt"))
+        _         (write-temp-file! (str worktree "/subdir/result.txt") "done")]
+    (testing "a valid nested path inside the worktree is copied out"
+      (let [r (sut/copy-file-from worktree "subdir/result.txt"
+                                  (str dest-dir "/result.txt"))]
+        (is (result/ok? r))
+        (is (pos? (:copied-bytes (:data r))))))))


### PR DESCRIPTION
## What

`copy-file-to` and `copy-file-from` in
`components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj`
built the in-worktree path via plain string concatenation:

```clojure
;; before — no canonicalization
(str worktree-path "/" remote-path)
```

A `remote-path` of `../../.ssh/authorized_keys` resolved outside the
worktree sandbox and the `Files/copy` proceeded silently, giving any
task payload a host-filesystem read/write primitive as the process user.

## Fix

Add `safe-worktree-path`, which canonicalizes both the worktree root
and the resolved target via `.getCanonicalFile`, then verifies the
target starts with the canonicalized worktree prefix:

```clojure
(defn- safe-worktree-path [worktree-path relative-path]
  (let [worktree (.getCanonicalFile (File. ^String worktree-path))
        file     (.getCanonicalFile (File. worktree ^String relative-path))]
    (when (path-inside-worktree? worktree file)
      file)))
```

Both copy functions now call `safe-worktree-path` and return
`:path-traversal` on escape attempts — a distinct error keyword, not
silently absorbed in `:copy-failed`.

## Why

The `WorktreeExecutor` is the standard fallback when no container
runtime is available (common developer mode). The same containment
pattern already existed in
`components/gate/src/ai/miniforge/gate/policy_pack.clj`
(`safe-worktree-file` / `path-inside-worktree?`) but had not been
applied to the executor's copy operations.

## Scope

- 1 file changed, 42 insertions(+), 22 deletions(-)
- No new deps; uses `java.io.File` already imported in the namespace
- No test file changes needed (no prior tests for these functions; callers that exercise copy paths will pick up the guard automatically)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDw7aDagSAtFHh2eRCDoAz)_