### PR TITLE
Return event-stream snowflake anomalies

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -68,8 +68,11 @@
 
 (defn- next-event-id
   [generator]
-  (if generator
+  (cond
+    (response/anomaly-map? generator) generator
+    generator
     (snowflake/next-id! generator)
+    :else
     (random-uuid)))
 
 (defn create-envelope
@@ -106,29 +109,29 @@
    ;; window where two concurrent producers see the same number.
    ;; The previous read-then-swap pattern WAS racey; reviewers
    ;; flagged it on PR #814.
-   (let [[old _new] (swap-vals! stream
-                                update-in
-                                [:sequence-numbers workflow-id]
-                                (fnil inc 0))
-         seq-num    (get-in old [:sequence-numbers workflow-id] 0)
-         generator  (:snowflake-generator @stream)
-         event-id   (next-event-id generator)]
+   (let [generator (:snowflake-generator @stream)
+         event-id  (next-event-id generator)]
      (if (response/anomaly-map? event-id)
        event-id
-       (cond-> {:event/type event-type
-                :event/id event-id
-                :event/timestamp (java.util.Date.)
-                :event/version event-version
-                :event/sequence-number seq-num
-                :workflow/id workflow-id
-                :message message}
-         (:org/id opts)            (assoc :org/id (:org/id opts))
-         (:workspace/id opts)      (assoc :workspace/id (:workspace/id opts))
-         (:repo/id opts)           (assoc :repo/id (:repo/id opts))
-         (:auth/context opts)      (assoc :auth/context (:auth/context opts))
-         (:event/parent-id opts)   (assoc :event/parent-id (:event/parent-id opts))
-         (:agent/id opts)          (assoc :agent/id (:agent/id opts))
-         (:agent/instance-id opts) (assoc :agent/instance-id (:agent/instance-id opts)))))))
+       (let [[old _new] (swap-vals! stream
+                                    update-in
+                                    [:sequence-numbers workflow-id]
+                                    (fnil inc 0))
+             seq-num    (get-in old [:sequence-numbers workflow-id] 0)]
+         (cond-> {:event/type event-type
+                  :event/id event-id
+                  :event/timestamp (java.util.Date.)
+                  :event/version event-version
+                  :event/sequence-number seq-num
+                  :workflow/id workflow-id
+                  :message message}
+           (:org/id opts)            (assoc :org/id (:org/id opts))
+           (:workspace/id opts)      (assoc :workspace/id (:workspace/id opts))
+           (:repo/id opts)           (assoc :repo/id (:repo/id opts))
+           (:auth/context opts)      (assoc :auth/context (:auth/context opts))
+           (:event/parent-id opts)   (assoc :event/parent-id (:event/parent-id opts))
+           (:agent/id opts)          (assoc :agent/id (:agent/id opts))
+           (:agent/instance-id opts) (assoc :agent/instance-id (:agent/instance-id opts))))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Event bus operations

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -66,6 +66,12 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event envelope constructor
 
+(defn- next-event-id
+  [generator]
+  (if generator
+    (snowflake/next-id! generator)
+    (random-uuid)))
+
 (defn create-envelope
   "Create an event envelope with sequence numbering.
 
@@ -105,23 +111,24 @@
                                 [:sequence-numbers workflow-id]
                                 (fnil inc 0))
          seq-num    (get-in old [:sequence-numbers workflow-id] 0)
-         generator  (:snowflake-generator @stream)]
-     (cond-> {:event/type event-type
-              :event/id (if generator
-                          (snowflake/next-id! generator)
-                          (random-uuid))
-              :event/timestamp (java.util.Date.)
-              :event/version event-version
-              :event/sequence-number seq-num
-              :workflow/id workflow-id
-              :message message}
-       (:org/id opts)            (assoc :org/id (:org/id opts))
-       (:workspace/id opts)      (assoc :workspace/id (:workspace/id opts))
-       (:repo/id opts)           (assoc :repo/id (:repo/id opts))
-       (:auth/context opts)      (assoc :auth/context (:auth/context opts))
-       (:event/parent-id opts)   (assoc :event/parent-id (:event/parent-id opts))
-       (:agent/id opts)          (assoc :agent/id (:agent/id opts))
-       (:agent/instance-id opts) (assoc :agent/instance-id (:agent/instance-id opts))))))
+         generator  (:snowflake-generator @stream)
+         event-id   (next-event-id generator)]
+     (if (response/anomaly-map? event-id)
+       event-id
+       (cond-> {:event/type event-type
+                :event/id event-id
+                :event/timestamp (java.util.Date.)
+                :event/version event-version
+                :event/sequence-number seq-num
+                :workflow/id workflow-id
+                :message message}
+         (:org/id opts)            (assoc :org/id (:org/id opts))
+         (:workspace/id opts)      (assoc :workspace/id (:workspace/id opts))
+         (:repo/id opts)           (assoc :repo/id (:repo/id opts))
+         (:auth/context opts)      (assoc :auth/context (:auth/context opts))
+         (:event/parent-id opts)   (assoc :event/parent-id (:event/parent-id opts))
+         (:agent/id opts)          (assoc :agent/id (:agent/id opts))
+         (:agent/instance-id opts) (assoc :agent/instance-id (:agent/instance-id opts)))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Event bus operations
@@ -343,25 +350,27 @@
    eliminating the TOCTOU window that allowed a publish to slip through
    after `quiesce!` fenced the workflow."
   [stream event]
-  ;; Fast path: check quiesce before acquiring the in-flight slot so
-  ;; already-quiesced workflows skip the swap! entirely.
-  (or (rejection-if-quiesced stream event)
-      (let [result (with-in-flight stream event
-                     (fn []
-                       (let [{:keys [sinks subscribers filters logger]} @stream]
-                         (deliver-to-sinks! sinks event logger)
-                         (record-event! stream event)
-                         (deliver-to-subscribers! subscribers filters event logger)
-                         (log-published! logger event)
-                         event)))]
-        ;; with-in-flight returns quiesced-sentinel when the workflow was
-        ;; fenced during the atomic acquire (the TOCTOU window). Convert
-        ;; to the canonical rejection shape so callers see a consistent
-        ;; {:rejected? true ...} map regardless of which path triggered it.
-        (if (= result quiesced-sentinel)
-          (do (log-rejection! (:logger @stream) event)
-              (rejection-result event :workflow-quiesced))
-          result))))
+  (if (response/anomaly-map? event)
+    event
+    ;; Fast path: check quiesce before acquiring the in-flight slot so
+    ;; already-quiesced workflows skip the swap! entirely.
+    (or (rejection-if-quiesced stream event)
+        (let [result (with-in-flight stream event
+                       (fn []
+                         (let [{:keys [sinks subscribers filters logger]} @stream]
+                           (deliver-to-sinks! sinks event logger)
+                           (record-event! stream event)
+                           (deliver-to-subscribers! subscribers filters event logger)
+                           (log-published! logger event)
+                           event)))]
+          ;; with-in-flight returns quiesced-sentinel when the workflow was
+          ;; fenced during the atomic acquire (the TOCTOU window). Convert
+          ;; to the canonical rejection shape so callers see a consistent
+          ;; {:rejected? true ...} map regardless of which path triggered it.
+          (if (= result quiesced-sentinel)
+            (do (log-rejection! (:logger @stream) event)
+                (rejection-result event :workflow-quiesced))
+            result)))))
 
 (defn subscribe!
   ([stream subscriber-id callback]

--- a/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
@@ -166,7 +166,9 @@
             :worker-id id
             :lease-path (.getAbsolutePath lease-path)
             :workers-dir (.getAbsolutePath workers-dir)})
-    error (assoc :anomaly/cause (ex-message error))))
+    error (assoc :anomaly/ex-message (ex-message error)
+                 :anomaly/ex-class (str (class error)))
+    (ex-data error) (assoc :anomaly/ex-data (ex-data error))))
 
 (defn- workers-exhausted-anomaly
   [workers-dir]
@@ -291,7 +293,8 @@
   "Allocate a new snowflake generator. Acquires a worker-id lease under
    `:workers-dir` (default `~/.miniforge/events/.workers/`).
 
-   Returns a map carrying:
+   Returns a canonical anomaly when worker lease acquisition fails.
+   Otherwise returns a map carrying:
      :state      atom with {:last-ts :last-seq :worker-id}
      :worker-id  long, 0..1023
      :lease      lease handle (release on close!)

--- a/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
@@ -56,8 +56,8 @@
   (:require
    [ai.miniforge.config.interface :as config]
    [ai.miniforge.event-stream.messages :as messages]
+   [ai.miniforge.response.interface :as response]
    [clojure.java.io :as io]
-   [clojure.string :as str]
    [ai.miniforge.logging.interface :as log]))
 
 ;; NOTE: The worker-id lease path constructs java.io.RandomAccessFile,
@@ -155,6 +155,29 @@
   []
   (io/file (config/miniforge-home) "events" ".workers"))
 
+(defn- lease-io-anomaly
+  [workers-dir lease-path id error]
+  (cond-> (response/make-anomaly
+           :anomalies/unavailable
+           (messages/t :snowflake/lease-io-failure
+                       {:worker-id id
+                        :lease-path (.getAbsolutePath lease-path)})
+           {:reason :lease-io-failure
+            :worker-id id
+            :lease-path (.getAbsolutePath lease-path)
+            :workers-dir (.getAbsolutePath workers-dir)})
+    error (assoc :anomaly/cause (ex-message error))))
+
+(defn- workers-exhausted-anomaly
+  [workers-dir]
+  (response/make-anomaly
+   :anomalies/busy
+   (messages/t :snowflake/workers-exhausted
+               {:max max-workers})
+   {:reason :workers-exhausted
+    :max    max-workers
+    :workers-dir (.getAbsolutePath workers-dir)}))
+
 (defn- write-lease-metadata!
   "Truncate `channel` and write the worker-id + acquire timestamp as
    EDN. Force to disk. Metadata is informational only — the OS-level
@@ -188,41 +211,32 @@
    `:workers-exhausted` even when no slots are actually contended."
   [workers-dir ^long id]
   (.mkdirs workers-dir)
-  (let [lease-path (io/file workers-dir (str id ".lease"))
-        raf       (java.io.RandomAccessFile. lease-path "rw")
-        channel   (.getChannel raf)]
+  (let [lease-path (io/file workers-dir (str id ".lease"))]
     ;; Resolve OverlappingFileLockException lazily via Class/forName so
     ;; this namespace stays loadable in Babashka (which doesn't ship
     ;; java.nio.channels). A typed `(catch java.nio.channels...)` would
     ;; force compile-time class resolution and break BB load.
     (try
-      (let [lock (.tryLock channel)]
-        (if lock
-          (do
-            (write-lease-metadata! channel id)
-            {:channel channel :lock lock :worker-id id :raf raf})
-          (do (.close raf) nil)))
+      (let [raf     (java.io.RandomAccessFile. lease-path "rw")
+            channel (.getChannel raf)]
+        (try
+          (let [lock (.tryLock channel)]
+            (if lock
+              (do
+                (write-lease-metadata! channel id)
+                {:channel channel :lock lock :worker-id id :raf raf})
+              (do (.close raf) nil)))
+          (catch Exception e
+            (try (.close raf) (catch Exception _))
+            (if (instance? (Class/forName "java.nio.channels.OverlappingFileLockException") e)
+              ;; This JVM already holds an overlapping lock on the same
+              ;; file. Treat as "slot held" and let the caller advance.
+              nil
+              ;; Real IO/permission failure. Return an explicit anomaly
+              ;; rather than silently masking it as :workers-exhausted later.
+              (lease-io-anomaly workers-dir lease-path id e)))))
       (catch Exception e
-        (try (.close raf) (catch Exception _))
-        (if (instance? (Class/forName "java.nio.channels.OverlappingFileLockException") e)
-          ;; This JVM already holds an overlapping lock on the same
-          ;; file. Treat as "slot held" and let the caller advance.
-          nil
-          ;; Real IO/permission failure. Wrap with context and propagate
-          ;; rather than silently masking as :workers-exhausted later.
-          ;; Localized via messages/t. acquire-worker-lease! and its
-          ;; sole caller (create-generator at process startup) are at
-          ;; the edge — an exception is the right shape vs a data
-          ;; anomaly that callers would have to convert back to a
-          ;; failure signal.
-          (throw (ex-info (messages/t :snowflake/lease-io-failure
-                                      {:worker-id id
-                                       :lease-path (.getAbsolutePath lease-path)})
-                          {:reason :lease-io-failure
-                           :worker-id id
-                           :lease-path (.getAbsolutePath lease-path)
-                           :workers-dir (.getAbsolutePath workers-dir)}
-                          e)))))))
+        (lease-io-anomaly workers-dir lease-path id e)))))
 
 (defn acquire-worker-lease!
   "Walk slots 0..1023 and acquire the first whose lease file is
@@ -244,24 +258,20 @@
    or crash), so stale leases reclaim themselves without explicit
    teardown.
 
-   Throws ex-info (localized) when all slots are held — typical only
-   when 1024+ miniforge processes coexist on the same host. This is
-   an edge condition raised at generator construction; an exception
-   is the right shape vs a data anomaly per the project's
-   exceptions-as-data conventions."
+   Returns a canonical anomaly when all slots are held — typical only
+   when 1024+ miniforge processes coexist on the same host — or when
+   lease-file I/O fails."
   [workers-dir]
   (loop [id 0]
     (cond
       (>= id max-workers)
-      (throw (ex-info (messages/t :snowflake/workers-exhausted
-                                  {:max max-workers})
-                      {:reason :workers-exhausted
-                       :max    max-workers
-                       :workers-dir (.getAbsolutePath workers-dir)}))
+      (workers-exhausted-anomaly workers-dir)
       :else
-      (if-let [lease (try-acquire-slot workers-dir id)]
-        lease
-        (recur (inc id))))))
+      (let [lease (try-acquire-slot workers-dir id)]
+        (cond
+          (response/anomaly-map? lease) lease
+          lease lease
+          :else (recur (inc id)))))))
 
 (defn release-lease!
   "Release a worker-id lease. Idempotent. The OS would release on JVM
@@ -292,13 +302,15 @@
    side effects."
   [& [{:keys [workers-dir now-fn logger lease]
        :or   {now-fn (fn ^long [] (System/currentTimeMillis))}}]]
-  (let [lease (or lease (acquire-worker-lease! (or workers-dir (default-workers-dir))))
-        worker-id (:worker-id lease)]
-    {:state     (atom (initial-state worker-id))
-     :worker-id worker-id
-     :lease     lease
-     :now-fn    now-fn
-     :logger    logger}))
+  (let [lease (or lease (acquire-worker-lease! (or workers-dir (default-workers-dir))))]
+    (if (response/anomaly-map? lease)
+      lease
+      (let [worker-id (:worker-id lease)]
+        {:state     (atom (initial-state worker-id))
+         :worker-id worker-id
+         :lease     lease
+         :now-fn    now-fn
+         :logger    logger}))))
 
 (defn close!
   "Release the generator's worker-id lease. Idempotent."
@@ -349,14 +361,16 @@
            nil
            (into-array Object [(Long/valueOf park-budget-nanos)])))
 
-(defn- pre-epoch-error
+(defn- pre-epoch-anomaly
   [now-ms worker-id]
-  (ex-info (messages/t :snowflake/pre-epoch-clock
-                       {:now-ms now-ms :epoch-ms miniforge-epoch-ms})
-           {:reason     :pre-epoch-clock
-            :now-ms     now-ms
-            :epoch-ms   miniforge-epoch-ms
-            :worker-id  worker-id}))
+  (response/make-anomaly
+   :anomalies/incorrect
+   (messages/t :snowflake/pre-epoch-clock
+               {:now-ms now-ms :epoch-ms miniforge-epoch-ms})
+   {:reason     :pre-epoch-clock
+    :now-ms     now-ms
+    :epoch-ms   miniforge-epoch-ms
+    :worker-id  worker-id}))
 
 (defn- handle-rollback!
   "Side-effect: warn once on first rollback observation. Park before
@@ -379,17 +393,20 @@
                 ^long (:last-seq new-state))))
 
 (defn next-id-long!
-  "Internal: generate the next snowflake as a primitive long. Parks on
+  "Internal: generate the next snowflake as a long. Parks on
    clock rollback or sequence exhaustion (≤100µs per retry via
    `LockSupport/parkNanos` rather than `Thread/sleep`).
-   Public id functions (`next-id!`, `next-id-hex!`) wrap this."
-  ^long [{:keys [state now-fn ^long worker-id] :as gen}]
+   Public id functions (`next-id!`, `next-id-hex!`) wrap this.
+
+   Returns a canonical anomaly when the wall clock is before the
+   miniforge epoch."
+  [{:keys [state now-fn ^long worker-id] :as gen}]
   (loop [warned? false]
     (let [now-ms (long (now-fn))
           old    @state
           r      (next-state old now-ms)]
       (cond
-        (= r ::pre-epoch)        (throw (pre-epoch-error now-ms worker-id))
+        (= r ::pre-epoch)        (pre-epoch-anomaly now-ms worker-id)
         (= r ::clock-rollback)   (recur (handle-rollback! gen now-ms (:last-ts old) warned?))
         (= r ::seq-exhausted)    (do (park-briefly!) (recur warned?))
         :else
@@ -402,12 +419,18 @@
    snowflake bits live in the UUID's most-significant 64 bits; low 64
    bits are zero. The UUID's string form sorts lexically by creation
    order on a single host."
-  ^java.util.UUID [generator]
-  (long->uuid (next-id-long! generator)))
+  [generator]
+  (let [id (next-id-long! generator)]
+    (if (response/anomaly-map? id)
+      id
+      (long->uuid id))))
 
 (defn next-id-hex!
   "Generate the next snowflake event id as a 16-char lowercase hex
    string. Use this for filenames and other places where the UUID's
    hyphens are inconvenient."
-  ^String [generator]
-  (format-hex (next-id-long! generator)))
+  [generator]
+  (let [id (next-id-long! generator)]
+    (if (response/anomaly-map? id)
+      id
+      (format-hex id))))

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -23,6 +23,7 @@
    [ai.miniforge.event-stream.messages :as messages]
    [ai.miniforge.phase.interface :as phase]
    [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.event-stream.core :as core]))
 
 ;------------------------------------------------------------------------------ Helpers
@@ -83,6 +84,20 @@
       (is (nil? (:workflow/id env)))
       (is (= 0 (:event/sequence-number env))))))
 
+(deftest create-envelope-propagates-snowflake-anomaly
+  (let [generator {:state     (atom {:last-ts -1
+                                     :last-seq -1
+                                     :worker-id 0})
+                   :worker-id 0
+                   :lease     {:worker-id 0}
+                   :now-fn    (constantly 0)}
+        stream (core/create-event-stream {:sinks []
+                                          :snowflake-generator generator})
+        result (core/create-envelope stream :test/event (random-uuid) "hello")]
+    (is (response/anomaly-map? result))
+    (is (= :anomalies/incorrect (:anomaly/category result)))
+    (is (= :pre-epoch-clock (:reason result)))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; publish! sink integration
 
@@ -93,6 +108,17 @@
       (core/publish! stream event)
       (is (= 1 (count @collected)))
       (is (= :test/sink (:event/type (first @collected)))))))
+
+(deftest publish-returns-anomaly-without-delivery
+  (let [{:keys [stream collected]} (collect-stream)
+        anomaly (response/make-anomaly
+                 :anomalies/incorrect
+                 "invalid event"
+                 {:reason :pre-epoch-clock})
+        result (core/publish! stream anomaly)]
+    (is (identical? anomaly result))
+    (is (empty? @collected))
+    (is (empty? (:events @stream)))))
 
 (deftest publish-sink-error-handling-test
   (testing "publish! continues when a sink throws"

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -98,6 +98,32 @@
     (is (= :anomalies/incorrect (:anomaly/category result)))
     (is (= :pre-epoch-clock (:reason result)))))
 
+(deftest create-envelope-propagates-anomaly-generator
+  (let [generator-anomaly (response/make-anomaly
+                           :anomalies/busy
+                           "No worker slots"
+                           {:reason :workers-exhausted})
+        stream (core/create-event-stream {:sinks []
+                                          :snowflake-generator generator-anomaly})
+        result (core/create-envelope stream :test/event (random-uuid) "hello")]
+    (is (identical? generator-anomaly result))))
+
+(deftest create-envelope-does-not-consume-sequence-on-id-anomaly
+  (let [wf-id (random-uuid)
+        generator {:state     (atom {:last-ts -1
+                                     :last-seq -1
+                                     :worker-id 0})
+                   :worker-id 0
+                   :lease     {:worker-id 0}
+                   :now-fn    (constantly 0)}
+        stream (core/create-event-stream {:sinks []
+                                          :snowflake-generator generator})
+        result (core/create-envelope stream :test/event wf-id "bad")]
+    (is (response/anomaly-map? result))
+    (swap! stream dissoc :snowflake-generator)
+    (is (= 0 (:event/sequence-number
+              (core/create-envelope stream :test/event wf-id "good"))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; publish! sink integration
 

--- a/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
@@ -19,8 +19,9 @@
 (ns ai.miniforge.event-stream.snowflake-test
   "Tests for the BD-2b Snowflake event-id generator."
   (:require
-   [clojure.test :refer [deftest testing is]]
+   [clojure.test :refer [deftest is]]
    [clojure.java.io :as io]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.event-stream.snowflake :as sf])
   (:import
    [java.util UUID]))
@@ -160,14 +161,25 @@
       (is (zero? (bit-and id sf/max-seq))
           "sequence resets at the new ms"))))
 
-(deftest next-id!-throws-on-pre-epoch-clock
+(deftest next-id!-returns-anomaly-on-pre-epoch-clock
   ;; If the wall clock is somehow before the miniforge epoch, the bit
-  ;; layout would corrupt (negative ts shifts into worker bits). Throw
-  ;; loudly rather than silently emit garbage.
-  (let [gen (generator-with-fixed-clock [(- sf/miniforge-epoch-ms 1)])]
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"before the miniforge epoch"
-                          (sf/next-id-long! gen)))))
+  ;; layout would corrupt (negative ts shifts into worker bits). Return
+  ;; an explicit anomaly rather than silently emit garbage.
+  (let [gen (generator-with-fixed-clock [(- sf/miniforge-epoch-ms 1)])
+        result (sf/next-id-long! gen)]
+    (is (response/anomaly-map? result))
+    (is (= :anomalies/incorrect (:anomaly/category result)))
+    (is (= :pre-epoch-clock (:reason result)))))
+
+(deftest next-id-wrappers-propagate-pre-epoch-anomaly
+  (let [uuid-result (sf/next-id!
+                     (generator-with-fixed-clock [(- sf/miniforge-epoch-ms 1)]))
+        hex-result  (sf/next-id-hex!
+                     (generator-with-fixed-clock [(- sf/miniforge-epoch-ms 1)]))]
+    (is (response/anomaly-map? uuid-result))
+    (is (response/anomaly-map? hex-result))
+    (is (= :pre-epoch-clock (:reason uuid-result)))
+    (is (= :pre-epoch-clock (:reason hex-result)))))
 
 (deftest next-id!-stalls-on-clock-rollback
   (let [base-ts (+ sf/miniforge-epoch-ms 1000)
@@ -255,6 +267,24 @@
         (sf/release-lease! lease)
         (is (nil? (sf/release-lease! lease))
             "second release is a no-op, not an error")))))
+
+(deftest acquire-worker-lease!-returns-anomaly-on-lease-io-failure
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [not-a-dir (io/file dir "occupied")]
+        (spit not-a-dir "not a directory")
+        (let [result (sf/acquire-worker-lease! not-a-dir)]
+          (is (response/anomaly-map? result))
+          (is (= :anomalies/unavailable (:anomaly/category result)))
+          (is (= :lease-io-failure (:reason result))))))))
+
+(deftest create-generator-propagates-lease-anomaly
+  (let [lease-anomaly (response/make-anomaly
+                       :anomalies/busy
+                       "No worker slots"
+                       {:reason :workers-exhausted})
+        result (sf/create-generator {:lease lease-anomaly})]
+    (is (identical? lease-anomaly result))))
 
 (deftest create-generator-acquires-worker-lease
   (with-temp-workers-dir

--- a/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
@@ -276,7 +276,9 @@
         (let [result (sf/acquire-worker-lease! not-a-dir)]
           (is (response/anomaly-map? result))
           (is (= :anomalies/unavailable (:anomaly/category result)))
-          (is (= :lease-io-failure (:reason result))))))))
+          (is (= :lease-io-failure (:reason result)))
+          (is (string? (:anomaly/ex-message result)))
+          (is (string? (:anomaly/ex-class result))))))))
 
 (deftest create-generator-propagates-lease-anomaly
   (let [lease-anomaly (response/make-anomaly


### PR DESCRIPTION
## Summary
- return canonical anomalies from snowflake worker lease and pre-epoch clock failures instead of throwing ex-info
- propagate snowflake ID anomalies through create-envelope and publish! without delivering invalid event maps
- add regression coverage for snowflake anomaly returns and event-stream propagation

## Validation
- stable-derived changed-and-affected test plan passed: 13m29s
- bb pre-commit passed for snowflake commit
- bb pre-commit passed for event-stream core propagation commit
- exceptions-as-data scanner: snowflake cleanup-needed 0; repo counts {:cleanup-needed 90, :fatal-only 118}