### PR TITLE
refactor: return workflow runner failures as data

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -187,16 +187,27 @@
     (while (:paused @control-state)
       (Thread/sleep (defaults/pause-poll-interval-ms)))))
 
-(defn- check-stopped!
-  "Throw if the control state indicates a stop command."
+(defn- check-stopped
+  "Return a dashboard-stop anomaly when the control state is stopped."
   [control-state]
   (when (:stopped @control-state)
     (log/warn runner-logger :system :workflow/execution-stopped
               {:message (messages/t :status/stopped-dashboard)
                :data {:reason :dashboard-stop}})
-    (response/throw-anomaly! :anomalies.dashboard/stop
-                             (messages/t :status/stopped-control)
-                             {:reason :dashboard-stop})))
+    (anomaly/sub-anomaly :conflict
+                         :anomalies.dashboard/stop
+                         (messages/t :status/stopped-control)
+                         {:reason :dashboard-stop})))
+
+(defn- apply-dashboard-stop
+  "Mark context failed after a dashboard stop request."
+  [context stop-anomaly]
+  (-> context
+      (update :execution/errors conj
+              (make-execution-error :dashboard-stop
+                                    (:anomaly/message stop-anomaly)
+                                    {:data (:anomaly/data stop-anomaly)}))
+      (ctx/transition-to-failed)))
 
 (defn- apply-rate-limit-failure
   "Mark context as failed due to rate limiting."
@@ -227,32 +238,33 @@
   "Execute single pipeline iteration: control check -> health -> phase -> backoff."
   [pipeline context callbacks iteration control-state]
   (await-resume! control-state)
-  (check-stopped! control-state)
-  (let [supervision-runtime (:execution/supervision-runtime context)
-        workflow-state (monitoring/build-supervision-state context iteration)
-        supervision-result (monitoring/check-workflow-supervision
-                            supervision-runtime
-                            workflow-state)
-        iteration-result
-        (if (= :halt (:status supervision-result))
-          (monitoring/handle-supervision-halt
-           context
-           supervision-result
-           ctx/transition-to-failed)
-          (let [phase-ctx (-> (exec/execute-phase-step pipeline context callbacks
-                                                       ctx/merge-metrics
-                                                       ctx/transition-to-completed
-                                                       ctx/transition-to-failed)
-                              (monitoring/clear-transient-state))
-                _ (env/persist-workspace-at-phase-boundary! context phase-ctx)
-                phase-error-msg (get-in phase-ctx
-                                        [:execution/phase-results
-                                         (:execution/current-phase phase-ctx)
-                                         :error :message] "")]
-            (if (rate-limited? phase-error-msg)
-              (apply-rate-limit-failure phase-ctx phase-error-msg)
-              (do (apply-backoff-if-retrying! phase-ctx context)
-                  (apply-health-switch phase-ctx)))))]
+  (let [iteration-result
+        (if-let [stop-anomaly (check-stopped control-state)]
+          (apply-dashboard-stop context stop-anomaly)
+          (let [supervision-runtime (:execution/supervision-runtime context)
+                workflow-state (monitoring/build-supervision-state context iteration)
+                supervision-result (monitoring/check-workflow-supervision
+                                    supervision-runtime
+                                    workflow-state)]
+            (if (= :halt (:status supervision-result))
+              (monitoring/handle-supervision-halt
+               context
+               supervision-result
+               ctx/transition-to-failed)
+              (let [phase-ctx (-> (exec/execute-phase-step pipeline context callbacks
+                                                           ctx/merge-metrics
+                                                           ctx/transition-to-completed
+                                                           ctx/transition-to-failed)
+                                  (monitoring/clear-transient-state))
+                    _ (env/persist-workspace-at-phase-boundary! context phase-ctx)
+                    phase-error-msg (get-in phase-ctx
+                                            [:execution/phase-results
+                                             (:execution/current-phase phase-ctx)
+                                             :error :message] "")]
+                (if (rate-limited? phase-error-msg)
+                  (apply-rate-limit-failure phase-ctx phase-error-msg)
+                  (do (apply-backoff-if-retrying! phase-ctx context)
+                      (apply-health-switch phase-ctx)))))))]
     (checkpoint-store/persist-execution-state! iteration-result)
     iteration-result))
 
@@ -411,18 +423,34 @@
    mode forbids worktree fallback (N11 §7.4).
 
    This is the canonical, anomaly-returning entry point. The single
-   in-component caller (`run-pipeline`) escalates the anomaly to a
-   slingshot throw at the boundary so external callers (CLI / MCP /
-   orchestrator) keep their existing exception-shaped contract."
+   in-component caller (`run-pipeline`) converts the anomaly into a
+   failed execution context so external callers still receive the
+   runner's normal context-shaped result."
   [workflow input opts]
   (or (governed-capsule-missing-anomaly opts)
       (assemble-initial-context workflow input opts)))
 
+(defn- initial-context-anomaly->failed-context
+  [workflow input opts context-anomaly]
+  (-> (ctx/create-context workflow input opts)
+      (update :execution/errors conj
+              (make-execution-error :initial-context-anomaly
+                                    (:anomaly/message context-anomaly)
+                                    {:data (:anomaly/data context-anomaly)
+                                     :anomaly context-anomaly}))
+      (ctx/transition-to-failed)))
+
 (defn- execute-pipeline-loop
   "Execute the phase pipeline loop. Returns final context."
   [pipeline initial-ctx callbacks control-state max-phases]
-  (if (empty? pipeline)
+  (cond
+    (terminal-state? initial-ctx)
+    initial-ctx
+
+    (empty? pipeline)
     (handle-empty-pipeline initial-ctx)
+
+    :else
     (let [max-phase-retries (defaults/max-consecutive-phase-retries)]
       ;; `consecutive` counts how many times the phase about to run has been
       ;; the active phase in immediately consecutive iterations. A healthy
@@ -483,18 +511,10 @@
          callbacks           (wrap-phase-callbacks event-stream opts)
          skip-lifecycle?     (:skip-lifecycle-events opts)
          ctx-or-anomaly      (build-initial-context workflow input opts)
-         _                   (when (anomaly/anomaly? ctx-or-anomaly)
-                               ;; Boundary throw: run-pipeline is the
-                               ;; runner's escalation point. External
-                               ;; callers (CLI / MCP / orchestrator)
-                               ;; expect either a final context map or
-                               ;; an exception, so a governed-mode
-                               ;; misconfiguration becomes a slingshot
-                               ;; throw with the legacy ex-info shape.
-                               (response/throw-anomaly! :anomalies.workflow/no-capsule-executor
-                                                        (:anomaly/message ctx-or-anomaly)
-                                                        {}))
-         initial-ctx         ctx-or-anomaly
+         initial-ctx         (if (anomaly/anomaly? ctx-or-anomaly)
+                               (initial-context-anomaly->failed-context workflow input opts
+                                                                        ctx-or-anomaly)
+                               ctx-or-anomaly)
          output-ctx-vol      (volatile! nil)
          exception-vol       (volatile! nil)]
 
@@ -513,7 +533,8 @@
                          #_{:clj-kondo/ignore [:unresolved-namespace :unresolved-symbol]}
                          (catch [:anomaly/category :anomalies.dashboard/stop]
                                 {:keys [anomaly/message]}
-                           (vreset! exception-vol (ex-info message {:type :dashboard-stop}))
+                           (vreset! exception-vol {:type :dashboard-stop
+                                                   :message message})
                            (-> initial-ctx
                                (update :execution/errors conj
                                        (make-execution-error :dashboard-stop message))
@@ -522,7 +543,9 @@
                          (catch Object e
                            (let [throwable (:throwable &throw-context)
                                  msg (if (instance? Throwable e) (ex-message e) (str e))]
-                             (vreset! exception-vol (or throwable (ex-info msg {})))
+                             (vreset! exception-vol (or throwable
+                                                        {:type :pipeline-exception
+                                                         :message msg}))
                              (-> initial-ctx
                                  (update :execution/errors conj
                                          (make-execution-error :pipeline-exception msg

--- a/components/workflow/src/ai/miniforge/workflow/runner_cleanup.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_cleanup.clj
@@ -41,12 +41,20 @@
    :metrics       (:execution/metrics output-ctx)
    :timestamp     (java.time.Instant/now)})
 
+(defn- exception-message
+  [exception]
+  (cond
+    (instance? Throwable exception) (ex-message exception)
+    (map? exception) (:message exception)
+    (some? exception) (str exception)
+    :else nil))
+
 (defn- make-exception-signal
   "Build a minimal failure signal when execution context is unavailable."
   [workflow exception]
   {:signal/type :workflow-failed
    :workflow-id (:workflow/id workflow)
-   :error       (when exception (ex-message exception))
+   :error       (exception-message exception)
    :timestamp   (java.time.Instant/now)})
 
 ;------------------------------------------------------------------------------ Layer 0

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
@@ -88,13 +88,14 @@
 
 (deftest run-pipeline-context-anomaly-returns-failed-context
   (testing "run-pipeline converts build-initial-context anomaly to failed context"
-    (with-redefs [runner/acquire-environment
-                  (fn [_workflow _input opts] [nil opts])]
-      (let [result (runner/run-pipeline workflow input
-                                        {:execution-mode :governed
-                                         :skip-lifecycle-events true})]
-        (is (= :failed (:execution/status result)))
-        (is (some #(= :initial-context-anomaly (:type %))
-                  (:execution/errors result)))
-        (is (= :governed
-               (-> result :execution/errors first :data :execution-mode)))))))
+    (with-redefs-fn {#'runner/acquire-environment
+                     (fn [_workflow _input opts] [nil opts])}
+      (fn []
+        (let [result (runner/run-pipeline workflow input
+                                          {:execution-mode :governed
+                                           :skip-lifecycle-events true})]
+          (is (= :failed (:execution/status result)))
+          (is (some #(= :initial-context-anomaly (:type %))
+                    (:execution/errors result)))
+          (is (= :governed
+                 (-> result :execution/errors first :data :execution-mode))))))))

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
@@ -18,14 +18,14 @@
 
 (ns ai.miniforge.workflow.anomaly.build-initial-context-test
   "Coverage for `runner/build-initial-context` (anomaly-returning) and
-   its boundary escalation in `runner/run-pipeline`.
+   its failed-context conversion in `runner/run-pipeline`.
 
    The single failure mode this site protects is the N11 §7.4
    invariant: `:governed` execution-mode requires a pre-acquired
    capsule executor + environment-id; missing either is
-   `:invalid-input`. The boundary at `run-pipeline` rethrows via
-   slingshot so external callers (CLI / MCP / orchestrator) keep
-   their existing exception-shaped contract."
+   `:invalid-input`. `run-pipeline` converts that anomaly to a failed
+   execution context so callers receive the runner's normal result
+   shape."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.workflow.runner :as runner]))
@@ -33,8 +33,8 @@
 (def workflow
   {:workflow/id :test
    :workflow/version "1.0.0"
-   :workflow/phases [{:phase/id :start}]
-   :workflow/pipeline [{:phase :start}]})
+   :workflow/phases []
+   :workflow/pipeline []})
 
 (def input {:repo-url "https://example.test/repo"})
 
@@ -78,19 +78,23 @@
       (is (true? (get-in result [:anomaly/data :has-executor?])))
       (is (false? (get-in result [:anomaly/data :has-environment-id?]))))))
 
-;------------------------------------------------------------------------------ Boundary escalation
+;------------------------------------------------------------------------------ run-pipeline conversion
 ;;
-;; `run-pipeline` is the runner's escalation point: external callers
-;; expect either a final context map or a thrown exception. A governed
-;; misconfiguration becomes a slingshot
-;; `:anomalies.workflow/no-capsule-executor` ex-info at the
-;; `run-pipeline` boundary.
-;;
-;; That escalation is *not* exercised here because `run-pipeline`'s
-;; happy path runs `acquire-environment` first, which has its own
-;; governed-mode throw at `acquire-execution-environment!` (covered by
-;; `check_executor_for_mode_test.clj`). For an end-to-end test of the
-;; build-initial-context boundary throw specifically, the caller would
-;; need to stub `acquire-environment` so the no-capsule-executor path
-;; surfaces in `run-pipeline`'s let bindings rather than upstream. The
-;; runner's existing pipeline tests cover that integration.
+;; `run-pipeline` runs `acquire-environment` before
+;; `build-initial-context`; the test below stubs the private acquire
+;; helper so the context-building anomaly is exercised directly rather
+;; than being masked by runner-environment's separate governed-mode
+;; acquisition checks.
+
+(deftest run-pipeline-context-anomaly-returns-failed-context
+  (testing "run-pipeline converts build-initial-context anomaly to failed context"
+    (with-redefs [runner/acquire-environment
+                  (fn [_workflow _input opts] [nil opts])]
+      (let [result (runner/run-pipeline workflow input
+                                        {:execution-mode :governed
+                                         :skip-lifecycle-events true})]
+        (is (= :failed (:execution/status result)))
+        (is (some #(= :initial-context-anomaly (:type %))
+                  (:execution/errors result)))
+        (is (= :governed
+               (-> result :execution/errors first :data :execution-mode)))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -229,6 +229,22 @@
       (is (= :failed (:execution/status result)))
       (is (some #(= :empty-pipeline (:type %)) (:execution/errors result))))))
 
+(deftest run-pipeline-stopped-control-state-test
+  (testing "dashboard stop request returns a failed context"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase test-done-phase}]}
+          result (runner/run-pipeline
+                  workflow
+                  {:task "Test"}
+                  {:control-state (atom {:paused false
+                                         :stopped true
+                                         :adjustments {}})
+                   :skip-lifecycle-events true})]
+      (is (= :failed (:execution/status result)))
+      (is (some #(= :dashboard-stop (:type %))
+                (:execution/errors result))))))
+
 (deftest run-pipeline-done-only-test
   (testing "run-pipeline completes with just :done phase"
     (let [workflow {:workflow/id :test

--- a/docs/pull-requests/2026-07-01-chris-workflow-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-workflow-runner-anomalies.md
@@ -1,0 +1,27 @@
+# refactor: return workflow runner failures as data
+
+## Summary
+
+Convert the workflow runner's local cleanup-needed exception paths to
+context/result data.
+
+## Changes
+
+- Dashboard stop control flow now returns a canonical stop anomaly and marks
+  the workflow context failed instead of throwing through the loop.
+- Initial context anomalies now become failed execution contexts from
+  `run-pipeline`.
+- Synthetic cleanup exceptions are replaced with map-shaped failure data, and
+  cleanup signal construction accepts either maps or throwables.
+- Terminal initial contexts now bypass empty-pipeline failure handling to avoid
+  double-failing an already terminal context.
+
+## Validation
+
+- Focused runner tests:
+  `ai.miniforge.workflow.runner-test`,
+  `ai.miniforge.workflow.anomaly.build-initial-context-test`
+- Targeted `clj-kondo` over edited workflow files and tests.
+- Exceptions-as-data scanner: `workflow/runner.clj` now has `0`
+  cleanup-needed rows; repository total is `82`.
+- `bb pre-commit`


### PR DESCRIPTION
## Summary
- convert workflow runner cleanup-needed exception paths to data-shaped failure handling
- return dashboard stop as failed context instead of throwing through the loop
- convert initial context anomalies to failed execution contexts
- replace synthetic cleanup ex-info values with map-shaped failure data

## Validation
- focused runner tests: ai.miniforge.workflow.runner-test and ai.miniforge.workflow.anomaly.build-initial-context-test
- targeted clj-kondo over edited workflow files/tests
- exceptions-as-data scanner: workflow/runner.clj 0 cleanup-needed rows; repo total 82
- bb pre-commit