### PR TITLE
refactor: classify registry invariant throws

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -204,9 +204,12 @@
    "invariant"
    "missing"
    "missing-resource"
+   "non-fn"
+   "non-keyword"
    "classpath"
    "integrity"
-   "invalid-config"])
+   "invalid-config"
+   "unregistered-at-resolve"])
 
 (defn- collect-text
   "Collect every string-shaped piece of evidence — string literals plus

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
@@ -54,6 +54,34 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
+(deftest registry-contract-message-key-is-fatal-only
+  (testing "localized registry contract keys are programmer-error guards"
+    (let [src "(ns ai.miniforge.foo.registry)
+              (defn register-widget! [widget-key f]
+                (when-not (keyword? widget-key)
+                  (throw (IllegalArgumentException.
+                           (messages/t :widgets/non-keyword-key
+                                       {:value (pr-str widget-key)}))))
+                (when-not (ifn? f)
+                  (throw (IllegalArgumentException.
+                           (messages/t :widgets/non-fn-value
+                                       {:value (pr-str f)})))))"
+          {:keys [violations]} (exc/analyze-content "registry.clj" src)]
+      (is (= 2 (count violations)))
+      (is (every? #(= :fatal-only (:classification %)) violations)))))
+
+(deftest registry-resolution-invariant-is-fatal-only
+  (testing "validated-but-missing registry resolution keys are fatal-only"
+    (let [src "(ns ai.miniforge.foo.registry)
+              (defn resolve-widget [k]
+                (or (lookup-widget k)
+                    (throw (IllegalStateException.
+                             (messages/t :widgets/unregistered-at-resolve
+                                         {:widget k})))))"
+          {:keys [violations]} (exc/analyze-content "registry.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
 (deftest plain-failure-is-cleanup-needed
   (testing "messages without programmer-error markers are :cleanup-needed"
     (let [src "(ns ai.miniforge.foo.core)

--- a/docs/pull-requests/2026-07-01-chris-exceptions-scanner-fatal-registry.md
+++ b/docs/pull-requests/2026-07-01-chris-exceptions-scanner-fatal-registry.md
@@ -1,0 +1,43 @@
+# Refactor: classify registry invariant throws as fatal-only
+
+## Overview
+
+This PR refines the exceptions-as-data compliance scanner's programmer-error
+classification for registry contract failures.
+
+## Motivation
+
+The workflow guard/action registries intentionally throw for namespace-load
+contract failures and post-validation resolution invariants. Those sites are
+documented programmer-error guards, but the scanner currently reports them as
+`:cleanup-needed`, which pollutes the actionable cleanup queue.
+
+## Changes in Detail
+
+- Add fatal-only markers for localized registry message keys:
+  `non-keyword`, `non-fn`, and `unregistered-at-resolve`.
+- Add regression coverage for the localized `messages/t` call shape used by
+  registry invariant throws.
+- Preserve plain runtime failure classification as `:cleanup-needed`.
+
+## Testing Plan
+
+- Run focused compliance-scanner tests.
+- Run the exceptions-as-data scanner and confirm the workflow guard/action
+  registry sites move out of `:cleanup-needed`.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+No deployment special handling. This only changes local/CI scanner
+classification output.
+
+## Related Issues/PRs
+
+- Follows the exceptions-as-data cleanup waves through #1337.
+
+## Checklist
+
+- [x] Focused compliance-scanner tests pass.
+- [x] Scanner count drops by the documented registry sites.
+- [x] `bb pre-commit` passes.


### PR DESCRIPTION
# Refactor: classify registry invariant throws as fatal-only

## Overview

This PR refines the exceptions-as-data compliance scanner's programmer-error
classification for registry contract failures.

## Motivation

The workflow guard/action registries intentionally throw for namespace-load
contract failures and post-validation resolution invariants. Those sites are
documented programmer-error guards, but the scanner currently reports them as
`:cleanup-needed`, which pollutes the actionable cleanup queue.

## Changes in Detail

- Add fatal-only markers for localized registry message keys:
  `non-keyword`, `non-fn`, and `unregistered-at-resolve`.
- Add regression coverage for the localized `messages/t` call shape used by
  registry invariant throws.
- Preserve plain runtime failure classification as `:cleanup-needed`.

## Testing Plan

- Run focused compliance-scanner tests.
- Run the exceptions-as-data scanner and confirm the workflow guard/action
  registry sites move out of `:cleanup-needed`.
- Run `bb pre-commit`.

## Deployment Plan

No deployment special handling. This only changes local/CI scanner
classification output.

## Related Issues/PRs

- Follows the exceptions-as-data cleanup waves through #1337.

## Checklist

- [x] Focused compliance-scanner tests pass.
- [x] Scanner count drops by the documented registry sites.
- [x] `bb pre-commit` passes.
