### PR TITLE
refactor: return task executor runner failures as data

### DIFF
--- a/components/task-executor/src/ai/miniforge/task_executor/interface.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/interface.clj
@@ -99,8 +99,9 @@
   Args: task-id (string), task (definition map), run-context (shared context).
 
   Returns {:ok? true :value lifecycle-result} on success, or
-  {:ok? false :error throwable :error-classification map} on failure. Never
-  throws — all exceptions are caught and the task is marked failed in the DAG."
+  {:ok? false :error error-map :error-classification map} on expected DAG
+  failures. Unexpected exceptions are caught and returned as throwables, and the
+  task is marked failed in the DAG."
   runner/execute-task)
 
 ;; Orchestrator - concurrent execution and scheduler integration

--- a/components/task-executor/src/ai/miniforge/task_executor/runner.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/runner.clj
@@ -65,7 +65,7 @@
 (defn acquire-resources!
   "Acquire worktree and environment for task execution.
 
-  Returns: {:worktree-acquired? bool, :env-record map} or throws on error"
+  Returns DAG ok with {:worktree-acquired? bool, :env-record map}, or DAG error."
   [task-id lock-pool executor logger config]
   (log-event logger :acquiring-resources task-id {})
 
@@ -73,28 +73,31 @@
   (let [worktree-result (dag/acquire-worktree! lock-pool task-id
                                                (:worktree-acquire-timeout-ms defaults)
                                                logger)]
-    (when (dag/err? worktree-result)
-      (throw (ex-info "Failed to acquire worktree"
-                      {:task-id task-id
-                       :error (:error worktree-result)})))
+    (if (dag/err? worktree-result)
+      (dag/err :task-executor/worktree-acquire-failed
+               "Failed to acquire worktree"
+               {:task-id task-id
+                :error (:error worktree-result)})
+      ;; Acquire environment from executor
+      (let [env-config {:repo-url (:repo-url config)
+                        :branch (:branch config "main")
+                        :env (:env config {})
+                        :resources (:resources config {})}
+            env-result (dag/acquire-environment! executor task-id env-config)]
+        (if (dag/err? env-result)
+          (do
+            (dag/release-worktree! lock-pool task-id logger)
+            (dag/err :task-executor/environment-acquire-failed
+                     "Failed to acquire environment"
+                     {:task-id task-id
+                      :error (:error env-result)}))
 
-    ;; Acquire environment from executor
-    (let [env-config {:repo-url (:repo-url config)
-                      :branch (:branch config "main")
-                      :env (:env config {})
-                      :resources (:resources config {})}
-          env-result (dag/acquire-environment! executor task-id env-config)]
-      (when (dag/err? env-result)
-        (dag/release-worktree! lock-pool task-id logger)
-        (throw (ex-info "Failed to acquire environment"
-                        {:task-id task-id
-                         :error (:error env-result)})))
+          (do
+            (log-event logger :resources-acquired task-id
+                       {:env-id (get-in env-result [:data :env-id])})
 
-      (log-event logger :resources-acquired task-id
-                 {:env-id (get-in env-result [:value :env-id])})
-
-      {:worktree-acquired? true
-       :env-record (:value env-result)})))
+            (dag/ok {:worktree-acquired? true
+                     :env-record (:data env-result)})))))))
 
 (defn generate-code!
   "Run inner loop to generate code artifact.
@@ -199,26 +202,28 @@
    A parse failure means the agent would have no structured context and
    would waste its entire turn budget exploring the codebase.
 
-   Returns nil on success. Throws ex-info on failure so the caller
-   can fail-fast and surface a clear error without touching the environment."
+   Returns DAG ok on success. Returns DAG error on failure so the caller
+   can fail-fast before touching the environment."
   [task-id task logger]
-  (when-let [spec-path (or (get-in task [:spec/provenance :source-file])
-                           (get task :spec/source-file)
-                           (get task :spec-path))]
-    (log-event logger :validating-spec task-id {:spec-path spec-path})
-    (try
-      (spec-parser/parse-spec-file spec-path)
-      (log-event logger :spec-valid task-id {:spec-path spec-path})
-      nil
-      (catch Exception e
-        (throw (ex-info
-                (str "Spec validation failed — refusing to spawn agent without valid spec. "
-                     "Fix the spec at: " spec-path ". "
-                     "Cause: " (ex-message e))
-                {:task-id   task-id
-                 :spec-path spec-path
-                 :cause     (ex-message e)}
-                e))))))
+  (if-let [spec-path (or (get-in task [:spec/provenance :source-file])
+                         (get task :spec/source-file)
+                         (get task :spec-path))]
+    (do
+      (log-event logger :validating-spec task-id {:spec-path spec-path})
+      (try
+        (spec-parser/parse-spec-file spec-path)
+        (log-event logger :spec-valid task-id {:spec-path spec-path})
+        (dag/ok nil)
+        (catch Exception e
+          (dag/err
+           :task-executor/spec-validation-failed
+           (str "Spec validation failed — refusing to spawn agent without valid spec. "
+                "Fix the spec at: " spec-path ". "
+                "Cause: " (ex-message e))
+           {:task-id task-id
+            :spec-path spec-path
+            :cause (ex-message e)}))))
+    (dag/ok nil)))
 
 (defn calculate-cost-usd
   "Calculate estimated cost in USD based on tokens used.
@@ -265,6 +270,68 @@
                  :end-time end-time}]
     (dag/update-metrics! run-atom task-id metrics)))
 
+(defn- task-state
+  [run-atom task-id]
+  (when run-atom
+    (get-in @run-atom [:tasks task-id :state])))
+
+(defn- fail-task-with-error!
+  [task-id run-atom logger start-time error]
+  (log-event logger :task-execution-failed task-id
+             {:error (:message error)
+              :duration-ms (- (System/currentTimeMillis) start-time)
+              :error-classification (:code error)})
+  (dag/mark-failed! run-atom task-id error logger)
+  {:ok? false
+   :error error
+   :error-classification {:type (:code error)}})
+
+(defn- fail-task-with-exception!
+  [task-id run-atom logger start-time e]
+  (let [classified (error-classifier/classify-error e (task-state run-atom task-id))]
+    (log-event logger :task-execution-failed task-id
+               {:error (ex-message e)
+                :cause (ex-cause e)
+                :duration-ms (- (System/currentTimeMillis) start-time)
+                :error-classification (:type classified)
+                :vendor (:vendor classified)})
+
+    (dag/mark-failed! run-atom task-id e logger)
+
+    {:ok? false
+     :error e
+     :error-classification classified}))
+
+(defn- run-task-after-resources!
+  [task-id task task-context run-atom logger start-time env-record]
+  (let [task-context-with-env (assoc task-context :env-record env-record)
+        generation-result (generate-code! task-id task task-context-with-env)
+        code-artifact (:artifact generation-result)
+        lifecycle-result (run-pr-lifecycle! task-id task code-artifact task-context-with-env)]
+    (update-task-metrics! run-atom task-id lifecycle-result start-time)
+    (log-event logger :task-execution-completed task-id
+               {:status (:status lifecycle-result)
+                :pr-url (:pr-url lifecycle-result)
+                :duration-ms (- (System/currentTimeMillis) start-time)})
+    {:ok? true
+     :value lifecycle-result}))
+
+(defn- continue-with-resources!
+  [task-id task task-context run-atom logger start-time env-record resource-result]
+  (if (dag/err? resource-result)
+    (fail-task-with-error! task-id run-atom logger start-time (:error resource-result))
+    (let [env (get-in resource-result [:data :env-record])]
+      (reset! env-record env)
+      (run-task-after-resources! task-id task task-context run-atom logger start-time env))))
+
+(defn- continue-after-spec-validation!
+  [task-id task task-context run-atom lock-pool executor logger config start-time env-record spec-result]
+  (if (dag/err? spec-result)
+    (fail-task-with-error! task-id run-atom logger start-time (:error spec-result))
+    (continue-with-resources!
+     task-id task task-context run-atom logger start-time env-record
+     (acquire-resources! task-id lock-pool executor logger config))))
+
 (defn execute-task
   [task-id task run-context]
   (let [{:keys [run-atom executor logger lock-pool config]} run-context
@@ -277,53 +344,12 @@
 
     (let [env-record (atom nil)]
       (try
-        ;; Step 0: Validate spec — fail fast before spending any resources
-        (validate-spec! task-id task logger)
-
-        ;; Step 1: Acquire resources
-        (let [resources (acquire-resources! task-id lock-pool executor logger config)]
-          (reset! env-record (:env-record resources)))
-
-        ;; Step 2: Generate code
-        (let [generation-result (generate-code! task-id task
-                                               (assoc task-context
-                                                      :env-record @env-record))
-              code-artifact (:artifact generation-result)
-
-              ;; Step 3 & 4: Run PR lifecycle (blocking)
-              lifecycle-result (run-pr-lifecycle! task-id task code-artifact
-                                                 (assoc task-context
-                                                        :env-record @env-record))]
-
-          ;; Step 5: Update metrics (with timing)
-          (update-task-metrics! run-atom task-id lifecycle-result start-time)
-
-          (log-event logger :task-execution-completed task-id
-                     {:status (:status lifecycle-result)
-                      :pr-url (:pr-url lifecycle-result)
-                      :duration-ms (- (System/currentTimeMillis) start-time)})
-
-          {:ok? true
-           :value lifecycle-result})
+        (continue-after-spec-validation!
+         task-id task task-context run-atom lock-pool executor logger config start-time env-record
+         (validate-spec! task-id task logger))
 
         (catch Exception e
-          ;; Classify the error to provide user-friendly context
-          (let [task-state (when run-atom
-                            (get-in @run-atom [:tasks task-id :state]))
-                classified (error-classifier/classify-error e task-state)]
-            (log-event logger :task-execution-failed task-id
-                       {:error (ex-message e)
-                        :cause (ex-cause e)
-                        :duration-ms (- (System/currentTimeMillis) start-time)
-                        :error-classification (:type classified)
-                        :vendor (:vendor classified)})
-
-            ;; Mark task as failed in DAG
-            (dag/mark-failed! run-atom task-id e logger)
-
-            {:ok? false
-             :error e
-             :error-classification classified}))
+          (fail-task-with-exception! task-id run-atom logger start-time e))
 
         (finally
           ;; Always clean up resources

--- a/components/task-executor/src/ai/miniforge/task_executor/runner.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/runner.clj
@@ -253,7 +253,7 @@
    - review-cycles: Number of review iterations
    - pr-url: GitHub PR URL
    - status: Final status (:merged, :failed, etc.)"
-  [run-atom task-id lifecycle-result start-time]
+  [run-atom _task-id lifecycle-result start-time]
   (let [total-tokens (get lifecycle-result :total-tokens 0)
         end-time (System/currentTimeMillis)
         duration-ms (- end-time start-time)
@@ -268,12 +268,12 @@
                  :status (:status lifecycle-result)
                  :start-time start-time
                  :end-time end-time}]
-    (dag/update-metrics! run-atom task-id metrics)))
+    (dag/update-metrics! run-atom metrics nil)))
 
 (defn- task-state
   [run-atom task-id]
   (when run-atom
-    (get-in @run-atom [:tasks task-id :state])))
+    (get-in @run-atom [:run/tasks task-id])))
 
 (defn- fail-task-with-error!
   [task-id run-atom logger start-time error]

--- a/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
@@ -298,6 +298,25 @@
                  (get-in result [:error :data :error :code])))
           (is (true? @released?)))))))
 
+(deftest execute-task-resource-failure-returns-error-data-test
+  (testing "DAG error data is recorded in state and returned to the caller"
+    (let [run-atom (atom (dag/create-run-state
+                          (random-uuid)
+                          {"task-1" (assoc (dag/create-task-state "task-1" #{})
+                                           :task/status :running)}))]
+      (with-redefs [dag/acquire-worktree! (fn [& _]
+                                            (dag/err :timeout
+                                                     "worktree timeout"
+                                                     {:holder-id "task-1"}))]
+        (let [result (runner/execute-task "task-1" {:task/id "task-1"} {:run-atom run-atom})]
+          (is (false? (:ok? result)))
+          (is (= :task-executor/worktree-acquire-failed
+                 (get-in result [:error-classification :type])))
+          (is (= :task-executor/worktree-acquire-failed
+                 (get-in result [:error :code])))
+          (is (= :task-executor/worktree-acquire-failed
+                 (get-in @run-atom [:run/tasks "task-1" :task/error :code]))))))))
+
 (deftest code-generation-failure-test
   (testing "Code generation failure marks task as failed"
     (let [dag-executor (mock-dag-executor)
@@ -413,6 +432,22 @@
       (is (> (:duration-ms @metrics-tracker 0) 10000)
           "Should accumulate duration from both phases"))))
 
+(deftest update-task-metrics-updates-dag-run-metrics-test
+  (testing "task lifecycle metrics are passed to DAG run metrics as a map"
+    (let [run-atom (atom (dag/create-run-state
+                          (random-uuid)
+                          {"task-1" (dag/create-task-state "task-1" #{})}))
+          start-time (- (System/currentTimeMillis) 100)
+          lifecycle-result {:total-tokens 1000
+                            :fix-iterations 2
+                            :ci-runs 1
+                            :review-cycles 1
+                            :pr-url "https://github.com/org/repo/pull/123"
+                            :status :merged}]
+      (runner/update-task-metrics! run-atom "task-1" lifecycle-result start-time)
+      (is (= 1000 (get-in @run-atom [:run/metrics :tokens-used])))
+      (is (= :merged (get-in @run-atom [:run/metrics :status]))))))
+
 (deftest task-execution-exception-handling-test
   (testing "Unexpected exceptions are caught and logged"
     (let [dag-executor (-> (mock-dag-executor)
@@ -485,10 +520,10 @@
 (deftest validate-spec-no-path-test
   (testing "no-op when task has no spec path"
     (is (dag/ok? (runner/validate-spec! "task-1" {} nil))
-        "Should return nil when no spec-related key present"))
+        "Should return DAG ok when no spec-related key present"))
   (testing "no-op when task has other keys but no spec path"
     (is (dag/ok? (runner/validate-spec! "task-1" {:task/description "Do stuff"} nil))
-        "Should return nil for task with no spec path")))
+        "Should return DAG ok for task with no spec path")))
 
 (deftest validate-spec-valid-file-test
   (testing "returns nil for a well-formed markdown spec"
@@ -500,7 +535,7 @@
                      "## Design\n\nSome design content.\n"))
           task {:spec/source-file path}]
       (is (dag/ok? (runner/validate-spec! "task-1" task nil))
-          "Should return nil for valid spec"))))
+          "Should return DAG ok for valid spec"))))
 
 (deftest validate-spec-missing-file-test
   (testing "returns DAG error when spec path points to a nonexistent file"

--- a/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
@@ -23,6 +23,7 @@
   code generation → PR lifecycle → metrics accumulation → cleanup."
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.task-executor.runner :as runner]
    [clojure.test :refer [deftest testing is]]))
 
@@ -264,6 +265,39 @@
       (is (= :active (:status env))
           "Environment should be active"))))
 
+(deftest acquire-resources-worktree-failure-test
+  (testing "worktree acquisition failure returns DAG error data"
+    (with-redefs [dag/acquire-worktree! (fn [& _]
+                                          (dag/err :timeout
+                                                   "worktree timeout"
+                                                   {:holder-id "task-1"}))]
+      (let [result (runner/acquire-resources! "task-1" nil nil nil {})]
+        (is (dag/err? result))
+        (is (= :task-executor/worktree-acquire-failed
+               (get-in result [:error :code])))
+        (is (= :timeout
+               (get-in result [:error :data :error :code])))))))
+
+(deftest acquire-resources-environment-failure-test
+  (testing "environment acquisition failure releases the worktree and returns DAG error data"
+    (let [released? (atom false)]
+      (with-redefs [dag/acquire-worktree! (fn [& _]
+                                            (dag/ok {:holder-id "task-1"}))
+                    dag/acquire-environment! (fn [& _]
+                                               (dag/err :environment-unavailable
+                                                        "environment unavailable"
+                                                        {:executor :mock}))
+                    dag/release-worktree! (fn [& _]
+                                            (reset! released? true)
+                                            (dag/ok {:released true}))]
+        (let [result (runner/acquire-resources! "task-1" nil nil nil {})]
+          (is (dag/err? result))
+          (is (= :task-executor/environment-acquire-failed
+                 (get-in result [:error :code])))
+          (is (= :environment-unavailable
+                 (get-in result [:error :data :error :code])))
+          (is (true? @released?)))))))
+
 (deftest code-generation-failure-test
   (testing "Code generation failure marks task as failed"
     (let [dag-executor (mock-dag-executor)
@@ -450,10 +484,10 @@
 
 (deftest validate-spec-no-path-test
   (testing "no-op when task has no spec path"
-    (is (nil? (runner/validate-spec! "task-1" {} nil))
+    (is (dag/ok? (runner/validate-spec! "task-1" {} nil))
         "Should return nil when no spec-related key present"))
   (testing "no-op when task has other keys but no spec path"
-    (is (nil? (runner/validate-spec! "task-1" {:task/description "Do stuff"} nil))
+    (is (dag/ok? (runner/validate-spec! "task-1" {:task/description "Do stuff"} nil))
         "Should return nil for task with no spec path")))
 
 (deftest validate-spec-valid-file-test
@@ -465,25 +499,31 @@
                      "---\n\n"
                      "## Design\n\nSome design content.\n"))
           task {:spec/source-file path}]
-      (is (nil? (runner/validate-spec! "task-1" task nil))
+      (is (dag/ok? (runner/validate-spec! "task-1" task nil))
           "Should return nil for valid spec"))))
 
 (deftest validate-spec-missing-file-test
-  (testing "throws when spec path points to a nonexistent file"
-    (let [task {:spec/source-file "/nonexistent/path/spec.md"}]
-      (is (thrown-with-msg? Exception #"Spec validation failed"
-            (runner/validate-spec! "task-1" task nil))))))
+  (testing "returns DAG error when spec path points to a nonexistent file"
+    (let [task {:spec/source-file "/nonexistent/path/spec.md"}
+          result (runner/validate-spec! "task-1" task nil)]
+      (is (dag/err? result))
+      (is (= :task-executor/spec-validation-failed
+             (get-in result [:error :code])))
+      (is (re-find #"Spec validation failed"
+                   (get-in result [:error :message]))))))
 
 (deftest validate-spec-malformed-spec-test
   (testing "plain markdown without frontmatter is now valid — decorated from H1"
     (let [path (write-temp-spec! "# Compliance Scanner M2\n\nExecute phase design.")
           task {:spec/source-file path}]
-      (is (nil? (runner/validate-spec! "task-1" task nil)))))
+      (is (dag/ok? (runner/validate-spec! "task-1" task nil)))))
 
-  (testing "spec-path key is also checked — throws for nonexistent file"
-    (let [task {:spec-path "/nonexistent/spec.md"}]
-      (is (thrown-with-msg? Exception #"Spec validation failed"
-            (runner/validate-spec! "task-1" task nil))))))
+  (testing "spec-path key is also checked — returns DAG error for nonexistent file"
+    (let [task {:spec-path "/nonexistent/spec.md"}
+          result (runner/validate-spec! "task-1" task nil)]
+      (is (dag/err? result))
+      (is (= :task-executor/spec-validation-failed
+             (get-in result [:error :code]))))))
 
 (deftest validate-spec-provenance-key-test
   (testing "reads spec path from :spec/provenance :source-file"
@@ -493,7 +533,7 @@
                      "description: D\n"
                      "---\n"))
           task {:spec/provenance {:source-file path}}]
-      (is (nil? (runner/validate-spec! "task-1" task nil))
+      (is (dag/ok? (runner/validate-spec! "task-1" task nil))
           "Should accept path nested under :spec/provenance"))))
 
 ;------------------------------------------------------------------------------ calculate-cost-usd Tests

--- a/docs/pull-requests/2026-07-01-chris-task-executor-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-task-executor-runner-anomalies.md
@@ -1,0 +1,42 @@
+# Refactor: return task executor runner failures as data
+
+## Overview
+
+This PR migrates normal task-executor runner failure paths away from thrown
+exceptions and into DAG result data.
+
+## Motivation
+
+`task-executor.runner` still throws for worktree acquisition, environment
+acquisition, and spec-validation failures. Those are expected orchestration
+outcomes, not process-boundary failures, so they should flow as data and let
+the runner mark the task failed without stack unwinding.
+
+## Changes in Detail
+
+- Replace acquisition throws with typed DAG errors.
+- Replace spec-validation throws with a typed DAG error result.
+- Keep the outer exception catch for unexpected exceptions from effects.
+- Update runner tests to assert data-returning failure paths.
+
+## Testing Plan
+
+- Run focused task-executor runner tests.
+- Run the exceptions-as-data scanner for `task_executor/runner.clj`.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+No deployment special handling. The public runner surface remains the same
+success/failure map shape from `execute-task`.
+
+## Related Issues/PRs
+
+- Continues the exceptions-as-data cleanup wave after #1337.
+- Independent of #1338.
+
+## Checklist
+
+- [x] Focused task-executor tests pass.
+- [x] `task_executor/runner.clj` scanner cleanup-needed count reaches zero.
+- [x] `bb pre-commit` passes.


### PR DESCRIPTION
# Refactor: return task executor runner failures as data

## Overview

This PR migrates normal task-executor runner failure paths away from thrown
exceptions and into DAG result data.

## Motivation

`task-executor.runner` still throws for worktree acquisition, environment
acquisition, and spec-validation failures. Those are expected orchestration
outcomes, not process-boundary failures, so they should flow as data and let
the runner mark the task failed without stack unwinding.

## Changes in Detail

- Replace acquisition throws with typed DAG errors.
- Replace spec-validation throws with a typed DAG error result.
- Keep the outer exception catch for unexpected exceptions from effects.
- Update runner tests to assert data-returning failure paths.

## Testing Plan

- Run focused task-executor runner tests.
- Run the exceptions-as-data scanner for `task_executor/runner.clj`.
- Run `bb pre-commit`.

## Deployment Plan

No deployment special handling. The public runner surface remains the same
success/failure map shape from `execute-task`.

## Related Issues/PRs

- Continues the exceptions-as-data cleanup wave after #1337.
- Independent of #1338.

## Checklist

- [x] Focused task-executor tests pass.
- [x] `task_executor/runner.clj` scanner cleanup-needed count reaches zero.
- [x] `bb pre-commit` passes.
