### PR TITLE
Refactor bb test runner parse failures as data

### DIFF
--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.cljc
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.cljc
@@ -34,7 +34,7 @@
             [clojure.test :as t])
   (:import
    [clojure.lang PersistentQueue]
-   [java.lang Long NumberFormatException String System]
+   [java.lang Exception Long NumberFormatException String System]
    [java.nio.charset StandardCharsets]
    [java.nio.file Files]
    [java.util ArrayList Collection Collections Random]))
@@ -211,13 +211,20 @@
         marker "get:changes:changed-or-affected-projects"
         marker-index (.indexOf argv marker)]
     (if (neg? marker-index)
-      (throw (ex-info "Changed-projects command is missing the Polylith change marker."
+      (throw (ex-info "Invariant failed: changed-projects command is missing the Polylith change marker."
                       {:argv argv
                        :marker marker}))
       (let [insert-index (inc marker-index)]
         (vec (concat (subvec argv 0 insert-index)
                      ["since:stable"]
                      (subvec argv insert-index)))))))
+
+(defn- parse-error
+  [code message data]
+  {:ok? false
+   :error {:code code
+           :message message
+           :data data}})
 
 (defn parse-project-list-output
   "Parse a Polylith `ws get:changes:changed-or-affected-projects`
@@ -226,13 +233,20 @@
   (let [trimmed (some-> output str/trim not-empty)]
     (if-not trimmed
       []
-      (let [parsed (edn/read-string trimmed)]
-        (cond
-          (sequential? parsed) (mapv str parsed)
-          (set? parsed) (->> parsed (map str) sort vec)
-          :else (throw (ex-info "Expected a sequential or set project list."
-                                {:output output
-                                 :parsed parsed})))))))
+      (try
+        (let [parsed (edn/read-string trimmed)]
+          (cond
+            (sequential? parsed) (mapv str parsed)
+            (set? parsed) (->> parsed (map str) sort vec)
+            :else (parse-error :bb-test-runner/invalid-project-list
+                               "Expected a sequential or set project list."
+                               {:output output
+                                :parsed parsed})))
+        (catch Exception e
+          (parse-error :bb-test-runner/invalid-project-list
+                       "Failed to parse project list output."
+                       {:output output
+                        :cause (.getMessage e)}))))))
 
 (defn sanitize-git-worktree-env
   "Remove git worktree/index variables that must not leak into child
@@ -266,13 +280,21 @@
   [arg prefix]
   (let [raw (subs arg (count prefix))]
     (try
-      (Long/parseLong raw)
+      {:ok? true :data (Long/parseLong raw)}
       (catch NumberFormatException ex
-        (throw (ex-info "Invalid stable-derived diagnostic argument."
-                        {:arg arg
-                         :prefix prefix
-                         :expected-format (str prefix "N")}
-                        ex))))))
+        (parse-error :bb-test-runner/invalid-diagnostic-arg
+                     "Invalid stable-derived diagnostic argument."
+                     {:arg arg
+                      :prefix prefix
+                      :expected-format (str prefix "N")
+                      :cause (.getMessage ex)})))))
+
+(defn- assoc-long-arg
+  [acc k arg prefix]
+  (let [parsed (parse-long-arg arg prefix)]
+    (if (:ok? parsed)
+      (assoc acc k (:data parsed))
+      (reduced parsed))))
 
 (defn parse-diagnostic-args
   "Parse supported stable-derived diagnostic CLI arguments.
@@ -295,7 +317,7 @@
        (assoc acc :projects (parse-project-selector arg))
 
        (str/starts-with? arg "start-size:")
-       (assoc acc :start-size (parse-long-arg arg "start-size:"))
+       (assoc-long-arg acc :start-size arg "start-size:")
 
        (str/starts-with? arg "direction:")
        (assoc acc :direction (keyword (subs arg (count "direction:"))))
@@ -304,7 +326,7 @@
        (assoc acc :order (keyword (subs arg (count "order:"))))
 
        (str/starts-with? arg "seed:")
-       (assoc acc :seed (parse-long-arg arg "seed:"))
+       (assoc-long-arg acc :seed arg "seed:")
 
        :else acc))
    {}
@@ -461,7 +483,7 @@
    (defn- classpath-test-roots
      "JVM placeholder for the Babashka-only classpath discovery path."
      []
-     (throw (ex-info "bb-test-runner run-all is only available under Babashka"
+     (throw (ex-info "Unsupported runtime: bb-test-runner run-all is only available under Babashka"
                      {:runtime :jvm
                       :namespace 'ai.miniforge.bb-test-runner.core}))))
 

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.cljc
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.cljc
@@ -228,7 +228,10 @@
 
 (defn parse-project-list-output
   "Parse a Polylith `ws get:changes:changed-or-affected-projects`
-   response into a vector of project names."
+   response into a vector of project names.
+
+   Returns a vector on valid blank/sequential/set output, or
+   `{:ok? false :error ...}` when the output is invalid or unparseable."
   [output]
   (let [trimmed (some-> output str/trim not-empty)]
     (if-not trimmed

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
@@ -84,7 +84,9 @@
   (core/changed-projects-since-stable-command))
 
 (defn parse-project-list-output
-  "Parse a changed-or-affected project list response into project names."
+  "Parse a changed-or-affected project list response into project names.
+
+   Returns a vector on success, or `{:ok? false :error ...}` on invalid input."
   [output]
   (core/parse-project-list-output output))
 

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -202,6 +202,18 @@
     (is (= ["miniforge" "miniforge-core"]
            (sut/parse-project-list-output "[\"miniforge\" \"miniforge-core\"]")))))
 
+(deftest test-parse-project-list-output-returns-error-data-for-invalid-output
+  (testing "invalid Polylith ws output is returned as error data"
+    (let [result (sut/parse-project-list-output "{:not :a-project-list}")]
+      (is (false? (:ok? result)))
+      (is (= :bb-test-runner/invalid-project-list
+             (get-in result [:error :code])))))
+  (testing "unparseable Polylith ws output is returned as error data"
+    (let [result (sut/parse-project-list-output "[")]
+      (is (false? (:ok? result)))
+      (is (= :bb-test-runner/invalid-project-list
+             (get-in result [:error :code]))))))
+
 (deftest test-sanitize-git-worktree-env-strips-worktree-vars
   (testing "git worktree vars do not leak into child test processes"
     (is (= {"PATH" "/usr/bin" "FOO" "bar"}
@@ -244,15 +256,15 @@
              "seed:17"])))))
 
 (deftest test-parse-diagnostic-args-rejects-invalid-numeric-values
-  (testing "numeric diagnostic args fail with contextual ex-info"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid stable-derived diagnostic argument"
-         (sut/parse-diagnostic-args ["start-size:abc"])))
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid stable-derived diagnostic argument"
-         (sut/parse-diagnostic-args ["seed:not-a-number"])))))
+  (testing "numeric diagnostic args return contextual error data"
+    (let [result (sut/parse-diagnostic-args ["start-size:abc"])]
+      (is (false? (:ok? result)))
+      (is (= :bb-test-runner/invalid-diagnostic-arg
+             (get-in result [:error :code]))))
+    (let [result (sut/parse-diagnostic-args ["seed:not-a-number"])]
+      (is (false? (:ok? result)))
+      (is (= :bb-test-runner/invalid-diagnostic-arg
+             (get-in result [:error :code]))))))
 
 (deftest test-order-projects-supports-declared-and-backward-order
   (testing "diagnostic ordering keeps stable sequences controllable"

--- a/docs/pull-requests/2026-07-01-chris-bb-test-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-bb-test-runner-anomalies.md
@@ -1,0 +1,43 @@
+# Refactor: return bb test runner parse failures as data
+
+## Overview
+
+This PR cleans up the actionable exceptions-as-data sites in
+`bb-test-runner.core`.
+
+## Motivation
+
+The stable-derived test runner still throws for parse/derivation failures that
+can be represented as data. Keeping those paths data-first lets callers decide
+whether to surface a CLI boundary error or recover.
+
+## Changes in Detail
+
+- Add data-returning parsing helpers for project-list and diagnostic arguments.
+- Keep existing public parse functions compatible where callers still expect
+  plain values.
+- Reclassify the JVM-only `run-all` placeholder as a programmer-error guard if
+  appropriate.
+- Update focused bb-test-runner tests.
+
+## Testing Plan
+
+- Run focused bb-test-runner tests.
+- Run the exceptions-as-data scanner for `bb_test_runner/core.cljc`.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+No deployment special handling. This affects local test-runner helper behavior
+only.
+
+## Related Issues/PRs
+
+- Continues the exceptions-as-data cleanup waves after #1338.
+- Independent of #1339.
+
+## Checklist
+
+- [x] Focused bb-test-runner tests pass.
+- [x] `bb_test_runner/core.cljc` scanner cleanup-needed count reaches zero.
+- [x] `bb pre-commit` passes.

--- a/scripts/test-since-stable.bb
+++ b/scripts/test-since-stable.bb
@@ -58,6 +58,26 @@
             (recur (+ elapsed heartbeat-ms)))
           (:exit result))))))
 
+(defn- parse-error?
+  [value]
+  (false? (:ok? value)))
+
+(defn- print-parse-error!
+  [result]
+  (let [{:keys [code message data]} (:error result)]
+    (binding [*out* *err*]
+      (println (str "Stable-derived test input failed: " (name code)))
+      (println message)
+      (when (seq data)
+        (println (pr-str data))))))
+
+(defn- exit-on-parse-error!
+  [result]
+  (when (parse-error? result)
+    (print-parse-error! result)
+    (System/exit 2))
+  result)
+
 (defn- stable-tags
   []
   (->> (sh-string (concat ["git" "tag" "-l"]
@@ -69,8 +89,9 @@
 
 (defn- changed-projects-since-stable
   []
-  (->> (sh-string (bb-test-runner/changed-projects-since-stable-command))
-       bb-test-runner/parse-project-list-output))
+  (-> (sh-string (bb-test-runner/changed-projects-since-stable-command))
+      bb-test-runner/parse-project-list-output
+      exit-on-parse-error!))
 
 (defn- full-suite-step
   []
@@ -90,7 +111,8 @@
 
 (defn -main
   [& args]
-  (let [parsed-args (bb-test-runner/parse-diagnostic-args args)]
+  (let [parsed-args (exit-on-parse-error!
+                     (bb-test-runner/parse-diagnostic-args args))]
     (if-not (bb-test-runner/stable-tags-present? (stable-tags))
       (System/exit (run-step! (full-suite-step)))
       (if-let [plan (effective-plan parsed-args)]


### PR DESCRIPTION
# Refactor: return bb test runner parse failures as data

## Overview

This PR cleans up the actionable exceptions-as-data sites in
`bb-test-runner.core`.

## Motivation

The stable-derived test runner still throws for parse/derivation failures that
can be represented as data. Keeping those paths data-first lets callers decide
whether to surface a CLI boundary error or recover.

## Changes in Detail

- Add data-returning parsing helpers for project-list and diagnostic arguments.
- Keep existing public parse functions compatible where callers still expect
  plain values.
- Reclassify the JVM-only `run-all` placeholder as a programmer-error guard if
  appropriate.
- Update focused bb-test-runner tests.

## Testing Plan

- Run focused bb-test-runner tests.
- Run the exceptions-as-data scanner for `bb_test_runner/core.cljc`.
- Run `bb pre-commit`.

## Deployment Plan

No deployment special handling. This affects local test-runner helper behavior
only.

## Related Issues/PRs

- Continues the exceptions-as-data cleanup waves after #1338.
- Independent of #1339.

## Checklist

- [x] Focused bb-test-runner tests pass.
- [x] `bb_test_runner/core.cljc` scanner cleanup-needed count reaches zero.
- [x] `bb pre-commit` passes.
