### PR TITLE
refactor: return pr responder anomalies as data

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -22,8 +22,10 @@
    [babashka.process :as process]
    [cheshire.core :as json]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.commands.pr-monitor :as pr-monitor]
    [ai.miniforge.cli.main.commands.pr-review :as pr-review]
    [ai.miniforge.cli.messages :as messages]
@@ -169,12 +171,12 @@
       (let [{:keys [number]} (pr-lifecycle/parse-pr-url url)]
         (when-not number
           (display/print-error (messages/t :pr/respond-bad-url))
-          (System/exit 1))
+          (shared/exit! 1))
         (display/print-info (messages/t :pr/respond-checkout {:number number}))
         (let [branch (checkout-pr! number)]
           (when-not branch
             (display/print-error (messages/t :pr/respond-checkout-failed))
-            (System/exit 1))
+            (shared/exit! 1))
           (display/print-info (messages/t :pr/respond-on-branch {:branch branch}))
           (let [cwd (System/getProperty "user.dir")
                 result (pr-lifecycle/respond-to-comments!
@@ -183,14 +185,18 @@
                           (workflow-runner/run-workflow-from-spec! spec (merge {:quiet true} run-opts)))
                         push!
                         opts)]
-            (display/print-info
-             (messages/t :pr/respond-done
-                         {:comments (:comments-found result)
-                          :files    (:files-processed result)
-                          :fixed    (count (filter :succeeded? (:fixes result)))
-                          :pushed   (if (:pushed? result)
-                                      (messages/t :pr/respond-pushed)
-                                      "")}))))))))
+            (if (anomaly/anomaly? result)
+              (do
+                (display/print-error (:anomaly/message result))
+                (shared/exit! 1))
+              (display/print-info
+               (messages/t :pr/respond-done
+                           {:comments (:comments-found result)
+                            :files    (:files-processed result)
+                            :fixed    (count (filter :succeeded? (:fixes result)))
+                            :pushed   (if (:pushed? result)
+                                        (messages/t :pr/respond-pushed)
+                                        "")})))))))))
 
 (defn pr-merge-cmd
   [opts]

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -1068,6 +1068,9 @@
    Returns:
    {:pr-number :comments-found :files-processed :fixes :pushed?}
 
+   Returns an anomaly map unchanged when the PR URL is invalid or PR
+   comment fetching fails.
+
    Example:
      (respond-to-comments!
        \"https://github.com/org/repo/pull/123\"

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
@@ -30,7 +30,6 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.github :as github]
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]
-   [ai.miniforge.response.interface :as response]
    [babashka.process :as process]
    [clojure.string :as str]))
 
@@ -51,9 +50,9 @@
    when `url` is a recognizable GitHub PR URL, or an `:invalid-input`
    anomaly carrying `:url` in `:anomaly/data`.
 
-   This is the canonical, anomaly-returning entry point. The boundary
-   site `respond-to-comments!` consumes the anomaly and rethrows via
-   `response/throw-anomaly!` with `:anomalies/incorrect`."
+   This is the canonical, anomaly-returning entry point. The
+   orchestrator returns the anomaly unchanged so callers can decide
+   how to surface it."
   [url]
   (or (parse-pr-url url)
       (anomaly/anomaly :invalid-input
@@ -212,10 +211,9 @@
    `{:comments vector :groups vector}` on success, or a `:fault`
    anomaly when the upstream `poller/fetch-pr-comments` errors.
 
-   This is the canonical, anomaly-returning entry point. The boundary
-   helper `fetch-actionable-comments` rethrows via
-   `response/throw-anomaly!` with `:anomalies/fault` for legacy
-   slingshot consumers."
+   This is the canonical, anomaly-returning entry point. The
+   orchestrator returns the anomaly unchanged so callers can decide
+   how to surface it."
   [worktree-path pr-number]
   (let [result (poller/fetch-pr-comments worktree-path pr-number)]
     (if (dag/err? result)
@@ -227,19 +225,6 @@
             actionable (filter-actionable-comments all)]
         {:comments actionable
          :groups (group-comments-by-file actionable)}))))
-
-(defn- fetch-actionable-comments
-  "Boundary helper. Calls `fetch-actionable-comments-result`; on
-   anomaly result raises a slingshot `:anomalies/fault` throw.
-
-   Returns `{:comments vector :groups vector}` on success."
-  [worktree-path pr-number]
-  (let [result (fetch-actionable-comments-result worktree-path pr-number)]
-    (if (anomaly/anomaly? result)
-      (response/throw-anomaly! :anomalies/fault
-                               (:anomaly/message result)
-                               (:anomaly/data result))
-      result)))
 
 (defn- respond-result
   "Build the response summary map."
@@ -272,22 +257,26 @@
     :comments-found int
     :files-processed int
     :fixes [{:path :succeeded? :comment-ids :replied? :resolved?}]
-    :pushed? bool}"
+    :pushed? bool}
+
+   Returns an anomaly map unchanged when the PR URL is invalid or PR
+   comment fetching fails."
   [pr-url worktree-path run-fix-fn push-fn opts]
   (let [parsed (parse-pr-url-result pr-url)]
-    (when (anomaly/anomaly? parsed)
-      (response/throw-anomaly! :anomalies/incorrect
-                               (:anomaly/message parsed)
-                               (:anomaly/data parsed)))
-    (let [{:keys [number]} parsed
-          {:keys [comments groups]} (fetch-actionable-comments worktree-path number)]
-      (if (empty? groups)
-        (respond-result number 0 0 [] false)
-        (let [context (gather-context worktree-path number groups)
-              ;; Process comment groups in parallel
-              fix-futures (mapv #(future (process-comment-group
-                                         worktree-path number run-fix-fn context opts %))
-                                groups)
-              fixes (mapv deref fix-futures)
-              pushed? (if (some :succeeded? fixes) (push-fn) false)]
-          (respond-result number (count comments) (count groups) fixes pushed?))))))
+    (if (anomaly/anomaly? parsed)
+      parsed
+      (let [{:keys [number]} parsed
+            fetch-result (fetch-actionable-comments-result worktree-path number)]
+        (if (anomaly/anomaly? fetch-result)
+          fetch-result
+          (let [{:keys [comments groups]} fetch-result]
+            (if (empty? groups)
+              (respond-result number (count comments) 0 [] false)
+              (let [context (gather-context worktree-path number groups)
+                    ;; Process comment groups in parallel
+                    fix-futures (mapv #(future (process-comment-group
+                                               worktree-path number run-fix-fn context opts %))
+                                      groups)
+                    fixes (mapv deref fix-futures)
+                    pushed? (if (some :succeeded? fixes) (push-fn) false)]
+                (respond-result number (count comments) (count groups) fixes pushed?)))))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/fetch_actionable_comments_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/fetch_actionable_comments_result_test.clj
@@ -18,11 +18,10 @@
 
 (ns ai.miniforge.pr-lifecycle.anomaly.fetch-actionable-comments-result-test
   "Coverage for `responder/fetch-actionable-comments-result`
-   (anomaly-returning) and the private boundary helper.
+   (anomaly-returning).
 
-   Upstream poller error → `:fault` anomaly. The private boundary
-   helper rethrows via `response/throw-anomaly!` with
-   `:anomalies/fault`."
+   Upstream poller error -> `:fault` anomaly. The orchestrator returns
+   the anomaly unchanged so callers can decide how to surface it."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.anomaly.interface :as anomaly]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/parse_pr_url_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/parse_pr_url_result_test.clj
@@ -18,16 +18,15 @@
 
 (ns ai.miniforge.pr-lifecycle.anomaly.parse-pr-url-result-test
   "Coverage for `responder/parse-pr-url-result` (anomaly-returning) and
-   the boundary throw via `responder/respond-to-comments!`.
+   the anomaly passthrough via `responder/respond-to-comments!`.
 
-   Unrecognized URL → `:invalid-input` anomaly. The boundary helper
-   escalates via `response/throw-anomaly!` with `:anomalies/incorrect`."
+   Unrecognized URL -> `:invalid-input` anomaly. The orchestrator
+   returns the anomaly unchanged so callers can decide how to surface
+   it."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.anomaly.interface :as anomaly]
-   [ai.miniforge.pr-lifecycle.responder :as responder])
-  (:import
-   (clojure.lang ExceptionInfo)))
+   [ai.miniforge.pr-lifecycle.responder :as responder]))
 
 ;------------------------------------------------------------------------------ Happy path
 
@@ -59,15 +58,15 @@
   (testing "nil URL yields :invalid-input anomaly"
     (is (anomaly/anomaly? (responder/parse-pr-url-result nil)))))
 
-;------------------------------------------------------------------------------ Boundary helper escalates via slingshot
+;------------------------------------------------------------------------------ Orchestrator preserves anomaly values
 
-(deftest respond-to-comments-escalates-url-parse-anomaly
-  (testing "respond-to-comments! rethrows anomaly as ExceptionInfo"
-    (is (thrown-with-msg?
-         ExceptionInfo
-         #"Could not parse PR number from URL"
-         (responder/respond-to-comments! "https://gitlab.com/x/y/pull/1"
-                                         "/tmp"
-                                         (fn [& _] {})
-                                         (fn [] true)
-                                         {})))))
+(deftest respond-to-comments-preserves-url-parse-anomaly
+  (testing "respond-to-comments! returns parse anomaly unchanged"
+    (let [result (responder/respond-to-comments! "https://gitlab.com/x/y/pull/1"
+                                                 "/tmp"
+                                                 (fn [& _] {})
+                                                 (fn [] true)
+                                                 {})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= "Could not parse PR number from URL" (:anomaly/message result))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
@@ -23,6 +23,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.github :as github]
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]
@@ -150,6 +151,20 @@
         (is (= 0 (:files-processed result)))
         (is (false? (:pushed? result)))))))
 
+(deftest respond-to-comments-comments-without-file-groups-test
+  (testing "counts actionable comments even when no file groups are processable"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _] (dag/ok {:comments [(dissoc review-comment :comment/path)]}))]
+      (let [result (responder/respond-to-comments!
+                    "https://github.com/org/repo/pull/1"
+                    "/tmp/worktree"
+                    (fn [_ _] {})
+                    (fn [] true)
+                    {})]
+        (is (= 1 (:comments-found result)))
+        (is (= 0 (:files-processed result)))
+        (is (false? (:pushed? result)))))))
+
 (deftest respond-to-comments-with-comments-test
   (testing "processes comments, runs fix, and reports results"
     (let [fix-calls (atom [])]
@@ -228,9 +243,31 @@
         (is (false? (:pushed? result)))))))
 
 (deftest respond-to-comments-invalid-url-test
-  (testing "throws on unparseable PR URL"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Could not parse"
-          (responder/respond-to-comments! "not-a-url" "/tmp" (fn [_ _] {}) (fn [] true) {})))))
+  (testing "returns anomaly on unparseable PR URL"
+    (let [result (responder/respond-to-comments! "not-a-url" "/tmp" (fn [_ _] {}) (fn [] true) {})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
+
+(deftest respond-to-comments-fetch-failure-test
+  (testing "returns fetch anomaly without running fixes or pushing"
+    (let [fix-called? (atom false)
+          push-called? (atom false)]
+      (with-redefs [poller/fetch-pr-comments
+                    (fn [_ _] (dag/err :network "down"))]
+        (let [result (responder/respond-to-comments!
+                      "https://github.com/org/repo/pull/1"
+                      "/tmp/worktree"
+                      (fn [& _]
+                        (reset! fix-called? true)
+                        {})
+                      (fn []
+                        (reset! push-called? true)
+                        true)
+                      {})]
+          (is (anomaly/anomaly? result))
+          (is (= :fault (:anomaly/type result)))
+          (is (false? @fix-called?))
+          (is (false? @push-called?)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-07-01-chris-pr-responder-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-pr-responder-anomalies.md
@@ -1,0 +1,29 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# PR Responder Expected Anomalies
+
+## Summary
+
+Remove exception-driven expected anomaly handling from the PR comment
+responder orchestration path.
+
+## Changes
+
+- Return invalid-URL and fetch-failure anomalies from `respond-to-comments!`
+  instead of rethrowing them through response exceptions.
+- Remove the private throwing fetch boundary and route orchestration through
+  the anomaly-returning fetch helper.
+- Make the CLI `pr respond` command explicitly fail on returned anomalies.
+- Update responder tests to assert anomaly values and fetch-failure short
+  circuiting.
+
+## Validation
+
+- `clojure -M:poly test brick:pr-lifecycle`
+- `clojure -M:poly test brick:cli`
+- Exceptions-as-data scanner target check for
+  `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# PR Responder Expected Anomalies

## Summary

Remove exception-driven expected anomaly handling from the PR comment
responder orchestration path.

## Changes

- Return invalid-URL and fetch-failure anomalies from `respond-to-comments!`
  instead of rethrowing them through response exceptions.
- Remove the private throwing fetch boundary and route orchestration through
  the anomaly-returning fetch helper.
- Make the CLI `pr respond` command explicitly fail on returned anomalies.
- Update responder tests to assert anomaly values and fetch-failure short
  circuiting.

## Validation

- `clojure -M:poly test brick:pr-lifecycle`
- `clojure -M:poly test brick:cli`
- Exceptions-as-data scanner target check for
  `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj`
