### PR TITLE
refactor: return release sandbox path anomalies as data

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -418,30 +418,34 @@
     (failed? state) state
     (not (:create-pr? state)) state
     :else
-    (let [{:keys [worktree-path release-meta pr-number pr-url branch
+    (let [{:keys [release-meta pr-number pr-url branch
                   executor environment-id logger]} state
           filename (pr-doc-filename (:release/pr-title release-meta))
           rel-path (str "docs/pull-requests/" filename)
-          full-path (str worktree-path "/" rel-path)
           content (render-pr-doc release-meta
                                  {:pr-number pr-number
                                   :pr-url pr-url
                                   :branch branch})]
       (try
         ;; Write via executor (governed) — never touch host filesystem
-        (sandbox/write-file! executor environment-id full-path content)
-        (when logger
-          (log/info logger :release-executor :pr-doc-written
-                    {:data {:path rel-path}}))
-        ;; Stage the doc and amend the commit to include it
-        (sandbox/exec! executor environment-id
-                       (str "git add " rel-path))
-        (sandbox/exec! executor environment-id
-                       "git commit --amend --no-edit --no-verify")
-        ;; Force-push since we amended — route through executor with token
-        (sandbox/exec! executor environment-id
-                       "git push --force-with-lease"
-                       (gh-exec-opts state))
+        (let [write-r (sandbox/write-file! executor environment-id rel-path content)]
+          (if (result/succeeded? write-r)
+            (do
+              (when logger
+                (log/info logger :release-executor :pr-doc-written
+                          {:data {:path rel-path}}))
+              ;; Stage the doc and amend the commit to include it
+              (sandbox/exec! executor environment-id
+                             (str "git add " rel-path))
+              (sandbox/exec! executor environment-id
+                             "git commit --amend --no-edit --no-verify")
+              ;; Force-push since we amended — route through executor with token
+              (sandbox/exec! executor environment-id
+                             "git push --force-with-lease"
+                             (gh-exec-opts state)))
+            (when logger
+              (log/warn logger :release-executor :pr-doc-write-failed
+                        {:message (:error write-r)}))))
         state
       (catch Exception e
         (when logger
@@ -570,7 +574,7 @@
                   executor environment-id logger code-artifacts workflow-data]} state
           filename (pr-doc-filename (:release/pr-title release-meta))
           ;; Relative to the container workdir (the worktree root). The sandbox
-          ;; rejects absolute paths (assert-safe-container-path!), so this must
+          ;; rejects absolute paths, so this must
           ;; NOT be prefixed with worktree-path — the executor resolves it
           ;; against the workdir. The git add below already uses rel-path.
           rel-path (str "docs/pull-requests/" filename)
@@ -581,22 +585,29 @@
                    workflow-data)]
       (try
         ;; Write via executor (governed) — never touch host filesystem
-        (sandbox/write-file! executor environment-id rel-path content)
-        (when logger
-          (log/info logger :release-executor :pr-doc-generated
-                    {:data {:path rel-path}}))
-        ;; Stage the doc and amend the commit to include it
-        (sandbox/exec! executor environment-id
-                       (str "git add " rel-path))
-        (sandbox/exec! executor environment-id
-                       "git commit --amend --no-edit --no-verify")
-        ;; Force-push since we amended — route through executor with token
-        (sandbox/exec! executor environment-id
-                       "git push --force-with-lease"
-                       (gh-exec-opts state))
-        (assoc state
-               :pr-doc-path rel-path
-               :pr-doc-content content)
+        (let [write-r (sandbox/write-file! executor environment-id rel-path content)]
+          (if (result/succeeded? write-r)
+            (do
+              (when logger
+                (log/info logger :release-executor :pr-doc-generated
+                          {:data {:path rel-path}}))
+              ;; Stage the doc and amend the commit to include it
+              (sandbox/exec! executor environment-id
+                             (str "git add " rel-path))
+              (sandbox/exec! executor environment-id
+                             "git commit --amend --no-edit --no-verify")
+              ;; Force-push since we amended — route through executor with token
+              (sandbox/exec! executor environment-id
+                             "git push --force-with-lease"
+                             (gh-exec-opts state))
+              (assoc state
+                     :pr-doc-path rel-path
+                     :pr-doc-content content))
+            (do
+              (when logger
+                (log/warn logger :release-executor :pr-doc-generation-failed
+                          {:message (:error write-r)}))
+              state)))
         (catch Exception e
           (when logger
             (log/warn logger :release-executor :pr-doc-generation-failed

--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -34,8 +34,12 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Helpers
 
-(defn assert-safe-container-path!
-  "Assert that `path` is safe to interpolate into a single-quoted shell argument
+(defn- unsafe-container-path-result
+  [message type path]
+  (result/shell-failure message {:type type :path path}))
+
+(defn validate-safe-container-path
+  "Return nil when `path` is safe to interpolate into a single-quoted shell argument
    and cannot escape the container working directory.
 
    Two classes of attack are blocked:
@@ -48,23 +52,29 @@
       single-quote, backslash, backtick, $, !, space, tab, newline, NUL,
       and the glob/redirect set (; | & > < ( ) { } * ? [ ] # ~).
 
-   Throws ex-info with {:type :path-traversal} or {:type :shell-injection}
-   on violation."
+   Returns a shell failure result with `:type :path-traversal` or
+   `:type :shell-injection` on violation."
   [path]
   (let [s (str path)]
-    (when (or (str/starts-with? s "/")
-              (re-find #"^[A-Za-z]:" s))
-      (throw (ex-info "Path traversal rejected: sandbox path must be relative"
-                      {:type :path-traversal
-                       :path s})))
-    (when (re-find #"(^|[/\\])\.\.([/\\]|$)" s)
-      (throw (ex-info "Path traversal rejected: sandbox path contains .. segment"
-                      {:type :path-traversal
-                       :path s})))
-    (when (re-find #"['\\`$! \t\n\r\x00;|&><(){}*?\[\]#~]" s)
-      (throw (ex-info "Shell injection rejected: sandbox path contains unsafe character"
-                      {:type :shell-injection
-                       :path s})))))
+    (cond
+      (or (str/starts-with? s "/")
+          (re-find #"^[A-Za-z]:" s))
+      (unsafe-container-path-result
+       "Path traversal rejected: sandbox path must be relative"
+       :path-traversal
+       s)
+
+      (re-find #"(^|[/\\])\.\.([/\\]|$)" s)
+      (unsafe-container-path-result
+       "Path traversal rejected: sandbox path contains .. segment"
+       :path-traversal
+       s)
+
+      (re-find #"['\\`$! \t\n\r\x00;|&><(){}*?\[\]#~]" s)
+      (unsafe-container-path-result
+       "Shell injection rejected: sandbox path contains unsafe character"
+       :shell-injection
+       s))))
 
 (defn exec!
   "Execute a command in the sandbox environment.
@@ -174,21 +184,23 @@
 (defn write-file!
   "Write content to a file inside the sandbox container.
    Uses base64 encoding to safely transfer arbitrary content.
-   Throws ex-info with {:type :path-traversal} if path contains `..` segments."
+   Returns a shell failure result if `path` is unsafe."
   [executor env-id path content]
-  (assert-safe-container-path! path)
-  (let [encoded (.encodeToString (java.util.Base64/getEncoder)
-                                  (.getBytes content "UTF-8"))
-        cmd (str "mkdir -p \"$(dirname '" path "')\" && "
-                 "echo '" encoded "' | base64 -d > '" path "'")]
-    (exec! executor env-id cmd)))
+  (if-let [invalid (validate-safe-container-path path)]
+    invalid
+    (let [encoded (.encodeToString (java.util.Base64/getEncoder)
+                                   (.getBytes content "UTF-8"))
+          cmd (str "mkdir -p \"$(dirname '" path "')\" && "
+                   "echo '" encoded "' | base64 -d > '" path "'")]
+      (exec! executor env-id cmd))))
 
 (defn delete-file!
   "Delete a file inside the sandbox container.
-   Throws ex-info with {:type :path-traversal} if path contains `..` segments."
+   Returns a shell failure result if `path` is unsafe."
   [executor env-id path]
-  (assert-safe-container-path! path)
-  (exec! executor env-id (str "rm -f '" path "'")))
+  (if-let [invalid (validate-safe-container-path path)]
+    invalid
+    (exec! executor env-id (str "rm -f '" path "'"))))
 
 (defn stage-files!
   "Stage files in the sandbox container."

--- a/components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj
@@ -518,6 +518,29 @@
     (let [state {:failure {:type :prior :message "x"}}]
       (is (= state (sut/step-write-pr-doc state))))))
 
+(deftest step-write-pr-doc-writes-relative-path-test
+  (testing "write-file! receives a relative docs/pull-requests path, never absolute"
+    (let [seen-path (atom :unset)]
+      (with-redefs [sandbox/write-file! (fn [_exec _env path _content]
+                                          (reset! seen-path path)
+                                          {:success? true})
+                    sandbox/exec! (fn [& _] {:success? true :output ""})]
+        (let [result (sut/step-write-pr-doc
+                      {:create-pr? true
+                       :worktree-path "/abs/host/worktree"
+                       :executor :mock
+                       :environment-id "env-1"
+                       :branch "mf/feature"
+                       :release-meta {:release/pr-title "feat: add thing"}})]
+          (is (not (sut/failed? result)))
+          (is (string? @seen-path) "write-file! must have been called")
+          (is (not (str/starts-with? @seen-path "/"))
+              "path must be relative — absolute paths are rejected by the sandbox")
+          (is (not (str/includes? @seen-path "/abs/host/worktree"))
+              "path must not embed the host worktree-path")
+          (is (str/starts-with? @seen-path "docs/pull-requests/")
+              "doc lands under docs/pull-requests/ relative to the container workdir"))))))
+
 ;; ============================================================================
 ;; format-files-changed
 ;; ============================================================================
@@ -687,7 +710,7 @@
   ;; The 2026-06-15 rn-03 dogfood logged `pr-doc-generation-failed - Path
   ;; traversal rejected: sandbox path must be relative` on every release: the
   ;; step passed an ABSOLUTE `worktree-path/docs/...` to sandbox/write-file!,
-  ;; but assert-safe-container-path! rejects any leading `/`. The doc must be
+  ;; but sandbox path validation rejects any leading `/`. The doc must be
   ;; written with a path relative to the container workdir (the git add already
   ;; uses rel-path). Pin the contract so the regression cannot return.
   (testing "write-file! receives a relative docs/pull-requests path, never absolute"

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -404,64 +404,70 @@
              result)))))
 
 ;; ============================================================================
-;; assert-safe-container-path! / path-validation tests
+;; safe container path validation tests
 ;; ============================================================================
 
+(defn- assert-rejected-path
+  [result expected-type expected-message-pattern]
+  (is (false? (:success? result)))
+  (is (re-find expected-message-pattern (:error result)))
+  (is (= expected-type (:type result))))
+
 (deftest write-file-rejects-path-traversal-test
-  (testing "write-file! throws on path containing .. segment"
+  (testing "write-file! returns failure on path containing .. segment"
     (let [[exec _cmds] (create-mock-executor)]
-      (let [e (is (thrown? clojure.lang.ExceptionInfo
-                           (sandbox/write-file! exec "env-1" "../etc/passwd" "evil")))]
-        (is (re-find #"Path traversal rejected" (ex-message e)))
-        (is (= :path-traversal (:type (ex-data e))))))))
+      (assert-rejected-path
+       (sandbox/write-file! exec "env-1" "../etc/passwd" "evil")
+       :path-traversal
+       #"Path traversal rejected"))))
 
 (deftest write-file-rejects-embedded-traversal-test
-  (testing "write-file! throws on path with embedded .. segment"
+  (testing "write-file! returns failure on path with embedded .. segment"
     (let [[exec _cmds] (create-mock-executor)]
-      (let [e (is (thrown? clojure.lang.ExceptionInfo
-                           (sandbox/write-file! exec "env-1" "src/../../etc/passwd" "evil")))]
-        (is (re-find #"Path traversal rejected" (ex-message e)))
-        (is (= :path-traversal (:type (ex-data e))))))))
+      (assert-rejected-path
+       (sandbox/write-file! exec "env-1" "src/../../etc/passwd" "evil")
+       :path-traversal
+       #"Path traversal rejected"))))
 
 (deftest write-file-rejects-single-quote-injection-test
-  (testing "write-file! throws on path containing single-quote (shell injection)"
+  (testing "write-file! returns failure on path containing single-quote (shell injection)"
     (let [[exec _cmds] (create-mock-executor)]
-      (let [e (is (thrown? clojure.lang.ExceptionInfo
-                           (sandbox/write-file! exec "env-1" "src/a'.clj" "evil")))]
-        (is (re-find #"Shell injection rejected" (ex-message e)))
-        (is (= :shell-injection (:type (ex-data e))))))))
+      (assert-rejected-path
+       (sandbox/write-file! exec "env-1" "src/a'.clj" "evil")
+       :shell-injection
+       #"Shell injection rejected"))))
 
 (deftest write-file-rejects-dollar-injection-test
-  (testing "write-file! throws on path containing $ (shell injection)"
+  (testing "write-file! returns failure on path containing $ (shell injection)"
     (let [[exec _cmds] (create-mock-executor)]
-      (let [e (is (thrown? clojure.lang.ExceptionInfo
-                           (sandbox/write-file! exec "env-1" "src/$HOME/x.clj" "evil")))]
-        (is (re-find #"Shell injection rejected" (ex-message e)))
-        (is (= :shell-injection (:type (ex-data e))))))))
+      (assert-rejected-path
+       (sandbox/write-file! exec "env-1" "src/$HOME/x.clj" "evil")
+       :shell-injection
+       #"Shell injection rejected"))))
 
 (deftest write-file-rejects-semicolon-injection-test
-  (testing "write-file! throws on path containing ; (shell injection)"
+  (testing "write-file! returns failure on path containing ; (shell injection)"
     (let [[exec _cmds] (create-mock-executor)]
-      (let [e (is (thrown? clojure.lang.ExceptionInfo
-                           (sandbox/write-file! exec "env-1" "src/a;rm -rf /;b.clj" "evil")))]
-        (is (re-find #"Shell injection rejected" (ex-message e)))
-        (is (= :shell-injection (:type (ex-data e))))))))
+      (assert-rejected-path
+       (sandbox/write-file! exec "env-1" "src/a;rm -rf /;b.clj" "evil")
+       :shell-injection
+       #"Shell injection rejected"))))
 
 (deftest delete-file-rejects-path-traversal-test
-  (testing "delete-file! throws on path containing .. segment"
+  (testing "delete-file! returns failure on path containing .. segment"
     (let [[exec _cmds] (create-mock-executor)]
-      (let [e (is (thrown? clojure.lang.ExceptionInfo
-                           (sandbox/delete-file! exec "env-1" "../etc/shadow")))]
-        (is (re-find #"Path traversal rejected" (ex-message e)))
-        (is (= :path-traversal (:type (ex-data e))))))))
+      (assert-rejected-path
+       (sandbox/delete-file! exec "env-1" "../etc/shadow")
+       :path-traversal
+       #"Path traversal rejected"))))
 
 (deftest delete-file-rejects-single-quote-injection-test
-  (testing "delete-file! throws on path containing single-quote (shell injection)"
+  (testing "delete-file! returns failure on path containing single-quote (shell injection)"
     (let [[exec _cmds] (create-mock-executor)]
-      (let [e (is (thrown? clojure.lang.ExceptionInfo
-                           (sandbox/delete-file! exec "env-1" "src/a' || rm -rf /;b.clj")))]
-        (is (re-find #"Shell injection rejected" (ex-message e)))
-        (is (= :shell-injection (:type (ex-data e))))))))
+      (assert-rejected-path
+       (sandbox/delete-file! exec "env-1" "src/a' || rm -rf /;b.clj")
+       :shell-injection
+       #"Shell injection rejected"))))
 
 (deftest write-file-accepts-normal-paths-test
   (testing "write-file! accepts well-formed relative source paths"
@@ -476,9 +482,9 @@
                                           "(ns ai.company.my-comp.core)"))))))
 
 (deftest write-file-rejects-absolute-path-test
-  (testing "write-file! throws on absolute path (cannot escape container workspace)"
+  (testing "write-file! returns failure on absolute path (cannot escape container workspace)"
     (let [[exec _cmds] (create-mock-executor)]
-      (let [e (is (thrown? clojure.lang.ExceptionInfo
-                           (sandbox/write-file! exec "env-1" "/etc/passwd" "evil")))]
-        (is (re-find #"Path traversal rejected" (ex-message e)))
-        (is (= :path-traversal (:type (ex-data e))))))))
+      (assert-rejected-path
+       (sandbox/write-file! exec "env-1" "/etc/passwd" "evil")
+       :path-traversal
+       #"Path traversal rejected"))))

--- a/docs/pull-requests/2026-07-01-chris-release-sandbox-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-release-sandbox-anomalies.md
@@ -1,0 +1,29 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Release Sandbox Path Anomalies
+
+## Summary
+
+Convert release sandbox path-safety rejections from exceptions into
+structured shell-result failures.
+
+## Changes
+
+- Replace `assert-safe-container-path!` throwing behavior with
+  `validate-safe-container-path`, which returns a failed shell result
+  for traversal and shell-injection inputs.
+- Return failed shell results from sandbox `write-file!` and `delete-file!`
+  when paths are unsafe.
+- Update release PR-doc steps to inspect sandbox write results and preserve
+  their non-fatal degraded behavior without relying on exceptions.
+- Update sandbox path-safety tests to assert failed result data.
+
+## Validation
+
+- Direct release-executor sandbox/core-pipeline test namespaces
+- Exceptions-as-data scanner target check for
+  `components/release-executor/src/ai/miniforge/release_executor/sandbox.clj`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Release Sandbox Path Anomalies

## Summary

Convert release sandbox path-safety rejections from exceptions into
structured shell-result failures.

## Changes

- Replace `assert-safe-container-path!` throwing behavior with
  `validate-safe-container-path`, which returns a failed shell result
  for traversal and shell-injection inputs.
- Return failed shell results from sandbox `write-file!` and `delete-file!`
  when paths are unsafe.
- Update release PR-doc steps to inspect sandbox write results and preserve
  their non-fatal degraded behavior without relying on exceptions.
- Update sandbox path-safety tests to assert failed result data.

## Validation

- Direct release-executor sandbox/core-pipeline test namespaces
- Exceptions-as-data scanner target check for
  `components/release-executor/src/ai/miniforge/release_executor/sandbox.clj`
