### PR TITLE
refactor: return failure taxonomy constructor anomalies as data

### DIFF
--- a/components/failure-classifier/deps.edn
+++ b/components/failure-classifier/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/response {:local/root "../response"}}
 

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
@@ -14,6 +14,7 @@
    Layer 1: Classification strategies (pure)
    Layer 2: Orchestration (pure)"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.failure-classifier.taxonomy :as taxonomy]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -192,14 +193,16 @@
   (let [message (failure-message failure-context)
         context (failure-record-context failure-context)
         attribution (dependency-attribution dependency-pattern)]
-    (taxonomy/make-classified-dependency-failure
-     {:failure/class failure-class
-      :failure/message message
-      :failure/source (:failure/source attribution)
-      :failure/vendor (:failure/vendor attribution)
-      :dependency/class (:dependency/class attribution)
-      :dependency/retryability (:dependency/retryability attribution)
-      :failure/context context})))
+    (if (anomaly/anomaly? attribution)
+      attribution
+      (taxonomy/make-classified-dependency-failure
+       {:failure/class failure-class
+        :failure/message message
+        :failure/source (:failure/source attribution)
+        :failure/vendor (:failure/vendor attribution)
+        :dependency/class (:dependency/class attribution)
+        :dependency/retryability (:dependency/retryability attribution)
+        :failure/context context}))))
 
 (defn- classify-standard-record
   "Construct canonical classified failure without dependency attribution."

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
@@ -165,7 +165,8 @@
 
 (defn- constructor-anomaly?
   [x]
-  (and (map? x) (= :invalid-input (:anomaly/type x))))
+  (and (anomaly/anomaly? x)
+       (= :invalid-input (:anomaly/type x))))
 
 (defn- require-field
   "Return an anomaly when a required field is nil."

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
@@ -154,35 +154,35 @@
     value))
 
 (defn- invalid-constructor-input
-  "Create a canonical ex-info payload for invalid constructor inputs.
+  "Create a canonical anomaly map for invalid constructor inputs.
 
-   The ex-data carries the canonical anomaly classification key
-   (`:anomaly/type :invalid-input`) so any catcher routing through
-   `classify-failure` resolves to the same `:failure.class/*` it would
-   have under the legacy `:anomaly/category :anomalies/incorrect`
-   shape. `:anomalies/incorrect` is one of the eight cognitect-standard
-   categories the convergence runbook maps 1:1 to a generic
-   `:anomaly/type` with no subtype."
+   The top-level `:anomaly/type :invalid-input` lets callers route the
+   result through `classify-failure` the same way they routed the
+   former exception data shape."
   [message data]
-  (ex-info message (assoc data :anomaly/type :invalid-input)))
+  {:anomaly/type :invalid-input
+   :anomaly/message message
+   :anomaly/data data})
 
-(defn- require-field!
-  "Require a non-nil field and throw ex-info when missing."
+(defn- constructor-anomaly?
+  [x]
+  (and (map? x) (= :invalid-input (:anomaly/type x))))
+
+(defn- require-field
+  "Return an anomaly when a required field is nil."
   [field-name value data]
   (when (nil? value)
-    (throw (invalid-constructor-input
-            (str "Missing required field " field-name)
-            (assoc data :field field-name))))
-  value)
+    (invalid-constructor-input
+     (str "Missing required field " field-name)
+     (assoc data :field field-name))))
 
-(defn- validate-enum!
-  "Validate an enum field when present and throw ex-info when invalid."
+(defn- validate-enum
+  "Return an anomaly when a present enum field is invalid."
   [field-name value valid-fn data]
   (when (and (some? value) (not (valid-fn value)))
-    (throw (invalid-constructor-input
-            (str "Invalid value for " field-name)
-            (assoc data :field field-name :value value))))
-  value)
+    (invalid-constructor-input
+     (str "Invalid value for " field-name)
+     (assoc data :field field-name :value value))))
 
 (defn make-dependency-attribution
   "Construct canonical dependency attribution.
@@ -194,21 +194,23 @@
     vendor :failure/vendor
     dependency-class :dependency/class
     retryability :dependency/retryability}]
-  (require-field! :failure/source source {:constructor :dependency-attribution})
-  (validate-enum! :failure/source source valid-failure-source?
-                  {:constructor :dependency-attribution})
-  (validate-enum! :failure/vendor vendor valid-dependency-vendor?
-                  {:constructor :dependency-attribution})
-  (validate-enum! :dependency/class dependency-class valid-dependency-class?
-                  {:constructor :dependency-attribution})
-  (validate-enum! :dependency/retryability retryability valid-dependency-retryability?
-                  {:constructor :dependency-attribution})
-  (let [resolved-class (value-or-default dependency-class :unknown)
-        resolved-retryability (value-or-default retryability :non-retryable)]
-    (cond-> {:failure/source source
-             :dependency/class resolved-class
-             :dependency/retryability resolved-retryability}
-      vendor (assoc :failure/vendor vendor))))
+  (if-let [validation-error
+           (or (require-field :failure/source source {:constructor :dependency-attribution})
+               (validate-enum :failure/source source valid-failure-source?
+                              {:constructor :dependency-attribution})
+               (validate-enum :failure/vendor vendor valid-dependency-vendor?
+                              {:constructor :dependency-attribution})
+               (validate-enum :dependency/class dependency-class valid-dependency-class?
+                              {:constructor :dependency-attribution})
+               (validate-enum :dependency/retryability retryability valid-dependency-retryability?
+                              {:constructor :dependency-attribution}))]
+    validation-error
+    (let [resolved-class (value-or-default dependency-class :unknown)
+          resolved-retryability (value-or-default retryability :non-retryable)]
+      (cond-> {:failure/source source
+               :dependency/class resolved-class
+               :dependency/retryability resolved-retryability}
+        vendor (assoc :failure/vendor vendor)))))
 
 (defn make-classified-dependency-failure
   "Construct canonical classified dependency failure."
@@ -216,35 +218,41 @@
     message :failure/message
     context :failure/context
     :as dependency-attribution}]
-  (require-field! :failure/class failure-class
-                  {:constructor :classified-dependency-failure})
-  (require-field! :failure/message message
-                  {:constructor :classified-dependency-failure})
-  (validate-enum! :failure/class failure-class valid-failure-class?
-                  {:constructor :classified-dependency-failure})
-  (let [attribution (make-dependency-attribution dependency-attribution)]
-    (cond-> {:failure/class failure-class
-             :failure/message message
-             :failure/source (:failure/source attribution)
-             :dependency/class (:dependency/class attribution)
-             :dependency/retryability (:dependency/retryability attribution)}
-      (:failure/vendor attribution) (assoc :failure/vendor (:failure/vendor attribution))
-      context (assoc :failure/context context))))
+  (if-let [validation-error
+           (or (require-field :failure/class failure-class
+                              {:constructor :classified-dependency-failure})
+               (require-field :failure/message message
+                              {:constructor :classified-dependency-failure})
+               (validate-enum :failure/class failure-class valid-failure-class?
+                              {:constructor :classified-dependency-failure}))]
+    validation-error
+    (let [attribution (make-dependency-attribution dependency-attribution)]
+      (if (constructor-anomaly? attribution)
+        attribution
+        (cond-> {:failure/class failure-class
+                 :failure/message message
+                 :failure/source (:failure/source attribution)
+                 :dependency/class (:dependency/class attribution)
+                 :dependency/retryability (:dependency/retryability attribution)}
+          (:failure/vendor attribution) (assoc :failure/vendor (:failure/vendor attribution))
+          context (assoc :failure/context context))))))
 
 (defn make-classified-failure
   "Construct canonical classified failure."
   [{failure-class :failure/class
     message :failure/message
     context :failure/context}]
-  (require-field! :failure/class failure-class
-                  {:constructor :classified-failure})
-  (require-field! :failure/message message
-                  {:constructor :classified-failure})
-  (validate-enum! :failure/class failure-class valid-failure-class?
-                  {:constructor :classified-failure})
-  (cond-> {:failure/class failure-class
-           :failure/message message}
-    context (assoc :failure/context context)))
+  (if-let [validation-error
+           (or (require-field :failure/class failure-class
+                              {:constructor :classified-failure})
+               (require-field :failure/message message
+                              {:constructor :classified-failure})
+               (validate-enum :failure/class failure-class valid-failure-class?
+                              {:constructor :classified-failure}))]
+    validation-error
+    (cond-> {:failure/class failure-class
+             :failure/message message}
+      context (assoc :failure/context context))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
@@ -9,6 +9,7 @@
    Layer 0: Config loading
    Layer 1: Schemas and predicates"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
@@ -160,9 +161,7 @@
    result through `classify-failure` the same way they routed the
    former exception data shape."
   [message data]
-  {:anomaly/type :invalid-input
-   :anomaly/message message
-   :anomaly/data data})
+  (anomaly/anomaly :invalid-input message data))
 
 (defn- constructor-anomaly?
   [x]

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
@@ -22,6 +22,7 @@
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.failure-classifier.interface :as fc]
+   [ai.miniforge.failure-classifier.taxonomy :as taxonomy]
    [clojure.test :refer [deftest is testing]]))
 
 ;; ---------------------------------------------------------------------------- Taxonomy tests
@@ -374,6 +375,18 @@
                  (select-keys record (keys expected))))
           (is (= (:error/message input) (:failure/message record)))
           (is (fc/dependency-failure? record)))))))
+
+(deftest classify-record-propagates-dependency-attribution-anomaly-test
+  (testing "dependency attribution anomalies are returned directly"
+    (let [expected (anomaly/anomaly :invalid-input
+                                    "Synthetic dependency attribution failure"
+                                    {:source :test})]
+      (with-redefs [taxonomy/make-dependency-attribution (fn [_] expected)]
+        (let [result (fc/classify-record
+                      {:error/message "Anthropic API service unavailable"})]
+          (is (identical? expected result))
+          (is (anomaly/anomaly? result))
+          (is (= :invalid-input (:anomaly/type result))))))))
 
 (deftest classify-exception-record-test
   (let [record (fc/classify-exception-record

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
@@ -20,8 +20,9 @@
 
 (ns ai.miniforge.failure-classifier.classifier-test
   (:require
-   [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.failure-classifier.interface :as fc]))
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.failure-classifier.interface :as fc]
+   [clojure.test :refer [deftest is testing]]))
 
 ;; ---------------------------------------------------------------------------- Taxonomy tests
 
@@ -134,7 +135,9 @@
 (deftest dependency-constructor-validation-test
   (testing "dependency attribution constructor returns anomaly for missing required fields"
     (let [result (fc/make-dependency-attribution {})]
+      (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
+      (is (inst? (:anomaly/at result)))
       (is (re-find #"Missing required field :failure/source"
                    (:anomaly/message result)))))
 
@@ -142,13 +145,17 @@
     (let [result (fc/make-dependency-attribution
                   {:failure/source :external-provider
                    :dependency/class :bogus})]
+      (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
+      (is (inst? (:anomaly/at result)))
       (is (re-find #"Invalid value for :dependency/class"
                    (:anomaly/message result))))
     (let [result (fc/make-dependency-attribution
                   {:failure/source :external-provider
                    :failure/vendor :bogus})]
+      (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
+      (is (inst? (:anomaly/at result)))
       (is (re-find #"Invalid value for :failure/vendor"
                    (:anomaly/message result)))))
 
@@ -156,14 +163,18 @@
     (let [result (fc/make-classified-dependency-failure
                   {:failure/message "oops"
                    :failure/source :external-provider})]
+      (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
+      (is (inst? (:anomaly/at result)))
       (is (re-find #"Missing required field :failure/class"
                    (:anomaly/message result))))
     (let [result (fc/make-classified-dependency-failure
                   {:failure/class :bogus
                    :failure/message "oops"
                    :failure/source :external-provider})]
+      (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
+      (is (inst? (:anomaly/at result)))
       (is (re-find #"Invalid value for :failure/class"
                    (:anomaly/message result))))))
 

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
@@ -132,40 +132,40 @@
              :failure/context {:phase :plan}})))))
 
 (deftest dependency-constructor-validation-test
-  (testing "dependency attribution constructor rejects missing required fields"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Missing required field :failure/source"
-         (fc/make-dependency-attribution {}))))
+  (testing "dependency attribution constructor returns anomaly for missing required fields"
+    (let [result (fc/make-dependency-attribution {})]
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (re-find #"Missing required field :failure/source"
+                   (:anomaly/message result)))))
 
-  (testing "dependency attribution constructor rejects invalid enum values"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid value for :dependency/class"
-         (fc/make-dependency-attribution
-          {:failure/source :external-provider
-           :dependency/class :bogus})))
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid value for :failure/vendor"
-         (fc/make-dependency-attribution
-          {:failure/source :external-provider
-           :failure/vendor :bogus}))))
+  (testing "dependency attribution constructor returns anomaly for invalid enum values"
+    (let [result (fc/make-dependency-attribution
+                  {:failure/source :external-provider
+                   :dependency/class :bogus})]
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (re-find #"Invalid value for :dependency/class"
+                   (:anomaly/message result))))
+    (let [result (fc/make-dependency-attribution
+                  {:failure/source :external-provider
+                   :failure/vendor :bogus})]
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (re-find #"Invalid value for :failure/vendor"
+                   (:anomaly/message result)))))
 
-  (testing "classified dependency failure constructor rejects invalid required fields"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Missing required field :failure/class"
-         (fc/make-classified-dependency-failure
-          {:failure/message "oops"
-           :failure/source :external-provider})))
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid value for :failure/class"
-         (fc/make-classified-dependency-failure
-          {:failure/class :bogus
-           :failure/message "oops"
-           :failure/source :external-provider})))))
+  (testing "classified dependency failure constructor returns anomaly for invalid required fields"
+    (let [result (fc/make-classified-dependency-failure
+                  {:failure/message "oops"
+                   :failure/source :external-provider})]
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (re-find #"Missing required field :failure/class"
+                   (:anomaly/message result))))
+    (let [result (fc/make-classified-dependency-failure
+                  {:failure/class :bogus
+                   :failure/message "oops"
+                   :failure/source :external-provider})]
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (re-find #"Invalid value for :failure/class"
+                   (:anomaly/message result))))))
 
 ;; ---------------------------------------------------------------------------- Classification by anomaly category
 

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/exception_anomaly_hint_shape_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/exception_anomaly_hint_shape_test.clj
@@ -42,8 +42,9 @@
    and the dispatch test below pins the canonical-hint-only dispatch
    path it relies on."
   (:require
-   [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.failure-classifier.interface :as fc]))
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.failure-classifier.interface :as fc]
+   [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Named literals + test factories.
@@ -72,8 +73,10 @@
   (testing ":anomaly/type :invalid-input is returned by constructor anomaly"
     (let [result (fc/make-classified-failure incomplete-attribution)]
       (is (some? result) "incomplete attribution returns anomaly data")
+      (is (anomaly/anomaly? result) "constructor result satisfies canonical anomaly schema")
       (is (= :invalid-input (:anomaly/type result))
-          "canonical :anomaly/type is set per the runbook generic-standard map")))
+          "canonical :anomaly/type is set per the runbook generic-standard map")
+      (is (inst? (:anomaly/at result)) ":anomaly/at is a construction timestamp")))
 
   (testing "legacy hint keys are absent from the producer anomaly"
     ;; `contains?` (not nil-check) — pre-flip the producer wrote

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/exception_anomaly_hint_shape_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/exception_anomaly_hint_shape_test.clj
@@ -17,13 +17,13 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.failure-classifier.exception-anomaly-hint-shape-test
-  "Lock the anomaly-classification hint shape written into ex-data by
-   the brick's private `invalid-constructor-input` exception builder
+  "Lock the anomaly-classification hint shape returned by
+   the brick's private `invalid-constructor-input` constructor helper
    (taxonomy.clj) after the W2 anomaly convergence flip, and the
    dispatch-equivalence of the new shape against the legacy one.
 
    Pre-flip the builder wrote `:anomaly/category :anomalies/incorrect`
-   into ex-data — the legacy classification key. Post-flip it writes
+   into ex-data — the legacy classification key. Post-flip it returns
    `:anomaly/type :invalid-input` directly, because
    `:anomalies/incorrect` is one of the cognitect-standard categories
    that the convergence runbook maps 1:1 to a generic type with no
@@ -50,7 +50,7 @@
 
 (def ^:private incomplete-attribution
   "Attribution map missing `:failure/class` — triggers
-   `require-field!` → `invalid-constructor-input` through
+   `require-field` -> `invalid-constructor-input` through
    `make-classified-failure`."
   {:failure/message "boom"})
 
@@ -61,37 +61,30 @@
 
 (def ^:private invalid-input-canonical-hint
   "Canonical anomaly hint for the cognitect-standard
-   `:invalid-input` class — what `invalid-constructor-input` writes
-   into ex-data post-flip."
+   `:invalid-input` class — what `invalid-constructor-input` returns
+   post-flip."
   {:anomaly/type :invalid-input})
-
-(defn- catch-ex-data
-  "Run `thunk`, return the ex-data of any thrown ex-info (nil
-   otherwise). Lets the producer assertions stay flat."
-  [thunk]
-  (try (thunk) nil
-       (catch clojure.lang.ExceptionInfo e (ex-data e))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Shape assertions on the post-flip producers.
 
 (deftest invalid-constructor-input-emits-canonical-invalid-input-hint
-  (testing ":anomaly/type :invalid-input is written into ex-data"
-    (let [data (catch-ex-data #(fc/make-classified-failure incomplete-attribution))]
-      (is (some? data) "incomplete attribution throws ex-info")
-      (is (= :invalid-input (:anomaly/type data))
+  (testing ":anomaly/type :invalid-input is returned by constructor anomaly"
+    (let [result (fc/make-classified-failure incomplete-attribution)]
+      (is (some? result) "incomplete attribution returns anomaly data")
+      (is (= :invalid-input (:anomaly/type result))
           "canonical :anomaly/type is set per the runbook generic-standard map")))
 
-  (testing "legacy hint keys are absent from the producer ex-data"
+  (testing "legacy hint keys are absent from the producer anomaly"
     ;; `contains?` (not nil-check) — pre-flip the producer wrote
     ;; `:anomaly/category :anomalies/incorrect`, and `(:anomaly/category
     ;; data)` would also return nil when the key were re-introduced with
     ;; an explicit nil value. Pin absence so a regression to either of
     ;; the legacy producer shapes is caught.
-    (let [data (catch-ex-data #(fc/make-classified-failure incomplete-attribution))]
-      (is (false? (contains? data :anomaly/category))
+    (let [result (fc/make-classified-failure incomplete-attribution)]
+      (is (false? (contains? result :anomaly/category))
           ":anomaly/category key is not present on post-flip producer")
-      (is (false? (contains? data :anomaly/subtype))
+      (is (false? (contains? result :anomaly/subtype))
           ":anomalies/incorrect is cognitect-standard, no subtype key attached"))))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/docs/pull-requests/2026-07-01-chris-failure-taxonomy-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-failure-taxonomy-anomalies.md
@@ -1,0 +1,26 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Failure Taxonomy Constructor Anomalies
+
+## Summary
+
+Return invalid constructor inputs from the failure taxonomy as anomaly
+values instead of exceptions.
+
+## Changes
+
+- Convert taxonomy constructor validation helpers to return
+  `:invalid-input` anomaly maps.
+- Preserve valid constructor return shapes for classified failures and
+  dependency attribution.
+- Update classifier and anomaly-hint tests to assert returned anomaly data.
+
+## Validation
+
+- Direct failure-classifier classifier/anomaly-hint test namespaces
+- Exceptions-as-data scanner target check for
+  `components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Failure Taxonomy Constructor Anomalies

## Summary

Return invalid constructor inputs from the failure taxonomy as anomaly
values instead of exceptions.

## Changes

- Convert taxonomy constructor validation helpers to return
  `:invalid-input` anomaly maps.
- Preserve valid constructor return shapes for classified failures and
  dependency attribution.
- Update classifier and anomaly-hint tests to assert returned anomaly data.

## Validation

- Direct failure-classifier classifier/anomaly-hint test namespaces
- Exceptions-as-data scanner target check for
  `components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj`
