### PR TITLE
Return tool profile validation anomalies as data

### DIFF
--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/tool_profiles.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/tool_profiles.clj
@@ -33,6 +33,7 @@
    `register-profiles!` is itself idempotent (each entry overwrites
    by :tool/id) so re-invocation in tests or after reload is safe."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.progress-detector.interface :as pd]
    [clojure.edn                              :as edn]
    [clojure.java.io                          :as io]))
@@ -79,15 +80,26 @@
    Arguments:
      registry - registry atom (defaults to pd/default-tool-registry)
 
-   Returns: the final registry map."
+   Returns the final registry map on success. If a profile is invalid,
+   returns the first `:invalid-input` anomaly from progress-detector;
+   profiles registered before the anomaly remain registered and later
+   profiles are skipped."
   ([]
    (register-profiles! pd/default-tool-registry))
   ([registry]
-   (last (mapv #(pd/register-tool-profile! registry %) claude-cli-profiles))))
+   (reduce
+    (fn [_ profile]
+      (let [result (pd/register-tool-profile! registry profile)]
+        (if (anomaly/anomaly? result)
+          (reduced result)
+          result)))
+    @registry
+    claude-cli-profiles)))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Load-time contribution
 
+#_{:clj-kondo/ignore [:unused-private-var]}
 (defonce ^:private registered?
   ;; Side-effect at namespace load: contribute the eight profiles to
   ;; the process-wide registry. defonce makes it a one-shot;
@@ -99,7 +111,6 @@
 
 (comment
   ;; Inspect the registered profiles
-  (require '[ai.miniforge.progress-detector.interface :as pd])
   (pd/all-tool-ids)
   ;; => [:tool/Bash :tool/Edit :tool/Glob :tool/Grep :tool/Read
   ;;     :tool/WebFetch :tool/WebSearch :tool/Write]

--- a/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/tool_profiles_test.clj
+++ b/components/adapter-claude-code/test/ai/miniforge/adapter_claude_code/tool_profiles_test.clj
@@ -24,9 +24,10 @@
    default-tool-registry is also asserted, but indirectly — the act
    of requiring `tool-profiles` triggers the defonce side-effect."
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.adapter-claude-code.tool-profiles :as sut]
-   [ai.miniforge.progress-detector.interface :as pd]))
+   [ai.miniforge.progress-detector.interface :as pd]
+   [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Expected-shape constants
@@ -87,6 +88,21 @@
         (sut/register-profiles! registry)
         (is (= after-first @registry)
             "registry value identical after second register call")))))
+
+(deftest register-profiles-propagates-first-anomaly-test
+  (testing "bulk registration returns the first invalid profile anomaly"
+    (let [registry (pd/make-tool-registry)
+          first-profile {:tool/id :tool/First
+                         :determinism :unstable}
+          bad-profile {:tool/id :tool/Bad
+                       :determinism :NOT_VALID}
+          skipped-profile {:tool/id :tool/Skipped
+                           :determinism :unstable}]
+      (with-redefs [sut/claude-cli-profiles [first-profile bad-profile skipped-profile]]
+        (let [result (sut/register-profiles! registry)]
+          (is (anomaly/anomaly? result))
+          (is (= :invalid-input (:anomaly/type result)))
+          (is (= #{:tool/First} (set (pd/all-tool-ids registry)))))))))
 
 (deftest registry-determinism-lookup-test
   (testing "registered profiles answer pd/tool-determinism queries"

--- a/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
@@ -225,7 +225,8 @@
   "Add or overwrite a tool profile in `registry-atom`.
 
    Returns the new registry map on success, or an `:invalid-input`
-   anomaly if the profile fails ToolProfile schema validation.
+   anomaly if the profile is missing `:tool/id` or fails ToolProfile
+   schema validation.
 
    Arguments:
      registry-atom - atom holding the registry (typically the

--- a/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/interface.clj
@@ -224,8 +224,8 @@
 (defn register-tool-profile!
   "Add or overwrite a tool profile in `registry-atom`.
 
-   Throws via ex-info if the profile fails ToolProfile schema
-   validation — caller bug. Returns the new registry map.
+   Returns the new registry map on success, or an `:invalid-input`
+   anomaly if the profile fails ToolProfile schema validation.
 
    Arguments:
      registry-atom - atom holding the registry (typically the

--- a/components/progress-detector/src/ai/miniforge/progress_detector/tool_profile.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/tool_profile.clj
@@ -46,8 +46,8 @@
    should use `make-registry` and pass the result explicitly to the
    2-arity query functions to avoid global state."
   (:require
-   [ai.miniforge.progress-detector.schema :as schema]
-   [ai.miniforge.response.interface :as response]))
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.progress-detector.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Registry construction
@@ -75,20 +75,24 @@
      registry-atom - atom holding the registry map
      profile       - map satisfying the ToolProfile schema
 
-   Returns the new registry map. Throws via ex-info if profile is
-   missing :tool/id or fails schema validation — caller bug."
+   Returns the new registry map on success, or an `:invalid-input`
+   anomaly when profile is missing :tool/id or fails schema validation."
   [registry-atom profile]
   (let [tool-id (:tool/id profile)]
-    (when-not tool-id
-      (response/throw-anomaly! :anomalies/incorrect
-                               "Tool profile must include :tool/id"
-                               {:profile profile}))
-    (when-not (schema/valid-tool-profile? profile)
-      (response/throw-anomaly! :anomalies/incorrect
-                               "Tool profile fails ToolProfile schema validation"
-                               {:profile profile
-                                :errors  (schema/explain-tool-profile profile)})))
-  (swap! registry-atom assoc (:tool/id profile) profile))
+    (cond
+      (nil? tool-id)
+      (anomaly/anomaly :invalid-input
+                       "Tool profile must include :tool/id"
+                       {:profile profile})
+
+      (not (schema/valid-tool-profile? profile))
+      (anomaly/anomaly :invalid-input
+                       "Tool profile fails ToolProfile schema validation"
+                       {:profile profile
+                        :errors  (schema/explain-tool-profile profile)})
+
+      :else
+      (swap! registry-atom assoc tool-id profile))))
 
 (defn unregister!
   [registry-atom tool-id]

--- a/components/progress-detector/test/ai/miniforge/progress_detector/anomaly/progress_detector_anomaly_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/anomaly/progress_detector_anomaly_test.clj
@@ -18,9 +18,10 @@
 
 (ns ai.miniforge.progress-detector.anomaly.progress-detector-anomaly-test
   "Coverage for `event-envelope/validate-observation!`,
-   `config/merge-config`, and `tool-profile/register!` boundary
-   escalation via `response/throw-anomaly!`."
-  (:require [clojure.test :refer [deftest is testing]]
+   `config/merge-config`, and `tool-profile/register!` anomaly return
+   contracts."
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.progress-detector.config :as config]
             [ai.miniforge.progress-detector.event-envelope :as envelope]
             [ai.miniforge.progress-detector.tool-profile :as tool-profile])
@@ -52,23 +53,22 @@
       (is (re-find #"requires at least one layer" (.getMessage thrown)))
       (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
-(deftest register-missing-tool-id-throws-anomaly
-  (testing "profile missing :tool/id raises :anomalies/incorrect"
+(deftest register-missing-tool-id-returns-anomaly
+  (testing "profile missing :tool/id returns :invalid-input"
     (let [registry (atom {})
-          thrown (try (tool-profile/register! registry {})
-                      nil
-                      (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"must include :tool/id" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+          result (tool-profile/register! registry {})]
+      (is (anomaly/anomaly? result))
+      (is (re-find #"must include :tool/id" (:anomaly/message result)))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= {} @registry)))))
 
-(deftest register-invalid-schema-throws-anomaly
-  (testing "profile failing schema validation raises :anomalies/incorrect"
+(deftest register-invalid-schema-returns-anomaly
+  (testing "profile failing schema validation returns :invalid-input"
     (let [registry (atom {})
-          thrown (try (tool-profile/register! registry {:tool/id :bogus
-                                                        :tool/garbage 42})
-                      nil
-                      (catch ExceptionInfo e e))]
-      (is (some? thrown))
-      (is (re-find #"ToolProfile schema validation" (.getMessage thrown)))
-      (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+          result (tool-profile/register! registry {:tool/id :bogus
+                                                   :tool/garbage 42})]
+      (is (anomaly/anomaly? result))
+      (is (re-find #"ToolProfile schema validation" (:anomaly/message result)))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (seq (get-in result [:anomaly/data :errors])))
+      (is (= {} @registry)))))

--- a/components/progress-detector/test/ai/miniforge/progress_detector/interface_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/interface_test.clj
@@ -150,11 +150,12 @@
   (testing "tool-determinism returns :unstable for unregistered tools"
     (is (= :unstable (pd/tool-determinism :tool/Unknown (pd/make-tool-registry)))))
 
-  (testing "register-tool-profile! validates against ToolProfile schema"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (pd/register-tool-profile! (pd/make-tool-registry)
+  (testing "register-tool-profile! returns anomaly data on invalid ToolProfile"
+    (let [result (pd/register-tool-profile! (pd/make-tool-registry)
                                             {:tool/id :tool/Bad
-                                             :determinism :NOT_VALID})))))
+                                             :determinism :NOT_VALID})]
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (seq (get-in result [:anomaly/data :errors]))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Config merge

--- a/components/progress-detector/test/ai/miniforge/progress_detector/tool_profile_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/tool_profile_test.clj
@@ -9,6 +9,7 @@
    The API is registration-based — components contribute profiles via
    register!. There is no built-in EDN-driven default registry."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.progress-detector.tool-profile :as sut]))
 
@@ -59,16 +60,21 @@
       (is (= :stable-with-resource-version
              (sut/determinism-of :tool/Read reg)))))
 
-  (testing "register! throws on profile missing :tool/id"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (sut/register! (sut/make-registry)
-                                {:determinism :unstable}))))
+  (testing "register! returns anomaly data on profile missing :tool/id"
+    (let [reg (sut/make-registry)
+          result (sut/register! reg {:determinism :unstable})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= {} @reg))))
 
-  (testing "register! throws on profile failing schema validation"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (sut/register! (sut/make-registry)
-                                {:tool/id :tool/Bad
-                                 :determinism :NOT_A_VALID_LEVEL})))))
+  (testing "register! returns anomaly data on profile failing schema validation"
+    (let [reg (sut/make-registry)
+          result (sut/register! reg {:tool/id :tool/Bad
+                                     :determinism :NOT_A_VALID_LEVEL})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (seq (get-in result [:anomaly/data :errors])))
+      (is (= {} @reg)))))
 
 (deftest unregister!-test
   (testing "unregister! removes the profile"

--- a/docs/pull-requests/2026-07-01-chris-progress-tool-profile-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-progress-tool-profile-anomalies.md
@@ -22,6 +22,12 @@ response anomalies to canonical anomaly data.
 
 ## Validation
 
-- `clojure -M:dev:test -e '(require ...progress-detector tests...) ...'`
+- `clojure -M:dev:test -e '(require (quote clojure.test) (quote ai.miniforge.progress-detector.tool-profile-test) (quote
+  ai.miniforge.progress-detector.anomaly.progress-detector-anomaly-test) (quote
+  ai.miniforge.progress-detector.interface-test) (quote ai.miniforge.adapter-claude-code.tool-profiles-test)) (let [r
+  (clojure.test/run-tests (quote ai.miniforge.progress-detector.tool-profile-test) (quote
+  ai.miniforge.progress-detector.anomaly.progress-detector-anomaly-test) (quote
+  ai.miniforge.progress-detector.interface-test) (quote ai.miniforge.adapter-claude-code.tool-profiles-test))] (when
+  (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
 - `clj-kondo --lint` on changed progress-detector files
 - `bb pre-commit`

--- a/docs/pull-requests/2026-07-01-chris-progress-tool-profile-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-progress-tool-profile-anomalies.md
@@ -1,0 +1,27 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Progress Detector Tool Profile Anomalies
+
+## Summary
+
+Convert progress-detector tool profile registration validation from thrown
+response anomalies to canonical anomaly data.
+
+## Changes
+
+- Return `:invalid-input` anomaly maps when `register!` receives a profile
+  missing `:tool/id` or failing the `ToolProfile` schema.
+- Preserve successful registration behavior: valid profiles still return the
+  updated registry map.
+- Update public interface documentation and regression tests to assert the
+  data-returning contract.
+
+## Validation
+
+- `clojure -M:dev:test -e '(require ...progress-detector tests...) ...'`
+- `clj-kondo --lint` on changed progress-detector files
+- `bb pre-commit`


### PR DESCRIPTION
## Summary
- return canonical :invalid-input anomalies from progress-detector tool profile registration validation
- keep successful registration returning the updated registry map
- update interface docs and regression tests for the data-returning contract

## Validation
- clojure -M:dev:test targeted progress-detector tests
- clj-kondo --lint changed progress-detector files
- bb pre-commit