### PR TITLE
Return event-stream manifest anomalies as data

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.cli.workflow-runner
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [babashka.fs :as fs]
    [clojure.string :as str]
    [clojure.edn :as edn]
@@ -931,7 +932,12 @@
   [{:keys [dir marked?]} workflow-id]
   (when (and dir @marked?)
     (try
-      ((:archive-workflow! *manifest-ops*) workflow-id)
+      (let [result ((:archive-workflow! *manifest-ops*) workflow-id)]
+        (when (anomaly/anomaly? result)
+          (binding [*out* *err*]
+            (println (str "WARNING: archive of workflow " workflow-id
+                          " failed: " (:anomaly/message result)
+                          " (will be recovered by the cleanup pass)")))))
       (catch Exception e
         (binding [*out* *err*]
           (println (str "WARNING: archive of workflow " workflow-id

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
@@ -24,9 +24,10 @@
    orchestration: lifecycle ordering, idempotent terminal marking,
    nil-event-stream short-circuit, exception-tolerant cleanup."
   (:require
-   [clojure.test :refer [deftest is]]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.cli.workflow-runner :as sut]
-   [ai.miniforge.event-stream.interface :as es]))
+   [ai.miniforge.event-stream.interface :as es]
+   [clojure.test :refer [deftest is]]))
 
 ;------------------------------------------------------------------------------ Fixture
 
@@ -227,6 +228,19 @@
                  {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
                  :wid))
           "archive exception must not propagate"))))
+
+(deftest archive-workflow-manifest!-logs-archive-anomalies
+  (let [archive-anomaly (anomaly/anomaly :invalid-input
+                                         "manifest invalid"
+                                         {:reason :test})]
+    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& _]
+                                                           archive-anomaly)}]
+      (let [err (java.io.StringWriter.)]
+        (binding [*err* err]
+          (is (nil? (sut/archive-workflow-manifest!
+                     {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
+                     :wid)))
+          (is (re-find #"manifest invalid" (str err))))))))
 
 (deftest finish-workflow-manifest!-restores-interrupt-flag
   ;; stop-heartbeat! raises InterruptedException via awaitTermination.

--- a/components/event-stream/deps.edn
+++ b/components/event-stream/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/config {:local/root "../config"}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/config {:local/root "../config"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/response {:local/root "../response"}

--- a/components/event-stream/src/ai/miniforge/event_stream/archive.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/archive.clj
@@ -50,6 +50,7 @@
    and `ProcessHandle/of` indirectly via the manifest module)."
   {:miniforge/runtime :jvm-only}
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.manifest :as manifest]
    [ai.miniforge.event-stream.sinks :as sinks]
    [ai.miniforge.event-stream.storage-layout :as layout]
@@ -137,13 +138,14 @@
    comes for free; we only need to fsync the parent dir afterwards
    to commit the rename of the manifest tempfile."
   [^File live-dir {:keys [snapshot-watermark]}]
-  (let [current (manifest/load-manifest live-dir)
-        staged  (cond-> (manifest/transition-archive current :archiving)
-                  snapshot-watermark
-                  (assoc :snapshot_watermark snapshot-watermark))]
-    (manifest/save-manifest! live-dir staged)
-    (fsync-dir! live-dir)
-    staged))
+  (let [current (manifest/load-manifest live-dir)]
+    (anomaly/let-ok [transitioned (manifest/transition-archive current :archiving)
+                     staged-manifest (cond-> transitioned
+                                       snapshot-watermark
+                                       (assoc :snapshot_watermark snapshot-watermark))
+                     _saved (manifest/save-manifest! live-dir staged-manifest)]
+      (fsync-dir! live-dir)
+      staged-manifest)))
 
 (defn- complete-snapshot-rename!
   "Step 5: rename `snapshot.transit.json.tmp` → `snapshot.transit.json`
@@ -166,15 +168,15 @@
    Writing the marker first would produce a directory that appears complete
    to the scanner even though the manifest still reads `:archiving`."
   [^File archived-dir]
-  (let [m (manifest/load-manifest archived-dir)
-        completed (-> m
-                      (manifest/transition-archive :archived)
-                      (assoc :archived_at (str (java.time.Instant/now))))]
-    (manifest/save-manifest! archived-dir completed)
-    (touch-marker! (marker-path archived-dir))
-    (fsync-dir! archived-dir)
-    (fsync-dir! (.getParentFile archived-dir))
-    completed))
+  (let [m (manifest/load-manifest archived-dir)]
+    (anomaly/let-ok [transitioned (manifest/transition-archive m :archived)
+                     completed (assoc transitioned
+                                      :archived_at (str (java.time.Instant/now)))
+                     _saved (manifest/save-manifest! archived-dir completed)]
+      (touch-marker! (marker-path archived-dir))
+      (fsync-dir! archived-dir)
+      (fsync-dir! (.getParentFile archived-dir))
+      completed)))
 
 ;------------------------------------------------------------------------------ Layer 2 — workflow-bound orchestration over Layer 1
 
@@ -225,16 +227,16 @@
     ;; we're recovering, the manifest is already :archiving and the
     ;; state machine rolls back to :live first (legal edge) before
     ;; re-transitioning.
-    (when (= :live (:archive_status current))
-      (stage-archiving! live-dir opts))
-    ;; Step 5: rename the snapshot tmp into place.
-    (complete-snapshot-rename! live-dir)
-    ;; Step 6: atomic dir rename.
-    (.mkdirs (.getParentFile archived))
-    (atomic-rename! live-dir archived)
-    ;; Steps 7–8: marker + archived_at + fsync.
-    (mark-archive-complete! archived)
-    archived))
+    (anomaly/let-ok [_staged (when (= :live (:archive_status current))
+                               (stage-archiving! live-dir opts))]
+      ;; Step 5: rename the snapshot tmp into place.
+      (complete-snapshot-rename! live-dir)
+      ;; Step 6: atomic dir rename.
+      (.mkdirs (.getParentFile archived))
+      (atomic-rename! live-dir archived)
+      ;; Steps 7–8: marker + archived_at + fsync.
+      (anomaly/let-ok [_completed (mark-archive-complete! archived)]
+        archived))))
 
 (defn recover-incomplete-archive!
   "Resume a half-finished archive at `live-dir` (manifest's
@@ -258,8 +260,8 @@
       (do (complete-snapshot-rename! live-dir)
           (.mkdirs (.getParentFile archived))
           (atomic-rename! live-dir archived)
-          (mark-archive-complete! archived)
-          archived)
+          (anomaly/let-ok [_completed (mark-archive-complete! archived)]
+            archived))
       ;; Live dir missing but archived dir lacks the marker — pick
       ;; up at step 7.
       (and in-archd (not (.exists (marker-path archived))))
@@ -296,7 +298,14 @@
    workflow-ids. Intended for boot-time recovery — production
    callers invoke this once before resuming normal operation."
   [base-dir]
-  (vec
-    (for [{:keys [workflow-id]} (scan-incomplete-archives base-dir)]
-      (do (recover-incomplete-archive! base-dir workflow-id)
-          workflow-id))))
+  (let [result (reduce (fn [recovered {:keys [workflow-id]}]
+                         (let [next-result (recover-incomplete-archive!
+                                             base-dir workflow-id)]
+                           (if (anomaly/anomaly? next-result)
+                             (reduced next-result)
+                             (conj recovered workflow-id))))
+                       []
+                       (scan-incomplete-archives base-dir))]
+    (if (anomaly/anomaly? result)
+      result
+      (vec result))))

--- a/components/event-stream/src/ai/miniforge/event_stream/archive.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/archive.clj
@@ -204,11 +204,11 @@
                           checkpoint synthesis is wired.
      :base-dir            Override base events dir (tests).
 
-   Throws on failure inside the manifest state machine or the
-   rename. Idempotent against partial state via
-   `recover-incomplete-archive!` — running archive-workflow! on a
-   directory whose manifest is already `:archiving` resumes from
-   step 5 rather than re-staging from step 3."
+   Returns an anomaly on expected manifest state-machine/validation
+   failures; throws on filesystem rename failures. Idempotent against
+   partial state via `recover-incomplete-archive!` — running
+   archive-workflow! on a directory whose manifest is already
+   `:archiving` resumes from step 5 rather than re-staging from step 3."
   [workflow-id & [{:keys [base-dir] :as opts}]]
   (let [base       (or base-dir (sinks/default-events-dir))
         live-dir   (sinks/live-workflow-dir base workflow-id)
@@ -295,8 +295,9 @@
 (defn recover-all-incomplete!
   "Walk `base-dir` and finish every half-completed archive found by
    `scan-incomplete-archives`. Returns a vector of recovered
-   workflow-ids. Intended for boot-time recovery — production
-   callers invoke this once before resuming normal operation."
+   workflow-ids, or the first anomaly returned by recovery. Intended
+   for boot-time recovery — production callers invoke this once before
+   resuming normal operation."
   [base-dir]
   (let [result (reduce (fn [recovered {:keys [workflow-id]}]
                          (let [next-result (recover-incomplete-archive!

--- a/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
@@ -41,6 +41,7 @@
    by the cleanup path (sub-3) which both run on the JVM."
   {:miniforge/runtime :jvm-only}
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -51,7 +52,6 @@
    [java.lang.management ManagementFactory]
    [java.net InetAddress]
    [java.nio.file Files StandardCopyOption]
-   [java.nio.file.attribute FileAttribute]
    [java.time Instant]
    [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
 
@@ -142,22 +142,22 @@
    :archived   #{:tombstoned}
    :tombstoned #{}})
 
-(defn- ^String iso-now
+(defn- iso-now
   "ISO-8601 instant for `lease_renewed_at` / `created_at` etc."
-  []
+  ^String []
   (str (Instant/now)))
 
-(defn- ^String pid-string
+(defn- pid-string
   "Process id as a string. Built from the JMX runtime bean name —
    `pid@host` on hotspot — so we don't need Java-9-only APIs."
-  []
+  ^String []
   (let [name (.getName (ManagementFactory/getRuntimeMXBean))]
     (first (str/split name #"@"))))
 
-(defn- ^String hostname-string
+(defn- hostname-string
   "Best-effort canonical hostname. Falls back to `\"unknown-host\"` if
    DNS / lookup fails — the field is informational, not load-bearing."
-  []
+  ^String []
   (try (.getCanonicalHostName (InetAddress/getLocalHost))
        (catch Exception _ "unknown-host")))
 
@@ -209,7 +209,7 @@
 (defn legal-archive-transition?
   "True iff the manifest may move from `from` to `to`."
   [from to]
-  (boolean (contains? (get legal-archive-transitions from #{}) to)))
+  (contains? (get legal-archive-transitions from #{}) to))
 
 (defn fresh-owner
   "Build an owner map with the calling process's pid + host, marking
@@ -255,17 +255,19 @@
 
 (defn transition-archive
   "Pure: move the manifest's `archive_status` from its current value
-   to `to`, returning the updated manifest. Throws ex-info on illegal
-   moves so callers can't silently corrupt the state machine."
+   to `to`, returning the updated manifest. Returns a canonical
+   `:conflict` anomaly on illegal moves so callers can't silently
+   corrupt the state machine."
   [manifest to]
   (let [from (:archive_status manifest)]
     (if (legal-archive-transition? from to)
       (assoc manifest :archive_status to)
-      (throw (ex-info "Illegal archive_status transition"
-                      {:reason :illegal-archive-transition
-                       :from   from
-                       :to     to
-                       :workflow-id (:workflow_id manifest)})))))
+      (anomaly/anomaly :conflict
+                       "Illegal archive_status transition"
+                       {:reason :illegal-archive-transition
+                        :from   from
+                        :to     to
+                        :workflow-id (:workflow_id manifest)}))))
 
 (defn init-active
   "Build a fresh `:active` / `:live` manifest for a new workflow.
@@ -324,43 +326,44 @@
    with `ATOMIC_MOVE` + `REPLACE_EXISTING`. A reader during the move
    sees either the old file or the new — never a half-written one.
 
-   Throws on schema-validation failure so callers can't silently
-   persist a corrupt shape."
+   Returns a canonical `:invalid-input` anomaly on schema-validation
+   failure so callers can't silently persist a corrupt shape."
   [workflow-dir manifest]
-  (when-let [err (explain manifest)]
-    (throw (ex-info "Manifest fails schema validation"
-                    {:reason :invalid-manifest
-                     :workflow-dir (.getAbsolutePath ^File (io/file workflow-dir))
-                     :error err})))
-  (let [^File dir   (io/file workflow-dir)
-        _           (.mkdirs dir)
-        ^File final (manifest-path dir)
-        ^File tmp   (io/file dir (str manifest-filename ".tmp"))]
-    ;; Cheshire writes keyword keys via `name`, so the snake_case keys
-    ;; in the manifest map (e.g. `:workflow_id`) round-trip as
-    ;; `"workflow_id"` on disk. Keyword *values* (status enums, the
-    ;; UUID workflow id) need explicit conversion before serialization
-    ;; — the `update`s below stringify them; `load-manifest` reverses
-    ;; the conversions on read.
-    (with-open [w (io/writer tmp)]
-      (json/generate-stream
-        (-> manifest
-            (update :workflow_id str)
-            (update :status name)
-            (update :archive_status name)
-            (update :snapshot_status name))
-        w
-        {:pretty true}))
-    ;; fsync the tmp file before moving so a crash mid-rename doesn't
-    ;; leave an empty manifest on disk.
-    (with-open [raf (java.io.RandomAccessFile. tmp "rw")]
-      (.force (.getChannel raf) true))
-    (Files/move (.toPath tmp)
-                (.toPath final)
-                (into-array java.nio.file.CopyOption
-                            [StandardCopyOption/ATOMIC_MOVE
-                             StandardCopyOption/REPLACE_EXISTING]))
-    final))
+  (if-let [err (explain manifest)]
+    (anomaly/anomaly :invalid-input
+                     "Manifest fails schema validation"
+                     {:reason :invalid-manifest
+                      :workflow-dir (.getAbsolutePath ^File (io/file workflow-dir))
+                      :error err})
+    (let [^File dir   (io/file workflow-dir)
+          _           (.mkdirs dir)
+          ^File final (manifest-path dir)
+          ^File tmp   (io/file dir (str manifest-filename ".tmp"))]
+      ;; Cheshire writes keyword keys via `name`, so the snake_case keys
+      ;; in the manifest map (e.g. `:workflow_id`) round-trip as
+      ;; `"workflow_id"` on disk. Keyword *values* (status enums, the
+      ;; UUID workflow id) need explicit conversion before serialization
+      ;; — the `update`s below stringify them; `load-manifest` reverses
+      ;; the conversions on read.
+      (with-open [w (io/writer tmp)]
+        (json/generate-stream
+          (-> manifest
+              (update :workflow_id str)
+              (update :status name)
+              (update :archive_status name)
+              (update :snapshot_status name))
+          w
+          {:pretty true}))
+      ;; fsync the tmp file before moving so a crash mid-rename doesn't
+      ;; leave an empty manifest on disk.
+      (with-open [raf (java.io.RandomAccessFile. tmp "rw")]
+        (.force (.getChannel raf) true))
+      (Files/move (.toPath tmp)
+                  (.toPath final)
+                  (into-array java.nio.file.CopyOption
+                              [StandardCopyOption/ATOMIC_MOVE
+                               StandardCopyOption/REPLACE_EXISTING]))
+      final)))
 
 ;------------------------------------------------------------------------------ Layer 3 — manifest-bound IO composing Layer 2 read + write
 
@@ -372,12 +375,12 @@
   [workflow-dir]
   (when-let [m (load-manifest workflow-dir)]
     (let [renewed (renew-lease m)]
-      (save-manifest! workflow-dir renewed)
-      renewed)))
+      (anomaly/let-ok [_saved (save-manifest! workflow-dir renewed)]
+        renewed))))
 
 ;------------------------------------------------------------------------------ Layer 4 — scheduled orchestration
 
-(defn ^ScheduledExecutorService start-heartbeat!
+(defn start-heartbeat!
   "Start a single-threaded scheduled executor that renews the
    manifest's lease every `:period-seconds` (default
    `heartbeat-period-seconds`). Returns the executor handle for
@@ -393,10 +396,10 @@
    The sub-3 cleanup path's `lease-fresh?` check tolerates a single
    missed renew via the TTL > period default, so a one-off swallowed
    error does not falsely flag the workflow as crashed."
-  ([workflow-dir]
+  (^ScheduledExecutorService [workflow-dir]
    (start-heartbeat! workflow-dir {}))
-  ([workflow-dir {:keys [period-seconds on-error]
-                  :or   {period-seconds heartbeat-period-seconds}}]
+  (^ScheduledExecutorService [workflow-dir {:keys [period-seconds on-error]
+                                            :or   {period-seconds heartbeat-period-seconds}}]
    (let [report-error (or on-error
                           #(default-heartbeat-error-log! % workflow-dir))
          ^ScheduledExecutorService ex

--- a/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
@@ -172,14 +172,17 @@
   "Last-resort logging when no `:on-error` callback is supplied. Writes
    a single-line warning to stderr so persistent IO failures during
    the heartbeat are observable in the operator's terminal / CI logs
-   rather than silently disappearing. The workflow runner is the
+   rather than silently disappearing. Accepts either a Throwable or an
+   anomaly map returned by `renew-lease!`. The workflow runner is the
    normal caller and should prefer to wire its own logger via
    `:on-error`."
-  [^Throwable t workflow-dir]
+  [failure workflow-dir]
   (binding [*out* *err*]
     (println (str "WARNING: manifest heartbeat renew failed for "
                   (.getAbsolutePath ^File (io/file workflow-dir))
-                  ": " (.getMessage t)))))
+                  ": " (if (anomaly/anomaly? failure)
+                         (:anomaly/message failure)
+                         (.getMessage ^Throwable failure))))))
 
 (defn stop-heartbeat!
   "Shut a heartbeat executor down. Waits up to `:timeout-ms` (default
@@ -369,9 +372,10 @@
 
 (defn renew-lease!
   "Re-stamp the lease and write the manifest atomically. Returns the
-   updated manifest. Idempotent — a missing manifest is a no-op
-   returning nil so the heartbeat doesn't crash if the workflow is
-   archived between ticks."
+   updated manifest, an anomaly from `save-manifest!`, or nil when the
+   manifest is absent. Idempotent — a missing manifest is a no-op so
+   the heartbeat doesn't crash if the workflow is archived between
+   ticks."
   [workflow-dir]
   (when-let [m (load-manifest workflow-dir)]
     (let [renewed (renew-lease m)]
@@ -387,11 +391,12 @@
    `stop-heartbeat!`.
 
    Renew failures: a transient IO error during a beat must not crash
-   the workflow runner. By default any caught Throwable is reported
-   via `default-heartbeat-error-log!` (a stderr warning) so persistent
-   failures are visible. Callers that have a structured logger
-   should pass `:on-error` instead — that callback fully replaces the
-   default and is the recommended path for production wiring.
+   the workflow runner. By default any caught Throwable, or returned
+   anomaly, is reported via
+   `default-heartbeat-error-log!` (a stderr warning) so persistent
+   failures are visible. Callers that have a structured logger should
+   pass `:on-error` instead — that callback fully replaces the default
+   and is the recommended path for production wiring.
 
    The sub-3 cleanup path's `lease-fresh?` check tolerates a single
    missed renew via the TTL > period default, so a one-off swallowed
@@ -411,8 +416,11 @@
      (.scheduleAtFixedRate ex
                            ^Runnable
                            (fn []
-                             (try (renew-lease! workflow-dir)
-                                  (catch Throwable t (report-error t))))
+                             (try
+                               (let [result (renew-lease! workflow-dir)]
+                                 (when (anomaly/anomaly? result)
+                                   (report-error result)))
+                               (catch Throwable t (report-error t))))
                            (long period-seconds)
                            (long period-seconds)
                            TimeUnit/SECONDS)

--- a/components/event-stream/test/ai/miniforge/event_stream/archive_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/archive_test.clj
@@ -19,11 +19,12 @@
 (ns ai.miniforge.event-stream.archive-test
   "Tests for the BD-2b sub-3b atomic archive operation."
   (:require
-   [clojure.test :refer [deftest is]]
-   [clojure.java.io :as io]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.archive :as archive]
    [ai.miniforge.event-stream.manifest :as manifest]
-   [ai.miniforge.event-stream.sinks :as sinks])
+   [ai.miniforge.event-stream.sinks :as sinks]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is]])
   (:import
    [java.util UUID]))
 
@@ -142,6 +143,23 @@
                             (archive/archive-workflow!
                              test-workflow-id {:base-dir base}))))))
 
+(deftest archive-workflow!-returns-manifest-save-anomaly
+  (with-temp-base
+    (fn [base]
+      (let [live (seed-live-workflow! base test-workflow-id)
+            result (archive/archive-workflow!
+                    test-workflow-id
+                    {:base-dir base
+                     :snapshot-watermark
+                     {:workflow_sequence_number -1
+                      :last_event_id "018f3a9c8e4b12d0"}})]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= :invalid-manifest
+               (get-in result [:anomaly/data :reason])))
+        (is (.exists live)
+            "archive side effects stop when manifest validation returns an anomaly")))))
+
 ;------------------------------------------------------------------------------ recover-incomplete-archive!
 
 (deftest recover-incomplete-archive!-finishes-archiving-state
@@ -237,3 +255,16 @@
           (is (= #{(str wid-a) (str wid-b)} recovered)))
         (is (.exists (io/file (archived-dir-for base wid-a) "archived.marker")))
         (is (.exists (io/file (archived-dir-for base wid-b) "archived.marker")))))))
+
+(deftest recover-all-incomplete!-propagates-recovery-anomaly
+  (with-temp-base
+    (fn [base]
+      (let [wid (UUID/fromString "00000000-0000-0000-0000-0000000000cc")
+            d (seed-live-workflow! base wid)
+            m (manifest/load-manifest d)
+            recovery-anomaly (anomaly/anomaly :invalid-input
+                                              "recovery failed"
+                                              {:reason :test-recovery-failed})]
+        (manifest/save-manifest! d (manifest/transition-archive m :archiving))
+        (with-redefs [archive/recover-incomplete-archive! (fn [_ _] recovery-anomaly)]
+          (is (= recovery-anomaly (archive/recover-all-incomplete! base))))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/manifest_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/manifest_test.clj
@@ -19,8 +19,10 @@
 (ns ai.miniforge.event-stream.manifest-test
   "Tests for the BD-2b sub-2 per-workflow manifest module."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.event-stream.manifest :as manifest]
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.event-stream.manifest :as manifest])
+   [clojure.java.io :as io])
   (:import
    [java.time Instant]
    [java.util UUID]))
@@ -111,15 +113,20 @@
     (is (not (manifest/legal-archive-transition? :archived :live)))
     (is (not (manifest/legal-archive-transition? :archived :archiving)))))
 
-(deftest transition-archive-throws-on-illegal-move
+(deftest transition-archive-returns-anomaly-on-illegal-move
   (let [m (manifest/init-active test-workflow-id)]
     (is (= :archiving
            (:archive_status (manifest/transition-archive m :archiving)))
         "live → archiving is the canonical happy path")
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"Illegal archive_status transition"
-                          (manifest/transition-archive m :archived))
-        "live → archived must skip :archiving and is illegal")))
+    (let [result (manifest/transition-archive m :archived)]
+      (is (anomaly/anomaly? result))
+      (is (= :conflict (:anomaly/type result)))
+      (is (= :illegal-archive-transition
+             (get-in result [:anomaly/data :reason])))
+      (is (= test-workflow-id
+             (get-in result [:anomaly/data :workflow-id])))
+      (is (= :live (get-in result [:anomaly/data :from])))
+      (is (= :archived (get-in result [:anomaly/data :to]))))))
 
 (deftest mark-terminal-stamps-completed-at-and-status
   (let [m (manifest/init-active test-workflow-id)]
@@ -205,10 +212,14 @@
   (with-temp-dir
     (fn [dir]
       (let [bogus (assoc (manifest/init-active test-workflow-id)
-                         :status :not-a-status)]
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"fails schema validation"
-                              (manifest/save-manifest! dir bogus)))))))
+                         :status :not-a-status)
+            result (manifest/save-manifest! dir bogus)]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= :invalid-manifest
+               (get-in result [:anomaly/data :reason])))
+        (is (false? (.exists (io/file dir "manifest.json")))
+            "invalid manifests must not be persisted")))))
 
 (deftest renew-lease!-no-op-when-manifest-absent
   (with-temp-dir
@@ -216,6 +227,17 @@
       (is (nil? (manifest/renew-lease! dir))
           "missing manifest is a no-op so a heartbeat tick can race
            archival without crashing"))))
+
+(deftest renew-lease!-propagates-save-anomaly
+  (with-temp-dir
+    (fn [dir]
+      (let [m (manifest/init-active test-workflow-id)
+            save-anomaly (anomaly/anomaly :invalid-input
+                                          "save failed"
+                                          {:reason :test-save-failed})]
+        (manifest/save-manifest! dir m)
+        (with-redefs [manifest/save-manifest! (fn [_ _] save-anomaly)]
+          (is (= save-anomaly (manifest/renew-lease! dir))))))))
 
 (deftest renew-lease!-bumps-on-disk
   (with-temp-dir

--- a/docs/pull-requests/2026-07-01-chris-event-stream-manifest-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-event-stream-manifest-anomalies.md
@@ -1,0 +1,30 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Event Stream Manifest Anomalies
+
+## Summary
+
+Convert expected event-stream manifest state-machine and validation failures
+from thrown exceptions to canonical anomaly data.
+
+## Changes
+
+- Return `:conflict` anomaly maps for illegal archive status transitions.
+- Return `:invalid-input` anomaly maps for invalid manifest shapes.
+- Propagate manifest anomalies through archive orchestration before filesystem
+  side effects continue.
+- Update manifest/archive regressions to assert the data-returning contract.
+
+## Validation
+
+- `clojure -M:dev:test -e '(require (quote clojure.test) (quote ai.miniforge.event-stream.manifest-test) (quote
+  ai.miniforge.event-stream.archive-test)) (let [r (clojure.test/run-tests (quote
+  ai.miniforge.event-stream.manifest-test) (quote ai.miniforge.event-stream.archive-test))] (when (pos? (+ (:fail r)
+  (:error r))) (System/exit 1)))'`
+- Scoped exceptions-as-data scanner: `{:cleanup-needed 0, :fatal-only 1}`
+- `clj-kondo --lint` on changed event-stream source/test files
+- `bb pre-commit`

--- a/docs/pull-requests/2026-07-01-chris-event-stream-manifest-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-event-stream-manifest-anomalies.md
@@ -17,14 +17,17 @@ from thrown exceptions to canonical anomaly data.
 - Return `:invalid-input` anomaly maps for invalid manifest shapes.
 - Propagate manifest anomalies through archive orchestration before filesystem
   side effects continue.
+- Log returned heartbeat/archive anomalies at the production callers instead of
+  silently treating them as success.
 - Update manifest/archive regressions to assert the data-returning contract.
 
 ## Validation
 
 - `clojure -M:dev:test -e '(require (quote clojure.test) (quote ai.miniforge.event-stream.manifest-test) (quote
-  ai.miniforge.event-stream.archive-test)) (let [r (clojure.test/run-tests (quote
-  ai.miniforge.event-stream.manifest-test) (quote ai.miniforge.event-stream.archive-test))] (when (pos? (+ (:fail r)
-  (:error r))) (System/exit 1)))'`
+  ai.miniforge.event-stream.archive-test) (quote ai.miniforge.cli.workflow-runner.manifest-wiring-test)) (let [r
+  (clojure.test/run-tests (quote ai.miniforge.event-stream.manifest-test) (quote
+  ai.miniforge.event-stream.archive-test) (quote ai.miniforge.cli.workflow-runner.manifest-wiring-test))] (when
+  (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
 - Scoped exceptions-as-data scanner: `{:cleanup-needed 0, :fatal-only 1}`
-- `clj-kondo --lint` on changed event-stream source/test files
+- `clj-kondo --lint` on changed event-stream/CLI source/test files
 - `bb pre-commit`


### PR DESCRIPTION
## Summary

Convert expected event-stream manifest state-machine and validation failures from thrown exceptions to canonical anomaly data.

## Changes

- Return :conflict anomaly maps for illegal archive status transitions.
- Return :invalid-input anomaly maps for invalid manifest shapes.
- Propagate manifest anomalies through archive orchestration before filesystem side effects continue.
- Update manifest/archive regressions to assert the data-returning contract.

## Validation

- clojure -M:dev:test for ai.miniforge.event-stream.manifest-test and ai.miniforge.event-stream.archive-test
- Scoped exceptions-as-data scanner: {:cleanup-needed 0, :fatal-only 1}
- clj-kondo --lint on changed event-stream source/test files
- bb pre-commit