### PR TITLE
Return workflow resume anomalies as data

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -74,6 +74,7 @@
    ;; GROUP 3b: timeline-based events show
    [ai.miniforge.cli.main.commands.events :as cmd-events]
    [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.mcp-context-server.interface :as mcp-context-server]
    [ai.miniforge.pr-train.interface :as pr-train]
@@ -245,6 +246,8 @@
         events (es/read-workflow-events-by-id events-dir workflow-id)
         reconstructed (wr/reconstruct-context events-dir workflow-id)
         last-event (last events)]
+    (when (anomaly/anomaly? reconstructed)
+      (throw (ex-info (:anomaly/message reconstructed) reconstructed)))
     {:workflow-id workflow-id
      :status (reconstructed-status reconstructed (:event/timestamp last-event))
      :spec-name (some-> reconstructed :workflow-spec :name)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -20,7 +20,7 @@
   "CLI adapter for workflow resume.
 
    Domain logic lives in the `workflow-resume` component — this
-   namespace is the thin CLI shell: parses args, wires runtime
+  namespace is the thin CLI shell: parses args, wires runtime
    (event-stream, supervisory, LLM client), prints progress, invokes
    `run-pipeline` on the trimmed workflow.
 
@@ -28,6 +28,7 @@
    — for backward compatibility — via the `--resume <id>` flag on
    `mf run`."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.display :as display]
@@ -58,6 +59,20 @@
    CLI boundary without dynamic namespace resolution."
   workflow/run-pipeline)
 
+(defn- anomaly-category
+  [a]
+  (case (:anomaly/type a)
+    :not-found :anomalies/not-found
+    :invalid-input :anomalies/incorrect
+    :anomalies/fault))
+
+(defn- throw-resume-anomaly!
+  [a]
+  (when (anomaly/anomaly? a)
+    (response/throw-anomaly! (anomaly-category a)
+                             (:anomaly/message a)
+                             (:anomaly/data a))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Thin delegations kept for compatibility with existing callers/tests
 
@@ -73,9 +88,11 @@
    default selection profile as fallback. Thin wrapper over the
    component's `resolve-workflow-identity`."
   [reconstructed]
-  (wr/resolve-workflow-identity
-    reconstructed
-    #(selection-config/resolve-selection-profile :default)))
+  (let [result (wr/resolve-workflow-identity
+                reconstructed
+                #(selection-config/resolve-selection-profile :default))]
+    (throw-resume-anomaly! result)
+    result))
 
 ;------------------------------------------------------------------------------ Layer 1.5
 ;; Status semantics
@@ -117,7 +134,8 @@
         _ (when-not quiet
             (display/print-info (messages/t :resume/resuming
                                             {:workflow-id workflow-id})))
-        reconstructed (wr/reconstruct-context events-dir (str workflow-id))]
+        reconstructed (wr/reconstruct-context events-dir (str workflow-id))
+        _ (throw-resume-anomaly! reconstructed)]
 
     (if (:completed? reconstructed)
       (do (display/print-info (messages/t :resume/already-completed)) nil)
@@ -133,7 +151,9 @@
                   (messages/t :resume/events-found
                               {:count (:event-count reconstructed)})))
 
-            {:keys [workflow-type workflow-version]} (resolve-resume-workflow reconstructed)
+            identity (resolve-resume-workflow reconstructed)
+            _ (throw-resume-anomaly! identity)
+            {:keys [workflow-type workflow-version]} identity
             {:keys [workflow]} (load-workflow workflow-type workflow-version {})
 
             machine-snapshot (:machine-snapshot reconstructed)
@@ -141,6 +161,7 @@
             resume-workflow (if (and machine-snapshot (not failed-checkpoint?))
                               workflow
                               (wr/trim-pipeline workflow completed-phases))
+            _ (throw-resume-anomaly! resume-workflow)
             remaining-pipeline (:workflow/pipeline resume-workflow)
             resume-run-id (or (:execution/id machine-snapshot) (random-uuid))
             _ (when-not quiet

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -71,7 +71,10 @@
   (when (anomaly/anomaly? a)
     (response/throw-anomaly! (anomaly-category a)
                              (:anomaly/message a)
-                             (:anomaly/data a))))
+                             (merge (:anomaly/data a)
+                                    (select-keys a [:anomaly/type
+                                                    :anomaly/subtype
+                                                    :anomaly/at])))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Thin delegations kept for compatibility with existing callers/tests

--- a/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
@@ -18,6 +18,8 @@
 
 (ns ai.miniforge.cli.main.commands.resume-test
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [clojure.test :refer [deftest is testing]]
    [clojure.java.io :as io]
    [cheshire.core :as json]
@@ -28,8 +30,8 @@
    [ai.miniforge.cli.workflow-selection-config :as selection-config]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.supervisory-state.interface :as supervisory]
-   [ai.miniforge.automation-edge-correlator.interface :as correlator]
-   [ai.miniforge.workflow-resume.interface :as wr]))
+   [ai.miniforge.workflow-resume.interface :as wr]
+   [slingshot.slingshot :refer [try+]]))
 
 (deftest resolve-resume-workflow-test
   (testing "recorded workflow spec wins over configured fallback"
@@ -58,6 +60,19 @@
            clojure.lang.ExceptionInfo
            #"Could not resolve a workflow type for resume"
            (sut/resolve-resume-workflow {}))))))
+
+(deftest throw-resume-anomaly-preserves-canonical-metadata-test
+  (testing "CLI escalation keeps the original return-value anomaly fields"
+    (let [source (anomaly/anomaly :invalid-input
+                                  "Invalid resume request"
+                                  {:workflow-id "bad"})
+          thrown (try+
+                  (#'sut/throw-resume-anomaly! source)
+                  (catch [:anomaly/category :anomalies/incorrect] m m))]
+      (is (= :anomalies/incorrect (:anomaly/category thrown)))
+      (is (= :invalid-input (:anomaly/type thrown)))
+      (is (= (:anomaly/at source) (:anomaly/at thrown)))
+      (is (= "bad" (:workflow-id thrown))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; read-event-file — bug fix coverage

--- a/components/workflow-resume/deps.edn
+++ b/components/workflow-resume/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/event-stream {:local/root "../event-stream"}
+ :deps {ai.miniforge/anomaly      {:local/root "../anomaly"}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/response     {:local/root "../response"}
         ai.miniforge/workflow     {:local/root "../workflow"}
         metosin/malli             {:mvn/version "0.16.4"}}

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -35,6 +35,7 @@
    keyword `:event/type` are dropped at the boundary, so everything
   the extractors see is well-shaped."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.interface.checkpoints :as workflow-checkpoints]
@@ -145,14 +146,14 @@
        first
        :workflow/spec))
 
-(defn- ensure-reconstruction-source!
+(defn- ensure-reconstruction-source
   [checkpoint-data events-dir workflow-id raw-events]
   (when-not (or checkpoint-data (seq raw-events))
-    (response/throw-anomaly! :anomalies/not-found
-                             (str "No events found for workflow: " workflow-id)
-                             {:workflow-id workflow-id
-                              :events-dir (str events-dir)
-                              :raw-event-count (count raw-events)})))
+    (anomaly/anomaly :not-found
+                     (str "No events found for workflow: " workflow-id)
+                     {:workflow-id workflow-id
+                      :events-dir (str events-dir)
+                      :raw-event-count (count raw-events)})))
 
 (defn- checkpoint-status
   [checkpoint-data]
@@ -183,10 +184,10 @@
   []
   (if-let [resource (io/resource resume-config-resource)]
     (:workflow-resume/resume (edn/read-string (slurp resource)))
-    (response/throw-anomaly! :anomalies/not-found
-                             "Workflow resume config resource not found"
-                             {:resource resume-config-resource
-                              :config/error :invalid-config})))
+    (anomaly/anomaly :not-found
+                     "Workflow resume config resource not found"
+                     {:resource resume-config-resource
+                      :config/error :invalid-config})))
 
 (def ^:private resume-config
   (delay (read-resume-config)))
@@ -318,46 +319,50 @@
      :dag-paused?          — boolean
      :dag-pause-reason     — keyword or nil
 
-   Throws `:anomalies/not-found` if no valid events exist for the
-   workflow — adapters translate that to a user-facing error. Events
-   that fail shape validation (missing or non-keyword `:event/type`)
-   are silently dropped at the boundary."
+   Returns a `:not-found` anomaly if no valid events exist for the
+   workflow. Events that fail shape validation (missing or non-keyword
+   `:event/type`) are silently dropped at the boundary."
   [events-dir workflow-id]
-  (schema/validate! schema/ReconstructContextInput
-                    {:events-dir events-dir :workflow-id workflow-id}
-                    {:message "Invalid reconstruct-context input"})
-  (let [checkpoint-data (workflow-checkpoints/load-checkpoint-data workflow-id)
-        raw-events (or (es/read-workflow-events-by-id events-dir workflow-id) [])
-        events (vec (filter schema/valid-event? raw-events))
-        _ (ensure-reconstruction-source! checkpoint-data events-dir workflow-id raw-events)
-        by-type (group-by :event/type events)
-        phase-results (restored-phase-results checkpoint-data events)
-        completed-phases (restored-completed-phases checkpoint-data events phase-results)
-        workflow-spec (find-workflow-spec events)
-        started-event (first (get by-type :workflow/started))
-        machine-snapshot (:machine-snapshot checkpoint-data)
-        completed? (reconstructed-completed? by-type checkpoint-data)
-        failed? (reconstructed-failed? by-type checkpoint-data)
-        completed-dag-tasks (restored-completed-dag-tasks checkpoint-data events)
-        completed-dag-artifacts (restored-completed-dag-artifacts checkpoint-data events)
-        workspace-checkpoint (restored-workspace-checkpoint events)
-        dag-pause-info (restored-dag-pause-info checkpoint-data events)]
-    {:phase-results phase-results
-     :completed-phases completed-phases
-     :workflow-spec workflow-spec
-     :workflow-id (or (:execution/id machine-snapshot)
-                      (:workflow/id started-event)
-                      workflow-id)
-     :completed? completed?
-     :failed? failed?
-     :event-count (count events)
-     :completed-dag-tasks completed-dag-tasks
-     :completed-dag-artifacts completed-dag-artifacts
-     :workspace-checkpoint workspace-checkpoint
-     :dag-paused? (boolean dag-pause-info)
-     :dag-pause-reason (:pause-reason dag-pause-info)
-     :machine-snapshot machine-snapshot
-     :checkpoint-manifest (:manifest checkpoint-data)}))
+  (anomaly/let-ok [_valid (schema/validate! schema/ReconstructContextInput
+                                            {:events-dir events-dir
+                                             :workflow-id workflow-id}
+                                            {:message "Invalid reconstruct-context input"
+                                             :schema-name :workflow-resume/reconstruct-context})]
+    (let [checkpoint-data (workflow-checkpoints/load-checkpoint-data workflow-id)
+          raw-events (or (es/read-workflow-events-by-id events-dir workflow-id) [])
+          events (vec (filter schema/valid-event? raw-events))]
+      (anomaly/let-ok [_source (ensure-reconstruction-source checkpoint-data
+                                                             events-dir
+                                                             workflow-id
+                                                             raw-events)]
+        (let [by-type (group-by :event/type events)
+              phase-results (restored-phase-results checkpoint-data events)
+              completed-phases (restored-completed-phases checkpoint-data events phase-results)
+              workflow-spec (find-workflow-spec events)
+              started-event (first (get by-type :workflow/started))
+              machine-snapshot (:machine-snapshot checkpoint-data)
+              completed? (reconstructed-completed? by-type checkpoint-data)
+              failed? (reconstructed-failed? by-type checkpoint-data)
+              completed-dag-tasks (restored-completed-dag-tasks checkpoint-data events)
+              completed-dag-artifacts (restored-completed-dag-artifacts checkpoint-data events)
+              workspace-checkpoint (restored-workspace-checkpoint events)
+              dag-pause-info (restored-dag-pause-info checkpoint-data events)]
+          {:phase-results phase-results
+           :completed-phases completed-phases
+           :workflow-spec workflow-spec
+           :workflow-id (or (:execution/id machine-snapshot)
+                            (:workflow/id started-event)
+                            workflow-id)
+           :completed? completed?
+           :failed? failed?
+           :event-count (count events)
+           :completed-dag-tasks completed-dag-tasks
+           :completed-dag-artifacts completed-dag-artifacts
+           :workspace-checkpoint workspace-checkpoint
+           :dag-paused? (boolean dag-pause-info)
+           :dag-pause-reason (:pause-reason dag-pause-info)
+           :machine-snapshot machine-snapshot
+           :checkpoint-manifest (:manifest checkpoint-data)})))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pipeline trimming
@@ -370,13 +375,15 @@
    leading completed phases removed. Completed phases after the first
    incomplete phase are preserved."
   [workflow completed-phases]
-  (schema/validate! schema/TrimPipelineInput
-                    {:workflow workflow :completed-phases completed-phases}
-                    {:message "Invalid trim-pipeline input"})
-  (let [completed-set (set completed-phases)
-        remaining (vec (drop-while #(completed-set (:phase %))
-                                   (get workflow :workflow/pipeline [])))]
-    (assoc workflow :workflow/pipeline remaining)))
+  (anomaly/let-ok [_valid (schema/validate! schema/TrimPipelineInput
+                                            {:workflow workflow
+                                             :completed-phases completed-phases}
+                                            {:message "Invalid trim-pipeline input"
+                                             :schema-name :workflow-resume/trim-pipeline})]
+    (let [completed-set (set completed-phases)
+          remaining (vec (drop-while #(completed-set (:phase %))
+                                     (get workflow :workflow/pipeline [])))]
+      (assoc workflow :workflow/pipeline remaining))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Identity resolution
@@ -441,7 +448,7 @@
       it's a synthetic DAG-task key.
    3. The caller-supplied `fallback-fn` (typically a selection profile).
 
-   Throws `:anomalies/not-found` if no source yields a loadable type.
+   Returns a `:not-found` anomaly if no source yields a loadable type.
 
    Arguments:
    - `reconstructed` — context map from `reconstruct-context`
@@ -455,23 +462,25 @@
    identifier-regex gate above keeps the legacy path working for
    well-formed names while rejecting human-title strings."
   [reconstructed fallback-fn]
-  (schema/validate! schema/ResolveWorkflowIdentityInput
-                    {:reconstructed reconstructed :fallback-fn fallback-fn}
-                    {:message "Invalid resolve-workflow-identity input"})
-  (let [workflow-spec (:workflow-spec reconstructed)
-        machine-snapshot (:machine-snapshot reconstructed)
-        workflow-id-from-snapshot (:execution/workflow-id machine-snapshot)
-        workflow-type (or (candidate-workflow-type workflow-spec)
-                          (when-not (synthetic-dag-task-workflow-id? workflow-id-from-snapshot)
-                            workflow-id-from-snapshot)
-                          (fallback-fn))
-        workflow-version (or (get workflow-spec :version)
-                             (:execution/workflow-version machine-snapshot)
-                             "latest")]
-    (when-not workflow-type
-      (response/throw-anomaly! :anomalies/not-found
-                              "Could not resolve a workflow type for resume"
-                              {:operation :resume-workflow
-                               :workflow-spec workflow-spec}))
-    {:workflow-type workflow-type
-     :workflow-version workflow-version}))
+  (anomaly/let-ok [_valid (schema/validate! schema/ResolveWorkflowIdentityInput
+                                            {:reconstructed reconstructed
+                                             :fallback-fn fallback-fn}
+                                            {:message "Invalid resolve-workflow-identity input"
+                                             :schema-name :workflow-resume/resolve-workflow-identity})]
+    (let [workflow-spec (:workflow-spec reconstructed)
+          machine-snapshot (:machine-snapshot reconstructed)
+          workflow-id-from-snapshot (:execution/workflow-id machine-snapshot)
+          workflow-type (or (candidate-workflow-type workflow-spec)
+                            (when-not (synthetic-dag-task-workflow-id? workflow-id-from-snapshot)
+                              workflow-id-from-snapshot)
+                            (fallback-fn))
+          workflow-version (or (get workflow-spec :version)
+                               (:execution/workflow-version machine-snapshot)
+                               "latest")]
+      (if workflow-type
+        {:workflow-type workflow-type
+         :workflow-version workflow-version}
+        (anomaly/anomaly :not-found
+                         "Could not resolve a workflow type for resume"
+                         {:operation :resume-workflow
+                          :workflow-spec workflow-spec})))))

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -30,7 +30,7 @@
 
    Validation boundary: public API fns (`reconstruct-context`,
    `trim-pipeline`, `resolve-workflow-identity`) validate their inputs
-   via `schema/validate!` before the pure core runs. Events read from
+   via `schema/validate` before the pure core runs. Events read from
    disk are filtered with `schema/valid-event?` — events without a
    keyword `:event/type` are dropped at the boundary, so everything
   the extractors see is well-shaped."
@@ -147,8 +147,8 @@
        :workflow/spec))
 
 (defn- ensure-reconstruction-source
-  [checkpoint-data events-dir workflow-id raw-events]
-  (when-not (or checkpoint-data (seq raw-events))
+  [checkpoint-data events-dir workflow-id events raw-events]
+  (when-not (or checkpoint-data (seq events))
     (anomaly/anomaly :not-found
                      (str "No events found for workflow: " workflow-id)
                      {:workflow-id workflow-id
@@ -323,17 +323,19 @@
    workflow. Events that fail shape validation (missing or non-keyword
    `:event/type`) are silently dropped at the boundary."
   [events-dir workflow-id]
-  (anomaly/let-ok [_valid (schema/validate! schema/ReconstructContextInput
-                                            {:events-dir events-dir
-                                             :workflow-id workflow-id}
-                                            {:message "Invalid reconstruct-context input"
-                                             :schema-name :workflow-resume/reconstruct-context})]
+  (anomaly/let-ok [_config @resume-config
+                   _valid (schema/validate schema/ReconstructContextInput
+                                           {:events-dir events-dir
+                                            :workflow-id workflow-id}
+                                           {:message "Invalid reconstruct-context input"
+                                            :schema-name :workflow-resume/reconstruct-context})]
     (let [checkpoint-data (workflow-checkpoints/load-checkpoint-data workflow-id)
           raw-events (or (es/read-workflow-events-by-id events-dir workflow-id) [])
           events (vec (filter schema/valid-event? raw-events))]
       (anomaly/let-ok [_source (ensure-reconstruction-source checkpoint-data
                                                              events-dir
                                                              workflow-id
+                                                             events
                                                              raw-events)]
         (let [by-type (group-by :event/type events)
               phase-results (restored-phase-results checkpoint-data events)
@@ -375,11 +377,11 @@
    leading completed phases removed. Completed phases after the first
    incomplete phase are preserved."
   [workflow completed-phases]
-  (anomaly/let-ok [_valid (schema/validate! schema/TrimPipelineInput
-                                            {:workflow workflow
-                                             :completed-phases completed-phases}
-                                            {:message "Invalid trim-pipeline input"
-                                             :schema-name :workflow-resume/trim-pipeline})]
+  (anomaly/let-ok [_valid (schema/validate schema/TrimPipelineInput
+                                           {:workflow workflow
+                                            :completed-phases completed-phases}
+                                           {:message "Invalid trim-pipeline input"
+                                            :schema-name :workflow-resume/trim-pipeline})]
     (let [completed-set (set completed-phases)
           remaining (vec (drop-while #(completed-set (:phase %))
                                      (get workflow :workflow/pipeline [])))]
@@ -462,11 +464,11 @@
    identifier-regex gate above keeps the legacy path working for
    well-formed names while rejecting human-title strings."
   [reconstructed fallback-fn]
-  (anomaly/let-ok [_valid (schema/validate! schema/ResolveWorkflowIdentityInput
-                                            {:reconstructed reconstructed
-                                             :fallback-fn fallback-fn}
-                                            {:message "Invalid resolve-workflow-identity input"
-                                             :schema-name :workflow-resume/resolve-workflow-identity})]
+  (anomaly/let-ok [_valid (schema/validate schema/ResolveWorkflowIdentityInput
+                                           {:reconstructed reconstructed
+                                            :fallback-fn fallback-fn}
+                                           {:message "Invalid resolve-workflow-identity input"
+                                            :schema-name :workflow-resume/resolve-workflow-identity})]
     (let [workflow-spec (:workflow-spec reconstructed)
           machine-snapshot (:machine-snapshot reconstructed)
           workflow-id-from-snapshot (:execution/workflow-id machine-snapshot)

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
@@ -116,9 +116,9 @@
    :workspace-checkpoint :dag-paused? bool :dag-pause-reason keyword-or-nil
    :machine-snapshot :checkpoint-manifest}.
 
-   Throws `:anomalies/not-found` when no valid events exist for the
-   workflow. Throws on invalid input args. Events failing shape
-   validation (missing/non-keyword `:event/type`) are dropped silently."
+   Returns a canonical anomaly when no valid events exist for the
+   workflow or input args are invalid. Events failing shape validation
+   (missing/non-keyword `:event/type`) are dropped silently."
   core/reconstruct-context)
 
 (def trim-pipeline
@@ -127,7 +127,7 @@
    Args: a workflow map with `:workflow/pipeline` and a collection of
    completed phase keywords. Returns the workflow with only the leading
    completed-phase prefix removed (completed phases after the first
-   incomplete phase are preserved). Throws on invalid input args."
+   incomplete phase are preserved), or an anomaly on invalid input."
   core/trim-pipeline)
 
 (def resolve-workflow-identity
@@ -140,6 +140,6 @@
 
    Preference for type: keyword-valid id from the recorded spec, then the
    machine-snapshot `:execution/workflow-id` (unless a synthetic DAG-task
-   key), then `fallback-fn`. Throws `:anomalies/not-found` if no source
-   yields a loadable type; throws on invalid input args."
+   key), then `fallback-fn`. Returns a canonical anomaly if no source
+   yields a loadable type or input args are invalid."
   core/resolve-workflow-identity)

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/schema.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/schema.clj
@@ -29,6 +29,7 @@
 
    Core stays schema-free — it runs on pre-validated data."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [malli.core :as m]
    [malli.error :as me]))
 
@@ -75,14 +76,15 @@
   (m/validate EventBase ev))
 
 (defn validate!
-  "Throw ex-info if `value` doesn't match `schema`. Returns `value`
-   unchanged on success, so it composes cleanly into threading
-   pipelines."
+  "Return `value` if it matches `schema`, otherwise return a canonical
+   `:invalid-input` anomaly."
   [schema value opts]
   (if (m/validate schema value)
     value
-    (throw (ex-info (get opts :message "Invalid input")
-                    (merge {:schema (m/form schema)
-                            :value value
-                            :errors (me/humanize (m/explain schema value))}
-                           (dissoc opts :message))))))
+    (anomaly/validation-anomaly
+     (get opts :message "Invalid input")
+     (get opts :schema-name :workflow-resume/input)
+     value
+     (merge {:schema (m/form schema)
+             :errors (me/humanize (m/explain schema value))}
+            (dissoc opts :message :schema-name)))))

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/schema.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/schema.clj
@@ -75,7 +75,7 @@
   [ev]
   (m/validate EventBase ev))
 
-(defn validate!
+(defn validate
   "Return `value` if it matches `schema`, otherwise return a canonical
    `:invalid-input` anomaly."
   [schema value opts]

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -18,14 +18,14 @@
 
 (ns ai.miniforge.workflow-resume.core-test
   (:require
-   [clojure.test :refer [deftest testing is]]
-   [clojure.java.io :as io]
-   [cheshire.core :as json]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.workflow.interface.checkpoints :as workflow-checkpoints]
    [ai.miniforge.workflow-resume.core :as core]
    [ai.miniforge.workflow-resume.interface :as wr]
-   [slingshot.slingshot :refer [try+]]))
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest testing is]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure extractors
@@ -33,13 +33,13 @@
 (deftest missing-resume-config-resource-carries-invalid-config-marker
   (testing "Missing classpath resume config is an invalid configuration fault"
     (with-redefs [io/resource (constantly nil)]
-      (let [anomaly (try+
-                      (@#'core/read-resume-config)
-                      (catch [:anomaly/category :anomalies/not-found] m
-                        m))]
-        (is (= :anomalies/not-found (:anomaly/category anomaly)))
-        (is (= "config/workflow-resume/resume.edn" (:resource anomaly)))
-        (is (= :invalid-config (:config/error anomaly)))))))
+      (let [result (@#'core/read-resume-config)]
+        (is (anomaly/anomaly? result))
+        (is (= :not-found (:anomaly/type result)))
+        (is (= "config/workflow-resume/resume.edn"
+               (get-in result [:anomaly/data :resource])))
+        (is (= :invalid-config
+               (get-in result [:anomaly/data :config/error])))))))
 
 (deftest reconstructed-status-predicates-test
   (testing "predicates read the reconstructed status flags"
@@ -242,12 +242,11 @@
              (fn [] :default-sdlc)))))
 
   (testing "neither spec nor fallback → :anomalies/not-found"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Could not resolve a workflow type for resume"
-         (core/resolve-workflow-identity
-           {}
-           (constantly nil))))))
+    (let [result (core/resolve-workflow-identity {} (constantly nil))]
+      (is (anomaly/anomaly? result))
+      (is (= :not-found (:anomaly/type result)))
+      (is (= :resume-workflow
+             (get-in result [:anomaly/data :operation]))))))
 
 (deftest resolve-workflow-identity-prefers-workflow-type-key-test
   (testing ":workflow-type wins over :name when both are present"
@@ -422,11 +421,10 @@
 (deftest reconstruct-context-missing-workflow-test
   (with-temp-events-dir
     (fn [base-dir]
-      (testing "missing workflow dir → :anomalies/not-found"
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"No events found for workflow:"
-             (core/reconstruct-context base-dir (str (random-uuid)))))))))
+      (testing "missing workflow dir → :not-found anomaly"
+        (let [result (core/reconstruct-context base-dir (str (random-uuid)))]
+          (is (anomaly/anomaly? result))
+          (is (= :not-found (:anomaly/type result))))))))
 
 (deftest reconstruct-context-prefers-machine-snapshot-test
   (testing "checkpoint data restores workflow and DAG resume state without requiring event files"
@@ -523,16 +521,14 @@
   (with-temp-events-dir
     (fn [base-dir]
       (testing "nil workflow-id is rejected before disk access"
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"Invalid reconstruct-context input"
-             (core/reconstruct-context base-dir nil))))
+        (let [result (core/reconstruct-context base-dir nil)]
+          (is (anomaly/anomaly? result))
+          (is (= :invalid-input (:anomaly/type result)))))
 
       (testing "non-string/non-uuid workflow-id is rejected"
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"Invalid reconstruct-context input"
-             (core/reconstruct-context base-dir 42)))))))
+        (let [result (core/reconstruct-context base-dir 42)]
+          (is (anomaly/anomaly? result))
+          (is (= :invalid-input (:anomaly/type result))))))))
 
 (deftest reconstruct-context-filters-malformed-events-test
   (with-temp-events-dir
@@ -557,22 +553,19 @@
 
 (deftest trim-pipeline-validates-workflow-shape-test
   (testing "workflow without :workflow/pipeline is rejected"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid trim-pipeline input"
-         (core/trim-pipeline {:wrong-shape true} []))))
+    (let [result (core/trim-pipeline {:wrong-shape true} [])]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))))
 
   (testing "pipeline entries without :phase keyword are rejected"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid trim-pipeline input"
-         (core/trim-pipeline {:workflow/pipeline [{:no-phase "here"}]} [])))))
+    (let [result (core/trim-pipeline {:workflow/pipeline [{:no-phase "here"}]} [])]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
 
 (deftest resolve-workflow-identity-validates-fallback-fn-test
   (testing "non-function fallback is rejected"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid resolve-workflow-identity input"
-         (core/resolve-workflow-identity
-           {:workflow-spec {:name "x"}}
-           "not a function")))))
+    (let [result (core/resolve-workflow-identity
+                  {:workflow-spec {:name "x"}}
+                  "not a function")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -41,6 +41,22 @@
         (is (= :invalid-config
                (get-in result [:anomaly/data :config/error])))))))
 
+(deftest reconstruct-context-propagates-resume-config-anomaly-test
+  (testing "configuration faults short-circuit before disk reads"
+    (let [config-anomaly (anomaly/anomaly
+                          :not-found
+                          "Missing resume configuration"
+                          {:resource "config/workflow-resume/resume.edn"})]
+      (with-redefs [core/resume-config (delay config-anomaly)
+                    workflow-checkpoints/load-checkpoint-data
+                    (fn [_workflow-id]
+                      (throw (ex-info "checkpoint should not be read" {})))
+                    es/read-workflow-events-by-id
+                    (fn [_events-dir _workflow-id]
+                      (throw (ex-info "events should not be read" {})))]
+        (is (= config-anomaly
+               (core/reconstruct-context "/tmp/unused-events" (str (random-uuid)))))))))
+
 (deftest reconstructed-status-predicates-test
   (testing "predicates read the reconstructed status flags"
     (let [completed {:completed? true}
@@ -550,6 +566,21 @@
           (let [ctx (core/reconstruct-context base-dir wf-id)]
             (is (= 1 (:event-count ctx)))
             (is (= [:plan] (:completed-phases ctx)))))))))
+
+(deftest reconstruct-context-rejects-malformed-only-events-test
+  (with-temp-events-dir
+    (fn [base-dir]
+      (let [wf-id (str (random-uuid))
+            wf-dir (doto (io/file base-dir wf-id) .mkdirs)]
+        (write-event! wf-dir "20260421T000002Z-b.json"
+                      {"legacy" "no event/type here"})
+        (write-event! wf-dir "20260421T000003Z-c.json"
+                      {"~:event/type" "workflow/phase-completed"})
+        (testing "parseable events without a valid discriminator are not a resume source"
+          (let [result (core/reconstruct-context base-dir wf-id)]
+            (is (anomaly/anomaly? result))
+            (is (= :not-found (:anomaly/type result)))
+            (is (= 2 (get-in result [:anomaly/data :raw-event-count])))))))))
 
 (deftest trim-pipeline-validates-workflow-shape-test
   (testing "workflow without :workflow/pipeline is rejected"

--- a/docs/pull-requests/2026-07-01-chris-workflow-resume-anomaly-returns.md
+++ b/docs/pull-requests/2026-07-01-chris-workflow-resume-anomaly-returns.md
@@ -1,0 +1,29 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Workflow Resume Anomaly Returns
+
+## Summary
+
+Convert workflow-resume validation and expected not-found paths from thrown
+exceptions to canonical anomaly data.
+
+## Changes
+
+- Return `:invalid-input` anomalies from workflow-resume schema validation.
+- Return `:not-found` anomalies for missing resume event sources and unresolved
+  workflow identities.
+- Update CLI resume/status adapters to re-escalate returned anomalies at the
+  user boundary.
+- Update workflow-resume regressions to assert returned anomaly maps.
+
+## Validation
+
+- `clojure -M:dev:test` for `ai.miniforge.workflow-resume.core-test`,
+  `ai.miniforge.cli.main.commands.resume-test`, and `ai.miniforge.cli.main-test`
+- Scoped exceptions-as-data scanner on touched source files:
+  `{:cleanup-needed 0, :fatal-only 0}`
+- `clj-kondo --lint` on changed workflow-resume/CLI source and test files


### PR DESCRIPTION
## Summary

Convert workflow-resume validation and expected not-found paths from thrown exceptions to canonical anomaly data.

## Changes

- Return :invalid-input anomalies from workflow-resume schema validation.
- Return :not-found anomalies for missing resume event sources and unresolved workflow identities.
- Update CLI resume/status adapters to re-escalate returned anomalies at the user boundary.
- Update workflow-resume regressions to assert returned anomaly maps.

## Validation

- clojure -M:dev:test for ai.miniforge.workflow-resume.core-test, ai.miniforge.cli.main.commands.resume-test, and ai.miniforge.cli.main-test
- Scoped exceptions-as-data scanner on touched source files: {:cleanup-needed 0, :fatal-only 0}
- clj-kondo --lint on changed workflow-resume/CLI source and test files
- bb pre-commit