### PR TITLE
Classify component anomaly boundaries

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -79,8 +79,13 @@
   "Whole namespace prefixes that mark boundary bases whose Polylith name
    cannot be represented as a standalone dotted segment. Keep this list
    narrow so component names that merely contain boundary words, such as
-   `bb-data-plane-http`, remain non-boundary."
-  #{"ai.miniforge.mcp-context-server"})
+   `bb-data-plane-http`, remain non-boundary.
+
+   `ai.miniforge.response.anomaly` is the repository's canonical
+   thrown-anomaly bridge; it is intentionally a boundary even though the
+   component name is not a generic protocol segment."
+  #{"ai.miniforge.mcp-context-server"
+    "ai.miniforge.response.anomaly"})
 
 (def ^:private boundary-suffix-patterns
   "Whole-namespace suffixes that mark boundary files."
@@ -209,7 +214,9 @@
    "classpath"
    "integrity"
    "invalid-config"
-   "unregistered-at-resolve"])
+   "unregistered-at-resolve"
+   "unmapped"
+   "no matching"])
 
 (defn- collect-text
   "Collect every string-shaped piece of evidence — string literals plus
@@ -218,7 +225,7 @@
    because i18n messages live as keyword tokens (e.g.
    `:config/missing-resource`) and the inventory uses those names as the
    programmer-error signal. Bounded depth keeps the walk cheap."
-  ([form] (collect-text form 6))
+  ([form] (collect-text form 8))
   ([form depth]
    (cond
      (zero? depth)        []

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/boundary_exemption_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/boundary_exemption_test.clj
@@ -51,6 +51,11 @@
     (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp-context-server.tools)))
     (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp-context-server.server)))))
 
+(deftest response-anomaly-bridge-is-boundary
+  (testing "the canonical thrown-anomaly bridge is an explicit boundary"
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.response.anomaly)))
+    (is (false? (exc/boundary-namespace? 'ai.miniforge.response.translate)))))
+
 (deftest core-namespaces-are-not-boundaries
   (testing "ordinary component core namespaces are not boundaries"
     (is (false? (exc/boundary-namespace? 'ai.miniforge.agent.planner)))
@@ -72,5 +77,14 @@
               (defn boom []
                 (throw (ex-info \"500\" {:status 500})))"
           {:keys [boundary? violations]} (exc/analyze-content "routes.clj" src)]
+      (is (true? boundary?))
+      (is (zero? (count violations))))))
+
+(deftest response-anomaly-bridge-yields-zero-violations
+  (testing "throw+ inside response.anomaly is the canonical escalation bridge"
+    (let [src "(ns ai.miniforge.response.anomaly)
+              (defn throw-anomaly! [a]
+                (throw+ a))"
+          {:keys [boundary? violations]} (exc/analyze-content "anomaly.clj" src)]
       (is (true? boundary?))
       (is (zero? (count violations))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
@@ -82,6 +82,38 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
+(deftest no-matching-reflection-helper-is-fatal-only
+  (testing "reflection helper arity misses are programmer errors"
+    (let [src "(ns ai.miniforge.foo.reflect)
+              (defn construct [ctor]
+                (or ctor
+                    (throw (ex-info \"No matching constructor\" {:arity 3}))))"
+          {:keys [violations]} (exc/analyze-content "reflect.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
+(deftest unmapped-dispatch-table-category-is-fatal-only
+  (testing "unmapped category guards protect closed dispatch tables"
+    (let [src "(ns ai.miniforge.foo.dispatch)
+              (defn category-type [category]
+                (or (lookup category)
+                    (throw (IllegalArgumentException.
+                            (str \"Unmapped category: \" category)))))"
+          {:keys [violations]} (exc/analyze-content "dispatch.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
+(deftest nested-invalid-config-marker-is-fatal-only
+  (testing "nested invalid-config ex-data marks fail-fast config guards"
+    (let [src "(ns ai.miniforge.foo.config)
+              (defn read-config [path]
+                (throw (ex-info \"Malformed config resource\"
+                                (assoc {:config/resource path}
+                                       :config/error :invalid-config))))"
+          {:keys [violations]} (exc/analyze-content "config.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
 (deftest plain-failure-is-cleanup-needed
   (testing "messages without programmer-error markers are :cleanup-needed"
     (let [src "(ns ai.miniforge.foo.core)

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -1565,26 +1565,34 @@
 ;------------------------------------------------------------------------------ Layer 7
 ;; Observer / knowledge failure events
 
+(defn- failure-message
+  [failure]
+  (cond
+    (instance? Throwable failure) (ex-message failure)
+    (map? failure) (or (:error failure) (:message failure) (pr-str failure))
+    (some? failure) (str failure)
+    :else nil))
+
 (defn observer-signal-failed
   "Emit when observe-workflow-signal! fails to forward a signal to the meta-loop."
   [stream workflow-id error]
   (-> (create-envelope stream :observer/signal-failed workflow-id
-                       (str "Observer signal failed: " (ex-message error)))
-      (assoc :observer/error (ex-message error))))
+                       (str "Observer signal failed: " (failure-message error)))
+      (assoc :observer/error (failure-message error))))
 
 (defn knowledge-synthesis-failed
   "Emit when synthesize-patterns! fails."
   [stream error]
   (-> (create-envelope stream :knowledge/synthesis-failed nil
-                       (str "Knowledge synthesis failed: " (ex-message error)))
-      (assoc :knowledge/error (ex-message error))))
+                       (str "Knowledge synthesis failed: " (failure-message error)))
+      (assoc :knowledge/error (failure-message error))))
 
 (defn knowledge-promotion-failed
   "Emit when promote-mature-learnings! fails."
   [stream error]
   (-> (create-envelope stream :knowledge/promotion-failed nil
-                       (str "Knowledge promotion failed: " (ex-message error)))
-      (assoc :knowledge/error (ex-message error))))
+                       (str "Knowledge promotion failed: " (failure-message error)))
+      (assoc :knowledge/error (failure-message error))))
 
 ;------------------------------------------------------------------------------ Layer 9
 ;; Routing trigger events (N5-delta-4 §4.2)

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -84,6 +84,28 @@
       (is (nil? (:workflow/id env)))
       (is (= 0 (:event/sequence-number env))))))
 
+;------------------------------------------------------------------------------ Layer 0
+;; knowledge failure constructors
+
+(deftest knowledge-promotion-failed-accepts-failure-data-test
+  (testing "promotion failure event can be built from error data without ex-info"
+    (let [stream (no-op-stream)
+          event (core/knowledge-promotion-failed stream
+                                                 {:zettel/id "z-1"
+                                                  :error "promotion blocked"})]
+      (is (= :knowledge/promotion-failed (:event/type event)))
+      (is (= "promotion blocked" (:knowledge/error event)))
+      (is (= "Knowledge promotion failed: promotion blocked"
+             (:message event))))))
+
+(deftest knowledge-failure-constructors-preserve-throwable-messages-test
+  (testing "existing Throwable callers keep the same message behavior"
+    (let [stream (no-op-stream)
+          err (ex-info "synthesis failed" {:cause :test})
+          event (core/knowledge-synthesis-failed stream err)]
+      (is (= :knowledge/synthesis-failed (:event/type event)))
+      (is (= "synthesis failed" (:knowledge/error event))))))
+
 (deftest create-envelope-propagates-snowflake-anomaly
   (let [generator {:state     (atom {:last-ts -1
                                      :last-seq -1

--- a/components/workflow/src/ai/miniforge/workflow/runner_cleanup.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_cleanup.clj
@@ -113,7 +113,7 @@
     (doseq [err errors]
       (when event-stream
         (events/publish-event! event-stream
-                        (es/knowledge-promotion-failed event-stream (ex-info (:error err) err)))))))
+                        (es/knowledge-promotion-failed event-stream err))))))
 
 (defn- release-acquired-environments! [acquired-env]
   (when acquired-env

--- a/docs/pull-requests/2026-07-01-chris-component-anomaly-boundaries.md
+++ b/docs/pull-requests/2026-07-01-chris-component-anomaly-boundaries.md
@@ -1,0 +1,27 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Component Anomaly Boundary Classification
+
+## Summary
+
+Refine exception-as-data scanner classification for known boundary and
+programmer-error cases, and remove an artificial workflow cleanup `ex-info`.
+
+## Changes
+
+- Treat `ai.miniforge.response.anomaly` as the canonical thrown-anomaly bridge.
+- Classify `No matching ...` reflection guards and unmapped dispatch categories
+  as fatal-only programmer errors.
+- Read nested `:invalid-config` markers when classifying fail-fast config guards.
+- Let event-stream knowledge failure constructors accept failure data maps, so
+  workflow cleanup does not need to fabricate an exception.
+
+## Verification
+
+- Focused Clojure tests for compliance-scanner and event-stream constructors.
+- `clj-kondo` on changed source and test files.
+- Exception-as-data repo scan: cleanup-needed rows dropped from 51 to 45.


### PR DESCRIPTION
## Summary
- classify the response anomaly bridge as an explicit exception-as-data boundary
- classify no-matching reflection guards and unmapped dispatch categories as fatal-only programmer errors
- allow event-stream knowledge failure events to use failure data maps so workflow cleanup does not fabricate ex-info

## Verification
- clojure -M:dev:test focused compliance-scanner/event-stream tests
- clj-kondo on changed source and tests
- bb pre-commit
- exception-as-data repo scan drops cleanup-needed rows from 51 to 45