### PR TITLE
Classify interrupted rethrows as fatal-only

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -335,8 +335,10 @@
   "Return the severity classification for a throw-shaped form found in
    a non-boundary namespace. Programmer-error guards are `:fatal-only`
    (informational); everything else is `:cleanup-needed`."
-  [form]
-  (if (programmer-error-guard? form)
+  [form context]
+  (if (or (and (:interrupted-catch? context)
+               (:simple-rethrow? context))
+          (programmer-error-guard? form))
     :fatal-only
     :cleanup-needed))
 
@@ -357,6 +359,30 @@
    block and its body is dev-only. The inventory excludes these."
   #{'comment 'clojure.core/comment})
 
+(defn- interrupted-exception-catch?
+  [form]
+  (and (seq? form)
+       (= 'catch (first form))
+       (let [class-sym (second form)]
+         (and (symbol? class-sym)
+              (= "InterruptedException" (name class-sym))))))
+
+(defn- simple-rethrow?
+  [form]
+  (and (seq? form)
+       (= 'throw (first form))
+       (= 2 (count form))
+       (symbol? (second form))))
+
+(defn- child-context
+  [context form child]
+  (cond-> context
+    (interrupted-exception-catch? form)
+    (assoc :interrupted-catch? true)
+
+    (simple-rethrow? child)
+    (assoc :simple-rethrow? true)))
+
 (defn- visit-form
   "Walk a single form and conj violation records onto `acc!` (a transient
    vector). Recurses into seqable children, including vectors and maps.
@@ -368,7 +394,9 @@
 
    `boundary?` is computed once at the file level — when true, the file
    yields no violations regardless of contents."
-  [acc! file-path boundary? form]
+  ([acc! file-path boundary? form]
+   (visit-form acc! file-path boundary? {} form))
+  ([acc! file-path boundary? context form]
   (cond
     boundary?
     acc!
@@ -382,29 +410,34 @@
 
         kind
         (conj! acc! (->violation-record file-path form
-                                        (classify-throw-site form)
+                                        (classify-throw-site form context)
                                         kind))
 
         :else
-        (reduce (fn [a child] (visit-form a file-path boundary? child))
+        (reduce (fn [a child]
+                  (visit-form a
+                              file-path
+                              boundary?
+                              (child-context context form child)
+                              child))
                 acc!
                 form)))
 
     (or (vector? form) (set? form))
-    (reduce (fn [a child] (visit-form a file-path boundary? child))
+    (reduce (fn [a child] (visit-form a file-path boundary? context child))
             acc!
             form)
 
     (map? form)
     (reduce (fn [a [k v]]
               (-> a
-                  (visit-form file-path boundary? k)
-                  (visit-form file-path boundary? v)))
+                  (visit-form file-path boundary? context k)
+                  (visit-form file-path boundary? context v)))
             acc!
             form)
 
     :else
-    acc!))
+    acc!)))
 
 (defn analyze-content
   "Analyze a single Clojure source file's content. Returns a map with:

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -331,13 +331,22 @@
       (str (subs one-line 0 max-len) " …")
       one-line)))
 
+(defn- simple-rethrow?
+  [form]
+  (and (seq? form)
+       (= 'throw (first form))
+       (= 2 (count form))
+       (symbol? (second form))))
+
 (defn- classify-throw-site
   "Return the severity classification for a throw-shaped form found in
-   a non-boundary namespace. Programmer-error guards are `:fatal-only`
+   a non-boundary namespace. Programmer-error guards and exact
+   `InterruptedException` catch-binding rethrows are `:fatal-only`
    (informational); everything else is `:cleanup-needed`."
   [form context]
-  (if (or (and (:interrupted-catch? context)
-               (:simple-rethrow? context))
+  (if (or (and (:interrupted-binding context)
+               (simple-rethrow? form)
+               (= (second form) (:interrupted-binding context)))
           (programmer-error-guard? form))
     :fatal-only
     :cleanup-needed))
@@ -367,21 +376,18 @@
          (and (symbol? class-sym)
               (= "InterruptedException" (name class-sym))))))
 
-(defn- simple-rethrow?
+(defn- interrupted-catch-binding
   [form]
-  (and (seq? form)
-       (= 'throw (first form))
-       (= 2 (count form))
-       (symbol? (second form))))
+  (when (interrupted-exception-catch? form)
+    (let [binding-sym (nth form 2 nil)]
+      (when (symbol? binding-sym)
+        binding-sym))))
 
 (defn- child-context
-  [context form child]
-  (cond-> context
-    (interrupted-exception-catch? form)
-    (assoc :interrupted-catch? true)
-
-    (simple-rethrow? child)
-    (assoc :simple-rethrow? true)))
+  [context form _child]
+  (if-let [binding-sym (interrupted-catch-binding form)]
+    (assoc context :interrupted-binding binding-sym)
+    context))
 
 (defn- visit-form
   "Walk a single form and conj violation records onto `acc!` (a transient

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
@@ -114,6 +114,19 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
+(deftest interrupted-exception-rethrow-is-fatal-only
+  (testing "InterruptedException rethrows preserve cancellation"
+    (let [src "(ns ai.miniforge.foo.loop)
+              (defn poll []
+                (try
+                  (Thread/sleep 1)
+                  (catch InterruptedException e
+                    (.interrupt (Thread/currentThread))
+                    (throw e))))"
+          {:keys [violations]} (exc/analyze-content "loop.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
 (deftest plain-failure-is-cleanup-needed
   (testing "messages without programmer-error markers are :cleanup-needed"
     (let [src "(ns ai.miniforge.foo.core)

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/positive_detection_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/positive_detection_test.clj
@@ -67,6 +67,19 @@
       (is (pos? (count violations)))
       (is (some #{:throw :ctor} (map :kind violations))))))
 
+(deftest ordinary-rethrow-remains-cleanup-needed
+  (testing "simple rethrow outside InterruptedException catch is still actionable"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn run []
+                (try
+                  (do-work)
+                  (catch Exception e
+                    (record e)
+                    (throw e))))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :cleanup-needed (:classification (first violations)))))))
+
 (deftest reports-line-and-column
   (testing "every violation carries a usable line:col location"
     (let [src "(ns ai.miniforge.foo.core)\n\n(defn b []\n  (throw (ex-info \"m\" {})))"

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/positive_detection_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/positive_detection_test.clj
@@ -80,6 +80,19 @@
       (is (= 1 (count violations)))
       (is (= :cleanup-needed (:classification (first violations)))))))
 
+(deftest interrupted-catch-different-symbol-remains-cleanup-needed
+  (testing "InterruptedException catches only exempt the caught binding rethrow"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn run []
+                (try
+                  (Thread/sleep 1)
+                  (catch InterruptedException e
+                    (let [ex (ex-info \"wrapped\" {:cause e})]
+                      (throw ex)))))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 2 (count violations)))
+      (is (every? #(= :cleanup-needed (:classification %)) violations)))))
+
 (deftest reports-line-and-column
   (testing "every violation carries a usable line:col location"
     (let [src "(ns ai.miniforge.foo.core)\n\n(defn b []\n  (throw (ex-info \"m\" {})))"

--- a/docs/pull-requests/2026-07-01-chris-interrupted-rethrow-classification.md
+++ b/docs/pull-requests/2026-07-01-chris-interrupted-rethrow-classification.md
@@ -1,0 +1,25 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Interrupted Rethrow Classification
+
+## Summary
+
+Teach the exceptions-as-data scanner to classify simple rethrows inside
+`InterruptedException` catch blocks as fatal-only cancellation propagation.
+
+## Changes
+
+- Carry minimal catch context while walking Clojure forms.
+- Classify `(throw e)` as fatal-only only when the enclosing catch class is
+  `InterruptedException`.
+- Keep ordinary simple rethrows in non-boundary namespaces actionable.
+
+## Verification
+
+- Focused compliance-scanner tests.
+- `clj-kondo` on changed scanner source and tests.
+- Exception-as-data repo scan: cleanup-needed rows dropped from 45 to 41.


### PR DESCRIPTION
## Summary
- classify simple rethrows inside InterruptedException catches as fatal-only cancellation propagation
- preserve cleanup-needed classification for ordinary rethrows outside interrupted catches
- add focused scanner regression coverage

## Verification
- focused compliance-scanner tests
- clj-kondo on changed scanner source and tests
- bb pre-commit
- exception-as-data repo scan drops cleanup-needed rows from 45 to 41