### PR TITLE
feat(dag-executor): execution-plan security gate (runtime capsule policies)

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/plan_security.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/plan_security.clj
@@ -1,0 +1,153 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.plan-security
+  "Execution-plan security gate — the runtime enforcement of the capsule
+   isolation policies (standards `foundations/runtime-*`). These policies check
+   execution-plan DATA (mounts, image digest, runtime capabilities), so they
+   cannot be enforced by the changed-files policy pack; this gate runs against a
+   built plan before it is handed to the runtime.
+
+   Each policy keeps its own designed action:
+   - no-host-docker-socket    -> :hard-stop (no opt-out; catastrophic escape)
+   - require-image-digest-pin -> :hard-stop (no reproducibility without it, N6)
+   - restrict-host-mounts     -> :review    (human decision, allowlist captures
+                                             the recurring cases)
+   - require-rootless         -> :warn in OSS, :hard-stop in Fleet (a hard-stop
+                                             on Docker would break the OSS setup)
+
+   `check-plan-security` reduces the findings to one outcome: a forbidden
+   anomaly when any hard-stop fires, otherwise a success carrying any review /
+   warning findings for the caller to surface."
+  (:require
+   [ai.miniforge.dag-executor.protocols.impl.runtime.descriptor :as descriptor]
+   [ai.miniforge.response.interface :as response]
+   [clojure.string :as str]))
+
+;; --- Security invariants (never operator-tunable) -------------------------
+
+(def ^:private runtime-socket-suffixes
+  "Host-path suffixes that identify a container-runtime control socket.
+   Bind-mounting any of these hands the capsule the host daemon — the single
+   most catastrophic isolation failure (runtime-no-host-docker-socket). There is
+   no safe reason to allow one, so this is a code invariant, not config."
+  #{"docker.sock" "podman.sock" "containerd.sock"})
+
+(def ^:private image-digest-pattern
+  "The only acceptable `:image-digest` value shape: a content-addressed sha256
+   digest (runtime-require-image-digest-pin, per N6). A tag or bare reference is
+   mutable and has no reproducibility story. Fixed by the digest format, not
+   operator-tunable."
+  #"^sha256:[a-f0-9]{64}$")
+
+;; --- Deployment-tunable defaults (config-as-data fallbacks) ---------------
+
+(def default-rootless-action
+  "Enforcement action for a runtime lacking the :rootless capability when the
+   deployment's security config is silent. OSS default is :warn — Podman is
+   rootless but Docker is not, and hard-stopping Docker would break the default
+   OSS posture. Fleet deployments override this to :hard-stop via config."
+  :warn)
+
+;; --- Detection predicates (pure) ------------------------------------------
+
+(defn- host-socket-mount?
+  "True when `mount`'s host path is a container-runtime control socket."
+  [mount]
+  (let [host-path (:host-path mount)]
+    (boolean (and host-path
+                  (some #(str/ends-with? host-path %) runtime-socket-suffixes)))))
+
+(defn- valid-image-digest?
+  "True when `image-digest` is a bare sha256:<64 hex> digest."
+  [image-digest]
+  (boolean (and (string? image-digest)
+                (re-matches image-digest-pattern image-digest))))
+
+(defn- allowlisted-host-path?
+  "True when `host-path` is on the deployment's mount allowlist."
+  [allowlist host-path]
+  (contains? (set allowlist) host-path))
+
+(defn- finding
+  "A single policy finding — the rule that fired, its designed action, an
+   audit-facing message, and the offending detail."
+  [rule action message detail]
+  {:security/rule rule :security/action action
+   :security/message message :security/detail detail})
+
+;; --- Scan (plan -> findings) ----------------------------------------------
+
+(defn scan-plan
+  "Return the seq of security findings for `plan`, given the runtime
+   `descriptor` and `security-config`
+   {:host-path-allowlist [...] :rootless-action :warn|:hard-stop}.
+
+   A host-socket mount is reported once as a :hard-stop and is not also raised
+   as a host-mount review — the hard-stop already blocks it."
+  [plan descriptor {:keys [host-path-allowlist rootless-action]
+                    :or   {rootless-action default-rootless-action}}]
+  (let [mounts          (get plan :mounts [])
+        {socket-mounts true other-mounts false} (group-by host-socket-mount? mounts)
+        socket-findings (map (fn [m]
+                               (finding :std/runtime-no-host-docker-socket :hard-stop
+                                        "Host runtime-socket mount is forbidden — grants the capsule full host-daemon control."
+                                        {:host-path (:host-path m)}))
+                             socket-mounts)
+        digest-findings (when-not (valid-image-digest? (:image-digest plan))
+                          [(finding :std/runtime-require-image-digest-pin :hard-stop
+                                    "Execution plan :image-digest must be a content-addressed sha256:<64 hex> digest."
+                                    {:image-digest (:image-digest plan)})])
+        mount-findings  (->> other-mounts
+                             (remove #(allowlisted-host-path? host-path-allowlist (:host-path %)))
+                             (map (fn [m]
+                                    (finding :std/runtime-restrict-host-mounts :review
+                                             "Host mount outside the allowlist — needs human review before the capsule runs."
+                                             {:host-path (:host-path m)}))))
+        rootless-finding (when-not (descriptor/capable? descriptor :rootless)
+                           [(finding :std/runtime-require-rootless rootless-action
+                                     "Runtime does not advertise the :rootless capability."
+                                     {:runtime/capabilities (descriptor/capabilities descriptor)})])]
+    (concat socket-findings digest-findings mount-findings rootless-finding)))
+
+;; --- Decide (findings -> outcome) -----------------------------------------
+
+(defn check-plan-security
+  "Evaluate `plan` against the runtime capsule-isolation policies and reduce the
+   findings to a single outcome:
+   - any :hard-stop finding  -> a :anomalies/forbidden anomaly carrying every
+                                hard-stop finding (the plan MUST NOT run)
+   - otherwise               -> a success whose output is
+                                {:security/decision :review|:pass
+                                 :security/review [...] :security/warnings [...]}.
+
+   The caller rejects the plan on a failed? result, surfaces :security/review
+   items for human approval, and logs :security/warnings."
+  [plan descriptor security-config]
+  (let [findings   (scan-plan plan descriptor security-config)
+        by-action  (group-by :security/action findings)
+        hard-stops (get by-action :hard-stop)
+        reviews    (get by-action :review)
+        warnings   (get by-action :warn)]
+    (if (seq hard-stops)
+      (response/make-anomaly :anomalies/forbidden
+                             "Execution plan violates a hard-stop capsule-isolation policy"
+                             {:security/findings (vec hard-stops)})
+      (response/success {:security/decision (if (seq reviews) :review :pass)
+                         :security/review   (vec reviews)
+                         :security/warnings (vec warnings)}))))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/plan_security.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/plan_security.clj
@@ -141,13 +141,17 @@
   [plan descriptor security-config]
   (let [findings   (scan-plan plan descriptor security-config)
         by-action  (group-by :security/action findings)
-        hard-stops (get by-action :hard-stop)
-        reviews    (get by-action :review)
-        warnings   (get by-action :warn)]
+        reviews    (get by-action :review [])
+        warnings   (get by-action :warn [])
+        ;; Fail closed: any finding whose action is not explicitly :review or
+        ;; :warn — e.g. a :rootless-action misconfigured to an unknown keyword —
+        ;; is treated as a hard-stop rather than silently dropped. A security
+        ;; gate must never weaken enforcement on unexpected input.
+        hard-stops (into [] (remove (comp #{:review :warn} :security/action)) findings)]
     (if (seq hard-stops)
       (response/make-anomaly :anomalies/forbidden
                              "Execution plan violates a hard-stop capsule-isolation policy"
-                             {:security/findings (vec hard-stops)})
+                             {:security/findings hard-stops})
       (response/success {:security/decision (if (seq reviews) :review :pass)
-                         :security/review   (vec reviews)
-                         :security/warnings (vec warnings)}))))
+                         :security/review   reviews
+                         :security/warnings warnings}))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/plan_security_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/plan_security_test.clj
@@ -106,6 +106,15 @@
       (is (contains? (rules-fired (:security/findings result))
                      :std/runtime-require-rootless)))))
 
+(deftest unknown-action-fails-closed-test
+  (testing "a finding with an unexpected action (misconfigured :rootless-action) is escalated to a hard-stop, never dropped"
+    (let [result (sut/check-plan-security base-plan rooted-descriptor
+                                          (assoc config :rootless-action :bogus-typo))]
+      (is (response/anomaly-map? result) "unknown action must not silently pass")
+      (is (= :anomalies/forbidden (:anomaly/category result)))
+      (is (contains? (rules-fired (:security/findings result))
+                     :std/runtime-require-rootless)))))
+
 (deftest hard-stop-precedes-review-test
   (testing "a socket mount hard-stops and is not also double-reported as a host-mount review"
     (let [plan   (assoc base-plan :mounts

--- a/components/dag-executor/test/ai/miniforge/dag_executor/plan_security_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/plan_security_test.clj
@@ -1,0 +1,126 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.plan-security-test
+  (:require
+   [ai.miniforge.dag-executor.plan-security :as sut]
+   [ai.miniforge.response.interface :as response]
+   [clojure.test :refer [deftest is testing]]))
+
+(def ^:private valid-digest
+  (str "sha256:" (apply str (repeat 64 \a))))
+
+(def ^:private base-plan
+  "A clean plan: pinned digest, one allowlisted mount, no socket."
+  {:image-digest    valid-digest
+   :command         ["bb" "run"]
+   :mounts          [{:host-path "/workspace" :container-path "/work" :read-only? false}]
+   :env             {}
+   :secrets-refs    []
+   :network-profile :standard
+   :time-limit-ms   60000
+   :memory-limit-mb 512
+   :trust-level     :trusted})
+
+(def ^:private rootless-descriptor {:runtime/capabilities #{:rootless}})
+(def ^:private rooted-descriptor {:runtime/capabilities #{}})
+(def ^:private config {:host-path-allowlist #{"/workspace"} :rootless-action :warn})
+
+(defn- rules-fired [findings] (set (map :security/rule findings)))
+
+(deftest clean-plan-passes-test
+  (testing "a pinned, allowlisted, rootless plan passes with no findings"
+    (let [result (sut/check-plan-security base-plan rootless-descriptor config)]
+      (is (response/success? result))
+      (is (= :pass (get-in result [:output :security/decision])))
+      (is (empty? (get-in result [:output :security/review])))
+      (is (empty? (get-in result [:output :security/warnings]))))))
+
+(deftest host-socket-mount-hard-stops-test
+  (testing "a runtime-socket mount is a forbidden hard-stop, whatever the mount target"
+    (let [plan   (assoc base-plan :mounts
+                        [{:host-path "/var/run/docker.sock" :container-path "/x" :read-only? false}])
+          result (sut/check-plan-security plan rootless-descriptor config)]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/forbidden (:anomaly/category result)))
+      (is (= #{:std/runtime-no-host-docker-socket}
+             (rules-fired (:security/findings result))))))
+
+  (testing "podman/containerd sockets and suffix matches are caught too"
+    (doseq [p ["/run/podman/podman.sock" "/some/weird/path/containerd.sock" "renamed-docker.sock"]]
+      (let [plan   (assoc base-plan :mounts [{:host-path p :container-path "/x" :read-only? false}])
+            result (sut/check-plan-security plan rootless-descriptor config)]
+        (is (response/anomaly-map? result) (str "should hard-stop on " p))))))
+
+(deftest unpinned-image-digest-hard-stops-test
+  (testing "a tag or non-sha256 :image-digest is a forbidden hard-stop"
+    (doseq [d ["task-runner:latest" "sha256:short" "" "abc123"]]
+      (let [result (sut/check-plan-security (assoc base-plan :image-digest d)
+                                            rootless-descriptor config)]
+        (is (response/anomaly-map? result) (str "should hard-stop on digest " (pr-str d)))
+        (is (contains? (rules-fired (:security/findings result))
+                       :std/runtime-require-image-digest-pin)))))
+
+  (testing "a well-formed sha256 digest passes"
+    (let [result (sut/check-plan-security base-plan rootless-descriptor config)]
+      (is (response/success? result)))))
+
+(deftest non-allowlisted-host-mount-reviews-test
+  (testing "a host mount outside the allowlist is a review, not a hard-stop"
+    (let [plan   (assoc base-plan :mounts
+                        [{:host-path "/Users/alice" :container-path "/home" :read-only? false}])
+          result (sut/check-plan-security plan rootless-descriptor config)]
+      (is (response/success? result) "review does not auto-block")
+      (is (= :review (get-in result [:output :security/decision])))
+      (is (= #{:std/runtime-restrict-host-mounts}
+             (rules-fired (get-in result [:output :security/review])))))))
+
+(deftest missing-rootless-warns-by-default-hard-stops-in-fleet-test
+  (testing "OSS default: a non-rootless runtime warns, does not block"
+    (let [result (sut/check-plan-security base-plan rooted-descriptor config)]
+      (is (response/success? result))
+      (is (= :pass (get-in result [:output :security/decision]))
+          "a warning alone does not force review")
+      (is (= #{:std/runtime-require-rootless}
+             (rules-fired (get-in result [:output :security/warnings]))))))
+
+  (testing "Fleet override: rootless-action :hard-stop makes it a forbidden block"
+    (let [result (sut/check-plan-security base-plan rooted-descriptor
+                                          (assoc config :rootless-action :hard-stop))]
+      (is (response/anomaly-map? result))
+      (is (contains? (rules-fired (:security/findings result))
+                     :std/runtime-require-rootless)))))
+
+(deftest hard-stop-precedes-review-test
+  (testing "a socket mount hard-stops and is not also double-reported as a host-mount review"
+    (let [plan   (assoc base-plan :mounts
+                        [{:host-path "/var/run/docker.sock" :container-path "/x" :read-only? false}])
+          result (sut/check-plan-security plan rootless-descriptor config)]
+      (is (response/anomaly-map? result))
+      (is (= #{:std/runtime-no-host-docker-socket} (rules-fired (:security/findings result)))
+          "socket mount reported once as hard-stop, not also as a review"))))
+
+(deftest multiple-hard-stops-all-reported-test
+  (testing "a socket mount AND an unpinned digest both surface in the forbidden anomaly"
+    (let [plan   (assoc base-plan
+                        :image-digest "latest"
+                        :mounts [{:host-path "/run/docker.sock" :container-path "/x" :read-only? false}])
+          result (sut/check-plan-security plan rootless-descriptor config)]
+      (is (response/anomaly-map? result))
+      (is (= #{:std/runtime-no-host-docker-socket :std/runtime-require-image-digest-pin}
+             (rules-fired (:security/findings result)))))))


### PR DESCRIPTION
Adds the enforcement **mechanism** for the runtime capsule-isolation policies (`standards/foundations/runtime-*`). These policies check execution-plan **data** — `:mounts` host paths, `:image-digest`, and the runtime `:runtime/capabilities` — so the changed-files policy pack cannot enforce them; this gate evaluates a built plan directly.

## What it does

`check-plan-security` scans a plan + descriptor + security-config and applies each policy's **designed** action (not a uniform flip):

| Policy | Action | Trigger |
|---|---|---|
| `no-host-docker-socket` | hard-stop | `:host-path` ends in a runtime socket |
| `require-image-digest-pin` | hard-stop | `:image-digest` ≠ `sha256:<64 hex>` |
| `restrict-host-mounts` | review | host mount off the allowlist |
| `require-rootless` | warn (OSS) / hard-stop (Fleet) | descriptor lacks `:rootless` |

It reduces findings to one outcome: a `:anomalies/forbidden` anomaly when any hard-stop fires, else a `success` carrying the review + warning findings for the caller to surface. Security invariants (socket suffixes, sha256 shape) are code constants; the allowlist and rootless action come from config (config-as-data). 7 tests / 31 assertions.

## Scope — honest boundary

This is the **mechanism, not live enforcement**. Investigation while building it found the execution-plan data the policies check is **not threaded through the executor launch path**: `create-execution-plan` has zero callers, and `acquire-environment!` → `create-container` runs from `env-config` with no plan (so plan-driven mounts never happen today). The gate enforces the moment execution-plans flow.

**Next step (tracked):** thread execution-plans (`:mounts`/`:image-digest`/`:runtime/capabilities`) through the DAG → executor → launch path, then wire this gate at the control-plane build (full gate incl. review) and the last-line launch (hard-stop). That closes the "runtime-* policies are defined but unenforced" gap end-to-end.

Note: budget override used (206 vs 200 reportable lines) — the gate and its interdependent tests land atomically per tests-with-code.