### PR TITLE
fix(compliance-scanner): classify local exception boundaries

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -29,7 +29,8 @@
    positives.
 
    Layer 0: Pure classification — boundary namespace patterns,
-            programmer-error guards, throw-shaped form recognition
+            local boundary wrappers, programmer-error guards,
+            throw-shaped form recognition
    Layer 1: File-level analysis — read forms with location metadata,
             walk recursively, classify each candidate site
    Layer 2: Repo-level scan entry point — enumerate target files,
@@ -253,6 +254,64 @@
         joined (str/lower-case (str/join " " tokens))]
     (boolean (some #(str/includes? joined %) programmer-error-markers))))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Local boundary-wrapper classification
+
+(defn- defn-form?
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (contains? #{"defn" "defn-"} (name (first form)))))
+
+(defn- bang-symbol?
+  [sym]
+  (and (symbol? sym)
+       (str/ends-with? (name sym) "!")))
+
+(defn- defn-context
+  "Extract the local function name, docstring, and metadata from a defn form.
+   This is intentionally small: enough for classifier context, not a full
+   defn parser."
+  [form]
+  (when (defn-form? form)
+    (let [name-sym (second form)
+          tail     (nnext form)
+          [doc tail'] (if (string? (first tail))
+                        [(first tail) (next tail)]
+                        [nil tail])
+          attr-map (when (map? (first tail')) (first tail'))
+          metadata (merge (meta name-sym) attr-map)]
+      {:defn-name name-sym
+       :defn-doc  doc
+       :defn-meta metadata})))
+
+(defn- local-boundary-wrapper?
+  "True when the enclosing defn is a documented local compatibility boundary.
+
+   Whole boundary namespaces are exempt earlier. This narrower classifier
+   covers the post-cleanup shape used inside ordinary component namespaces:
+   a canonical anomaly-returning function plus a retained thrower that bridges
+   old exception callers. Undocumented throwers remain `:cleanup-needed`."
+  [context]
+  (let [doc-text  (str/lower-case (or (:defn-doc context) ""))
+        meta-text (str/lower-case (str/join " " (collect-text (:defn-meta context))))
+        evidence  (str doc-text " " meta-text)]
+    (boolean
+     (or
+      (and (str/includes? evidence "exceptions-as-data")
+           (str/includes? evidence "prefer"))
+      (and (str/includes? doc-text "boundary")
+           (or (str/includes? doc-text "anomaly-returning")
+               (str/includes? doc-text "canonical")))
+      (and (str/includes? doc-text "throws via")
+           (str/includes? doc-text "anomaly-returning"))
+      (and (bang-symbol? (:defn-name context))
+           (str/includes? doc-text "anomaly")
+           (or (str/includes? doc-text "boundary")
+               (str/includes? doc-text "legacy")
+               (str/includes? doc-text "compat")
+               (str/includes? doc-text "prefer")))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Reader integration
 
@@ -340,15 +399,22 @@
 
 (defn- classify-throw-site
   "Return the severity classification for a throw-shaped form found in
-   a non-boundary namespace. Programmer-error guards and exact
-   `InterruptedException` catch-binding rethrows are `:fatal-only`
-   (informational); everything else is `:cleanup-needed`."
+   a non-boundary namespace. Documented local boundary wrappers are
+   `:local-boundary`; programmer-error guards and exact `InterruptedException`
+   catch-binding rethrows are `:fatal-only` (informational); everything else
+   is `:cleanup-needed`."
   [form context]
-  (if (or (and (:interrupted-binding context)
-               (simple-rethrow? form)
-               (= (second form) (:interrupted-binding context)))
-          (programmer-error-guard? form))
+  (cond
+    (local-boundary-wrapper? context)
+    :local-boundary
+
+    (or (and (:interrupted-binding context)
+             (simple-rethrow? form)
+             (= (second form) (:interrupted-binding context)))
+        (programmer-error-guard? form))
     :fatal-only
+
+    :else
     :cleanup-needed))
 
 (defn- ->violation-record
@@ -385,9 +451,11 @@
 
 (defn- child-context
   [context form _child]
-  (if-let [binding-sym (interrupted-catch-binding form)]
-    (assoc context :interrupted-binding binding-sym)
-    context))
+  (let [defn-data   (defn-context form)
+        interrupted (interrupted-catch-binding form)]
+    (cond-> context
+      defn-data (merge defn-data)
+      interrupted (assoc :interrupted-binding interrupted))))
 
 (defn- visit-form
   "Walk a single form and conj violation records onto `acc!` (a transient
@@ -526,6 +594,9 @@
                     :fatal-only
                     (str kind-name " classified :fatal-only "
                          "(programmer-error guard); informational only")
+                    :local-boundary
+                    (str kind-name " inside documented local boundary wrapper; "
+                         "informational only")
                     (str kind-name " outside boundary namespace; "
                          "consider returning an anomaly map"))]
     (-> (factory/->violation
@@ -610,7 +681,7 @@
      :violations    - vector of Violation maps (severity :warning)
      :files-scanned - count of files inspected
      :rule/id       - rule identifier
-     :counts        - {:cleanup-needed N :fatal-only M}
+     :counts        - {:cleanup-needed N :fatal-only M :local-boundary K}
 
    Pure data. The function does not write reports, does not throw, and
    does not call System/exit — this is the linter, not a gate."
@@ -622,12 +693,14 @@
          per-file    (mapv (fn [rel] (analyze-file repo-root rel)) files)
          violations  (vec (apply concat per-file))
          cleanup     (count (filter #(= :cleanup-needed (:classification %)) violations))
-         fatal       (count (filter #(= :fatal-only (:classification %)) violations))]
+         fatal       (count (filter #(= :fatal-only (:classification %)) violations))
+         local-boundary (count (filter #(= :local-boundary (:classification %)) violations))]
      {:violations    violations
       :files-scanned (count files)
       :rule/id       rule-id
       :counts        {:cleanup-needed cleanup
-                      :fatal-only     fatal}})))
+                      :fatal-only     fatal
+                      :local-boundary local-boundary}})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
@@ -430,10 +430,11 @@
    rule selector leaves the linter off. Returned rows are already in the
    canonical scanner shape.
 
-   The raw exceptions-as-data scanner preserves `:fatal-only` records for
-   audit counts, but the top-level compliance review treats only
-   `:cleanup-needed` rows as standards debt. Programmer-error guards are
-   an explicit rule carve-out and should not inflate `bb review` totals.
+   The raw exceptions-as-data scanner preserves `:fatal-only` and
+   `:local-boundary` records for audit counts, but the top-level compliance
+   review treats only `:cleanup-needed` rows as standards debt.
+   Programmer-error guards and documented local boundary wrappers are explicit
+   rule carve-outs and should not inflate `bb review` totals.
 
    When `changed-files` is non-nil (incremental mode via `:since`), the
    linter restricts its file walk to the changed set — matching the

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_test.clj
@@ -1,0 +1,98 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.exceptions-as-data.local-boundary-classification-test
+  "Local boundary throwers retained for compatibility are informational, while
+   ordinary throwers in component code remain actionable."
+  (:require
+   [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest documented-boundary-wrapper-is-local-boundary
+  (testing "defn docstrings can mark retained component-local boundary throwers"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn make-widget [request]
+                (if (:ok? request)
+                  request
+                  {:anomaly/type :invalid-input}))
+
+              (defn make-widget!
+                \"Boundary wrapper around `make-widget`. Calls the canonical
+                 anomaly-returning fn and throws only for legacy callers.
+
+                 Prefer `make-widget` in non-boundary code.\"
+                [request]
+                (let [result (make-widget request)]
+                  (if (:anomaly/type result)
+                    (throw (ex-info \"Invalid widget\" result))
+                    result)))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :local-boundary (:classification (first violations)))))))
+
+(deftest throwing-boundary-with-data-equivalent-is-local-boundary
+  (testing "response/throw-anomaly! bridges with anomaly-returning equivalents are local boundaries"
+    (let [src "(ns ai.miniforge.foo.core
+                (:require [ai.miniforge.response.interface :as response]))
+              (defn load-thing
+                \"Load a thing.
+
+                 Throws via `response/throw-anomaly!` when no thing exists.
+
+                 For an anomaly-returning equivalent that callers can branch
+                 on as data, use `try-load-thing` directly.\"
+                [id]
+                (let [result (try-load-thing id)]
+                  (if (:anomaly/type result)
+                    (response/throw-anomaly! :anomalies/not-found
+                                             (:anomaly/message result)
+                                             (:anomaly/data result))
+                    result)))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :local-boundary (:classification (first violations)))))))
+
+(deftest deprecated-exceptions-as-data-wrapper-is-local-boundary
+  (testing "deprecated throwers with exceptions-as-data metadata are local boundaries"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn unwrap-anomaly [result]
+                (if (:ok? result)
+                  (:data result)
+                  {:anomaly/type :fault}))
+
+              (defn unwrap
+                \"Extract data from an ok result; throw on error.\"
+                {:deprecated \"exceptions-as-data — prefer unwrap-anomaly\"}
+                [result]
+                (if (:ok? result)
+                  (:data result)
+                  (throw (ex-info \"Unwrap called on error result\" result))))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :local-boundary (:classification (first violations)))))))
+
+(deftest undocumented-bang-thrower-remains-cleanup-needed
+  (testing "a bang name alone is not enough to exempt a throw"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn fetch!
+                \"Fetch remote data.\"
+                [url]
+                (throw (ex-info \"GET request failed\" {:url url})))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :cleanup-needed (:classification (first violations)))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/output_format_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/output_format_test.clj
@@ -67,7 +67,7 @@
        (testing "linter contract keys"
          (is (= :warning (:severity v)) "severity is :warning, never :error")
          (is (false? (:auto-fixable? v)) "linter does not auto-fix")
-         (is (contains? #{:cleanup-needed :fatal-only}
+         (is (contains? #{:cleanup-needed :fatal-only :local-boundary}
                         (:classification v))))))))
 
 (deftest empty-repo-yields-zero-violations
@@ -76,7 +76,8 @@
      (let [result (exc/scan-repo (.getAbsolutePath root))]
        (is (= [] (:violations result)))
        (is (= 0 (:files-scanned result)))
-       (is (= {:cleanup-needed 0 :fatal-only 0} (:counts result)))))))
+       (is (= {:cleanup-needed 0 :fatal-only 0 :local-boundary 0}
+              (:counts result)))))))
 
 (deftest summary-counts-match-classifications
   (with-temp-repo
@@ -87,8 +88,14 @@
            "(defn cleanup-site []\n"
            "  (throw (ex-info \"GET failed\" {})))\n"
            "(defn fatal-site []\n"
-           "  (throw (ex-info \"Unknown thing\" {})))\n"))
+           "  (throw (ex-info \"Unknown thing\" {})))\n"
+           "(defn boundary-site!\n"
+           "  \"Boundary wrapper around `boundary-site`. Calls the canonical\n"
+           "   anomaly-returning fn and throws only for legacy callers.\"\n"
+           "  []\n"
+           "  (throw (ex-info \"legacy boundary\" {})))\n"))
      (let [{:keys [counts violations]} (exc/scan-repo (.getAbsolutePath root))]
-       (is (= 2 (count violations)))
+       (is (= 3 (count violations)))
        (is (= 1 (:cleanup-needed counts)))
-       (is (= 1 (:fatal-only counts)))))))
+       (is (= 1 (:fatal-only counts)))
+       (is (= 1 (:local-boundary counts)))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
@@ -168,7 +168,12 @@
                  "(defn cleanup-site []\n"
                  "  (throw (ex-info \"GET failed\" {})))\n"
                  "(defn fatal-site []\n"
-                 "  (throw (ex-info \"Unknown kind\" {})))\n"))
+                 "  (throw (ex-info \"Unknown kind\" {})))\n"
+                 "(defn boundary-site!\n"
+                 "  \"Boundary wrapper around `boundary-site`. Calls the canonical\n"
+                 "   anomaly-returning fn and throws only for legacy callers.\"\n"
+                 "  []\n"
+                 "  (throw (ex-info \"legacy boundary\" {})))\n"))
           (run! "git" "add" ".")
           (run! "git" "-c" "user.email=test@test.com" "-c" "user.name=Test"
                 "commit" "-m" "add exceptions"))

--- a/docs/pull-requests/2026-07-03-chris-exceptions-local-boundary-classification.md
+++ b/docs/pull-requests/2026-07-03-chris-exceptions-local-boundary-classification.md
@@ -34,20 +34,10 @@ remain in the raw scanner output for audit visibility.
 
 ## Verification
 
-- `clj-kondo --lint components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
-  components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
-  components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_te
-  st.clj components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/output_format_test.clj
-  components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj`
-- `clojure -M:dev:test -e '(require (quote clojure.test) (quote
-  ai.miniforge.compliance-scanner.exceptions-as-data.local-boundary-classification-test) (quote
-  ai.miniforge.compliance-scanner.exceptions-as-data.output-format-test) (quote
-  ai.miniforge.compliance-scanner.scan-test)) (let [r (clojure.test/run-tests (quote
-  ai.miniforge.compliance-scanner.exceptions-as-data.local-boundary-classification-test) (quote
-  ai.miniforge.compliance-scanner.exceptions-as-data.output-format-test) (quote
-  ai.miniforge.compliance-scanner.scan-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
-- `clojure -M:dev -e '(require (quote ai.miniforge.compliance-scanner.exceptions-as-data)) (let [result
-  (ai.miniforge.compliance-scanner.exceptions-as-data/scan-repo "." nil)] (prn (:counts result)))'`
+- `clj-kondo` on the scanner source and touched tests
+- focused `clojure -M:dev:test` coverage for local boundary classification,
+  output shape, and top-level scan filtering
+- raw exceptions-as-data scanner count check
 
 Scan delta on this branch:
 

--- a/docs/pull-requests/2026-07-03-chris-exceptions-local-boundary-classification.md
+++ b/docs/pull-requests/2026-07-03-chris-exceptions-local-boundary-classification.md
@@ -1,0 +1,60 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Exceptions-as-Data Local Boundary Classification
+
+Branch: `fix/exceptions-local-boundary-classification`
+
+## Summary
+
+The exceptions-as-data scanner previously reported documented local compatibility
+throwers as actionable cleanup rows, even when the production namespace already
+had a canonical anomaly-returning function and retained the thrower only as a
+boundary bridge for legacy callers.
+
+This PR adds a distinct `:local-boundary` classification for those documented
+component-local wrappers. The top-level compliance scanner still reports only
+`:cleanup-needed` rows as standards debt; `:fatal-only` and `:local-boundary`
+remain in the raw scanner output for audit visibility.
+
+## Scope
+
+- Carry enclosing `defn` / `defn-` docstring and metadata through the AST walk.
+- Classify only documented local boundary wrappers:
+  - deprecated `exceptions-as-data` compatibility throwers that point to a
+    preferred data-returning equivalent
+  - documented boundary wrappers around canonical anomaly-returning functions
+  - documented `response/throw-anomaly!` bridges with named data equivalents
+- Preserve ordinary component throwers as `:cleanup-needed`.
+- Add scanner tests for local boundary, deprecated compatibility, top-level
+  filtering, and output counts.
+
+## Verification
+
+- `clj-kondo --lint components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+  components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
+  components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_te
+  st.clj components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/output_format_test.clj
+  components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj`
+- `clojure -M:dev:test -e '(require (quote clojure.test) (quote
+  ai.miniforge.compliance-scanner.exceptions-as-data.local-boundary-classification-test) (quote
+  ai.miniforge.compliance-scanner.exceptions-as-data.output-format-test) (quote
+  ai.miniforge.compliance-scanner.scan-test)) (let [r (clojure.test/run-tests (quote
+  ai.miniforge.compliance-scanner.exceptions-as-data.local-boundary-classification-test) (quote
+  ai.miniforge.compliance-scanner.exceptions-as-data.output-format-test) (quote
+  ai.miniforge.compliance-scanner.scan-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'`
+- `clojure -M:dev -e '(require (quote ai.miniforge.compliance-scanner.exceptions-as-data)) (let [result
+  (ai.miniforge.compliance-scanner.exceptions-as-data/scan-repo "." nil)] (prn (:counts result)))'`
+
+Scan delta on this branch:
+
+```clojure
+;; before
+{:cleanup-needed 41, :fatal-only 129}
+
+;; after
+{:cleanup-needed 28, :fatal-only 126, :local-boundary 16}
+```


### PR DESCRIPTION
## Summary
- add a distinct :local-boundary classification for documented component-local exception bridges
- carry enclosing defn/defn- docstring and metadata through the AST walk
- keep ordinary undocumented throwers actionable as :cleanup-needed

## Scan delta
- before: {:cleanup-needed 41, :fatal-only 129}
- after: {:cleanup-needed 28, :fatal-only 126, :local-boundary 16}

## Verification
- bb pre-commit
- focused compliance-scanner local-boundary/output/top-level filter tests
- exceptions-as-data raw scan