### PR TITLE
fix(knowledge): return trust graph errors as data

### DIFF
--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -242,15 +242,15 @@
   [pack-graph]
   ;; Rule 3: Validate cross-trust references first (graph structure)
   (let [graph-validation (validate-cross-trust-references pack-graph)]
-    (when-not (valid? graph-validation)
-      (throw (ex-info "Invalid pack graph" graph-validation)))
-
-    ;; Collect all validation errors
-    (let [errors (concat (collect-authority-errors pack-graph)
-                         (collect-tainted-errors pack-graph))]
-      (if (empty? errors)
-        (schema/valid {:packs (keys pack-graph)})
-        (schema/invalid-with-errors (vec errors))))))
+    (if-not (valid? graph-validation)
+      (schema/invalid-with-errors [(:error graph-validation)]
+                                  {:graph-validation graph-validation})
+      ;; Collect all validation errors
+      (let [errors (concat (collect-authority-errors pack-graph)
+                           (collect-tainted-errors pack-graph))]
+        (if (empty? errors)
+          (schema/valid {:packs (keys pack-graph)})
+          (schema/invalid-with-errors (vec errors)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/test/ai/miniforge/knowledge/trust_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/trust_test.clj
@@ -281,15 +281,23 @@
       (is (not (:valid? result)))
       (is (seq (:errors result)))))
 
-	  (testing "INVALID: Fails on circular dependency"
-	    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
-	                                               :dependencies ["pack-b"])
-	                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
-	                                               :dependencies ["pack-a"])}
-	          result (trust/validate-transitive-trust graph)]
-	      (is (not (:valid? result)))
-	      (is (seq (:errors result)))
-	      (is (re-find #"Circular dependency" (first (:errors result)))))))
+  (testing "INVALID: Fails on circular dependency"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+                                               :dependencies ["pack-a"])}
+          result (trust/validate-transitive-trust graph)]
+      (is (not (:valid? result)))
+      (is (seq (:errors result)))
+      (is (re-find #"Circular dependency" (first (:errors result))))))
+
+  (testing "INVALID: Fails on missing dependency"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
+                                               :dependencies ["missing-pack"])}
+          result (trust/validate-transitive-trust graph)]
+      (is (not (:valid? result)))
+      (is (seq (:errors result)))
+      (is (re-find #"Missing dependency" (first (:errors result)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/test/ai/miniforge/knowledge/trust_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/trust_test.clj
@@ -281,13 +281,15 @@
       (is (not (:valid? result)))
       (is (seq (:errors result)))))
 
-  (testing "INVALID: Fails on circular dependency"
-    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
-                                               :dependencies ["pack-b"])
-                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
-                                               :dependencies ["pack-a"])}]
-      (is (thrown? Exception
-                   (trust/validate-transitive-trust graph))))))
+	  (testing "INVALID: Fails on circular dependency"
+	    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
+	                                               :dependencies ["pack-b"])
+	                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+	                                               :dependencies ["pack-a"])}
+	          result (trust/validate-transitive-trust graph)]
+	      (is (not (:valid? result)))
+	      (is (seq (:errors result)))
+	      (is (re-find #"Circular dependency" (first (:errors result)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-07-03-chris-knowledge-trust-graph-errors.md
+++ b/docs/pull-requests/2026-07-03-chris-knowledge-trust-graph-errors.md
@@ -1,0 +1,23 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Knowledge Trust Graph Errors
+
+Branch: `fix/knowledge-trust-graph-errors`
+
+## Summary
+
+`knowledge.trust/validate-transitive-trust` already returned validation data for
+authority and tainted-isolation failures, but graph-shape failures still threw
+`ex-info`. This PR makes circular or missing dependency graph failures return the
+same `schema/invalid-with-errors` shape.
+
+## Verification
+
+- `clj-kondo` on the touched trust source and test
+- focused `knowledge.trust-test`
+- raw exceptions-as-data scan:
+  `{:cleanup-needed 27, :fatal-only 126, :local-boundary 16}`


### PR DESCRIPTION
## Summary
- return circular/missing trust graph failures as schema/invalid-with-errors
- update trust tests to assert invalid data instead of a thrown exception
- remove one exceptions-as-data cleanup row from knowledge/trust

## Verification
- bb pre-commit
- focused knowledge.trust-test
- raw scanner count: {:cleanup-needed 27, :fatal-only 126, :local-boundary 16}