### PR TITLE
fix(loop): add anomaly-returning transition result

### DIFF
--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -129,17 +129,35 @@
   [state]
   (contains? terminal-states state))
 
-(defn transition
-  "Attempt a state transition. Returns updated loop state or throws if invalid."
+(defn transition-result
+  "Attempt a state transition.
+
+   Returns the updated loop state on success, or an `:invalid-input` anomaly
+   when the FSM rejects the transition."
   [loop-state new-state]
   (let [current-state (:loop/state loop-state)
         transition-event (get transition-events [current-state new-state])]
-    (when-not transition-event
+    (if-not transition-event
+      (anomaly/anomaly :invalid-input
+                       invalid-transition-message
+                       (invalid-transition-data current-state new-state))
+      (assoc loop-state
+             :loop/state new-state
+             :loop/updated-at (java.util.Date.)))))
+
+(defn transition
+  "Boundary compatibility wrapper around [[transition-result]].
+
+   Returns updated loop state on success. On FSM rejection, throws `ex-info`
+   to preserve the existing caller contract. Prefer the anomaly-returning
+   [[transition-result]] in non-boundary code when callers can branch on
+   anomaly data."
+  [loop-state new-state]
+  (let [result (transition-result loop-state new-state)]
+    (if (anomaly/anomaly? result)
       (throw (ex-info invalid-transition-message
-                      (invalid-transition-data current-state new-state))))
-    (assoc loop-state
-           :loop/state new-state
-           :loop/updated-at (java.util.Date.))))
+                      (:anomaly/data result)))
+      result)))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Loop state constructors (pure functions)

--- a/components/loop/test/ai/miniforge/loop/inner_test.clj
+++ b/components/loop/test/ai/miniforge/loop/inner_test.clj
@@ -121,6 +121,17 @@
 
 (deftest transition-test
   (let [loop-state (inner/create-inner-loop test-task {})]
+    (testing "transition-result returns updated state for valid transition"
+      (let [next-state (inner/transition-result loop-state :generating)]
+        (is (= :generating (:loop/state next-state)))))
+
+    (testing "transition-result returns anomaly for invalid transition"
+      (let [result (inner/transition-result loop-state :complete)]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= :pending (get-in result [:anomaly/data :from])))
+        (is (= :complete (get-in result [:anomaly/data :to])))))
+
     (testing "valid transition updates state"
       (let [next-state (inner/transition loop-state :generating)]
         (is (= :generating (:loop/state next-state)))))

--- a/components/loop/test/ai/miniforge/loop/inner_test.clj
+++ b/components/loop/test/ai/miniforge/loop/inner_test.clj
@@ -132,6 +132,14 @@
         (is (= :pending (get-in result [:anomaly/data :from])))
         (is (= :complete (get-in result [:anomaly/data :to])))))
 
+    (testing "transition-result returns anomaly for terminal state transition"
+      (let [terminal-state (assoc loop-state :loop/state :complete)
+            result (inner/transition-result terminal-state :generating)]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= :complete (get-in result [:anomaly/data :from])))
+        (is (= :generating (get-in result [:anomaly/data :to])))))
+
     (testing "valid transition updates state"
       (let [next-state (inner/transition loop-state :generating)]
         (is (= :generating (:loop/state next-state)))))

--- a/docs/pull-requests/2026-07-03-chris-loop-transition-anomaly.md
+++ b/docs/pull-requests/2026-07-03-chris-loop-transition-anomaly.md
@@ -1,0 +1,22 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Loop Transition Anomaly Result
+
+Branch: `fix/loop-transition-anomaly`
+
+## Summary
+
+`loop.inner/transition` threw directly on invalid FSM transitions. This PR adds
+`transition-result` as the canonical anomaly-returning sibling and keeps
+`transition` as the documented compatibility wrapper for existing callers.
+
+## Verification
+
+- `clj-kondo` on touched loop source and test
+- focused `loop.inner-test`
+- raw exceptions-as-data scan:
+  `{:cleanup-needed 26, :fatal-only 126, :local-boundary 17}`


### PR DESCRIPTION
## Summary
- add loop.inner/transition-result as the anomaly-returning FSM transition path
- keep transition as the documented compatibility wrapper for existing throwing callers
- cover valid and invalid transition-result behavior

## Verification
- bb pre-commit
- focused loop.inner-test
- raw scanner count: {:cleanup-needed 26, :fatal-only 126, :local-boundary 17}