### PR TITLE
feat(dag-executor): enforce capsule security gate at launch

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
@@ -33,10 +33,12 @@
    and the executor picks it up without code changes."
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.dag-executor.plan-security :as plan-security]
    [ai.miniforge.dag-executor.result :as result]
    [ai.miniforge.dag-executor.workspace :as workspace]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
    [ai.miniforge.dag-executor.protocols.impl.runtime.descriptor :as descriptor]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.dag-executor.protocols.impl.runtime.images :as images]
    [ai.miniforge.dag-executor.protocols.impl.runtime.process :as runtime-process]
    [ai.miniforge.dag-executor.protocols.impl.runtime.registry :as registry]
@@ -467,6 +469,21 @@
           (when (seq digest) digest))))
     (catch Exception _ nil)))
 
+(defn image-config-digest
+  "Return the bare `sha256:<64hex>` content-addressed config digest for a local
+   image, or nil on failure. Uses the image `.Id` (always present on any local
+   image, including ones built locally that carry no registry RepoDigests), so
+   the pinned digest can be resolved BEFORE the container is created — the value
+   the capsule security gate checks (runtime-require-image-digest-pin)."
+  [descriptor image]
+  (try
+    (let [result (run-runtime descriptor
+                              "image" "inspect" image
+                              "--format" "{{.Id}}")]
+      (when (zero? (:exit result))
+        (some-> (:out result) str/trim not-empty)))
+    (catch Exception _ nil)))
+
 ;; ============================================================================
 ;; Image Management
 ;; ============================================================================
@@ -708,6 +725,34 @@
     (result/ok nil)))
 
 ;; ============================================================================
+;; Capsule security gate — runtime enforcement of the runtime-* policies
+;; ============================================================================
+
+(defn security-gate-check
+  "Run the capsule-isolation security gate for a pending launch. Resolves the
+   image's content-addressed digest via `digest-fn` (injected for testing),
+   synthesizes the plan the gate inspects (pinned digest + host mounts), and
+   applies `plan-security/check-plan-security`. The host-path allowlist is the
+   sandbox workdir (the only host path a well-formed plan mounts today).
+
+   Returns `result/ok` carrying the gate decision when the launch may proceed
+   (a passing gate may still carry non-blocking :security/warnings — e.g. a
+   non-rootless runtime in OSS), or `result/err :security-policy-violation`
+   with the findings on a hard-stop. A nil digest fails closed (hard-stop),
+   since a plan with no pinned digest cannot satisfy require-image-digest-pin."
+  [descriptor image env-config digest-fn]
+  (let [plan            {:image-digest (digest-fn descriptor image)
+                         :mounts       (get env-config :mounts [])}
+        security-config {:host-path-allowlist #{(get env-config :workdir default-workdir)}
+                         :rootless-action     plan-security/default-rootless-action}
+        decision        (plan-security/check-plan-security plan descriptor security-config)]
+    (if (response/anomaly-map? decision)
+      (result/err :security-policy-violation
+                  (:anomaly/message decision)
+                  {:security/findings (:security/findings decision)})
+      (result/ok (:output decision)))))
+
+;; ============================================================================
 ;; OciCliExecutor Record
 ;; ============================================================================
 
@@ -749,31 +794,37 @@
           (when-let [image-key (->> task-runner-images
                                     (some (fn [[k v]] (when (= image (:image v)) k))))]
             (ensure-image! descriptor image-key)))
-        (let [container-name (str container-name-prefix
-                                   (subs (str task-id) 0 container-name-uuid-slice))
-              workdir (get env-config :workdir default-workdir)
-              create-result (create-container descriptor
-                                              container-name
-                                              image
-                                              workdir
-                                              (:env env-config)
-                                              (:resources env-config)
-                                              network)]
-          (if (result/ok? create-result)
-            ;; Bootstrap workspace: clone repo into container if repo-url provided (N11 §4.2)
-            (let [bootstrap-result (bootstrap-workspace! descriptor container-name workdir env-config)]
-              (if (result/ok? bootstrap-result)
-                (let [bootstrap-metadata (:data bootstrap-result)
-                      ;; Capture image SHA256 digest for evidence record (N11 §11 SHOULD)
-                      image-digest (container-image-digest descriptor container-name)
-                      metadata (cond-> (merge (get create-result :data {})
-                                               bootstrap-metadata)
-                                 image-digest (assoc :image-digest image-digest))]
-                  (result/ok (proto/create-environment-record
-                              container-name (descriptor/kind descriptor) task-id workdir
-                              (assoc env-config :metadata metadata))))
-                bootstrap-result))
-            create-result)))))
+        ;; Capsule security gate (runtime-* policies): resolve the pinned image
+        ;; digest and check the plan BEFORE launch. A hard-stop (forbidden)
+        ;; aborts the acquire without creating a container.
+        (let [gate-result (security-gate-check descriptor image env-config image-config-digest)]
+          (if (result/err? gate-result)
+            gate-result
+            (let [container-name (str container-name-prefix
+                                      (subs (str task-id) 0 container-name-uuid-slice))
+                  workdir (get env-config :workdir default-workdir)
+                  create-result (create-container descriptor
+                                                  container-name
+                                                  image
+                                                  workdir
+                                                  (:env env-config)
+                                                  (:resources env-config)
+                                                  network)]
+              (if (result/ok? create-result)
+                ;; Bootstrap workspace: clone repo into container if repo-url provided (N11 §4.2)
+                (let [bootstrap-result (bootstrap-workspace! descriptor container-name workdir env-config)]
+                  (if (result/ok? bootstrap-result)
+                    (let [bootstrap-metadata (:data bootstrap-result)
+                          ;; Capture image SHA256 digest for evidence record (N11 §11 SHOULD)
+                          image-digest (container-image-digest descriptor container-name)
+                          metadata (cond-> (merge (get create-result :data {})
+                                                   bootstrap-metadata)
+                                     image-digest (assoc :image-digest image-digest))]
+                      (result/ok (proto/create-environment-record
+                                  container-name (descriptor/kind descriptor) task-id workdir
+                                  (assoc env-config :metadata metadata))))
+                    bootstrap-result))
+                create-result)))))))
 
   (execute! [_this environment-id command opts]
     (try

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
@@ -514,6 +514,24 @@
     (catch Exception _e
       nil)))
 
+(defn pull-image!
+  "Pull `image` via the runtime. Best-effort: a failed pull (e.g. a
+   locally-built image with no registry) leaves the image absent, which the
+   caller surfaces as a nil digest."
+  [descriptor image]
+  (try (run-runtime descriptor "pull" image) (catch Exception _ nil)))
+
+(defn resolve-image-digest!
+  "Resolve the pinned `sha256:<64hex>` digest for `image`, pulling it first when
+   it is not present locally so `image inspect` can read it (inspect does not
+   pull). Returns nil only when the image cannot be resolved even after a pull —
+   a genuinely unpinnable image, which the security gate then blocks. This is
+   the production digest resolver injected into `security-gate-check`."
+  [descriptor image]
+  (when-not (image-exists? descriptor image)
+    (pull-image! descriptor image))
+  (image-config-digest descriptor image))
+
 (defn find-dockerfile-path
   "Find the Dockerfile resource on the classpath or filesystem.
    Returns absolute path to the Dockerfile."
@@ -797,7 +815,7 @@
         ;; Capsule security gate (runtime-* policies): resolve the pinned image
         ;; digest and check the plan BEFORE launch. A hard-stop (forbidden)
         ;; aborts the acquire without creating a container.
-        (let [gate-result (security-gate-check descriptor image env-config image-config-digest)]
+        (let [gate-result (security-gate-check descriptor image env-config resolve-image-digest!)]
           (if (result/err? gate-result)
             gate-result
             (let [container-name (str container-name-prefix
@@ -817,9 +835,15 @@
                     (let [bootstrap-metadata (:data bootstrap-result)
                           ;; Capture image SHA256 digest for evidence record (N11 §11 SHOULD)
                           image-digest (container-image-digest descriptor container-name)
+                          ;; Surface the gate's non-blocking findings (rootless
+                          ;; warning, host-mount review) on the environment record.
+                          gate-warnings (get-in gate-result [:data :security/warnings])
+                          gate-review   (get-in gate-result [:data :security/review])
                           metadata (cond-> (merge (get create-result :data {})
                                                    bootstrap-metadata)
-                                     image-digest (assoc :image-digest image-digest))]
+                                     image-digest (assoc :image-digest image-digest)
+                                     (seq gate-warnings) (assoc :security/warnings gate-warnings)
+                                     (seq gate-review)   (assoc :security/review gate-review))]
                       (result/ok (proto/create-environment-record
                                   container-name (descriptor/kind descriptor) task-id workdir
                                   (assoc env-config :metadata metadata))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_security_gate_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_security_gate_test.clj
@@ -1,0 +1,87 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli-security-gate-test
+  "Capsule security gate wiring: acquire-environment! runs check-plan-security
+   on the resolved plan before launch. The digest resolver is injected so these
+   run without a container runtime."
+  (:require
+   [ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli :as oci-cli]
+   [ai.miniforge.dag-executor.result :as result]
+   [clojure.test :refer [deftest is testing]]))
+
+(def ^:private valid-digest (str "sha256:" (apply str (repeat 64 \a))))
+(def ^:private good-digest-fn (fn [_descriptor _image] valid-digest))
+(def ^:private rootless-descriptor {:runtime/capabilities #{:rootless}})
+(def ^:private rooted-descriptor {:runtime/capabilities #{}})
+(def ^:private base-env {:workdir "/workspace" :mounts []})
+
+(defn- err-rules [r] (set (map :security/rule (get-in r [:error :data :security/findings]))))
+
+(deftest clean-launch-passes-test
+  (testing "pinned digest, rootless runtime, no mounts -> ok, decision :pass"
+    (let [r (oci-cli/security-gate-check rootless-descriptor "img" base-env good-digest-fn)]
+      (is (result/ok? r))
+      (is (= :pass (get-in r [:data :security/decision])))
+      (is (empty? (get-in r [:data :security/warnings]))))))
+
+(deftest nil-digest-fails-closed-test
+  (testing "a nil resolved digest (resolution failed) is a hard-stop, not a silent pass"
+    (let [r (oci-cli/security-gate-check rootless-descriptor "img" base-env (fn [_ _] nil))]
+      (is (result/err? r))
+      (is (= :security-policy-violation (get-in r [:error :code])))
+      (is (contains? (err-rules r) :std/runtime-require-image-digest-pin)))))
+
+(deftest unpinned-digest-hard-stops-test
+  (testing "a tag / non-sha256 digest is a hard-stop"
+    (let [r (oci-cli/security-gate-check rootless-descriptor "img" base-env (fn [_ _] "latest"))]
+      (is (result/err? r))
+      (is (contains? (err-rules r) :std/runtime-require-image-digest-pin)))))
+
+(deftest socket-mount-hard-stops-test
+  (testing "a host runtime-socket mount aborts the launch"
+    (let [env (assoc base-env :mounts
+                     [{:host-path "/var/run/docker.sock" :container-path "/x" :read-only? false}])
+          r   (oci-cli/security-gate-check rootless-descriptor "img" env good-digest-fn)]
+      (is (result/err? r))
+      (is (contains? (err-rules r) :std/runtime-no-host-docker-socket)))))
+
+(deftest non-rootless-warns-does-not-block-test
+  (testing "OSS default: a non-rootless runtime warns but the launch proceeds"
+    (let [r (oci-cli/security-gate-check rooted-descriptor "img" base-env good-digest-fn)]
+      (is (result/ok? r) "rootless is a warning in OSS, not a block")
+      (is (= #{:std/runtime-require-rootless}
+             (set (map :security/rule (get-in r [:data :security/warnings]))))))))
+
+(deftest non-allowlisted-mount-reviews-not-blocks-test
+  (testing "a host mount outside the workdir allowlist is a review, launch proceeds"
+    (let [env (assoc base-env :mounts
+                     [{:host-path "/Users/alice" :container-path "/home" :read-only? false}])
+          r   (oci-cli/security-gate-check rootless-descriptor "img" env good-digest-fn)]
+      (is (result/ok? r))
+      (is (= :review (get-in r [:data :security/decision])))
+      (is (= #{:std/runtime-restrict-host-mounts}
+             (set (map :security/rule (get-in r [:data :security/review]))))))))
+
+(deftest workdir-mount-is-allowlisted-test
+  (testing "a mount of the sandbox workdir itself is on the allowlist -> no review"
+    (let [env (assoc base-env :mounts
+                     [{:host-path "/workspace" :container-path "/work" :read-only? false}])
+          r   (oci-cli/security-gate-check rootless-descriptor "img" env good-digest-fn)]
+      (is (result/ok? r))
+      (is (= :pass (get-in r [:data :security/decision]))))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_security_gate_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_security_gate_test.clj
@@ -17,9 +17,10 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli-security-gate-test
-  "Capsule security gate wiring: acquire-environment! runs check-plan-security
-   on the resolved plan before launch. The digest resolver is injected so these
-   run without a container runtime."
+  "Capsule security gate: unit tests for `security-gate-check`, the gate step
+   `acquire-environment!` runs on the resolved plan before launch. The digest
+   resolver is injected, so these exercise the gate decision (block / warn /
+   review / pass) without a container runtime."
   (:require
    [ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli :as oci-cli]
    [ai.miniforge.dag-executor.result :as result]


### PR DESCRIPTION
Wires the `plan_security` gate (#1352) into the live OCI launch path, so the `runtime-*` capsule-isolation policies now **block** — the enforcement that #1352 left as a tracked follow-up.

## Where

In `oci_cli/acquire-environment!`, after `ensure-image!` and before `create-container`:

1. Resolve the image's bare `sha256:<64hex>` config digest upfront — new `image-config-digest` (`docker image inspect --format {{.Id}}`, present on every local image, including locally-built ones that carry no `RepoDigests`).
2. `security-gate-check` synthesizes the plan the gate inspects (pinned digest + host mounts from `env-config`) and runs `check-plan-security`, with the sandbox `:workdir` as the host-path allowlist and the OSS `:warn` rootless action.
3. A hard-stop (forbidden anomaly — a runtime-socket mount, or a non-`sha256` / nil digest) returns `result/err :security-policy-violation` and the container is never created. **A nil digest fails closed.** Non-rootless → warn (OSS, non-blocking); host mount off the allowlist → review (non-blocking at this layer).

## What is enforced now

| Policy | Effect at launch |
|---|---|
| `require-image-digest-pin` | **live** — a resolvable `sha256` digest is pinned + validated; missing/malformed hard-stops |
| `no-host-docker-socket` | **live** — a socket mount aborts the launch |
| `restrict-host-mounts` | surfaced as review (dormant — no plan-driven mounts today) |
| `require-rootless` | surfaced as an OSS warning |

`security-gate-check` takes an injected `digest-fn`, so it is unit-tested without a runtime (7 tests / 17 assertions). Existing oci-cli tests unchanged (30 pass); poly + GraalVM green.

## Follow-up (tracked)

Fuller plan threading — real `:mounts`, `:trust-level`, `:secrets-refs`, `:command`, `:time-limit-ms` from the workflow/DAG layer — remains next; that activates host-mount review and lets `create-container` consume the plan directly. Today `:mounts` is empty, so socket/host-mount checks are forward-protection.