### PR TITLE
fix(compliance-scanner): classify cleanup-preserving rethrows

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -485,8 +485,9 @@
       (when (symbol? binding-sym)
         binding-sym))))
 
-(defn- child-context
-  [context form _child]
+(defn- form-context
+  "Enrich traversal context once for a parent form before walking children."
+  [context form]
   (let [defn-data   (defn-context form)
         interrupted (interrupted-catch-binding form)
         catch-binding (when (and (seq? form)
@@ -530,14 +531,11 @@
                                         kind))
 
         :else
-        (reduce (fn [a child]
-                  (visit-form a
-                              file-path
-                              boundary?
-                              (child-context context form child)
-                              child))
-                acc!
-                form)))
+        (let [child-context (form-context context form)]
+          (reduce (fn [a child]
+                    (visit-form a file-path boundary? child-context child))
+                  acc!
+                  form))))
 
     (or (vector? form) (set? form))
     (reduce (fn [a child] (visit-form a file-path boundary? context child))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -397,12 +397,45 @@
        (= 2 (count form))
        (symbol? (second form))))
 
+(def ^:private cleanup-rethrow-markers
+  "Cleanup operations that make a same-catch rethrow informational.
+
+   This is deliberately narrow: a log-and-rethrow remains actionable, while
+   scheduler shutdown and future cancellation preserve resources before
+   propagating the original failure."
+  #{"shutdownNow" ".shutdownNow" "future-cancel"})
+
+(defn- cleanup-call?
+  [form]
+  (boolean
+   (some cleanup-rethrow-markers
+         (map name (filter symbol? (tree-seq coll? seq form))))))
+
+(defn- cleanup-before-rethrow?
+  [catch-form binding-sym]
+  (let [body (drop 3 catch-form)]
+    (loop [forms body
+           saw-cleanup? false]
+      (if-let [form (first forms)]
+        (cond
+          (and (simple-rethrow? form)
+               (= binding-sym (second form)))
+          saw-cleanup?
+
+          (cleanup-call? form)
+          (recur (next forms) true)
+
+          :else
+          (recur (next forms) saw-cleanup?))
+        false))))
+
 (defn- classify-throw-site
   "Return the severity classification for a throw-shaped form found in
    a non-boundary namespace. Documented local boundary wrappers are
-   `:local-boundary`; programmer-error guards and exact `InterruptedException`
-   catch-binding rethrows are `:fatal-only` (informational); everything else
-   is `:cleanup-needed`."
+   `:local-boundary`; programmer-error guards, exact `InterruptedException`
+   catch-binding rethrows, and explicit cleanup-preserving same-binding
+   rethrows are `:fatal-only` (informational); everything else is
+   `:cleanup-needed`."
   [form context]
   (cond
     (local-boundary-wrapper? context)
@@ -411,6 +444,9 @@
     (or (and (:interrupted-binding context)
              (simple-rethrow? form)
              (= (second form) (:interrupted-binding context)))
+        (and (:cleanup-rethrow-binding context)
+             (simple-rethrow? form)
+             (= (second form) (:cleanup-rethrow-binding context)))
         (programmer-error-guard? form))
     :fatal-only
 
@@ -452,10 +488,16 @@
 (defn- child-context
   [context form _child]
   (let [defn-data   (defn-context form)
-        interrupted (interrupted-catch-binding form)]
+        interrupted (interrupted-catch-binding form)
+        catch-binding (when (and (seq? form)
+                                 (= 'catch (first form)))
+                        (nth form 2 nil))]
     (cond-> context
       defn-data (merge defn-data)
-      interrupted (assoc :interrupted-binding interrupted))))
+      interrupted (assoc :interrupted-binding interrupted)
+      (and (symbol? catch-binding)
+           (cleanup-before-rethrow? form catch-binding))
+      (assoc :cleanup-rethrow-binding catch-binding))))
 
 (defn- visit-form
   "Walk a single form and conj violation records onto `acc!` (a transient

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
@@ -127,6 +127,46 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
+(deftest cleanup-preserving-rethrow-is-fatal-only
+  (testing "resource cleanup followed by same-binding rethrow is informational"
+    (let [src "(ns ai.miniforge.foo.scheduler)
+              (defn schedule [executor task]
+                (try
+                  (.schedule executor task)
+                  (catch Throwable t
+                    (.shutdownNow executor)
+                    (throw t))))"
+          {:keys [violations]} (exc/analyze-content "scheduler.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
+(deftest future-cancel-rethrow-is-fatal-only
+  (testing "future cancellation before rethrow preserves task cleanup"
+    (let [src "(ns ai.miniforge.foo.batch)
+              (defn await-all [futures]
+                (try
+                  (mapv deref futures)
+                  (catch Throwable t
+                    (doseq [f futures]
+                      (future-cancel f))
+                    (throw t))))"
+          {:keys [violations]} (exc/analyze-content "batch.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
+(deftest log-only-rethrow-remains-cleanup-needed
+  (testing "logging before rethrow does not make the site informational"
+    (let [src "(ns ai.miniforge.foo.runner)
+              (defn run []
+                (try
+                  (step)
+                  (catch Exception e
+                    (log/error e)
+                    (throw e))))"
+          {:keys [violations]} (exc/analyze-content "runner.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :cleanup-needed (:classification (first violations)))))))
+
 (deftest plain-failure-is-cleanup-needed
   (testing "messages without programmer-error markers are :cleanup-needed"
     (let [src "(ns ai.miniforge.foo.core)

--- a/docs/pull-requests/2026-07-03-chris-cleanup-rethrow-classification.md
+++ b/docs/pull-requests/2026-07-03-chris-cleanup-rethrow-classification.md
@@ -1,0 +1,31 @@
+<!--
+  Title: Cleanup-Preserving Rethrow Classification
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Cleanup-Preserving Rethrow Classification
+
+Branch: `fix/cleanup-rethrow-classification`
+
+## Summary
+
+The exceptions-as-data scanner counted cleanup-preserving rethrows as
+actionable debt even when the catch body releases resources and then
+rethrows the original failure.
+
+This PR classifies the narrow same-binding rethrow pattern as
+`:fatal-only` only when the catch body performs explicit cleanup before the
+rethrow:
+
+- scheduled executor shutdown via `.shutdownNow`
+- future cancellation via `future-cancel`
+
+Plain log-and-rethrow sites remain `:cleanup-needed`.
+
+## Verification
+
+- Focused scanner tests:
+  `ai.miniforge.compliance-scanner.exceptions-as-data.fatal-only-classification-test`
+- Raw scanner count:
+  `{:cleanup-needed 24, :fatal-only 128, :local-boundary 17}`


### PR DESCRIPTION
## Summary
- classify same-binding rethrows as fatal-only only when recognized cleanup happens before the rethrow
- recognize scheduled executor shutdown and future cancellation cleanup patterns
- keep log-only rethrows classified as cleanup-needed

## Verification
- bb pre-commit
- focused fatal-only scanner tests
- raw scanner count: {:cleanup-needed 24, :fatal-only 128, :local-boundary 17}