### PR TITLE
fix(validation): add anomaly-returning result helpers

### DIFF
--- a/components/control-plane/src/ai/miniforge/control_plane/interface.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/interface.clj
@@ -61,6 +61,10 @@
    (valid-transition? profile :running :blocked) ;=> true"
   sm/valid-transition?)
 
+(def validate-transition-result
+  "Validate a state transition. Returns nil on success or an anomaly on invalid."
+  sm/validate-transition-result)
+
 (def terminal?
   "Check if a status is terminal.
    (terminal? profile :completed) ;=> true"

--- a/components/control-plane/src/ai/miniforge/control_plane/state_machine.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/state_machine.clj
@@ -28,8 +28,9 @@
    Layer 1: Transition validation
    Layer 2: Event mapping"
   (:require
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
+  [clojure.edn :as edn]
+  [clojure.java.io :as io]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.control-plane.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -96,22 +97,31 @@
   (let [transitions (:valid-transitions profile)]
     (contains? (get transitions from-status #{}) to-status)))
 
-(defn validate-transition
-  "Validate a state transition. Returns nil on success, throws on invalid.
+(defn validate-transition-result
+  "Validate a state transition. Returns nil on success or an anomaly on invalid.
 
    Arguments:
    - profile    - State profile map
    - from-status - Current agent status
-   - to-status  - Desired agent status
-
-   Throws: ExceptionInfo if transition is invalid."
+   - to-status  - Desired agent status"
   [profile from-status to-status]
   (when-not (valid-transition? profile from-status to-status)
-    (throw (ex-info (messages/t :state-machine/invalid-transition)
-                    {:from from-status
-                     :to to-status
-                     :valid-targets (get (:valid-transitions profile)
-                                        from-status #{})}))))
+    (anomaly/anomaly :invalid-input
+                     (messages/t :state-machine/invalid-transition)
+                     {:from from-status
+                      :to to-status
+                      :valid-targets (get (:valid-transitions profile)
+                                         from-status #{})})))
+
+(defn validate-transition
+  "Boundary wrapper around the canonical anomaly-returning
+   [[validate-transition-result]]. Returns nil on success and throws only for
+   legacy callers. Prefer `validate-transition-result` in non-boundary code."
+  [profile from-status to-status]
+  (let [result (validate-transition-result profile from-status to-status)]
+    (when (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      (:anomaly/data result))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Event mapping

--- a/components/control-plane/src/ai/miniforge/control_plane/state_machine.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/state_machine.clj
@@ -25,11 +25,11 @@
    completed, failed, unreachable, terminated.
 
    Layer 0: Profile loading
-   Layer 1: Transition validation
-   Layer 2: Event mapping"
+  Layer 1: Transition validation
+  Layer 2: Event mapping"
   (:require
-  [clojure.edn :as edn]
-  [clojure.java.io :as io]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.control-plane.messages :as messages]))
 

--- a/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
@@ -18,8 +18,10 @@
 
 (ns ai.miniforge.control-plane.interface-test
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest testing is are]]
+   [ai.miniforge.control-plane.state-machine :as sm]
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.interface :as cp]))
 
@@ -68,6 +70,22 @@
         :failed    :running
         :terminated :running
         :blocked   :completed))))
+
+(deftest validate-transition-result-test
+  (let [profile (cp/get-profile)]
+    (testing "valid transitions return nil"
+      (is (nil? (cp/validate-transition-result profile :running :blocked))))
+
+    (testing "invalid transitions return anomaly data"
+      (let [result (cp/validate-transition-result profile :completed :running)]
+        (is (anomaly/anomaly? result))
+        (is (= :invalid-input (:anomaly/type result)))
+        (is (= :completed (get-in result [:anomaly/data :from])))
+        (is (= :running (get-in result [:anomaly/data :to])))))
+
+    (testing "legacy validate-transition still throws"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (sm/validate-transition profile :completed :running))))))
 
 (deftest terminal-test
   (let [profile (cp/get-profile)]

--- a/components/decision/src/ai/miniforge/decision/interface.clj
+++ b/components/decision/src/ai/miniforge/decision/interface.clj
@@ -69,6 +69,9 @@
 (def explain
   "Humanized explanation of why `value` fails `schema`. (schema value) -> map|nil."
   spec/explain)
+(def validate-result
+  "Return `value` if it validates against `schema`, else return an anomaly."
+  spec/validate-result)
 (def validate
   "Return `value` if it validates against `schema`, else throw. (schema value) -> value."
   spec/validate)

--- a/components/decision/src/ai/miniforge/decision/spec.clj
+++ b/components/decision/src/ai/miniforge/decision/spec.clj
@@ -22,6 +22,7 @@
    Layer 1: Checkpoint and episode schemas
    Layer 2: Validation helpers"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [malli.core :as m]
    [malli.error :as me]))
 
@@ -188,11 +189,24 @@
   (some-> (m/explain schema value)
           me/humanize))
 
-(defn validate
+(defn validate-result
+  "Return `value` when it validates against `schema`, else return an anomaly."
   [schema value]
   (if (valid? schema value)
     value
-    (throw (ex-info "Decision schema validation failed"
-                    {:schema schema
-                     :value value
-                     :errors (explain schema value)}))))
+    (anomaly/anomaly :invalid-input
+                     "Decision schema validation failed"
+                     {:schema schema
+                      :value value
+                      :errors (explain schema value)})))
+
+(defn validate
+  "Boundary wrapper around the canonical anomaly-returning
+   [[validate-result]]. Returns `value` on success and throws only for
+   legacy callers. Prefer `validate-result` in non-boundary code."
+  [schema value]
+  (let [result (validate-result schema value)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      (:anomaly/data result)))
+      result)))

--- a/components/decision/test/ai/miniforge/decision/interface_test.clj
+++ b/components/decision/test/ai/miniforge/decision/interface_test.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.decision.interface-test
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.decision.interface :as decision]
    [ai.miniforge.decision.spec :as spec]))
@@ -483,6 +484,21 @@
     (is (thrown? clojure.lang.ExceptionInfo
                  (decision/validate spec/DecisionResponse
                                     {:type :approve :authority-role :alien})))))
+
+(deftest validate-result-returns-anomaly-on-malformed-input-test
+  (testing "validate-result returns a typed anomaly instead of throwing"
+    (let [result (decision/validate-result
+                  spec/DecisionResponse
+                  {:type :approve :authority-role :alien})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (contains? (get-in result [:anomaly/data :errors])
+                     :authority-role)))))
+
+(deftest validate-result-returns-value-on-valid-input-test
+  (testing "validate-result returns the original valid value"
+    (let [response (valid-approve-response)]
+      (is (= response (decision/validate-result spec/DecisionResponse response))))))
 
 (deftest constructed-checkpoints-conform-to-schema-test
   (testing "Each happy-path constructor produces a value that satisfies DecisionCheckpoint"

--- a/docs/pull-requests/2026-07-03-chris-validation-result-wrappers.md
+++ b/docs/pull-requests/2026-07-03-chris-validation-result-wrappers.md
@@ -1,0 +1,29 @@
+<!--
+  Title: Validation Result Wrappers
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Validation Result Wrappers
+
+Branch: `fix/validation-result-wrappers`
+
+## Summary
+
+This PR adds anomaly-returning validation APIs for two remaining validation
+helpers while preserving their legacy throwing behavior as documented local
+boundary wrappers.
+
+- Add `decision/validate-result` and re-export it through the decision
+  interface.
+- Add `control-plane/validate-transition-result` and re-export it through the
+  control-plane interface.
+- Keep `decision/validate` and `state-machine/validate-transition` as
+  compatibility wrappers around their canonical anomaly-returning helpers.
+
+## Verification
+
+- Focused decision interface tests
+- Focused control-plane interface tests
+- Raw scanner count:
+  `{:cleanup-needed 22, :fatal-only 128, :local-boundary 19}`


### PR DESCRIPTION
## Summary
- add decision/validate-result and export it through the decision interface
- add control-plane validate-transition-result and export it through the control-plane interface
- keep existing throwing validators as documented compatibility wrappers

## Verification
- bb pre-commit
- focused decision interface tests
- focused control-plane interface tests
- raw scanner count: {:cleanup-needed 22, :fatal-only 128, :local-boundary 19}