### PR TITLE
docs(boundaries): classify retained throwing wrappers

### DIFF
--- a/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
+++ b/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
@@ -83,8 +83,11 @@
 ;; Process invocations
 
 (defn run!
-  "Run a command inheriting stdio. Throws ex-info on non-zero exit.
-   Accepts an optional opts map as the first arg."
+  "Boundary wrapper around the canonical result-returning `sh`.
+
+   Run a command inheriting stdio. Throws ex-info on non-zero exit for legacy
+   bang-callers; prefer `sh` in non-boundary code when callers can branch on
+   the process result map. Accepts an optional opts map as the first arg."
   [& args]
   (let [[opts cmd] (split-opts args)
         result     (apply p/sh (merge {:continue true} opts) (resolved-cmd cmd))]

--- a/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
+++ b/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
@@ -85,9 +85,10 @@
 (defn run!
   "Boundary wrapper around the canonical result-returning `sh`.
 
-   Run a command inheriting stdio. Throws ex-info on non-zero exit for legacy
-   bang-callers; prefer `sh` in non-boundary code when callers can branch on
-   the process result map. Accepts an optional opts map as the first arg."
+   Run a command through babashka.process/sh. Throws ex-info on non-zero exit
+   for legacy bang-callers; prefer `sh` in non-boundary code when callers can
+   branch on the process result map. Accepts an optional opts map as the first
+   arg, including stdio overrides such as `:out` / `:err`."
   [& args]
   (let [[opts cmd] (split-opts args)
         result     (apply p/sh (merge {:continue true} opts) (resolved-cmd cmd))]

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -176,7 +176,12 @@
 
 (defn acquire-execution-environment!
   "Acquire an isolated execution environment before pipeline starts.
-   Returns env map, or nil (local) / throws (governed) on failure."
+   Boundary wrapper around the anomaly-returning executor availability check.
+
+   Returns env map, or nil (local) / throws (governed) on failure. Governed
+   acquisition failure deliberately escalates for legacy runner callers that
+   rely on try+ exception flow; prefer anomaly-returning helpers such as
+   `check-executor-for-mode` for non-boundary branching."
   [workflow-id {:keys [repo-url branch repo-path execution-mode executor-config
                        resume-workspace]}]
   (let [mode (get {:governed :governed} execution-mode :local)]

--- a/docs/pull-requests/2026-07-03-chris-boundary-wrapper-docs.md
+++ b/docs/pull-requests/2026-07-03-chris-boundary-wrapper-docs.md
@@ -1,0 +1,27 @@
+<!--
+  Title: Boundary Wrapper Documentation
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Boundary Wrapper Documentation
+
+Branch: `fix/boundary-wrapper-docs`
+
+## Summary
+
+This PR documents retained throwing wrappers that already have
+data-returning paths underneath them:
+
+- `workflow.runner-environment/acquire-execution-environment!` escalates
+  governed acquisition failures for legacy runner callers, while
+  `check-executor-for-mode` remains the anomaly-returning branch point.
+- `bb-proc/run!` remains the bang/throwing wrapper, while `bb-proc/sh`
+  returns the process result map for callers that branch on data.
+
+No runtime behavior changes.
+
+## Verification
+
+- Raw scanner count:
+  `{:cleanup-needed 19, :fatal-only 128, :local-boundary 22}`


### PR DESCRIPTION
## Summary
- document workflow runner environment acquisition as a retained governed-mode throwing boundary over anomaly-returning executor checks
- document bb-proc/run! as the legacy bang wrapper over result-returning sh
- move three scanner rows from cleanup-needed to local-boundary without runtime behavior changes

## Verification
- bb pre-commit
- raw scanner count: {:cleanup-needed 19, :fatal-only 128, :local-boundary 22}