### PR TITLE
fix(compliance-scanner): classify gate boundary throws

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -215,6 +215,7 @@
    "classpath"
    "integrity"
    "invalid-config"
+   "not-function"
    "unregistered-at-resolve"
    "unmapped"
    "no matching"])
@@ -397,6 +398,12 @@
        (= 2 (count form))
        (symbol? (second form))))
 
+(defn- throw-anomaly-form?
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (= "throw-anomaly!" (name (first form)))))
+
 (def ^:private cleanup-rethrow-markers
   "Cleanup operations that make a same-catch rethrow informational.
 
@@ -439,6 +446,10 @@
   [form context]
   (cond
     (local-boundary-wrapper? context)
+    :local-boundary
+
+    (and (:response-chain-boundary? context)
+         (throw-anomaly-form? form))
     :local-boundary
 
     (or (and (:interrupted-binding context)
@@ -495,6 +506,10 @@
                         (nth form 2 nil))]
     (cond-> context
       defn-data (merge defn-data)
+      (and (seq? form)
+           (symbol? (first form))
+           (= "execute-with-handling" (name (first form))))
+      (assoc :response-chain-boundary? true)
       interrupted (assoc :interrupted-binding interrupted)
       (and (symbol? catch-binding)
            (cleanup-before-rethrow? form catch-binding))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
@@ -114,6 +114,18 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
+(deftest localized-not-function-message-key-is-fatal-only
+  (testing "localized non-callable function guards are programmer errors"
+    (let [src "(ns ai.miniforge.foo.gate)
+              (defn check [provided]
+                (when (and (some? provided) (not (ifn? provided)))
+                  (throw (IllegalArgumentException.
+                          (messages/t :behavioral/check-fn-not-function
+                                      {:class (class provided)})))))"
+          {:keys [violations]} (exc/analyze-content "gate.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
 (deftest interrupted-exception-rethrow-is-fatal-only
   (testing "InterruptedException rethrows preserve cancellation"
     (let [src "(ns ai.miniforge.foo.loop)

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_test.clj
@@ -86,6 +86,25 @@
       (is (= 1 (count violations)))
       (is (= :local-boundary (:classification (first violations)))))))
 
+(deftest response-chain-execute-with-handling-throw-anomaly-is-local-boundary
+  (testing "throw-anomaly inside response-chain handling is captured into returned data"
+    (let [src "(ns ai.miniforge.foo.core
+                (:require [ai.miniforge.response.interface :as response]))
+              (defn run-gate [chain result]
+                (response/execute-with-handling
+                 chain
+                 :gate
+                 (fn [_] :anomalies.gate/check-failed)
+                 (fn []
+                   (if (:passed? result)
+                     result
+                     (response/throw-anomaly! :anomalies.gate/validation-failed
+                                              \"Gate validation failed\"
+                                              {:errors (:errors result)})))))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :local-boundary (:classification (first violations)))))))
+
 (deftest undocumented-bang-thrower-remains-cleanup-needed
   (testing "a bang name alone is not enough to exempt a throw"
     (let [src "(ns ai.miniforge.foo.core)

--- a/docs/pull-requests/2026-07-03-chris-scanner-gate-boundaries.md
+++ b/docs/pull-requests/2026-07-03-chris-scanner-gate-boundaries.md
@@ -1,0 +1,27 @@
+<!--
+  Title: Scanner Gate Boundary Classification
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Scanner Gate Boundary Classification
+
+Branch: `fix/scanner-gate-boundaries`
+
+## Summary
+
+This PR tightens exceptions-as-data scanner classification for two gate
+patterns:
+
+- `response/throw-anomaly!` inside `response/execute-with-handling` is a
+  local response-chain boundary because the exception is captured into the
+  returned chain.
+- Localized `:behavioral/check-fn-not-function` guards are programmer-error
+  checks and classify as `:fatal-only`.
+
+## Verification
+
+- Focused fatal-only scanner tests
+- Focused local-boundary scanner tests
+- Raw scanner count:
+  `{:cleanup-needed 17, :fatal-only 129, :local-boundary 23}`


### PR DESCRIPTION
## Summary
- classify response/throw-anomaly! inside response/execute-with-handling as a local response-chain boundary
- classify localized :behavioral/check-fn-not-function guards as fatal-only programmer errors
- cover both scanner cases with focused tests

## Verification
- bb pre-commit
- focused fatal-only scanner tests
- focused local-boundary scanner tests
- raw scanner count: {:cleanup-needed 17, :fatal-only 129, :local-boundary 23}