### PR TITLE
fix(workspace): add anomaly-returning workdir resolver

### DIFF
--- a/components/workspace/deps.edn
+++ b/components/workspace/deps.edn
@@ -2,6 +2,6 @@
 ;; Author: Christopher Lester (christopher@miniforge.ai)
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 {:paths ["src"]
- :deps {}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/workspace/src/ai/miniforge/workspace/core.clj
+++ b/components/workspace/src/ai/miniforge/workspace/core.clj
@@ -24,7 +24,9 @@
    worktree was absent — the wrong-tree source of greenfield/empty work that
    passed gates against the wrong files. This is the intended single home for
    that read; a lint forbidding `(System/getProperty \"user.dir\")` elsewhere
-   in execution namespaces is a planned follow-up (it does not exist yet).")
+   in execution namespaces is a planned follow-up (it does not exist yet)."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]))
 
 (def ^:private worktree-path-keys
   "Context keys, in priority order, that carry the execution worktree path.
@@ -49,8 +51,42 @@
                    (get-in ctx [:execution/opts :execution-mode])
                    :local)))
 
+(defn- workdir-unresolved-message
+  [label]
+  (str "Execution worktree-path unresolved in a governed run"
+       (when label (str " (" label ")"))
+       " -- refusing to fall back to the process CWD (no silent downgrade)."))
+
+(defn- workdir-unresolved-data
+  [ctx label]
+  {:anomaly/category :anomalies/workdir-unresolved
+   :workspace/site label
+   :execution/mode (or (:execution/mode ctx)
+                       (get-in ctx [:execution/opts :execution-mode])
+                       :local)
+   :workspace/tried worktree-path-keys})
+
+(defn resolve-execution-workdir-result
+  "Resolve the execution worktree path from `ctx`, returning a string or a
+   canonical anomaly map instead of throwing.
+
+   Governed runs with no ctx worktree path fail closed with an
+   `:invalid-input` / `:anomalies/workdir-unresolved` anomaly. Local runs keep
+   the dev-convenience process-CWD fallback."
+  ([ctx] (resolve-execution-workdir-result ctx nil))
+  ([ctx label]
+   (if-let [wt (ctx-worktree-path ctx)]
+     wt
+     (if (governed? ctx)
+       (anomaly/sub-anomaly :invalid-input
+                            :anomalies/workdir-unresolved
+                            (workdir-unresolved-message label)
+                            (workdir-unresolved-data ctx label))
+       (System/getProperty "user.dir")))))
+
 (defn resolve-execution-workdir
-  "Resolve the execution worktree path from `ctx`.
+  "Boundary wrapper around the anomaly-returning
+   `resolve-execution-workdir-result`.
 
    - Worktree path present on ctx → return it.
    - Absent on a GOVERNED run → throw a typed `:anomalies/workdir-unresolved`
@@ -63,16 +99,8 @@
    that want to log which resolver site degraded."
   ([ctx] (resolve-execution-workdir ctx nil))
   ([ctx label]
-   (if-let [wt (ctx-worktree-path ctx)]
-     wt
-     (if (governed? ctx)
-       (throw (ex-info (str "Execution worktree-path unresolved in a governed run"
-                            (when label (str " (" label ")"))
-                            " — refusing to fall back to the process CWD (no silent downgrade).")
-                       {:anomaly/category :anomalies/workdir-unresolved
-                        :workspace/site label
-                        :execution/mode (or (:execution/mode ctx)
-                                            (get-in ctx [:execution/opts :execution-mode])
-                                            :local)
-                        :workspace/tried worktree-path-keys}))
-       (System/getProperty "user.dir")))))
+   (let [result (resolve-execution-workdir-result ctx label)]
+     (if (anomaly/anomaly? result)
+       (throw (ex-info (:anomaly/message result)
+                       (:anomaly/data result)))
+       result))))

--- a/components/workspace/src/ai/miniforge/workspace/interface.clj
+++ b/components/workspace/src/ai/miniforge/workspace/interface.clj
@@ -28,3 +28,9 @@
    local → process CWD. The single sanctioned `(System/getProperty
    \"user.dir\")` read. See `core` ns."
   core/resolve-execution-workdir)
+
+(def resolve-execution-workdir-result
+  "Resolve the execution worktree path from ctx. Present → return it; absent +
+   governed → return a canonical `:anomalies/workdir-unresolved` anomaly
+   (fail closed); absent + local → process CWD."
+  core/resolve-execution-workdir-result)

--- a/components/workspace/test/ai/miniforge/workspace/core_test.clj
+++ b/components/workspace/test/ai/miniforge/workspace/core_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.workspace.core-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.workspace.interface :as sut]))
 
 (deftest resolves-worktree-path-from-ctx
@@ -41,6 +42,16 @@
   (testing "governed mode via :execution/opts :execution-mode also fails closed"
     (is (thrown? clojure.lang.ExceptionInfo
                  (sut/resolve-execution-workdir {:execution/opts {:execution-mode :governed}})))))
+
+(deftest governed-run-can-return-workdir-anomaly
+  (testing "result API returns anomaly data instead of throwing"
+    (let [result (sut/resolve-execution-workdir-result {:execution/mode :governed} "verify")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :anomalies/workdir-unresolved (:anomaly/subtype result)))
+      (is (= :anomalies/workdir-unresolved
+             (get-in result [:anomaly/data :anomaly/category])))
+      (is (= "verify" (get-in result [:anomaly/data :workspace/site]))))))
 
 (deftest local-run-falls-back-to-cwd
   (testing "no worktree path + local (default) mode → process CWD"


### PR DESCRIPTION
## Summary
- add resolve-execution-workdir-result for data-first governed workdir failures
- keep resolve-execution-workdir as a documented compatibility boundary wrapper
- cover the anomaly-returning path in workspace tests

## Verification
- clojure -M:dev:test -e '(require (quote ai.miniforge.workspace.core-test) (quote clojure.test)) (let [r (clojure.test/run-tests (quote ai.miniforge.workspace.core-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) ...' => cleanup-needed 16
- bb pre-commit