### PR TITLE
fix(phase-factory): add result guards for phase entry

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -21,8 +21,9 @@
 
    Generates code artifacts from plans.
    Agent: :implementer
-   Default gates: [:syntax :lint]"
+  Default gates: [:syntax :lint]"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]
@@ -104,13 +105,26 @@
    :test-output (truncate-test-output
                  (get-in verify-result [:result :metrics :test-output]))})
 
-(defn- resolve-worktree-path
-  "Resolve the worktree path from execution context.
-   Fails fast if no environment has been acquired — do not fall back to host filesystem."
+(defn- resolve-worktree-path-result
+  "Resolve the worktree path from execution context, returning a path or a
+   canonical anomaly. Do not fall back to the host filesystem when no
+   environment has been acquired."
   [ctx]
   (or (get ctx :execution/worktree-path)
-      (throw (ex-info (messages/t :implement/no-worktree)
-                      {:ctx-keys (keys ctx)}))))
+      (anomaly/sub-anomaly :invalid-input
+                           :anomalies.phase/enter-failed
+                           (messages/t :implement/no-worktree)
+                           {:ctx-keys (vec (keys ctx))})))
+
+(defn- resolve-worktree-path
+  "Boundary wrapper around the anomaly-returning
+   `resolve-worktree-path-result`; retained for existing exception callers."
+  [ctx]
+  (let [result (resolve-worktree-path-result ctx)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      (:anomaly/data result)))
+      result)))
 
 (defn- base-ref-candidates
   "Return candidate refs for collecting the promoted task artifact."

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -23,7 +23,8 @@
    No tester agent: the implementer wrote both source and test files;
    this phase validates them by running the test suite.
    Default gates: [:tests-pass :coverage]"
-  (:require [ai.miniforge.phase.interface :as phase]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.workspace.interface :as workspace]
             [ai.miniforge.phase-software-factory.phase-config :as phase-config]
             [ai.miniforge.phase-software-factory.messages :as messages]
@@ -269,6 +270,25 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
 
+(defn- require-environment-result
+  "Return nil when the verify execution environment exists, otherwise return a
+   canonical anomaly describing the fail-closed phase entry error."
+  [ctx]
+  (when-not (get ctx :execution/environment-id)
+    (anomaly/sub-anomaly :invalid-input
+                         :anomalies.phase/enter-failed
+                         (messages/t :verify/no-environment)
+                         {:phase :verify
+                          :hint (messages/t :verify/no-environment-hint)})))
+
+(defn- require-environment!
+  "Boundary wrapper around the anomaly-returning
+   `require-environment-result`; retained for existing exception callers."
+  [ctx]
+  (when-let [result (require-environment-result ctx)]
+    (throw (ex-info (:anomaly/message result)
+                    (:anomaly/data result)))))
+
 (defn enter-verify
   "Execute verification phase.
 
@@ -284,10 +304,7 @@
         _ (phase/emit-phase-started! ctx :verify)
 
         ;; Fail fast if no executor environment has been acquired
-        _ (when-not (get ctx :execution/environment-id)
-            (throw (ex-info (messages/t :verify/no-environment)
-                            {:phase :verify
-                             :hint (messages/t :verify/no-environment-hint)})))
+        _ (require-environment! ctx)
 
         worktree-path (workspace/resolve-execution-workdir ctx "verify")
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -22,6 +22,7 @@
   Tests artifact creation, validation, and error handling."
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase-software-factory.implement :as implement]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
@@ -84,6 +85,14 @@
   [{:keys [implementer-result]}]
   (response/success (:output implementer-result)
                     {:metrics (:metrics implementer-result)}))
+
+(deftest resolve-worktree-path-result-returns-anomaly-test
+  (testing "missing implement worktree is available as anomaly data"
+    (let [result (#'implement/resolve-worktree-path-result {:execution/id :test})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :anomalies.phase/enter-failed (:anomaly/subtype result)))
+      (is (= [:execution/id] (get-in result [:anomaly/data :ctx-keys]))))))
 
 (defn mock-curator-error
   "Mock for agent/curate-implement-output that returns the same error

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
@@ -25,6 +25,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest testing is use-fixtures]]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase-software-factory.verify :as verify]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]))
@@ -145,6 +146,16 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"Verify phase has no execution environment"
                             (verify/enter-verify ctx))))))
+
+(deftest require-environment-result-returns-anomaly-test
+  (testing "missing verify environment is available as anomaly data"
+    (let [ctx (-> (create-base-context)
+                  (dissoc :execution/environment-id))
+          result (#'verify/require-environment-result ctx)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :anomalies.phase/enter-failed (:anomaly/subtype result)))
+      (is (= :verify (get-in result [:anomaly/data :phase]))))))
 
 (deftest enter-verify-uses-execution-worktree-path-test
   (testing "enter-verify passes :execution/worktree-path to test runner"


### PR DESCRIPTION
## Summary
- add anomaly-returning guards for implement worktree and verify environment entry failures
- keep existing throwing paths as documented compatibility boundary wrappers
- cover both result helpers with focused tests

## Verification
- clojure -M:dev:test -e '(require (quote ai.miniforge.phase-software-factory.implement-test) (quote ai.miniforge.phase-software-factory.verify-test) (quote clojure.test)) ...' => 61 tests, 200 assertions, 0 failures
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) ...' => cleanup-needed 14
- bb pre-commit