### PR TITLE
fix(release): add zero-files result helper

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -26,6 +26,7 @@
    Agent: :releaser
    Default gates: [:release-ready]"
   (:require [clojure.java.io :as io]
+            [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.workspace.interface :as workspace]
             [clojure.java.shell :as shell]
             [clojure.string :as str]
@@ -190,6 +191,35 @@
       structured
       (vec (get review-output :review/warnings [])))))
 
+(defn- zero-files-data
+  [impl-result worktree-path]
+  {:type           :release/zero-files
+   :phase          :release
+   :environment-id (:environment-id impl-result)
+   :worktree-path  worktree-path})
+
+(defn- release-files-result
+  "Return release file data or a canonical anomaly when there is no
+   substantive work to release."
+  [committed dirty impl-result worktree-path]
+  (or (not-empty committed)
+      (not-empty dirty)
+      (anomaly/sub-anomaly :invalid-input
+                           :anomalies.phase/enter-failed
+                           (messages/t :release/zero-files)
+                           (zero-files-data impl-result worktree-path))))
+
+(defn- release-files!
+  "Boundary wrapper around the anomaly-returning `release-files-result`;
+   retained for release phase control flow that treats `:release/zero-files`
+   as a terminal exception."
+  [committed dirty impl-result worktree-path]
+  (let [result (release-files-result committed dirty impl-result worktree-path)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      (:anomaly/data result)))
+      result)))
+
 (defn build-workflow-state
   "Build workflow state from phase context for the release executor.
 
@@ -230,13 +260,7 @@
                            (if (and governed? execute-fn executor env-id)
                              (git-dirty-files-capsule execute-fn executor env-id worktree-path)
                              (git-dirty-files worktree-path)))
-          files          (or (not-empty committed)
-                             (not-empty dirty)
-                             (throw (ex-info (messages/t :release/zero-files)
-                                             {:type           :release/zero-files
-                                              :phase          :release
-                                              :environment-id (:environment-id impl-result)
-                                              :worktree-path  worktree-path})))
+          files          (release-files! committed dirty impl-result worktree-path)
           code-artifacts [{:artifact/type    :code
                            :artifact/content {:code/id        (random-uuid)
                                               :code/language  "mixed"

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -32,6 +32,7 @@
    [clojure.java.shell :as shell]
    [clojure.string :as str]
    [babashka.fs :as fs]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase-software-factory.release :as release]
@@ -635,6 +636,19 @@
                               #"Release phase received code artifact with zero files"
                               ((:enter interceptor) ctx-with-config))
             "Release should fail fast when environment has no changed files"))))))
+
+(deftest release-files-result-returns-zero-files-anomaly-test
+  (testing "zero-files is available as anomaly data"
+    (let [impl-result {:environment-id "task-1"}
+          result (#'release/release-files-result [] [] impl-result "/tmp/task-1")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :anomalies.phase/enter-failed (:anomaly/subtype result)))
+      (is (= {:type :release/zero-files
+              :phase :release
+              :environment-id "task-1"
+              :worktree-path "/tmp/task-1"}
+             (:anomaly/data result))))))
 
 (deftest release-ignores-non-substantive-paths-test
   (testing "iter-23 regression: a worktree dirty ONLY with .miniforge-session-id


### PR DESCRIPTION
## Summary
- extract release zero-files detection into an anomaly-returning helper
- keep the existing terminal exception path as a documented boundary wrapper
- cover the zero-files anomaly data shape in release tests

## Verification
- clojure -M:dev:test -e '(require (quote ai.miniforge.phase-software-factory.release-test) (quote clojure.test)) ...' => 28 tests, 72 assertions, 0 failures
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) ...' => cleanup-needed 13
- bb pre-commit