### PR TITLE
fix(fsm): add anomaly-returning transition result

### DIFF
--- a/components/fsm/deps.edn
+++ b/components/fsm/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}}
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {}}}}

--- a/components/fsm/src/ai/miniforge/fsm/core.clj
+++ b/components/fsm/src/ai/miniforge/fsm/core.clj
@@ -35,6 +35,7 @@
      :completed {:type :final}
      :failed    {:type :final}}}"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [statecharts.core :as sc]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -124,8 +125,53 @@
   [machine]
   (sc/initialize machine))
 
+(defn- event-map
+  [event]
+  (if (keyword? event)
+    {:type event}
+    event))
+
+(defn- unknown-event-message
+  [state event-map]
+  (str "FSM unknown event " (pr-str (:type event-map))
+       " at state " (pr-str (get state :_state state))))
+
+(defn- unknown-event-data
+  [state event-map]
+  {:anomaly/category :anomalies/fsm-unknown-event
+   :fsm/state state
+   :fsm/event event-map})
+
+(defn- statechart-transition-result
+  "Boundary wrapper around clj-statecharts transition, returning a canonical
+   unknown-event anomaly while preserving unexpected statechart failures as
+   exceptions."
+  [machine state event-map]
+  (try
+    (sc/transition machine state event-map)
+    (catch clojure.lang.ExceptionInfo e
+      (if (re-find #"got unknown event" (ex-message e))
+        (with-meta
+          (anomaly/sub-anomaly :invalid-input
+                               :anomalies/fsm-unknown-event
+                               (unknown-event-message state event-map)
+                               (unknown-event-data state event-map))
+          {:cause e})
+        (throw e)))))
+
+(defn transition-result
+  "Transition the machine given an event, returning the new state or a
+   canonical anomaly for a state-local unknown event.
+
+   Unexpected `ExceptionInfo` failures are rethrown as-is so this public API
+   never returns a Throwable where callers expect state-or-anomaly data."
+  [machine state event]
+  (statechart-transition-result machine state (event-map event)))
+
 (defn transition
-  "Transition the machine given an event.
+  "Boundary wrapper around the anomaly-returning `transition-result`.
+
+   Transition the machine given an event.
 
    Arguments:
      machine - Compiled machine definition
@@ -142,23 +188,12 @@
    error or an ignore that MUST be declared in the machine — both should be
    loud. Callers that legitimately tolerate it catch this category."
   [machine state event]
-  (let [event-map (if (keyword? event)
-                    {:type event}
-                    event)]
-    (try
-      (sc/transition machine state event-map)
-      (catch clojure.lang.ExceptionInfo e
-        (if (re-find #"got unknown event" (ex-message e))
-          ;; Compact message — just the state NAME (:_state), not the whole
-          ;; state map (which can be large / carry sensitive context). The
-          ;; full state is in ex-data :fsm/state for diagnosis.
-          (throw (ex-info (str "FSM unknown event " (pr-str (:type event-map))
-                               " at state " (pr-str (get state :_state state)))
-                          {:anomaly/category :anomalies/fsm-unknown-event
-                           :fsm/state state
-                           :fsm/event event-map}
-                          e))
-          (throw e))))))
+  (let [result (transition-result machine state event)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      (:anomaly/data result)
+                      (:cause (meta result))))
+      result)))
 
 (defn current-state
   "Get the current state value from a state map.

--- a/components/fsm/src/ai/miniforge/fsm/interface.clj
+++ b/components/fsm/src/ai/miniforge/fsm/interface.clj
@@ -76,6 +76,12 @@
      (transition machine state {:type :fail :data {:error \"timeout\"}})"
   core/transition)
 
+(def transition-result
+  "Transition given an event, returning a state or a canonical anomaly for a
+   state-local unknown event. Non-unknown statechart failures are thrown
+   unchanged."
+  core/transition-result)
+
 (def current-state
   "Get current state keyword from state map.
 

--- a/components/fsm/test/ai/miniforge/fsm/interface_test.clj
+++ b/components/fsm/test/ai/miniforge/fsm/interface_test.clj
@@ -20,6 +20,7 @@
   "Tests for the FSM component."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.fsm.interface :as fsm]))
 
 ;; ============================================================================
@@ -99,6 +100,25 @@
           "typed category so boundaries can catch + emit :fsm/unknown-event")
       (is (= {:type :unknown-event} (:fsm/event (ex-data ex)))
           "ex-data names the offending event for diagnosis"))))
+
+(deftest transition-result-unknown-event-returns-anomaly-test
+  (testing "transition-result returns a canonical anomaly for unknown events"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/states {:idle {:on {:start :running}}
+                                 :running {:type :final}}})
+          s0 (fsm/initialize machine)
+          result (fsm/transition-result machine s0 :unknown-event)]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :anomalies/fsm-unknown-event (:anomaly/subtype result)))
+      (is (= {:anomaly/category :anomalies/fsm-unknown-event
+              :fsm/state s0
+              :fsm/event {:type :unknown-event}}
+             (:anomaly/data result)))
+      (is (some? (:cause (meta result)))
+          "preserves the clj-statecharts cause for the boundary wrapper"))))
 
 (deftest transition-with-event-data-test
   (testing "transition accepts event with data"


### PR DESCRIPTION
## Summary
- add `fsm/transition-result` for state-local unknown events as canonical anomalies
- keep `fsm/transition` as the legacy throwing boundary wrapper
- cover canonical anomaly shape and preserved clj-statecharts cause

## Verification
- focused FSM tests: 15 tests, 41 assertions, 0 failures, 0 errors
- resolver scanner: `:cleanup-needed` 13 -> 12; `components/fsm/src/ai/miniforge/fsm/core.clj` removed from cleanup list
- `bb pre-commit`