### PR TITLE
fix(validation): add result helpers for local guards

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review_convergence.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review_convergence.clj
@@ -26,6 +26,7 @@
    when that file is absent."
   (:require
    [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase-software-factory.messages :as messages]
    [clojure.string :as str]
    [malli.core :as m]))
@@ -62,20 +63,39 @@
     {:default default-max-warning-only-cycles}
     [:int {:min 1}]]])
 
-(defn validate-convergence-config!
-  "Throw IllegalArgumentException when `config`'s convergence keys are
-   invalid. Merges the fallbacks UNDER config first, so a partial override
-   (only one key) is accepted while an invalid VALUE still fails fast."
+(defn- convergence-config-candidate
   [config]
-  (let [merged (merge {:review/warning-churn-policy    default-warning-churn-policy
-                       :review/max-warning-only-cycles default-max-warning-only-cycles}
-                      (select-keys config [:review/warning-churn-policy
-                                           :review/max-warning-only-cycles]))]
-    (when-not (m/validate ReviewConvergenceConfigSchema merged)
+  (merge {:review/warning-churn-policy    default-warning-churn-policy
+          :review/max-warning-only-cycles default-max-warning-only-cycles}
+         (select-keys config [:review/warning-churn-policy
+                              :review/max-warning-only-cycles])))
+
+(defn validate-convergence-config-result
+  "Validate `config`'s convergence keys. Returns config on success or a
+   canonical invalid-input anomaly on failure. Merges the fallbacks UNDER
+   config first, so a partial override is accepted while an invalid VALUE
+   remains explicit data."
+  [config]
+  (let [merged (convergence-config-candidate config)]
+    (if (m/validate ReviewConvergenceConfigSchema merged)
+      (merge config merged)
+      (anomaly/validation-anomaly
+       (messages/ts :review/invalid-convergence-config)
+       :review-convergence/config
+       merged
+       (m/explain ReviewConvergenceConfigSchema merged)))))
+
+(defn validate-convergence-config!
+  "Boundary wrapper around the canonical anomaly-returning
+   `validate-convergence-config-result`. Prefer the result function; this
+   wrapper preserves fail-fast startup semantics for invalid defaults.edn."
+  [config]
+  (let [result (validate-convergence-config-result config)]
+    (when (anomaly/anomaly? result)
       (throw (IllegalArgumentException.
-              (str (messages/ts :review/invalid-convergence-config)
+              (str (:anomaly/message result)
                    " "
-                   (pr-str (m/explain ReviewConvergenceConfigSchema merged))))))))
+                   (pr-str (:anomaly/data result))))))))
 
 ;; ----------------------------------------------------------------------------
 ;; Decision primitives (pure)

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_convergence_config_test.clj
@@ -20,6 +20,7 @@
   "Tests for review convergence policy config — named constants, Malli schema,
    and defaults loaded from resources/config/phase/defaults.edn."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]
    [ai.miniforge.phase-software-factory.messages :as messages]
@@ -96,6 +97,27 @@
           candidate (select-keys cfg [:review/warning-churn-policy
                                       :review/max-warning-only-cycles])]
       (is (valid? candidate)))))
+
+(deftest test-validate-convergence-config-result-returns-anomaly
+  (testing "invalid convergence config is returned as a canonical anomaly"
+    (let [result (rconv/validate-convergence-config-result
+                  {:review/warning-churn-policy  :unknown-policy
+                   :review/max-warning-only-cycles 0})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :review-convergence/config
+             (get-in result [:anomaly/data :anomaly/schema])))
+      (is (some? (get-in result [:anomaly/data :anomaly/explain]))))))
+
+(deftest test-validate-convergence-config-result-normalizes-defaults
+  (testing "valid partial config returns the validated defaults merged in"
+    (let [result (rconv/validate-convergence-config-result
+                  {:review/max-warning-only-cycles 4
+                   :review/other-key :kept})]
+      (is (= :accept-with-warnings
+             (:review/warning-churn-policy result)))
+      (is (= 4 (:review/max-warning-only-cycles result)))
+      (is (= :kept (:review/other-key result))))))
 
 (deftest test-defaults-edn-policy-matches-constant
   (testing "defaults.edn :review/warning-churn-policy matches the fallback constant"

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
@@ -112,16 +112,29 @@
    :resume/listener     (cond-> {:agent/id (:agent/id listener)}
                           (:session/id listener) (assoc :session/id (:session/id listener)))})
 
-(defn validate-primer!
-  "Throw on invalid primer; return primer otherwise. Used by
-   `dispatch-to-channel!` before any I/O."
+(defn validate-primer-result
+  "Validate primer shape. Returns a DAG ok result carrying the primer, or a
+   DAG err result with the same diagnostic payload the legacy throwing wrapper
+   exposes."
   [primer]
-  (when-not (m/validate ResumePrimer primer)
-    (throw (ex-info "invalid resume primer"
-                    {:errors  (m/explain ResumePrimer primer)
-                     :anomaly :resume-dispatcher/invalid-primer
-                     :primer  primer})))
-  primer)
+  (if (m/validate ResumePrimer primer)
+    (dag/ok primer)
+    (dag/err :resume-dispatcher/invalid-primer
+             "invalid resume primer"
+             {:errors (m/explain ResumePrimer primer)
+              :anomaly :resume-dispatcher/invalid-primer
+              :primer primer})))
+
+(defn validate-primer!
+  "Boundary wrapper around the canonical DAG-result-returning
+   `validate-primer-result`. Prefer `validate-primer-result`; this retains
+   the historical ex-info contract for direct callers."
+  [primer]
+  (let [result (validate-primer-result primer)]
+    (if (dag/ok? result)
+      (:data result)
+      (throw (ex-info (get-in result [:error :message])
+                      (get-in result [:error :data]))))))
 
 (defn channel-supported?
   "Pure predicate: true when the listener's channel kind has a real
@@ -276,17 +289,14 @@
    invoke. Returns DAG result. Does NOT mark the listener
    `:dispatched` — that's the caller's job after success."
   [primer listener]
-  (try
-    (validate-primer! primer)
-    (let [kind (get-in listener [:resume-channel :channel/kind])
-          handler (get channel-handlers kind)]
-      (if handler
-        (handler primer listener)
-        (not-yet-wired-error listener)))
-    (catch clojure.lang.ExceptionInfo e
-      (dag/err (or (:anomaly (ex-data e)) :resume-dispatcher/invalid-primer)
-               (.getMessage e)
-               (ex-data e)))))
+  (let [primer-result (validate-primer-result primer)]
+    (if-not (dag/ok? primer-result)
+      primer-result
+      (let [kind (get-in listener [:resume-channel :channel/kind])
+            handler (get channel-handlers kind)]
+        (if handler
+          (handler (:data primer-result) listener)
+          (not-yet-wired-error listener))))))
 
 (defn dispatch-listener!
   "Build primer + dispatch + mark dispatched on success.

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
@@ -100,6 +100,18 @@
     (is (thrown? clojure.lang.ExceptionInfo
                  (sut/validate-primer! {:resume/pr-url "x"})))))
 
+(deftest validate-primer-result-returns-dag-error-on-bad-shape
+  (testing "validate-primer-result returns a DAG error instead of throwing"
+    (let [result (sut/validate-primer-result {:resume/pr-url "x"})]
+      (is (false? (get result :ok?)))
+      (is (= :resume-dispatcher/invalid-primer
+             (get-in result [:error :code])))
+      (is (= :resume-dispatcher/invalid-primer
+             (get-in result [:error :data :anomaly])))
+      (is (= {:resume/pr-url "x"}
+             (get-in result [:error :data :primer])))
+      (is (some? (get-in result [:error :data :errors]))))))
+
 ;; ── channel-supported? + not-yet-wired ───────────────────────────────
 
 (deftest channel-supported-only-webhook-in-v0

--- a/components/progress-detector/src/ai/miniforge/progress_detector/event_envelope.clj
+++ b/components/progress-detector/src/ai/miniforge/progress_detector/event_envelope.clj
@@ -104,18 +104,34 @@
       (and attach-vh? (contains? event :resource/version-hash))
       (assoc :resource/version-hash (:resource/version-hash event)))))
 
-(defn- validate-observation!
-  "Throw ex-info if obs fails Observation schema validation, else
-   return obs unchanged."
+(defn- validate-observation-result
+  "Validate obs against Observation. Returns obs on success or a legacy
+   response anomaly map on failure."
   [event obs]
   (if (m/validate schema/Observation obs)
     obs
-    (response/throw-anomaly! :anomalies/incorrect
-                             (msg/t :envelope/validation-failed)
-                             {:type   ::validation-failed
-                              :event  event
-                              :obs    obs
-                              :errors (m/explain schema/Observation obs)})))
+    (response/make-anomaly :anomalies/incorrect
+                           (msg/t :envelope/validation-failed)
+                           {:type   ::validation-failed
+                            :event  event
+                            :obs    obs
+                            :errors (m/explain schema/Observation obs)})))
+
+(defn- validate-observation!
+  "Boundary wrapper around the anomaly-returning
+   `validate-observation-result`. Preserves the historical throwing
+   normalizer contract for callers."
+  [event obs]
+  (let [result (validate-observation-result event obs)]
+    (if (response/anomaly-map? result)
+      (response/throw-anomaly! (:anomaly/category result)
+                               (:anomaly/message result)
+                               (dissoc result
+                                       :anomaly/category
+                                       :anomaly/message
+                                       :anomaly/id
+                                       :anomaly/timestamp))
+      result)))
 
 (defn make-normalizer
   "Return a per-run normalizer function. The returned fn closes over

--- a/components/progress-detector/test/ai/miniforge/progress_detector/anomaly/progress_detector_anomaly_test.clj
+++ b/components/progress-detector/test/ai/miniforge/progress_detector/anomaly/progress_detector_anomaly_test.clj
@@ -24,7 +24,8 @@
             [clojure.test :refer [deftest is testing]]
             [ai.miniforge.progress-detector.config :as config]
             [ai.miniforge.progress-detector.event-envelope :as envelope]
-            [ai.miniforge.progress-detector.tool-profile :as tool-profile])
+            [ai.miniforge.progress-detector.tool-profile :as tool-profile]
+            [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
 (deftest validate-observation-schema-failure-throws-anomaly
@@ -45,6 +46,16 @@
       ;; entries.
       (is (seq (.getMessage thrown)))
       (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
+
+(deftest validate-observation-result-returns-anomaly
+  (testing "private validate-observation-result returns the anomaly map"
+    (let [result (@#'envelope/validate-observation-result
+                  {}
+                  {:not-a-real :observation})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (= ::envelope/validation-failed (:type result)))
+      (is (some? (:errors result))))))
 
 (deftest merge-config-empty-layers-throws-anomaly
   (testing "empty layers raises :anomalies/incorrect"


### PR DESCRIPTION
## Summary
- add DAG-result primer validation and use it in PR resume dispatch
- add canonical anomaly result validation for review convergence config while preserving fail-fast startup wrapper
- add response-anomaly result validation for progress-detector observations while preserving the throwing normalizer wrapper

## Verification
- focused tests: 38 tests, 102 assertions, 0 failures, 0 errors
- resolver scanner: `:cleanup-needed` 12 -> 9; removed PR lifecycle, review convergence, and progress-detector validation sites
- `bb pre-commit`