### PR TITLE
fix(boundaries): add result helpers for local invariants

### DIFF
--- a/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
@@ -121,22 +121,38 @@
 
 ;; -- Download --
 
-(defn- download-to-temp
-  "Download a URL to a temporary file. Returns the File."
+(defn- download-to-temp-result
+  "Download a URL to a temporary file. Returns the File or a legacy response
+   anomaly map when the HTTP response is not successful."
   [url]
   (let [resp (http/get url {:as      :bytes
                             :headers {"User-Agent" "Mozilla/5.0"}
                             :throw   false})
         status (:status resp)]
-    (when-not (<= 200 status 299)
-      (response/throw-anomaly! :anomalies/unavailable
-                               (msg/t :excel/download-failed {:error (str "HTTP " status)})
-                               {:status status}))
-    (let [tmp (File/createTempFile "connector-excel-" ".xls")]
-      (.deleteOnExit tmp)
-      (with-open [out (FileOutputStream. tmp)]
-        (.write out ^bytes (:body resp)))
-      tmp)))
+    (if-not (<= 200 status 299)
+      (response/make-anomaly :anomalies/unavailable
+                             (msg/t :excel/download-failed {:error (str "HTTP " status)})
+                             {:status status})
+      (let [tmp (File/createTempFile "connector-excel-" ".xls")]
+        (.deleteOnExit tmp)
+        (with-open [out (FileOutputStream. tmp)]
+          (.write out ^bytes (:body resp)))
+        tmp))))
+
+(defn- download-to-temp
+  "Boundary wrapper around the anomaly-returning `download-to-temp-result`.
+   Preserves the connector's historical throwing download contract."
+  [url]
+  (let [result (download-to-temp-result url)]
+    (if (response/anomaly-map? result)
+      (response/throw-anomaly! (:anomaly/category result)
+                               (:anomaly/message result)
+                               (dissoc result
+                                       :anomaly/category
+                                       :anomaly/message
+                                       :anomaly/id
+                                       :anomaly/timestamp))
+      result)))
 
 ;; -- Lifecycle --
 

--- a/components/connector-excel/test/ai/miniforge/connector_excel/anomaly/excel_anomaly_test.clj
+++ b/components/connector-excel/test/ai/miniforge/connector_excel/anomaly/excel_anomaly_test.clj
@@ -23,6 +23,7 @@
    `response/throw-anomaly!`."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-excel.impl :as impl]
+            [ai.miniforge.response.interface :as response]
             [babashka.http-client :as http])
   (:import (clojure.lang ExceptionInfo)
            (org.apache.poi.xssf.usermodel XSSFWorkbook)))
@@ -89,3 +90,11 @@
         (catch ExceptionInfo e
           (is (= :anomalies/unavailable (:anomaly/category (ex-data e))))
           (is (= 503 (:status (ex-data e)))))))))
+
+(deftest download-to-temp-result-non-2xx-returns-anomaly
+  (testing "non-2xx HTTP response can be represented without throwing"
+    (with-redefs [http/get (fn [_url _opts] {:status 503 :body (byte-array 0)})]
+      (let [result (@#'impl/download-to-temp-result "http://x/y.xls")]
+        (is (response/anomaly-map? result))
+        (is (= :anomalies/unavailable (:anomaly/category result)))
+        (is (= 503 (:status result)))))))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/descriptor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/descriptor.clj
@@ -30,6 +30,7 @@
       :runtime/rootless?    boolean
       :runtime/capabilities #{keyword}}"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.protocols.impl.runtime.messages :as messages]
    [ai.miniforge.dag-executor.protocols.impl.runtime.process :as runtime-process]
    [ai.miniforge.dag-executor.protocols.impl.runtime.registry :as registry]
@@ -105,6 +106,29 @@
 ;------------------------------------------------------------------------------ Layer 3
 ;; Construction
 
+(defn- validate-descriptor-result
+  "Validate a constructed descriptor. Returns descriptor on success or a
+   canonical invalid-input anomaly on schema drift."
+  [descriptor]
+  (if (m/validate DescriptorSchema descriptor)
+    descriptor
+    (anomaly/validation-anomaly
+     "Constructed descriptor failed schema validation"
+     :runtime/descriptor
+     descriptor
+     (m/explain DescriptorSchema descriptor))))
+
+(defn- validate-descriptor!
+  "Boundary wrapper around the canonical anomaly-returning
+   `validate-descriptor-result`. This preserves fail-fast descriptor
+   construction for callers while keeping schema drift representable as data."
+  [descriptor]
+  (let [result (validate-descriptor-result descriptor)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      {:runtime/invalid-descriptor descriptor}))
+      result)))
+
 (defn make-descriptor
   "Build a runtime descriptor from a config map.
 
@@ -131,10 +155,7 @@
                         :runtime/version      nil
                         :runtime/rootless?    false
                         :runtime/capabilities capabilities}]
-      (when-not (m/validate DescriptorSchema descriptor)
-        (throw (ex-info "Constructed descriptor failed schema validation"
-                        {:runtime/invalid-descriptor descriptor})))
-      descriptor)))
+      (validate-descriptor! descriptor))))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Accessors

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_test.clj
@@ -20,6 +20,7 @@
   "Tests for OCI-CLI executor: token sanitization, URL auth, image
    management, descriptor wiring."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.test :refer [deftest is testing]]
    [clojure.string]
    [ai.miniforge.dag-executor.result :as result]
@@ -91,6 +92,15 @@
       (is false "expected ex-info")
       (catch clojure.lang.ExceptionInfo e
         (is (= :unknown-runtime (-> e ex-data :runtime/unknown-kind)))))))
+
+(deftest descriptor-validation-result-returns-anomaly-test
+  (testing "constructed descriptor schema drift returns a canonical anomaly"
+    (let [result (@#'descriptor/validate-descriptor-result
+                  {:runtime/kind :docker})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :runtime/descriptor
+             (get-in result [:anomaly/data :anomaly/schema]))))))
 
 ;; ============================================================================
 ;; sanitize-token

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/golden_fixtures.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/golden_fixtures.clj
@@ -35,6 +35,7 @@
    can never be mistaken for captured production data."
   (:require
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.supervisory-state.emitter :as emitter]
    [ai.miniforge.supervisory-state.schema :as schema]
    [clojure.java.io :as io]
@@ -263,18 +264,29 @@
    {:family :decision     :ctor emitter/decision-upserted     :schema schema/DecisionCard       :entity decision-entity}
    {:family :intervention :ctor emitter/intervention-upserted :schema schema/InterventionRequest :entity intervention-entity}])
 
+(defn- validate-result
+  "Validate `entity` against `entity-schema`, returning the entity on success
+   or a legacy response anomaly map on schema drift."
+  [family entity-schema entity]
+  (if (m/validate entity-schema entity)
+    entity
+    (response/make-anomaly :anomalies/incorrect
+                           (str "Golden fixture entity invalid for " family)
+                           {:family family
+                            :errors (me/humanize (m/explain entity-schema entity))})))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Event construction — real constructor + real encoder, pinned envelope
 
 (defn- validate!
-  "Throw with a malli explanation when `entity` does not conform to
-   `entity-schema`. The generator fails closed: a fixture that does not
-   validate against the current schema must never be written."
+  "Boundary wrapper around the anomaly-returning `validate-result`.
+   The generator fails closed: a fixture that does not validate against the
+   current schema must never be written."
   [family entity-schema entity]
-  (when-not (m/validate entity-schema entity)
-    (throw (ex-info (str "Golden fixture entity invalid for " family)
-                    {:family family
-                     :errors (me/humanize (m/explain entity-schema entity))}))))
+  (let [result (validate-result family entity-schema entity)]
+    (when (response/anomaly-map? result)
+      (throw (ex-info (:anomaly/message result)
+                      (select-keys result [:family :errors]))))))
 
 (defn- pin-envelope
   "Replace the nondeterministic envelope fields (`create-envelope`

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/golden_fixtures_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/golden_fixtures_test.clj
@@ -25,6 +25,7 @@
    a fresh generation — so any entity-shape change fails here with a
    regenerate instruction instead of silently breaking the Rust consumer."
   (:require
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.supervisory-state.golden-fixtures :as golden-fixtures]
    [ai.miniforge.supervisory-state.schema :as schema]
    [clojure.java.io :as io]
@@ -82,6 +83,17 @@
    :task-node    schema/TaskNode
    :decision     schema/DecisionCard
    :intervention schema/InterventionRequest})
+
+(deftest validate-result-returns-anomaly-for-invalid-entity
+  (testing "invalid golden fixture entities are represented as anomaly data"
+    (let [result (@#'golden-fixtures/validate-result
+                  :workflow-run
+                  schema/WorkflowRun
+                  {:not :valid})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/incorrect (:anomaly/category result)))
+      (is (= :workflow-run (:family result)))
+      (is (some? (:errors result))))))
 
 ;------------------------------------------------------------------------------ Tests
 


### PR DESCRIPTION
## Summary
- add result-returning descriptor schema validation with a throwing construction boundary
- add anomaly-returning golden fixture validation with fail-closed fixture generation preserved
- add Excel download result handling while preserving connector throwing behavior

## Verification
- focused tests: 41 tests, 139 assertions, 0 failures, 0 errors
- resolver scanner: `:cleanup-needed` 9 -> 6; removed descriptor, golden fixture, and connector-excel sites
- `bb pre-commit`