### PR TITLE
fix(boundaries): convert cleanup rethrows to data

### DIFF
--- a/components/knowledge/src/ai/miniforge/knowledge/store.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/store.clj
@@ -158,17 +158,23 @@
 
 
 (defn- atomic-write!
-  "Write content to file atomically via temp + rename."
+  "Write content to file via temp + move, preferring atomic replacement."
   [file content]
   (let [parent (.getParentFile file)
         tmp (java.io.File/createTempFile "zettel-" ".edn.tmp" parent)]
     (try
       (spit tmp content)
-      (Files/move (.toPath tmp)
-                  (.toPath file)
-                  (into-array StandardCopyOption
-                              [StandardCopyOption/ATOMIC_MOVE
-                               StandardCopyOption/REPLACE_EXISTING]))
+      (try
+        (Files/move (.toPath tmp)
+                    (.toPath file)
+                    (into-array StandardCopyOption
+                                [StandardCopyOption/ATOMIC_MOVE
+                                 StandardCopyOption/REPLACE_EXISTING]))
+        (catch Exception _e
+          (Files/move (.toPath tmp)
+                      (.toPath file)
+                      (into-array StandardCopyOption
+                                  [StandardCopyOption/REPLACE_EXISTING]))))
       (finally
         (when (.exists tmp)
           (.delete tmp))))))

--- a/components/knowledge/src/ai/miniforge/knowledge/store.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/store.clj
@@ -29,7 +29,9 @@
    [ai.miniforge.logging.interface :as log]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.string :as str]))
+   [clojure.string :as str])
+  (:import
+   [java.nio.file Files StandardCopyOption]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Store protocol and in-memory implementation
@@ -162,10 +164,14 @@
         tmp (java.io.File/createTempFile "zettel-" ".edn.tmp" parent)]
     (try
       (spit tmp content)
-      (.renameTo tmp file)
-      (catch Exception e
-        (when (.exists tmp) (.delete tmp))
-        (throw e)))))
+      (Files/move (.toPath tmp)
+                  (.toPath file)
+                  (into-array StandardCopyOption
+                              [StandardCopyOption/ATOMIC_MOVE
+                               StandardCopyOption/REPLACE_EXISTING]))
+      (finally
+        (when (.exists tmp)
+          (.delete tmp))))))
 
 (defn- load-zettel-file
   "Load a single .edn zettel file. Returns zettel map or nil."

--- a/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
@@ -149,7 +149,8 @@
       {:ok? false
        :error {:code :scheduler-exception
                :message (ex-message e)
-               :exception e}})))
+               :class (some-> e class .getName)
+               :data (ex-data e)}})))
 
 (defn- scheduler-result-state
   [result]
@@ -165,9 +166,16 @@
 
 (defn- scheduler-count
   [state old-key run-key]
-  (count (or (get state old-key)
-             (get state run-key)
-             #{})))
+  (if-let [task-statuses (seq (vals (:run/tasks state)))]
+    (case old-key
+      :pending (count (filter #(= :pending (:task/status %)) task-statuses))
+      :running (count (filter #(#{:running :implementing} (:task/status %)) task-statuses))
+      :completed (+ (count (:run/completed state))
+                    (count (:run/merged state)))
+      (count (or (get state run-key) #{})))
+    (count (or (get state old-key)
+               (get state run-key)
+               #{}))))
 
 (defn- continue-scheduler?
   [result status]

--- a/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
@@ -138,6 +138,51 @@
      :max-parallel (:max-parallel config (:max-parallel defaults))
      :config config}))
 
+(defn- schedule-iteration-result
+  "Run one scheduler iteration, returning failures as data so the orchestrator
+   can record a terminal failed run instead of relying on exception control
+   flow from the scheduler boundary."
+  [run-atom scheduler-context]
+  (try
+    (dag/schedule-iteration run-atom scheduler-context)
+    (catch Exception e
+      {:ok? false
+       :error {:code :scheduler-exception
+               :message (ex-message e)
+               :exception e}})))
+
+(defn- scheduler-result-state
+  [result]
+  (cond
+    (:ok? result) (:value result)
+    (contains? result :run-state) (:run-state result)
+    :else result))
+
+(defn- scheduler-status
+  [state]
+  (or (:status state)
+      (:run/status state)))
+
+(defn- scheduler-count
+  [state old-key run-key]
+  (count (or (get state old-key)
+             (get state run-key)
+             #{})))
+
+(defn- continue-scheduler?
+  [result status]
+  (if (contains? result :continue?)
+    (:continue? result)
+    (not (#{:completed :failed :budget-exceeded} status))))
+
+(defn- mark-scheduler-error!
+  [run-atom error]
+  (swap! run-atom assoc
+         :status :failed
+         :run/status :failed
+         :error error
+         :run/error error))
+
 (defn execute-dag!
   [dag-id task-defs config]
   (let [{:keys [logger budget state-profile state-profile-provider]} config
@@ -155,29 +200,28 @@
                                                 :task-count (count task-defs)})
 
     ;; Run scheduler loop
-    (try
-      (loop [iteration 0]
-        (let [result (dag/schedule-iteration run-atom scheduler-context)]
+    (loop [iteration 0]
+      (let [result (schedule-iteration-result run-atom scheduler-context)]
+        (if (= false (:ok? result))
+          (let [error (:error result)]
+            (log-event logger :dag-execution-error
+                       {:error (:message error)
+                        :code (:code error)})
+            (mark-scheduler-error! run-atom error))
+          (let [state (scheduler-result-state result)
+                status (scheduler-status state)]
 
-          (when (:ok? result)
-            (let [state (:value result)
-                  status (:status state)]
+            (log-event logger :scheduler-iteration
+                       {:iteration iteration
+                        :status status
+                        :tasks-pending (scheduler-count state :pending :run/pending)
+                        :tasks-running (scheduler-count state :running :run/running)
+                        :tasks-completed (scheduler-count state :completed :run/completed)})
 
-              (log-event logger :scheduler-iteration
-                         {:iteration iteration
-                          :status status
-                          :tasks-pending (count (:pending state))
-                          :tasks-running (count (:running state))
-                          :tasks-completed (count (:completed state))})
-
-              ;; Continue if not terminal
-              (when-not (#{:completed :failed :budget-exceeded} status)
-                (Thread/sleep (:scheduler-poll-interval-ms defaults)) ; Poll interval
-                (recur (inc iteration)))))))
-
-      (catch Exception e
-        (log-event logger :dag-execution-error {:error (ex-message e)})
-        (throw e)))
+            ;; Continue if not terminal
+            (when (continue-scheduler? result status)
+              (Thread/sleep (:scheduler-poll-interval-ms defaults)) ; Poll interval
+              (recur (inc iteration)))))))
 
     ;; Return final state
     (let [final-state @run-atom]

--- a/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
@@ -521,3 +521,29 @@
           (is (= run-state final-state))
           (is (= :software-factory (get-in @captured [:opts :state-profile])))
           (is (= provider (get-in @captured [:opts :state-profile-provider]))))))))
+
+(deftest execute-dag-records-scheduler-exceptions-as-failed-data-test
+  (testing "scheduler exceptions are recorded on the run state instead of escaping"
+    (let [run-state {:run/status :running
+                     :run/tasks {}}
+          run-atom (atom run-state)
+          events (atom [])]
+      (with-redefs [dag/create-dag-from-tasks (fn [_dag-id _task-defs & _opts]
+                                                run-state)
+                    dag/create-run-atom (fn [_] run-atom)
+                    dag/schedule-iteration (fn [_ _]
+                                             (throw (ex-info "scheduler boom"
+                                                             {:phase :test})))
+                    orchestrator/create-orchestrated-scheduler-context
+                    (fn [_ _] {:execute-task-fn (fn [& _] nil)})
+                    orchestrator/log-event (fn [_logger event data]
+                                             (swap! events conj [event data]))]
+        (let [final-state (orchestrator/execute-dag! "dag-123" [] {})]
+          (is (= :failed (:run/status final-state)))
+          (is (= :failed (:status final-state)))
+          (is (= :scheduler-exception (get-in final-state [:run/error :code])))
+          (is (some (fn [[event data]]
+                      (and (= :dag-execution-error event)
+                           (= "scheduler boom" (:error data))
+                           (= :scheduler-exception (:code data))))
+                    @events)))))))

--- a/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
@@ -542,8 +542,42 @@
           (is (= :failed (:run/status final-state)))
           (is (= :failed (:status final-state)))
           (is (= :scheduler-exception (get-in final-state [:run/error :code])))
+          (is (= "clojure.lang.ExceptionInfo" (get-in final-state [:run/error :class])))
+          (is (= {:phase :test} (get-in final-state [:run/error :data])))
+          (is (not (contains? (:run/error final-state) :exception)))
           (is (some (fn [[event data]]
                       (and (= :dag-execution-error event)
                            (= "scheduler boom" (:error data))
                            (= :scheduler-exception (:code data))))
                     @events)))))))
+
+(deftest execute-dag-logs-current-run-state-task-counts-test
+  (testing "scheduler iteration logging derives counts from dag-executor run-state"
+    (let [run-state {:run/status :running
+                     :run/tasks {"pending" {:task/status :pending}
+                                 "running" {:task/status :running}
+                                 "implementing" {:task/status :implementing}
+                                 "completed" {:task/status :completed}
+                                 "merged" {:task/status :merged}}
+                     :run/completed #{"completed"}
+                     :run/merged #{"merged"}}
+          run-atom (atom run-state)
+          events (atom [])]
+      (with-redefs [dag/create-dag-from-tasks (fn [_dag-id _task-defs & _opts]
+                                                run-state)
+                    dag/create-run-atom (fn [_] run-atom)
+                    dag/schedule-iteration (fn [_ _]
+                                             {:continue? false
+                                              :run-state run-state})
+                    orchestrator/create-orchestrated-scheduler-context
+                    (fn [_ _] {:execute-task-fn (fn [& _] nil)})
+                    orchestrator/log-event (fn [_logger event data]
+                                             (swap! events conj [event data]))]
+        (orchestrator/execute-dag! "dag-123" [] {})
+        (let [iteration-data (some (fn [[event data]]
+                                     (when (= :scheduler-iteration event)
+                                       data))
+                                   @events)]
+          (is (= 1 (:tasks-pending iteration-data)))
+          (is (= 2 (:tasks-running iteration-data)))
+          (is (= 2 (:tasks-completed iteration-data))))))))


### PR DESCRIPTION
## Summary
- replace knowledge-store temp cleanup catch/rethrow with a finally-backed atomic move
- convert task-executor scheduler exceptions into terminal failed run data
- preserve scheduler compatibility for both legacy ok/value and current continue/run-state result shapes

## Scanner delta
- cleanup-needed: 6 -> 4
- remaining sites are llm stream signal, supervisory projection, workflow FSM, and loop FSM boundaries

## Validation
- clojure -M:dev:test knowledge store/file-backed focused tests
- clojure -M:dev:test task-executor orchestrator focused tests
- compliance scanner cleanup-needed count
- bb test:since-stable:subset
- bb lint:clj
- bb pre-commit