### PR TITLE
fix(fsm): use anomaly-returning phase transitions

### DIFF
--- a/components/loop/src/ai/miniforge/loop/outer.clj
+++ b/components/loop/src/ai/miniforge/loop/outer.clj
@@ -26,6 +26,7 @@
    Layer 1: Loop state management
    Layer 2: Phase execution (stub)"
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.loop.messages :as loop-messages]
@@ -149,21 +150,16 @@
    Returns updated loop state, or nil if the transition is forbidden — the FSM
    has no such event from the current state (advancing past the terminal
    :observe phase, rolling back to a later phase, etc.). The FSM raises
-   :anomalies/fsm-unknown-event for a forbidden transition; that one anomaly is
-   converted to the documented nil here (callers — advance-phase, rollback-phase,
-   valid-phase-transition? — branch on nil) rather than letting it escape. Any
-   other failure propagates."
+   :anomalies/fsm-unknown-event for a forbidden transition through its
+   anomaly-returning result API; that one anomaly is converted to the documented
+   nil here (callers — advance-phase, rollback-phase, valid-phase-transition? —
+   branch on nil). Any other failure propagates from the FSM result API."
   [loop-state event]
   (let [current-state (phase-fsm-state loop-state)
-        transitioned (try
-                       (fsm/transition phase-machine current-state event)
-                       (catch clojure.lang.ExceptionInfo e
-                         (if (= :anomalies/fsm-unknown-event
-                                (:anomaly/category (ex-data e)))
-                           nil
-                           (throw e))))
+        transitioned (fsm/transition-result phase-machine current-state event)
         next-phase (some-> transitioned fsm/current-state)]
-    (when (and next-phase
+    (when (and (not (anomaly/anomaly? transitioned))
+               next-phase
                (not= (fsm/current-state current-state) next-phase))
       (assoc loop-state
              :loop/fsm-state transitioned

--- a/components/loop/src/ai/miniforge/loop/outer.clj
+++ b/components/loop/src/ai/miniforge/loop/outer.clj
@@ -156,15 +156,16 @@
    branch on nil). Any other failure propagates from the FSM result API."
   [loop-state event]
   (let [current-state (phase-fsm-state loop-state)
-        transitioned (fsm/transition-result phase-machine current-state event)
-        next-phase (some-> transitioned fsm/current-state)]
-    (when (and (not (anomaly/anomaly? transitioned))
-               next-phase
-               (not= (fsm/current-state current-state) next-phase))
-      (assoc loop-state
-             :loop/fsm-state transitioned
-             :loop/phase next-phase
-             :loop/updated-at (java.util.Date.)))))
+        current-phase (fsm/current-state current-state)
+        transitioned (fsm/transition-result phase-machine current-state event)]
+    (when-not (anomaly/anomaly? transitioned)
+      (let [next-phase (fsm/current-state transitioned)]
+        (when (and next-phase
+                   (not= current-phase next-phase))
+          (assoc loop-state
+                 :loop/fsm-state transitioned
+                 :loop/phase next-phase
+                 :loop/updated-at (java.util.Date.)))))))
 
 (defn valid-phase-transition?
   "Check whether a phase transition event is allowed."

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -111,7 +111,8 @@
    :artifact-store — Artifact persistence store
    :knowledge-store — Knowledge base store
    :event-stream   — Event stream for telemetry"
-  (:require [ai.miniforge.response.interface :as response]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.response.interface :as response]
             [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
             [ai.miniforge.workflow.fsm :as fsm]
             [ai.miniforge.workflow.monitoring :as monitoring]
@@ -180,6 +181,25 @@
                         (:execution/status next-ctx))
              (nil? (:execution/ended-at next-ctx)))
         (assoc :execution/ended-at (System/currentTimeMillis))))
+    ctx))
+
+(defn transition-execution-result
+  "Apply an event to the authoritative execution machine and refresh
+   projections, returning a canonical FSM anomaly for state-local unknown
+   events instead of throwing."
+  [ctx event]
+  (if-let [machine (:execution/fsm-machine ctx)]
+    (let [fsm-state (:execution/fsm-state ctx)
+          result (fsm/transition-execution-result machine fsm-state event)]
+      (if (anomaly/anomaly? result)
+        result
+        (let [next-ctx (sync-machine-projections
+                        (assoc ctx :execution/fsm-state result))]
+          (cond-> next-ctx
+            (and (contains? #{:completed :failed :cancelled}
+                            (:execution/status next-ctx))
+                 (nil? (:execution/ended-at next-ctx)))
+            (assoc :execution/ended-at (System/currentTimeMillis))))))
     ctx))
 
 (defn active-or-last-phase

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -352,7 +352,7 @@
    keyed off.
 
    Returns updated context with refreshed machine projections or
-  terminal failure."
+   terminal failure."
   [ctx event _pipeline _transition-to-completed-fn transition-to-failed-fn]
   (let [prior-state (:execution/fsm-state ctx)
         prior-current-state (workflow-fsm/current-state prior-state)

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -24,6 +24,7 @@
   (:require [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]
+            [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.event-stream.interface :as events]
             [ai.miniforge.gate.interface :as gate]
             [ai.miniforge.phase.interface :as phase]
@@ -196,13 +197,6 @@
    :anomalies.workflow/invalid-transition
    (phase-transition-event-message event)))
 
-(defn- max-redirects-exceeded-anomaly
-  []
-  (let [max-redirects (defaults/max-redirects)]
-    (response/make-anomaly
-     :anomalies.workflow/max-redirects-exceeded
-     (messages/t :status/max-redirects {:max-redirects max-redirects}))))
-
 (defn- phase-transition-failure
   [ctx event anomaly transition-to-failed-fn]
   (let [message (phase-transition-event-message event)]
@@ -358,20 +352,15 @@
    keyed off.
 
    Returns updated context with refreshed machine projections or
-   terminal failure."
+  terminal failure."
   [ctx event _pipeline _transition-to-completed-fn transition-to-failed-fn]
   (let [prior-state (:execution/fsm-state ctx)
-        ;; The FSM kernel now THROWS a typed :anomalies/fsm-unknown-event
-        ;; instead of silently returning the state unchanged (Fable §2.2). At
-        ;; this boundary an unknown phase event is a terminal invalid
-        ;; transition: catch it and route through the same fail path as a
-        ;; no-op transition — loud, but graceful, not a crashed run.
-        next-ctx (try
-                   (context/transition-execution ctx event)
-                   (catch clojure.lang.ExceptionInfo e
-                     (if (= :anomalies/fsm-unknown-event (:anomaly/category (ex-data e)))
-                       ::unknown-event
-                       (throw e))))
+        prior-current-state (workflow-fsm/current-state prior-state)
+        ;; At this boundary an unknown phase event is a terminal invalid
+        ;; transition: route the anomaly-returning FSM result through the same
+        ;; fail path as a no-op transition — loud, but graceful, not a crashed
+        ;; run.
+        next-ctx (context/transition-execution-result ctx event)
         fail (fn [] (phase-transition-failure ctx
                                               event
                                               (invalid-phase-transition-anomaly event)
@@ -379,8 +368,9 @@
     (cond
       ;; Unknown event is always a terminal invalid transition here — never
       ;; return the sentinel; never let :phase/retry leak it out.
-      (= ::unknown-event next-ctx) (fail)
-      (not= prior-state (:execution/fsm-state next-ctx)) next-ctx
+      (anomaly/anomaly? next-ctx) (fail)
+      (not= prior-current-state
+            (workflow-fsm/current-state (:execution/fsm-state next-ctx))) next-ctx
       (= :phase/retry event) next-ctx
       :else (fail))))
 

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -193,6 +193,12 @@
   [machine state event]
   (fsm/transition machine state event))
 
+(defn transition-execution-result
+  "Apply an event to a compiled execution machine snapshot, returning the new
+   state or a canonical FSM anomaly for state-local unknown events."
+  [machine state event]
+  (fsm/transition-result machine state event))
+
 (defn- terminal-state-message
   [current-state]
   (messages/t :status/terminal-state-transition {:state current-state}))


### PR DESCRIPTION
## Summary
- add workflow execution transition-result path for FSM unknown-event handling
- route workflow phase invalid transitions from anomaly data instead of local catch/rethrow
- use the FSM anomaly-returning API in the outer-loop phase transition helper
- remove a dead redirect anomaly helper surfaced by staged lint

## Scanner delta
- cleanup-needed: 4 -> 2
- remaining sites are the LLM stream signal and supervisory projection boundaries

## Validation
- focused workflow/loop/FSM tests
- compliance scanner cleanup-needed count
- bb lint:clj
- bb pre-commit