### PR TITLE
fix(agent): add anomaly projection invoke path

### DIFF
--- a/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
+++ b/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
@@ -25,6 +25,7 @@
    family, so this bridge emits equivalent events for direct in-process agents
   when a workflow event-stream is present."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.agent.core :as core]
    [ai.miniforge.config.interface :as config]
    [ai.miniforge.event-stream.interface :as events])
@@ -261,18 +262,34 @@
                       :executing
                       :failed))))
 
+(defn- invocation-exception-anomaly
+  [e]
+  (anomaly/exception-anomaly :fault
+                             (or (ex-message e) "Agent invocation failed")
+                             {:agent/error-source :direct-invocation}
+                             e))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Public wrapper
 
-(defn invoke-with-projection
+(defn invoke-with-projection-result
   "Run `invoke-fn` while mirroring the invocation into `:control-plane/agent-*`
-   events when the context is bound to a workflow event-stream."
+   events when the context is bound to a workflow event-stream.
+
+   Returns the agent result on success, or an anomaly when invocation throws.
+   This is the canonical anomaly-returning API for non-boundary callers."
   [agent task context invoke-fn]
   (if-not (executable-context? context)
-    (invoke-fn)
+    (try
+      (invoke-fn)
+      (catch Exception e
+        (invocation-exception-anomaly e)))
     (let [session-id-value (session-id agent task context)]
       (if-not session-id-value
-        (invoke-fn)
+        (try
+          (invoke-fn)
+          (catch Exception e
+            (invocation-exception-anomaly e)))
         (do
           (emit-started! agent task context session-id-value)
           (try
@@ -281,4 +298,19 @@
               result)
             (catch Exception e
               (emit-failed! task context session-id-value)
-              (throw e))))))))
+              (invocation-exception-anomaly e))))))))
+
+(defn invoke-with-projection
+  "Boundary compatibility wrapper around [[invoke-with-projection-result]].
+
+   Returns the agent result on success. When the canonical anomaly-returning
+   function reports invocation failure, throws `ex-info` to preserve the
+   existing `agent/invoke` caller contract. Prefer
+   [[invoke-with-projection-result]] in non-boundary code when callers can
+   branch on anomaly data."
+  [agent task context invoke-fn]
+  (let [result (invoke-with-projection-result agent task context invoke-fn)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      (:anomaly/data result)))
+      result)))

--- a/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
+++ b/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
@@ -269,6 +269,29 @@
                              {:agent/error-source :direct-invocation}
                              e))
 
+(defn- invoke-with-projection*
+  [agent task context invoke-fn handle-exception]
+  (if-not (executable-context? context)
+    (try
+      (invoke-fn)
+      (catch Exception e
+        (handle-exception e)))
+    (let [session-id-value (session-id agent task context)]
+      (if-not session-id-value
+        (try
+          (invoke-fn)
+          (catch Exception e
+            (handle-exception e)))
+        (do
+          (emit-started! agent task context session-id-value)
+          (try
+            (let [result (invoke-fn)]
+              (emit-finished! task context session-id-value result)
+              result)
+            (catch Exception e
+              (emit-failed! task context session-id-value)
+              (handle-exception e))))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Public wrapper
 
@@ -279,26 +302,11 @@
    Returns the agent result on success, or an anomaly when invocation throws.
    This is the canonical anomaly-returning API for non-boundary callers."
   [agent task context invoke-fn]
-  (if-not (executable-context? context)
-    (try
-      (invoke-fn)
-      (catch Exception e
-        (invocation-exception-anomaly e)))
-    (let [session-id-value (session-id agent task context)]
-      (if-not session-id-value
-        (try
-          (invoke-fn)
-          (catch Exception e
-            (invocation-exception-anomaly e)))
-        (do
-          (emit-started! agent task context session-id-value)
-          (try
-            (let [result (invoke-fn)]
-              (emit-finished! task context session-id-value result)
-              result)
-            (catch Exception e
-              (emit-failed! task context session-id-value)
-              (invocation-exception-anomaly e))))))))
+  (invoke-with-projection* agent
+                           task
+                           context
+                           invoke-fn
+                           invocation-exception-anomaly))
 
 (defn invoke-with-projection
   "Boundary compatibility wrapper around [[invoke-with-projection-result]].
@@ -309,8 +317,9 @@
    [[invoke-with-projection-result]] in non-boundary code when callers can
    branch on anomaly data."
   [agent task context invoke-fn]
-  (let [result (invoke-with-projection-result agent task context invoke-fn)]
-    (if (anomaly/anomaly? result)
-      (throw (ex-info (:anomaly/message result)
-                      (:anomaly/data result)))
-      result)))
+  (invoke-with-projection* agent
+                           task
+                           context
+                           invoke-fn
+                           (fn [e]
+                             (throw e))))

--- a/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
+++ b/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
@@ -19,9 +19,11 @@
 (ns ai.miniforge.agent.runtime-supervisory-projection-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.agent.supervisory-bridge :as supervisory-bridge]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.agent.interface.protocols.agent :as agent-proto]
    [ai.miniforge.agent.specialized :as specialized]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.supervisory-state.interface :as supervisory]))
 
@@ -160,6 +162,31 @@
           agent-upserted (last-event stream :supervisory/agent-upserted)
           agent-entity (:supervisory/entity agent-upserted)]
       (is (= error-result result))
+      (is (= :failed (:cp/status heartbeat)))
+      (is (= :failed (:cp/to-status state-change)))
+      (is (= :failed (:agent/status agent-entity))))))
+
+(deftest direct-agent-invoke-result-projects-failure-events-as-anomaly
+  (testing "the canonical result path returns anomaly data after projecting failed events"
+    (let [stream (create-stream)
+          _supervisor (supervisory/attach! stream)
+          workflow-id (random-uuid)
+          task (invoke-task)
+          ctx (invoke-context stream workflow-id)
+          ex (ex-info "projection boom" {:cause :test})
+          result (supervisory-bridge/invoke-with-projection-result
+                  (throwing-agent ex)
+                  task
+                  ctx
+                  (fn [] (throw ex)))
+          heartbeat (last-event stream :control-plane/agent-heartbeat)
+          state-change (last-event stream :control-plane/agent-state-changed)
+          agent-upserted (last-event stream :supervisory/agent-upserted)
+          agent-entity (:supervisory/entity agent-upserted)]
+      (is (anomaly/anomaly? result))
+      (is (= :fault (:anomaly/type result)))
+      (is (= "projection boom" (:anomaly/message result)))
+      (is (= {:cause :test} (get-in result [:anomaly/data :anomaly/ex-data])))
       (is (= :failed (:cp/status heartbeat)))
       (is (= :failed (:cp/to-status state-change)))
       (is (= :failed (:agent/status agent-entity))))))

--- a/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
+++ b/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
@@ -203,6 +203,7 @@
         (agent/invoke (throwing-agent ex) task ctx)
         (is false "expected invoke to rethrow the original exception")
         (catch clojure.lang.ExceptionInfo caught
+          (is (identical? ex caught))
           (is (= "projection boom" (ex-message caught)))))
       (let [heartbeat (last-event stream :control-plane/agent-heartbeat)
             state-change (last-event stream :control-plane/agent-state-changed)


### PR DESCRIPTION
## Summary
- add an anomaly-returning supervisory projection invoke path for direct agent calls
- keep the existing agent/invoke exception behavior behind a documented compatibility boundary
- cover the result path so failed projection events are emitted before anomaly return

## Verification
- clojure -M:dev:test -e '(require (quote ai.miniforge.agent.runtime-supervisory-projection-test) (quote ai.miniforge.agent.invoke-error-shape-test) (quote clojure.test)) (let [r (clojure.test/run-tests (quote ai.miniforge.agent.runtime-supervisory-projection-test) (quote ai.miniforge.agent.invoke-error-shape-test))] (when (pos? (+ (:fail r) (:error r))) (System/exit 1)))'
- clojure -M:dev:test -e '(require (quote [ai.miniforge.compliance-scanner.interface :as scanner])) (let [r (scanner/scan-exceptions-as-data .) cleanup (filter #(= :cleanup-needed (:classification %)) (:violations r))] (println (:counts r)) (doseq [[file rows] (sort-by (fn [[_ rows]] [(- (count rows))]) (group-by :file cleanup))] (println (count rows) file)))'
- git diff --check
- bb pre-commit

Scanner delta: cleanup-needed 2 -> 1; remaining site is components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj.