### PR TITLE
fix(orchestrator): log promote-learning failures instead of swallowing

### DIFF
--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -173,8 +173,10 @@
                   (try
                     (knowledge/promote-learning knowledge-store learning-id {})
                     (catch Exception e
-                      (log/warn e :orchestrator :orchestrator/promote-learning-failed
-                                {:learning-id learning-id})
+                      (log/warn (:logger knowledge-store)
+                                :orchestrator
+                                :orchestrator/promote-learning-failed
+                                {:error (ex-message e) :learning-id learning-id})
                       nil)))))
             learning)))))
 

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -172,7 +172,10 @@
                 (when (and (:promote? promotion-check) learning-id)
                   (try
                     (knowledge/promote-learning knowledge-store learning-id {})
-                    (catch Exception _e nil)))))
+                    (catch Exception e
+                      (log/warn e :orchestrator :orchestrator/promote-learning-failed
+                                {:learning-id learning-id})
+                      nil)))))
             learning)))))
 
   (should-promote-learning? [_this learning]


### PR DESCRIPTION
## What

In `capture-execution-learning` (orchestrator/core.clj:173–175), a bare `(catch Exception _e nil)` silently discarded any exception thrown by `knowledge/promote-learning`. The exception was bound to `_e` and never surfaced — no log, no metric, no re-throw.

## Why it matters

`promote-learning` writes a learning to the knowledge store as a candidate rule. A failure here means the system misses a promotion opportunity and the operator has no signal that anything went wrong. Under production load (repeated task cycles), systematic failures would silently accumulate, degrading the rule base over time with no observable cause.

## Fix

Replaced the silent `_e` binding with a named `e` and added a `log/warn` call (using the already-required `[ai.miniforge.logging.interface :as log]`) before returning `nil`. Behaviour is unchanged — the function still returns `nil` on failure so the outer `capture-execution-learning` result is unaffected — but the failure is now observable.

```clojure
;; before
(catch Exception _e nil)

;; after
(catch Exception e
  (log/warn e :orchestrator :orchestrator/promote-learning-failed
            {:learning-id learning-id})
  nil)
```

## Checklist

- [x] Minimal change — no behaviour change, logging only
- [x] Uses existing `log` alias already required in the namespace
- [x] No new dependencies

---
_Generated by [Claude Code](https://claude.ai/code/session_012inNgHgsxB84jknuLwTHqR)_