### PR TITLE
test(policy-calibration): grow corpus to 19; strengthen the thin rules

### DIFF
--- a/eval/policy-fidelity/fixtures/seed/cli_main.clj.txt
+++ b/eval/policy-fidelity/fixtures/seed/cli_main.clj.txt
@@ -1,0 +1,10 @@
+(ns eval.seed.cli-main
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(defn -main
+  "Process entry point (absolute boundary). Parses argv into a map or aborts."
+  [& argv]
+  (when (odd? (count argv))
+    (throw (ex-info (messages/t :cli/odd-argv)
+                    {:anomaly/category :cli/malformed-args})))
+  (into {} (map vec (partition 2 argv))))

--- a/eval/policy-fidelity/fixtures/seed/internal_revalidate.clj.txt
+++ b/eval/policy-fidelity/fixtures/seed/internal_revalidate.clj.txt
@@ -1,0 +1,13 @@
+(ns eval.seed.internal-revalidate
+  (:require [malli.core :as m]))
+
+(def ^:private Order
+  "Shape of an order, validated once at the component interface."
+  [:map [:id :string] [:total :int]])
+
+(defn- mark-shipped
+  "Internal helper. `order` already passed interface validation upstream."
+  [order]
+  (if (m/validate Order order)
+    (assoc order :shipped? true)
+    order))

--- a/eval/policy-fidelity/fixtures/seed/item_processor.clj.txt
+++ b/eval/policy-fidelity/fixtures/seed/item_processor.clj.txt
@@ -1,0 +1,8 @@
+(ns eval.seed.item-processor)
+
+(defn process-items [items handle]
+  ;; loop over every item in the collection
+  (doseq [item items]
+    ;; if the item is active, call the handler on it
+    (when (:active? item)
+      (handle item))))

--- a/eval/policy-fidelity/fixtures/seed/swap_ordering.clj.txt
+++ b/eval/policy-fidelity/fixtures/seed/swap_ordering.clj.txt
@@ -1,0 +1,8 @@
+(ns eval.seed.swap-ordering)
+
+(defn record-and-count
+  "Append `event` to `log` and return the new count."
+  [log event]
+  ;; Count from the swap! return value, not a separate deref: a concurrent
+  ;; append landing between the swap! and a deref would over-count.
+  (count (swap! log conj event)))

--- a/eval/policy-fidelity/fixtures/seed/time_constants.clj.txt
+++ b/eval/policy-fidelity/fixtures/seed/time_constants.clj.txt
@@ -1,0 +1,12 @@
+(ns eval.seed.time-constants)
+
+(def ^:private seconds-per-day
+  "Seconds in a calendar day (24*60*60). A fixed unit conversion, not an
+   operator-tunable value — a day is always 86400 seconds — so it lives in
+   code as a constant, never in .edn config."
+  (* 24 60 60))
+
+(defn days->seconds
+  "Convert a whole-day count to seconds."
+  [days]
+  (* days seconds-per-day))

--- a/eval/policy-fidelity/fixtures/seed/time_constants.clj.txt
+++ b/eval/policy-fidelity/fixtures/seed/time_constants.clj.txt
@@ -1,8 +1,8 @@
 (ns eval.seed.time-constants)
 
 (def ^:private seconds-per-day
-  "Seconds in a calendar day (24*60*60). A fixed unit conversion, not an
-   operator-tunable value — a day is always 86400 seconds — so it lives in
+  "Seconds in a 24-hour day (24*60*60). A fixed unit conversion, not an
+   operator-tunable value — 24 hours is always 86400 seconds — so it lives in
    code as a constant, never in .edn config."
   (* 24 60 60))
 

--- a/eval/policy-fidelity/fixtures/truth.edn
+++ b/eval/policy-fidelity/fixtures/truth.edn
@@ -71,4 +71,24 @@
 
   "seed/span_merge.clj"
   {:violates #{}
-   :notes "self-documenting-code specificity: the comment explains WHY (sort-then-sweep avoids O(n^2)), a non-obvious algorithmic rationale — not narrating WHAT. A faithful judge does not fire self-documenting-code."}}}
+   :notes "self-documenting-code specificity: the comment explains WHY (sort-then-sweep avoids O(n^2)), a non-obvious algorithmic rationale — not narrating WHAT. A faithful judge does not fire self-documenting-code."}
+
+  "seed/cli_main.clj"
+  {:violates #{:std/clojure-exception-handling}
+   :notes "211 THROW-side (distinct from step_runner's catch-side): -main is an absolute boundary, so throwing is 005-COMPLIANT — but a STRUCTURED payload (:anomaly/category map) thrown via plain ex-info must use throw+/throw-anomaly! per 211. Message is localized via messages/t (localization clean); no magic literals."}
+
+  "seed/item_processor.clj"
+  {:violates #{:std/self-documenting-code}
+   :notes "self-documenting-code (distinct from billing_calc's arithmetic narration): comments narrate WHAT the control flow does ('loop over every item', 'if active call the handler') — pure restatement, no WHY. No strings/throws/magic/validation."}
+
+  "seed/internal_revalidate.clj"
+  {:violates #{:std/validation-boundaries}
+   :notes "validation-boundaries (distinct from row_aggregator's type guards): an internal helper re-runs m/validate on `order` that the docstring states already passed interface validation upstream — redundant interior validation. No magic literals or strings."}
+
+  "seed/time_constants.clj"
+  {:violates #{}
+   :notes "config-as-data specificity (distinct from frame_codec): seconds-per-day (24*60*60) LOOKS like a magic number but is a fixed unit conversion, not operator-tunable — correctly a code constant with composed-math intent + rationale docstring. Clean w.r.t. config-as-data AND named-constants."}
+
+  "seed/swap_ordering.clj"
+  {:violates #{}
+   :notes "self-documenting-code specificity (distinct from span_merge): the comment explains WHY (read the count from swap!'s return, not a separate deref, to avoid an over-count race) — a non-obvious concurrency rationale, not WHAT. A faithful judge flags nothing."}}}


### PR DESCRIPTION
Grows the gate-readiness calibration corpus 14 → 19 fixtures (7 clean) — item 2 of the post-sweep plan. Every rule now has ≥ 2 violating examples (the thinnest had 1), and the subjective rules gain clean near-misses.

## New fixtures

| Fixture | Role | Distinct from |
|---|---|---|
| `cli_main` | 211 throw-side violator (structured payload thrown via plain `ex-info` at an absolute boundary) | `step_runner` (catch-side) |
| `item_processor` | self-documenting-code control-flow narration | `billing_calc` (arithmetic narration) |
| `internal_revalidate` | validation-boundaries redundant interior `m/validate` | `row_aggregator` (type guards) |
| `time_constants` | clean config-as-data near-miss (`24*60*60` — looks operational, is fixed) | `frame_codec` (protocol invariant) |
| `swap_ordering` | clean self-documenting-code near-miss (concurrency WHY) | `span_merge` (algorithmic WHY) |

## The growth earned its keep

`cli_main` first carried a WHAT-narrating comment (`;; ... abort at the boundary`), which the judge faithfully flagged as self-documenting-code — a false-positive on a fixture I had labeled clean (oracle must be ≥ judge). Removed it; the 211 violation is structural and needs no comment. That is exactly the specificity stress-test the extra fixtures exist for.

## Result

Re-calibrated (opus-4.8, 3×3 over 19 fixtures): **all 9 rules gate-ready, stable, recall 1.0, 0 clean false-positives, 0 failed cells.** Build-time `shipped-pack-gate-readiness-test` green.