### PR TITLE
fix(knowledge): localize trust-graph validation diagnostics

### DIFF
--- a/components/knowledge/resources/config/knowledge/messages/en-US.edn
+++ b/components/knowledge/resources/config/knowledge/messages/en-US.edn
@@ -13,4 +13,11 @@
 
   ;; Pattern detection / synthesis
   :pattern/title   "Recurring pattern: {tag} ({count} occurrences)"
-  :pattern/content "## Recurring Pattern\n\nThe tag `{tag}` appears across {count} learnings, suggesting a systemic pattern.\n\n### Related Learnings\n\n{learnings}"}}
+  :pattern/content "## Recurring Pattern\n\nThe tag `{tag}` appears across {count} learnings, suggesting a systemic pattern.\n\n### Related Learnings\n\n{learnings}"
+
+  ;; Trust-graph validation diagnostics
+  :trust/instruction-not-transitive "Instruction authority cannot be granted transitively: Pack {pack-id} is {trust-level} but has :authority/instruction. Only :trusted packs may have instruction authority."
+  :trust/circular-dependency        "Circular dependency detected: {path}"
+  :trust/path-separator             " -> "
+  :trust/missing-dependency         "Missing dependency: {pack-id}"
+  :trust/tainted-in-instruction-chain "Pack {pack-id} has :authority/instruction but transitively includes tainted content from {found-id}"}}

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -35,6 +35,7 @@
    - :authority/data        - Reference material only (any trust level)"
   (:require
    [ai.miniforge.algorithms.interface :as alg]
+   [ai.miniforge.knowledge.messages :as msg]
    [ai.miniforge.schema.interface :as schema]
    [clojure.string]))
 
@@ -105,10 +106,9 @@
     (if (and (= :authority/instruction (:authority target-pack))
              (not= :trusted (:trust-level target-pack)))
       (schema/invalid
-       (str "Instruction authority cannot be granted transitively: "
-            "Pack " (:pack-id target-pack) " is " (:trust-level target-pack)
-            " but has :authority/instruction. "
-            "Only :trusted packs may have instruction authority."))
+       (msg/t :trust/instruction-not-transitive
+              {:pack-id (:pack-id target-pack)
+               :trust-level (:trust-level target-pack)}))
       (schema/valid))))
 
 (defn compute-inherited-trust-level
@@ -137,11 +137,12 @@
      (cond
        (:cycle? context)
        (schema/invalid
-        (str "Circular dependency detected: "
-             (clojure.string/join " -> " (:path context))))
+        (msg/t :trust/circular-dependency
+               {:path (clojure.string/join (msg/t :trust/path-separator)
+                                           (:path context))}))
 
        (:missing? context)
-       (schema/invalid (str "Missing dependency: " pack-id))
+       (schema/invalid (msg/t :trust/missing-dependency {:pack-id pack-id}))
 
        :else nil))))
 
@@ -169,9 +170,8 @@
                       (fn [_node-id node _path]
                         (= :tainted (:trust-level node))))]
         (schema/invalid
-         (str "Pack " pack-id " has :authority/instruction but "
-              "transitively includes tainted content from "
-              (:found-id found))
+         (msg/t :trust/tainted-in-instruction-chain
+                {:pack-id pack-id :found-id (:found-id found)})
          {:tainted-path (:path found)})
         (schema/valid)))))
 

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -35,7 +35,7 @@
    - :authority/data        - Reference material only (any trust level)"
   (:require
    [ai.miniforge.algorithms.interface :as alg]
-   [ai.miniforge.knowledge.messages :as msg]
+   [ai.miniforge.knowledge.messages :as messages]
    [ai.miniforge.schema.interface :as schema]
    [clojure.string]))
 
@@ -106,7 +106,7 @@
     (if (and (= :authority/instruction (:authority target-pack))
              (not= :trusted (:trust-level target-pack)))
       (schema/invalid
-       (msg/t :trust/instruction-not-transitive
+       (messages/t :trust/instruction-not-transitive
               {:pack-id (:pack-id target-pack)
                :trust-level (:trust-level target-pack)}))
       (schema/valid))))
@@ -137,12 +137,12 @@
      (cond
        (:cycle? context)
        (schema/invalid
-        (msg/t :trust/circular-dependency
-               {:path (clojure.string/join (msg/t :trust/path-separator)
+        (messages/t :trust/circular-dependency
+               {:path (clojure.string/join (messages/t :trust/path-separator)
                                            (:path context))}))
 
        (:missing? context)
-       (schema/invalid (msg/t :trust/missing-dependency {:pack-id pack-id}))
+       (schema/invalid (messages/t :trust/missing-dependency {:pack-id pack-id}))
 
        :else nil))))
 
@@ -170,7 +170,7 @@
                       (fn [_node-id node _path]
                         (= :tainted (:trust-level node))))]
         (schema/invalid
-         (msg/t :trust/tainted-in-instruction-chain
+         (messages/t :trust/tainted-in-instruction-chain
                 {:pack-id pack-id :found-id (:found-id found)})
          {:tainted-path (:path found)})
         (schema/valid)))))


### PR DESCRIPTION
First PR of the **localization fix-violation wave** (item 3 — applying the now-blocking `localization` rule to existing code).

Routes the four raw error strings in `knowledge/trust.clj` through the existing knowledge message catalog:

| Key | was |
|---|---|
| `:trust/instruction-not-transitive` | `(str "Instruction authority cannot be granted transitively: ...")` |
| `:trust/circular-dependency` | `(str "Circular dependency detected: ...")` |
| `:trust/missing-dependency` | `(str "Missing dependency: " pack-id)` |
| `:trust/tainted-in-instruction-chain` | `(str "Pack " pack-id " has ...")` |

Plus `:trust/path-separator` — the graph-path `join` delimiter (` -> `), because the semantic judge flags even the separator as emitted output.

## Verified (the ratchet)

- localization judge on the fixed file: **4 → 0** violations.
- trust tests: 11/64 pass (localized output matches assertions).
- catalog keys resolve with no leftover `{placeholder}`.

## Context — wave scale

A 15-file representative sample estimates the localization backlog at **~1,700 raw strings** repo-wide (the largest of the 9 blocking rules), and the judge flags even separators/format tokens. This wave is many component-scoped PRs. Landing this one first proves the fix→judge-clean→merge ratchet before scaling.