### PR TITLE
fix(no-dead-code): delete two unused private helpers

### DIFF
--- a/components/evaluation/src/ai/miniforge/evaluation/comparator.clj
+++ b/components/evaluation/src/ai/miniforge/evaluation/comparator.clj
@@ -35,9 +35,6 @@
           n (count vals)]
       (/ (reduce + (map #(squared-deviation m %) vals)) (dec n)))))
 
-(defn- std-dev [vals]
-  (Math/sqrt (variance vals)))
-
 (defn- welch-t-test
   "Welch's t-test for unequal variances. Returns approximate p-value.
    This is a simplified two-tailed test."

--- a/components/reliability/src/ai/miniforge/reliability/sli.clj
+++ b/components/reliability/src/ai/miniforge/reliability/sli.clj
@@ -46,13 +46,6 @@
                 (.after ^java.util.Date ts cutoff)))
             metrics)))
 
-(defn- filter-by-tier
-  "Filter metrics by workflow tier, if specified."
-  [metrics tier]
-  (if tier
-    (filter #(= tier (:tier %)) metrics)
-    metrics))
-
 (defn- percentile
   "Compute percentile from sorted values."
   [sorted-vals p]


### PR DESCRIPTION
no-dead-code wave (item 3). Deletes two clearly-dead private helpers with no callers and no documentation value:

- `evaluation/comparator` `std-dev` — `welch-t-test` uses `variance` directly.
- `reliability/sli` `filter-by-tier` — unwired tier filter; git history preserves it.

Left for a considered decision (documented vocabulary, **not** blind-deletable):
- `verify/verdicts` — a `def` verdict-tag set with a rich docstring.
- `progress-detector/config` `directive-precedence` — documented ordering, "used to sanity-check" but the check was never wired.

Both want either wiring into a real invariant or a deliberate drop, not a mechanical delete.

## Finding: no-dead-code is not cleanly auto-fixable

clj-kondo already detects dead code deterministically — **52 unused-private-var warnings repo-wide** (4 prod, 48 test). But only 2 of the 4 prod hits are safe mechanical deletes; the other 2 are documented data. So the "scanner + autofix" premise holds for detection (clj-kondo) but not for a blind bulk fix — each hit needs judgment.

Verified: clj-kondo clean; reliability tests pass; comparator loads.