### PR TITLE
feat(compliance-scanner): deterministic named-constants locator

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -125,8 +125,10 @@
 
 (defn scan-named-constants
   "Locate magic NUMERIC literals against `repo-root` (Dewey 006). Deterministic,
-   LLM-free MEASUREMENT: returns `:violations` (line/col/token), `:files-scanned`,
-   `:counts` {:magic-numeric N}, `:rule/id`. A triage LOCATOR, not a gate — it
+   LLM-free MEASUREMENT: returns `:violations` (each with `:file`, `:line`,
+   `:column`, `:current` (the literal token), `:kind` `:magic-numeric`, and
+   `:rule/id`), plus `:files-scanned`, `:counts` {:magic-numeric N}, `:rule/id`.
+   A triage LOCATOR, not a gate — it
    over-reports (no math-identity / self-documenting-keyword exemptions) and does
    not cover structured-string magic literals; the semantic judge still owns
    those and the fix (extraction needs a name + intent docstring)."

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -32,7 +32,8 @@
             [ai.miniforge.compliance-scanner.report             :as report]
             [ai.miniforge.compliance-scanner.execute            :as execute]
             [ai.miniforge.compliance-scanner.comments           :as comments]
-            [ai.miniforge.compliance-scanner.exceptions-as-data :as exc-data]))
+            [ai.miniforge.compliance-scanner.exceptions-as-data :as exc-data]
+            [ai.miniforge.compliance-scanner.named-constants    :as named-const]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
@@ -117,6 +118,20 @@
    with `:violations`, `:files-scanned`, `:counts`, and `:rule/id`."
   [repo-root]
   (exc-data/scan-repo repo-root))
+
+(def named-constants-rule-id
+  "Stable rule id for the named-constants locator."
+  named-const/rule-id)
+
+(defn scan-named-constants
+  "Locate magic NUMERIC literals against `repo-root` (Dewey 006). Deterministic,
+   LLM-free MEASUREMENT: returns `:violations` (line/col/token), `:files-scanned`,
+   `:counts` {:magic-numeric N}, `:rule/id`. A triage LOCATOR, not a gate — it
+   over-reports (no math-identity / self-documenting-keyword exemptions) and does
+   not cover structured-string magic literals; the semantic judge still owns
+   those and the fix (extraction needs a name + intent docstring)."
+  [repo-root]
+  (named-const/scan-repo repo-root))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Phase entry points

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/named_constants.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/named_constants.clj
@@ -1,0 +1,176 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.named-constants
+  "Named-constants locator (Dewey 006) — deterministic MEASUREMENT tool.
+
+   Locates magic NUMERIC literals in Clojure source: numbers whose value is
+   not a structural sentinel. It is a repeatable, LLM-free replacement for the
+   semantic judge when counting/locating the named-constants backlog. It does
+   NOT fix (extraction needs a name + intent docstring — a judgment call), and
+   it is a LOCATOR, not a gate: it deliberately over-reports (it does not model
+   the rule's every semantic exemption — math identities, self-documenting
+   keywords), so its output is a triage list.
+
+   A hand character-lexer tracks string / comment / char-literal state so a
+   number inside a string or a `;` comment is never counted — only numeric
+   tokens in code positions. Structured-string magic literals (paths, format
+   placeholders) are out of scope here; the judge still covers those.
+
+   Layer 0: char-lexer + numeric classification
+   Layer 1: file + repo scan"
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+(def rule-id :std/named-constants)
+(def rule-category "006")
+
+(def ^:private exempt-values
+  "Numeric values that are structural sentinels, never magic: loop / index
+   bounds (-1, 0, 1) and the doubling identity (2). Mirrors the rule's
+   \"larger than 2 or smaller than -1\" threshold."
+  #{-1.0 0.0 1.0 2.0})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Numeric classification
+
+(def ^:private numeric-token-pattern
+  "A token that is a Clojure numeric literal: integers, decimals (with optional
+   exponent and M/N suffix), leading-dot decimals, hex, radix, and ratios."
+  #"[-+]?(?:\d+\.?\d*(?:[eE][-+]?\d+)?[MN]?|\.\d+(?:[eE][-+]?\d+)?M?|0[xX][0-9a-fA-F]+|\d+r[0-9a-zA-Z]+|\d+/\d+)")
+
+(defn- numeric-token? [tok]
+  (boolean (re-matches numeric-token-pattern tok)))
+
+(defn- magic-numeric?
+  "True when `tok` is a numeric literal whose value is not a structural
+   sentinel. Hex / radix / ratio literals (which Double/parseDouble cannot
+   read) are treated as magic — they carry meaning worth naming."
+  [tok]
+  (and (numeric-token? tok)
+       (let [t (str/replace tok #"[MN]$" "")]
+         (try
+           (not (contains? exempt-values (Double/parseDouble t)))
+           (catch Exception _ true)))))
+
+(def ^:private token-char?
+  "Characters that may appear inside a symbol / number token. A token ends at
+   whitespace or a structural delimiter."
+  (complement #{\space \tab \newline \return \, \( \) \[ \] \{ \} \" \; \' \` \~ \@ \^}))
+
+(defn- skip-string
+  "Given `content` and the index just AFTER an opening quote, return
+   `[end-index end-line end-col]` positioned just after the closing quote,
+   counting newlines so later line numbers stay correct."
+  [^String content start line col]
+  (let [n (count content)]
+    (loop [j start, l line, cl col]
+      (cond
+        (>= j n) [j l cl]
+        (= (.charAt content j) \\) (recur (+ j 2) l (+ cl 2))
+        (= (.charAt content j) \newline) (recur (inc j) (inc l) 1)
+        (= (.charAt content j) \") [(inc j) l (inc cl)]
+        :else (recur (inc j) l (inc cl))))))
+
+(defn scan-numeric-tokens
+  "Char-lex `content`, returning `[{:line :col :token}]` for every numeric
+   literal token in a CODE position (outside strings, comments, char-literals)."
+  [^String content]
+  (let [n (count content)]
+    (loop [i 0, line 1, col 1, acc (transient [])]
+      (if (>= i n)
+        (persistent! acc)
+        (let [c (.charAt content i)]
+          (cond
+            (= c \newline) (recur (inc i) (inc line) 1 acc)
+
+            ;; line comment — skip to end of line
+            (= c \;)
+            (let [eol (let [j (str/index-of content "\n" i)] (or j n))]
+              (recur eol line (+ col (- eol i)) acc))
+
+            ;; char literal \x — skip the backslash and the next char
+            (= c \\)
+            (recur (min n (+ i 2)) line (+ col 2) acc)
+
+            ;; string literal — skip to the closing unescaped quote
+            (= c \")
+            (let [[j l cl] (skip-string content (inc i) line (inc col))]
+              (recur j l cl acc))
+
+            (not (token-char? c)) (recur (inc i) line (inc col) acc)
+
+            ;; start of a token — consume the maximal token run
+            :else
+            (let [end (loop [j i] (if (and (< j n) (token-char? (.charAt content j))) (recur (inc j)) j))
+                  tok (subs content i end)]
+              (recur end line (+ col (- end i))
+                     (if (magic-numeric? tok)
+                       (conj! acc {:line line :col col :token tok})
+                       acc)))))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; File + repo scan
+
+(defn analyze-content
+  "Return violation maps for magic numeric literals in `content`.
+   `rel` is the repo-relative path used in the record."
+  [rel ^String content]
+  (mapv (fn [{:keys [line col token]}]
+          {:rule/id  rule-id
+           :rule/category rule-category
+           :file     rel
+           :line     line
+           :column   col
+           :current  token
+           :kind     :magic-numeric})
+        (scan-numeric-tokens content)))
+
+(defn- normalize-separators [^String p] (str/replace p "\\" "/"))
+
+(defn- target-file? [rel]
+  (and (str/ends-with? rel ".clj")
+       (or (re-find #"^components/[^/]+/src/" rel)
+           (re-find #"^bases/[^/]+/src/" rel))))
+
+(defn- list-target-files [repo-root]
+  (let [root (io/file repo-root)
+        root-len (inc (count (.getAbsolutePath root)))]
+    (->> (file-seq root)
+         (filter #(.isFile ^java.io.File %))
+         (map (fn [^java.io.File f]
+                (normalize-separators (subs (.getAbsolutePath f) root-len))))
+         (filter target-file?)
+         vec)))
+
+(defn scan-repo
+  "Scan `repo-root` for magic numeric literals. Returns
+   {:violations [...] :files-scanned N :rule/id :std/named-constants
+    :counts {:magic-numeric N}}. Pure locator: no writes, no throw, no exit."
+  ([repo-root] (scan-repo repo-root nil))
+  ([repo-root changed-files]
+   (let [files (cond->> (list-target-files repo-root)
+                 changed-files (filterv (set changed-files)))
+         violations (vec (mapcat (fn [rel]
+                                   (analyze-content rel (slurp (io/file repo-root rel))))
+                                 files))]
+     {:violations    violations
+      :files-scanned (count files)
+      :rule/id       rule-id
+      :counts        {:magic-numeric (count violations)}})))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/named_constants.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/named_constants.clj
@@ -105,9 +105,17 @@
             (let [eol (let [j (str/index-of content "\n" i)] (or j n))]
               (recur eol line (+ col (- eol i)) acc))
 
-            ;; char literal \x — skip the backslash and the next char
+            ;; char literal — skip the backslash AND the whole char name, so a
+            ;; unicode/octal literal's digits (e.g. u0030, o101) aren't
+            ;; re-tokenized as a number. A named/unicode/octal literal is a run
+            ;; of alphanumerics; a punctuation literal is a single char.
             (= c \\)
-            (recur (min n (+ i 2)) line (+ col 2) acc)
+            (let [j (inc i)]
+              (if (and (< j n) (Character/isLetterOrDigit (.charAt content j)))
+                (let [end (loop [k j] (if (and (< k n) (Character/isLetterOrDigit (.charAt content k)))
+                                        (recur (inc k)) k))]
+                  (recur end line (+ col (- end i)) acc))
+                (recur (min n (+ i 2)) line (+ col 2) acc)))
 
             ;; string literal — skip to the closing unescaped quote
             (= c \")
@@ -159,16 +167,26 @@
          (filter target-file?)
          vec)))
 
+(defn- safe-slurp
+  "Read a file, returning its content or nil on any I/O error (permissions,
+   encoding, transient failure). The locator is best-effort — a single
+   unreadable file must not abort the whole scan."
+  [f]
+  (try (slurp f) (catch Exception _ nil)))
+
 (defn scan-repo
   "Scan `repo-root` for magic numeric literals. Returns
    {:violations [...] :files-scanned N :rule/id :std/named-constants
-    :counts {:magic-numeric N}}. Pure locator: no writes, no throw, no exit."
+    :counts {:magic-numeric N}}. Pure locator: no writes, no throw, no exit —
+   an unreadable file is skipped, not raised."
   ([repo-root] (scan-repo repo-root nil))
   ([repo-root changed-files]
    (let [files (cond->> (list-target-files repo-root)
                  changed-files (filterv (set changed-files)))
          violations (vec (mapcat (fn [rel]
-                                   (analyze-content rel (slurp (io/file repo-root rel))))
+                                   (if-let [content (safe-slurp (io/file repo-root rel))]
+                                     (analyze-content rel content)
+                                     []))
                                  files))]
      {:violations    violations
       :files-scanned (count files)

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/named_constants_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/named_constants_test.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.named-constants-test
+  (:require
+   [ai.miniforge.compliance-scanner.named-constants :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(defn- tokens [s] (mapv :token (sut/scan-numeric-tokens s)))
+
+(deftest flags-magic-numeric-literals-test
+  (testing "numbers outside the sentinel set are magic"
+    (is (= ["300000"] (tokens "(def x {:t 300000})")))
+    (is (= ["130"] (tokens "(recur 130 acc)")))
+    (is (= ["10" "60"] (tokens "(max 10 (- cols 60))")))
+    (is (= ["0xFF"] (tokens "(bit-and x 0xFF)")) "hex is magic")
+    (is (= ["7200"] (tokens "\"sleep\" 7200")) "int after a string still flagged")))
+
+(deftest exempts-structural-sentinels-test
+  (testing "-1, 0, 1, 2 are structural and never flagged"
+    (is (= [] (tokens "(if (< n 2) 0 1)")))
+    (is (= [] (tokens "(dec 1) (inc 0) (nth xs -1)")))
+    (is (= [] (tokens "(* x 2)")) "the doubling identity is exempt")))
+
+(deftest ignores-strings-comments-symbols-test
+  (testing "numbers inside strings, comments, or symbols are not code literals"
+    (is (= [] (tokens "(def p \"config/foo/messages/64.edn\")")) "in a string")
+    (is (= [] (tokens ";; timeout is 300000 ms")) "in a comment")
+    (is (= [] (tokens "(def h sha256-hex)")) "digits inside a symbol")
+    (is (= [] (tokens "(str \"ver 300\")")) "number in a string arg")))
+
+(deftest string-with-newline-keeps-line-numbers-test
+  (testing "a multi-line string does not desync line tracking"
+    (let [r (sut/scan-numeric-tokens "(def s \"a\nb\")\n(def n 42)")]
+      (is (= [{:token "42"}] (mapv #(select-keys % [:token]) r)))
+      (is (= 3 (:line (first r))) "42 is on line 3, after the 2-line string"))))
+
+(deftest analyze-content-shape-test
+  (testing "violation records carry rule id, file, line, and the token"
+    (let [[v] (sut/analyze-content "x.clj" "(def t 5000)")]
+      (is (= :std/named-constants (:rule/id v)))
+      (is (= "x.clj" (:file v)))
+      (is (= "5000" (:current v)))
+      (is (= :magic-numeric (:kind v)))
+      (is (pos-int? (:line v))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/named_constants_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/named_constants_test.clj
@@ -44,6 +44,14 @@
     (is (= [] (tokens "(def h sha256-hex)")) "digits inside a symbol")
     (is (= [] (tokens "(str \"ver 300\")")) "number in a string arg")))
 
+(deftest char-literals-not-retokenized-test
+  (testing "unicode/octal/named char literals don't leak digits as numbers"
+    (is (= [] (tokens "(def c \\u0030)")) "\\u0030 digits not a number")
+    (is (= [] (tokens "(def c \\o101)")) "\\o101 digits not a number")
+    (is (= [] (tokens "(when (= ch \\newline) x)")) "named char literal")
+    (is (= [] (tokens "(def c \\1)")) "digit char literal is not a magic number")
+    (is (= ["42"] (tokens "(def c \\a) (def n 42)")) "a real number after a char literal still flags")))
+
 (deftest string-with-newline-keeps-line-numbers-test
   (testing "a multi-line string does not desync line tracking"
     (let [r (sut/scan-numeric-tokens "(def s \"a\nb\")\n(def n 42)")]

--- a/components/evaluation/src/ai/miniforge/evaluation/comparator.clj
+++ b/components/evaluation/src/ai/miniforge/evaluation/comparator.clj
@@ -35,9 +35,6 @@
           n (count vals)]
       (/ (reduce + (map #(squared-deviation m %) vals)) (dec n)))))
 
-(defn- std-dev [vals]
-  (Math/sqrt (variance vals)))
-
 (defn- welch-t-test
   "Welch's t-test for unequal variances. Returns approximate p-value.
    This is a simplified two-tailed test."

--- a/components/reliability/src/ai/miniforge/reliability/sli.clj
+++ b/components/reliability/src/ai/miniforge/reliability/sli.clj
@@ -46,13 +46,6 @@
                 (.after ^java.util.Date ts cutoff)))
             metrics)))
 
-(defn- filter-by-tier
-  "Filter metrics by workflow tier, if specified."
-  [metrics tier]
-  (if tier
-    (filter #(= tier (:tier %)) metrics)
-    metrics))
-
 (defn- percentile
   "Compute percentile from sorted values."
   [sorted-vals p]


### PR DESCRIPTION
Adds `scan-named-constants` (Dewey 006) — a deterministic, LLM-free locator for magic **numeric** literals. The force-multiplier for measuring the named-constants backlog (item 3) without the semantic judge (~2 min/file → ~32 h over the repo). Runs over all 928 source files in **seconds**.

## How

A hand character-lexer tracks string / comment / char-literal state, so a number inside a string (`"config/.../64.edn"`) or a `;` comment is never counted — only numeric tokens in code positions. `-1/0/1/2` are exempt as structural sentinels (the rule’s "larger than 2 or smaller than -1" threshold); digits inside a symbol (`sha256-hex`) are not flagged. No new dependency; pure string ops (GraalVM-safe).

Repo-wide result: **1,708 magic numeric literals** across 928 files (top clusters are TUI/layout files).

## Scope — honest boundary

It is a triage **locator, not a gate**:
- It **over-reports** (1,708 vs the judge’s ~990 estimate) — it does not model the rule’s semantic exemptions (math identities, self-documenting keywords).
- It does **not** cover structured-string magic literals — the semantic judge still owns those.
- It does **not** fix — extraction needs a name + an intent docstring, which is judgment, not a transform.

Its job is cheap, repeatable measurement + exact locations for the fixing phase. 5 tests / 19 assertions cover the lexer (magic / exempt / string / comment / symbol / multiline) + the record shape.