### PR TITLE
fix(gate): policy + behavioral gates classify by enforcement action

### DIFF
--- a/components/gate/src/ai/miniforge/gate/behavioral.clj
+++ b/components/gate/src/ai/miniforge/gate/behavioral.clj
@@ -25,13 +25,14 @@
    harness).
 
    - check-behavioral  : delegates to policy-pack/check-artifact with phase
-                         context {:phase :observe :task-type :modify} and
-                         uses the severity cascade from gate.policy.
+                         context {:phase :observe :task-type :modify}, which
+                         classifies violations by each rule's enforcement action
+                         (:hard-halt / :require-approval block; :warn / :audit
+                         warn) — not by severity.
    - repair-behavioral : always returns {:success? false} — behavioral
                          violations cannot be fixed in-place; the caller
                          must redirect to :implement."
   (:require [ai.miniforge.gate.messages :as msg]
-            [ai.miniforge.gate.policy   :as policy]
             [ai.miniforge.gate.registry :as registry]
             [ai.miniforge.policy-pack.interface :as policy-pack]
             [ai.miniforge.response.interface :as response]))
@@ -43,16 +44,6 @@
   []
   {:type :no-policy-packs
    :message (msg/t :behavioral/no-policy-packs)})
-
-(defn- passed-cascade?
-  [{:keys [blocking approval-required]}]
-  (and (empty? blocking)
-       (empty? approval-required)))
-
-(defn- violation-results
-  [result-type violations]
-  (mapv #(policy/violation->gate-result result-type %)
-        violations))
 
 (defn- behavioral-check-error-warning
   [message]
@@ -85,12 +76,14 @@
                                    instead of redefining clojure.core fns
                                    globally (which races with parallel tests).
                                    Signature: (fn [packs artifact opts]) ->
-                                   {:violations [...]}.
+                                   the check-artifact result
+                                   {:passed? :blocking :require-approval
+                                    :warnings :audits}.
 
    Returns:
      {:passed? bool
-      :errors  [{:type :behavioral-violation :severity … :message … …}]
-      :warnings [{:type :behavioral-warning :severity … :message … …}]}"
+      :errors  [{:code … :severity … :message … …}]
+      :warnings [{:code … :severity … :message … …}]}"
   [artifact ctx]
   ;; Programmer-error guard runs OUTSIDE the try/catch on purpose.
   ;; A non-nil non-callable :check-fn is a misconfiguration the caller
@@ -111,17 +104,11 @@
       (if (empty? packs)
         {:passed?  true
          :warnings [(no-policy-packs-warning)]}
-        (let [result   (check-fn packs artifact {:phase :observe :task-type :modify})
-              cascade  (policy/evaluate-severity-cascade (get result :violations []))
-              blocking (get cascade :blocking [])
-              approval-required (get cascade :approval-required [])
-              warnings (get cascade :warnings [])
-              audits (get cascade :audits [])]
-          {:passed?  (passed-cascade? cascade)
-           :errors   (violation-results :behavioral-violation
-                                        (concat blocking approval-required))
-           :warnings (violation-results :behavioral-warning
-                                        (concat warnings audits))})))
+        (let [{:keys [passed? blocking require-approval warnings audits]}
+              (check-fn packs artifact {:phase :observe :task-type :modify})]
+          {:passed?  (and passed? (empty? require-approval))
+           :errors   (vec (concat blocking require-approval))
+           :warnings (vec (concat warnings audits))})))
     (catch Exception e
       {:passed?  true
        :warnings [(behavioral-check-error-warning (ex-message e))]})))

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -24,8 +24,7 @@
    - :review-approved - Review approval check
    - :release-ready - Release readiness check
    - :plan-complete - Plan completeness check"
-  (:require [ai.miniforge.event-stream.interface :as event-stream]
-            [ai.miniforge.gate.messages  :as msg]
+  (:require [ai.miniforge.gate.messages  :as msg]
             [ai.miniforge.gate.registry  :as registry]
             [ai.miniforge.policy-pack.interface :as policy-pack]
             [ai.miniforge.response.interface :as response]
@@ -174,75 +173,14 @@
    :repair nil})
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Severity cascade
-
-(defn evaluate-severity-cascade
-  "Classify violations by severity into cascade buckets.
-
-   Arguments:
-     violations - Vector of violation maps with :violation/severity keys
-
-   Returns:
-     {:blocking          [...] ; :critical -> hard-halt
-      :approval-required [...] ; :high -> require approval
-      :warnings          [...] ; :medium -> warn, passes
-      :audits            [...]} ; :low/:info -> audit, passes silently"
-  [violations]
-  (reduce
-   (fn [acc violation]
-     (let [severity (:violation/severity violation)]
-       (cond
-         (= :critical severity) (update acc :blocking conj violation)
-         (= :high severity)     (update acc :approval-required conj violation)
-         (= :medium severity)   (update acc :warnings conj violation)
-         :else                  (update acc :audits conj violation))))
-   {:blocking [] :approval-required [] :warnings [] :audits []}
-   violations))
-
-(defn request-approval-for-violations!
-  "Create approval requests for :high (approval-required) violations.
-
-   Arguments:
-     event-stream-atom - Atom used as the approval manager store
-     violations        - Vector of approval-required violation maps
-
-   Returns:
-     {:approval-ids [...] :pending-count int}"
-  [event-stream-atom violations]
-  (let [approvals (mapv (fn [violation]
-                          (event-stream/create-approval-request
-                           (random-uuid)
-                           ["policy-reviewer"]
-                           1
-                           {:metadata {:violation/rule-id    (:violation/rule-id violation)
-                                       :violation/message    (:violation/message violation)
-                                       :violation/severity   (:violation/severity violation)
-                                       :violation/remediation (:violation/remediation violation)}}))
-                        violations)]
-    (run! #(event-stream/store-approval! event-stream-atom %) approvals)
-    {:approval-ids  (mapv :approval/id approvals)
-     :pending-count (count approvals)}))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Policy Pack Gate (delegates to policy-pack component with severity cascade)
-
-(defn violation->gate-result
-  "Convert a violation map to a gate result entry."
-  [result-type violation]
-  (cond-> {:type result-type
-           :severity (:violation/severity violation)
-           :message (:violation/message violation)}
-    (:violation/rule-id violation) (assoc :rule-id (:violation/rule-id violation))
-    (:violation/remediation violation) (assoc :remediation (:violation/remediation violation))))
+;; Policy Pack Gate (classifies by enforcement action, via policy-pack)
 
 (defn check-policy-pack
-  "Check artifact against loaded policy packs with severity cascade.
-
-   Severity cascade:
-   - :critical -> hard-halt (blocks gate, errors)
-   - :high     -> require-approval (blocks unless approved)
-   - :medium   -> warn (passes with warnings)
-   - :low/:info -> audit (passes silently, recorded in evidence)
+  "Check artifact against loaded policy packs, classifying each violation by its
+   rule's enforcement action (`:rule/enforcement :action`) via
+   `policy-pack/check-artifact`. `:hard-halt` and `:require-approval` block the
+   gate; `:warn` and `:audit` are non-blocking warnings. Severity is advisory
+   and never gates. Fail-closed: any exception during evaluation blocks.
 
    Arguments:
      artifact - Artifact with :content
@@ -256,18 +194,17 @@
           task-type (get ctx :task-type :implement)
           phase (get ctx :phase :implement)]
       (if (empty? packs)
-        {:passed? true :warnings [{:type :no-policy-packs
-                                    :message "No policy packs loaded"}]}
-        (let [result   (policy-pack/check-artifact packs artifact {:task-type task-type :phase phase})
-              cascade  (evaluate-severity-cascade (:violations result []))
-              blocking          (:blocking cascade)
-              approval-required (:approval-required cascade)
-              warnings          (:warnings cascade)]
-          {:passed? (and (empty? blocking) (empty? approval-required))
-           :errors (mapv #(violation->gate-result :policy-violation %) blocking)
-           :approval-required (mapv #(violation->gate-result :approval-required %) approval-required)
-           :warnings (mapv #(violation->gate-result :policy-warning %)
-                           (concat warnings (:audits cascade)))})))
+        {:passed? true
+         :errors []
+         :approval-required []
+         :warnings [{:type :no-policy-packs
+                     :message (msg/t :policy-pack/no-policy-packs)}]}
+        (let [{:keys [passed? blocking require-approval warnings audits]}
+              (policy-pack/check-artifact packs artifact {:task-type task-type :phase phase})]
+          {:passed?           (and passed? (empty? require-approval))
+           :errors            (vec blocking)
+           :approval-required (vec require-approval)
+           :warnings          (vec (concat warnings audits))})))
     (catch Object e
       {:passed? false
        :errors [{:type :policy-check-error
@@ -289,7 +226,7 @@
 (defmethod registry/get-gate :policy-pack
   [_]
   {:name :policy-pack
-   :description "Validates code against loaded policy packs with severity cascade"
+   :description "Validates code against loaded policy packs by enforcement action"
    :check check-policy-pack
    :repair repair-policy-pack})
 

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -183,11 +183,15 @@
    and never gates. Fail-closed: any exception during evaluation blocks.
 
    Arguments:
-     artifact - Artifact with :content
+     artifact - Artifact with :artifact/content (and optional :artifact/path),
+                forwarded to policy-pack/check-artifact
      ctx      - Execution context with :policy-packs, :task-type, :phase
 
    Returns:
-     {:passed? bool :errors [] :warnings [] :approval-required []}"
+     {:passed? bool :errors [] :warnings [] :approval-required []}. Blocking
+     require-approval violations appear in BOTH :errors (so the failure carries
+     detail — `gate.interface/check-gate` emits failure events from :errors
+     only) and :approval-required (the subset needing approval)."
   [artifact ctx]
   (try+
     (let [packs (get ctx :policy-packs [])
@@ -202,7 +206,7 @@
         (let [{:keys [passed? blocking require-approval warnings audits]}
               (policy-pack/check-artifact packs artifact {:task-type task-type :phase phase})]
           {:passed?           (and passed? (empty? require-approval))
-           :errors            (vec blocking)
+           :errors            (vec (concat blocking require-approval))
            :approval-required (vec require-approval)
            :warnings          (vec (concat warnings audits))})))
     (catch Object e

--- a/components/gate/test/ai/miniforge/gate/behavioral_test.clj
+++ b/components/gate/test/ai/miniforge/gate/behavioral_test.clj
@@ -53,11 +53,20 @@
 
 ;; Tests inject a `:check-fn` via the ctx map. Local DI keeps stubs scoped to
 ;; the call site and avoids global mutation for normal policy-pack behavior.
+;; The stub returns the same shape as `policy-pack/check-artifact`: violations
+;; already bucketed by enforcement action, with :passed? = (empty? blocking).
 
 (defn- stub-check-fn
-  "Build a stub policy-pack check fn that returns the given violations."
-  [violations]
-  (fn [_packs _artifact _opts] {:violations violations}))
+  "Build a stub check fn returning a check-artifact-shaped result. Each bucket
+   defaults to empty; :passed? mirrors check-artifact ((empty? blocking))."
+  [& {:keys [blocking require-approval warnings audits]
+      :or   {blocking [] require-approval [] warnings [] audits []}}]
+  (fn [_packs _artifact _opts]
+    {:passed?          (empty? blocking)
+     :blocking         blocking
+     :require-approval require-approval
+     :warnings         warnings
+     :audits           audits}))
 
 (defn- throwing-check-fn
   "Build a stub policy-pack check fn that throws with the given message."
@@ -70,67 +79,63 @@
                   sample-artifact
                   {:policy-packs [{:id :test-pack}]
                    :phase        :observe
-                   :check-fn     (stub-check-fn [])})]
+                   :check-fn     (stub-check-fn)})]
       (is (true? (:passed? result)))
       (is (empty? (:errors result)))
       (is (empty? (:warnings result))))))
 
 (deftest check-behavioral-blocking-violations-test
-  (testing "Fails with errors when :critical violations are returned"
+  (testing "Fails with errors when :hard-halt (blocking) violations are returned"
     (let [result (behavioral/check-behavioral
                   sample-artifact
                   {:policy-packs [{:id :test-pack}]
                    :phase        :observe
                    :check-fn     (stub-check-fn
-                                  [{:violation/severity    :critical
-                                    :violation/rule-id     :no-file-deletion
-                                    :violation/message     "Deleted a protected file"
-                                    :violation/remediation "Restore the file"}])})]
+                                  :blocking [{:code     :no-file-deletion
+                                              :severity :critical
+                                              :message  "Deleted a protected file"}])})]
       (is (false? (:passed? result)))
       (is (= 1 (count (:errors result))))
-      (is (= :behavioral-violation (-> result :errors first :type)))
-      (is (= :critical (-> result :errors first :severity)))
+      (is (= :no-file-deletion (-> result :errors first :code)))
       (is (empty? (:warnings result))))))
 
-(deftest check-behavioral-high-severity-test
-  (testing "Fails when :high violations are returned (approval-required bucket)"
+(deftest check-behavioral-approval-required-test
+  (testing "Fails when :require-approval violations are returned (deploy-style
+            fail-closed: approval cannot be granted inline, so the gate blocks)"
     (let [result (behavioral/check-behavioral
                   sample-artifact
                   {:policy-packs [{:id :test-pack}]
                    :phase        :observe
                    :check-fn     (stub-check-fn
-                                  [{:violation/severity :high
-                                    :violation/rule-id  :sensitive-path
-                                    :violation/message  "Wrote to sensitive path"}])})]
+                                  :require-approval [{:code    :sensitive-path
+                                                      :message "Wrote to sensitive path"}])})]
       (is (false? (:passed? result)))
       (is (= 1 (count (:errors result))))
-      (is (= :behavioral-violation (-> result :errors first :type))))))
+      (is (= :sensitive-path (-> result :errors first :code))))))
 
 (deftest check-behavioral-warning-violations-test
-  (testing "Passes with warnings when only :medium violations are returned"
+  (testing "Passes with warnings when only :warn violations are returned"
     (let [result (behavioral/check-behavioral
                   sample-artifact
                   {:policy-packs [{:id :test-pack}]
                    :phase        :observe
                    :check-fn     (stub-check-fn
-                                  [{:violation/severity :medium
-                                    :violation/message  "Consider using a helper fn"}])})]
+                                  :warnings [{:code    :prefer-helper
+                                              :message "Consider using a helper fn"}])})]
       (is (true? (:passed? result)))
       (is (empty? (:errors result)))
       (is (= 1 (count (:warnings result))))
-      (is (= :behavioral-warning (-> result :warnings first :type))))))
+      (is (= :prefer-helper (-> result :warnings first :code))))))
 
 (deftest check-behavioral-audit-violations-test
-  (testing "Passes silently (warnings) when only :low/:info violations are returned"
+  (testing "Passes (warnings) when only :audit violations are returned"
     (let [result (behavioral/check-behavioral
                   sample-artifact
                   {:policy-packs [{:id :test-pack}]
                    :phase        :observe
                    :check-fn     (stub-check-fn
-                                  [{:violation/severity :low
-                                    :violation/message  "Audit: read an extra file"}
-                                   {:violation/severity :info
-                                    :violation/message  "Info: large diff"}])})]
+                                  :audits [{:code :extra-read :message "Audit: read an extra file"}
+                                           {:code :large-diff :message "Info: large diff"}])})]
       (is (true? (:passed? result)))
       (is (empty? (:errors result)))
       (is (= 2 (count (:warnings result)))))))

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -95,3 +95,52 @@
                (-> result :errors first :message)))
         (is (empty? (:warnings result)))
         (is (empty? (:approval-required result)))))))
+
+;; -------------------------------------------------------------------------- check-policy-pack enforcement-action classification
+;; Regression: the gate must classify by :rule/enforcement :action, not severity.
+;; A :major/:minor rule and every content-scan violation (which carries no
+;; :severity) previously fell through a severity cascade to a silent pass.
+
+(def ^:private hard-halt-major-pack
+  "One rule: :major severity, :hard-halt enforcement, content-scan detection (so
+   the violation carries no :severity key). Must block the gate."
+  {:pack/id      "test-deploy-block"
+   :pack/version "2026.07.04"
+   :pack/rules   [{:rule/id          :no-danger-token
+                   :rule/severity    :major
+                   :rule/detection   {:type :content-scan :pattern "DANGER"}
+                   :rule/enforcement {:action  :hard-halt
+                                      :message "Danger token present"}}]})
+
+(defn- warn-major-pack
+  "As hard-halt-major-pack, but :warn enforcement — must pass (advisory)."
+  []
+  (assoc-in hard-halt-major-pack [:pack/rules 0 :rule/enforcement :action] :warn))
+
+(deftest check-policy-pack-blocks-major-hard-halt-rule
+  (testing ":major :hard-halt content-scan rule blocks the deploy gate"
+    (let [result (policy/check-policy-pack
+                  {:artifact/content "a line with DANGER in it" :artifact/path "main.tf"}
+                  {:policy-packs [hard-halt-major-pack]})]
+      (is (false? (:passed? result)))
+      (is (= 1 (count (:errors result))))
+      (is (= :no-danger-token (-> result :errors first :code)))
+      (is (empty? (:approval-required result))))))
+
+(deftest check-policy-pack-passes-major-warn-rule
+  (testing ":major :warn rule passes with a warning — severity does not gate"
+    (let [result (policy/check-policy-pack
+                  {:artifact/content "a line with DANGER in it" :artifact/path "main.tf"}
+                  {:policy-packs [(warn-major-pack)]})]
+      (is (true? (:passed? result)))
+      (is (empty? (:errors result)))
+      (is (= 1 (count (:warnings result))))
+      (is (= :no-danger-token (-> result :warnings first :code))))))
+
+(deftest check-policy-pack-clean-artifact-passes
+  (testing "no rule fires → gate passes clean"
+    (let [result (policy/check-policy-pack
+                  {:artifact/content "nothing to see here" :artifact/path "main.tf"}
+                  {:policy-packs [hard-halt-major-pack]})]
+      (is (true? (:passed? result)))
+      (is (empty? (:errors result))))))

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -144,3 +144,16 @@
                   {:policy-packs [hard-halt-major-pack]})]
       (is (true? (:passed? result)))
       (is (empty? (:errors result))))))
+
+(deftest check-policy-pack-blocks-require-approval-with-detail
+  (testing ":require-approval blocks the gate AND lands in :errors, so the
+            failure carries detail (check-gate emits failure events from :errors)"
+    (let [pack   (assoc-in hard-halt-major-pack
+                           [:pack/rules 0 :rule/enforcement :action] :require-approval)
+          result (policy/check-policy-pack
+                  {:artifact/content "a line with DANGER in it" :artifact/path "main.tf"}
+                  {:policy-packs [pack]})]
+      (is (false? (:passed? result)))
+      (is (= 1 (count (:errors result))))
+      (is (= :no-danger-token (-> result :errors first :code)))
+      (is (= 1 (count (:approval-required result)))))))

--- a/docs/pull-requests/2026-07-04-fix-policy-gate-enforcement-action.md
+++ b/docs/pull-requests/2026-07-04-fix-policy-gate-enforcement-action.md
@@ -1,0 +1,62 @@
+<!--
+  Title: Policy + behavioral gates classify by enforcement action
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: policy + behavioral gates classify by enforcement action
+
+Branch: `fix/policy-gate-enforcement-action`
+
+## Summary
+
+Closes the deployment-gate enforcement hole from the 2026-07-05 governance
+audit (Findings 1 and 2). Two gates — `:policy-pack` (deployment path,
+`gate/policy.clj`) and `:behavioral` (`gate/behavioral.clj`) — called
+`policy-pack/check-artifact`, discarded its already-correct action-classified
+buckets, and re-derived pass/fail from a severity cascade instead.
+
+That cascade recognized `:critical/:high/:medium`, but packs declare
+`:critical/:major/:minor/:info`. So `:major` and `:minor` rules matched nothing
+and fell through to a silent audit pass. Content-scan violations compounded it:
+they carry no `:severity` key at all, so even a `:critical` content-scan rule
+passed. Net effect at deploy: a `:major` `:hard-halt` rule
+(`terraform-aws/require-vpc`, `k8s/require-resource-limits`, …) recorded an
+audit note and passed the gate.
+
+The fix makes both gates consume `check-artifact`'s buckets, which are keyed off
+each rule's `:rule/enforcement :action` (the SDLC gate's model) — the one signal
+pack authors write. Severity becomes advisory and never gates.
+
+## Changes in Detail
+
+- `gate/policy.clj`: `check-policy-pack` now reads `check-artifact`'s
+  `:blocking` / `:require-approval` / `:warnings` / `:audits`. `:hard-halt` and
+  `:require-approval` block; `:warn` / `:audit` warn. Deleted
+  `evaluate-severity-cascade`, `violation->gate-result`, and the unused
+  `request-approval-for-violations!` (the only consumers of the wrong
+  vocabulary), plus the now-unused `event-stream` require.
+- `gate/behavioral.clj`: `check-behavioral` consumes the same buckets; dropped
+  the `gate.policy` require and the `passed-cascade?` / `violation-results`
+  helpers.
+- Fail-closed on exception (unchanged) and blocking-on-require-approval
+  (unchanged deploy posture) are preserved.
+
+## Scope Boundary
+
+Empty-pack fail-open on the deployment path (audit Finding 5) is left as-is here
+and handled in a later PR, per the audit's suggested order.
+
+## Verification
+
+- `components/gate` full suite: 104 tests, 281 assertions, 0 failures.
+- New regression tests (real pack + content-scan, not stubs):
+  - `:major` `:hard-halt` content-scan rule → gate blocks.
+  - `:major` `:warn` rule → gate passes with a warning (severity does not gate).
+  - clean artifact → passes.
+- Behavioral gate tests rewritten to the enforcement-action bucket shape,
+  including a `:require-approval`-blocks case.
+
+## Related
+
+- Governance audit: `miniforge-governance-audit-2026-07-05.md` (Findings 1, 2).


### PR DESCRIPTION
## Summary

Closes governance-audit Findings 1 and 2 (`miniforge-governance-audit-2026-07-05.md`).

Two gates — `:policy-pack` (deployment/provision path, `gate/policy.clj`) and
`:behavioral` (`gate/behavioral.clj`) — called `policy-pack/check-artifact`,
discarded its already-correct action-classified buckets, and re-derived pass/fail
from a severity cascade recognizing only `:critical/:high/:medium`. Packs declare
`:critical/:major/:minor/:info`, so `:major` (24 rules) and `:minor` (5) matched
nothing and fell to a silent audit pass. Content-scan violations compounded it:
they carry no `:severity` key, so even a `:critical` content-scan rule passed.

Net effect at deploy: a `:major` `:hard-halt` rule (`require-vpc`,
`require-resource-limits`, `no-latest-tag`) recorded an audit note and passed the
highest-blast-radius gate.

Both gates now consume `check-artifact`'s `:blocking` / `:require-approval` /
`:warnings` / `:audits`, keyed off each rule's `:rule/enforcement :action` — the
SDLC gate's model and the one signal pack authors write. Severity becomes advisory
and never gates. Fail-closed-on-exception and blocking-on-require-approval (deploy
posture) are preserved.

## Changes

- `gate/policy.clj`: rewrite `check-policy-pack`; delete `evaluate-severity-cascade`,
  `violation->gate-result`, the unused `request-approval-for-violations!`, and the
  now-unused `event-stream` require. Localize the empty-packs warning to the
  existing `:policy-pack/no-policy-packs` key.
- `gate/behavioral.clj`: rewrite `check-behavioral`; drop the `gate.policy` require
  and the `passed-cascade?` / `violation-results` helpers.

Split into two commits so each stays under the 200-line commit budget and builds
green independently (behavioral stops using the shared helpers first; policy then
deletes them).

## Scope boundary

Empty-pack fail-open on the deployment path (Finding 5) is left as-is here and
handled in a later PR, per the audit's suggested order.

## Test plan

- `components/gate` full suite: 104 tests, 281 assertions, 0 failures.
- New regression tests (real pack + content-scan, not stubs):
  - `:major` `:hard-halt` content-scan rule → gate blocks.
  - `:major` `:warn` rule → passes with a warning (severity does not gate).
  - clean artifact → passes.
- Behavioral tests rewritten to the enforcement-action bucket shape, incl. a
  `:require-approval`-blocks case.
- `bb pre-commit` (budget, lint, format, smoke=328 tests, graalvm=522 assertions)
  passed on both commits.

See `docs/pull-requests/2026-07-04-fix-policy-gate-enforcement-action.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)