### PR TITLE
fix(gate): unknown gate fails closed; add explicit :noop

### DIFF
--- a/components/gate/src/ai/miniforge/gate/registry.clj
+++ b/components/gate/src/ai/miniforge/gate/registry.clj
@@ -49,15 +49,32 @@
       :repair (fn [artifact errors ctx] -> {:success? bool :artifact ...})}"
   identity)
 
-;; Default: unknown gates pass through with warning
+;; Unknown gates fail CLOSED. A phase that references a gate the registry cannot
+;; resolve — misspelled, renamed, or never registered — must halt, not wave the
+;; artifact through. In a system that sells fail-closed governance the unknown
+;; case is the dangerous one. Deliberate pass-through has an explicit, separate
+;; home: the :noop gate below, so "unknown" and "intentionally skipped" stay
+;; distinct and greppable.
 (defmethod get-gate :default
   [gate-kw]
   {:name gate-kw
-   :description "Unknown gate (pass-through)"
+   :description "Unknown gate (fail-closed)"
    :check (fn [_artifact _ctx]
-            {:passed? true
-             :warnings [{:type :unknown-gate
-                         :message (str "Unknown gate: " gate-kw ", passing through")}]})
+            {:passed? false
+             :errors [{:type :unknown-gate
+                       :message (str "Unknown gate: " gate-kw
+                                     " — no registered implementation")}]})
+   :repair nil})
+
+;; Explicit, named pass-through for a phase that intentionally runs no blocking
+;; gate. Distinct from an unknown gate (which fails closed above).
+(register-gate! :noop)
+
+(defmethod get-gate :noop
+  [_]
+  {:name :noop
+   :description "Intentional pass-through (no gate)"
+   :check (fn [_artifact _ctx] {:passed? true})
    :repair nil})
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -70,6 +87,18 @@
      Set of gate keywords"
   []
   @registered-gates)
+
+(defn gate-registered?
+  "True when gate-kw resolves to its own get-gate implementation rather than the
+   fail-closed :default. `get-method` returns the :default method for any
+   unregistered keyword, so comparing against it detects a real registration.
+
+   Callers that check gates defined in other namespaces (policy, behavioral, …)
+   must load those implementations first (require `gate.interface`); a gate whose
+   defmethod has not been loaded reads as unregistered."
+  [gate-kw]
+  (not= (get-method get-gate gate-kw)
+        (get-method get-gate :default)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/gate/test/ai/miniforge/gate/interface_test.clj
+++ b/components/gate/test/ai/miniforge/gate/interface_test.clj
@@ -77,14 +77,15 @@
       (is (fn? (:check g))))))
 
 (deftest get-gate-unknown-test
-  (testing "get-gate returns default for unknown gate"
+  (testing "get-gate returns a fail-closed default for an unknown gate"
     (let [g (gate/get-gate :unknown-gate)]
       (is (map? g))
       (is (= :unknown-gate (:name g)))
       (is (fn? (:check g)))
-      ;; Default gate should pass
+      ;; Unknown gate must fail closed, not pass through.
       (let [result ((:check g) {} {})]
-        (is (:passed? result))))))
+        (is (false? (:passed? result)))
+        (is (= :unknown-gate (-> result :errors first :type)))))))
 
 ;; ============================================================================
 ;; Gate check tests

--- a/components/gate/test/ai/miniforge/gate/registry_test.clj
+++ b/components/gate/test/ai/miniforge/gate/registry_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.registry-test
+  (:require [clojure.test :refer [deftest is testing]]
+            ;; Loads every gate-component defmethod (syntax, lint, policy, …) so
+            ;; gate-registered? sees them. Without this the resolve-check below
+            ;; would read every real gate as unregistered.
+            [ai.miniforge.gate.interface]
+            [ai.miniforge.gate.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Unknown gate fails closed
+
+(deftest unknown-gate-fails-closed-test
+  (testing "a gate keyword with no registration resolves to a fail-closed check"
+    (let [gate   (registry/get-gate :totally-unregistered-gate)
+          result ((:check gate) {:content "x"} {})]
+      (is (false? (:passed? result))
+          "unknown gate must NOT pass through")
+      (is (= :unknown-gate (-> result :errors first :type)))
+      (is (nil? (:repair gate))))))
+
+(deftest noop-gate-passes-test
+  (testing ":noop is the explicit, registered pass-through"
+    (let [gate   (registry/get-gate :noop)
+          result ((:check gate) {:content "x"} {})]
+      (is (true? (:passed? result)))
+      (is (empty? (:errors result)))
+      (is (contains? (registry/list-gates) :noop)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Resolve-check
+
+(deftest gate-registered?-distinguishes-real-from-default-test
+  (testing "gate-registered? is true for a real gate, false for an unknown one"
+    (is (true? (registry/gate-registered? :noop)))
+    (is (true? (registry/gate-registered? :syntax)))
+    (is (false? (registry/gate-registered? :totally-unregistered-gate)))
+    (is (false? (registry/gate-registered? :default))
+        ":default itself is not a resolvable gate")))
+
+;; The gate names the shipped SDLC + security-compliance workflows reference in
+;; their phase `:gates` vectors — all owned by the gate component. Regenerate
+;; with:
+;;   grep -rhoE ':gates \[[^]]*\]' components bases projects --include=*.edn \
+;;     | grep -oE ':[a-z][a-z0-9-]+' | sort -u
+;; and drop the deploy-owned gates (covered by phase-deployment's gates-test).
+;; A gate referenced here that no longer resolves is a fail-closed footgun: a
+;; workflow would halt on it at runtime. Fix by registering the gate or, for a
+;; deliberate skip, referencing :noop in the workflow.
+(def shipped-gate-references
+  #{:syntax :format :lint :no-secrets :pre-verify-lint :tests-pass :coverage
+    :policy-verify :review-approved :quality-check :policy-review :plan-complete
+    :release-ready :policy-pack :noop})
+
+(deftest shipped-gate-references-resolve-test
+  (testing "every gate-owned reference in a shipped workflow resolves to a real
+            registration (never the fail-closed default)"
+    (doseq [gate-kw shipped-gate-references]
+      (is (registry/gate-registered? gate-kw)
+          (str gate-kw " is referenced by a shipped workflow but has no "
+               "registered gate — it would fail closed at runtime")))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/gates_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/gates_test.clj
@@ -18,6 +18,9 @@
 
 (ns ai.miniforge.phase-deployment.gates-test
   (:require [ai.miniforge.gate.registry :as registry]
+            ;; Loads the gate-component gates (e.g. :policy-pack) the deploy
+            ;; defaults reference alongside the deployment-owned gates below.
+            [ai.miniforge.gate.interface]
             [ai.miniforge.phase-deployment.gates :as sut]
             [clojure.test :refer [deftest is testing]]))
 
@@ -46,3 +49,14 @@
   (testing "gate descriptions are loaded from EDN-backed configuration"
     (is (= "Validates health endpoints return HTTP 2xx"
            (:description (registry/get-gate :health-check))))))
+
+(deftest deploy-default-gate-references-resolve-test
+  (testing "every gate the shipped deploy defaults reference resolves to a real
+            registration — none falls through to the fail-closed :default. The
+            deployment gates (deploy-healthy/health-check/provision-validated)
+            register via defmethod without register-gate!, so this guards the
+            resolve path list-gates would miss."
+    (doseq [gate-kw [:policy-pack :provision-validated :deploy-healthy :health-check]]
+      (is (registry/gate-registered? gate-kw)
+          (str gate-kw " is referenced by deploy-defaults but has no registered "
+               "gate — it would fail closed at deploy")))))

--- a/components/workflow-security-compliance/resources/workflows/security-compliance-v1.0.0.edn
+++ b/components/workflow-security-compliance/resources/workflows/security-compliance-v1.0.0.edn
@@ -70,8 +70,14 @@
              :time-seconds 300}}
 
    :sec-classify
+   ;; Classification runs in this phase's body (see workflow_security_compliance
+   ;; core.clj), not as a registry gate — :classification-gate belongs to the
+   ;; loop Gate protocol, a different system from the multimethod :gates runner.
+   ;; :noop marks the deliberate skip explicitly (the multimethod default now
+   ;; fails closed on an unresolved gate, so the prior bare :classification-gate
+   ;; reference would halt this phase).
    {:agent nil
-    :gates [:classification-gate]
+    :gates [:noop]
     :budget {:tokens 5000
              :iterations 1
              :time-seconds 120}}

--- a/docs/pull-requests/2026-07-05-fix-unknown-gate-fails-closed.md
+++ b/docs/pull-requests/2026-07-05-fix-unknown-gate-fails-closed.md
@@ -1,0 +1,72 @@
+<!--
+  Title: Unknown gate fails closed
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: unknown gate fails closed
+
+Branch: `fix/unknown-gate-fails-closed`
+
+## Summary
+
+Closes governance-audit Finding 3 (`miniforge-governance-audit-2026-07-05.md`).
+
+`gate/registry.clj`'s `get-gate :default` returned a pass-through check
+(`{:passed? true :warnings [{:type :unknown-gate}]}`). A gate keyword that is
+misspelled, renamed, or never registered passed the phase with a warning buried
+in the result. In a system that sells fail-closed governance, the unknown case
+is the dangerous one.
+
+- `get-gate :default` now returns `{:passed? false :errors [{:type
+  :unknown-gate}]}` — an unresolvable gate halts the phase.
+- Added an explicit, registered `:noop` gate for deliberate pass-through, so
+  "unknown" (fails closed) and "intentionally skipped" (`:noop`) are distinct
+  and greppable.
+- Added `registry/gate-registered?` — true only when a keyword resolves to its
+  own `get-gate` implementation, not the fail-closed default.
+
+## Blast radius
+
+Every gate referenced by a shipped workflow / phase-default was cross-checked
+against the registered `defmethod`s. Exactly one referenced gate did not
+resolve: `:classification-gate`, referenced by
+`security-compliance-v1.0.0.edn`'s `:sec-classify` phase. That gate belongs to
+the separate `loop` Gate protocol (`gate-classification` component), not the
+multimethod `:gates` runner; the phase's classification actually runs in its
+body, and the gate reference only "worked" because the old default passed it
+through silently. Changed that reference to `:noop` (deliberate skip) so the
+prototype does not halt under the fail-closed default.
+
+`deploy-healthy` / `health-check` / `provision-validated` register via
+`defmethod` without `register-gate!`, so they resolve fine (they were only
+absent from `list-gates`, not from dispatch).
+
+## Resolve-check
+
+Two tests guard the gate-name space so a future unresolved reference is caught
+at CI time, not at runtime:
+
+- `registry-test/shipped-gate-references-resolve-test` — the SDLC /
+  gate-component references.
+- `phase-deployment gates-test/deploy-default-gate-references-resolve-test` —
+  the deploy references (that test already loads the deployment gates).
+
+They split by ownership because the gate component's test cannot depend on
+phase-deployment (backwards dependency).
+
+## Test plan
+
+- `components/gate` + `phase-deployment` gates: 113 tests, 322 assertions, 0
+  failures.
+- `workflow-security-compliance` (e2e + phases) and workflow gate-path tests:
+  51 tests, 175 assertions, 0 failures.
+- Updated `interface-test/get-gate-unknown-test` from the old pass-through
+  assertion to fail-closed.
+- `bb poly:check` clean.
+
+## Related
+
+- Governance audit Finding 3. Follow-up worth considering: a runtime boot-time
+  resolve-check (this PR guards at CI/test time; a workflow-registration-time
+  check would need the workflow layer, which knows both gates and workflows).


### PR DESCRIPTION
## Summary

Closes governance-audit Finding 3 (`miniforge-governance-audit-2026-07-05.md`).

`gate/registry.clj`'s `get-gate :default` returned a pass-through
(`{:passed? true :warnings [{:type :unknown-gate}]}`), so a misspelled, renamed,
or never-registered gate keyword passed the phase with a buried warning. In a
system that sells fail-closed governance, the unknown case is the dangerous one.

- `get-gate :default` → `{:passed? false :errors [{:type :unknown-gate}]}`.
- New registered `:noop` gate for deliberate pass-through — so "unknown" (fails
  closed) and "intentionally skipped" (`:noop`) are distinct and greppable.
- New `registry/gate-registered?` (resolves to a real `defmethod`, not the
  default).

## Blast radius

Cross-checked every gate referenced by a shipped workflow/phase-default against
the registered `defmethod`s. Exactly one did not resolve: `:classification-gate`
(`security-compliance-v1.0.0` `:sec-classify`). It belongs to the separate
`loop` Gate protocol (`gate-classification` component), the classification runs
in the phase body, and the reference only "worked" via the old silent default.
Changed it to `:noop`. `deploy-healthy`/`health-check`/`provision-validated`
register via `defmethod` without `register-gate!` — they resolve fine.

## Resolve-check

Two CI-time tests guard the gate-name space so a future unresolved reference is
caught at CI, not runtime — split by owning component (the gate test cannot
depend on phase-deployment):
- `registry-test/shipped-gate-references-resolve-test` (SDLC / gate-owned).
- `phase-deployment gates-test/deploy-default-gate-references-resolve-test`.

## Test plan

- `components/gate` + `phase-deployment` gates: 113 tests, 322 assertions, 0 failures.
- `workflow-security-compliance` e2e/phases + workflow gate-path: 51 tests, 175 assertions, 0 failures.
- Flipped `interface-test/get-gate-unknown-test` from pass-through to fail-closed.
- `bb pre-commit` (budget, lint, format, smoke, graalvm) green; `bb poly:check` clean.

See `docs/pull-requests/2026-07-05-fix-unknown-gate-fails-closed.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)