### PR TITLE
fix(phase): merge-with-defaults preserves policy gates

### DIFF
--- a/components/phase/src/ai/miniforge/phase/registry.clj
+++ b/components/phase/src/ai/miniforge/phase/registry.clj
@@ -114,8 +114,40 @@
   []
   (set (keys @defaults-registry)))
 
+(def policy-gates
+  "Governance gates a phase-config override must never drop from the phase-type
+   default. A workflow's per-phase `:gates` may add or trim mechanical gates
+   (syntax, lint, coverage, …) freely, but silently losing policy enforcement is
+   the one merge outcome a governance system cannot allow: the shallow
+   `(merge defaults config)` let a workflow that declared `:gates [...]` at
+   verify/review replace the default vector wholesale, dropping
+   `:policy-verify`/`:policy-review` with no signal (e.g. quick-fix-v2's verify).
+   `merge-with-defaults` re-adds any of these the default enforced but the
+   override omitted. Extend this set when a new governance gate ships."
+  #{:policy-verify :policy-review :policy-pack})
+
+(defn merge-gates
+  "Merge an override `:gates` vector over the phase-type default's. The result is
+   the override's gates in declared order, followed by any policy gate (see
+   `policy-gates`) the default enforced that the override dropped — so an
+   override can extend or trim mechanical gates but cannot disable policy
+   enforcement."
+  [default-gates override-gates]
+  (let [override-set (set override-gates)
+        preserved    (filterv #(and (contains? policy-gates %)
+                                     (not (contains? override-set %)))
+                              default-gates)]
+    (into (vec override-gates) preserved)))
+
 (defn merge-with-defaults
   "Merge user config with phase defaults.
+
+   Shallow-merges `config` over the phase-type defaults, with one exception for
+   `:gates`: a config `:gates` override replaces the default vector, EXCEPT that
+   policy gates (`policy-gates`) the default enforced are re-added if the override
+   dropped them. This closes the silent-override footgun where a workflow
+   declaring `:gates [...]` at verify/review dropped `:policy-verify`/
+   `:policy-review` wholesale.
 
    Arguments:
      config - User-provided phase config
@@ -123,8 +155,11 @@
    Returns:
      Merged config with defaults"
   [{:keys [phase] :as config}]
-  (let [defaults (phase-defaults phase)]
-    (merge defaults config)))
+  (let [defaults (phase-defaults phase)
+        merged   (merge defaults config)]
+    (if (contains? config :gates)
+      (assoc merged :gates (merge-gates (:gates defaults) (:gates config)))
+      merged)))
 
 (defn valid-config?
   "Check if phase config is valid against schema."

--- a/components/phase/test/ai/miniforge/phase/registry_test.clj
+++ b/components/phase/test/ai/miniforge/phase/registry_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.registry-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.phase.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; merge-gates
+
+(deftest merge-gates-preserves-dropped-policy-gate-test
+  (testing "an override that drops a policy gate gets it re-added (appended)"
+    (is (= [:tests-pass :policy-verify]
+           (registry/merge-gates
+            [:pre-verify-lint :tests-pass :coverage :policy-verify]
+            [:tests-pass])))))
+
+(deftest merge-gates-keeps-order-and-no-duplicate-test
+  (testing "an override that keeps the policy gate is returned as-is (no dup)"
+    (is (= [:tests-pass :policy-verify]
+           (registry/merge-gates
+            [:pre-verify-lint :tests-pass :coverage :policy-verify]
+            [:tests-pass :policy-verify])))))
+
+(deftest merge-gates-mechanical-only-default-unchanged-test
+  (testing "no policy gate in the default → override is returned verbatim
+            (mechanical trim/add is the author's choice)"
+    (is (= [:syntax :lint :no-secrets]
+           (registry/merge-gates
+            [:syntax :format :lint]
+            [:syntax :lint :no-secrets])))))
+
+(deftest merge-gates-empty-override-still-restores-policy-test
+  (testing "an explicitly empty override cannot disable a default policy gate"
+    (is (= [:policy-review]
+           (registry/merge-gates
+            [:review-approved :quality-check :policy-review]
+            [])))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; merge-with-defaults
+
+(def ^:private verify-like-phase :registry-test/verify-like)
+
+(registry/register-phase-defaults!
+ verify-like-phase
+ {:phase verify-like-phase
+  :agent nil
+  :gates [:pre-verify-lint :tests-pass :coverage :policy-verify]
+  :budget {:tokens 0 :iterations 3 :time-seconds 300}})
+
+(deftest merge-with-defaults-no-gates-override-keeps-defaults-test
+  (testing "a config without :gates keeps the full default gate vector"
+    (is (= [:pre-verify-lint :tests-pass :coverage :policy-verify]
+           (:gates (registry/merge-with-defaults
+                    {:phase verify-like-phase :budget {:tokens 5}}))))))
+
+(deftest merge-with-defaults-override-cannot-drop-policy-gate-test
+  (testing "a :gates override that omits :policy-verify still enforces it —
+            the quick-fix-v2 footgun (verify :gates [:tests-pass]) is closed"
+    (is (= [:tests-pass :policy-verify]
+           (:gates (registry/merge-with-defaults
+                    {:phase verify-like-phase :gates [:tests-pass]}))))))

--- a/docs/pull-requests/2026-07-05-fix-additive-gate-merge.md
+++ b/docs/pull-requests/2026-07-05-fix-additive-gate-merge.md
@@ -17,9 +17,9 @@ shallow merge. A workflow phase that declared `:gates [...]` replaced the
 phase-type default's gate vector wholesale, silently dropping
 `:policy-verify` / `:policy-review` with no error and no warning.
 
-This was not hypothetical: `quick-fix-v2.0.0` declares `:verify :gates
-[:tests-pass]`, so every quick-fix run dropped `:policy-verify` — the verify
-phase ran no policy enforcement.
+This was not hypothetical: `quick-fix-v2.0.0` declares
+`:verify :gates [:tests-pass]`, so every quick-fix run dropped `:policy-verify`
+— the verify phase ran no policy enforcement.
 
 ## Fix
 

--- a/docs/pull-requests/2026-07-05-fix-additive-gate-merge.md
+++ b/docs/pull-requests/2026-07-05-fix-additive-gate-merge.md
@@ -1,0 +1,61 @@
+<!--
+  Title: Gate merge preserves policy gates
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: gate merge preserves policy gates
+
+Branch: `fix/additive-gate-merge`
+
+## Summary
+
+Closes governance-audit Finding 4 (`miniforge-governance-audit-2026-07-05.md`).
+
+`phase/registry.clj`'s `merge-with-defaults` was `(merge defaults config)` — a
+shallow merge. A workflow phase that declared `:gates [...]` replaced the
+phase-type default's gate vector wholesale, silently dropping
+`:policy-verify` / `:policy-review` with no error and no warning.
+
+This was not hypothetical: `quick-fix-v2.0.0` declares `:verify :gates
+[:tests-pass]`, so every quick-fix run dropped `:policy-verify` — the verify
+phase ran no policy enforcement.
+
+## Fix
+
+`merge-with-defaults` now preserves policy gates across a `:gates` override: an
+override may add or trim mechanical gates (syntax, lint, coverage, …), but any
+policy gate (`policy-gates` = `#{:policy-verify :policy-review :policy-pack}`)
+the phase-type default enforced is re-added if the override dropped it.
+
+- `quick-fix-v2` verify → `[:tests-pass :policy-verify]` (policy restored, the
+  lightweight mechanical set preserved).
+- `canonical-sdlc-v2` implement `[:syntax :lint :no-secrets]` → unchanged (no
+  policy gate in the implement default).
+
+Chosen over blanket additive-union (the audit's other option) because union
+would also force `:format` back onto canonical's implement and
+`:coverage`/`:pre-verify-lint` back onto quick-fix's verify — changing author
+intent for non-policy gates. Re-adding only policy gates is the precise fix.
+
+`policy-gates` is defined in the phase registry (a small, documented data
+reference to gate names, not a code dependency); the merge stays a pure data
+operation, so no logging dependency is added. Re-adding is strictly safer than
+the audit's "loud warning" minimum: enforcement is preserved, not merely
+flagged.
+
+## Test plan
+
+- New `phase/registry-test`: `merge-gates` (dropped policy gate re-added; kept
+  gate not duplicated; mechanical-only default returned verbatim; empty override
+  still restores policy) and `merge-with-defaults` (no-`:gates` config keeps the
+  full default; the quick-fix footgun is closed).
+- phase-software-factory verify + verify-failure-modes + workflow
+  environment-promotion integration: 32 tests, 96 assertions, 0 failures.
+- `bb poly:check` clean.
+
+## Related
+
+- Governance audit Finding 4. `quick-fix-v2.0.0.edn` is intentionally left
+  declaring `:gates [:tests-pass]` — the invariant is enforced centrally in the
+  merge, so no workflow can footgun regardless of what it declares.


### PR DESCRIPTION
## Summary

Closes governance-audit Finding 4 (`miniforge-governance-audit-2026-07-05.md`).

`phase/registry.clj`'s `merge-with-defaults` was `(merge defaults config)` — a
shallow merge. A workflow phase declaring `:gates [...]` replaced the phase-type
default gate vector wholesale, silently dropping `:policy-verify`/`:policy-review`
with no error and no warning.

Live instance: `quick-fix-v2.0.0` declares `:verify :gates [:tests-pass]`, so
every quick-fix run dropped `:policy-verify` — verify ran no policy enforcement.

## Fix

`merge-with-defaults` preserves policy gates across a `:gates` override: an
override may add/trim mechanical gates, but any gate in `policy-gates`
(`#{:policy-verify :policy-review :policy-pack}`) the default enforced is re-added
if the override dropped it.

- `quick-fix-v2` verify → `[:tests-pass :policy-verify]`.
- `canonical-sdlc-v2` implement `[:syntax :lint :no-secrets]` → unchanged (no
  policy gate in the default).

Chosen over blanket additive-union (the audit's other option): union would force
`:format` back onto canonical's implement and `:coverage`/`:pre-verify-lint` back
onto quick-fix's verify, changing author intent for non-policy gates. Re-adding
only policy gates is precise. Re-adding is strictly safer than the audit's "loud
warning" minimum — enforcement is preserved, not just flagged — and keeps the
merge a pure data op (no logging dependency in the phase registry).

## Test plan

- New `phase/registry-test`: `merge-gates` (dropped policy gate re-added; kept
  gate not duplicated; mechanical-only default verbatim; empty override still
  restores policy) + `merge-with-defaults` (no-`:gates` keeps full default; the
  quick-fix footgun closed).
- phase-software-factory verify + verify-failure-modes + workflow
  environment-promotion integration: 32 tests, 96 assertions, 0 failures.
- `bb pre-commit` green; `bb poly:check` clean.

See `docs/pull-requests/2026-07-05-fix-additive-gate-merge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)