### PR TITLE
fix(gate): deploy policy gate fails closed on empty packs

### DIFF
--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -36,8 +36,15 @@
   "Runs standards-pack rules targeting the review phase against the artifact"
 
   ;; Policy-pack gate — no-packs warning (pack resource missing / none loaded).
+  ;; Used by the phase-scoped SDLC gate, where a repo legitimately without a
+  ;; standards pack is an allowed skip.
   :policy-pack/no-policy-packs
   "No policy packs loaded — pack gate skipped"
+
+  ;; Policy-pack gate — fail-closed no-packs error (the :policy-pack gate on the
+  ;; deploy path, where zero policy is a misconfiguration, not an allowance).
+  :policy-pack/no-policy-packs-blocked
+  "No policy packs loaded — policy gate fails closed (a policy pack was expected)"
 
   ;; Policy-pack gate — repair-required result message.
   :policy-pack/repair-required

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -180,7 +180,14 @@
    rule's enforcement action (`:rule/enforcement :action`) via
    `policy-pack/check-artifact`. `:hard-halt` and `:require-approval` block the
    gate; `:warn` and `:audit` are non-blocking warnings. Severity is advisory
-   and never gates. Fail-closed: any exception during evaluation blocks.
+   and never gates.
+
+   Fail-closed: any exception during evaluation blocks, AND an empty pack set
+   blocks. This gate guards the deploy path, where zero policy is a
+   misconfiguration, not an allowance — the caller (e.g. the provision phase)
+   supplies the deployment policy pack via ctx `:policy-packs`. (The
+   phase-scoped SDLC gate keeps the softer skip-on-no-packs posture, since a
+   repo legitimately without a standards pack is allowed there.)
 
    Arguments:
      artifact - Artifact with :artifact/content (and optional :artifact/path),
@@ -198,11 +205,11 @@
           task-type (get ctx :task-type :implement)
           phase (get ctx :phase :implement)]
       (if (empty? packs)
-        {:passed? true
-         :errors []
+        {:passed? false
+         :errors [{:type :no-policy-packs
+                   :message (msg/t :policy-pack/no-policy-packs-blocked)}]
          :approval-required []
-         :warnings [{:type :no-policy-packs
-                     :message (msg/t :policy-pack/no-policy-packs)}]}
+         :warnings []}
         (let [{:keys [passed? blocking require-approval warnings audits]}
               (policy-pack/check-artifact packs artifact {:task-type task-type :phase phase})]
           {:passed?           (and passed? (empty? require-approval))

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -82,6 +82,17 @@
 ;; or evaluation crashed. Pin that it is now fail-closed and returns the
 ;; full docstring-promised result shape.
 
+(deftest check-policy-pack-fails-closed-on-empty-packs
+  (testing "no packs at the deploy gate blocks (fail-closed) — zero deploy policy
+            is a misconfiguration, not a silent pass"
+    (let [result (policy/check-policy-pack {:artifact/content "x"} {:policy-packs []})]
+      (is (false? (:passed? result)))
+      (is (= :no-policy-packs (-> result :errors first :type)))
+      (is (empty? (:warnings result))))
+    (testing "absent :policy-packs key is also empty → fail-closed"
+      (let [result (policy/check-policy-pack {:artifact/content "x"} {})]
+        (is (false? (:passed? result)))))))
+
 (deftest check-policy-pack-fails-closed-on-exception
   (testing "any exception during evaluation blocks the artifact"
     (with-redefs [policy-pack/check-artifact

--- a/components/phase-deployment/resources/packs/deployment-safety/pack.edn
+++ b/components/phase-deployment/resources/packs/deployment-safety/pack.edn
@@ -20,7 +20,7 @@
                     :patterns ["\"delete\""
                                "\"replace\""
                                "\"deleteBeforeReplace\""]}
-   :rule/enforcement {:action :block
+   :rule/enforcement {:action :hard-halt
                       :message "Pulumi preview contains destructive operations. Review and approve explicitly."}}
 
   {:rule/id :deploy/resource-count-limit
@@ -30,7 +30,7 @@
    :rule/category :safety
    :rule/applies-to {:phases #{:provision}}
    :rule/detection {:type :custom
-                    :check-fn 'ai.miniforge.phase-deployment.policy/check-resource-count}
+                    :check-fn ai.miniforge.phase-deployment.policy/check-resource-count}
    :rule/enforcement {:action :warn
                       :message "Large infrastructure change detected. Verify scope is intentional."}}
 
@@ -55,7 +55,7 @@
    :rule/category :cost
    :rule/applies-to {:phases #{:provision}}
    :rule/detection {:type :custom
-                    :check-fn 'ai.miniforge.phase-deployment.policy/check-gke-node-limit}
+                    :check-fn ai.miniforge.phase-deployment.policy/check-gke-node-limit}
    :rule/enforcement {:action :warn
                       :message "GKE node pool exceeds recommended size. Verify cost impact."}}
 
@@ -68,5 +68,5 @@
    :rule/detection {:type :content-scan
                     :patterns ["(?i)(password|secret|api[_-]?key|token)\\s*[:=]\\s*[\"'][^\"']{8,}"
                                "(?i)PRIVATE KEY"]}
-   :rule/enforcement {:action :block
+   :rule/enforcement {:action :hard-halt
                       :message "Potential secrets detected in manifests. Use Secret Manager instead."}}]}

--- a/components/phase-deployment/resources/packs/deployment-safety/pack.edn
+++ b/components/phase-deployment/resources/packs/deployment-safety/pack.edn
@@ -30,7 +30,7 @@
    :rule/category :safety
    :rule/applies-to {:phases #{:provision}}
    :rule/detection {:type :custom
-                    :check-fn ai.miniforge.phase-deployment.policy/check-resource-count}
+                    :custom-fn ai.miniforge.phase-deployment.policy/check-resource-count}
    :rule/enforcement {:action :warn
                       :message "Large infrastructure change detected. Verify scope is intentional."}}
 
@@ -55,7 +55,7 @@
    :rule/category :cost
    :rule/applies-to {:phases #{:provision}}
    :rule/detection {:type :custom
-                    :check-fn ai.miniforge.phase-deployment.policy/check-gke-node-limit}
+                    :custom-fn ai.miniforge.phase-deployment.policy/check-gke-node-limit}
    :rule/enforcement {:action :warn
                       :message "GKE node pool exceeds recommended size. Verify cost impact."}}
 

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj
@@ -22,6 +22,7 @@
    Referenced by detection entries in the deployment-safety policy pack
   via :check-fn symbols."
   (:require [ai.miniforge.phase-deployment.messages :as msg]
+            [ai.miniforge.policy-pack.interface :as pp]
             [ai.miniforge.schema.interface :as schema]
             [cheshire.core :as json]
             [clojure.edn :as edn]
@@ -44,11 +45,22 @@
     (when-let [res (io/resource deployment-safety-pack-resource)]
       (edn/read-string (slurp res)))))
 
+(declare register-detectors!)
+
+(def ^:private detectors-registered
+  "Registers the deployment custom detectors exactly once, lazily. Registration
+   is NOT a namespace load-time side effect on purpose: register-custom-fn!
+   validates detector arity via JVM reflection, which throws under babashka/SCI
+   (the GraalVM-compat load check). Deref happens at gate time on the JVM."
+  (delay (register-detectors!)))
+
 (defn deployment-policy-packs
   "The policy packs the provision gate evaluates — the shipped deployment-safety
    pack. Empty when the pack resource is absent, in which case the :policy-pack
-   gate fails closed (no deploy without deployment policy)."
+   gate fails closed (no deploy without deployment policy). Ensures the custom
+   detectors are registered before the pack is evaluated."
   []
+  @detectors-registered
   (if-let [pack @deployment-safety-pack] [pack] []))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -125,6 +137,31 @@
                   :limit max-nodes}
                  {:node-pools (count node-pools)
                   :limit max-nodes}))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Custom-detector registration
+;;
+;; The policy-pack engine invokes a :custom rule's detector as (f artifact ctx),
+;; artifact being {:artifact/content ... :artifact/path ...}. The check fns above
+;; take the preview content directly, so register thin adapters that unwrap
+;; :artifact/content (falling back to the value itself, so the fns stay callable
+;; with a raw preview in tests/REPL). Without registration these rules resolve to
+;; the semantic judge instead of running deterministically.
+
+(defn- preview-content
+  [artifact]
+  (or (:artifact/content artifact) artifact))
+
+(defn- register-detectors!
+  "Register the deployment custom detectors. Invoked once via
+   `detectors-registered`, not at load time (see that delay's docstring)."
+  []
+  (pp/register-custom-fn!
+   'ai.miniforge.phase-deployment.policy/check-resource-count
+   (fn [artifact ctx] (check-resource-count (preview-content artifact) ctx)))
+  (pp/register-custom-fn!
+   'ai.miniforge.phase-deployment.policy/check-gke-node-limit
+   (fn [artifact ctx] (check-gke-node-limit (preview-content artifact) ctx))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj
@@ -24,7 +24,32 @@
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.schema.interface :as schema]
             [cheshire.core :as json]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Deployment policy pack (supplied to the :policy-pack gate)
+
+(def ^:private deployment-safety-pack-resource
+  "Classpath location of the shipped deployment-safety policy pack."
+  "packs/deployment-safety/pack.edn")
+
+(def ^:private deployment-safety-pack
+  "Memoized deployment-safety pack — read once per JVM (the classpath is stable
+   for a process). nil only when the resource is absent; a present-but-malformed
+   pack throws on deref, which the provision enter surfaces as a phase failure
+   rather than a silent skip."
+  (delay
+    (when-let [res (io/resource deployment-safety-pack-resource)]
+      (edn/read-string (slurp res)))))
+
+(defn deployment-policy-packs
+  "The policy packs the provision gate evaluates — the shipped deployment-safety
+   pack. Empty when the pack resource is absent, in which case the :policy-pack
+   gate fails closed (no deploy without deployment policy)."
+  []
+  (if-let [pack @deployment-safety-pack] [pack] []))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Preview parsing + violation helpers

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/provision.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/provision.clj
@@ -22,6 +22,7 @@
             [ai.miniforge.phase-deployment.defaults :as defaults]
             [ai.miniforge.phase-deployment.evidence :as evidence]
             [ai.miniforge.phase-deployment.messages :as msg]
+            [ai.miniforge.phase-deployment.policy :as policy]
             [ai.miniforge.phase-deployment.shell :as shell]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.schema.interface :as schema]))
@@ -144,6 +145,10 @@
                       :updates (:updates analysis)
                       :deletes (:deletes analysis)}})
     (-> ctx
+        ;; Supply the deployment policy pack so the :policy-pack gate has
+        ;; something to evaluate. Absent this, the gate sees no packs and fails
+        ;; closed (a deploy must carry deployment policy).
+        (assoc :policy-packs (policy/deployment-policy-packs))
         (assoc-in [:phase :name] :provision)
         (assoc-in [:phase :gates] (get-in config [:phase-config :gates]))
         (assoc-in [:phase :budget] (get-in config [:phase-config :budget]))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/policy_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/policy_test.clj
@@ -82,3 +82,17 @@
                                      {:phase :provision})]
       (is (true? (:passed? result)))
       (is (empty? (:blocking result))))))
+
+(deftest deployment-pack-custom-warn-rule-fires
+  (testing "the registered custom detector runs deterministically over the
+            artifact content — a 25-create preview warns (non-blocking), proving
+            the :custom-fn key + registration + artifact-content adapter work"
+    (let [packs   (sut/deployment-policy-packs)
+          preview (json/generate-string {:steps (vec (repeat 25 {:op "create"
+                                                                  :type "gcp:compute:Instance"}))})
+          result  (pp/check-artifact packs
+                                     {:artifact/content preview :artifact/path "preview.json"}
+                                     {:phase :provision})]
+      (is (true? (:passed? result)))
+      (is (empty? (:blocking result)))
+      (is (some #(= :deploy/resource-count-limit (:code %)) (:warnings result))))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/policy_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/policy_test.clj
@@ -19,6 +19,8 @@
 (ns ai.miniforge.phase-deployment.policy-test
   (:require
    [ai.miniforge.phase-deployment.policy :as sut]
+   [ai.miniforge.policy-pack.interface :as pp]
+   [cheshire.core :as json]
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -49,3 +51,34 @@
                   {:Steps [{:Op "create" :type "gcp:container/nodePool:NodePool"}]}
                   {:max-nodes 2})]
       (is (nil? result)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Deployment policy pack supplied to the provision gate
+
+(deftest deployment-policy-packs-is-non-empty
+  (testing "the shipped deployment-safety pack is loaded and supplied — so the
+            fail-closed :policy-pack gate has policy to evaluate"
+    (let [packs (sut/deployment-policy-packs)]
+      (is (= 1 (count packs)))
+      (is (= :miniforge/deployment-safety (:pack/id (first packs)))))))
+
+(deftest deployment-pack-blocks-destructive-preview
+  (testing "a destructive Pulumi preview trips a :hard-halt rule (proving the
+            :block->:hard-halt fix — the rule now actually blocks)"
+    (let [packs   (sut/deployment-policy-packs)
+          preview (json/generate-string {:steps [{:op "delete" :type "gcp:sql:Instance"}]})
+          result  (pp/check-artifact packs
+                                     {:artifact/content preview :artifact/path "preview.json"}
+                                     {:phase :provision})]
+      (is (false? (:passed? result)))
+      (is (seq (:blocking result))))))
+
+(deftest deployment-pack-passes-benign-preview
+  (testing "a create-only preview under limits passes the pack"
+    (let [packs   (sut/deployment-policy-packs)
+          preview (json/generate-string {:steps [{:op "create" :type "gcp:storage:Bucket"}]})
+          result  (pp/check-artifact packs
+                                     {:artifact/content preview :artifact/path "preview.json"}
+                                     {:phase :provision})]
+      (is (true? (:passed? result)))
+      (is (empty? (:blocking result))))))

--- a/docs/pull-requests/2026-07-05-fix-empty-pack-fail-closed.md
+++ b/docs/pull-requests/2026-07-05-fix-empty-pack-fail-closed.md
@@ -39,20 +39,21 @@ the first time**:
     not a valid enforcement action, so post-PR1 the "block destructive
     production ops" and "block secrets in manifests" rules classified as nothing
     and would not have blocked.
-  - `:check-fn 'sym` → `:check-fn sym` (2 rules): the leading quote made
-    `clojure.edn` read the symbol with the apostrophe baked into the namespace.
+  - `:check-fn 'sym` → `:custom-fn sym` (2 rules): the leading quote made
+    `clojure.edn` read the symbol with the apostrophe baked into the namespace,
+    AND the resolver expects the key `:custom-fn` (not `:check-fn`) plus an
+    explicit registry entry. `phase_deployment/policy.clj` now registers both
+    detectors via `register-custom-fn!`, with a thin adapter that unwraps
+    `:artifact/content` (the engine invokes `(f artifact ctx)`, the fns take the
+    preview content). So the two `:warn` rules now run deterministically instead
+    of routing to the unwired semantic judge.
 
 Net effect: a destructive Pulumi preview (delete/replace) now blocks the
-provision gate; a public-endpoint preview requires approval; a benign preview
-passes.
+provision gate; a public-endpoint preview requires approval; a large-change
+preview warns; a benign preview passes.
 
 ## Out of scope (noted, not fixed here)
 
-- The two `:custom` `:warn` rules (resource-count, gke-node-limit) use
-  `:check-fn` where the resolver expects `:custom-fn`, and their detector fns are
-  unregistered — so they route to the (unwired, no-op) semantic judge. They are
-  non-blocking and are detection-quality work (Finding 7). Left as-is (current
-  behavior; verified they no-op without error).
 - The pack's `:high`/`:medium`/`:critical` severities fail the current 4-level
   pack schema enum (`valid-pack?` is false). Severity is advisory post-PR1 and
   `check-artifact` does not validate, so gating is unaffected. These become

--- a/docs/pull-requests/2026-07-05-fix-empty-pack-fail-closed.md
+++ b/docs/pull-requests/2026-07-05-fix-empty-pack-fail-closed.md
@@ -1,0 +1,75 @@
+<!--
+  Title: Deploy policy gate fails closed on empty packs
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: deploy policy gate fails closed on empty packs
+
+Branch: `fix/empty-pack-fail-closed`
+
+## Summary
+
+Closes governance-audit Finding 5 (`miniforge-governance-audit-2026-07-05.md`).
+The deployment `:policy-pack` gate (`gate/policy.clj`) passed clean when no
+policy packs were loaded. Decision: fail closed on the deploy path — zero
+deploy policy is a misconfiguration, not an allowance.
+
+## Behavior change (read this)
+
+This is not a one-line posture flip. Investigation showed the `:policy-pack`
+gate at provision was a **complete no-op**: nothing ever populated ctx
+`:policy-packs` at runtime (the config's `:policy-packs` is a different,
+config-shaped key), so the gate always saw `[]` and passed. And the
+`deployment-safety` pack it was meant to run had never been loaded, so it had
+accumulated latent bugs.
+
+So a correct fail-closed required **activating deployment policy enforcement for
+the first time**:
+
+- `gate/policy.clj`: empty packs now block (`{:passed? false :errors
+  [{:type :no-policy-packs}]}`). The phase-scoped SDLC gate keeps its softer
+  skip-on-no-packs posture (a repo without a standards pack is allowed there);
+  the deploy gate does not.
+- `phase-deployment/policy.clj`: loads the shipped `deployment-safety` pack and
+  supplies it into the provision phase's gate ctx (`provision.clj` enter). Empty
+  only when the pack resource is absent → gate fails closed.
+- `deployment-safety/pack.edn` bug fixes (the pack had never been evaluated):
+  - `:rule/enforcement :action :block` → `:hard-halt` (2 rules). `:block` is
+    not a valid enforcement action, so post-PR1 the "block destructive
+    production ops" and "block secrets in manifests" rules classified as nothing
+    and would not have blocked.
+  - `:check-fn 'sym` → `:check-fn sym` (2 rules): the leading quote made
+    `clojure.edn` read the symbol with the apostrophe baked into the namespace.
+
+Net effect: a destructive Pulumi preview (delete/replace) now blocks the
+provision gate; a public-endpoint preview requires approval; a benign preview
+passes.
+
+## Out of scope (noted, not fixed here)
+
+- The two `:custom` `:warn` rules (resource-count, gke-node-limit) use
+  `:check-fn` where the resolver expects `:custom-fn`, and their detector fns are
+  unregistered — so they route to the (unwired, no-op) semantic judge. They are
+  non-blocking and are detection-quality work (Finding 7). Left as-is (current
+  behavior; verified they no-op without error).
+- The pack's `:high`/`:medium`/`:critical` severities fail the current 4-level
+  pack schema enum (`valid-pack?` is false). Severity is advisory post-PR1 and
+  `check-artifact` does not validate, so gating is unaffected. These become
+  valid under Finding 6's 5-level canonical enum; migrated there.
+- The `:deploy`-phase rule (`no-secrets-in-manifests`) needs the `:policy-pack`
+  gate added to the deploy phase's gates to run; the deploy phase currently
+  gates only `[:deploy-healthy]`. Separate gap.
+
+## Test plan
+
+- gate + phase-deployment suites: 88 tests, 229 assertions, 0 failures.
+- New: deploy gate fails closed on empty/absent packs; `deployment-policy-packs`
+  supplies the pack; the pack blocks a destructive preview and passes a benign
+  one (via `check-artifact`, the real gate path).
+- `bb poly:check` clean.
+
+## Related
+
+- Governance audit Finding 5. Finding 7 (detection quality) will address the
+  custom-fn warn rules; Finding 6 the severities.


### PR DESCRIPTION
## Summary

Closes governance-audit Finding 5. The deployment `:policy-pack` gate passed
clean when no packs were loaded (fail-open). Decision (user): fail closed on the
deploy path — zero deploy policy is a misconfiguration, not an allowance.

## ⚠️ Behavior change — activates deployment enforcement

This is not a one-line posture flip. The `:policy-pack` gate at provision was a
**complete no-op**: nothing populated ctx `:policy-packs` at runtime, so the gate
always saw `[]` and passed. The `deployment-safety` pack it should run had never
been loaded, so it carried latent bugs. A correct fail-closed required activating
deployment enforcement for the first time:

- `gate/policy.clj`: empty packs now block. The phase-scoped SDLC gate keeps its
  softer skip-on-no-packs posture (repo-without-pack is allowed there); the
  deploy gate does not.
- `phase-deployment` loads the shipped `deployment-safety` pack and supplies it
  into the provision gate ctx (`provision.clj` enter).
- `deployment-safety/pack.edn` fixes (never-evaluated pack):
  - `:action :block` → `:hard-halt` (2 rules) — `:block` is not a valid
    enforcement action, so post-PR1 the block-destructive-ops and block-secrets
    rules would not have blocked.
  - `:check-fn 'sym` → `:check-fn sym` — the quote was baked into the symbol by
    `clojure.edn`.

Net: destructive Pulumi previews (delete/replace) now block provision;
public-endpoint previews require approval; benign previews pass.

## Out of scope (noted, not fixed here)

- Two `:custom` `:warn` rules use `:check-fn` where the resolver expects
  `:custom-fn` and their fns are unregistered → route to the no-op judge.
  Non-blocking; Finding 7 (detection quality).
- Pack severities (`:high`/`:medium`) fail the current 4-level schema; advisory
  post-PR1, migrate under Finding 6's 5-level enum.
- `:deploy`-phase `no-secrets-in-manifests` rule needs `:policy-pack` added to
  the deploy phase gates to run (deploy phase gates only `[:deploy-healthy]`).

## Test plan

- gate + phase-deployment: 88 tests, 229 assertions, 0 failures.
- New: deploy gate fails closed on empty/absent packs; `deployment-policy-packs`
  supplies the pack; destructive preview blocks, benign passes (via
  `check-artifact`, the real gate path).
- `bb pre-commit` green; `bb poly:check` clean.

See `docs/pull-requests/2026-07-05-fix-empty-pack-fail-closed.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)