### PR TITLE
refactor(severity): migrate consumer sites to the canonical enum

### DIFF
--- a/components/connector-linter/resources/connector_linter/linter-mappings.edn
+++ b/components/connector-linter/resources/connector_linter/linter-mappings.edn
@@ -46,8 +46,8 @@
    :severity [:level]}
   :mapping/severity-map
   {"error"   :critical
-   "warning" :major
-   "info"    :minor}}
+   "warning" :high
+   "info"    :low}}
 
  ;; ── Clippy (Rust) ──────────────────────────────────────────────────────────
  {:mapping/id          :clippy
@@ -62,8 +62,8 @@
    :severity [:message :level]}
   :mapping/severity-map
   {"error"   :critical
-   "warning" :major
-   "note"    :minor
+   "warning" :high
+   "note"    :low
    "help"    :info}}
 
  ;; ── ESLint ─────────────────────────────────────────────────────────────────
@@ -80,7 +80,7 @@
    :severity [:severity]}
   :mapping/severity-map
   {2 :critical
-   1 :major}}
+   1 :high}}
 
  ;; ── golangci-lint ──────────────────────────────────────────────────────────
  {:mapping/id          :golangci-lint
@@ -95,8 +95,8 @@
    :severity [:Severity]}
   :mapping/severity-map
   {"error"   :critical
-   "warning" :major
-   "info"    :minor}}
+   "warning" :high
+   "info"    :low}}
 
  ;; ── ruff (Python) ──────────────────────────────────────────────────────────
  {:mapping/id          :ruff
@@ -110,10 +110,10 @@
    :severity [:type]}
   :mapping/severity-map
   {"E"       :critical
-   "W"       :major
-   "C"       :minor
+   "W"       :high
+   "C"       :low
    "R"       :info
-   "warning" :major
+   "warning" :high
    "error"   :critical}}
 
  ;; ── SwiftLint ──────────────────────────────────────────────────────────────
@@ -128,4 +128,4 @@
    :severity [:severity]}
   :mapping/severity-map
   {"error"   :critical
-   "warning" :major}}]
+   "warning" :high}}]

--- a/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
@@ -43,7 +43,7 @@
   [severity-map raw-value]
   (let [key (if (keyword? raw-value) (name raw-value) raw-value)]
     (get severity-map key
-         (get severity-map raw-value :minor))))
+         (get severity-map raw-value :low))))
 
 (defn- record->violation
   "Transform a single parsed record into the canonical violation shape

--- a/components/connector-linter/test/ai/miniforge/connector_linter/etl_test.clj
+++ b/components/connector-linter/test/ai/miniforge/connector_linter/etl_test.clj
@@ -40,10 +40,10 @@
     (is (= :critical (map-severity {"error" :critical} "error"))))
 
   (testing "maps keyword values by name"
-    (is (= :major (map-severity {"warning" :major} :warning))))
+    (is (= :high (map-severity {"warning" :high} :warning))))
 
-  (testing "defaults to :minor for unknown"
-    (is (= :minor (map-severity {"error" :critical} "unknown")))))
+  (testing "defaults to :low for unknown"
+    (is (= :low (map-severity {"error" :critical} "unknown")))))
 
 ;; ============================================================================
 ;; Filter matching
@@ -115,7 +115,7 @@
           result  (sut/apply-mapping mapping output)]
       (is (= 1 (count result)))
       (is (= "src/main.rs" (:file (first result))))
-      (is (= :major (:rule/severity (first result)))))))
+      (is (= :high (:rule/severity (first result)))))))
 
 ;; ============================================================================
 ;; Full mapping application — ruff
@@ -128,7 +128,7 @@
           result  (sut/apply-mapping mapping output)]
       (is (= 1 (count result)))
       (is (= "app.py" (:file (first result))))
-      (is (= :major (:rule/severity (first result)))))))
+      (is (= :high (:rule/severity (first result)))))))
 
 ;; ============================================================================
 ;; Empty / error cases

--- a/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
+++ b/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
@@ -61,7 +61,7 @@
    :line     (get v :line 0)
    :message  (get v :current "")
    :rule-id  (get v :rule/id)
-   :severity (get v :rule/severity :major)})
+   :severity (get v :rule/severity :high)})
 
 (defn check-pre-verify-lint
   "Run configured linters on the worktree before verify."

--- a/components/gate/test/ai/miniforge/gate/lint_test.clj
+++ b/components/gate/test/ai/miniforge/gate/lint_test.clj
@@ -30,7 +30,7 @@
                                  :severity :critical}]
                      :warnings [{:code :no-todos
                                  :message "Found TODO"
-                                 :severity :minor}]})]
+                                 :severity :low}]})]
       (is (= {:passed? false
               :errors [{:type :policy-violation
                         :message "Found secret"
@@ -38,7 +38,7 @@
                         :rule-id :no-secrets}]
               :warnings [{:type :policy-warning
                           :message "Found TODO"
-                          :severity :minor
+                          :severity :low
                           :rule-id :no-todos}]}
              (lint/run-policy-pack-check {:content "SECRET TODO"}
                                          {:policy-packs [:standards]}))))))

--- a/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_pack_test.clj
@@ -141,7 +141,7 @@
    (LLM-judge) detector. Defaults to an acting (:hard-halt) enforcement action."
   [& {:keys [id phases action severity]
       :or   {id :test/semantic phases #{:verify :review}
-             action :hard-halt severity :major}}]
+             action :hard-halt severity :high}}]
   {:rule/id          id
    :rule/enabled?    true
    :rule/severity    severity

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -112,7 +112,7 @@
 ;; A :high/:low rule and every content-scan violation (which carries no
 ;; :severity) previously fell through a severity cascade to a silent pass.
 
-(def ^:private hard-halt-major-pack
+(def ^:private hard-halt-high-pack
   "One rule: :high severity, :hard-halt enforcement, content-scan detection (so
    the violation carries no :severity key). Must block the gate."
   {:pack/id      "test-deploy-block"
@@ -123,26 +123,26 @@
                    :rule/enforcement {:action  :hard-halt
                                       :message "Danger token present"}}]})
 
-(defn- warn-major-pack
-  "As hard-halt-major-pack, but :warn enforcement — must pass (advisory)."
+(defn- warn-high-pack
+  "As hard-halt-high-pack, but :warn enforcement — must pass (advisory)."
   []
-  (assoc-in hard-halt-major-pack [:pack/rules 0 :rule/enforcement :action] :warn))
+  (assoc-in hard-halt-high-pack [:pack/rules 0 :rule/enforcement :action] :warn))
 
-(deftest check-policy-pack-blocks-major-hard-halt-rule
+(deftest check-policy-pack-blocks-high-hard-halt-rule
   (testing ":high :hard-halt content-scan rule blocks the deploy gate"
     (let [result (policy/check-policy-pack
                   {:artifact/content "a line with DANGER in it" :artifact/path "main.tf"}
-                  {:policy-packs [hard-halt-major-pack]})]
+                  {:policy-packs [hard-halt-high-pack]})]
       (is (false? (:passed? result)))
       (is (= 1 (count (:errors result))))
       (is (= :no-danger-token (-> result :errors first :code)))
       (is (empty? (:approval-required result))))))
 
-(deftest check-policy-pack-passes-major-warn-rule
+(deftest check-policy-pack-passes-high-warn-rule
   (testing ":high :warn rule passes with a warning — severity does not gate"
     (let [result (policy/check-policy-pack
                   {:artifact/content "a line with DANGER in it" :artifact/path "main.tf"}
-                  {:policy-packs [(warn-major-pack)]})]
+                  {:policy-packs [(warn-high-pack)]})]
       (is (true? (:passed? result)))
       (is (empty? (:errors result)))
       (is (= 1 (count (:warnings result))))
@@ -152,14 +152,14 @@
   (testing "no rule fires → gate passes clean"
     (let [result (policy/check-policy-pack
                   {:artifact/content "nothing to see here" :artifact/path "main.tf"}
-                  {:policy-packs [hard-halt-major-pack]})]
+                  {:policy-packs [hard-halt-high-pack]})]
       (is (true? (:passed? result)))
       (is (empty? (:errors result))))))
 
 (deftest check-policy-pack-blocks-require-approval-with-detail
   (testing ":require-approval blocks the gate AND lands in :errors, so the
             failure carries detail (check-gate emits failure events from :errors)"
-    (let [pack   (assoc-in hard-halt-major-pack
+    (let [pack   (assoc-in hard-halt-high-pack
                            [:pack/rules 0 :rule/enforcement :action] :require-approval)
           result (policy/check-policy-pack
                   {:artifact/content "a line with DANGER in it" :artifact/path "main.tf"}

--- a/components/gate/test/ai/miniforge/gate/policy_test.clj
+++ b/components/gate/test/ai/miniforge/gate/policy_test.clj
@@ -109,16 +109,16 @@
 
 ;; -------------------------------------------------------------------------- check-policy-pack enforcement-action classification
 ;; Regression: the gate must classify by :rule/enforcement :action, not severity.
-;; A :major/:minor rule and every content-scan violation (which carries no
+;; A :high/:low rule and every content-scan violation (which carries no
 ;; :severity) previously fell through a severity cascade to a silent pass.
 
 (def ^:private hard-halt-major-pack
-  "One rule: :major severity, :hard-halt enforcement, content-scan detection (so
+  "One rule: :high severity, :hard-halt enforcement, content-scan detection (so
    the violation carries no :severity key). Must block the gate."
   {:pack/id      "test-deploy-block"
    :pack/version "2026.07.04"
    :pack/rules   [{:rule/id          :no-danger-token
-                   :rule/severity    :major
+                   :rule/severity    :high
                    :rule/detection   {:type :content-scan :pattern "DANGER"}
                    :rule/enforcement {:action  :hard-halt
                                       :message "Danger token present"}}]})
@@ -129,7 +129,7 @@
   (assoc-in hard-halt-major-pack [:pack/rules 0 :rule/enforcement :action] :warn))
 
 (deftest check-policy-pack-blocks-major-hard-halt-rule
-  (testing ":major :hard-halt content-scan rule blocks the deploy gate"
+  (testing ":high :hard-halt content-scan rule blocks the deploy gate"
     (let [result (policy/check-policy-pack
                   {:artifact/content "a line with DANGER in it" :artifact/path "main.tf"}
                   {:policy-packs [hard-halt-major-pack]})]
@@ -139,7 +139,7 @@
       (is (empty? (:approval-required result))))))
 
 (deftest check-policy-pack-passes-major-warn-rule
-  (testing ":major :warn rule passes with a warning — severity does not gate"
+  (testing ":high :warn rule passes with a warning — severity does not gate"
     (let [result (policy/check-policy-pack
                   {:artifact/content "a line with DANGER in it" :artifact/path "main.tf"}
                   {:policy-packs [(warn-major-pack)]})]

--- a/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
+++ b/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
@@ -64,7 +64,7 @@
    :risk {:risk/score 0.2 :risk/level :low :risk/factors []}
    :policy {:policy/overall :pass
             :policy/packs-applied []
-            :policy/summary {:critical 0 :major 0 :minor 0 :info 0 :total 0}
+            :policy/summary {:critical 0 :high 0 :low 0 :info 0 :total 0}
             :policy/violations []}
    :recommendation :merge})
 

--- a/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
+++ b/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
@@ -95,7 +95,7 @@
 (deftest raw->violation-test
   (testing "produces canonical violation shape"
     (let [rule {:rule/id :std/test :rule/category "001"
-                :rule/title "Test Rule" :rule/severity :major}
+                :rule/title "Test Rule" :rule/severity :high}
           v    {:line 42 :current "(bad code)" :message "This is bad"}
           result (raw->violation rule "src/foo.clj" v)]
       (is (= :std/test (:rule/id result)))
@@ -145,7 +145,7 @@
     (let [rule       {:rule/id :std/stratified-design
                       :rule/title "Stratified Design"
                       :rule/category "001"
-                      :rule/severity :major
+                      :rule/severity :high
                       :rule/knowledge-content "Use layers."}
           mock-complete (fn [_client _request]
                           {:success true
@@ -202,7 +202,7 @@
     (let [rule {:rule/id :std/test
                 :rule/title "Test Rule"
                 :rule/category "001"
-                :rule/severity :minor
+                :rule/severity :low
                 :rule/knowledge-content "Check for test."
                 :rule/applies-to {:file-globs ["components/semantic-analyzer/test/**/*.clj"]}}
           call-count (atom 0)
@@ -220,7 +220,7 @@
     (let [rule    {:rule/id :std/test
                    :rule/title "Test Rule"
                    :rule/category "001"
-                   :rule/severity :minor
+                   :rule/severity :low
                    :rule/knowledge-content "Check it."
                    :rule/applies-to {:file-globs ["src/*.clj"]}}
           judged  (atom [])
@@ -241,9 +241,9 @@
 
 (deftest analyze-rules-on-files-batched-test
   (testing "one LLM call per file across many rules; violations distributed by rule-id"
-    (let [rule-a {:rule/id :std/a :rule/title "A" :rule/category "001" :rule/severity :major
+    (let [rule-a {:rule/id :std/a :rule/title "A" :rule/category "001" :rule/severity :high
                   :rule/knowledge-content "no a" :rule/applies-to {:file-globs ["src/*.clj"]}}
-          rule-b {:rule/id :std/b :rule/title "B" :rule/category "002" :rule/severity :major
+          rule-b {:rule/id :std/b :rule/title "B" :rule/category "002" :rule/severity :high
                   :rule/knowledge-content "no b" :rule/applies-to {:file-globs ["src/*.clj"]}}
           calls  (atom 0)
           mock   (fn [_client _request]
@@ -260,7 +260,7 @@
       (is (= 1 (count (get-in result [:by-rule :std/b]))))
       (is (= :std/a (:rule/id (first (get-in result [:by-rule :std/a])))))))
   (testing "a rule whose glob does not match a file is not judged against it"
-    (let [clj-rule {:rule/id :std/clj :rule/title "Clj" :rule/category "001" :rule/severity :minor
+    (let [clj-rule {:rule/id :std/clj :rule/title "Clj" :rule/category "001" :rule/severity :low
                     :rule/knowledge-content "k" :rule/applies-to {:file-globs ["src/*.clj"]}}
           calls    (atom 0)
           mock     (fn [_client _request] (swap! calls inc) {:success true :content "[]"})
@@ -273,9 +273,9 @@
   (testing "an untagged violation is attributed to EVERY rule in the batch
             (fail-closed), never dropped — the model forgetting :rule-id must not
             silently lose a real finding"
-    (let [rule-a {:rule/id :std/a :rule/title "A" :rule/category "001" :rule/severity :major
+    (let [rule-a {:rule/id :std/a :rule/title "A" :rule/category "001" :rule/severity :high
                   :rule/knowledge-content "k" :rule/applies-to {:file-globs ["src/*.clj"]}}
-          rule-b {:rule/id :std/b :rule/title "B" :rule/category "002" :rule/severity :major
+          rule-b {:rule/id :std/b :rule/title "B" :rule/category "002" :rule/severity :high
                   :rule/knowledge-content "k" :rule/applies-to {:file-globs ["src/*.clj"]}}
           mock   (fn [_client _request]
                    {:success true :content "[{:line 1 :message \"untagged finding\"}]"})
@@ -288,7 +288,7 @@
   {:rule/id :std/test
    :rule/title "Test"
    :rule/category "001"
-   :rule/severity :minor
+   :rule/severity :low
    :rule/knowledge-content "Test rule."
    :rule/applies-to {:file-globs ["src/*.clj"]}})
 

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
@@ -195,11 +195,15 @@
 
 (defn severity-prefix [severity]
   (case severity
-    :critical "\u2718 CRIT " :major "\u2718 MAJR "
-    :minor    "\u26a0 MINR " :info  "\u2139 INFO " "\u26a0 "))
+    :critical "\u2718 CRIT " :high "\u2718 HIGH "
+    :medium   "\u26a0 MEDM " :low  "\u26a0 LOW  "
+    :info     "\u2139 INFO " "\u26a0 "))
 
 (defn severity-color [severity]
-  (case severity :critical status-fail :major status-fail :minor status-warning :info status-info nil))
+  (case severity
+    :critical status-fail :high status-fail
+    :medium   status-warning :low status-warning
+    :info status-info nil))
 
 (defn pack-detail-nodes
   "Build detail child nodes for a pack at depth 3.
@@ -231,8 +235,9 @@
   (when summary
     (let [parts (cond-> []
                   (pos? (:critical summary 0)) (conj (str (:critical summary) " critical"))
-                  (pos? (:major summary 0))    (conj (str (:major summary) " major"))
-                  (pos? (:minor summary 0))    (conj (str (:minor summary) " minor"))
+                  (pos? (:high summary 0))     (conj (str (:high summary) " high"))
+                  (pos? (:medium summary 0))   (conj (str (:medium summary) " medium"))
+                  (pos? (:low summary 0))      (conj (str (:low summary) " low"))
                   (pos? (:info summary 0))     (conj (str (:info summary) " info")))]
       (when (seq parts)
         [(tree-node (str "Summary: " (str/join ", " parts)) 1)]))))

--- a/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
@@ -298,17 +298,17 @@
 
 (deftest severity-summary-nodes-all-zero
   (testing "All-zero summary → nil"
-    (is (nil? (sut/severity-summary-nodes {:critical 0 :major 0 :minor 0 :info 0})))))
+    (is (nil? (sut/severity-summary-nodes {:critical 0 :high 0 :medium 0 :low 0 :info 0})))))
 
 (deftest severity-summary-nodes-mixed
   (testing "Mixed counts → summary string"
-    (let [nodes (sut/severity-summary-nodes {:critical 1 :major 0 :minor 3 :info 2})]
+    (let [nodes (sut/severity-summary-nodes {:critical 1 :high 0 :medium 3 :low 0 :info 2})]
       (is (= 1 (count nodes)))
       (let [label (:label (first nodes))]
         (is (.contains label "1 critical"))
-        (is (.contains label "3 minor"))
+        (is (.contains label "3 medium"))
         (is (.contains label "2 info"))
-        (is (not (.contains label "major")))))))
+        (is (not (.contains label "high")))))))
 
 ;; ============================================================================
 ;; violation-nodes
@@ -321,7 +321,7 @@
 (deftest violation-nodes-present
   (testing "Non-empty violations → header + colored child nodes"
     (let [violations [{:severity :critical :message "Bad thing" :auto-fixable? false}
-                      {:severity :minor :message "Small thing" :auto-fixable? true}]
+                      {:severity :low :message "Small thing" :auto-fixable? true}]
           nodes (sut/violation-nodes violations)]
       (is (= 3 (count nodes)))
       (is (.contains (:label (first nodes)) "2"))

--- a/docs/pull-requests/2026-07-06-fix-consumer-severity.md
+++ b/docs/pull-requests/2026-07-06-fix-consumer-severity.md
@@ -1,0 +1,51 @@
+<!--
+  Title: Migrate severity consumer sites to the canonical enum
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: migrate severity consumer sites to the canonical enum
+
+Branch: `fix/consumer-severity`
+
+## Summary
+
+Step 3 of governance-audit Finding 6. Migrates the in-repo severity **consumers**
+off `:major`/`:minor` onto the canonical `:critical/:high/:medium/:low/:info`
+(established in #1382, made authoritative for packs in #1383). `:major` → `:high`,
+`:minor` → `:low`.
+
+One of these was silently broken by #1383: `tui-views` renders the policy-pack
+`:evaluation/summary` histogram, whose keys became `:high`/`:medium`/`:low` — but
+`tui-views` still read `:major`/`:minor`, so those counts stopped displaying.
+
+## Changes
+
+- `tui-views/.../trees.clj`: `severity-prefix` / `severity-color` labels and
+  `severity-summary-nodes` now use the 5-level keys (adds `:medium`).
+- `connector-linter/etl.clj`: the `map-severity` default is `:low` (was
+  `:minor`); `resources/.../linter-mappings.edn` maps sources to canonical
+  values.
+- `gate/pre_verify_lint.clj`: lint-error severity default `:high` (was `:major`).
+- Test fixtures across `gate`, `connector-linter`, `pr-scoring`,
+  `semantic-analyzer`, `tui-views` migrated so the codebase carries one severity
+  vocabulary.
+
+## Remaining (not this PR)
+
+- `supervisory-state` / `evidence-bundle` `violation-severities` copies + the
+  `:policy/summary` histogram + golden fixtures + miniforge-control re-vendor
+  (step 4, cross-repo).
+- One line of embedded doc text in `miniforge-standards.pack.edn` ("compiles at
+  `:major` severity") originates from `meta/rule-format.mdc` in the standards
+  submodule — a standards-repo edit, not this repo.
+
+## Test plan
+
+- Migrated components: `tui-views`, `connector-linter`, `gate`, `pr-scoring`,
+  `semantic-analyzer` — all green (170 tests across the runs).
+- `bb pre-commit` green; `bb poly:check` clean.
+
+## Related
+
+- Governance audit Finding 6. Depends on #1382, #1383.


### PR DESCRIPTION
## Summary

Step 3 of governance-audit Finding 6 (depends on #1382, #1383). Migrates the
in-repo severity **consumers** off `:major`/`:minor` onto the canonical
`:critical/:high/:medium/:low/:info`. `:major` → `:high`, `:minor` → `:low`.

One consumer was silently broken by #1383: `tui-views` renders the policy-pack
`:evaluation/summary` histogram, whose keys became `:high`/`:medium`/`:low` — but
it still read `:major`/`:minor`, so those counts stopped displaying.

## Changes

- `tui-views/trees.clj`: `severity-prefix`/`severity-color` labels +
  `severity-summary-nodes` use the 5-level keys (adds `:medium`).
- `connector-linter`: `map-severity` default `:low`; `linter-mappings.edn` values.
- `gate/pre_verify_lint`: lint-error severity default `:high`.
- Test fixtures across `gate`, `connector-linter`, `pr-scoring`,
  `semantic-analyzer`, `tui-views` migrated so the codebase carries one vocabulary.

## Remaining (not this PR)

- `supervisory-state`/`evidence-bundle` + `:policy/summary` histogram + golden
  fixtures + miniforge-control re-vendor (step 4, cross-repo).
- One line of embedded doc text in the compiled standards pack ("compiles at
  `:major` severity") comes from `meta/rule-format.mdc` in the standards
  submodule — a standards-repo edit.

## Test plan

- Migrated components (`tui-views`, `connector-linter`, `gate`, `pr-scoring`,
  `semantic-analyzer`) all green.
- `bb pre-commit` green; `bb poly:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)