### PR TITLE
fix(agent): delete commented-out make-task and generate-plan dead code

### DIFF
--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -117,20 +117,6 @@
           :else
           {:valid? true :errors nil})))))
 
-;; NOTE: Helper function for commented-out generate-plan function
-#_(defn make-task
-  "Helper to create a task with generated ID."
-  [{:keys [description type dependencies acceptance-criteria estimated-effort]
-    :or {dependencies []
-         acceptance-criteria []
-         estimated-effort :medium}}]
-  (cond-> {:task/id (random-uuid)
-           :task/description description
-           :task/type type}
-    (seq dependencies) (assoc :task/dependencies dependencies)
-    (seq acceptance-criteria) (assoc :task/acceptance-criteria acceptance-criteria)
-    estimated-effort (assoc :task/estimated-effort estimated-effort)))
-
 (defn format-existing-files
   "Format existing file contents for inclusion in the user prompt.
 
@@ -322,64 +308,6 @@
 
 ;; make-fallback-plan removed — silent fallback masks real failures.
 ;; Plan generation now throws with evidence on failure (see invoke-fn below).
-
-;; NOTE: This function is currently unused but kept as reference for future implementation
-;; where plan generation may be delegated to a separate function rather than done inline.
-#_(defn generate-plan
-  "Generate a plan from analyzed specification.
-   In a real implementation, this would use an LLM with the system prompt."
-  [analysis context]
-  ;; Generate a basic plan structure
-  ;; In production, this would be LLM-generated based on the system prompt
-  (let [{:keys [spec-text estimated-complexity has-tests?]} analysis
-        plan-id (random-uuid)
-        base-name (or (:plan-name context)
-                      (str "plan-" (subs (str plan-id) 0 8)))
-        design-task (make-task
-                     {:description (str "Design solution for: " (subs spec-text 0 (min 100 (count spec-text))))
-                      :type :design
-                      :acceptance-criteria ["Design document created"
-                                            "Approach reviewed and approved"]
-                      :estimated-effort :medium})
-        impl-task (make-task
-                   {:description "Implement the designed solution"
-                    :type :implement
-                    :dependencies [(:task/id design-task)]
-                    :acceptance-criteria ["Code compiles without errors"
-                                          "Follows project conventions"
-                                          "No linter warnings"]
-                    :estimated-effort (case estimated-complexity
-                                        :low :small
-                                        :medium :medium
-                                        :high :large)})
-        test-task (make-task
-                   {:description "Write tests for the implementation"
-                    :type :test
-                    :dependencies [(:task/id impl-task)]
-                    :acceptance-criteria ["Unit tests pass"
-                                          "Edge cases covered"
-                                          "Test coverage meets threshold"]
-                    :estimated-effort :medium})
-        review-task (make-task
-                     {:description "Code review checkpoint"
-                      :type :review
-                      :dependencies [(:task/id test-task)]
-                      :acceptance-criteria ["Code reviewed"
-                                            "All comments addressed"]
-                      :estimated-effort :small})]
-    {:plan/id plan-id
-     :plan/name base-name
-     :plan/tasks [design-task impl-task test-task review-task]
-     :plan/estimated-complexity estimated-complexity
-     :plan/risks (cond-> []
-                   (= :high estimated-complexity)
-                   (conj "High complexity may require iteration")
-
-                   (not has-tests?)
-                   (conj "No existing test infrastructure"))
-     :plan/assumptions ["Requirements are complete and stable"
-                        "Dependencies are available"]
-     :plan/created-at (java.util.Date.)}))
 
 (defn repair-plan
   "Attempt to repair a plan based on validation errors."


### PR DESCRIPTION
## Summary

- Deleted `#_(defn make-task ...)` (14 lines) labelled "helper function for commented-out generate-plan function" — dead code supporting dead code
- Deleted `#_(defn generate-plan ...)` (58 lines) labelled "currently unused but kept as reference for future implementation" — exactly what rule 008 prohibits
- Net: 72 lines removed from `components/agent/src/ai/miniforge/agent/planner.clj`

## Motivation

Both blocks are `#_`-disabled in production code (not inside a `comment` block) and have no callers anywhere in the workspace. The `make-task` helper has zero call sites even in the disabled `generate-plan` body in the live codebase. Rule 008 (`no-dead-code`, `alwaysApply: true`, `enforcement.action: hard-halt`) is explicit: "Commented-out code blocks of any size, in any file" must be deleted; "git history is the archive."

Keeping them violated two sub-rules simultaneously:
1. `#_`-commented function bodies ("might need this later")
2. Helper fn with zero active call sites

## Changes

| File/Area | Change |
|-----------|--------|
| `components/agent/src/ai/miniforge/agent/planner.clj` | Deleted `make-task` (#_ block, lines 120–132) and `generate-plan` (#_ block, lines 326–382) |

## Testing

- Both functions were `#_`-disabled — no runtime path touches them; deletion cannot introduce a regression
- `bb` toolchain unavailable in this environment; change is deletion-only with no logic rewrite
- [ ] `bb test` — passes unmodified (no behavior change)
- [ ] `bb lint:clj:all` — passes (removed symbols have no call sites to break)

## Checklist

### Required

- [x] No commented-out tests
- [x] Focused PR (single concern: dead-code removal)
- [ ] `bb test` — deletion-only, no behavior change
- [ ] Pre-commit validation passes

### Best Practices

- [x] Follows `foundations/no-dead-code` (rule 008)
- [x] PR is under ~400 lines of diff (72 lines deleted)

## Related

- Caught by daily repo health sweep 2026-07-06


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAUDXVsQFmWfeQwQoc2GMo)_