### PR TITLE
fix(knowledge): localize the rest of the component's emitted strings

### DIFF
--- a/components/knowledge/resources/config/knowledge/messages/en-US.edn
+++ b/components/knowledge/resources/config/knowledge/messages/en-US.edn
@@ -20,4 +20,33 @@
   :trust/circular-dependency        "Circular dependency detected: {path}"
   :trust/path-separator             " -> "
   :trust/missing-dependency         "Missing dependency: {pack-id}"
-  :trust/tainted-in-instruction-chain "Pack {pack-id} has :authority/instruction but transitively includes tainted content from {found-id}"}}
+  :trust/tainted-in-instruction-chain "Pack {pack-id} has :authority/instruction but transitively includes tainted content from {found-id}"
+
+  ;; Learning capture (cont.)
+  :learning/implementation-rationale "Learned during implementation related to this rule"
+  :learning/bullet-prefix            "- "
+
+  ;; Pack promotion justification templates
+  :promotion/safety-scan-passed     "passed knowledge-safety scans with no violations"
+  :promotion/manual-review-approved "manual review approved by trusted administrator"
+  :promotion/signature-verified     "verified signature from trusted key"
+  :promotion/policy-compliance      "meets all policy compliance requirements"
+  :promotion/automated-validation   "passed automated validation and security checks"
+  :promotion/generic                "promoted via {template}"
+  :promotion/with-details           "{base} ({details})"
+
+  ;; Pack promotion validation diagnostics
+  :promotion/invalid-path           "Invalid promotion path: {from} -> {to}"
+  :promotion/justification-required "promotion-justification is required and cannot be empty"
+  :promotion/pack-id-string         "pack/id must be a string"
+
+  ;; Loader diagnostics
+  :loader/error-loading             "Error loading {file}: {error}"
+
+  ;; Store diagnostics
+  :store/rules-injected             "{count} rules from {categories} categories for agent :{agent}"
+  :store/learning-suffix            " (learning)"
+
+  ;; Zettel prompt formatting
+  :store/zettel-heading             "### {title}"
+  :store/zettel-dewey-tag           " [{dewey}]"}}

--- a/components/knowledge/src/ai/miniforge/knowledge/learning.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/learning.clj
@@ -270,7 +270,8 @@
                                    :tags [:pattern]
                                    :text-search (name tag)})]
         (when (empty? existing)
-          (let [learning-list (str/join "\n" (map #(str (messages/t :learning/bullet-prefix) (:title %)) learnings))]
+          (let [bullet (messages/t :learning/bullet-prefix)
+                learning-list (str/join "\n" (map #(str bullet (:title %)) learnings))]
             (capture-meta-loop-learning
              knowledge-store
              {:title (messages/t :pattern/title {:tag (name tag) :count count})

--- a/components/knowledge/src/ai/miniforge/knowledge/learning.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/learning.clj
@@ -119,7 +119,7 @@
                      :links (when related-to
                               [{:target related-to
                                 :type :extends
-                                :rationale "Learned during implementation related to this rule"}])
+                                :rationale (messages/t :learning/implementation-rationale)}])
                      :confidence 0.7}))
 
 (defn capture-meta-loop-learning
@@ -270,7 +270,7 @@
                                    :tags [:pattern]
                                    :text-search (name tag)})]
         (when (empty? existing)
-          (let [learning-list (str/join "\n" (map #(str "- " (:title %)) learnings))]
+          (let [learning-list (str/join "\n" (map #(str (messages/t :learning/bullet-prefix) (:title %)) learnings))]
             (capture-meta-loop-learning
              knowledge-store
              {:title (messages/t :pattern/title {:tag (name tag) :count count})

--- a/components/knowledge/src/ai/miniforge/knowledge/loader.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/loader.clj
@@ -27,6 +27,7 @@
    - Layer 1: File loading operations
    - Layer 2: Orchestration (initialize function)"
   (:require
+   [ai.miniforge.knowledge.messages :as messages]
    [ai.miniforge.knowledge.store :as store]
    [ai.miniforge.knowledge.yaml :as yaml]
    [clojure.java.io :as io]
@@ -112,7 +113,7 @@
        :zettel/metadata (or frontmatter {})})
 
     (catch Exception e
-      (println "Error loading" (.getName file) ":" (.getMessage e))
+      (println (messages/t :loader/error-loading {:file (.getName file) :error (.getMessage e)}))
       nil)))
 
 (defn load-markdown-file
@@ -148,7 +149,7 @@
        :zettel/metadata {}})
 
     (catch Exception e
-      (println "Error loading" (.getName file) ":" (.getMessage e))
+      (println (messages/t :loader/error-loading {:file (.getName file) :error (.getMessage e)}))
       nil)))
 
 (defn load-files-from-directory

--- a/components/knowledge/src/ai/miniforge/knowledge/promotion.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/promotion.clj
@@ -18,33 +18,26 @@
 
 (ns ai.miniforge.knowledge.promotion
   "Pack promotion with trust level elevation and justification tracking.
-   Implements N6 §2.1 pack promotion evidence requirements.")
+   Implements N6 §2.1 pack promotion evidence requirements."
+  (:require [ai.miniforge.knowledge.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Promotion Justification Examples
 
-(def justification-templates
-  "Standard justification templates for pack promotions."
-  {:safety-scan-passed
-   "passed knowledge-safety scans with no violations"
-
-   :manual-review-approved
-   "manual review approved by trusted administrator"
-
-   :signature-verified
-   "verified signature from trusted key"
-
-   :policy-compliance
-   "meets all policy compliance requirements"
-
-   :automated-validation
-   "passed automated validation and security checks"})
+(def justification-template-keys
+  "Standard justification template keys for pack promotions. The display text
+   for each lives in the message catalog under :promotion/<key>."
+  #{:safety-scan-passed
+    :manual-review-approved
+    :signature-verified
+    :policy-compliance
+    :automated-validation})
 
 (defn format-justification
   "Format a promotion justification with optional details.
 
    Arguments:
-   - template-key - Keyword referencing justification-templates
+   - template-key - Keyword in justification-template-keys (text from the catalog)
    - details      - (optional) Additional context string
 
    Returns formatted justification string.
@@ -56,10 +49,11 @@
      (format-justification :safety-scan-passed \"3 scans completed\")
      => \"passed knowledge-safety scans with no violations (3 scans completed)\""
   [template-key & [details]]
-  (let [base (get justification-templates template-key
-                  (str "promoted via " (name template-key)))]
+  (let [base (if (contains? justification-template-keys template-key)
+               (messages/t (keyword "promotion" (name template-key)))
+               (messages/t :promotion/generic {:template (name template-key)}))]
     (if details
-      (str base " (" details ")")
+      (messages/t :promotion/with-details {:base base :details details})
       base)))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -148,15 +142,15 @@
   (let [errors (cond-> []
                  (not (valid-promotion? (:from-trust promotion-record)
                                         (:to-trust promotion-record)))
-                 (conj (str "Invalid promotion path: "
-                            (:from-trust promotion-record) " -> "
-                            (:to-trust promotion-record)))
+                 (conj (messages/t :promotion/invalid-path
+                                   {:from (:from-trust promotion-record)
+                                    :to (:to-trust promotion-record)}))
 
                  (not (seq (:promotion-justification promotion-record)))
-                 (conj "promotion-justification is required and cannot be empty")
+                 (conj (messages/t :promotion/justification-required))
 
                  (not (string? (:pack/id promotion-record)))
-                 (conj "pack/id must be a string"))]
+                 (conj (messages/t :promotion/pack-id-string)))]
     {:valid? (empty? errors)
      :errors errors}))
 

--- a/components/knowledge/src/ai/miniforge/knowledge/store.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/store.clj
@@ -436,9 +436,10 @@
                                              manifest-entries)}})
       (let [categories (into #{} (keep :zettel/type) zettels)]
         (log/info logger :knowledge :knowledge/rules-injected
-                  {:message (str (count manifest-entries) " rules from "
-                                 (count categories) " categories for agent :"
-                                 (name agent-role))
+                  {:message (messages/t :store/rules-injected
+                                        {:count (count manifest-entries)
+                                         :categories (count categories)
+                                         :agent (name agent-role)})
                    :data {:agent-role     agent-role
                           :rule-count     (count manifest-entries)
                           :categories     (vec (sort-by name categories))
@@ -456,11 +457,11 @@
 (defn format-zettel-for-prompt
   "Format a single zettel as a compact markdown block for LLM context."
   [zettel]
-  (str "### " (:zettel/title zettel)
+  (str (messages/t :store/zettel-heading {:title (:zettel/title zettel)})
        (when-let [dewey (:zettel/dewey zettel)]
-         (str " [" dewey "]"))
+         (messages/t :store/zettel-dewey-tag {:dewey dewey}))
        (when (= :learning (:zettel/type zettel))
-         " (learning)")
+         (messages/t :store/learning-suffix))
        "\n"
        (:zettel/content zettel)
        "\n"))


### PR DESCRIPTION
Localization wave (item 3), completing the **knowledge** component after `trust.clj` (#1374). Routes 17 raw emitted strings across four files through the knowledge message catalog.

| File | Localized |
|---|---|
| `promotion.clj` | 5 justification templates (now catalog keys off `justification-template-keys`), the generic/with-details format strings, and 3 `validate-promotion` error strings |
| `learning.clj` | the extends-link rationale, the `"- "` list bullet prefix |
| `loader.clj` | two `Error loading {file}: {error}` log lines |
| `store.clj` | the rules-injected log message, `### {title}` heading, ` [{dewey}]` tag, ` (learning)` suffix |

## Verified (the ratchet)

- localization judge over `knowledge/src`: **17 → 0**.
- knowledge tests pass (promotion / learning / store); all new catalog keys resolve with no leftover `{placeholder}`.

## Note on judge recall

The judge surfaced the `store.clj` heading + dewey-tag hits only on a **second** pass (~90-95% recall) — the first scan missed them. Mitigation: re-verify per-file after fixing, plus a grep for residual emit-position literals. Worth carrying forward for the rest of the wave — one judge pass is not a guarantee of 0.