### PR TITLE
fix(policy-pack): content-scan honors :mode :negative (Finding 7)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -106,20 +106,32 @@
    - artifact - Artifact with :artifact/content
    - context - Execution context (unused for content-scan)
 
+   Honors `:rule/detection :mode`:
+   - `:positive` (default) — a pattern MATCH is a violation.
+   - `:negative` — the ABSENCE of any pattern match is a violation (the rule
+     requires the pattern to be present, e.g. a copyright header or a k8s
+     resource limit). Applicability (file-globs, phases) scopes which artifacts
+     a negative rule can flag, so a missing pattern only fires on relevant files.
+
    Returns:
    - Violation map if detected, nil otherwise"
   [rule artifact _context]
   (let [detection (:rule/detection rule)
         content (:artifact/content artifact)
         patterns (extract-patterns detection)
-        context-lines (:context-lines detection 2)]
+        context-lines (:context-lines detection 2)
+        mode (:mode detection :positive)
+        violation (fn [matches]
+                    {:type :content-scan
+                     :rule-id (:rule/id rule)
+                     :matches (vec matches)
+                     :artifact-path (:artifact/path artifact)
+                     :message (get-in rule [:rule/enforcement :message])})]
     (when (and content (seq patterns))
-      (when-let [matches (any-pattern-matches? patterns content context-lines)]
-        {:type :content-scan
-         :rule-id (:rule/id rule)
-         :matches matches
-         :artifact-path (:artifact/path artifact)
-         :message (get-in rule [:rule/enforcement :message])}))))
+      (let [matches (any-pattern-matches? patterns content context-lines)]
+        (if (= :negative mode)
+          (when-not matches (violation nil))
+          (when matches (violation matches)))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Diff analysis detection

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -72,6 +72,39 @@
       (is (clojure.string/includes? (:context match) "line2"))
       (is (clojure.string/includes? (:context match) "line4")))))
 
+;; :mode :negative — absence of the pattern is the violation (a required
+;; pattern, e.g. a copyright header or a k8s resource limit). Regression: the
+;; detector previously ignored :mode and always flagged presence, so every
+;; negative-mode rule (require-*, header-copyright) ran inverted.
+
+(deftest content-scan-negative-mode-test
+  (let [require-header {:rule/id :require-header
+                        :rule/detection {:type :content-scan
+                                         :pattern "Christopher Lester"
+                                         :mode :negative}
+                        :rule/enforcement {:action :hard-halt
+                                           :message "Missing copyright header"}}]
+    (testing "negative mode: pattern PRESENT → no violation (requirement met)"
+      (is (nil? (detection/detect-content-scan
+                 require-header
+                 {:artifact/content "Copyright Christopher Lester" :artifact/path "a.clj"}
+                 {}))))
+
+    (testing "negative mode: pattern ABSENT → violation (requirement unmet)"
+      (let [result (detection/detect-content-scan
+                    require-header
+                    {:artifact/content "no header here" :artifact/path "a.clj"}
+                    {})]
+        (is (some? result))
+        (is (= :require-header (:rule-id result)))))
+
+    (testing "positive mode (default) is unaffected: presence is the violation"
+      (let [pos {:rule/id :no-todo
+                 :rule/detection {:type :content-scan :pattern "TODO"}
+                 :rule/enforcement {:action :warn :message "TODO"}}]
+        (is (some? (detection/detect-content-scan pos {:artifact/content "x TODO"} {})))
+        (is (nil? (detection/detect-content-scan pos {:artifact/content "clean"} {})))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Diff analysis detection tests
 

--- a/docs/detection-quality-audit-2026-07-06.md
+++ b/docs/detection-quality-audit-2026-07-06.md
@@ -1,0 +1,85 @@
+<!--
+  Title: Detection-quality audit (governance Finding 7)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Detection-quality audit — governance Finding 7
+
+Adversarial pass over the policy-pack detection surface (25 content-scan regexes,
+93 `:custom` rules across the shipped packs), per the 2026-07-05 governance
+audit's Finding 7. Per rule: the false-positive (FP) and false-negative (FN)
+classes, and whether a regex is the right tool.
+
+## Fixed in this PR (correctness, not FP/FN)
+
+**`:mode :negative` was declared but unimplemented — 6 rules ran inverted.**
+The schema defines `:negative` ("absence of a match is a violation"), the
+mdc-compiler reads it, and 6 rules declare it (`header-copyright`,
+`require-probes`, `require-resource-limits`, `require-vpc`,
+`require-encryption`, `require-resource-tags`). But `detect-content-scan`
+ignored `:mode` and always flagged presence. Runtime effect: `header-copyright`
+fired on files that *had* the copyright and passed files that *lacked* it;
+`require-probes` flagged manifests that *had* probes. `detect-content-scan` now
+honors `:mode`, with tests. This is the one outright correctness defect in the
+set; the rest below are FP/FN quality issues for follow-up.
+
+## Content-scan FP/FN classes (follow-up)
+
+- `foundations/no-hardcoded-secrets`
+  `(?i)(password|secret|api[._-]?key|token)\s*[:=]\s*["'][^"']{8,}`
+  - FN: base64 blobs, concatenated (`"AKIA"+rest`), heredocs, unquoted YAML
+    (`password: hunter2`), tokens < 8 chars, other key names (`pwd`,
+    `passphrase`, `credential`), known-prefix keys with no keyword.
+  - FP: fixtures/placeholders (`api_key: "your-key-here"`), any 8-char literal
+    after `token:`, docs.
+  - Verdict: regex is the wrong primary tool for secrets. Add known-prefix
+    patterns (`AKIA`, `ghp_`, `sk-`, `xox`, `-----BEGIN * KEY-----`) and/or a
+    Shannon-entropy check; keep this as a cheap tripwire, not a detector.
+
+- `kubernetes/no-latest-tag` `image:\s*\S+:latest`
+  - FN: **untagged images** (`image: nginx`) — implicitly `:latest`, the most
+    common case, entirely missed. Quoted images.
+  - FP: `image: app:latest-stable` (matches the `:latest` prefix of a longer
+    tag).
+
+- `foundations/no-inline-anon-fns`
+  `(?:map|keep|filter|mapcat|remove|reduce)\s+\(fn\s+\[`
+  - FN: `#(...)` reader anonymous fns — the *more common* inline form — are
+    missed; only `(fn [...])` is caught.
+  - FP: `filter`/`map` as bindings or in strings.
+
+- `terraform-aws/no-open-ingress` `cidr_blocks\s*=\s*\["0\.0\.0\.0/0"\]`
+  - FN: `0.0.0.0/0` as one of several CIDRs (regex requires it be the sole
+    element); IPv6 any (`::/0`); variable references.
+
+- `terraform-aws/approved-instance-types` (negative-lookahead allowlist)
+  - FN: `instance_type = var.x` (variable) bypasses the allowlist entirely.
+  - Config smell: the approved list is baked into a regex; a new type needs a
+    regex edit rather than a data change (config-as-data).
+
+- `terraform-aws/no-public-s3` `acl\s*=\s*"public-read"` — FN: `public-read-write`.
+- `standards/datever` `\b\d+\.\d+\.\d+\b(?!\.\d)` — high FP: matches any semver
+  anywhere (deps, docstrings); only meaningful in files where DateVer is
+  required, which the pattern cannot express — applicability scoping is
+  load-bearing.
+- `no-unwrap-in-lib` `\.unwrap\(\)` — FP: unwrap in tests/examples; FN:
+  `.expect(...)` (also panics).
+
+## Custom / judge-backed rules
+
+The 93 `:custom` rules resolve to a registered detector fn or, absent one, to
+the LLM judge. The judge path fails **closed** when its wiring is absent —
+`compile-check-fn` emits a `missing-semantic-wiring` violation rather than
+silently passing (verified in `compiler.clj`). That fail-closed posture is the
+right default and should stay pinned; a dedicated per-rule pass should still
+confirm each custom-fn's registration and signature (see the deployment-safety
+`:check-fn`→`:custom-fn` fix in #1381 for the failure mode where a `:custom`
+rule silently routed to the judge).
+
+## Recommended follow-up order
+
+1. `no-hardcoded-secrets` — known-prefix + entropy (highest security value).
+2. `no-latest-tag` untagged-image FN; `no-inline-anon-fns` `#(...)` FN.
+3. `no-open-ingress` multi-CIDR + IPv6; `approved-instance-types` as data.
+4. A per-custom-rule registration/signature sweep.

--- a/docs/pull-requests/2026-07-06-audit-detection-quality.md
+++ b/docs/pull-requests/2026-07-06-audit-detection-quality.md
@@ -1,0 +1,43 @@
+<!--
+  Title: Detection quality — implement :mode :negative
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: content-scan honors :mode :negative (Finding 7)
+
+Branch: `audit/detection-quality`
+
+## Summary
+
+First step of governance-audit Finding 7 (detection quality). The content-scan
+detector ignored `:rule/detection :mode`, so the 6 rules declaring
+`:mode :negative` (`header-copyright`, `require-probes`,
+`require-resource-limits`, `require-vpc`, `require-encryption`,
+`require-resource-tags`) ran **inverted** — they flagged the *presence* of the
+required pattern and passed on its *absence*. `header-copyright` fired on files
+that had the copyright and passed files that lacked it.
+
+`detect-content-scan` now honors `:mode`: `:positive` (default) flags a match;
+`:negative` flags the absence of any match. Applicability (file-globs, phases)
+scopes which artifacts a negative rule can flag.
+
+## Deliverable
+
+`docs/detection-quality-audit-2026-07-06.md` — the adversarial FP/FN analysis of
+all 25 content-scan regexes and the custom/judge rules, with a recommended
+follow-up order. This PR fixes the one outright correctness defect (`:mode`);
+the FP/FN quality issues (secrets regex, untagged-image miss, `#(...)` miss) are
+catalogued there for follow-up PRs.
+
+## Test plan
+
+- New `content-scan-negative-mode-test`: negative mode fires on absence, passes
+  on presence; positive mode unaffected.
+- policy-pack detection + gate + standard-packs suites: 73 tests, 555
+  assertions, 0 failures.
+- `bb poly:check` clean.
+
+## Related
+
+- Governance audit Finding 7.


### PR DESCRIPTION
## Summary

First step of governance-audit Finding 7 (detection quality). `detect-content-scan`
ignored `:rule/detection :mode`, so the 6 rules declaring `:mode :negative`
(`header-copyright`, `require-probes`, `require-resource-limits`, `require-vpc`,
`require-encryption`, `require-resource-tags`) ran **inverted** — flagging the
*presence* of the required pattern and passing on its *absence*.
`header-copyright` fired on files that had the copyright and passed files that
lacked it.

The detector now honors `:mode`: `:positive` (default) flags a match;
`:negative` flags the absence of any match. Applicability (file-globs, phases)
scopes which artifacts a negative rule can flag.

## Deliverable

`docs/detection-quality-audit-2026-07-06.md` — the adversarial FP/FN analysis of
all 25 content-scan regexes + the custom/judge rules, with a follow-up order.
This PR fixes the one outright correctness defect (`:mode`); the FP/FN quality
issues (secrets regex is an FN sieve + FP generator; `no-latest-tag` misses
untagged images; `no-inline-anon-fns` misses `#(...)`; `no-open-ingress` misses
multi-CIDR + IPv6) are catalogued there for follow-up PRs.

## Test plan

- New `content-scan-negative-mode-test`: negative fires on absence, passes on
  presence; positive unaffected.
- policy-pack detection + gate + standard-packs: 73 tests, 555 assertions, 0
  failures.
- `bb pre-commit` green; `bb poly:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)