### PR TITLE
fix(policy-pack): broaden no-hardcoded-secrets detection (Finding 7)

### DIFF
--- a/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
@@ -58,7 +58,19 @@
                                     "**/*.env.example" "**/*.sh"]
                        :phases #{:implement :review}}
    :rule/detection   {:type :content-scan
-                      :pattern "(?i)(password|secret|api[._-]?key|token)\\s*[:=]\\s*[\"'][^\"']{8,}"}
+                      ;; Keyword-quoted assignments PLUS high-confidence
+                      ;; provider key shapes (caught regardless of a keyword)
+                      ;; PLUS a conservative unquoted case (16+ token-ish chars,
+                      ;; so config words like `password: required` don't match).
+                      :patterns
+                      ["(?i)(password|passphrase|secret|client[._-]?secret|api[._-]?key|access[._-]?token|auth[._-]?token|private[._-]?key|credential|token)\\s*[:=]\\s*[\"'][^\"']{8,}"
+                       "AKIA[0-9A-Z]{16}"
+                       "gh[pousr]_[0-9A-Za-z]{36,}"
+                       "sk-[0-9A-Za-z]{20,}"
+                       "xox[baprs]-[0-9A-Za-z-]{10,}"
+                       "AIza[0-9A-Za-z_-]{35}"
+                       "-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"
+                       "(?i)(password|passphrase|secret|api[._-]?key|access[._-]?token|token)\\s*:\\s*[A-Za-z0-9+/=_-]{16,}\\b"]}
    :rule/remediation {:strategy :manual
                       :auto-fixable-default true
                       :exclude-contexts

--- a/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
@@ -70,7 +70,7 @@
                        "xox[baprs]-[0-9A-Za-z-]{10,}"
                        "AIza[0-9A-Za-z_-]{35}"
                        "-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"
-                       "(?i)(password|passphrase|secret|api[._-]?key|access[._-]?token|token)\\s*:\\s*[A-Za-z0-9+/=_-]{16,}\\b"]}
+                       "(?i)(password|passphrase|secret|api[._-]?key|access[._-]?token|token)\\s*[:=]\\s*[A-Za-z0-9+/=_-]{16,}(?![\\w(])"]}
    :rule/remediation {:strategy :manual
                       :auto-fixable-default true
                       :exclude-contexts

--- a/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
@@ -117,20 +117,24 @@
   (let [rule (secrets-rule)
         fires? (fn [s] (boolean (detection/detect-content-scan
                                  rule {:artifact/content s :artifact/path "x.clj"} {})))]
+    (is (some? rule) "foundations pack must expose :foundations/no-hardcoded-secrets")
     (testing "real secrets fire (incl. provider key shapes with no keyword)"
       (doseq [s ["password = \"hunter2xyz\""
                  "AKIAIOSFODNN7EXAMPLE"
                  "ghp_1234567890123456789012345678901234ab"
+                 "ghs_1234567890123456789012345678901234ab"
                  "sk-abcdefghijklmnopqrstuvwxyz123456"
                  "-----BEGIN RSA PRIVATE KEY-----"
                  "password: aGVsbG8gd29ybGRzZWNyZXQ="
+                 "SECRET=aGVsbG8gd29ybGRzZWNyZXQ="
                  "api_key: \"abcdefgh12345678\""
                  "client_secret = \"s3cr3tvalue99\""]]
         (is (fires? s) (str "should fire: " s))))
-    (testing "non-secrets do not fire (env refs, config words, comments)"
+    (testing "non-secrets do not fire (env refs, function calls, config, comments)"
       (doseq [s ["password = env(\"SECRET\")"
                  "password: required"
                  "let token = getToken()"
+                 "apikey = getApiKeyFromVault()"
                  "# password: use a secrets manager"
                  "password_field: user_name_column"
                  "(def x 42)"]]

--- a/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
@@ -27,7 +27,8 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [clojure.java.io :as io]
+   [ai.miniforge.policy-pack.detection :as detection]))
 
 (def ^:private pack-specs
   "Expected pack metadata for each reference pack."
@@ -99,3 +100,38 @@
                                (count (:pack/rules pack)))))
                      (reduce + 0))]
       (is (>= total 53) (str "Expected at least 53 rules, got " total)))))
+
+;; Finding 7: no-hardcoded-secrets FP/FN. The original single regex was an FN
+;; sieve (missed provider key shapes, unquoted values) and an FP generator.
+;; Pin the improved patterns: high-confidence provider shapes + keyword-quoted
+;; + a conservative unquoted case fire; env refs, config words, and comments do
+;; not.
+
+(defn- secrets-rule []
+  (->> (load-pack-resource "foundations-1.0.0.pack.edn")
+       :pack/rules
+       (filter #(= :foundations/no-hardcoded-secrets (:rule/id %)))
+       first))
+
+(deftest no-hardcoded-secrets-detection-test
+  (let [rule (secrets-rule)
+        fires? (fn [s] (boolean (detection/detect-content-scan
+                                 rule {:artifact/content s :artifact/path "x.clj"} {})))]
+    (testing "real secrets fire (incl. provider key shapes with no keyword)"
+      (doseq [s ["password = \"hunter2xyz\""
+                 "AKIAIOSFODNN7EXAMPLE"
+                 "ghp_1234567890123456789012345678901234ab"
+                 "sk-abcdefghijklmnopqrstuvwxyz123456"
+                 "-----BEGIN RSA PRIVATE KEY-----"
+                 "password: aGVsbG8gd29ybGRzZWNyZXQ="
+                 "api_key: \"abcdefgh12345678\""
+                 "client_secret = \"s3cr3tvalue99\""]]
+        (is (fires? s) (str "should fire: " s))))
+    (testing "non-secrets do not fire (env refs, config words, comments)"
+      (doseq [s ["password = env(\"SECRET\")"
+                 "password: required"
+                 "let token = getToken()"
+                 "# password: use a secrets manager"
+                 "password_field: user_name_column"
+                 "(def x 42)"]]
+        (is (not (fires? s)) (str "should NOT fire: " s))))))

--- a/docs/pull-requests/2026-07-06-fix-secrets-detection.md
+++ b/docs/pull-requests/2026-07-06-fix-secrets-detection.md
@@ -1,0 +1,34 @@
+<!--
+  Title: no-hardcoded-secrets — known-prefix + broader coverage
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: no-hardcoded-secrets known-prefix + broader coverage (Finding 7)
+
+Branch: `fix/secrets-detection`
+
+## Summary
+
+Finding 7 follow-up. The single `no-hardcoded-secrets` regex was an FN sieve
+(missed provider key shapes with no keyword, unquoted values) and named in the
+audit. Replace it with a `:patterns` set:
+
+- broadened keyword-quoted assignments (adds passphrase, client-secret,
+  access/auth-token, private-key, credential);
+- high-confidence provider shapes caught regardless of a keyword — AWS `AKIA…`,
+  GitHub `gh[pousr]_…`, OpenAI `sk-…`, Slack `xox…`, Google `AIza…`, and
+  `-----BEGIN … PRIVATE KEY-----`;
+- a conservative unquoted case (16+ token-ish chars) so YAML/env secrets are
+  caught but config words like `password: required` are not.
+
+## Test plan
+
+- New `no-hardcoded-secrets-detection-test`: 8 secret fixtures fire (incl.
+  keyword-less provider keys); 6 non-secrets (env refs, config words, comments,
+  plain code) do not.
+- `standard-packs` suite: 5 tests, 363 assertions, 0 failures.
+
+## Related
+
+- Governance audit Finding 7; catalogued in `docs/detection-quality-audit-2026-07-06.md`.


### PR DESCRIPTION
## Summary

Finding 7 follow-up (catalogued in `docs/detection-quality-audit-2026-07-06.md`).
The single `no-hardcoded-secrets` regex was an FN sieve (missed provider key
shapes, unquoted values) — named in the audit. Replace `:pattern` with a
`:patterns` set:

- broadened keyword-quoted assignments (passphrase, client-secret,
  access/auth-token, private-key, credential);
- high-confidence provider shapes regardless of keyword — AWS `AKIA…`, GitHub
  `gh[pousr]_…`, OpenAI `sk-…`, Slack `xox…`, Google `AIza…`, `PRIVATE KEY`
  blocks;
- a conservative unquoted case (16+ token chars) — catches YAML/env secrets,
  skips config words like `password: required`.

## Test plan

- New `no-hardcoded-secrets-detection-test`: 8 secrets fire (incl. keyword-less
  provider keys); 6 non-secrets (env refs, config words, comments, plain code)
  do not.
- `standard-packs`: 5 tests, 363 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)