### PR TITLE
fix(tool): localize prose + make error :type tags keywords

### DIFF
--- a/components/tool/deps.edn
+++ b/components/tool/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/event-stream {:local/root "../event-stream"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/schema  {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/tool/resources/config/tool/messages/en-US.edn
+++ b/components/tool/resources/config/tool/messages/en-US.edn
@@ -1,0 +1,9 @@
+{:tool/messages
+ {;; Tool display / summary
+  :tool/summary            "{name} - {description}"
+
+  ;; Validation + execution diagnostics
+  :tool/missing-parameter  "Missing required parameter: {param}"
+  :tool/validation-failed  "Tool parameter validation failed: {error}"
+  :tool/id-must-be-keyword "Tool ID must be a namespaced keyword"
+  :tool/not-found          "Tool not found: {tool-id}"}}

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -26,6 +26,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as events]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.tool.messages :as messages]
    [ai.miniforge.tool.tracking :as tracking]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -71,7 +72,7 @@
     (if (empty? missing)
       {:valid? true}
       {:valid? false
-       :errors (mapv #(str "Missing required parameter: " (name %)) missing)})))
+       :errors (mapv #(messages/t :tool/missing-parameter {:param (name %)}) missing)})))
 
 (defn build-tool-definition
   "Build a tool definition map from parts."
@@ -87,7 +88,7 @@
 (defn tool-summary
   "Create a brief summary of a tool for display."
   [tool]
-  (str (:tool/name tool) " - " (:tool/description tool)))
+  (messages/t :tool/summary {:name (:tool/name tool) :description (:tool/description tool)}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Tool protocol and registry
@@ -141,16 +142,16 @@
                      (catch Exception e
                        (let [ex-msg (or (ex-message e) (.getName (class e)))]
                          {:success false
-                          :error {:type "execution_error"
+                          :error {:type :execution-error
                                   :message ex-msg}
                           :anomaly (anomaly/exception-anomaly :fault ex-msg e)})))
                    {:success false
-                    :error {:type "validation_error"
+                    :error {:type :validation-error
                             :errors (:errors validation)}
                     :anomaly (anomaly/anomaly
                               :invalid-input
-                              (str "Tool parameter validation failed: "
-                                   (first (:errors validation)))
+                              (messages/t :tool/validation-failed
+                                          {:error (first (:errors validation))})
                               {})})
           end-ms (System/currentTimeMillis)
           invocation (tracking/build-invocation id params start-ms end-ms result)]
@@ -210,7 +211,7 @@
   [{:keys [id name description parameters handler metadata]
     :or {parameters {} metadata {}}}]
   (when-not (valid-tool-id? id)
-    (throw (ex-info "Tool ID must be a namespaced keyword"
+    (throw (ex-info (messages/t :tool/id-must-be-keyword)
                     {:id id})))
   (->FunctionTool id
                   (or name (clojure.core/name id))
@@ -234,13 +235,11 @@
   [registry tool-id params context]
   (if-let [tool (get-tool registry tool-id)]
     (execute tool params context)
-    {:success false
-     :error {:type "not_found"
-             :message (str "Tool not found: " tool-id)}
-     :anomaly (anomaly/anomaly
-               :not-found
-               (str "Tool not found: " tool-id)
-               {})}))
+    (let [not-found-msg (messages/t :tool/not-found {:tool-id tool-id})]
+      {:success false
+       :error {:type :not-found
+               :message not-found-msg}
+       :anomaly (anomaly/anomaly :not-found not-found-msg {})})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -269,6 +268,6 @@
 
   ;; Validation failure
   (execute-tool registry :tools/echo {} {})
-  ;; => {:success false, :error {:type "validation_error", ...}}
+  ;; => {:success false, :error {:type :validation-error, ...}}
 
   :leave-this-here)

--- a/components/tool/src/ai/miniforge/tool/messages.clj
+++ b/components/tool/src/ai/miniforge/tool/messages.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool.messages
+  "Component-level message catalog for tool.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a tool message by key, with optional param substitution."
+  (messages/create-translator "config/tool/messages/en-US.edn"
+                              :tool/messages))

--- a/components/tool/test/ai/miniforge/tool/interface_test.clj
+++ b/components/tool/test/ai/miniforge/tool/interface_test.clj
@@ -172,7 +172,7 @@
                     :handler (constantly nil)})
           result (tool/execute my-tool {} {})]
       (is (not (tool/success? result)))
-      (is (= "validation_error" (get-in (tool/get-error result) [:type])))))
+      (is (= :validation-error (get-in (tool/get-error result) [:type])))))
 
   (testing "returns execution error on exception"
     (let [bad-tool (tool/create-tool
@@ -180,7 +180,7 @@
                      :handler throwing-handler})
           result (tool/execute bad-tool {} {})]
       (is (not (tool/success? result)))
-      (is (= "execution_error" (get-in (tool/get-error result) [:type]))))))
+      (is (= :execution-error (get-in (tool/get-error result) [:type]))))))
 
 (deftest execute-by-id-test
   (testing "executes tool by id from registry"
@@ -197,7 +197,7 @@
     (let [registry (tool/create-registry)
           result (tool/execute-by-id registry :test/unknown {} {})]
       (is (not (tool/success? result)))
-      (is (= "not_found" (get-in (tool/get-error result) [:type]))))))
+      (is (= :not-found (get-in (tool/get-error result) [:type]))))))
 
 ;; Invocation tracking tests
 
@@ -228,7 +228,7 @@
           _result (tool/execute my-tool {} context)
           [invocation] (tool/tool-invocations context)]
       (is (= :test/track-error (:tool/id invocation)))
-      (is (= "validation_error" (get-in invocation [:tool/error :type]))))))
+      (is (= :validation-error (get-in invocation [:tool/error :type]))))))
 
 ;; Protocol method tests (N1 conformance)
 


### PR DESCRIPTION
Localization wave (item 3), **tool** component. Bootstraps the tool message catalog (translator + `en-US.edn` + `messages` dep) — the first "bootstrap a catalog from scratch" example for a component that had none (most remaining components will need this).

## Localized (6 prose strings)

missing-parameter error, tool summary, validation-failed anomaly message, id-must-be-keyword throw message, and the two tool-not-found messages → catalog keys.

## ⚠️ Contract change to review: error `:type` string → keyword

The 3 other flagged strings — `"execution_error"`, `"validation_error"`, `"not_found"` — are **not prose**. They are machine dispatch identifiers the interface tests assert on (`(= "validation_error" (get-in ... [:type]))`). Localizing them would break the contract. The correct representation for a dispatch identifier is a **keyword**, so I converted them to `:execution-error` / `:validation-error` / `:not-found` (which also removes them from the localization scanner — keywords arent prose). Applying the rules *intent*, not cargo-culting it.

- No non-test consumer matches the old string values (grepped components + bases).
- The 4 interface-test assertions are updated to keywords.
- This is a small **tool-result contract change** (`:error :type` string → keyword). Flagging for review in case any agent-facing serialization depends on the string form.

## Verified

localization judge on `tool/core.clj` = **0**; tool tests pass (14/59); catalog keys resolve; poly + lint + GraalVM green.