### PR TITLE
fix(task): localize dependency-graph log messages

### DIFF
--- a/components/task/resources/config/task/messages/en-US.edn
+++ b/components/task/resources/config/task/messages/en-US.edn
@@ -10,4 +10,9 @@
   :task/failed "Task failed"
   :task/blocked "Task blocked"
   :task/unblocked "Task unblocked"
-  :task/decomposed "Task decomposed into sub-tasks"}}
+  :task/decomposed "Task decomposed into sub-tasks"
+
+  ;; Dependency-graph diagnostics
+  :task/dependency-cycle "Dependency would create cycle"
+  :task/dependency-added "Dependency added"
+  :task/dependency-removed "Dependency removed"}}

--- a/components/task/src/ai/miniforge/task/graph.clj
+++ b/components/task/src/ai/miniforge/task/graph.clj
@@ -24,7 +24,8 @@
    The dependency graph tracks which tasks depend on other tasks.
    A task can only start when all its dependencies are completed."
   (:require
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.task.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure graph algorithms
@@ -150,7 +151,7 @@
        (do
          (when logger
            (log/warn logger :agent :task/cycle-detected
-                     {:message "Dependency would create cycle"
+                     {:message (messages/t :task/dependency-cycle)
                       :data {:parent-id parent-id
                              :child-id child-id}}))
          false)
@@ -161,7 +162,7 @@
                             (update-in [:reverse child-id] (fnil conj #{}) parent-id))))
          (when logger
            (log/debug logger :agent :task/dependency-added
-                      {:message "Dependency added"
+                      {:message (messages/t :task/dependency-added)
                        :data {:parent-id parent-id
                               :child-id child-id}}))
          true)))))
@@ -176,7 +177,7 @@
                       (update-in [:reverse child-id] disj parent-id))))
    (when logger
      (log/debug logger :agent :task/dependency-removed
-                {:message "Dependency removed"
+                {:message (messages/t :task/dependency-removed)
                  :data {:parent-id parent-id
                         :child-id child-id}}))
    true))


### PR DESCRIPTION
Localization wave (item 3), **task** component. Routes the three static dependency-graph log messages in `graph.clj` through the existing task catalog: `:task/dependency-cycle`, `:task/dependency-added`, `:task/dependency-removed`.

Small, catalog-already-present component — no bootstrapping.

Verified: localization judge on `task/graph.clj` = **0**; task tests pass (6/26); catalog keys resolve; poly + lint + GraalVM green.