### PR TITLE
fix(policy-pack): untagged-image + reader-anon-fn detection (Finding 7)

### DIFF
--- a/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
@@ -232,7 +232,9 @@
    :rule/applies-to  {:file-globs ["**/*.clj" "**/*.cljc"]
                        :phases #{:implement :review}}
    :rule/detection   {:type :content-scan
-                      :pattern "(?:map|keep|filter|mapcat|remove|reduce)\\s+\\(fn\\s+\\["}
+                      ;; Both explicit `(fn [...])` and the reader `#(...)` — the
+                      ;; latter is the more common inline anon fn and was missed.
+                      :pattern "(?:map|keep|filter|mapcat|remove|reduce|some|every\\?|sort-by|group-by)\\s+(?:\\(fn\\s+\\[|#\\()"}
    :rule/remediation {:strategy :manual
                       :auto-fixable-default false}
    :rule/enforcement {:action :audit

--- a/components/policy-pack/resources/policy_pack/packs/kubernetes-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/kubernetes-1.0.0.pack.edn
@@ -52,7 +52,13 @@
                                     "**/helm/**/*.yaml" "**/helm/**/*.yml"]
                        :phases #{:implement :review}}
    :rule/detection   {:type :content-scan
-                      :pattern "image:\\s*\\S+:latest"}
+                      ;; Explicit :latest (bare or quoted; not :latest-stable)
+                      ;; AND untagged images (implicitly :latest) — the common
+                      ;; case that a plain :latest match misses. Digest-pinned
+                      ;; (@sha256) and tagged images are left alone.
+                      :patterns
+                      ["image:\\s*[\"']?\\S*?:latest(?![-\\w])"
+                       "(?m)image:\\s*[\"']?(?:[a-z0-9.-]+(?::[0-9]+)?/)*[a-z0-9._-]+[\"']?\\s*(?:$|#)"]}
    :rule/enforcement {:action :require-approval
                       :message "Container image uses :latest tag. Pin images to a specific digest or immutable version tag."
                       :remediation "Replace :latest with a specific version tag (e.g., v1.2.3) or SHA256 digest."}}

--- a/components/policy-pack/resources/policy_pack/packs/kubernetes-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/kubernetes-1.0.0.pack.edn
@@ -57,7 +57,7 @@
                       ;; case that a plain :latest match misses. Digest-pinned
                       ;; (@sha256) and tagged images are left alone.
                       :patterns
-                      ["image:\\s*[\"']?\\S*?:latest(?![-\\w])"
+                      ["image:\\s*[\"']?\\S*?:latest(?![\\w.@-])"
                        "(?m)image:\\s*[\"']?(?:[a-z0-9.-]+(?::[0-9]+)?/)*[a-z0-9._-]+[\"']?\\s*(?:$|#)"]}
    :rule/enforcement {:action :require-approval
                       :message "Container image uses :latest tag. Pin images to a specific digest or immutable version tag."

--- a/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
@@ -167,4 +167,7 @@
     (testing "pinned tags, digests, and :latest-* do not fire"
       (is (not (fires? "image: nginx:1.2.3")))
       (is (not (fires? "image: app@sha256:abcdef123")))
+      (is (not (fires? "image: nginx:latest@sha256:abcdef123"))
+          "tag+digest is pinned by the digest")
+      (is (not (fires? "image: nginx:latest.stable")) "latest.stable is a pinned tag")
       (is (not (fires? "image: nginx:latest-stable")) "latest-stable is a pinned tag"))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
@@ -139,3 +139,32 @@
                  "password_field: user_name_column"
                  "(def x 42)"]]
         (is (not (fires? s)) (str "should NOT fire: " s))))))
+
+;; Finding 7: no-inline-anon-fns missed the reader `#(...)` form; no-latest-tag
+;; missed untagged images (implicitly :latest) and false-fired on :latest-*.
+
+(defn- pack-rule [file id]
+  (->> (load-pack-resource file) :pack/rules (filter #(= id (:rule/id %))) first))
+
+(deftest no-inline-anon-fns-detection-test
+  (let [rule (pack-rule "foundations-1.0.0.pack.edn" :foundations/no-inline-anon-fns)
+        fires? (fn [s] (boolean (detection/detect-content-scan rule {:artifact/content s} {})))]
+    (is (some? rule))
+    (is (fires? "(map (fn [x] (inc x)) coll)") "explicit (fn [..])")
+    (is (fires? "(map #(inc %) coll)") "reader #(..) — the missed form")
+    (is (not (fires? "(map inc coll)")) "named fn is fine")
+    (is (not (fires? "(filter even? coll)")) "named predicate is fine")))
+
+(deftest no-latest-tag-detection-test
+  (let [rule (pack-rule "kubernetes-1.0.0.pack.edn" :k8s/no-latest-tag)
+        fires? (fn [s] (boolean (detection/detect-content-scan rule {:artifact/content s} {})))]
+    (is (some? rule))
+    (testing "explicit :latest and untagged images fire"
+      (is (fires? "image: nginx:latest"))
+      (is (fires? "image: \"nginx:latest\""))
+      (is (fires? "image: nginx") "untagged is implicitly :latest")
+      (is (fires? "image: myreg:5000/app") "registry-port but untagged"))
+    (testing "pinned tags, digests, and :latest-* do not fire"
+      (is (not (fires? "image: nginx:1.2.3")))
+      (is (not (fires? "image: app@sha256:abcdef123")))
+      (is (not (fires? "image: nginx:latest-stable")) "latest-stable is a pinned tag"))))

--- a/docs/pull-requests/2026-07-06-fix-image-anon-detection.md
+++ b/docs/pull-requests/2026-07-06-fix-image-anon-detection.md
@@ -1,0 +1,31 @@
+<!--
+  Title: Detection FN fixes — untagged images + reader anon fns
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: untagged-image + reader-anon-fn detection (Finding 7)
+
+Branch: `fix/image-anon-detection`
+
+## Summary
+
+Two false-negative fixes from the Finding-7 catalogue.
+
+- `k8s/no-latest-tag`: added untagged images (`image: nginx`, implicitly
+  `:latest` — the common case the old `:latest`-only pattern missed) and quoted
+  `:latest`; fixed the `:latest-stable` false positive. Digest-pinned
+  (`@sha256`) and tagged images are left alone.
+- `foundations/no-inline-anon-fns`: added the reader `#(...)` form (the more
+  common inline anon fn), which the `(fn [...])`-only pattern missed.
+
+## Test plan
+
+- New `no-latest-tag-detection-test` and `no-inline-anon-fns-detection-test`
+  pin the fire/no-fire cases (untagged, registry-port, tagged, digest,
+  latest-stable; `(fn [..])`, `#(..)`, named fns).
+- `standard-packs`: 7 tests, 380 assertions, 0 failures.
+
+## Related
+
+- Governance audit Finding 7 (`docs/detection-quality-audit-2026-07-06.md`).


### PR DESCRIPTION
## Summary

Two false-negative fixes from the Finding-7 catalogue.

- `k8s/no-latest-tag`: catch **untagged images** (`image: nginx`, implicitly
  `:latest` — the common case the `:latest`-only pattern missed) and quoted
  `:latest`; drop the `:latest-stable` false positive. Digest-pinned (`@sha256`)
  and tagged images are left alone.
- `foundations/no-inline-anon-fns`: catch the reader `#(...)` form (the more
  common inline anon fn), previously missed.

## Test plan

- New `no-latest-tag-detection-test` / `no-inline-anon-fns-detection-test` pin
  the fire/no-fire cases (untagged, registry-port, tagged, digest, latest-stable;
  `(fn [..])`, `#(..)`, named fns).
- `standard-packs`: 7 tests, 380 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)