### PR TITLE
fix(loop): localize gate/repair/escalation diagnostics

### DIFF
--- a/components/loop/resources/config/loop/messages/en-US.edn
+++ b/components/loop/resources/config/loop/messages/en-US.edn
@@ -16,6 +16,33 @@
   :repair/max-attempts-exceeded   "Maximum repair attempts exceeded"
   :repair/strategies-exhausted    "All repair strategies exhausted"
   :repair/escalated               "Repair escalated to outer loop"
+  :repair/attempting-llm          "Attempting LLM repair"
+  :repair/llm-success             "LLM successfully repaired artifact"
+  :repair/llm-failed              "LLM repair attempt failed"
+  :repair/no-repair-fn            "No repair function provided in context"
+  :repair/attempting-retry        "Attempting retry"
+  :repair/retry-completed         "Retry delay completed"
+  :repair/escalating              "Escalating to outer loop"
+  :repair/escalating-resolution   "Escalating to outer loop for resolution"
+  :repair/starting-orchestration  "Starting repair orchestration"
+
+  ;; Escalation (cont.)
+  :escalation/truncation-ellipsis "..."
+  :escalation/no-escalation-fn    "No escalation function provided"
+  :escalation/error-line-prefix   "  {n}. "
+  :escalation/error-code-tag      " [{code}]"
+
+  ;; Gate validation diagnostics
+  :gate/failed                    "Gate {gate-id} ({gate-type}) failed"
+  :gate/execution-failed          "Gate execution failed: {error}"
+  :gate/starting-validation       "Starting gate validation"
+  :gate/debug-println             "Debug println found in code"
+  :gate/unused-require            "Unused namespace alias found"
+  :gate/test-failed               "Test execution failed"
+  :gate/no-test-fn                "No test function configured"
+  :gate/hardcoded-secret          "Possible hardcoded secret detected"
+  :gate/todo-found                "TODO/FIXME comment found in code"
+  :gate/missing-docstring         "Public function missing docstring"
 
   ;; Inner loop lifecycle
   :inner/invalid-transition       "Invalid state transition"

--- a/components/loop/src/ai/miniforge/loop/escalation.clj
+++ b/components/loop/src/ai/miniforge/loop/escalation.clj
@@ -50,8 +50,8 @@
                              (:anomaly/category anomaly)))
         code (or (when classification (name classification))
                  (when-let [c (:code err)] (name c)))]
-    (str "  " (inc idx) ". " msg
-         (when code (str " [" code "]")))))
+    (str (messages/t :escalation/error-line-prefix {:n (inc idx)}) msg
+         (when code (messages/t :escalation/error-code-tag {:code code})))))
 
 (defn format-error-context
   "Format error context for user display.
@@ -74,7 +74,7 @@
                          (subs content 0 (min 200 (count content)))
                          (pr-str content))]
            (str "  " preview
-                (when (> (count (str content)) 200) "...")))
+                (when (> (count (str content)) 200) (messages/t :escalation/truncation-ellipsis))))
          (str "  " (messages/t :escalation/no-content)))))
 
 (defn format-escalation-prompt
@@ -213,12 +213,13 @@
             updated-episode (decision/update-episode episode resolved-checkpoint)]
         (escalated-result result resolved-checkpoint updated-episode))
       ;; No escalation function, default to abort
-      (let [result {:action :abort
-                    :reason "No escalation function provided"}
+      (let [no-fn-msg (messages/t :escalation/no-escalation-fn)
+            result {:action :abort
+                    :reason no-fn-msg}
             resolved-checkpoint (decision/resolve-checkpoint checkpoint
                                                              (result->response result))
             updated-episode (decision/update-episode episode resolved-checkpoint)]
-        (abort-escalation "No escalation function provided"
+        (abort-escalation no-fn-msg
                           resolved-checkpoint
                           updated-episode)))))
 

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -30,6 +30,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.loop.interface.protocols.gate :as p]
+   [ai.miniforge.loop.messages :as messages]
    [ai.miniforge.logging.interface :as log]
    [clojure.string]))
 
@@ -88,7 +89,7 @@
            :gate/anomaly (anomaly/sub-anomaly
                           :invalid-input
                           :anomalies.gate/validation-failed
-                          (str "Gate " (name gate-id) " (" (name gate-type) ") failed")
+                          (messages/t :gate/failed {:gate-id (name gate-id) :gate-type (name gate-type)})
                           {:gate/id gate-id
                            :gate/type gate-type
                            :gate/errors errors})}
@@ -172,12 +173,12 @@
                          ;; Check for println (common debug leftover)
                          (re-find #"\(println\s" content)
                          (conj (make-error :debug-println
-                                           "Debug println found in code"))
+                                           (messages/t :gate/debug-println)))
 
                          ;; Check for unused :require
                          (re-find #":as\s+_\]" content)
                          (conj (make-error :unused-require
-                                           "Unused namespace alias found")))]
+                                           (messages/t :gate/unused-require))))]
           (if (and fail-on-warning? (seq warnings))
             (fail-result id :lint warnings
                          :duration-ms (clock/elapsed-since start))
@@ -236,7 +237,7 @@
                            :duration-ms (clock/elapsed-since start))
               (fail-result id :test
                            (or (:errors result)
-                               [(make-error :test-failed "Test execution failed")])
+                               [(make-error :test-failed (messages/t :gate/test-failed))])
                            :duration-ms (clock/elapsed-since start))))
           (catch Exception e
             (fail-result id :test
@@ -244,7 +245,7 @@
                          :duration-ms (clock/elapsed-since start))))
         ;; No test function provided, pass by default
         (pass-result id :test
-                     :warnings [(make-error :no-test-fn "No test function configured")]
+                     :warnings [(make-error :no-test-fn (messages/t :gate/no-test-fn))]
                      :duration-ms (clock/elapsed-since start)))))
 
   (gate-id [_this] id)
@@ -286,7 +287,7 @@
                                  (or (re-find #"(?i)(api[_-]?key|secret|password)\s*=\s*['\"][^'\"]+['\"]" content)
                                      (re-find #"(?i)(bearer|token)\s+[a-zA-Z0-9]{20,}" content)))
                           (conj acc (make-error :hardcoded-secret
-                                                "Possible hardcoded secret detected"))
+                                                (messages/t :gate/hardcoded-secret)))
                           acc)
 
                         ;; No TODO comments in production code
@@ -294,7 +295,7 @@
                         (if (and (string? content)
                                  (re-find #"(?i)\b(TODO|FIXME|HACK|XXX)\b" content))
                           (conj acc (make-error :todo-found
-                                                "TODO/FIXME comment found in code"))
+                                                (messages/t :gate/todo-found)))
                           acc)
 
                         ;; Require docstrings
@@ -303,7 +304,7 @@
                                  (#{:code} artifact-type)
                                  (re-find #"\(defn\s+\S+\s+\[" content))
                           (conj acc (make-error :missing-docstring
-                                                "Public function missing docstring"))
+                                                (messages/t :gate/missing-docstring)))
                           acc)
 
                         ;; Unknown policy, ignore
@@ -390,7 +391,7 @@
     (catch Exception e
       (fail-result (gate-id gate) (gate-type gate)
                    [(make-error :gate-execution-error
-                                (str "Gate execution failed: " (.getMessage e)))]))))
+                                (messages/t :gate/execution-failed {:error (.getMessage e)}))]))))
 
 (defn run-gates
   "Run multiple gates against an artifact.
@@ -407,7 +408,7 @@
   (let [logger (:logger context)]
     (when logger
       (log/debug logger :loop :inner/validation-passed
-                 {:message "Starting gate validation"
+                 {:message (messages/t :gate/starting-validation)
                   :data {:gate-count (count gates)}}))
     (loop [remaining gates
            results []

--- a/components/loop/src/ai/miniforge/loop/repair.clj
+++ b/components/loop/src/ai/miniforge/loop/repair.clj
@@ -83,7 +83,7 @@
           max-tokens (:max-tokens config 4000)]
       (when logger
         (log/info logger :loop :inner/repair-attempted
-                  {:message "Attempting LLM repair"
+                  {:message (messages/t :repair/attempting-llm)
                    :data {:strategy :llm-fix
                           :error-count (count errors)
                           :error-codes (mapv :code errors)}}))
@@ -97,11 +97,11 @@
               (repair-success :llm-fix (:artifact result)
                               :tokens-used (:tokens-used result)
                               :duration-ms duration
-                              :message "LLM successfully repaired artifact")
+                              :message (messages/t :repair/llm-success))
               (repair-failure :llm-fix (get result :errors errors)
                               :tokens-used (:tokens-used result)
                               :duration-ms duration
-                              :message "LLM repair attempt failed")))
+                              :message (messages/t :repair/llm-failed))))
           (catch Exception e
             (repair-failure :llm-fix
                             [{:code :repair-exception
@@ -110,7 +110,7 @@
         ;; No repair function provided
         (repair-failure :llm-fix
                         [{:code :no-repair-fn
-                          :message "No repair function provided in context"}]
+                          :message (messages/t :repair/no-repair-fn)}]
                         :duration-ms (- (System/currentTimeMillis) start))))))
 
 (defn llm-fix-strategy
@@ -134,7 +134,7 @@
           delay-ms (:delay-ms config 1000)]
       (when logger
         (log/info logger :loop :inner/repair-attempted
-                  {:message "Attempting retry"
+                  {:message (messages/t :repair/attempting-retry)
                    :data {:strategy :retry
                           :delay-ms delay-ms}}))
       ;; Simple retry: wait and return the same artifact for re-validation
@@ -142,7 +142,7 @@
       ;; Retry doesn't modify the artifact, just allows re-running
       (repair-success :retry artifact
                       :duration-ms (- (System/currentTimeMillis) start)
-                      :message "Retry delay completed"))))
+                      :message (messages/t :repair/retry-completed)))))
 
 (defn retry-strategy
   "Create a simple retry strategy.
@@ -163,7 +163,7 @@
           logger (:logger context)]
       (when logger
         (log/warn logger :loop :inner/escalated
-                  {:message "Escalating to outer loop"
+                  {:message (messages/t :repair/escalating)
                    :data {:error-count (count errors)
                           :error-codes (mapv :code errors)}}))
       ;; Escalation signals that the inner loop cannot handle this
@@ -173,7 +173,7 @@
        :errors errors
        :strategy :escalate
        :duration-ms (- (System/currentTimeMillis) start)
-       :message "Escalating to outer loop for resolution"})))
+       :message (messages/t :repair/escalating-resolution)})))
 
 (defn escalate-strategy
   "Create an escalation strategy.
@@ -264,7 +264,7 @@
   (let [logger (:logger context)]
     (when logger
       (log/debug logger :loop :inner/repair-attempted
-                 {:message "Starting repair orchestration"
+                 {:message (messages/t :repair/starting-orchestration)
                   :data {:strategy-count (count strategies)
                          :max-attempts max-attempts}}))
     (loop [remaining-strategies strategies


### PR DESCRIPTION
Localization wave (item 3), **loop** component — the biggest so far (~23 strings across `gates.clj`, `repair.clj`, `escalation.clj`, all through the existing loop catalog).

- **gates.clj**: gate-failed anomaly message, the `make-error` descriptions (debug-println / unused-require / test-failed / no-test-fn / hardcoded-secret / todo-found / missing-docstring), execution-failed, start-of-validation.
- **repair.clj**: LLM / retry / escalate log messages + orchestration start.
- **escalation.clj**: no-escalation-function abort reason, truncation ellipsis, and the `"  N. msg [code]"` error-line prefix + code tag.

## Verified

localization judge on all three files = **0**; loop tests pass (gates / escalation / interface / repair-messages, 158+ assertions); catalog keys resolve; poly + lint + GraalVM green.

Judge-recall note: 3 of these surfaced only on a **second** pass (~90-95% recall) — re-verified per-file to 0.