### PR TITLE
fix(reliability): localize degradation transition reasons

### DIFF
--- a/components/reliability/resources/config/reliability/messages/en-US.edn
+++ b/components/reliability/resources/config/reliability/messages/en-US.edn
@@ -27,5 +27,8 @@
   :degradation/dependency-recovered "Dependency health recovered"
   :degradation/budget-recovered     "Error budgets recovered"
   :degradation/nominal-restored     "Nominal mode restored"
+  :degradation/critical-budget-exhausted "Critical error budget exhausted"
+  :degradation/critical-budget-low  "Critical error budget below 25%"
+  :degradation/operator-exit-reason "{principal}: {justification}"
   :safe-mode/entered    "Safe-mode entered: {trigger}"
   :safe-mode/exited     "Safe-mode exited after {duration}ms: {justification}"}}

--- a/components/reliability/src/ai/miniforge/reliability/degradation.clj
+++ b/components/reliability/src/ai/miniforge/reliability/degradation.clj
@@ -192,14 +192,14 @@
       any-critical-exhausted?
       (transition-signal :safe-mode
                          :emergency-stop
-                         "Critical error budget exhausted"
+                         (messages/t :degradation/critical-budget-exhausted)
                          {:safe-mode-trigger :error-budget
-                          :safe-mode-details "Critical error budget exhausted"})
+                          :safe-mode-details (messages/t :degradation/critical-budget-exhausted)})
 
       any-critical-low?
       (transition-signal :degraded
                          :budget-critical
-                         "Critical error budget below 25%"))))
+                         (messages/t :degradation/critical-budget-low)))))
 
 (defn- stronger-signal
   [left right]
@@ -344,7 +344,8 @@
       (let [new-mode (transition! manager
                                   (transition-signal :nominal
                                                      :operator-exit
-                                                     (str principal ": " justification)))]
+                                                     (messages/t :degradation/operator-exit-reason
+                                                                 {:principal principal :justification justification})))]
         (when-let [stream (:event-stream manager)]
           (stream/publish! stream
                            (events/safe-mode-exited stream principal justification 0 0)))


### PR DESCRIPTION
Localization wave (item 3), **reliability** component. Routes the 4 raw strings in `degradation.clj` through the existing reliability catalog: the critical-budget-exhausted safe-mode reason (+ its details), the critical-budget-low degraded reason, and the `{principal}: {justification}` operator-exit reason.

Small, catalog-already-present.

Verified: localization judge on `degradation.clj` = **0**; degradation tests pass (15/23); catalog keys resolve; poly + lint + GraalVM green.