### PR TITLE
fix(orchestrator): localize zettel-context heading + dewey tag

### DIFF
--- a/components/orchestrator/resources/config/orchestrator/messages/en-US.edn
+++ b/components/orchestrator/resources/config/orchestrator/messages/en-US.edn
@@ -3,6 +3,8 @@
   :knowledge/header         "## Relevant Knowledge for {role}\n\n"
   :knowledge/preamble       "The following rules and learnings apply to your task:\n\n"
   :knowledge/separator      "\n---\n\n"
+  :knowledge/zettel-heading "### {title}"
+  :knowledge/zettel-dewey-tag " [{dewey}]"
 
   ;; Task routing
   :route/reason             "Task type {task-type} maps to {agent-role}"

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -128,9 +128,9 @@
 (defn format-zettel-for-context
   "Format a zettel for inclusion in agent context."
   [zettel]
-  (str "### " (:zettel/title zettel)
+  (str (messages/t :knowledge/zettel-heading {:title (:zettel/title zettel)})
        (when-let [dewey (:zettel/dewey zettel)]
-         (str " [" dewey "]"))
+         (messages/t :knowledge/zettel-dewey-tag {:dewey dewey}))
        "\n"
        (:zettel/content zettel)
        "\n"))


### PR DESCRIPTION
Localization wave (item 3), **orchestrator** component. Routes the `### {title}` heading and ` [{dewey}]` tag in `format-zettel-for-context` through the existing orchestrator catalog (mirrors the knowledge/store.clj fix — same zettel-formatting shape).

Verified: localization judge on `orchestrator/core.clj` = **0**; orchestrator tests pass (21/79); catalog keys resolve; poly + lint + GraalVM green.