### PR TITLE
fix(policy-pack): content-scan :multiline? match mode (Finding 7)

### DIFF
--- a/components/policy-pack/resources/policy_pack/packs/kubernetes-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/kubernetes-1.0.0.pack.edn
@@ -74,9 +74,14 @@
                                     "**/manifests/**/*.yaml" "**/manifests/**/*.yml"
                                     "**/helm/**/*.yaml" "**/helm/**/*.yml"]
                        :phases #{:implement :review}}
-   :rule/detection   {:type    :content-scan
-                      :mode    :negative
-                      :pattern "resources:\\s*\\n\\s+limits:"}
+   :rule/detection   {:type       :content-scan
+                      :mode       :negative
+                      ;; The pattern spans two lines, so it must match against
+                      ;; the whole manifest, not line-by-line — otherwise it
+                      ;; never matches and the negative rule fires on EVERY
+                      ;; manifest, including compliant ones.
+                      :multiline? true
+                      :pattern    "resources:\\s*\\n\\s+limits:"}
    :rule/enforcement {:action :require-approval
                       :message "Container is missing resource limits. All containers must declare CPU and memory limits."
                       :remediation "Add a resources.limits block specifying cpu and memory limits."}}

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -96,6 +96,18 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Content scan detection
 
+(defn any-pattern-matches-multiline?
+  "Like `any-pattern-matches?` but matches each pattern against the WHOLE content
+   rather than line-by-line, for rules whose pattern must span lines (e.g. a k8s
+   `resources:` block followed by `limits:`). Returns a one-element matches vec
+   on the first hit, or nil."
+  [patterns content]
+  (some (fn [p]
+          (when-let [pat (ensure-pattern p)]
+            (when-let [m (re-find pat content)]
+              [{:match (if (string? m) m (first m)) :line 1 :context content}])))
+        patterns))
+
 (defn detect-content-scan
   "Detect violations by scanning artifact content.
 
@@ -113,6 +125,11 @@
      resource limit). Applicability (file-globs, phases) scopes which artifacts
      a negative rule can flag, so a missing pattern only fires on relevant files.
 
+   Honors `:rule/detection :multiline?`: when true the patterns are matched
+   against the whole content instead of line-by-line, so a pattern that spans
+   lines (`resources:\\n  limits:`) can match. Line-oriented patterns keep the
+   default per-line behavior.
+
    Returns:
    - Violation map if detected, nil otherwise"
   [rule artifact _context]
@@ -128,7 +145,9 @@
                      :artifact-path (:artifact/path artifact)
                      :message (get-in rule [:rule/enforcement :message])})]
     (when (and content (seq patterns))
-      (let [matches (any-pattern-matches? patterns content context-lines)]
+      (let [matches (if (:multiline? detection)
+                      (any-pattern-matches-multiline? patterns content)
+                      (any-pattern-matches? patterns content context-lines))]
         (if (= :negative mode)
           (when-not matches (violation nil))
           (when matches (violation matches)))))))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -100,12 +100,25 @@
   "Like `any-pattern-matches?` but matches each pattern against the WHOLE content
    rather than line-by-line, for rules whose pattern must span lines (e.g. a k8s
    `resources:` block followed by `limits:`). Returns a one-element matches vec
-   on the first hit, or nil."
+   (with the match's `:line`/`:column` and a bounded `:context` — never the whole
+   file, to avoid payload bloat and leaking unrelated content) on the first hit,
+   or nil."
   [patterns content]
   (some (fn [p]
           (when-let [pat (ensure-pattern p)]
-            (when-let [m (re-find pat content)]
-              [{:match (if (string? m) m (first m)) :line 1 :context content}])))
+            (let [matcher (re-matcher pat content)]
+              (when (.find matcher)
+                (let [start     (.start matcher)
+                      match-str (.group matcher)
+                      before    (subs content 0 start)
+                      last-nl   (str/last-index-of before "\n")
+                      match-cap (if (> (count match-str) 200)
+                                  (str (subs match-str 0 200) "…")
+                                  match-str)]
+                  [{:match   match-str
+                    :line    (inc (count (re-seq #"\n" before)))
+                    :column  (inc (- start (if last-nl (inc last-nl) 0)))
+                    :context match-cap}])))))
         patterns))
 
 (defn detect-content-scan

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -139,7 +139,12 @@
    - :context-lines - Lines of context to include
    - :custom-fn - Symbol for custom detection function
    - :capability - Keyword naming a registered mechanical-check capability
-     (used with :type :capability; resolved via the capability registry)"
+     (used with :type :capability; resolved via the capability registry)
+   - :mode - :positive (default; a match is a violation) or :negative
+     (the ABSENCE of a match is a violation, e.g. a required header)
+   - :multiline? - when true, match patterns against the whole content instead
+     of line-by-line (for patterns that span lines)
+   - :email-pattern - secondary regex (e.g. a copyright-header email check)"
   [:map
    [:type DetectionType]
    [:pattern {:optional true} [:or string? [:fn {:error/message "should be a regex pattern"} #(instance? java.util.regex.Pattern %)]]]

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -148,6 +148,7 @@
    [:custom-fn {:optional true} symbol?]
    [:capability {:optional true} keyword?]
    [:mode {:optional true} DetectionMode]
+   [:multiline? {:optional true} boolean?]
    [:email-pattern {:optional true} string?]])
 
 (def RuleEnforcementConfig

--- a/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
@@ -188,3 +188,17 @@
       (is (not (fires? "cidr_blocks = [\"10.0.0.0/8\"]")))
       (is (not (fires? "cidr_blocks = [\"192.168.1.0/24\"]")))
       (is (not (fires? "description = \"never allow 0.0.0.0/0 here\"")) "unquoted prose mention"))))
+
+;; Finding 7: content-scan matches per-line, so require-resource-limits's
+;; two-line pattern never matched and (negative mode) fired on EVERY manifest.
+;; :multiline? makes it match whole-content.
+
+(deftest require-resource-limits-multiline-test
+  (let [rule (pack-rule "kubernetes-1.0.0.pack.edn" :k8s/require-resource-limits)
+        fires? (fn [s] (boolean (detection/detect-content-scan rule {:artifact/content s} {})))]
+    (is (some? rule))
+    (is (true? (get-in rule [:rule/detection :multiline?])))
+    (is (not (fires? "spec:\n  containers:\n  - name: app\n    resources:\n      limits:\n        cpu: 500m"))
+        "a manifest WITH resource limits must pass (was firing pre-fix)")
+    (is (fires? "spec:\n  containers:\n  - name: app")
+        "a manifest WITHOUT resource limits fires")))

--- a/docs/pull-requests/2026-07-06-fix-content-scan-multiline.md
+++ b/docs/pull-requests/2026-07-06-fix-content-scan-multiline.md
@@ -1,0 +1,41 @@
+<!--
+  Title: content-scan multiline match mode
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: content-scan :multiline? match mode (Finding 7)
+
+Branch: `fix/content-scan-multiline`
+
+## Summary
+
+Finding-7 engine fix. `detect-content-scan` matches each line independently, so a
+pattern that spans lines can never match. `k8s/require-resource-limits`'s pattern
+(`resources:\n  limits:`, negative mode) therefore never matched — and after the
+mode-negative fix (#1388), it fired on **every** manifest, including compliant
+ones with limits.
+
+Add a `:multiline?` detection flag: when set, patterns match against the whole
+content instead of per-line. `require-resource-limits` now declares it, so a
+manifest with a resource-limits block passes and one without fires.
+
+## Changes
+
+- `detection.clj`: `any-pattern-matches-multiline?` + a `:multiline?` branch in
+  `detect-content-scan`.
+- `schema.clj`: `:multiline?` on `RuleDetection`.
+- `kubernetes` pack: `require-resource-limits` sets `:multiline? true`.
+
+## Test plan
+
+- New `require-resource-limits-multiline-test`: a manifest WITH limits passes
+  (was firing pre-fix); WITHOUT fires.
+- policy-pack detection + schema + standard-packs: 72 tests, 643 assertions, 0
+  failures.
+- `bb poly:check` clean.
+
+## Related
+
+- Governance audit Finding 7 (the per-line engine limitation noted in
+  `docs/detection-quality-audit-2026-07-06.md`).


### PR DESCRIPTION
## Summary

Finding-7 engine fix. `detect-content-scan` matches each line independently, so a
pattern that spans lines can never match. `k8s/require-resource-limits`'s pattern
(`resources:\n  limits:`, negative mode) therefore never matched — and after the
mode-negative fix (#1388), it fired on **every** manifest, including compliant
ones with limits.

A `:multiline?` detection flag now matches patterns against the whole content
instead of per-line. `require-resource-limits` declares it, so a manifest with a
resource-limits block passes and one without fires.

## Changes

- `detection.clj`: `any-pattern-matches-multiline?` + `:multiline?` branch.
- `schema.clj`: `:multiline?` on `RuleDetection`.
- `kubernetes` pack: `require-resource-limits` sets `:multiline? true`.

## Test plan

- New `require-resource-limits-multiline-test`: manifest WITH limits passes (was
  firing pre-fix); WITHOUT fires.
- detection + schema + standard-packs: 72 tests, 643 assertions, 0 failures.
- `bb poly:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)