### PR TITLE
fix(connector-http): localize the server-error label

### DIFF
--- a/components/connector-http/resources/config/connector-http/messages/en-US.edn
+++ b/components/connector-http/resources/config/connector-http/messages/en-US.edn
@@ -28,6 +28,7 @@
 
   ;; Extract
   :http/request-failed     "HTTP request failed: {status} {error}"
+  :http/server-error       "server error"
   :http/timeout            "HTTP request timed out for {url}"
   :http/rate-limited       "Rate limited by server (429)"
 

--- a/components/connector-http/src/ai/miniforge/connector_http/impl.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/impl.clj
@@ -78,7 +78,7 @@
                       {:error-type :rate-limited})
 
       (<= 500 status 599)
-      (schema/failure :body (msg/t :http/request-failed {:status status :error "server error"})
+      (schema/failure :body (msg/t :http/request-failed {:status status :error (msg/t :http/server-error)})
                       {:error-type :transient})
 
       :else

--- a/components/connector-http/src/ai/miniforge/connector_http/interface.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/interface.clj
@@ -85,8 +85,9 @@
   request/do-request)
 (def error-response
   "(fn [status resp msgs] failure): build a schema/failure from a non-success,
-   non-304 response. msgs map: {:rate-limited string :request-failed (fn [status
-   err-str] string)}. The :error-type in failure metadata is :rate-limited (429),
+   non-304 response. msgs map: {:rate-limited string :server-error string
+   :request-failed (fn [status err-str] string)} — callers supply their own
+   localized labels. The :error-type in failure metadata is :rate-limited (429),
    :transient (5xx), or :permanent (other 4xx)."
   request/error-response)
 (def next-url

--- a/components/connector-http/src/ai/miniforge/connector_http/request.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/request.clj
@@ -26,6 +26,7 @@
    Layer 1: Response builders
    Layer 2: Request execution and post-request helpers"
   (:require [ai.miniforge.connector-http.etag :as etag]
+            [ai.miniforge.connector-http.messages :as msg]
             [ai.miniforge.connector-http.pagination :as page]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
@@ -68,7 +69,7 @@
   (let [request-failed (:request-failed msgs)]
     (case (classify-error status)
       :rate-limited (schema/failure :body (:rate-limited msgs)                      {:error-type :rate-limited})
-      :server-error (schema/failure :body (request-failed status "server error")    {:error-type :transient})
+      :server-error (schema/failure :body (request-failed status (msg/t :http/server-error)) {:error-type :transient})
       :client-error (schema/failure :body (request-failed status (:body resp))      {:error-type :permanent}))))
 
 ;;------------------------------------------------------------------------------ Layer 2

--- a/components/connector-http/src/ai/miniforge/connector_http/request.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/request.clj
@@ -26,7 +26,6 @@
    Layer 1: Response builders
    Layer 2: Request execution and post-request helpers"
   (:require [ai.miniforge.connector-http.etag :as etag]
-            [ai.miniforge.connector-http.messages :as msg]
             [ai.miniforge.connector-http.pagination :as page]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
@@ -69,7 +68,7 @@
   (let [request-failed (:request-failed msgs)]
     (case (classify-error status)
       :rate-limited (schema/failure :body (:rate-limited msgs)                      {:error-type :rate-limited})
-      :server-error (schema/failure :body (request-failed status (msg/t :http/server-error)) {:error-type :transient})
+      :server-error (schema/failure :body (request-failed status (:server-error msgs)) {:error-type :transient})
       :client-error (schema/failure :body (request-failed status (:body resp))      {:error-type :permanent}))))
 
 ;;------------------------------------------------------------------------------ Layer 2

--- a/components/connector-http/test/ai/miniforge/connector_http/request_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/request_test.clj
@@ -29,6 +29,7 @@
 
 (def ^:private error-msgs
   {:rate-limited   "Rate limited"
+   :server-error   "server error"
    :request-failed (fn [s e] (str "Failed " s ": " e))})
 
 ;;------------------------------------------------------------------------------ Layer 1
@@ -91,9 +92,10 @@
       (is (false? (:success? result)))
       (is (= :permanent (:error-type result)))))
 
-  (testing "server error calls :request-failed fn with 'server error' string"
+  (testing "server error calls :request-failed fn with the caller's :server-error label"
     (let [calls (atom [])
           msgs  {:rate-limited   ""
+                 :server-error   "server error"
                  :request-failed (fn [s e] (swap! calls conj {:status s :error e}) "")}]
       (request/error-response 503 {:body "gateway timeout"} msgs)
       (is (= 1 (count @calls)))


### PR DESCRIPTION
Localization wave (item 3), **connector-http**. The generic `"server error"` label was a raw string passed into the localized `:http/request-failed` message in both code paths — `impl.clj` (via the `msg/t` translator) and `request.clj` (via the injected `msgs` map). Add a `:http/server-error` catalog key and source it through the connector-http translator in both.

Verified: localization judge on `impl.clj` + `request.clj` = **0**; connector-http tests pass (17/42); poly + lint + GraalVM green.