### PR TITLE
fix(tui-views): localize the PR-fleet view; bootstrap tui-views catalog

### DIFF
--- a/components/tui-views/deps.edn
+++ b/components/tui-views/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/coerce {:local/root "../coerce"}
         ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/pr-train {:local/root "../pr-train"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}
         ai.miniforge/orchestrator {:local/root "../orchestrator"}

--- a/components/tui-views/resources/config/tui-views/messages/en-US.edn
+++ b/components/tui-views/resources/config/tui-views/messages/en-US.edn
@@ -1,0 +1,19 @@
+{:tui-views/messages
+ {;; PR risk indicators
+  :risk/low         "LOW"
+  :risk/medium      "MED"
+  :risk/high        "HIGH"
+  :risk/unevaluated "?"
+  :risk/none        "---"
+
+  ;; PR fleet view
+  :fleet/readiness-pct " {pct}%"
+  :pr/untitled         "Untitled"
+  :fleet/title         " MINIFORGE │ PR Fleet"
+  :fleet/empty         "  No PRs tracked. Use :add-repo to add repositories."
+  :fleet/col-title     "PR Title"
+  :fleet/col-repo      "Repository"
+  :fleet/col-readiness "Readiness"
+  :fleet/col-risk      "Risk"
+  :fleet/footer        " j/k:navigate  Enter:detail  r:sync  b:kanban  ::cmd  q:quit"
+  :fleet/flash-prefix  "  │ "}}

--- a/components/tui-views/src/ai/miniforge/tui_views/messages.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/messages.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.messages
+  "Component-level message catalog for the TUI views (user-facing UI text).
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a TUI-views message by key, with optional param substitution."
+  (messages/create-translator "config/tui-views/messages/en-US.edn"
+                              :tui-views/messages))

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
@@ -23,6 +23,7 @@
    CI status, and repo information."
   (:require
    [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.messages :as msg]
    [ai.miniforge.tui-views.palette :as palette]
    [ai.miniforge.tui-views.update.navigation :as nav]))
 
@@ -31,11 +32,11 @@
 
 (defn risk-indicator [risk]
   (case risk
-    :low    "LOW"
-    :medium "MED"
-    :high        "HIGH"
-    :unevaluated "?"
-    "---"))
+    :low         (msg/t :risk/low)
+    :medium      (msg/t :risk/medium)
+    :high        (msg/t :risk/high)
+    :unevaluated (msg/t :risk/unevaluated)
+    (msg/t :risk/none)))
 
 (defn readiness-bar [readiness cols]
   (let [pct (int (* (or readiness 0) 100))
@@ -43,16 +44,16 @@
         filled (int (* bar-width (or readiness 0)))]
     (str (apply str (repeat filled "█"))
          (apply str (repeat (- bar-width filled) "░"))
-         " " pct "%")))
+         (msg/t :fleet/readiness-pct {:pct pct}))))
 
 (defn format-pr-row [pr cols]
-  {:title (get pr :pr/title "Untitled")
+  {:title (get pr :pr/title (msg/t :pr/untitled))
    :repo  (get pr :pr/repo "")
    :readiness (readiness-bar (:pr/readiness pr) (min 15 (max 8 (quot cols 6))))
    :risk (risk-indicator (:pr/risk pr))})
 
 (defn render-title-bar [[cols rows]]
-  (layout/text [cols rows] " MINIFORGE │ PR Fleet"
+  (layout/text [cols rows] (msg/t :fleet/title)
                {:fg palette/status-info :bold? true}))
 
 (defn auto-scroll-offset
@@ -65,24 +66,24 @@
 
 (defn render-table [pr-items selected [cols rows]]
   (if (empty? pr-items)
-    (layout/text [cols rows] "  No PRs tracked. Use :add-repo to add repositories."
+    (layout/text [cols rows] (msg/t :fleet/empty)
                  {:fg :default})
     (let [title-width (max 10 (- cols 60))
           visible-count (max 0 (- rows 2))
           offset (auto-scroll-offset selected visible-count)]
       (layout/table [cols rows]
-        {:columns [{:key :title :header "PR Title" :width title-width}
-                   {:key :repo :header "Repository" :width 25}
-                   {:key :readiness :header "Readiness" :width 18}
-                   {:key :risk :header "Risk" :width 6}]
+        {:columns [{:key :title :header (msg/t :fleet/col-title) :width title-width}
+                   {:key :repo :header (msg/t :fleet/col-repo) :width 25}
+                   {:key :readiness :header (msg/t :fleet/col-readiness) :width 18}
+                   {:key :risk :header (msg/t :fleet/col-risk) :width 6}]
          :data (mapv #(format-pr-row % cols) pr-items)
          :selected-row selected
          :offset offset}))))
 
 (defn render-footer [flash-message [cols rows]]
   (layout/text [cols rows]
-    (str " j/k:navigate  Enter:detail  r:sync  b:kanban  ::cmd  q:quit"
-         (when flash-message (str "  │ " flash-message)))
+    (str (msg/t :fleet/footer)
+         (when flash-message (str (msg/t :fleet/flash-prefix) flash-message)))
     {:fg :default}))
 
 (defn render


### PR DESCRIPTION
Localization wave (item 3), first **tui-views** file. Bootstraps the tui-views message catalog (translator + `en-US.edn` + `messages` dep) — the component had none; this is the pattern for the remaining no-catalog UI components (tui-engine etc.).

Routes the 15 user-facing UI strings in `views/pr_fleet.clj` through the catalog: risk indicators (LOW/MED/HIGH/?/---), the readiness `%` suffix, the `Untitled` fallback, the ` MINIFORGE │ PR Fleet` title bar, the empty-state message, the four table column headers, and the footer + flash-message prefix. The `█`/`░` bar glyphs are structural (not flagged).

Verified: localization judge on `pr_fleet.clj` = **0**; fleet-risk tests pass (14/49 — risk labels resolve to the same values via the catalog); catalog keys resolve; poly + lint + GraalVM green.

First of several tui-views view files; the rest follow in subsequent PRs.