### PR TITLE
fix(policy-pack): custom detector resolution fails closed

### DIFF
--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/policy.clj
@@ -45,22 +45,12 @@
     (when-let [res (io/resource deployment-safety-pack-resource)]
       (edn/read-string (slurp res)))))
 
-(declare register-detectors!)
-
-(def ^:private detectors-registered
-  "Registers the deployment custom detectors exactly once, lazily. Registration
-   is NOT a namespace load-time side effect on purpose: register-custom-fn!
-   validates detector arity via JVM reflection, which throws under babashka/SCI
-   (the GraalVM-compat load check). Deref happens at gate time on the JVM."
-  (delay (register-detectors!)))
-
 (defn deployment-policy-packs
   "The policy packs the provision gate evaluates — the shipped deployment-safety
    pack. Empty when the pack resource is absent, in which case the :policy-pack
-   gate fails closed (no deploy without deployment policy). Ensures the custom
-   detectors are registered before the pack is evaluated."
+   gate fails closed (no deploy without deployment policy). The custom detectors
+   are registered at namespace load (see the bottom of this file)."
   []
-  @detectors-registered
   (if-let [pack @deployment-safety-pack] [pack] []))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -153,8 +143,7 @@
   (or (:artifact/content artifact) artifact))
 
 (defn- register-detectors!
-  "Register the deployment custom detectors. Invoked once via
-   `detectors-registered`, not at load time (see that delay's docstring)."
+  "Register the deployment custom detectors with the policy-pack registry."
   []
   (pp/register-custom-fn!
    'ai.miniforge.phase-deployment.policy/check-resource-count
@@ -162,6 +151,11 @@
   (pp/register-custom-fn!
    'ai.miniforge.phase-deployment.policy/check-gke-node-limit
    (fn [artifact ctx] (check-gke-node-limit (preview-content artifact) ctx))))
+
+;; Register at load: `register-custom-fn!` is now babashka-tolerant (see
+;; policy-pack detector-predicate?), so these bind reliably before any pack
+;; evaluation instead of being deferred to first use.
+(register-detectors!)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
@@ -34,9 +34,10 @@
      (mechanical capabilities are injected by the gate layer at load), else
      it is :none (unbindable — correct fail-loud);
    - a :custom rule with a resolvable :custom-fn binds to :custom;
-   - a :custom rule with no resolvable :custom-fn binds to :semantic (the
-     LLM-as-judge, always an available mechanism per N4-delta's :heuristic
-     class);
+   - a :custom rule that DECLARES a :custom-fn which does not resolve is :none
+     (unbindable — fail-loud; a broken registration, not a judge rule);
+   - a :custom rule with NO :custom-fn binds to :semantic (the LLM-as-judge,
+     always an available mechanism per N4-delta's :heuristic class);
    - anything else is :none.
 
    All public fns return data: a failed compilation yields an :invalid-input
@@ -82,9 +83,15 @@
           :none))
 
       (= :custom detection-type)
-      (if (detection/custom-fn-resolvable? rule)
-        :custom
-        :semantic)
+      (cond
+        (detection/custom-fn-resolvable? rule) :custom
+        ;; A rule that DECLARES a :custom-fn symbol which does not resolve is a
+        ;; broken registration (the detector namespace never registered it), not
+        ;; an intentional judge rule. Bind to :none so the compiler fails loud
+        ;; (`compile-rule-check` returns an :invalid-input anomaly) instead of
+        ;; silently routing it to the LLM judge — the failure mode from #1381.
+        (get-in rule [:rule/detection :custom-fn]) :none
+        :else :semantic)
 
       :else
       :none)))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
@@ -68,7 +68,9 @@
    or `:none` when the rule binds to no available mechanism.
 
    - :capability binds only if its `:capability` keyword is registered.
-   - :custom binds to :custom when its `:custom-fn` resolves, else :semantic.
+   - :custom binds to :custom when its `:custom-fn` resolves; to :none when a
+     `:custom-fn` is declared but unresolvable (fail-loud); to :semantic when no
+     `:custom-fn` is declared.
    - An unknown/missing detection type is :none."
   [rule]
   (let [detection-type (get-in rule [:rule/detection :type])]

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -399,12 +399,12 @@ depending on ambient namespace loading or raw var resolution."}
                  (.getDeclaredMethods (class f)))))
 
 (defn- detector-predicate?
-  "True when `f` is a custom detector fn with a 2-arity shape. Arity is verified
-   by JVM reflection; under babashka/SCI (whose fn classes expose no reflectable
-   `invoke` methods, or where reflection is unavailable) we cannot introspect, so
-   accept any fn rather than reject a valid detector — this lets detector
-   namespaces register at LOAD time on both runtimes, instead of deferring
-   registration to first use."
+  "True when `f` is a custom detector fn. On the JVM its 2-arity shape is verified
+   by reflection; under babashka/SCI (whose fn classes expose no reflectable
+   `invoke` methods, or where reflection is unavailable) arity cannot be
+   introspected, so any `fn?` is accepted rather than rejecting a valid detector
+   we cannot check — this lets detector namespaces register at LOAD time on both
+   runtimes, instead of deferring registration to first use."
   [f]
   (and (fn? f)
        (try

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -411,7 +411,9 @@ depending on ambient namespace loading or raw var resolution."}
          (or (declared-method? "invoke" 2 f)
              (variadic-accepts-arity? 2 f)
              (not (reflectable-invoke? f)))
-         (catch Throwable _ true))))
+         ;; Reflection/introspection failure (e.g. babashka) → accept the fn.
+         ;; Catch Exception, not Throwable, so JVM Errors are not masked.
+         (catch Exception _ true))))
 
 (defn register-custom-fn!
   "Register `f` as the detector implementation for `custom-fn-sym`.

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -391,12 +391,27 @@ depending on ambient namespace loading or raw var resolution."}
       (<= (.getRequiredArity f) arity)
       (catch Throwable _ false))))
 
+(defn- reflectable-invoke?
+  "True when `f`'s class declares any `invoke` method. JVM functions do; SCI
+   functions under babashka do not, so arity reflection is blind there."
+  [f]
+  (boolean (some #(= "invoke" (.getName ^java.lang.reflect.Method %))
+                 (.getDeclaredMethods (class f)))))
+
 (defn- detector-predicate?
-  "True when `f` is a custom detector predicate with a supported 2-arity shape."
+  "True when `f` is a custom detector fn with a 2-arity shape. Arity is verified
+   by JVM reflection; under babashka/SCI (whose fn classes expose no reflectable
+   `invoke` methods, or where reflection is unavailable) we cannot introspect, so
+   accept any fn rather than reject a valid detector — this lets detector
+   namespaces register at LOAD time on both runtimes, instead of deferring
+   registration to first use."
   [f]
   (and (fn? f)
-       (or (declared-method? "invoke" 2 f)
-           (variadic-accepts-arity? 2 f))))
+       (try
+         (or (declared-method? "invoke" 2 f)
+             (variadic-accepts-arity? 2 f)
+             (not (reflectable-invoke? f)))
+         (catch Throwable _ true))))
 
 (defn register-custom-fn!
   "Register `f` as the detector implementation for `custom-fn-sym`.

--- a/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj
@@ -108,8 +108,10 @@
               :custom-fn resolvable-custom-fn-sym}}))))
   (testing "a :custom rule with no :custom-fn binds to :semantic (always available)"
     (is (= :semantic (sut/resolve-detector {:rule/detection {:type :custom}}))))
-  (testing "a :custom rule with an unresolvable :custom-fn binds to :semantic"
-    (is (= :semantic
+  (testing "a :custom rule that DECLARES an unresolvable :custom-fn is :none —
+            fail-loud, not silently routed to the judge (a broken registration
+            is a defect, mirroring the unregistered-:capability case below)"
+    (is (= :none
            (sut/resolve-detector
             {:rule/detection {:type :custom :custom-fn 'no.such.ns/missing}})))))
 
@@ -142,6 +144,15 @@
       (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
       (is (= [:doomed] (get-in result [:anomaly/data :unbindable-rule-ids]))))))
+
+(deftest compile-pack-broken-custom-fn-fails-loud-test
+  (testing "a :custom rule declaring an unresolvable :custom-fn is unbindable —
+            the compiler names it instead of silently routing it to the judge"
+    (let [pack   {:pack/rules [{:rule/id :broken
+                                :rule/detection {:type :custom :custom-fn 'no.such.ns/missing}}]}
+          result (sut/compile-pack pack)]
+      (is (anomaly/anomaly? result))
+      (is (= [:broken] (get-in result [:anomaly/data :unbindable-rule-ids]))))))
 
 (deftest compile-pack-skips-disabled-rules-test
   (testing "a DISABLED unbindable rule does not fail compilation"

--- a/docs/pull-requests/2026-07-08-fix-custom-detector-fail-closed.md
+++ b/docs/pull-requests/2026-07-08-fix-custom-detector-fail-closed.md
@@ -10,9 +10,9 @@ Branch: `fix/custom-detector-fail-closed`
 
 ## Summary
 
-Before this change, a `:custom` rule that declared a `:custom-fn` symbol which
-did not resolve bound silently to `:semantic` (the LLM judge) — indistinguishable
-from a rule that intentionally has no detector. That is the #1381 failure mode as a class: a
+Before this change, when a `:custom` rule declared a `:custom-fn` symbol that did
+not resolve, the rule bound silently to `:semantic` (the LLM judge) —
+indistinguishable from a rule that intentionally has no detector. That is the #1381 failure mode as a class: a
 broken registration silently degrades to the judge instead of failing loud.
 `resolve-detector` now binds such a rule to `:none`, so `compile-pack` names it
 as unbindable (an `:invalid-input` anomaly) — mirroring the existing

--- a/docs/pull-requests/2026-07-08-fix-custom-detector-fail-closed.md
+++ b/docs/pull-requests/2026-07-08-fix-custom-detector-fail-closed.md
@@ -1,0 +1,46 @@
+<!--
+  Title: Custom detector resolution fails closed
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: custom detector resolution fails closed
+
+Branch: `fix/custom-detector-fail-closed`
+
+## Summary
+
+A `:custom` rule that declares a `:custom-fn` symbol which does not resolve used
+to bind silently to `:semantic` (the LLM judge) — indistinguishable from a rule
+that intentionally has no detector. That is the #1381 failure mode as a class: a
+broken registration silently degrades to the judge instead of failing loud.
+`resolve-detector` now binds such a rule to `:none`, so `compile-pack` names it
+as unbindable (an `:invalid-input` anomaly) — mirroring the existing
+unregistered-`:capability` behavior. A rule with NO `:custom-fn` still binds to
+`:semantic` (intentional).
+
+## Reliable load-time registration
+
+The guard only works if registration is reliable at resolution time. `#1381`
+had to register the deployment detectors *lazily* because `register-custom-fn!`
+validated arity via JVM reflection, which throws under babashka/SCI. Root-cause
+fix: `detector-predicate?` now accepts a fn when reflection can't introspect it
+(babashka), so registration works at load time on both runtimes. The deployment
+detectors register at namespace load again (the lazy `delay` workaround is
+gone).
+
+## Changes
+
+- `detection.clj`: `detector-predicate?` is babashka-tolerant.
+- `compiler.clj`: `resolve-detector` binds a declared-but-unresolvable
+  `:custom-fn` to `:none`.
+- `phase-deployment/policy.clj`: register detectors at load (removed the lazy
+  `detectors-registered` delay).
+
+## Test plan
+
+- `resolve-detector` unresolvable-custom-fn case updated to `:none`; new
+  `compile-pack-broken-custom-fn-fails-loud-test`.
+- `bb test:graalvm` passes (load-time registration under babashka).
+- policy-pack + phase-deployment + gate suites: 68 tests, 589 assertions, 0
+  failures. `bb poly:check` clean.

--- a/docs/pull-requests/2026-07-08-fix-custom-detector-fail-closed.md
+++ b/docs/pull-requests/2026-07-08-fix-custom-detector-fail-closed.md
@@ -11,8 +11,8 @@ Branch: `fix/custom-detector-fail-closed`
 ## Summary
 
 A `:custom` rule that declares a `:custom-fn` symbol which does not resolve used
-to bind silently to `:semantic` (the LLM judge) — indistinguishable from a rule
-that intentionally has no detector. That is the #1381 failure mode as a class: a
+to bind — silently — to `:semantic` (the LLM judge), indistinguishable from a
+rule that intentionally has no detector. That is the #1381 failure mode as a class: a
 broken registration silently degrades to the judge instead of failing loud.
 `resolve-detector` now binds such a rule to `:none`, so `compile-pack` names it
 as unbindable (an `:invalid-input` anomaly) — mirroring the existing

--- a/docs/pull-requests/2026-07-08-fix-custom-detector-fail-closed.md
+++ b/docs/pull-requests/2026-07-08-fix-custom-detector-fail-closed.md
@@ -10,9 +10,9 @@ Branch: `fix/custom-detector-fail-closed`
 
 ## Summary
 
-A `:custom` rule that declares a `:custom-fn` symbol which does not resolve used
-to bind — silently — to `:semantic` (the LLM judge), indistinguishable from a
-rule that intentionally has no detector. That is the #1381 failure mode as a class: a
+Before this change, a `:custom` rule that declared a `:custom-fn` symbol which
+did not resolve bound silently to `:semantic` (the LLM judge) — indistinguishable
+from a rule that intentionally has no detector. That is the #1381 failure mode as a class: a
 broken registration silently degrades to the judge instead of failing loud.
 `resolve-detector` now binds such a rule to `:none`, so `compile-pack` names it
 as unbindable (an `:invalid-input` anomaly) — mirroring the existing


### PR DESCRIPTION
## Summary

A `:custom` rule that declares a `:custom-fn` which does not resolve bound
silently to `:semantic` (the LLM judge) — indistinguishable from a rule that
intentionally has no detector. That is the #1381 failure mode as a **class**: a
broken registration silently degrades to the judge instead of failing loud.

`resolve-detector` now binds such a rule to `:none`, so `compile-pack` names it
unbindable (an `:invalid-input` anomaly) — mirroring the existing
unregistered-`:capability` behavior. A rule with **no** `:custom-fn` still binds
to `:semantic` (intentional judge rule).

## Reliable load-time registration (root-cause of #1381's lazy workaround)

The guard only holds if registration is reliable at resolution time. #1381 had
to register the deployment detectors *lazily* because `register-custom-fn!`
validated arity via JVM reflection, which is blind to SCI fns under babashka.
`detector-predicate?` now accepts a fn when reflection can't introspect it, so
registration works at **load** time on both runtimes. The deployment detectors
register at load again (the lazy `delay` is gone).

## Changes

- `detection.clj`: `detector-predicate?` is babashka-tolerant.
- `compiler.clj`: `resolve-detector` binds a declared-but-unresolvable
  `:custom-fn` to `:none`.
- `phase-deployment/policy.clj`: register detectors at load.

## Test plan

- `resolve-detector` unresolvable-custom-fn case → `:none`; new
  `compile-pack-broken-custom-fn-fails-loud-test`.
- `bb test:graalvm` passes (load-time registration under babashka).
- policy-pack + phase-deployment + gate suites: 68 tests, 589 assertions, 0
  failures. `bb poly:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)