### PR TITLE
fix(policy-pack): approved instance types are data, not a regex

### DIFF
--- a/components/policy-pack/resources/policy_pack/packs/terraform-aws-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/terraform-aws-1.0.0.pack.edn
@@ -108,8 +108,11 @@
    :rule/category    "500"
    :rule/applies-to  {:file-globs ["**/*.tf"]
                        :phases #{:implement :review}}
-   :rule/detection   {:type :content-scan
-                      :pattern "instance_type\\s*=\\s*\"(?!t3\\.|t4g\\.|m5\\.|m6i\\.|c5\\.|c6i\\.|r5\\.|r6i\\.)"}
+   ;; The approved families are DATA in :detector-config — not baked into a
+   ;; regex — read by the builtin check-approved-instance-types detector.
+   :rule/detection   {:type :custom
+                      :custom-fn ai.miniforge.policy-pack.builtin-detectors/check-approved-instance-types
+                      :detector-config {:approved-families ["t3" "t4g" "m5" "m6i" "c5" "c6i" "r5" "r6i"]}}
    :rule/enforcement {:action :require-approval
                       :message "Instance type is not in the approved list (t3, t4g, m5, m6i, c5, c6i, r5, r6i families)."
                       :remediation "Use an instance type from the approved families: t3, t4g, m5, m6i, c5, c6i, r5, r6i."}}]

--- a/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj
@@ -1,0 +1,71 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.builtin-detectors
+  "Built-in :custom detectors, registered at namespace load. These exist so a
+   rule's policy parameters stay DATA — read from the rule's
+   `:rule/detection :detector-config` — instead of being encoded in a regex.
+   The rule reaches the detector via `:policy-pack/rule` in context (threaded in
+   by `detection/run-resolved-custom`)."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.policy-pack.detection :as detection]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Approved EC2 instance types
+
+(def ^:private default-approved-instance-families
+  "Fallback approved EC2 instance-type families, used only when a rule supplies
+   no :approved-families in its :detector-config."
+  ["t3" "t4g" "m5" "m6i" "c5" "c6i" "r5" "r6i"])
+
+(defn- approved-families
+  [context]
+  (set (or (get-in context [:policy-pack/rule :rule/detection :detector-config :approved-families])
+           default-approved-instance-families)))
+
+(defn- instance-type-literals
+  "String literals assigned to instance_type in Terraform content, e.g.
+   `instance_type = \"t3.micro\"` -> \"t3.micro\". Variable references
+   (`instance_type = var.x`) carry no literal and are not evaluated here — the
+   same limitation the prior regex had."
+  [content]
+  (map second (re-seq #"instance_type\s*=\s*\"([^\"]+)\"" (str content))))
+
+(defn check-approved-instance-types
+  "Flag EC2 `instance_type` literals whose family is not in the approved set. The
+   approved families come from the rule's `:detector-config :approved-families`
+   (data), falling back to `default-approved-instance-families`."
+  [artifact context]
+  (let [approved  (approved-families context)
+        offenders (remove #(contains? approved (first (str/split % #"\.")))
+                          (instance-type-literals (:artifact/content artifact)))]
+    (when (seq offenders)
+      {:matches  (vec offenders)
+       :message  (get-in context [:policy-pack/rule :rule/enforcement :message])})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registration (load-time side effect — see ns docstring)
+
+(defn- register!
+  []
+  (detection/register-custom-fn!
+   'ai.miniforge.policy-pack.builtin-detectors/check-approved-instance-types
+   check-approved-instance-types))
+
+(register!)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj
@@ -47,11 +47,13 @@
 
 (defn- instance-type-literals
   "String literals assigned to instance_type in Terraform content, e.g.
-   `instance_type = \"t3.micro\"` -> \"t3.micro\". Variable references
-   (`instance_type = var.x`) carry no literal and are not evaluated here — the
-   same limitation the prior regex had."
+   `instance_type = \"t3.micro\"` -> \"t3.micro\". The capture is `*`, not `+`, so
+   an empty literal (`instance_type = \"\"`) is captured (and later flagged as a
+   non-family) rather than ignored. Variable references (`instance_type = var.x`)
+   carry no literal and are not evaluated here — the same limitation the prior
+   regex had."
   [content]
-  (map second (re-seq #"instance_type\s*=\s*\"([^\"]+)\"" (str content))))
+  (map second (re-seq #"instance_type\s*=\s*\"([^\"]*)\"" (str content))))
 
 (defn- approved?
   "True when `literal` has a `family.size` shape whose family is approved. A

--- a/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj
@@ -23,7 +23,6 @@
    The rule reaches the detector via `:policy-pack/rule` in context (threaded in
    by `detection/run-resolved-custom`)."
   (:require
-   [clojure.string :as str]
    [ai.miniforge.policy-pack.detection :as detection]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -35,9 +34,16 @@
   ["t3" "t4g" "m5" "m6i" "c5" "c6i" "r5" "r6i"])
 
 (defn- approved-families
+  "The approved-family set for this rule. A configured `:approved-families` must
+   be a sequential collection of strings; anything else is a misconfigured pack
+   and throws (surfaced as a :custom-error by `run-resolved-custom`) rather than
+   silently coercing — e.g. a bare string would `set` into a char-set."
   [context]
-  (set (or (get-in context [:policy-pack/rule :rule/detection :detector-config :approved-families])
-           default-approved-instance-families)))
+  (let [configured (get-in context [:policy-pack/rule :rule/detection :detector-config :approved-families])]
+    (when (and configured (not (and (sequential? configured) (every? string? configured))))
+      (throw (ex-info "approved-families must be a sequential collection of strings"
+                      {:approved-families configured})))
+    (set (or configured default-approved-instance-families))))
 
 (defn- instance-type-literals
   "String literals assigned to instance_type in Terraform content, e.g.
@@ -47,13 +53,21 @@
   [content]
   (map second (re-seq #"instance_type\s*=\s*\"([^\"]+)\"" (str content))))
 
+(defn- approved?
+  "True when `literal` has a `family.size` shape whose family is approved. A
+   dotless/placeholder literal (\"t3\", \"\") has no family and is never approved
+   — matching the prior regex, which required a `family.` prefix."
+  [approved-set literal]
+  (boolean (when-let [[_ fam] (re-matches #"([^.]+)\..+" literal)]
+             (contains? approved-set fam))))
+
 (defn check-approved-instance-types
-  "Flag EC2 `instance_type` literals whose family is not in the approved set. The
-   approved families come from the rule's `:detector-config :approved-families`
-   (data), falling back to `default-approved-instance-families`."
+  "Flag EC2 `instance_type` literals whose family is not approved. The approved
+   families come from the rule's `:detector-config :approved-families` (data),
+   falling back to `default-approved-instance-families`."
   [artifact context]
   (let [approved  (approved-families context)
-        offenders (remove #(contains? approved (first (str/split % #"\.")))
+        offenders (remove #(approved? approved %)
                           (instance-type-literals (:artifact/content artifact)))]
     (when (seq offenders)
       {:matches  (vec offenders)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -449,10 +449,15 @@ depending on ambient namespace loading or raw var resolution."}
   "Run an already-resolved custom fn against `artifact`/`context`, adapting
    the result (or a thrown exception) into a violation map, or nil on pass.
    The fn is resolved once by the caller, so neither `detect-custom` nor the
-   dispatcher resolves twice."
+   dispatcher resolves twice.
+
+   The rule is threaded into `context` under `:policy-pack/rule` so a detector
+   can read its own `:rule/detection :detector-config` (data-driven policy) and
+   enforcement message — parity with the by-type detectors, which receive the
+   rule directly."
   [f rule artifact context]
   (try
-    (when-let [result (f artifact context)]
+    (when-let [result (f artifact (assoc context :policy-pack/rule rule))]
       (assoc result
              :type :custom
              :rule-id (:rule/id rule)))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -31,6 +31,10 @@
    [ai.miniforge.policy-pack.interface.mapping :as mapping]
    [ai.miniforge.policy-pack.interface.prompt-template :as prompt-template]
    [ai.miniforge.policy-pack.detection :as detection]
+   ;; Loaded for its side effect: registers the built-in :custom detectors so
+   ;; the fail-closed resolver (compiler/resolve-detector) sees them whenever a
+   ;; pack is compiled through this boundary.
+   [ai.miniforge.policy-pack.builtin-detectors]
    [ai.miniforge.policy-pack.mdc-compiler :as mdc-compiler]
    [ai.miniforge.policy-pack.software-factory :as software-factory]))
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -144,7 +144,10 @@
      (the ABSENCE of a match is a violation, e.g. a required header)
    - :multiline? - when true, match patterns against the whole content instead
      of line-by-line (for patterns that span lines)
-   - :email-pattern - secondary regex (e.g. a copyright-header email check)"
+   - :email-pattern - secondary regex (e.g. a copyright-header email check)
+   - :detector-config - a data map of policy parameters for a :custom detector
+     (e.g. an approved-values list), so the policy stays data instead of being
+     baked into a regex. The detector reads it via :policy-pack/rule in context."
   [:map
    [:type DetectionType]
    [:pattern {:optional true} [:or string? [:fn {:error/message "should be a regex pattern"} #(instance? java.util.regex.Pattern %)]]]
@@ -154,6 +157,7 @@
    [:capability {:optional true} keyword?]
    [:mode {:optional true} DetectionMode]
    [:multiline? {:optional true} boolean?]
+   [:detector-config {:optional true} [:map-of keyword? any?]]
    [:email-pattern {:optional true} string?]])
 
 (def RuleEnforcementConfig

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -144,10 +144,10 @@
      (the ABSENCE of a match is a violation, e.g. a required header)
    - :multiline? - when true, match patterns against the whole content instead
      of line-by-line (for patterns that span lines)
-   - :email-pattern - secondary regex (e.g. a copyright-header email check)
    - :detector-config - a data map of policy parameters for a :custom detector
      (e.g. an approved-values list), so the policy stays data instead of being
-     baked into a regex. The detector reads it via :policy-pack/rule in context."
+     baked into a regex. The detector reads it via :policy-pack/rule in context.
+   - :email-pattern - secondary regex (e.g. a copyright-header email check)"
   [:map
    [:type DetectionType]
    [:pattern {:optional true} [:or string? [:fn {:error/message "should be a regex pattern"} #(instance? java.util.regex.Pattern %)]]]

--- a/components/policy-pack/test/ai/miniforge/policy_pack/builtin_detectors_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/builtin_detectors_test.clj
@@ -43,7 +43,12 @@
     (testing "instance_type literals are checked against the approved families"
       (is (not (fires? rule "instance_type = \"t3.micro\"")) "approved family passes")
       (is (fires? rule "instance_type = \"p4d.24xlarge\"") "unapproved family fires")
+      (is (fires? rule "instance_type = \"t3\"") "dotless/placeholder literal is not a family and fires")
       (is (not (fires? rule "instance_type = var.size")) "variable ref is not evaluated"))
+    (testing "a misconfigured :approved-families fails loud (not a silent char-set)"
+      (let [bad (assoc-in rule [:rule/detection :detector-config :approved-families] "t3")
+            v   (detection/detect-custom bad {:artifact/content "instance_type = \"t3.micro\""} {})]
+        (is (= :custom-error (:type v)) "surfaces as a custom-error, not a bogus pass/fail")))
     (testing "the approved families are DATA in :detector-config, not a regex —
               changing the list changes the outcome"
       (let [p4d-only (assoc-in rule [:rule/detection :detector-config :approved-families] ["p4d"])]

--- a/components/policy-pack/test/ai/miniforge/policy_pack/builtin_detectors_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/builtin_detectors_test.clj
@@ -44,6 +44,7 @@
       (is (not (fires? rule "instance_type = \"t3.micro\"")) "approved family passes")
       (is (fires? rule "instance_type = \"p4d.24xlarge\"") "unapproved family fires")
       (is (fires? rule "instance_type = \"t3\"") "dotless/placeholder literal is not a family and fires")
+      (is (fires? rule "instance_type = \"\"") "empty placeholder literal fires")
       (is (not (fires? rule "instance_type = var.size")) "variable ref is not evaluated"))
     (testing "a misconfigured :approved-families fails loud (not a silent char-set)"
       (let [bad (assoc-in rule [:rule/detection :detector-config :approved-families] "t3")

--- a/components/policy-pack/test/ai/miniforge/policy_pack/builtin_detectors_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/builtin_detectors_test.clj
@@ -1,0 +1,56 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.builtin-detectors-test
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.policy-pack.compiler :as compiler]
+   [ai.miniforge.policy-pack.detection :as detection]
+   ;; loaded for its registration side effect
+   [ai.miniforge.policy-pack.builtin-detectors]))
+
+(defn- tf-rule [id]
+  (->> (edn/read-string (slurp (io/resource "policy_pack/packs/terraform-aws-1.0.0.pack.edn")))
+       :pack/rules
+       (filter #(= id (:rule/id %)))
+       first))
+
+(defn- fires? [rule content]
+  (boolean (detection/detect-custom rule {:artifact/content content} {})))
+
+(deftest approved-instance-types-detector-test
+  (let [rule (tf-rule :tf-aws/approved-instance-types)]
+    (testing "the rule is a registered :custom detector (binds :custom, not the judge)"
+      (is (some? rule))
+      (is (= :custom (compiler/resolve-detector rule))))
+    (testing "instance_type literals are checked against the approved families"
+      (is (not (fires? rule "instance_type = \"t3.micro\"")) "approved family passes")
+      (is (fires? rule "instance_type = \"p4d.24xlarge\"") "unapproved family fires")
+      (is (not (fires? rule "instance_type = var.size")) "variable ref is not evaluated"))
+    (testing "the approved families are DATA in :detector-config, not a regex —
+              changing the list changes the outcome"
+      (let [p4d-only (assoc-in rule [:rule/detection :detector-config :approved-families] ["p4d"])]
+        (is (not (fires? p4d-only "instance_type = \"p4d.24xlarge\"")) "now approved")
+        (is (fires? p4d-only "instance_type = \"t3.micro\"") "now unapproved")))
+    (testing "the violation carries the rule's enforcement message"
+      (let [v (detection/detect-custom rule {:artifact/content "instance_type = \"p4d.24xlarge\""} {})]
+        (is (= :tf-aws/approved-instance-types (:rule-id v)))
+        (is (= ["p4d.24xlarge"] (:matches v)))
+        (is (re-find #"approved list" (:message v)))))))

--- a/docs/pull-requests/2026-07-08-fix-instance-types-as-data.md
+++ b/docs/pull-requests/2026-07-08-fix-instance-types-as-data.md
@@ -1,0 +1,41 @@
+<!--
+  Title: Approved instance types as data
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: approved instance types are data, not a regex
+
+Branch: `fix/instance-types-as-data`
+
+## Summary
+
+`tf-aws/approved-instance-types` encoded its allowlist inside a negative-lookahead
+regex (`instance_type = "(?!t3\.|t4g\.|m5\.|...)"`) — policy baked into a pattern,
+opaque and unmaintainable. The approved families are now DATA on the rule
+(`:rule/detection :detector-config :approved-families`), read by a built-in
+`:custom` detector. Changing the approved list is a data edit, not a regex edit.
+
+## Mechanism
+
+- `detection/run-resolved-custom` threads the rule into `context` under
+  `:policy-pack/rule`, so a `:custom` detector can read its own
+  `:detector-config` and enforcement message — parity with the by-type
+  detectors, which already receive the rule.
+- New `:detector-config` key on `RuleDetection` (a data map of policy params).
+- `policy-pack.builtin-detectors/check-approved-instance-types` reads the
+  approved families from that data and flags `instance_type` literals whose
+  family is not approved. It registers at load; the interface loads it so the
+  fail-closed resolver (#1402) sees it whenever a pack compiles.
+
+The variable-reference case (`instance_type = var.x`) is still not evaluated —
+that limitation is inherent to static scanning and was equally true of the regex.
+
+## Test plan
+
+- `builtin-detectors-test`: rule binds `:custom`; approved passes, unapproved
+  fires; changing `:approved-families` flips the outcome (proves it is data);
+  violation carries the enforcement message.
+- policy-pack + gate suites: 104 tests, 749 assertions, 0 failures.
+- `bb test:graalvm` passes (load-time registration under babashka).
+- `bb poly:check` clean.


### PR DESCRIPTION
## Summary

`tf-aws/approved-instance-types` encoded its allowlist inside a negative-lookahead
regex (`instance_type = "(?!t3\.|t4g\.|m5\.|...)"`) — policy baked into a
pattern. The approved families are now **data** on the rule
(`:rule/detection :detector-config :approved-families`), read by a built-in
`:custom` detector. Changing the approved list is a data edit, not a regex edit.

## Mechanism

- `detection/run-resolved-custom` threads the rule into `context` under
  `:policy-pack/rule`, so a `:custom` detector can read its own
  `:detector-config` and enforcement message — parity with the by-type
  detectors.
- New `:detector-config` key on `RuleDetection`.
- `builtin-detectors/check-approved-instance-types` reads the families from that
  data; registers at load; the interface loads it so the fail-closed resolver
  (#1402) sees it whenever a pack compiles.

The `instance_type = var.x` case is still not evaluated — inherent to static
scanning, and equally true of the old regex.

## Test plan

- `builtin-detectors-test`: rule binds `:custom`; approved passes, unapproved
  fires; changing `:approved-families` flips the outcome (proves it is data);
  violation carries the enforcement message.
- policy-pack + gate suites: 104 tests, 749 assertions, 0 failures.
- `bb test:graalvm` passes; `bb poly:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)