### PR TITLE
fix(tool): return anomaly for invalid ids

### DIFF
--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -207,18 +207,22 @@
    - :description - What the tool does
    - :parameters  - Map of param specs {:param {:type :string :required true}}
    - :handler     - (fn [params context] -> result)
-   - :metadata    - Optional metadata map"
+   - :metadata    - Optional metadata map
+
+   Returns a tool on success, or an `:invalid-input` anomaly when `:id` is not
+   a namespaced keyword."
   [{:keys [id name description parameters handler metadata]
     :or {parameters {} metadata {}}}]
-  (when-not (valid-tool-id? id)
-    (throw (ex-info (messages/t :tool/id-must-be-keyword)
-                    {:id id})))
-  (->FunctionTool id
-                  (or name (clojure.core/name id))
-                  description
-                  parameters
-                  handler
-                  metadata))
+  (if-not (valid-tool-id? id)
+    (anomaly/anomaly :invalid-input
+                     (messages/t :tool/id-must-be-keyword)
+                     {:id id})
+    (->FunctionTool id
+                    (or name (clojure.core/name id))
+                    description
+                    parameters
+                    handler
+                    metadata)))
 
 (defn create-registry
   "Create a new tool registry.

--- a/components/tool/src/ai/miniforge/tool/interface.clj
+++ b/components/tool/src/ai/miniforge/tool/interface.clj
@@ -53,6 +53,9 @@
    - :handler     - (fn [params context] -> result)
    - :metadata    - Optional metadata map
 
+   Returns a tool on success, or an `:invalid-input` anomaly when `:id` is not
+   a namespaced keyword.
+
    Example:
      (create-tool
        {:id :tools/greet

--- a/components/tool/test/ai/miniforge/tool/interface_test.clj
+++ b/components/tool/test/ai/miniforge/tool/interface_test.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.tool.interface-test
   (:require [clojure.test :as test :refer [deftest testing is]]
+            [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.tool.interface :as tool]
             [ai.miniforge.event-stream.interface :as es]))
 
@@ -55,10 +56,12 @@
       (is (some? tool))
       (is (= :test/simple (tool/tool-id tool)))))
 
-  (testing "throws on non-namespaced id"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (tool/create-tool {:id :no-namespace
-                                    :handler (constantly :ok)})))))
+  (testing "returns anomaly on non-namespaced id"
+    (let [result (tool/create-tool {:id :no-namespace
+                                    :handler (constantly :ok)})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :no-namespace (get-in result [:anomaly/data :id]))))))
 
 (deftest tool-info-test
   (testing "returns tool information"

--- a/docs/pull-requests/2026-07-08-fix-tool-create-anomaly.md
+++ b/docs/pull-requests/2026-07-08-fix-tool-create-anomaly.md
@@ -1,0 +1,42 @@
+<!--
+  Title: Fix Tool Create Anomaly
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: Return anomaly for invalid tool IDs
+
+## Overview
+
+This PR changes `tool/create-tool` invalid-id handling from exception control
+flow to an anomaly return value.
+
+## Motivation
+
+`components/tool` is not a boundary namespace. Invalid user-provided tool
+configuration is normal data validation failure, so it should return an anomaly
+instead of throwing an `ex-info`.
+
+## Changes in Detail
+
+- Return `:invalid-input` anomaly data when `:id` is not a namespaced keyword.
+- Update public `create-tool` documentation to describe the anomaly return.
+- Update tests to assert anomaly shape instead of exception behavior.
+
+## Testing Plan
+
+- `bb pre-commit`
+
+## Deployment Plan
+
+No deployment steps. Merge after CI and review pass.
+
+## Related Issues/PRs
+
+- Follow-up from the current `bb review` exceptions-as-data finding.
+
+## Checklist
+
+- [ ] Validate the invalid tool-id path returns an anomaly.
+- [ ] Run pre-commit validation.
+- [ ] Open PR and resolve review comments.


### PR DESCRIPTION
# fix: Return anomaly for invalid tool IDs

## Overview

This PR changes `tool/create-tool` invalid-id handling from exception control
flow to an anomaly return value.

## Motivation

`components/tool` is not a boundary namespace. Invalid user-provided tool
configuration is normal data validation failure, so it should return an anomaly
instead of throwing an `ex-info`.

## Changes in Detail

- Return `:invalid-input` anomaly data when `:id` is not a namespaced keyword.
- Update public `create-tool` documentation to describe the anomaly return.
- Update tests to assert anomaly shape instead of exception behavior.

## Testing Plan

- `bb pre-commit`

## Deployment Plan

No deployment steps. Merge after CI and review pass.

## Related Issues/PRs

- Follow-up from the current `bb review` exceptions-as-data finding.

## Checklist

- [ ] Validate the invalid tool-id path returns an anomaly.
- [ ] Run pre-commit validation.
- [ ] Open PR and resolve review comments.
