### PR TITLE
feat(policy-calibration): majority-vote consensus (trial + run level)

### DIFF
--- a/components/policy-calibration/src/ai/miniforge/policy_calibration/core.clj
+++ b/components/policy-calibration/src/ai/miniforge/policy_calibration/core.clj
@@ -45,29 +45,66 @@
 ;; a backend/format-error cell is not evidence a rule is clean, and a rule with
 ;; no successful evaluation on its fixtures cannot be certified.
 
+(defn- strict-majority?
+  "True when `part` is more than half of `whole` — an outright majority, not a
+   tie. The shared predicate for both consensus levels (trials within a fixture,
+   passing runs among the evaluated). A tie is NOT a majority."
+  [part whole]
+  (> part (/ whole 2.0)))
+
+(defn- majority-fired?
+  "Over the OK trials of one fixture, did the rule fire in a strict majority?
+   Trials are the judge's repeated votes on the SAME cell; the consensus vote —
+   not any single stray call — is the fixture's verdict. This denoises transient
+   judge FP/FN, and, because the judge is batched (one call scores every rule on
+   a file), suppresses a single haywire call that would otherwise flip several
+   rules at once. Ties (an even OK-trial count split evenly) resolve to NOT
+   fired: a rule must win an outright majority to be charged a false positive or
+   credited a catch, so ambiguous 50/50 evidence never gates and never inflates
+   recall."
+  [ok-count fired-count]
+  (strict-majority? fired-count ok-count))
+
 (defn score-rule
   "Score one rule against a single run's cells. `cell-at` is
-   (fn [fixture-rel trial] -> cell). Returns
-   {:clean-fp :recall :evaluated? :failed :gate-ready? :fp-cases :fn-cases}."
+   (fn [fixture-rel trial] -> cell). Each fixture's verdict is the MAJORITY vote
+   across its OK trials (see `majority-fired?`) — a single stray trial does not
+   decide the cell. Returns
+   {:clean-fp :recall :evaluated? :failed :gate-ready? :fp-cases :fn-cases},
+   where :clean-fp and recall count FIXTURES (by consensus verdict), not raw
+   (fixture, trial) cells."
   [rule fixtures trials gate-bar cell-at]
-  (let [rid      (:rule/id rule)
-        seeded?  (fn [f] (contains? (:seeded f) rid))
-        clean-fx (remove seeded? fixtures)
-        viol-fx  (filter seeded? fixtures)
-        ok?      (fn [f t] (cell-ok? (cell-at (:rel f) t)))
-        fired?   (fn [f t] (contains? (cell-fired (cell-at (:rel f) t)) rid))
-        why      (fn [f t] (get (cell-why (cell-at (:rel f) t)) rid))
-        fp-cases (vec (for [f clean-fx t (range trials) :when (and (ok? f t) (fired? f t))]
-                        {:fixture (:rel f) :judge-said (why f t)}))
-        viol-ok  (vec (for [f viol-fx t (range trials) :when (ok? f t)] [f t]))
-        fn-cases (vec (for [[f t] viol-ok :when (not (fired? f t))] {:fixture (:rel f)}))
-        n-ok     (count viol-ok)
-        recall   (if (pos? n-ok) (/ (double (- n-ok (count fn-cases))) n-ok) 1.0)
-        clean-fp (count fp-cases)
-        clean-ok (count (for [f clean-fx t (range trials) :when (ok? f t)] 1))
-        failed   (count (for [f fixtures t (range trials) :when (not (ok? f t))] 1))
-        evaluated?  (and (or (empty? clean-fx) (pos? clean-ok))
-                         (or (empty? viol-fx) (pos? n-ok)))
+  (let [rid       (:rule/id rule)
+        seeded?   (fn [f] (contains? (:seeded f) rid))
+        clean-fx  (remove seeded? fixtures)
+        viol-fx   (filter seeded? fixtures)
+        ok?       (fn [f t] (cell-ok? (cell-at (:rel f) t)))
+        fired?    (fn [f t] (contains? (cell-fired (cell-at (:rel f) t)) rid))
+        why       (fn [f t] (get (cell-why (cell-at (:rel f) t)) rid))
+        ;; per-fixture consensus verdict across the OK trials
+        verdict   (fn [f]
+                    ;; realize once (filterv) — oks/fires are each traversed
+                    ;; several times (count/some), and each pass re-runs the
+                    ;; cell lookup
+                    (let [oks   (filterv #(ok? f %) (range trials))
+                          fires (filterv #(fired? f %) oks)]
+                      {:evaluated? (boolean (seq oks))
+                       :fired?     (majority-fired? (count oks) (count fires))
+                       :why        (some #(why f %) fires)}))
+        clean-v   (mapv (fn [f] [f (verdict f)]) clean-fx)
+        viol-v    (mapv (fn [f] [f (verdict f)]) viol-fx)
+        clean-ev  (filterv (fn [[_ v]] (:evaluated? v)) clean-v)
+        viol-ev   (filterv (fn [[_ v]] (:evaluated? v)) viol-v)
+        fp-cases  (vec (for [[f v] clean-ev :when (:fired? v)]
+                         {:fixture (:rel f) :judge-said (:why v)}))
+        fn-cases  (vec (for [[f v] viol-ev :when (not (:fired? v))]
+                         {:fixture (:rel f)}))
+        n-ev      (count viol-ev)
+        recall    (if (pos? n-ev) (/ (double (- n-ev (count fn-cases))) n-ev) 1.0)
+        clean-fp  (count fp-cases)
+        failed    (count (for [f fixtures t (range trials) :when (not (ok? f t))] 1))
+        evaluated?  (and (or (empty? clean-fx) (seq clean-ev))
+                         (or (empty? viol-fx) (pos? n-ev)))
         gate-ready? (and evaluated?
                          (<= clean-fp (:max-clean-fp gate-bar))
                          (>= recall (:min-recall gate-bar)))]
@@ -87,32 +124,56 @@
 (defn- round3 [x] (Double/parseDouble (format recall-precision-fmt x)))
 
 (defn aggregate
-  "Combine a rule's per-run scores into a stable verdict. CONSENSUS: gate-ready
-   only if it passes EVERY run; a verdict that flips across runs is unstable and
-   therefore not ready (a hard gate must be reliably ready, not on-average)."
+  "Combine a rule's per-run scores into a verdict. CONSENSUS: gate-ready if a
+   strict MAJORITY of the EVALUATED runs pass. Each run is already a trial-level
+   majority vote (see `majority-fired?`), so a run only fails on evidence
+   stronger than a single stray judge call; run-level majority then tolerates
+   one anomalous run without letting a rule that fails most runs gate.
+
+   A run that produced NO successfully-judged cells (a rate-limited / backend-out
+   window) is not evidence either way — it is EXCLUDED from the consensus, not
+   counted as a failure. Its default recall=1.0 / fp=0 would otherwise
+   masquerade as a clean pass. Certification still needs a strict majority of the
+   CONFIGURED runs to have evaluated; below that the record is `:inconclusive?`
+   and never gate-ready, so a run of crashes cannot certify by attrition.
+   `:stable?` reports unanimity among evaluated runs — a gate-ready-but-unstable
+   rule passed on majority, not consensus, and stays visible for audit."
   [per-run runs trials]
-  (let [flags        (mapv :gate-ready? per-run)
-        all-pass?    (every? true? flags)
-        recall-min   (round3 (apply min (map :recall per-run)))
-        recall-max   (round3 (apply max (map :recall per-run)))
-        clean-fp-max (apply max (map :clean-fp per-run))
+  (let [evaluated    (filterv :evaluated? per-run)
+        n-eval       (count evaluated)
+        enough-eval? (strict-majority? n-eval runs)
+        pass-runs    (count (filter :gate-ready? evaluated))
+        majority?    (and enough-eval? (strict-majority? pass-runs n-eval))
+        all-pass?    (and (pos? n-eval) (= pass-runs n-eval))
+        ;; recall / fp summarized over EVALUATED runs only — a crashed run's
+        ;; default recall=1.0 / fp=0 is not evidence
+        recalls      (map :recall evaluated)
+        fps          (map :clean-fp evaluated)
+        recall-min   (if (seq recalls) (round3 (apply min recalls)) 0.0)
+        recall-max   (if (seq recalls) (round3 (apply max recalls)) 0.0)
+        clean-fp-max (if (seq fps) (apply max fps) 0)
         ;; total non-:ok (errored / unparseable) judge cells across all runs —
         ;; a count of cells, not of runs
         failed-cells (reduce + (map :failed per-run))
         fp-cases     (vec (distinct (mapcat :fp-cases per-run)))
         fn-cases     (vec (distinct (mapcat :fn-cases per-run)))]
-    {:gate-ready?  all-pass?
-     :stable?      (or all-pass? (every? false? flags))
-     :runs         runs
-     :trials       trials
-     :run-verdicts flags
-     :recall-min   recall-min
-     :recall-max   recall-max
-     :clean-fp-max clean-fp-max
-     :evaluated?   (every? :evaluated? per-run)
-     :failed-cells failed-cells
-     :fp-cases     fp-cases
-     :fn-cases     fn-cases}))
+    {:gate-ready?     majority?
+     ;; unanimity among the EVALUATED runs — needs at least one, else an
+     ;; all-crashed (inconclusive) record would read as "stable"
+     :stable?         (and (pos? n-eval) (or all-pass? (zero? pass-runs)))
+     :runs            runs
+     :evaluated-runs  n-eval
+     :pass-runs       pass-runs
+     :inconclusive?   (not enough-eval?)
+     :trials          trials
+     :run-verdicts    (mapv :gate-ready? per-run)
+     :recall-min      recall-min
+     :recall-max      recall-max
+     :clean-fp-max    clean-fp-max
+     :evaluated?      (pos? n-eval)
+     :failed-cells    failed-cells
+     :fp-cases        fp-cases
+     :fn-cases        fn-cases}))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Orchestration — `judge-fn` is injected: (fn [rules fixture] -> cell).

--- a/components/policy-calibration/src/ai/miniforge/policy_calibration/interface.clj
+++ b/components/policy-calibration/src/ai/miniforge/policy_calibration/interface.clj
@@ -25,12 +25,17 @@
 
 ;; ---- scoring + aggregation ----
 (def score-rule
-  "Score one rule against a single run's cells.
+  "Score one rule against a single run's cells; each fixture's verdict is the
+   majority vote across its OK trials.
    (score-rule rule fixtures trials gate-bar cell-at) -> per-run score map."
   core/score-rule)
 (def aggregate
-  "Combine per-run scores into a stable consensus verdict.
-   (aggregate per-run runs trials) -> verdict map (gate-ready? only if every run passes)."
+  "Combine per-run scores into a consensus verdict.
+   (aggregate per-run runs trials) -> verdict map. gate-ready? iff a strict
+   majority of the EVALUATED runs pass AND a strict majority of the configured
+   runs actually evaluated (crashed/no-cell runs are excluded, not counted as
+   failures); otherwise :inconclusive?. :stable? reports unanimity among the
+   evaluated runs."
   core/aggregate)
 
 ;; ---- top-level ----

--- a/components/policy-calibration/test/ai/miniforge/policy_calibration/interface_test.clj
+++ b/components/policy-calibration/test/ai/miniforge/policy_calibration/interface_test.clj
@@ -123,18 +123,81 @@
       (is (not (:gate-ready? score))))))
 
 (deftest aggregate-consensus-test
-  (testing "gate-ready only if EVERY run passes; a flip is unstable and not ready"
+  (testing "gate-ready iff a strict majority of runs pass; :stable? reports unanimity"
     (let [ready {:clean-fp 0 :recall 1.0 :evaluated? true :failed 0 :gate-ready? true :fp-cases [] :fn-cases []}
           fail  {:clean-fp 1 :recall 1.0 :evaluated? true :failed 0 :gate-ready? false
                  :fp-cases [{:fixture "c.clj" :judge-said "x"}] :fn-cases []}]
       (let [a (sut/aggregate [ready ready ready] 3 1)]
-        (is (:gate-ready? a))
-        (is (:stable? a)))
+        (is (:gate-ready? a) "all runs pass -> gate-ready")
+        (is (:stable? a) "unanimous -> stable")
+        (is (= 3 (:pass-runs a))))
       (let [a (sut/aggregate [ready fail ready] 3 1)]
-        (is (not (:gate-ready? a)) "one failing run -> not gate-ready")
-        (is (not (:stable? a)) "verdict flipped across runs -> unstable")
+        (is (:gate-ready? a) "one anomalous run of three -> still a majority, gate-ready")
+        (is (not (:stable? a)) "verdict flipped across runs -> not stable (visible for audit)")
         (is (= [true false true] (:run-verdicts a)))
-        (is (= 1 (:clean-fp-max a)))))))
+        (is (= 2 (:pass-runs a)))
+        (is (= 1 (:clean-fp-max a))))
+      (let [a (sut/aggregate [ready fail fail] 3 1)]
+        (is (not (:gate-ready? a)) "fails a majority of runs -> not gate-ready")
+        (is (not (:stable? a)))
+        (is (= 1 (:pass-runs a))))
+      (let [a (sut/aggregate [fail fail fail] 3 1)]
+        (is (not (:gate-ready? a)) "all runs fail -> not gate-ready")
+        (is (:stable? a) "unanimous failure is stable"))))
+  (testing "a fully-failed run (no OK cells) is EXCLUDED from consensus, not counted as a fail"
+    (let [ready   {:clean-fp 0 :recall 1.0 :evaluated? true :failed 0 :gate-ready? true :fp-cases [] :fn-cases []}
+          fail    {:clean-fp 1 :recall 1.0 :evaluated? true :failed 0 :gate-ready? false
+                   :fp-cases [{:fixture "c.clj" :judge-said "x"}] :fn-cases []}
+          ;; a rate-limited run: every cell errored -> evaluated? nil, and its
+          ;; default recall=1.0 / fp=0 must NOT masquerade as a clean pass
+          crashed {:clean-fp 0 :recall 1.0 :evaluated? nil :failed 60 :gate-ready? nil :fp-cases [] :fn-cases []}]
+      (let [a (sut/aggregate [ready ready crashed] 3 1)]
+        (is (:gate-ready? a) "two clean runs + one crash -> majority of evaluated, gate-ready")
+        (is (= 2 (:evaluated-runs a)))
+        (is (= 2 (:pass-runs a)))
+        (is (not (:inconclusive? a))))
+      (let [a (sut/aggregate [ready fail crashed] 3 1)]
+        (is (not (:gate-ready? a)) "1 pass, 1 fail among 2 evaluated -> no majority")
+        (is (= 2 (:evaluated-runs a)))
+        (is (= 1 (:clean-fp-max a)) "fp summarized over evaluated runs only"))
+      (let [a (sut/aggregate [ready crashed crashed] 3 1)]
+        (is (not (:gate-ready? a)) "too few evaluated runs -> cannot certify by attrition")
+        (is (:inconclusive? a))
+        (is (= 1 (:evaluated-runs a))))
+      (let [a (sut/aggregate [crashed crashed crashed] 3 1)]
+        (is (not (:gate-ready? a)) "all runs crashed -> not gate-ready")
+        (is (:inconclusive? a))
+        (is (= 0 (:evaluated-runs a)))
+        (is (not (:stable? a)) "no evaluated runs -> not stable (an inconclusive record is not stable)")))))
+
+(deftest score-rule-trial-majority-denoises-test
+  (testing "a single stray trial does not decide a cell; the majority vote does"
+    (let [rule     {:rule/id :r/x}
+          fixtures [{:rel "clean.clj" :seeded #{}} {:rel "viol.clj" :seeded #{:r/x}}]
+          ;; clean fixture: one stray fire in three trials -> minority -> NOT an FP
+          cells    {["clean.clj" 0] (sut/cell-success #{:r/x} {:r/x "stray fire"})
+                    ["clean.clj" 1] (sut/cell-success #{} {})
+                    ["clean.clj" 2] (sut/cell-success #{} {})
+                    ;; violation fixture: caught in two of three trials -> majority catch
+                    ["viol.clj" 0]  (sut/cell-success #{:r/x} {:r/x "caught"})
+                    ["viol.clj" 1]  (sut/cell-success #{} {})
+                    ["viol.clj" 2]  (sut/cell-success #{:r/x} {:r/x "caught"})}
+          score    (sut/score-rule rule fixtures 3 bar (cell-at cells))]
+      (is (= 0 (:clean-fp score)) "1-of-3 stray fire on a clean fixture is denoised, not an FP")
+      (is (= 1.0 (:recall score)) "2-of-3 catches count as caught")
+      (is (:gate-ready? score))))
+  (testing "a majority-fire on a clean fixture IS an FP"
+    (let [rule     {:rule/id :r/x}
+          fixtures [{:rel "clean.clj" :seeded #{}} {:rel "viol.clj" :seeded #{:r/x}}]
+          cells    {["clean.clj" 0] (sut/cell-success #{:r/x} {:r/x "fire a"})
+                    ["clean.clj" 1] (sut/cell-success #{:r/x} {:r/x "fire b"})
+                    ["clean.clj" 2] (sut/cell-success #{} {})
+                    ["viol.clj" 0]  (sut/cell-success #{:r/x} {:r/x "caught"})
+                    ["viol.clj" 1]  (sut/cell-success #{:r/x} {:r/x "caught"})
+                    ["viol.clj" 2]  (sut/cell-success #{:r/x} {:r/x "caught"})}
+          score    (sut/score-rule rule fixtures 3 bar (cell-at cells))]
+      (is (= 1 (:clean-fp score)) "2-of-3 fires on a clean fixture is a real FP")
+      (is (not (:gate-ready? score))))))
 
 (deftest calibrate-end-to-end-test
   (testing "calibrate produces per-rule verdicts from an injected judge (no LLM)"


### PR DESCRIPTION
## What

Gate-readiness calibration certified a rule only if it passed **every** run with zero false-positives across every `(fixture, trial)` cell. As the corpus grew, that strict bar became statistically fragile — a genuinely gate-ready rule failed the record on stray judge noise.

Move consensus to a **majority vote** at both granularities where noise enters.

### Trial level (`score-rule`)
A fixture's verdict for a rule is the **majority of its OK trials**, not any single firing. Trials were previously counted as independent false-positive opportunities — more trials meant *more* FP exposure, backwards from their purpose. Because the judge is batched (one call scores every rule on a file), a single haywire call flipped several rules at once; a majority vote suppresses it.

- Applied symmetrically to false-positives **and** recall — never trades precision for recall.
- Ties resolve to NOT-fired, so ambiguous 50/50 evidence neither gates nor inflates recall.
- `:clean-fp` and recall now count **fixtures** by consensus verdict, not raw cells.

### Run level (`aggregate`)
Gate-ready iff a strict majority of the **evaluated** runs pass.

- A run that produced no successfully-judged cells (a rate-limited / backend-out window) is **excluded** from the consensus, not counted as a failure — its default `recall=1.0 / fp=0` must not masquerade as a clean pass.
- Below a majority of configured runs evaluating, the record is `:inconclusive?` and never gate-ready — a run of crashes cannot certify by attrition.
- `:stable?` still reports unanimity for audit; a gate-ready-but-unstable rule passed on majority, not consensus.

## Record

Keeps the shipped calibration record **unchanged** — no rule loses gate-readiness. This changes how *future* calibrations aggregate.

## Follow-up (tracked, not here)

A clean recalibration under majority reveals that the strict record's all-ready state was partly luck on borderline fixtures (e.g. self-documenting-code false-firing on `time_constants.clj`'s docstring — an exempt boundary). That is a corpus/rule-sharpening pass, separate from this methodology change.

## Test

65 assertions green, incl. new trial-majority denoise cases and crashed-run exclusion cases. Pre-commit smoke (330 tests) + GraalVM/bb compat green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)