### PR TITLE
fix(workflow): guard phase-boundary persist on a configured worktree

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -326,9 +326,17 @@
    destroying work on failure."
   [context phase-ctx]
   (when-let [executor (get context :execution/executor)]
-    (let [env-id (get context :execution/environment-id)
-          phase  (boundary-phase phase-ctx)]
-      (when env-id
+    (let [env-id  (get context :execution/environment-id)
+          mode    (get context :execution/mode)
+          workdir (get context :execution/worktree-path)
+          phase   (boundary-phase phase-ctx)]
+      ;; Governed mode pushes to a remote via the capsule, so it persists with or
+      ;; without a host worktree. LOCAL mode archives a git bundle of the
+      ;; worktree — with NO worktree-path there is nothing to archive and the git
+      ;; tier falls back to the process CWD, committing the HOST repo. That is
+      ;; what let a caller that drove run-pipeline without a sandbox leak a real
+      ;; commit into the live worktree. So local persistence requires a worktree.
+      (when (and env-id (or (= :governed mode) workdir))
         (try
           (let [result (dag/persist-workspace! executor env-id
                                                (persist-opts context phase env-id))

--- a/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
@@ -17,13 +17,8 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.runner-environment-test
-  "Tests for runner-environment — specifically the M1 base-sha
-   capture path that future label-action watchers consume.
-
-   This file appears in the artifact-warning-suppression PR because
-   `build-env-record` was touched in surrounding context (`:base-sha`
-   capture pre-dates this PR). These are additive regression tests only;
-   no behavior changes were made to runner-environment.clj itself."
+  "Regression tests for runner-environment's base-sha capture and
+   phase-boundary persistence guard behavior."
   (:require [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]

--- a/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
@@ -28,6 +28,7 @@
             [clojure.java.shell :as shell]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.dag-executor.interface :as dag]
             [ai.miniforge.dag-executor.result :as result]
             [ai.miniforge.workflow.runner-environment :as env]))
 
@@ -114,3 +115,27 @@
               ":base-sha must be absent (not nil) when HEAD can't be read"))
         (finally
           (.delete (io/file non-git-dir)))))))
+
+(deftest persist-at-phase-boundary-guards-on-worktree-test
+  (testing "an executor + env-id but NO :execution/worktree-path -> the persist
+            never runs; it must not fall back to committing the process CWD (the
+            leak that let a sandboxless run-pipeline commit into the live repo)"
+    (let [calls (atom 0)]
+      (with-redefs [dag/persist-workspace!
+                    (fn [& _] (swap! calls inc) (result/ok {:persisted? false}))]
+        (let [outcome (env/persist-workspace-at-phase-boundary!
+                       {:execution/executor ::stub-executor
+                        :execution/environment-id (random-uuid)}
+                       {})]
+          (is (nil? outcome) "no worktree -> no persist -> nil")
+          (is (zero? @calls) "persist-workspace! is never invoked without a worktree")))))
+  (testing "a configured worktree-path DOES run the persist"
+    (let [calls (atom 0)]
+      (with-redefs [dag/persist-workspace!
+                    (fn [& _] (swap! calls inc) (result/ok {:persisted? false}))]
+        (env/persist-workspace-at-phase-boundary!
+         {:execution/executor ::stub-executor
+          :execution/environment-id (random-uuid)
+          :execution/worktree-path "/tmp/sandbox-worktree"}
+         {})
+        (is (= 1 @calls) "persist runs when a worktree is configured")))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
@@ -17,8 +17,7 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.runner-environment-test
-  "Regression tests for runner-environment's base-sha capture and
-   phase-boundary persistence guard behavior."
+  "Regression tests for runner-environment's base-sha capture and phase-boundary persistence guard behavior."
   (:require [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -569,6 +569,10 @@
                 {:execution/executor :stub
                  :execution/mode :local
                  :execution/environment-id "env-1"
+                 ;; a real local run archives a worktree — carry its path so the
+                 ;; persist runs (worktree-less local persistence is a no-op guard
+                 ;; against committing the host CWD)
+                 :execution/worktree-path "/tmp/local-worktree"
                  :execution/environment-metadata {:base-branch "feat/foo"}
                  :event-stream :stub-stream
                  :execution/id #uuid "00000000-0000-0000-0000-000000000001"}


### PR DESCRIPTION
## Bug
`persist-workspace-at-phase-boundary!` runs whenever `:execution/executor` + `:execution/environment-id` are present, and passes `:execution/worktree-path` straight into `persist-opts` as `:workdir`. When `worktree-path` is **nil**, the git tier falls back to the process **CWD and commits the HOST repo**. So any caller that drives `run-pipeline` without a sandbox — e.g. a workflow integration test — leaks a real commit into the live worktree. (Observed downstream in thesium-workflows: a stray `"…phase completed"` commit that moved HEAD mid-commit and broke a real commit.)

## Fix
Guard the persist on a non-nil `:execution/worktree-path`: no configured worktree → no isolated workspace to persist → no-op. A genuine governed/local run always carries a worktree-path, so real phase-boundary persistence is unaffected.

## Test
`persist-at-phase-boundary-guards-on-worktree-test`: no-op (persist-workspace! never invoked) without a worktree; invoked once with a worktree-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)