### PR TITLE
fix(adapter-miniforge): wire deliver-decision to publish cp-decision-resolved event

### DIFF
--- a/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
+++ b/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
@@ -85,7 +85,8 @@
 
   (deliver-decision [_ agent-record decision-resolution]
     (try
-      (let [workflow-id (:agent/external-id agent-record)
+      (let [workflow-id (or (get-in agent-record [:agent/metadata :workflow-id])
+                            (:agent/external-id agent-record))
             event (es/cp-decision-resolved event-stream
                                            workflow-id
                                            (:decision/id decision-resolution)

--- a/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
+++ b/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
@@ -91,9 +91,15 @@
                                            workflow-id
                                            (:decision/id decision-resolution)
                                            (:decision/resolution decision-resolution)
-                                           (:decision/comment decision-resolution))]
-        (es/publish! event-stream event)
-        {:delivered? true})
+                                           (:decision/comment decision-resolution))
+            result (es/publish! event-stream event)]
+        (cond
+          (:rejected? result)
+          {:delivered? false :error (str "stream rejected: " (name (or (:reason result) :unknown)))}
+          (contains? result :anomaly/category)
+          {:delivered? false :error (str "stream anomaly: " (:anomaly/category result))}
+          :else
+          {:delivered? true}))
       (catch Exception e
         {:delivered? false :error (ex-message e)})))
 

--- a/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
+++ b/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
@@ -83,11 +83,18 @@
     ;; Return current known status.
     {:status (:agent/status agent-record)})
 
-  (deliver-decision [_ _agent-record _decision-resolution]
-    ;; For miniforge native agents, decisions flow through
-    ;; the approval system in event-stream.
-    ;; TODO: Wire to es/submit-approval when control-action integration is ready.
-    {:delivered? true})
+  (deliver-decision [_ agent-record decision-resolution]
+    (try
+      (let [workflow-id (:agent/external-id agent-record)
+            event (es/cp-decision-resolved event-stream
+                                           workflow-id
+                                           (:decision/id decision-resolution)
+                                           (:decision/resolution decision-resolution)
+                                           (:decision/comment decision-resolution))]
+        (es/publish! event-stream event)
+        {:delivered? true})
+      (catch Exception e
+        {:delivered? false :error (ex-message e)})))
 
   (send-command [_ agent-record command]
     (if-let [control-state (:control-state (:agent/metadata agent-record))]

--- a/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
+++ b/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
@@ -68,6 +68,37 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Protocol implementation
 
+(defn- delivery-failure
+  "Build the control-plane adapter decision-delivery failure shape."
+  [error]
+  {:delivered? false :error error})
+
+(defn- rejection-reason
+  "Return the event-stream rejection reason, preserving an explicit unknown default."
+  [result]
+  (name (get result :reason :unknown)))
+
+(defn- exception-message
+  "Return a useful exception message even when the throwable has no message."
+  [e]
+  (or (ex-message e)
+      (.getName (class e))))
+
+(defn- publish-result->delivery-result
+  "Translate the event-stream publish result into the adapter delivery contract."
+  [result]
+  (cond
+    (:rejected? result)
+    (delivery-failure (control-plane/t :adapter/stream-rejected
+                                       {:reason (rejection-reason result)}))
+
+    (contains? result :anomaly/category)
+    (delivery-failure (control-plane/t :adapter/stream-anomaly
+                                       {:category (:anomaly/category result)}))
+
+    :else
+    {:delivered? true}))
+
 (defrecord MiniforgeAdapter [event-stream]
   proto/ControlPlaneAdapter
 
@@ -93,15 +124,9 @@
                                            (:decision/resolution decision-resolution)
                                            (:decision/comment decision-resolution))
             result (es/publish! event-stream event)]
-        (cond
-          (:rejected? result)
-          {:delivered? false :error (str "stream rejected: " (name (or (:reason result) :unknown)))}
-          (contains? result :anomaly/category)
-          {:delivered? false :error (str "stream anomaly: " (:anomaly/category result))}
-          :else
-          {:delivered? true}))
+        (publish-result->delivery-result result))
       (catch Exception e
-        {:delivered? false :error (ex-message e)})))
+        (delivery-failure (exception-message e)))))
 
   (send-command [_ agent-record command]
     (if-let [control-state (:control-state (:agent/metadata agent-record))]

--- a/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
+++ b/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
@@ -94,7 +94,9 @@
 
     (contains? result :anomaly/category)
     (delivery-failure (control-plane/t :adapter/stream-anomaly
-                                       {:category (:anomaly/category result)}))
+                                       {:category (:anomaly/category result)
+                                        :message  (when-let [m (:anomaly/message result)]
+                                                    (str " — " m))}))
 
     :else
     {:delivered? true}))

--- a/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
+++ b/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
@@ -118,10 +118,12 @@
     (try
       (let [workflow-id (or (get-in agent-record [:agent/metadata :workflow-id])
                             (:agent/external-id agent-record))
+            resolution  (let [r (:decision/resolution decision-resolution)]
+                          (cond-> r (keyword? r) name))
             event (es/cp-decision-resolved event-stream
                                            workflow-id
                                            (:decision/id decision-resolution)
-                                           (:decision/resolution decision-resolution)
+                                           resolution
                                            (:decision/comment decision-resolution))
             result (es/publish! event-stream event)]
         (publish-result->delivery-result result))

--- a/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
+++ b/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
@@ -160,7 +160,7 @@
             (is (= :fake-stream (:stream built)))
             (is (= "wf-123" (:wf-id built)))
             (is (= decision-id (:dec-id built)))
-            (is (= :approve (:resolution built)))
+            (is (= "approve" (:resolution built)))
             (is (= "looks good" (:comment built))))
           (is (= 1 (count @published-events)))
           (is (= :fake-stream (:stream (first @published-events))))

--- a/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
+++ b/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
@@ -187,6 +187,15 @@
           (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
             (is (false? (:delivered? result)))
             (is (= "Stream reported decision delivery anomaly: :cognitect.anomalies/fault"
+                   (:error result))))))
+
+      (testing "includes anomaly message when present"
+        (with-redefs [es/cp-decision-resolved (fn [& _] fake-event)
+                      es/publish! (fn [_ _] {:anomaly/category :cognitect.anomalies/fault
+                                             :anomaly/message  "event-stream unavailable"})]
+          (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
+            (is (false? (:delivered? result)))
+            (is (= "Stream reported decision delivery anomaly: :cognitect.anomalies/fault — event-stream unavailable"
                    (:error result)))))))))
 
 ;; ---------------------------------------------------------------------------

--- a/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
+++ b/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
@@ -178,15 +178,16 @@
                       es/publish! (fn [_ _] {:rejected? true :reason :workflow-quiesced})]
           (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
             (is (false? (:delivered? result)))
-            (is (string? (:error result)))
-            (is (clojure.string/includes? (:error result) "workflow-quiesced")))))
+            (is (= "Stream rejected decision delivery: workflow-quiesced"
+                   (:error result))))))
 
       (testing "returns delivered false when publish! returns an anomaly"
         (with-redefs [es/cp-decision-resolved (fn [& _] fake-event)
                       es/publish! (fn [_ _] {:anomaly/category :cognitect.anomalies/fault})]
           (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
             (is (false? (:delivered? result)))
-            (is (string? (:error result)))))))))
+            (is (= "Stream reported decision delivery anomaly: :cognitect.anomalies/fault"
+                   (:error result)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — Protocol: send-command

--- a/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
+++ b/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
@@ -171,7 +171,22 @@
                       (fn [& _] (throw (Exception. "stream unavailable")))]
           (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
             (is (false? (:delivered? result)))
-            (is (= "stream unavailable" (:error result)))))))))
+            (is (= "stream unavailable" (:error result))))))
+
+      (testing "returns delivered false when publish! rejects (workflow quiesced)"
+        (with-redefs [es/cp-decision-resolved (fn [& _] fake-event)
+                      es/publish! (fn [_ _] {:rejected? true :reason :workflow-quiesced})]
+          (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
+            (is (false? (:delivered? result)))
+            (is (string? (:error result)))
+            (is (clojure.string/includes? (:error result) "workflow-quiesced")))))
+
+      (testing "returns delivered false when publish! returns an anomaly"
+        (with-redefs [es/cp-decision-resolved (fn [& _] fake-event)
+                      es/publish! (fn [_ _] {:anomaly/category :cognitect.anomalies/fault})]
+          (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
+            (is (false? (:delivered? result)))
+            (is (string? (:error result)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — Protocol: send-command

--- a/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
+++ b/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
@@ -139,7 +139,8 @@
         built-events     (atom [])
         fake-event       {:event/type :control-plane/decision-resolved}
         adapter          (sut/create-adapter :fake-stream)
-        resolution       {:decision/id         "d-1"
+        decision-id      #uuid "00000000-0000-0000-0000-000000000099"
+        resolution       {:decision/id         decision-id
                           :decision/resolution :approve
                           :decision/comment    "looks good"}]
     (with-redefs [es/cp-decision-resolved
@@ -158,10 +159,11 @@
           (let [built (first @built-events)]
             (is (= :fake-stream (:stream built)))
             (is (= "wf-123" (:wf-id built)))
-            (is (= "d-1" (:dec-id built)))
+            (is (= decision-id (:dec-id built)))
             (is (= :approve (:resolution built)))
             (is (= "looks good" (:comment built))))
           (is (= 1 (count @published-events)))
+          (is (= :fake-stream (:stream (first @published-events))))
           (is (= fake-event (:event (first @published-events))))))
 
       (testing "returns delivered false with error message on exception"

--- a/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
+++ b/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
@@ -135,10 +135,41 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest deliver-decision-test
-  (let [adapter (sut/create-adapter :fake-stream)]
-    (testing "returns delivered true (stub pending approval wiring)"
-      (let [result (proto/deliver-decision adapter sample-agent-record {:decision/id "d-1"})]
-        (is (true? (:delivered? result)))))))
+  (let [published-events (atom [])
+        built-events     (atom [])
+        fake-event       {:event/type :control-plane/decision-resolved}
+        adapter          (sut/create-adapter :fake-stream)
+        resolution       {:decision/id         "d-1"
+                          :decision/resolution :approve
+                          :decision/comment    "looks good"}]
+    (with-redefs [es/cp-decision-resolved
+                  (fn [stream wf-id dec-id resolution comment]
+                    (swap! built-events conj {:stream stream :wf-id wf-id
+                                             :dec-id dec-id :resolution resolution
+                                             :comment comment})
+                    fake-event)
+                  es/publish!
+                  (fn [stream event]
+                    (swap! published-events conj {:stream stream :event event}))]
+      (testing "publishes cp-decision-resolved event to the event stream"
+        (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
+          (is (true? (:delivered? result)))
+          (is (= 1 (count @built-events)))
+          (let [built (first @built-events)]
+            (is (= :fake-stream (:stream built)))
+            (is (= "wf-123" (:wf-id built)))
+            (is (= "d-1" (:dec-id built)))
+            (is (= :approve (:resolution built)))
+            (is (= "looks good" (:comment built))))
+          (is (= 1 (count @published-events)))
+          (is (= fake-event (:event (first @published-events))))))
+
+      (testing "returns delivered false with error message on exception"
+        (with-redefs [es/cp-decision-resolved
+                      (fn [& _] (throw (Exception. "stream unavailable")))]
+          (let [result (proto/deliver-decision adapter sample-agent-record resolution)]
+            (is (false? (:delivered? result)))
+            (is (= "stream unavailable" (:error result)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — Protocol: send-command

--- a/components/control-plane/resources/config/control-plane/messages/en-US.edn
+++ b/components/control-plane/resources/config/control-plane/messages/en-US.edn
@@ -15,7 +15,7 @@
   :adapter/no-pid               "No PID available for this agent"
   :adapter/no-control-state     "No control state available"
   :adapter/stream-rejected      "Stream rejected decision delivery: {reason}"
-  :adapter/stream-anomaly       "Stream reported decision delivery anomaly: {category}"
+  :adapter/stream-anomaly       "Stream reported decision delivery anomaly: {category}{message}"
 
   ;; vendor display
   :vendor/claude-code "C"

--- a/components/control-plane/resources/config/control-plane/messages/en-US.edn
+++ b/components/control-plane/resources/config/control-plane/messages/en-US.edn
@@ -14,6 +14,8 @@
   :adapter/unknown-command      "Unknown command: {command}"
   :adapter/no-pid               "No PID available for this agent"
   :adapter/no-control-state     "No control state available"
+  :adapter/stream-rejected      "Stream rejected decision delivery: {reason}"
+  :adapter/stream-anomaly       "Stream reported decision delivery anomaly: {category}"
 
   ;; vendor display
   :vendor/claude-code "C"


### PR DESCRIPTION
## Summary

- `MiniforgeAdapter.deliver-decision` was a stub returning `{:delivered? true}` without forwarding the human's decision to the workflow
- Replace the stub with `es/cp-decision-resolved` + `es/publish!`, using the same error-safe `catch Exception` boundary as `adapter-claude-code`
- Update the test to verify event construction and publish, and add an exception-path case

## Motivation

Every human-decision gate in a miniforge-native workflow silently discarded the operator's choice while reporting success. The orchestrator transitioned the blocked agent back to `:running` and published `cp-decision-resolved` on the control-plane side, but the workflow's event stream never received the decision payload. The infrastructure to fix it — `es/cp-decision-resolved` and `es/publish!` — was already imported in the file.

## Changes

| File/Area | Change |
|-----------|--------|
| `components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj` | Remove stub; call `es/cp-decision-resolved` with workflow-id, decision-id, resolution, and comment from `agent-record` and `decision-resolution`; publish to event stream; wrap in `catch Exception` per protocol contract |
| `components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj` | Replace stub test; verify event built with correct args and published; add exception-path case |

## Testing

- Logic verified by code review against the `cp-decision-resolved` signature (`stream workflow-id decision-id resolution & [comment]`) and the `deliver-decision` protocol contract (`{:delivered? bool :error string-or-nil}`)
- Pattern mirrors the tested `deliver-decision!` impl in `adapter-claude-code/impl.clj`
- `bb` not available in this environment; `bb test` could not be run

## Checklist

### Required

- [ ] All tests pass (`bb test`) — `bb` not available in sweep environment; logic verified by code review
- [x] Pre-commit validation passes (no `--no-verify`)
- [x] No commented-out tests
- [x] Functions are small and composable
- [x] New behavior has tests

### Best Practices

- [x] Focused PR (single concern)

## Related

- Caught by daily repo health sweep 2026-07-14.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtUsUVAHfa5zt5P8yf6YFa)_