### PR TITLE
fix(fleet-config): use advisory file lock for atomic config read-modify-write

### DIFF
--- a/components/pr-sync/resources/config/pr-sync/messages/en-US.edn
+++ b/components/pr-sync/resources/config/pr-sync/messages/en-US.edn
@@ -16,4 +16,11 @@
   :error/default       "Operation failed with no additional error details."
   :error/parse-pr      "Failed to parse PR list for {repo}."
   :error/parse-mr      "Failed to parse merge request list for {repo}."
-  :error/unknown       "Unknown error"}}
+  :error/unknown       "Unknown error"
+
+  ;; Config lock errors
+  :config-lock/update-failed  "Config update failed: {error}"
+  :config-lock/locked         "Config file is locked by another process; retry later."
+  :config-lock/interrupted    "Interrupted while waiting for config file lock."
+  :config-lock/unavailable    "Config file lock unavailable; retry later."
+  :config-lock/acquire-failed "Failed to acquire config file lock: {error}"}}

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -175,17 +175,17 @@
               (try
                 (thunk)
                 (catch Exception thunk-e
-                  (result-failure (str "Config update failed: " (ex-msg thunk-e))
+                  (result-failure (messages/t :config-lock/update-failed {:error (ex-msg thunk-e)})
                                   {:path path :exception (ex-msg thunk-e)}))
                 (finally (.close lk)))
               (if (< (System/currentTimeMillis) deadline)
                 (do (Thread/sleep config-lock-poll-ms) (recur))
-                (result-failure "Config file is locked by another process; retry later."
+                (result-failure (messages/t :config-lock/locked)
                                 {:path path}))))))
       (catch InterruptedException _
         ;; Restore interrupt flag for cooperative-cancellation callers.
         (.interrupt (Thread/currentThread))
-        (result-failure "Interrupted while waiting for config file lock." {:path path}))
+        (result-failure (messages/t :config-lock/interrupted) {:path path}))
       (catch Exception e
         ;; OverlappingFileLockException — same-JVM re-entrant attempt.
         ;; ClosedChannelException — channel closed concurrently.
@@ -193,8 +193,8 @@
         (if (contains? #{"java.nio.channels.OverlappingFileLockException"
                          "java.nio.channels.ClosedChannelException"}
                        (.getName (class e)))
-          (result-failure "Config file lock unavailable; retry later." {:path path})
-          (result-failure (str "Failed to acquire config file lock: " (ex-msg e))
+          (result-failure (messages/t :config-lock/unavailable) {:path path})
+          (result-failure (messages/t :config-lock/acquire-failed {:error (ex-msg e)})
                           {:path path}))))))
 
 (defn load-fleet-config

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -155,7 +155,8 @@
    with a bounded deadline — this runs on a CLI/worker thread, total wait is
    capped, and no thread pool is starved."
   [path thunk]
-  (let [nio-path (Paths/get path (make-array String 0))
+  (let [_        (some-> (io/file path) .getParentFile .mkdirs)
+        nio-path (Paths/get path (make-array String 0))
         opts     (into-array StandardOpenOption
                              [StandardOpenOption/READ
                               StandardOpenOption/WRITE
@@ -168,7 +169,11 @@
               ;; FileLock implements AutoCloseable; .close releases the lock.
               ;; Hinting AutoCloseable keeps the ns loadable under babashka,
               ;; which does not expose java.nio.channels.FileLock.
-              (try (thunk) (finally (.close lk)))
+              (try
+                (thunk)
+                (catch Exception thunk-e
+                  (result-failure (str "Config update failed: " (ex-msg thunk-e)) {:path path}))
+                (finally (.close lk)))
               (if (< (System/currentTimeMillis) deadline)
                 (do (Thread/sleep config-lock-poll-ms) (recur))
                 (result-failure "Config file is locked by another process; retry later."

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -172,7 +172,8 @@
               (try
                 (thunk)
                 (catch Exception thunk-e
-                  (result-failure (str "Config update failed: " (ex-msg thunk-e)) {:path path}))
+                  (result-failure (str "Config update failed: " (ex-msg thunk-e))
+                                  {:path path :exception (ex-msg thunk-e)}))
                 (finally (.close lk)))
               (if (< (System/currentTimeMillis) deadline)
                 (do (Thread/sleep config-lock-poll-ms) (recur))

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -614,19 +614,20 @@
                          vec)]
           ;; Hold the advisory lock across the read→merge→write so a concurrent
           ;; add-repo! or remove-repo! cannot overwrite our merged result.
-          (with-config-lock! path
-            (fn []
-              (let [cfg (load-fleet-config path)
-                    existing (normalized-repos cfg)
-                    merged (vec (distinct (concat existing repos)))
-                    added (vec (remove (set existing) merged))
-                    next-cfg (assoc-in cfg [:fleet :repos] merged)]
-                (save-fleet-config! next-cfg path)
-                (result-success {:owner owner*
-                                 :discovered (count repos)
-                                 :added (count added)
-                                 :repos merged
-                                 :added-repos added})))))
+          (merge {:owner owner*}
+                 (with-config-lock! path
+                   (fn []
+                     (let [cfg (load-fleet-config path)
+                           existing (normalized-repos cfg)
+                           merged (vec (distinct (concat existing repos)))
+                           added (vec (remove (set existing) merged))
+                           next-cfg (assoc-in cfg [:fleet :repos] merged)]
+                       (save-fleet-config! next-cfg path)
+                       (result-success {:owner owner*
+                                        :discovered (count repos)
+                                        :added (count added)
+                                        :repos merged
+                                        :added-repos added}))))))
         (catch Exception e
           (result-failure "Failed to parse repository list."
                           {:error (ex-msg e)}))))))

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -251,7 +251,8 @@
                     (save-fleet-config! next-cfg path)
                     (result-success {:added? (not (boolean exists?))
                                      :repo repo
-                                     :repos (get-in next-cfg [:fleet :repos])}))))))))
+                                     :repos (get-in next-cfg [:fleet :repos])}))))))))))
+
 
 (defn remove-repo!
   "Remove a repository slug from fleet configuration.

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -155,8 +155,8 @@
 
    Why advisory locking: the OS provides no blocking tryLock-with-timeout on
    file locks; `.tryLock` is non-blocking and `.lock` waits forever.  We poll
-   with a bounded deadline — this runs on a CLI/worker thread, total wait is
-   capped, and no thread pool is starved."
+   with a bounded deadline (≤ 500 ms); callers block for at most one timeout
+   window regardless of calling context."
   [path thunk]
   (let [_        (some-> (io/file path) .getParentFile .mkdirs)
         nio-path (Paths/get path (make-array String 0))

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -194,7 +194,7 @@
                          "java.nio.channels.ClosedChannelException"}
                        (.getName (class e)))
           (result-failure "Config file lock unavailable; retry later." {:path path})
-          (result-failure (str "Failed to acquire config file lock: " (.getMessage e))
+          (result-failure (str "Failed to acquire config file lock: " (ex-msg e))
                           {:path path}))))))
 
 (defn load-fleet-config
@@ -254,8 +254,7 @@
                     (save-fleet-config! next-cfg path)
                     (result-success {:added? (not (boolean exists?))
                                      :repo repo
-                                     :repos (get-in next-cfg [:fleet :repos])}))))))))))
-
+                                     :repos (get-in next-cfg [:fleet :repos])})))))))))
 
 (defn remove-repo!
   "Remove a repository slug from fleet configuration.

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -146,6 +146,9 @@
    Polls for up to `config-lock-timeout-ms` (500 ms) in `config-lock-poll-ms`
    (25 ms) increments before giving up.  Returns `(result-failure ...)` when
    the lock cannot be acquired — the expected no-op for concurrent callers.
+   Exception: same-JVM re-entrancy (OverlappingFileLockException) and a
+   concurrently closed channel (ClosedChannelException) return a failure
+   immediately without entering the poll loop.
 
    The file at `path` is created if absent so the FileChannel can open before
    the first write occurs.

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -35,7 +35,10 @@
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
    [clojure.string :as str]
-   [cheshire.core :as json]))
+   [cheshire.core :as json])
+  (:import
+   [java.nio.channels FileChannel]
+   [java.nio.file Paths StandardOpenOption]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants
@@ -48,6 +51,18 @@
 
 (def gitlab-repo-slug-pattern
   #"^gitlab:[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+$")
+
+(def ^:private config-lock-timeout-ms
+  "Upper bound (ms) on how long `with-config-lock!` polls for the advisory
+   file lock before giving up.  Bounded so a contended lock never stalls a CLI
+   command for more than half a second."
+  500)
+
+(def ^:private config-lock-poll-ms
+  "Backoff (ms) between `.tryLock` attempts while waiting for the config lock.
+   Small relative to `config-lock-timeout-ms` so contention resolves promptly
+   without busy-spinning."
+  25)
 
 ;------------------------------------------------------------------------------ Layer 0b
 ;; Pure helpers
@@ -125,6 +140,54 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Fleet config I/O
 
+(defn- with-config-lock!
+  "Acquire an exclusive advisory JVM file lock on `path`, call `thunk`, release.
+
+   Polls for up to `config-lock-timeout-ms` (500 ms) in `config-lock-poll-ms`
+   (25 ms) increments before giving up.  Returns `(result-failure ...)` when
+   the lock cannot be acquired — the expected no-op for concurrent callers.
+
+   The file at `path` is created if absent so the FileChannel can open before
+   the first write occurs.
+
+   Why advisory locking: the OS provides no blocking tryLock-with-timeout on
+   file locks; `.tryLock` is non-blocking and `.lock` waits forever.  We poll
+   with a bounded deadline — this runs on a CLI/worker thread, total wait is
+   capped, and no thread pool is starved."
+  [path thunk]
+  (let [nio-path (Paths/get path (make-array String 0))
+        opts     (into-array StandardOpenOption
+                             [StandardOpenOption/READ
+                              StandardOpenOption/WRITE
+                              StandardOpenOption/CREATE])]
+    (try
+      (with-open [^FileChannel ch (FileChannel/open nio-path opts)]
+        (let [deadline (+ (System/currentTimeMillis) config-lock-timeout-ms)]
+          (loop []
+            (if-let [^java.lang.AutoCloseable lk (.tryLock ch)]
+              ;; FileLock implements AutoCloseable; .close releases the lock.
+              ;; Hinting AutoCloseable keeps the ns loadable under babashka,
+              ;; which does not expose java.nio.channels.FileLock.
+              (try (thunk) (finally (.close lk)))
+              (if (< (System/currentTimeMillis) deadline)
+                (do (Thread/sleep config-lock-poll-ms) (recur))
+                (result-failure "Config file is locked by another process; retry later."
+                                {:path path}))))))
+      (catch InterruptedException _
+        ;; Restore interrupt flag for cooperative-cancellation callers.
+        (.interrupt (Thread/currentThread))
+        (result-failure "Interrupted while waiting for config file lock." {:path path}))
+      (catch Exception e
+        ;; OverlappingFileLockException — same-JVM re-entrant attempt.
+        ;; ClosedChannelException — channel closed concurrently.
+        ;; Both mean the lock is unavailable; surface the expected :locked no-op.
+        (if (contains? #{"java.nio.channels.OverlappingFileLockException"
+                         "java.nio.channels.ClosedChannelException"}
+                       (.getName (class e)))
+          (result-failure "Config file lock unavailable; retry later." {:path path})
+          (result-failure (str "Failed to acquire config file lock: " (.getMessage e))
+                          {:path path}))))))
+
 (defn load-fleet-config
   "Load fleet configuration from ~/.miniforge/config.edn.
    Returns {:fleet {:repos [...]}} or default empty config."
@@ -171,15 +234,17 @@
        (result-failure (messages/t :repo/invalid-format) {:repo repo})
 
        :else
-       (let [cfg (load-fleet-config path)
-             repos (normalized-repos cfg)
-             exists? (some #{repo} repos)
-             next-repos (if exists? repos (conj repos repo))
-             next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
-         (save-fleet-config! next-cfg path)
-         (result-success {:added? (not (boolean exists?))
-                          :repo repo
-                          :repos (get-in next-cfg [:fleet :repos])}))))))
+       (with-config-lock! path
+         (fn []
+           (let [cfg (load-fleet-config path)
+                 repos (normalized-repos cfg)
+                 exists? (some #{repo} repos)
+                 next-repos (if exists? repos (conj repos repo))
+                 next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
+             (save-fleet-config! next-cfg path)
+             (result-success {:added? (not (boolean exists?))
+                              :repo repo
+                              :repos (get-in next-cfg [:fleet :repos])}))))))))
 
 (defn remove-repo!
   "Remove a repository slug from fleet configuration.
@@ -189,15 +254,17 @@
    (let [repo (normalize-repo-slug repo-slug)]
      (if (str/blank? repo)
        (result-failure (messages/t :repo/required-short) {:repo repo})
-       (let [cfg (load-fleet-config path)
-             repos (normalized-repos cfg)
-             existed? (some #{repo} repos)
-             next-repos (vec (remove #{repo} repos))
-             next-cfg (assoc-in cfg [:fleet :repos] next-repos)]
-         (save-fleet-config! next-cfg path)
-         (result-success {:removed? (boolean existed?)
-                          :repo repo
-                          :repos next-repos}))))))
+       (with-config-lock! path
+         (fn []
+           (let [cfg (load-fleet-config path)
+                 repos (normalized-repos cfg)
+                 existed? (some #{repo} repos)
+                 next-repos (vec (remove #{repo} repos))
+                 next-cfg (assoc-in cfg [:fleet :repos] next-repos)]
+             (save-fleet-config! next-cfg path)
+             (result-success {:removed? (boolean existed?)
+                              :repo repo
+                              :repos next-repos}))))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Provider CLI interaction (I/O)
@@ -533,18 +600,22 @@
                          (filter valid-repo-slug?)
                          distinct
                          (take limit*)
-                         vec)
-              cfg (load-fleet-config path)
-              existing (normalized-repos cfg)
-              merged (vec (distinct (concat existing repos)))
-              added (vec (remove (set existing) merged))
-              next-cfg (assoc-in cfg [:fleet :repos] merged)]
-          (save-fleet-config! next-cfg path)
-          (result-success {:owner owner*
-                           :discovered (count repos)
-                           :added (count added)
-                           :repos merged
-                           :added-repos added}))
+                         vec)]
+          ;; Hold the advisory lock across the read→merge→write so a concurrent
+          ;; add-repo! or remove-repo! cannot overwrite our merged result.
+          (with-config-lock! path
+            (fn []
+              (let [cfg (load-fleet-config path)
+                    existing (normalized-repos cfg)
+                    merged (vec (distinct (concat existing repos)))
+                    added (vec (remove (set existing) merged))
+                    next-cfg (assoc-in cfg [:fleet :repos] merged)]
+                (save-fleet-config! next-cfg path)
+                (result-success {:owner owner*
+                                 :discovered (count repos)
+                                 :added (count added)
+                                 :repos merged
+                                 :added-repos added})))))
         (catch Exception e
           (result-failure "Failed to parse repository list."
                           {:error (ex-msg e)}))))))

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -240,17 +240,18 @@
        (result-failure (messages/t :repo/invalid-format) {:repo repo})
 
        :else
-       (with-config-lock! path
-         (fn []
-           (let [cfg (load-fleet-config path)
-                 repos (normalized-repos cfg)
-                 exists? (some #{repo} repos)
-                 next-repos (if exists? repos (conj repos repo))
-                 next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
-             (save-fleet-config! next-cfg path)
-             (result-success {:added? (not (boolean exists?))
-                              :repo repo
-                              :repos (get-in next-cfg [:fleet :repos])}))))))))
+       (merge {:repo repo}
+              (with-config-lock! path
+                (fn []
+                  (let [cfg (load-fleet-config path)
+                        repos (normalized-repos cfg)
+                        exists? (some #{repo} repos)
+                        next-repos (if exists? repos (conj repos repo))
+                        next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
+                    (save-fleet-config! next-cfg path)
+                    (result-success {:added? (not (boolean exists?))
+                                     :repo repo
+                                     :repos (get-in next-cfg [:fleet :repos])}))))))))
 
 (defn remove-repo!
   "Remove a repository slug from fleet configuration.
@@ -260,17 +261,18 @@
    (let [repo (normalize-repo-slug repo-slug)]
      (if (str/blank? repo)
        (result-failure (messages/t :repo/required-short) {:repo repo})
-       (with-config-lock! path
-         (fn []
-           (let [cfg (load-fleet-config path)
-                 repos (normalized-repos cfg)
-                 existed? (some #{repo} repos)
-                 next-repos (vec (remove #{repo} repos))
-                 next-cfg (assoc-in cfg [:fleet :repos] next-repos)]
-             (save-fleet-config! next-cfg path)
-             (result-success {:removed? (boolean existed?)
-                              :repo repo
-                              :repos next-repos}))))))))
+       (merge {:repo repo}
+              (with-config-lock! path
+                (fn []
+                  (let [cfg (load-fleet-config path)
+                        repos (normalized-repos cfg)
+                        existed? (some #{repo} repos)
+                        next-repos (vec (remove #{repo} repos))
+                        next-cfg (assoc-in cfg [:fleet :repos] next-repos)]
+                    (save-fleet-config! next-cfg path)
+                    (result-success {:removed? (boolean existed?)
+                                     :repo repo
+                                     :repos next-repos})))))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Provider CLI interaction (I/O)

--- a/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
@@ -338,6 +338,28 @@
           (.delete subdir)
           (.delete base))))))
 
+(deftest with-config-lock-timeout-test
+  (testing "returns lock-failure within timeout when another thread holds the lock"
+    (let [path   (str (System/getProperty "java.io.tmpdir") "/mf-lock-timeout-test-" (System/nanoTime) ".edn")
+          latch  (java.util.concurrent.CountDownLatch. 1)
+          release (java.util.concurrent.CountDownLatch. 1)]
+      (future (#'core/with-config-lock! path
+                (fn []
+                  (.countDown latch)
+                  (.await release))))
+      (.await latch)
+      (try
+        (let [start   (System/currentTimeMillis)
+              result  (#'core/with-config-lock! path #(throw (Exception. "should not run")))
+              elapsed (- (System/currentTimeMillis) start)]
+          (is (false? (:success? result)))
+          (is (str/includes? (str/lower-case (:error result)) "lock"))
+          ;; Should fail within timeout window (500ms) + generous CI margin.
+          (is (<= elapsed 1500)))
+        (finally
+          (.countDown release)
+          (.delete (io/file path)))))))
+
 (deftest with-config-lock-thunk-exception-test
   (testing "thunk exception reports config update failure, not lock failure"
     (let [path (str (System/getProperty "java.io.tmpdir") "/mf-lock-thunk-test-" (System/nanoTime) ".edn")

--- a/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
@@ -23,6 +23,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
+   [clojure.java.io :as io]
    [clojure.java.shell]
    [ai.miniforge.pr-sync.core :as core]))
 
@@ -321,6 +322,30 @@
       (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
       (let [result (core/remove-repo! "  " path)]
         (is (false? (:success? result)))))))
+
+(deftest with-config-lock-first-run-creates-parent-dir-test
+  (testing "add-repo! succeeds when parent directory does not yet exist"
+    (let [base    (java.io.File/createTempFile "miniforge-firstrun-" "")
+          _       (.delete base)
+          subdir  (io/file (.getAbsolutePath base) "nested")
+          path    (.getAbsolutePath (io/file subdir "config.edn"))]
+      (try
+        (let [result (core/add-repo! "acme/app" path)]
+          (is (true? (:success? result)))
+          (is (true? (:added? result))))
+        (finally
+          (.delete (io/file path))
+          (.delete subdir)
+          (.delete base))))))
+
+(deftest with-config-lock-thunk-exception-test
+  (testing "thunk exception reports config update failure, not lock failure"
+    (let [path (str (System/getProperty "java.io.tmpdir") "/mf-lock-thunk-test-" (System/nanoTime) ".edn")
+          result (#'core/with-config-lock! path #(throw (Exception. "disk full")))]
+      (.delete (io/file path))
+      (is (false? (:success? result)))
+      (is (str/includes? (:error result) "Config update failed"))
+      (is (not (str/includes? (str/lower-case (:error result)) "lock"))))))
 
 ;; ============================================================================
 ;; Layer 2: Provider CLI interaction (mocked)

--- a/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
@@ -340,13 +340,13 @@
 
 (deftest with-config-lock-timeout-test
   (testing "returns lock-failure within timeout when another thread holds the lock"
-    (let [path   (str (System/getProperty "java.io.tmpdir") "/mf-lock-timeout-test-" (System/nanoTime) ".edn")
-          latch  (java.util.concurrent.CountDownLatch. 1)
-          release (java.util.concurrent.CountDownLatch. 1)]
-      (future (#'core/with-config-lock! path
-                (fn []
-                  (.countDown latch)
-                  (.await release))))
+    (let [path    (str (System/getProperty "java.io.tmpdir") "/mf-lock-timeout-test-" (System/nanoTime) ".edn")
+          latch   (java.util.concurrent.CountDownLatch. 1)
+          release (java.util.concurrent.CountDownLatch. 1)
+          holder  (future (#'core/with-config-lock! path
+                            (fn []
+                              (.countDown latch)
+                              (.await release))))]
       (.await latch)
       (try
         (let [start   (System/currentTimeMillis)
@@ -358,6 +358,7 @@
           (is (<= elapsed 1500)))
         (finally
           (.countDown release)
+          (deref holder 2000 nil)
           (.delete (io/file path)))))))
 
 (deftest with-config-lock-thunk-exception-test

--- a/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
@@ -347,7 +347,8 @@
                             (fn []
                               (.countDown latch)
                               (.await release))))]
-      (.await latch)
+      (is (.await latch 5 java.util.concurrent.TimeUnit/SECONDS)
+          "lock holder did not acquire lock in time")
       (try
         (let [start   (System/currentTimeMillis)
               result  (#'core/with-config-lock! path #(throw (Exception. "should not run")))

--- a/components/web-dashboard/resources/config/web-dashboard/messages/en-US.edn
+++ b/components/web-dashboard/resources/config/web-dashboard/messages/en-US.edn
@@ -18,6 +18,15 @@
   :error-category/network      "Network"
   :error-category/fallback     "Error"
 
+  ;; fleet config errors
+  :repo/required              "Repository is required. Use owner/name."
+  :repo/invalid-format        "Invalid repository format. Expected owner/name."
+  :config-lock/update-failed  "Config update failed."
+  :config-lock/locked         "Config file is locked by another process; retry later."
+  :config-lock/interrupted    "Interrupted while waiting for config file lock."
+  :config-lock/unavailable    "Config file lock unavailable; retry later."
+  :config-lock/acquire-failed "Failed to acquire config file lock: {error}"
+
   ;; blocking-reason-line fallback
   :blocker/fallback-message    "Blocked"
 

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -195,8 +195,8 @@
 
    Why advisory locking: the OS provides no blocking tryLock-with-timeout on
    file locks; `.tryLock` is non-blocking and `.lock` waits forever.  We poll
-   with a bounded deadline — this runs on a worker thread, total wait is
-   capped, and no thread pool is starved."
+   with a bounded deadline (≤ 500 ms); callers block for at most one timeout
+   window regardless of calling context (CLI, HTTP handler, etc.)."
   [path thunk]
   (let [_        (some-> (io/file path) .getParentFile .mkdirs)
         nio-path (Paths/get path (make-array String 0))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -420,23 +420,24 @@
                        vec)]
         ;; Hold the advisory lock across the read→merge→write so a concurrent
         ;; add-configured-repo! cannot overwrite our merged result.
-        (with-config-lock! default-fleet-config-path
-          (fn []
-            (let [cfg (load-fleet-config)
-                  existing (->> (get-in cfg [:fleet :repos] [])
-                                (map normalize-repo-slug)
-                                (filter valid-repo-slug?)
-                                vec)
-                  merged (vec (distinct (concat existing repos)))
-                  added (vec (remove (set existing) merged))
-                  next-cfg (assoc-in cfg [:fleet :repos] merged)]
-              (save-fleet-config! next-cfg)
-              (result-success
-               {:owner owner*
-                :discovered (count repos)
-                :added (count added)
-                :repos merged
-                :added-repos added}))))))))
+        (merge {:owner owner*}
+               (with-config-lock! default-fleet-config-path
+                 (fn []
+                   (let [cfg (load-fleet-config)
+                         existing (->> (get-in cfg [:fleet :repos] [])
+                                       (map normalize-repo-slug)
+                                       (filter valid-repo-slug?)
+                                       vec)
+                         merged (vec (distinct (concat existing repos)))
+                         added (vec (remove (set existing) merged))
+                         next-cfg (assoc-in cfg [:fleet :repos] merged)]
+                     (save-fleet-config! next-cfg)
+                     (result-success
+                      {:owner owner*
+                       :discovered (count repos)
+                       :added (count added)
+                       :repos merged
+                       :added-repos added})))))))))
 
 (defn pr-status-from-provider
   [pr]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -195,7 +195,8 @@
    with a bounded deadline — this runs on a worker thread, total wait is
    capped, and no thread pool is starved."
   [path thunk]
-  (let [nio-path (Paths/get path (make-array String 0))
+  (let [_        (some-> (io/file path) .getParentFile .mkdirs)
+        nio-path (Paths/get path (make-array String 0))
         opts     (into-array StandardOpenOption
                              [StandardOpenOption/READ
                               StandardOpenOption/WRITE
@@ -208,7 +209,11 @@
               ;; FileLock implements AutoCloseable; .close releases the lock.
               ;; Hinting AutoCloseable keeps the ns loadable under babashka,
               ;; which does not expose java.nio.channels.FileLock.
-              (try (thunk) (finally (.close lk)))
+              (try
+                (thunk)
+                (catch Exception thunk-e
+                  (result-exception "Config update failed." thunk-e))
+                (finally (.close lk)))
               (if (< (System/currentTimeMillis) deadline)
                 (do (Thread/sleep config-lock-poll-ms) (recur))
                 (result-failure "Config file is locked by another process; retry later."
@@ -427,7 +432,7 @@
                 :discovered (count repos)
                 :added (count added)
                 :repos merged
-                :added-repos added})))))))
+                :added-repos added}))))))))
 
 (defn pr-status-from-provider
   [pr]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -25,7 +25,10 @@
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.repo-dag.interface :as repo-dag]
    [ai.miniforge.web-dashboard.state.core :as core]
-   [slingshot.slingshot :refer [try+]]))
+   [slingshot.slingshot :refer [try+]])
+  (:import
+   [java.nio.channels FileChannel]
+   [java.nio.file Paths StandardOpenOption]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Fleet repository config and provider helpers
@@ -62,6 +65,15 @@
    :behind-main 0.15})
 
 (def readiness-threshold 0.85)
+
+(def ^:private config-lock-timeout-ms
+  "Upper bound (ms) on how long `with-config-lock!` polls for the advisory
+   file lock before giving up."
+  500)
+
+(def ^:private config-lock-poll-ms
+  "Backoff (ms) between `.tryLock` attempts while waiting for the config lock."
+  25)
 
 (def ci-scores
   {:passed 1.0
@@ -167,6 +179,54 @@
   [out err]
   (ensure-message (if (str/blank? err) out err)
                   "Provider command failed. Check authentication and repository access."))
+
+(defn- with-config-lock!
+  "Acquire an exclusive advisory JVM file lock on `path`, call `thunk`, release.
+
+   Polls for up to `config-lock-timeout-ms` (500 ms) in `config-lock-poll-ms`
+   (25 ms) increments before giving up.  Returns `(result-failure ...)` when
+   the lock cannot be acquired — the expected no-op for concurrent callers.
+
+   The file at `path` is created if absent so the FileChannel can open before
+   the first write occurs.
+
+   Why advisory locking: the OS provides no blocking tryLock-with-timeout on
+   file locks; `.tryLock` is non-blocking and `.lock` waits forever.  We poll
+   with a bounded deadline — this runs on a worker thread, total wait is
+   capped, and no thread pool is starved."
+  [path thunk]
+  (let [nio-path (Paths/get path (make-array String 0))
+        opts     (into-array StandardOpenOption
+                             [StandardOpenOption/READ
+                              StandardOpenOption/WRITE
+                              StandardOpenOption/CREATE])]
+    (try
+      (with-open [^FileChannel ch (FileChannel/open nio-path opts)]
+        (let [deadline (+ (System/currentTimeMillis) config-lock-timeout-ms)]
+          (loop []
+            (if-let [^java.lang.AutoCloseable lk (.tryLock ch)]
+              ;; FileLock implements AutoCloseable; .close releases the lock.
+              ;; Hinting AutoCloseable keeps the ns loadable under babashka,
+              ;; which does not expose java.nio.channels.FileLock.
+              (try (thunk) (finally (.close lk)))
+              (if (< (System/currentTimeMillis) deadline)
+                (do (Thread/sleep config-lock-poll-ms) (recur))
+                (result-failure "Config file is locked by another process; retry later."
+                                {:path path}))))))
+      (catch InterruptedException _
+        ;; Restore interrupt flag for cooperative-cancellation callers.
+        (.interrupt (Thread/currentThread))
+        (result-failure "Interrupted while waiting for config file lock." {:path path}))
+      (catch Exception e
+        ;; OverlappingFileLockException — same-JVM re-entrant attempt.
+        ;; ClosedChannelException — channel closed concurrently.
+        ;; Both mean the lock is unavailable; surface the expected no-op.
+        (if (contains? #{"java.nio.channels.OverlappingFileLockException"
+                         "java.nio.channels.ClosedChannelException"}
+                       (.getName (class e)))
+          (result-failure "Config file lock unavailable; retry later." {:path path})
+          (result-failure (str "Failed to acquire config file lock: " (.getMessage e))
+                          {:path path}))))))
 
 (defn load-fleet-config
   []
@@ -280,19 +340,21 @@
        {:repo repo*})
 
       :else
-      (let [cfg (load-fleet-config)
-            repos (->> (get-in cfg [:fleet :repos] [])
-                       (map normalize-repo-slug)
-                       (filter valid-repo-slug?)
-                       vec)
-            exists? (some #{repo*} repos)
-            next-repos (if exists? repos (conj repos repo*))
-            next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
-        (save-fleet-config! next-cfg)
-        (result-success
-         {:added? (not exists?)
-          :repo repo*
-          :repos (get-in next-cfg [:fleet :repos])})))))
+      (with-config-lock! default-fleet-config-path
+        (fn []
+          (let [cfg (load-fleet-config)
+                repos (->> (get-in cfg [:fleet :repos] [])
+                           (map normalize-repo-slug)
+                           (filter valid-repo-slug?)
+                           vec)
+                exists? (some #{repo*} repos)
+                next-repos (if exists? repos (conj repos repo*))
+                next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
+            (save-fleet-config! next-cfg)
+            (result-success
+             {:added? (not exists?)
+              :repo repo*
+              :repos (get-in next-cfg [:fleet :repos])}))))))
 
 (defn run-gh
   [& args]
@@ -346,22 +408,26 @@
                        (filter valid-repo-slug?)
                        distinct
                        (take limit*)
-                       vec)
-            cfg (load-fleet-config)
-            existing (->> (get-in cfg [:fleet :repos] [])
-                          (map normalize-repo-slug)
-                          (filter valid-repo-slug?)
-                          vec)
-            merged (vec (distinct (concat existing repos)))
-            added (vec (remove (set existing) merged))
-            next-cfg (assoc-in cfg [:fleet :repos] merged)]
-        (save-fleet-config! next-cfg)
-        (result-success
-         {:owner owner*
-          :discovered (count repos)
-          :added (count added)
-          :repos merged
-          :added-repos added})))))
+                       vec)]
+        ;; Hold the advisory lock across the read→merge→write so a concurrent
+        ;; add-configured-repo! cannot overwrite our merged result.
+        (with-config-lock! default-fleet-config-path
+          (fn []
+            (let [cfg (load-fleet-config)
+                  existing (->> (get-in cfg [:fleet :repos] [])
+                                (map normalize-repo-slug)
+                                (filter valid-repo-slug?)
+                                vec)
+                  merged (vec (distinct (concat existing repos)))
+                  added (vec (remove (set existing) merged))
+                  next-cfg (assoc-in cfg [:fleet :repos] merged)]
+              (save-fleet-config! next-cfg)
+              (result-success
+               {:owner owner*
+                :discovered (count repos)
+                :added (count added)
+                :repos merged
+                :added-repos added})))))))
 
 (defn pr-status-from-provider
   [pr]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -212,7 +212,7 @@
               (try
                 (thunk)
                 (catch Exception thunk-e
-                  (result-exception "Config update failed." thunk-e))
+                  (result-exception "Config update failed." thunk-e {:path path}))
                 (finally (.close lk)))
               (if (< (System/currentTimeMillis) deadline)
                 (do (Thread/sleep config-lock-poll-ms) (recur))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -359,7 +359,7 @@
             (result-success
              {:added? (not exists?)
               :repo repo*
-              :repos (get-in next-cfg [:fleet :repos])}))))))
+              :repos (get-in next-cfg [:fleet :repos])})))))))
 
 (defn run-gh
   [& args]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -345,21 +345,22 @@
        {:repo repo*})
 
       :else
-      (with-config-lock! default-fleet-config-path
-        (fn []
-          (let [cfg (load-fleet-config)
-                repos (->> (get-in cfg [:fleet :repos] [])
-                           (map normalize-repo-slug)
-                           (filter valid-repo-slug?)
-                           vec)
-                exists? (some #{repo*} repos)
-                next-repos (if exists? repos (conj repos repo*))
-                next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
-            (save-fleet-config! next-cfg)
-            (result-success
-             {:added? (not exists?)
-              :repo repo*
-              :repos (get-in next-cfg [:fleet :repos])})))))))
+      (merge {:repo repo*}
+             (with-config-lock! default-fleet-config-path
+               (fn []
+                 (let [cfg (load-fleet-config)
+                       repos (->> (get-in cfg [:fleet :repos] [])
+                                  (map normalize-repo-slug)
+                                  (filter valid-repo-slug?)
+                                  vec)
+                       exists? (some #{repo*} repos)
+                       next-repos (if exists? repos (conj repos repo*))
+                       next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
+                   (save-fleet-config! next-cfg)
+                   (result-success
+                    {:added? (not exists?)
+                     :repo repo*
+                     :repos (get-in next-cfg [:fleet :repos])})))))))
 
 (defn run-gh
   [& args]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -233,7 +233,7 @@
                          "java.nio.channels.ClosedChannelException"}
                        (.getName (class e)))
           (result-failure "Config file lock unavailable; retry later." {:path path})
-          (result-failure (str "Failed to acquire config file lock: " (.getMessage e))
+          (result-failure (str "Failed to acquire config file lock: " (ex-msg e))
                           {:path path}))))))
 
 (defn load-fleet-config

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -1,4 +1,8 @@
-;; Copyright 2025 miniforge.ai
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -17,6 +21,7 @@
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.web-dashboard.messages :as messages]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
@@ -215,16 +220,16 @@
               (try
                 (thunk)
                 (catch Exception thunk-e
-                  (result-exception "Config update failed." thunk-e {:path path}))
+                  (result-exception (messages/t :config-lock/update-failed) thunk-e {:path path}))
                 (finally (.close lk)))
               (if (< (System/currentTimeMillis) deadline)
                 (do (Thread/sleep config-lock-poll-ms) (recur))
-                (result-failure "Config file is locked by another process; retry later."
+                (result-failure (messages/t :config-lock/locked)
                                 {:path path}))))))
       (catch InterruptedException _
         ;; Restore interrupt flag for cooperative-cancellation callers.
         (.interrupt (Thread/currentThread))
-        (result-failure "Interrupted while waiting for config file lock." {:path path}))
+        (result-failure (messages/t :config-lock/interrupted) {:path path}))
       (catch Exception e
         ;; OverlappingFileLockException — same-JVM re-entrant attempt.
         ;; ClosedChannelException — channel closed concurrently.
@@ -232,8 +237,8 @@
         (if (contains? #{"java.nio.channels.OverlappingFileLockException"
                          "java.nio.channels.ClosedChannelException"}
                        (.getName (class e)))
-          (result-failure "Config file lock unavailable; retry later." {:path path})
-          (result-failure (str "Failed to acquire config file lock: " (ex-msg e))
+          (result-failure (messages/t :config-lock/unavailable) {:path path})
+          (result-failure (messages/t :config-lock/acquire-failed {:error (ex-msg e)})
                           {:path path}))))))
 
 (defn load-fleet-config
@@ -339,12 +344,12 @@
     (cond
       (str/blank? repo*)
       (result-failure
-       "Repository is required. Use owner/name."
+       (messages/t :repo/required)
        {:repo repo*})
 
       (not (valid-repo-slug? repo*))
       (result-failure
-       "Invalid repository format. Expected owner/name."
+       (messages/t :repo/invalid-format)
        {:repo repo*})
 
       :else

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -186,6 +186,9 @@
    Polls for up to `config-lock-timeout-ms` (500 ms) in `config-lock-poll-ms`
    (25 ms) increments before giving up.  Returns `(result-failure ...)` when
    the lock cannot be acquired — the expected no-op for concurrent callers.
+   Exception: same-JVM re-entrancy (OverlappingFileLockException) and a
+   concurrently closed channel (ClosedChannelException) return a failure
+   immediately without entering the poll loop.
 
    The file at `path` is created if absent so the FileChannel can open before
    the first write occurs.

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -360,7 +360,7 @@
                    (result-success
                     {:added? (not exists?)
                      :repo repo*
-                     :repos (get-in next-cfg [:fleet :repos])})))))))
+                     :repos (get-in next-cfg [:fleet :repos])}))))))))
 
 (defn run-gh
   [& args]

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
@@ -186,7 +186,8 @@
                             (fn []
                               (.countDown latch)
                               (.await release))))]
-      (.await latch)
+      (is (.await latch 5 java.util.concurrent.TimeUnit/SECONDS)
+          "lock holder did not acquire lock in time")
       (try
         (let [start   (System/currentTimeMillis)
               result  (#'sut/with-config-lock! path #(throw (Exception. "should not run")))

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.web-dashboard.state.trains-test
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [cheshire.core :as json]
@@ -175,6 +176,28 @@
     (with-redefs-fn {#'sut/default-fleet-config-path "/nonexistent/path/config.edn"}
       (fn []
         (is (= [] (sut/get-configured-repos state)))))))
+
+(deftest with-config-lock-timeout-test
+  (testing "returns lock-failure within timeout when another thread holds the lock"
+    (let [path    (str (System/getProperty "java.io.tmpdir") "/mf-trains-lock-test-" (System/nanoTime) ".edn")
+          latch   (java.util.concurrent.CountDownLatch. 1)
+          release (java.util.concurrent.CountDownLatch. 1)
+          holder  (future (#'sut/with-config-lock! path
+                            (fn []
+                              (.countDown latch)
+                              (.await release))))]
+      (.await latch)
+      (try
+        (let [start   (System/currentTimeMillis)
+              result  (#'sut/with-config-lock! path #(throw (Exception. "should not run")))
+              elapsed (- (System/currentTimeMillis) start)]
+          (is (false? (:success? result)))
+          (is (str/includes? (str/lower-case (:error result)) "lock"))
+          (is (<= elapsed 1500)))
+        (finally
+          (.countDown release)
+          (deref holder 2000 nil)
+          (.delete (io/file path)))))))
 
 ;; ============================================================================
 ;; Layer 0: Provider PR field parsing

--- a/docs/pull-requests/2026-07-16-fix-fleet-config-atomic-write.md
+++ b/docs/pull-requests/2026-07-16-fix-fleet-config-atomic-write.md
@@ -1,0 +1,55 @@
+<!--
+  Title: Fleet config read-modify-write race condition
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(fleet-config): use advisory file lock for atomic config read-modify-write
+
+Branch: `fix/fleet-config-atomic-write`
+
+## Summary
+
+`~/.miniforge/config.edn` is shared state written by two independent
+components — `web-dashboard` and `pr-sync` — both of which performed
+bare `slurp`/`spit` read-modify-write cycles with no coordination.  A
+concurrent `add-repo!` from the TUI and a `discover-configured-repos!`
+from the dashboard could each read the same stale config, compute
+divergent next states, and silently clobber each other's write.  The
+last writer won; repos added by the first writer were lost.
+
+## Fix
+
+Both components now wrap every read→modify→write sequence in a
+`with-config-lock!` helper that holds an exclusive advisory
+`java.nio.channels.FileChannel` lock across the full window.  The
+pattern is taken directly from
+`ai.miniforge.dag-executor.scratch-gc-queue/with-queue-lock!`, which
+already uses this approach for the GC queue.
+
+Key behaviour:
+- Polls for up to 500 ms (25 ms intervals) before giving up with a
+  `result-failure` — same contract as the GC queue's `:locked` no-op.
+- `StandardOpenOption/CREATE` ensures the FileChannel can open before
+  the config file exists (first-run case).
+- `OverlappingFileLockException` / `ClosedChannelException` are caught
+  by class name (not a class literal) so the namespace remains loadable
+  under babashka, which does not expose `java.nio.channels.FileLock`.
+- Only the read→modify→write thunk is locked; pure reads
+  (`load-fleet-config`, `get-configured-repos`) are left unlocked —
+  they are idempotent and called at high frequency from the dashboard.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `components/pr-sync/src/ai/miniforge/pr_sync/core.clj` | Add `:import` for NIO; add `config-lock-timeout-ms` / `config-lock-poll-ms` constants; add `with-config-lock!`; wrap `add-repo!`, `remove-repo!`, and `discover-repos!` |
+| `components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj` | Same: add `:import`, constants, `with-config-lock!`; wrap `add-configured-repo!` and `discover-configured-repos!` |
+
+## Test plan
+
+- `bb poly:check` clean (no new deps introduced; NIO classes are JDK built-ins).
+- Manual concurrent test: run `add-repo!` and `discover-repos!` from two
+  processes simultaneously; verify neither writer loses entries.
+- Existing `pr-sync` and `web-dashboard` test suites pass unchanged —
+  locking is transparent to callers that don't exercise concurrency.


### PR DESCRIPTION
## Summary

- `web-dashboard` and `pr-sync` both performed bare `slurp`/`spit` read-modify-write cycles on `~/.miniforge/config.edn` with no file locking, creating a race condition where concurrent writers could silently clobber each other's changes.
- Add `with-config-lock!` (advisory `FileChannel/tryLock`, 500 ms timeout, 25 ms poll) to both components, wrapping every read→modify→write thunk atomically.
- Pattern follows `dag-executor/scratch_gc_queue`'s `with-queue-lock!` exactly — the correct model already exists in the codebase.

## Motivation

Two independently-runnable components write to the same file (`~/.miniforge/config.edn`) as shared state:

- `web-dashboard`: `add-configured-repo!` and `discover-configured-repos!`
- `pr-sync`: `add-repo!`, `remove-repo!`, and `discover-repos!`

Both used bare `slurp` + `spit` with no coordination. Under concurrent use (e.g. a TUI `add-repo!` racing a dashboard `discover-repos!`), each process reads the same stale config, computes a divergent next state, and the last writer wins — silently discarding the first writer's additions. This is a data-loss bug.

## Changes

| File/Area | Change |
|-----------|--------|
| `components/pr-sync/src/ai/miniforge/pr_sync/core.clj` | Add `:import` for NIO classes; add `config-lock-timeout-ms` / `config-lock-poll-ms` constants; add `with-config-lock!`; wrap `add-repo!`, `remove-repo!`, `discover-repos!` |
| `components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj` | Same: add `:import`, constants, `with-config-lock!`; wrap `add-configured-repo!` and `discover-configured-repos!` |
| `docs/pull-requests/2026-07-16-fix-fleet-config-atomic-write.md` | PR doc |

## Testing

- [x] `bb poly:check` passes — NIO classes are JDK built-ins; no new external deps
- [x] `OverlappingFileLockException` / `ClosedChannelException` caught by class name so namespace loads under babashka (same technique as `scratch_gc_queue`)
- [x] Pure reads (`load-fleet-config`, `get-configured-repos`) left unlocked — idempotent, high-frequency, no mutation
- [ ] Manual concurrent test: run `add-repo!` and `discover-repos!` in two processes simultaneously; verify neither write is lost

## Checklist

### Required

- [x] All tests pass (`bb test`)
- [x] Pre-commit validation passes (no `--no-verify`)
- [x] No commented-out tests
- [x] No giant functions
- [x] Functions are small and composable
- [x] New behavior has tests (covered by existing suites; locking is transparent to non-concurrent callers)

### Best Practices

- [x] Follows development guidelines
- [x] `bb lint:clj:all` passes
- [x] PR doc created in `docs/pull-requests/2026-07-16-fix-fleet-config-atomic-write.md`
- [x] Focused PR (single concern)

## Related

- Closes the race condition between `web-dashboard` and `pr-sync` on `~/.miniforge/config.edn`
- Pattern reference: `components/dag-executor/src/ai/miniforge/dag_executor/scratch_gc_queue.clj` (`with-queue-lock!`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyHD1dMU4o2qqRuVzkfnxq)_