### PR TITLE
refactor(llm): name magic timeout/threshold/cost constants (dewey 006)

### DIFF
--- a/components/llm/src/ai/miniforge/llm/model_selector.clj
+++ b/components/llm/src/ai/miniforge/llm/model_selector.clj
@@ -103,12 +103,10 @@
    from `llm/model-selector.edn :default-config` if present, else the
    code-side `default-config-fallback`. Realized via `delay` so the
    resource read happens once per process."
-  (delay (or (:default-config @model-selector-config)
-             default-config-fallback)))
+  (delay (get @model-selector-config :default-config default-config-fallback)))
 
 (def ^:private provider-env-vars
-  (delay (or (:provider-env-vars @model-selector-config)
-             fallback-provider-env-vars)))
+  (delay (get @model-selector-config :provider-env-vars fallback-provider-env-vars)))
 
 (def get-env-var
   "Wraps System/getenv; rebind in tests to inject env state without mutating
@@ -252,7 +250,7 @@
     :provider :anthropic
     :backend :claude
     :task-type :execution-focused
-    :confidence 0.9
+    :confidence <classification-confidence>
     :strategy :automatic
     :rationale \"...\"
     :fallback-used false}"

--- a/components/llm/src/ai/miniforge/llm/model_selector.clj
+++ b/components/llm/src/ai/miniforge/llm/model_selector.clj
@@ -54,16 +54,16 @@
    :require-local false})
 
 (def ^:private economical-cost-threshold-usd
-  "Minimum per-task budget ($) at which an :economical-cost model is
+  "Minimum per-task budget ($) at which an :economical model is
    affordable in meets-cost-constraint?."
   0.01)
 
 (def ^:private moderate-cost-threshold-usd
-  "Minimum per-task budget ($) at which a :moderate-cost model is affordable."
+  "Minimum per-task budget ($) at which a :moderate model is affordable."
   0.05)
 
 (def ^:private expensive-cost-threshold-usd
-  "Minimum per-task budget ($) at which an :expensive-cost model is
+  "Minimum per-task budget ($) at which an :expensive model is
    affordable. Equal to the default budget — the default is set to just afford
    an expensive model when the caller is silent."
   default-cost-limit-usd)

--- a/components/llm/src/ai/miniforge/llm/model_selector.clj
+++ b/components/llm/src/ai/miniforge/llm/model_selector.clj
@@ -66,7 +66,7 @@
   "Minimum per-task budget ($) at which an :expensive-cost model is
    affordable. Equal to the default budget — the default is set to just afford
    an expensive model when the caller is silent."
-  0.10)
+  default-cost-limit-usd)
 
 (def ^:private cost-optimized-default-limit-usd
   "Fallback per-task budget ($) for the cost-optimized selection strategy when
@@ -103,10 +103,12 @@
    from `llm/model-selector.edn :default-config` if present, else the
    code-side `default-config-fallback`. Realized via `delay` so the
    resource read happens once per process."
-  (delay (get @model-selector-config :default-config default-config-fallback)))
+  (delay (or (:default-config @model-selector-config)
+             default-config-fallback)))
 
 (def ^:private provider-env-vars
-  (delay (get @model-selector-config :provider-env-vars fallback-provider-env-vars)))
+  (delay (or (:provider-env-vars @model-selector-config)
+             fallback-provider-env-vars)))
 
 (def get-env-var
   "Wraps System/getenv; rebind in tests to inject env state without mutating
@@ -250,7 +252,7 @@
     :provider :anthropic
     :backend :claude
     :task-type :execution-focused
-    :confidence <classification-confidence>
+    :confidence 0.9
     :strategy :automatic
     :rationale \"...\"
     :fallback-used false}"

--- a/components/llm/src/ai/miniforge/llm/model_selector.clj
+++ b/components/llm/src/ai/miniforge/llm/model_selector.clj
@@ -36,15 +36,50 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constraints and availability
 
+(def ^:private default-cost-limit-usd
+  "Fallback per-task cost limit ($) when neither config nor caller specifies
+   one. Used by `default-config-fallback` and by the selection fns'
+   `(or cost-limit ...)` guards so the unspecified-budget default has a single
+   name. 0.10 comfortably covers a routine Sonnet/Haiku task."
+  0.10)
+
 (def default-config-fallback
   "Hard-coded fallback when `llm/model-selector.edn :default-config` is
    absent. The active value comes from that EDN file per rule 007."
   {:enabled true
    :strategy :automatic ; :automatic | :fixed | :cost-optimized
-   :cost-limit-per-task 0.10
+   :cost-limit-per-task default-cost-limit-usd
    :prefer-speed false
    :allow-downgrade true
    :require-local false})
+
+(def ^:private economical-cost-threshold-usd
+  "Minimum per-task budget ($) at which an :economical-cost model is
+   affordable in meets-cost-constraint?."
+  0.01)
+
+(def ^:private moderate-cost-threshold-usd
+  "Minimum per-task budget ($) at which a :moderate-cost model is affordable."
+  0.05)
+
+(def ^:private expensive-cost-threshold-usd
+  "Minimum per-task budget ($) at which an :expensive-cost model is
+   affordable. Equal to the default budget — the default is set to just afford
+   an expensive model when the caller is silent."
+  0.10)
+
+(def ^:private cost-optimized-default-limit-usd
+  "Fallback per-task budget ($) for the cost-optimized selection strategy when
+   the caller gives none. Tighter than the general default so cost-optimized
+   selection actually prefers cheaper tiers."
+  0.05)
+
+(def ^:private phase-classification-confidence
+  "Confidence assigned to a task classification derived from the SDLC phase
+   (rather than LLM-inferred). 0.9 — the phase→type mapping is deterministic
+   and near-certain, but a phase can occasionally host atypical work, so not
+   1.0."
+  0.9)
 
 (def ^:private fallback-provider-env-vars
   "Hard-coded fallback when `llm/model-selector.edn :provider-env-vars` is
@@ -106,9 +141,9 @@
     (let [cost-level (get-in model [:capabilities :cost])]
       (case cost-level
         :free true
-        :economical (>= cost-limit 0.01)
-        :moderate (>= cost-limit 0.05)
-        :expensive (>= cost-limit 0.10)
+        :economical (>= cost-limit economical-cost-threshold-usd)
+        :moderate (>= cost-limit moderate-cost-threshold-usd)
+        :expensive (>= cost-limit expensive-cost-threshold-usd)
         true))))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -133,7 +168,7 @@
     (or (first (filter (fn [model-key]
                          (and (model-available? model-key)
                               (meets-context-requirement? model-key (or context-size 0))
-                              (meets-cost-constraint? model-key (or cost-limit 0.10))))
+                              (meets-cost-constraint? model-key (or cost-limit default-cost-limit-usd))))
                        all-tiers))
         ;; Fallback to first available if no match
         (first (filter model-available? all-tiers)))))
@@ -151,7 +186,7 @@
     (first (filter (fn [model-key]
                      (and (model-available? model-key)
                           (meets-context-requirement? model-key (or context-size 0))
-                          (meets-cost-constraint? model-key (or cost-limit 0.05))))
+                          (meets-cost-constraint? model-key (or cost-limit cost-optimized-default-limit-usd))))
                    tiers))))
 
 (defn select-by-speed
@@ -177,7 +212,7 @@
     (first (filter (fn [model-key]
                      (and (model-available? model-key)
                           (meets-context-requirement? model-key (or context-size 0))
-                          (meets-cost-constraint? model-key (or cost-limit 0.10))))
+                          (meets-cost-constraint? model-key (or cost-limit default-cost-limit-usd))))
                    sorted-by-speed))))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -268,7 +303,7 @@
                                       (:plan :design :architecture) :thinking-heavy
                                       (:validate :format :lint) :simple-validation
                                       :execution-focused)
-                             :confidence 0.9
+                             :confidence phase-classification-confidence
                              :reason (format "Phase-based classification for '%s'" phase)}]
     (select-model task-classification config constraints)))
 

--- a/components/llm/src/ai/miniforge/llm/progress_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/progress_monitor.clj
@@ -45,7 +45,7 @@
   5000)
 
 (def ^:private min-substantive-chunk-length
-  "A streamed chunk shorter than this (characters) is treated as
+  "A streamed chunk with this length or fewer characters is treated as
    non-substantive — a spinner/keepalive blip, not real output — so it does
    not count as progress."
   10)

--- a/components/llm/src/ai/miniforge/llm/progress_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/progress_monitor.clj
@@ -23,6 +23,36 @@
    changes to detect when an agent is stuck vs actively working."
    )
 
+(def ^:private default-stagnation-threshold-ms
+  "Time without any progress signal before an agent is considered stuck —
+   the adaptive-timeout trip point. 2 minutes: long enough to ride out a slow
+   model turn or a quiet tool call, short enough that a genuinely hung agent
+   is caught before it burns a phase budget."
+  120000)
+
+(def ^:private default-max-total-ms
+  "Hard ceiling on a single monitored run regardless of progress. 10 minutes —
+   a backstop for an agent that keeps emitting just enough to look active but
+   never actually finishes."
+  600000)
+
+(def ^:private default-min-activity-interval-ms
+  "Minimum spacing between counted progress signals; debounces a burst of
+   chunks into one activity tick so rapid streaming doesn't reset the
+   stagnation clock on every token. 5 seconds."
+  5000)
+
+(def ^:private min-substantive-chunk-length
+  "A streamed chunk shorter than this (characters) is treated as
+   non-substantive — a spinner/keepalive blip, not real output — so it does
+   not count as progress."
+  10)
+
+(def ^:private active-window-ms
+  "Recency window for the :is-active? status flag: activity newer than this
+   marks the monitor active. 30 seconds."
+  30000)
+
  (defn create-progress-monitor
    "Create a progress monitor for adaptive timeout.
 
@@ -33,9 +63,9 @@
 
    Returns monitor state atom."
    [{:keys [stagnation-threshold-ms max-total-ms min-activity-interval-ms]
-     :or {stagnation-threshold-ms 120000  ; 2 minutes
-          max-total-ms 600000              ; 10 minutes
-          min-activity-interval-ms 5000}}] ; 5 seconds
+     :or {stagnation-threshold-ms default-stagnation-threshold-ms
+          max-total-ms default-max-total-ms
+          min-activity-interval-ms default-min-activity-interval-ms}}]
    (atom {:started-at (System/currentTimeMillis)
           :last-activity-at (System/currentTimeMillis)
           :last-chunk-content nil
@@ -60,7 +90,7 @@
          is-different? (not= chunk-content last-content)
          is-not-just-thinking? (and chunk-content
                                     (not (re-find #"(?i)^(thinking|analyzing|considering)" chunk-content)))
-         is-substantive? (and chunk-content (> (count chunk-content) 10))
+         is-substantive? (and chunk-content (> (count chunk-content) min-substantive-chunk-length))
          time-since-activity (- now last-activity)
          ;; First chunk always counts as progress (last-content will be nil)
          is-first-chunk? (nil? last-content)
@@ -235,7 +265,7 @@
      :unique-chunks (count unique-chunks)
      :files-written (count file-writes)
      :stagnant-cycles stagnant-cycles
-     :is-active? (< (- now last-activity-at) 30000)})) ; Active if activity in last 30s
+     :is-active? (< (- now last-activity-at) active-window-ms)}))
 
 (comment
   ;; Usage example

--- a/components/llm/src/ai/miniforge/llm/progress_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/progress_monitor.clj
@@ -17,11 +17,13 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.llm.progress-monitor
-   "Adaptive timeout monitoring based on actual progress detection.
+  "Adaptive timeout monitoring based on actual progress detection.
 
    Instead of fixed timeouts, monitors streaming activity and file system
-   changes to detect when an agent is stuck vs actively working."
-   )
+   changes to detect when an agent is stuck vs actively working.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Timeout thresholds and monitor state
 
 (def ^:private default-stagnation-threshold-ms
   "Time without any progress signal before an agent is considered stuck —
@@ -53,13 +55,13 @@
    marks the monitor active. 30 seconds."
   30000)
 
- (defn create-progress-monitor
+(defn create-progress-monitor
    "Create a progress monitor for adaptive timeout.
 
    Options:
-   - :stagnation-threshold-ms - Time without progress before considering stuck (default: 120000 = 2min)
-   - :max-total-ms - Hard limit regardless of progress (default: 600000 = 10min)
-   - :min-activity-interval-ms - Minimum time between progress signals (default: 5000 = 5sec)
+   - :stagnation-threshold-ms - Time without progress before considering stuck (default: default-stagnation-threshold-ms)
+   - :max-total-ms - Hard limit regardless of progress (default: default-max-total-ms)
+   - :min-activity-interval-ms - Minimum time between progress signals (default: default-min-activity-interval-ms)
 
    Returns monitor state atom."
    [{:keys [stagnation-threshold-ms max-total-ms min-activity-interval-ms]
@@ -77,7 +79,7 @@
           :min-activity-interval-ms min-activity-interval-ms
           :stagnant-cycles 0}))
 
- (defn record-chunk!
+(defn record-chunk!
    "Record a streaming chunk as activity.
 
    Returns true if this represents meaningful progress, false if stagnant."
@@ -270,8 +272,8 @@
 (comment
   ;; Usage example
   (def monitor (create-progress-monitor
-                {:stagnation-threshold-ms 120000  ; 2 minutes
-                 :max-total-ms 600000}))           ; 10 minutes
+                {:stagnation-threshold-ms default-stagnation-threshold-ms
+                 :max-total-ms default-max-total-ms}))
 
   ;; Record streaming chunks
   (record-chunk! monitor "Analyzing the requirements...")


### PR DESCRIPTION
First component of the **named-constants wave** (fix-violation program, wave 2; rule dewey 006). Establishes the pattern: extract inline numeric literals that carry real "why this value?" intent into named `^:private` defs with intent docstrings — behavior unchanged.

**llm/progress_monitor.clj** — the adaptive-timeout defaults (stagnation 120000, max-total 600000, min-activity-interval 5000), substantive-chunk length (10), is-active recency window (30000). The explanatory line-comments became the defs' docstrings; the three defaults are now shared between the `:or` destructure and their prior duplicate.

**llm/model_selector.clj** — per-tier cost thresholds (0.01/0.05/0.10), the general + cost-optimized default budgets, and the phase-classification confidence (0.9). `default-config-fallback`'s `:cost-limit-per-task` and the selection fns' `(or cost-limit …)` guards now reference one named default.

**Left as-is (correctly not magic / exempt):** literals the deterministic locator over-reports — already-named consts (the `network_*` probe timeouts are proper defs; the scanner flags the value token inside them), speed→rank ordinals, the `×100` percentage, index sentinels, and literals inside docstring/rich-comment examples.

**Verified:** kondo clean; namespaces load; full llm test suite (947 assertions) green; pre-commit + GraalVM green.

Note on scale: the locator reports ~1700 numeric hits across the repo, but the true-positive rate is far lower (a large fraction are already-named def values, ordinals, percentages, and example literals). The wave proceeds component-by-component, extracting genuine magic with intent docstrings.