### PR TITLE
fix(docs): add required published-content headers

### DIFF
--- a/docs/architecture/state-ownership-and-phase-graph.md
+++ b/docs/architecture/state-ownership-and-phase-graph.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # State Ownership and the Phase Graph
 
 Status: design note / direction (2026-05-27)

--- a/docs/architecture/state-ownership-and-phase-graph.md
+++ b/docs/architecture/state-ownership-and-phase-graph.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # State Ownership and the Phase Graph
 
 Status: design note / direction (2026-05-27)

--- a/docs/design/automation-edge-correlator.md
+++ b/docs/design/automation-edge-correlator.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Design RFC — Automation Edge Correlator
 
 - **Status:** Draft
@@ -65,7 +69,7 @@ not as a subsystem of supervisory-state. Two reasons:
 
 Component layout:
 
-```
+```text
 components/automation-edge-correlator/
 ├── deps.edn
 ├── src/ai/miniforge/automation_edge_correlator/
@@ -106,7 +110,7 @@ sibling task to this RFC — either land in the same PR or in a follow-on.
 
 ## Edge lifecycle + status state machine
 
-```
+```text
                            ┌─────────────┐
        trigger observed    │             │   handler workflow completes
        ────────────────►   │  :observed  │   ──────────────────────────►  :handled

--- a/docs/design/automation-edge-correlator.md
+++ b/docs/design/automation-edge-correlator.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Design RFC — Automation Edge Correlator
 
 - **Status:** Draft

--- a/docs/design/event-stream-replay-retention.md
+++ b/docs/design/event-stream-replay-retention.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Event-stream replay, retention, and quiesce (BD-2)
 
 Status: **draft v4**, opened 2026-05-07, revised three times 2026-05-07

--- a/docs/design/event-stream-replay-retention.md
+++ b/docs/design/event-stream-replay-retention.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Event-stream replay, retention, and quiesce (BD-2)
 
 Status: **draft v4**, opened 2026-05-07, revised three times 2026-05-07

--- a/docs/design/labeled-pr-actions-plan.md
+++ b/docs/design/labeled-pr-actions-plan.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Plan: Configurable PR-label-triggered actions on in-flight workflows
 
 ## Problem

--- a/docs/design/labeled-pr-actions-plan.md
+++ b/docs/design/labeled-pr-actions-plan.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Plan: Configurable PR-label-triggered actions on in-flight workflows
 
 ## Problem

--- a/docs/design/supervisory-spec-entity.md
+++ b/docs/design/supervisory-spec-entity.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Design RFC — Supervisory `Spec` Entity
 
 - **Status:** Draft

--- a/docs/design/supervisory-spec-entity.md
+++ b/docs/design/supervisory-spec-entity.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Design RFC — Supervisory `Spec` Entity
 
 - **Status:** Draft

--- a/docs/pull-requests/2026-05-01-feat-dependency-attribution-ux.md
+++ b/docs/pull-requests/2026-05-01-feat-dependency-attribution-ux.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: surface dependency attribution in CLI and dashboard workflows
 
 ## Summary

--- a/docs/pull-requests/2026-05-01-feat-dependency-attribution-ux.md
+++ b/docs/pull-requests/2026-05-01-feat-dependency-attribution-ux.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: surface dependency attribution in CLI and dashboard workflows
 
 ## Summary

--- a/docs/pull-requests/2026-05-01-feat-dependency-events-and-degradation.md
+++ b/docs/pull-requests/2026-05-01-feat-dependency-events-and-degradation.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat/dependency-events-degradation
 
 ## Summary

--- a/docs/pull-requests/2026-05-01-feat-dependency-events-and-degradation.md
+++ b/docs/pull-requests/2026-05-01-feat-dependency-events-and-degradation.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat/dependency-events-degradation
 
 ## Summary

--- a/docs/pull-requests/2026-05-01-feat-dependency-evidence-and-observe.md
+++ b/docs/pull-requests/2026-05-01-feat-dependency-evidence-and-observe.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat/dependency-evidence-observe
 
 ## Summary

--- a/docs/pull-requests/2026-05-01-feat-dependency-evidence-and-observe.md
+++ b/docs/pull-requests/2026-05-01-feat-dependency-evidence-and-observe.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat/dependency-evidence-observe
 
 ## Summary

--- a/docs/pull-requests/2026-05-01-fix-210-clojure-polylith-per-file-stratified-design.md
+++ b/docs/pull-requests/2026-05-01-fix-210-clojure-polylith-per-file-stratified-design.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: [210] Clojure Polylith + per-file stratified design compliance pass
 
 **Branch:** `fix/compliance-210-clojure-polylith-per-file-stratified-design`

--- a/docs/pull-requests/2026-05-01-fix-210-clojure-polylith-per-file-stratified-design.md
+++ b/docs/pull-requests/2026-05-01-fix-210-clojure-polylith-per-file-stratified-design.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: [210] Clojure Polylith + per-file stratified design compliance pass
 
 **Branch:** `fix/compliance-210-clojure-polylith-per-file-stratified-design`

--- a/docs/pull-requests/2026-05-01-refactor-exceptions-as-data-connector-callsite-migration.md
+++ b/docs/pull-requests/2026-05-01-refactor-exceptions-as-data-connector-callsite-migration.md
@@ -1,17 +1,28 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: migrate connector callsites to shared validation helpers
 
 ## Overview
 
-Migrates seven connector components from inline `require-handle!` / `validate-auth!` patterns to the shared anomaly-returning + throwing variants in `connector` core (which landed in PR #704). Retires 14 of the 158 cleanup-needed sites identified in `work/exception-cleanup-inventory.md`.
+Migrates seven connector components from inline `require-handle!` / `validate-auth!` patterns to the shared
+anomaly-returning + throwing variants in `connector` core (which landed in PR #704). Retires 14 of the 158
+cleanup-needed sites identified in `work/exception-cleanup-inventory.md`.
 
-This is the second tier of the exceptions-as-data cleanup — the foundation cleanup PR (#704) extracted the helpers; this PR migrates the callsites.
+This is the second tier of the exceptions-as-data cleanup — the foundation cleanup PR (#704) extracted the helpers; this
+PR migrates the callsites.
 
 ## Motivation
 
-Each connector component (`connector-jira` / `gitlab` / `github` / `excel` / `edgar` / `file` / `sarif`) reimplemented the same `require-handle!` / `validate-auth!` patterns inline before #704. With the shared helpers now available in `connector` core, callers can stop duplicating the validation logic and start participating in the canonical anomaly flow at non-boundary sites while preserving the legacy `ex-info` shape at boundary sites.
+Each connector component (`connector-jira` / `gitlab` / `github` / `excel` / `edgar` / `file` / `sarif`) reimplemented
+the same `require-handle!` / `validate-auth!` patterns inline before #704. With the shared helpers now available in
+`connector` core, callers can stop duplicating the validation logic and start participating in the canonical anomaly
+flow at non-boundary sites while preserving the legacy `ex-info` shape at boundary sites.
 
-The brief was deliberately scoped to handle-lookup and auth-validation patterns. Schema/`validate!`, exhaustive-case fallthroughs, HTTP errors, and config validation are out of scope — those land in subsequent cleanup PRs.
+The brief was deliberately scoped to handle-lookup and auth-validation patterns. Schema/`validate!`, exhaustive-case
+fallthroughs, HTTP errors, and config validation are out of scope — those land in subsequent cleanup PRs.
 
 ## Base Branch
 
@@ -19,7 +30,8 @@ The brief was deliberately scoped to handle-lookup and auth-validation patterns.
 
 ## Depends On
 
-- `ai.miniforge.connector.interface/{require-handle, require-handle!, validate-auth, validate-auth!}` — landed in PR #704 (foundation cleanup)
+- `ai.miniforge.connector.interface/{require-handle, require-handle!, validate-auth, validate-auth!}` — landed in PR
+  #704 (foundation cleanup)
 - `ai.miniforge.anomaly` — landed in PR #689
 
 ## Layer
@@ -38,14 +50,19 @@ Source + test files for seven connectors:
 - `components/connector-file/src/.../impl.clj` + `test/.../interface_test.clj`
 - `components/connector-sarif/src/.../impl.clj` + `test/.../impl_test.clj`
 
-14 files total. **+311 / -100 lines.** No `deps.edn` changes — every targeted connector already declared `ai.miniforge/connector` as a `:local/root` dep.
+14 files total. **+311 / -100 lines.** No `deps.edn` changes — every targeted connector already declared
+  `ai.miniforge/connector` as a `:local/root` dep.
 
 ## Migration patterns
 
 **Two patterns. Both retire inline validation in favor of shared helpers.**
 
-1. **Handle lookup.** Local `require-handle!` shrinks to a one-liner over `connector/require-handle!`, supplying the connector-specific localized `:message`. Inline `(or (get-handle h) (throw ex-info ...))` is removed.
-2. **Auth validation.** Local `validate-auth!` calls the anomaly-returning `connector/validate-auth`, then re-throws with the localized message that interpolates the actual validation errors. Matches the brief's `(if-let [a (connector/validate-auth auth)] a ...)` shape. The protocol method body remains the boundary that throws — `pipeline-runner`'s `try/catch` expects that contract and stays unchanged.
+1. **Handle lookup.** Local `require-handle!` shrinks to a one-liner over `connector/require-handle!`, supplying the
+  connector-specific localized `:message`. Inline `(or (get-handle h) (throw ex-info ...))` is removed.
+2. **Auth validation.** Local `validate-auth!` calls the anomaly-returning `connector/validate-auth`, then re-throws
+  with the localized message that interpolates the actual validation errors. Matches the brief's `(if-let [a
+  (connector/validate-auth auth)] a ...)` shape. The protocol method body remains the boundary that throws —
+  `pipeline-runner`'s `try/catch` expects that contract and stays unchanged.
 
 ## Inventory delta
 
@@ -61,32 +78,47 @@ Source + test files for seven connectors:
 | connector-file | 3 | format/path/file-not-found, format-unsupported |
 | connector-sarif | 1 | "Invalid SARIF config" |
 
-The left-in-place sites are config validation, exhaustive-case fallthroughs, HTTP errors, or `schema/validate!` — all out of scope per the brief, which restricts this PR to the `require-handle!` / `validate-auth!` patterns. They land in subsequent cleanup PRs.
+The left-in-place sites are config validation, exhaustive-case fallthroughs, HTTP errors, or `schema/validate!` — all
+out of scope per the brief, which restricts this PR to the `require-handle!` / `validate-auth!` patterns. They land in
+subsequent cleanup PRs.
 
 ## Strata Affected
 
-Per-connector implementation namespaces (`impl.clj` for most; `interface_test.clj` for connectors that test through their public interface). No public connector API changed.
+Per-connector implementation namespaces (`impl.clj` for most; `interface_test.clj` for connectors that test through
+their public interface). No public connector API changed.
 
 ## Testing Plan
 
 - **`bb pre-commit` green:**
-  - `lint:clj` — 0 errors. 8 warnings, all pre-existing in the touched files (unused `schema.interface` requires, unused `clojure.string` references, unused binding). None introduced by this PR.
+  - `lint:clj` — 0 errors. 8 warnings, all pre-existing in the touched files (unused `schema.interface` requires, unused
+    `clojure.string` references, unused binding). None introduced by this PR.
   - `fmt:md` — clean.
-  - `test` — **3530 tests / 15746 passes / 0 failures / 0 errors.** Net new assertions: 21 across the seven connectors, covering handle-not-found `ex-info` shape and auth-rejection / auth-success paths for jira / gitlab / github.
+  - `test` — **3530 tests / 15746 passes / 0 failures / 0 errors.** Net new assertions: 21 across the seven connectors,
+    covering handle-not-found `ex-info` shape and auth-rejection / auth-success paths for jira / gitlab / github.
   - `test:graalvm` — 6 tests / 479 assertions / 0 failures.
 
 ## Deployment Plan
 
 No migration required. Backward-compatible.
 
-- `pipeline-runner` already destructures protocol-method results and wraps in `try/catch Exception` for stage failures. The shared `require-handle!` / `validate-auth!` preserve the legacy `ex-info` shape, so existing CLI/MCP error handling is unchanged.
+- `pipeline-runner` already destructures protocol-method results and wraps in `try/catch Exception` for stage failures.
+  The shared `require-handle!` / `validate-auth!` preserve the legacy `ex-info` shape, so existing CLI/MCP error
+  handling is unchanged.
 - New non-boundary call sites (where they exist post-migration) consume the anomaly-returning variants directly.
 
 ## Notes / Surprises
 
-1. **`connector-sarif` used a private `(atom {})`** instead of `connector/create-handle-registry`. Migrated it to the shared registry as part of this PR — modest scope creep, but necessary to call the shared helper. Tests don't peek at the atom internals; behavior preserved.
-2. **`pipeline-runner` is the architectural boundary, not the connector protocol body.** A strict reading of "boundary call sites use throwing variants" could imply CLI/MCP only. But `pipeline-runner` destructures result maps directly inside a `try/catch Exception` outer wrapper. Returning anomalies there would silently produce empty `:records` instead of `:failed` stage results. So protocol method bodies kept the throw at exit; internal helpers use the anomaly form. Aligns with the "preserve legacy ex-info shape" intent in the brief. Pipeline-runner adapter changes belong to a separate workstream.
-3. **Duplicate `connector.interface` requires** — `connector-jira`, `connector-gitlab`, `connector-file`, and `connector-github` had the namespace listed twice in their `ns` form. Removed during the touch.
+1. **`connector-sarif` used a private `(atom {})`** instead of `connector/create-handle-registry`. Migrated it to the
+  shared registry as part of this PR — modest scope creep, but necessary to call the shared helper. Tests don't peek at
+  the atom internals; behavior preserved.
+2. **`pipeline-runner` is the architectural boundary, not the connector protocol body.** A strict reading of "boundary
+  call sites use throwing variants" could imply CLI/MCP only. But `pipeline-runner` destructures result maps directly
+  inside a `try/catch Exception` outer wrapper. Returning anomalies there would silently produce empty `:records`
+  instead of `:failed` stage results. So protocol method bodies kept the throw at exit; internal helpers use the anomaly
+  form. Aligns with the "preserve legacy ex-info shape" intent in the brief. Pipeline-runner adapter changes belong to a
+  separate workstream.
+3. **Duplicate `connector.interface` requires** — `connector-jira`, `connector-gitlab`, `connector-file`, and
+  `connector-github` had the namespace listed twice in their `ns` form. Removed during the touch.
 
 ## Related Issues/PRs
 

--- a/docs/pull-requests/2026-05-01-refactor-exceptions-as-data-connector-callsite-migration.md
+++ b/docs/pull-requests/2026-05-01-refactor-exceptions-as-data-connector-callsite-migration.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: migrate connector callsites to shared validation helpers
 
 ## Overview

--- a/docs/pull-requests/2026-05-02-feat-direct-workflow-agent-supervisory-projection.md
+++ b/docs/pull-requests/2026-05-02-feat-direct-workflow-agent-supervisory-projection.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat/direct-workflow-agent-supervisory-projection
 
 ## Summary

--- a/docs/pull-requests/2026-05-02-feat-direct-workflow-agent-supervisory-projection.md
+++ b/docs/pull-requests/2026-05-02-feat-direct-workflow-agent-supervisory-projection.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat/direct-workflow-agent-supervisory-projection
 
 ## Summary

--- a/docs/pull-requests/2026-05-02-feat-policy-attention-context.md
+++ b/docs/pull-requests/2026-05-02-feat-policy-attention-context.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat/policy-attention-context
 
 ## Summary

--- a/docs/pull-requests/2026-05-02-feat-policy-attention-context.md
+++ b/docs/pull-requests/2026-05-02-feat-policy-attention-context.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat/policy-attention-context
 
 ## Summary

--- a/docs/pull-requests/2026-05-02-fix-claude-dogfood-repair-loop-and-observability.md
+++ b/docs/pull-requests/2026-05-02-fix-claude-dogfood-repair-loop-and-observability.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Summary
 
 This PR packages the next set of Claude dogfood fixes from the `behavioral-verification-monitor` run on `main`.

--- a/docs/pull-requests/2026-05-02-fix-claude-dogfood-repair-loop-and-observability.md
+++ b/docs/pull-requests/2026-05-02-fix-claude-dogfood-repair-loop-and-observability.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Summary
 
 This PR packages the next set of Claude dogfood fixes from the `behavioral-verification-monitor` run on `main`.

--- a/docs/pull-requests/2026-05-02-fix-dogfood-review-boundaries.md
+++ b/docs/pull-requests/2026-05-02-fix-dogfood-review-boundaries.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Summary
 
 This PR hardens the dogfood phase boundaries that were allowing a failed DAG

--- a/docs/pull-requests/2026-05-02-fix-dogfood-review-boundaries.md
+++ b/docs/pull-requests/2026-05-02-fix-dogfood-review-boundaries.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Summary
 
 This PR hardens the dogfood phase boundaries that were allowing a failed DAG

--- a/docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md
+++ b/docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of repo-dag
 
 ## Overview

--- a/docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md
+++ b/docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of repo-dag
 
 ## Overview

--- a/docs/pull-requests/2026-05-03-fix-dogfood-backend-preflight-and-stream-supervision.md
+++ b/docs/pull-requests/2026-05-03-fix-dogfood-backend-preflight-and-stream-supervision.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Summary
 
 This stacked PR follows `#766` and packages the next Claude dogfood fixes from the `behavioral-verification-monitor`

--- a/docs/pull-requests/2026-05-03-fix-dogfood-backend-preflight-and-stream-supervision.md
+++ b/docs/pull-requests/2026-05-03-fix-dogfood-backend-preflight-and-stream-supervision.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Summary
 
 This stacked PR follows `#766` and packages the next Claude dogfood fixes from the `behavioral-verification-monitor`

--- a/docs/pull-requests/2026-05-03-fix-dogfood-source-root-mcp.md
+++ b/docs/pull-requests/2026-05-03-fix-dogfood-source-root-mcp.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Summary
 
 This PR fixes the Claude dogfood regression where planner exploration could start from the execution worktree instead of

--- a/docs/pull-requests/2026-05-03-fix-dogfood-source-root-mcp.md
+++ b/docs/pull-requests/2026-05-03-fix-dogfood-source-root-mcp.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Summary
 
 This PR fixes the Claude dogfood regression where planner exploration could start from the execution worktree instead of

--- a/docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md
+++ b/docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md
@@ -1,15 +1,25 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of workflow (runtime side)
 
 ## Overview
 
-Migrates the runtime-side `:cleanup-needed` throw sites in the `workflow` component to anomaly-returning variants alongside the existing throwers. Three sites retired: `runner/build-initial-context`, `runner-environment/assert-executor-for-mode!`, and `state/transition-status`. Loader/registry-side sites (~9) are deferred to a follow-on PR per the inventory's recommended split.
+Migrates the runtime-side `:cleanup-needed` throw sites in the `workflow` component to anomaly-returning variants
+alongside the existing throwers. Three sites retired: `runner/build-initial-context`,
+`runner-environment/assert-executor-for-mode!`, and `state/transition-status`. Loader/registry-side sites (~9) are
+deferred to a follow-on PR per the inventory's recommended split.
 
 ## Motivation
 
-Per `work/exception-cleanup-inventory.md`, `workflow` is the second-highest-density cleanup target after `repo-dag` (now merged in PR #758). The inventory explicitly recommended a 2-PR split (runtime + loader/registry) due to the risk surface — this PR is the runtime side only.
+Per `work/exception-cleanup-inventory.md`, `workflow` is the second-highest-density cleanup target after `repo-dag` (now
+merged in PR #758). The inventory explicitly recommended a 2-PR split (runtime + loader/registry) due to the risk
+surface — this PR is the runtime side only.
 
-Runtime cleanup has the highest downstream payoff: every workflow execution path now composes cleanly with response-chains and inference-evidence rather than relying on slingshot exceptions for non-control-flow failures.
+Runtime cleanup has the highest downstream payoff: every workflow execution path now composes cleanly with
+response-chains and inference-evidence rather than relying on slingshot exceptions for non-control-flow failures.
 
 ## Base Branch
 
@@ -32,8 +42,10 @@ Refactor / per-component cleanup tier. `workflow` runtime namespaces only — no
 
 Source files modified (3):
 
-- `components/workflow/src/ai/miniforge/workflow/runner.clj` — `build-initial-context-anomaly` added; private `governed-capsule-missing-anomaly` extracted; throwing variant delegates and re-wraps via `response/throw-anomaly!`
-- `components/workflow/src/ai/miniforge/workflow/runner_environment.clj` — `check-executor-for-mode-anomaly` added; throwing variant delegates
+- `components/workflow/src/ai/miniforge/workflow/runner.clj` — `build-initial-context-anomaly` added; private
+  `governed-capsule-missing-anomaly` extracted; throwing variant delegates and re-wraps via `response/throw-anomaly!`
+- `components/workflow/src/ai/miniforge/workflow/runner_environment.clj` — `check-executor-for-mode-anomaly` added;
+  throwing variant delegates
 - `components/workflow/src/ai/miniforge/workflow/state.clj` — `transition-status-anomaly` added; throwing variant delegates
 
 New decomposed test files (3):
@@ -46,20 +58,25 @@ Each pins happy-path / failure-path / throwing-variant-compatibility for its sco
 
 ## Cleavage line
 
-The inventory's 9 cleanup-needed sites for `workflow` are loader-side; the runtime sites came from the broader inventory recount. Final split:
+The inventory's 9 cleanup-needed sites for `workflow` are loader-side; the runtime sites came from the broader inventory
+recount. Final split:
 
 **Runtime side (this PR, 3 sites retired):**
+
 - `runner.clj` — `build-initial-context`
 - `runner_environment.clj` — `check-executor-for-mode!`
 - `state.clj` — `transition-status`
 
 **Loader side (deferred, 9 sites):**
+
 - `loader.clj` (×3)
 - `chain_loader.clj` (×1)
 - `registry.clj` (×4)
 - `schemas.clj` (×1)
 
-Other runtime-area files (`runner_cleanup.clj`, `monitoring.clj`, `observe_phase.clj`, `agent_factory.clj`, `supervision.clj`, `dag_orchestrator.clj`) had no `:cleanup-needed` sites — only `:fatal-only` (boot-time) and `:boundary` (re-throws / event payloads). No changes required in those files.
+Other runtime-area files (`runner_cleanup.clj`, `monitoring.clj`, `observe_phase.clj`, `agent_factory.clj`,
+`supervision.clj`, `dag_orchestrator.clj`) had no `:cleanup-needed` sites — only `:fatal-only` (boot-time) and
+`:boundary` (re-throws / event payloads). No changes required in those files.
 
 ## Per-site classification
 
@@ -71,13 +88,18 @@ Other runtime-area files (`runner_cleanup.clj`, `monitoring.clj`, `observe_phase
 
 ## Slingshot stop-anomaly in `runner.clj` — kept as control-flow
 
-The inventory flagged the dashboard-stop throw inside `runner.clj`'s `check-stopped!` helper (`response/throw-anomaly!` to `:anomalies.dashboard/stop`) as `:ambiguous`. Verified by reading the matching catch in the same file's pipeline-loop `try+`:
+The inventory flagged the dashboard-stop throw inside `runner.clj`'s `check-stopped!` helper (`response/throw-anomaly!`
+to `:anomalies.dashboard/stop`) as `:ambiguous`. Verified by reading the matching catch in the same file's pipeline-loop
+`try+`:
 
 ```clojure
 (catch [:anomaly/category :anomalies.dashboard/stop] {:keys [anomaly/message]} ...)
 ```
 
-This is true cooperative cancellation control flow — the inner `try+` selectively unwinds when the dashboard issues a stop, then transitions the workflow to `:failed`. Rewriting it as a return value would require threading a sentinel through every layer between `check-stopped!` and the outer pipeline loop. Kept as-is; rationale documented in the commit body.
+This is true cooperative cancellation control flow — the inner `try+` selectively unwinds when the dashboard issues a
+stop, then transitions the workflow to `:failed`. Rewriting it as a return value would require threading a sentinel
+through every layer between `check-stopped!` and the outer pipeline loop. Kept as-is; rationale documented in the commit
+body.
 
 ## New API surface
 
@@ -89,18 +111,22 @@ ai.miniforge.workflow.runner-environment/check-executor-for-mode-anomaly
 ai.miniforge.workflow.runner/build-initial-context-anomaly
 ```
 
-Throwing siblings retained, marked `^{:deprecated "exceptions-as-data — prefer *-anomaly"}`, and now delegate to the anomaly variants — re-wrapping the returned anomaly into the original `response/throw-anomaly!` shape so existing callers see no behavior change.
+Throwing siblings retained, marked `^{:deprecated "exceptions-as-data — prefer *-anomaly"}`, and now delegate to the
+anomaly variants — re-wrapping the returned anomaly into the original `response/throw-anomaly!` shape so existing
+callers see no behavior change.
 
 ## Inventory delta
 
 - **Runtime side:** 3 of 3 `:cleanup-needed` sites retired in this PR (plus the 1 ambiguous slingshot resolved as keep-as-is).
-- **Loader side:** 9 sites deferred to follow-on PR (`loader.clj` ×3, `chain_loader.clj` ×1, `registry.clj` ×4, `schemas.clj` ×1).
+- **Loader side:** 9 sites deferred to follow-on PR (`loader.clj` ×3, `chain_loader.clj` ×1, `registry.clj` ×4,
+  `schemas.clj` ×1).
 
 ## Strata Affected
 
 - `ai.miniforge.workflow.runner` — `build-initial-context-anomaly` added; thrower delegates
 - `ai.miniforge.workflow.runner-environment` — `check-executor-for-mode-anomaly` added
-- `ai.miniforge.workflow.state` — `transition-status-anomaly` added; downstream `mark-completed` / `mark-failed` / `transition-to-phase` continue to call the deprecated thrower (out of scope)
+- `ai.miniforge.workflow.state` — `transition-status-anomaly` added; downstream `mark-completed` / `mark-failed` /
+  `transition-to-phase` continue to call the deprecated thrower (out of scope)
 
 ## Testing Plan
 
@@ -109,8 +135,10 @@ Throwing siblings retained, marked `^{:deprecated "exceptions-as-data — prefer
   - `fmt:md` — clean
   - `test` — **4930 tests / 22631 passes / 0 failures / 0 errors**
   - `test:graalvm` — 6 tests / 487 assertions / 0 failures
-- 16 expected clj-kondo deprecation warnings on the deprecated throwers; only fire from in-component callers that exercise the legacy path.
-- **Commit-budget overridden** (358 reportable lines > 200 threshold). Rationale recorded in commit body: protocol-body changes must be atomic; splitting leaves intermediate commits uncompilable. Same precedent as PR #758 (repo-dag).
+- 16 expected clj-kondo deprecation warnings on the deprecated throwers; only fire from in-component callers that
+  exercise the legacy path.
+- **Commit-budget overridden** (358 reportable lines > 200 threshold). Rationale recorded in commit body: protocol-body
+  changes must be atomic; splitting leaves intermediate commits uncompilable. Same precedent as PR #758 (repo-dag).
 
 ## Deployment Plan
 
@@ -121,9 +149,15 @@ No migration required. Backward-compatible.
 
 ## Notes / Surprises
 
-- **`:anomalies.workflow/no-capsule-executor` is not in `response/anomaly/workflow-anomalies` taxonomy.** Pre-existing latent bug — `throw-anomaly!` doesn't validate against the taxonomy. Preserved in the throwing wrapper to keep behavior identical; flagged for the loader-side cleanup or a separate hygiene pass.
-- **`runner-test` and `runner-extended-test` have 14 errors / 1 failure on `main` when run in isolation against the workflow component.** They require the broader phase registry loaded via the polylith development project. Confirmed by stashing changes and rerunning — not regressions caused by this PR; project-level `bb test` passes 4930/4930.
-- **Commit-budget gate friction.** Same pattern as repo-dag (PR #758): mechanical many-site refactor + delegated wrappers + decomposed tests trips the line budget. Override path documented and worked. Worth flagging again as repeating friction; an `:exceptions-as-data` budget profile would simplify.
+- **`:anomalies.workflow/no-capsule-executor` is not in `response/anomaly/workflow-anomalies` taxonomy.** Pre-existing
+  latent bug — `throw-anomaly!` doesn't validate against the taxonomy. Preserved in the throwing wrapper to keep
+  behavior identical; flagged for the loader-side cleanup or a separate hygiene pass.
+- **`runner-test` and `runner-extended-test` have 14 errors / 1 failure on `main` when run in isolation against the
+  workflow component.** They require the broader phase registry loaded via the polylith development project. Confirmed
+  by stashing changes and rerunning — not regressions caused by this PR; project-level `bb test` passes 4930/4930.
+- **Commit-budget gate friction.** Same pattern as repo-dag (PR #758): mechanical many-site refactor + delegated
+  wrappers + decomposed tests trips the line budget. Override path documented and worked. Worth flagging again as
+  repeating friction; an `:exceptions-as-data` budget profile would simplify.
 
 ## Related Issues/PRs
 

--- a/docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md
+++ b/docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of workflow (runtime side)
 
 ## Overview

--- a/docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md
+++ b/docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix Claude Plan Stream Progress
 
 ## Summary

--- a/docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md
+++ b/docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix Claude Plan Stream Progress
 
 ## Summary

--- a/docs/pull-requests/2026-05-04-fix-workflow-taxonomy-no-capsule-executor.md
+++ b/docs/pull-requests/2026-05-04-fix-workflow-taxonomy-no-capsule-executor.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: register :anomalies.workflow/no-capsule-executor in workflow taxonomy
 
 ## Overview

--- a/docs/pull-requests/2026-05-04-fix-workflow-taxonomy-no-capsule-executor.md
+++ b/docs/pull-requests/2026-05-04-fix-workflow-taxonomy-no-capsule-executor.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: register :anomalies.workflow/no-capsule-executor in workflow taxonomy
 
 ## Overview

--- a/docs/pull-requests/2026-05-04-refactor-kill-workflow-runtime-deprecation.md
+++ b/docs/pull-requests/2026-05-04-refactor-kill-workflow-runtime-deprecation.md
@@ -1,25 +1,36 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: kill workflow runtime deprecated throwers (single API)
 
 ## Overview
 
-Follow-on cleanup to PR #769 (which migrated `workflow` runtime sites to the deprecate-and-coexist anomaly-returning pattern). This PR kills the deprecated throwers entirely so each site has a single canonical API. Three throwers retired:
+Follow-on cleanup to PR #769 (which migrated `workflow` runtime sites to the deprecate-and-coexist anomaly-returning
+pattern). This PR kills the deprecated throwers entirely so each site has a single canonical API. Three throwers
+retired:
 
 - `workflow.state/transition-status` (deprecated thrower)
 - `workflow.runner-environment/assert-executor-for-mode!` (deprecated thrower)
 - `workflow.runner/build-initial-context` (deprecated private thrower)
 
-The boundary throws that legitimately need to escalate to a slingshot ex-info shape (preserving the contract for `try+` callers above the workflow component) are inlined at their single call sites.
+The boundary throws that legitimately need to escalate to a slingshot ex-info shape (preserving the contract for `try+`
+callers above the workflow component) are inlined at their single call sites.
 
 ## Motivation
 
-PR #769 landed with the same deprecate-and-coexist pattern that earlier exceptions-as-data PRs (#704 foundation, #758 repo-dag) established. Reviewer feedback pointed out that pattern is over-cautious for a 17-star repo with one primary maintainer and a handful of internal callers per site:
+PR #769 landed with the same deprecate-and-coexist pattern that earlier exceptions-as-data PRs (#704 foundation, #758
+repo-dag) established. Reviewer feedback pointed out that pattern is over-cautious for a 17-star repo with one primary
+maintainer and a handful of internal callers per site:
 
 - The deprecated throwers were component-internal — zero external callers across the repo.
 - The pattern paid an ongoing surface-area + deprecation-warnings tax.
 - The savings (smaller individual PRs, easy revert) didn't justify it at this scale.
 
-This PR drops the coexistence and lands a single API per site. Future component-scope cleanups will follow this pattern. Foundation-tier APIs with >30 callers (`schema/validate`, `dag-primitives/unwrap`) keep coexistence — the call-site count makes hard cuts genuinely impractical there.
+This PR drops the coexistence and lands a single API per site. Future component-scope cleanups will follow this pattern.
+Foundation-tier APIs with >30 callers (`schema/validate`, `dag-primitives/unwrap`) keep coexistence — the call-site
+count makes hard cuts genuinely impractical there.
 
 ## Base Branch
 
@@ -27,7 +38,8 @@ This PR drops the coexistence and lands a single API per site. Future component-
 
 ## Depends On
 
-- PR #769 — `refactor/exceptions-as-data-workflow-runtime-cleanup` (merged) — introduced the anomaly variants this PR keeps as canonical.
+- PR #769 — `refactor/exceptions-as-data-workflow-runtime-cleanup` (merged) — introduced the anomaly variants this PR
+  keeps as canonical.
 
 ## Layer
 
@@ -39,25 +51,37 @@ Refactor / kill-the-deprecation cleanup. Three workflow-runtime files; component
 
 - Deleted the deprecated `transition-status` thrower.
 - Renamed `transition-status-anomaly` → `transition-status` (canonical name now belongs to the canonical fn).
-- Added private `transition-status!` boundary helper. Used by `mark-completed`, `mark-failed`, `transition-to-phase` — these represent workflow-definition invariants; an FSM rejection at one of them is a programmer error, so escalating to slingshot is appropriate. Preserves the legacy `:anomalies.workflow/invalid-transition` ex-info shape.
+- Added private `transition-status!` boundary helper. Used by `mark-completed`, `mark-failed`, `transition-to-phase` —
+  these represent workflow-definition invariants; an FSM rejection at one of them is a programmer error, so escalating
+  to slingshot is appropriate. Preserves the legacy `:anomalies.workflow/invalid-transition` ex-info shape.
 
 `components/workflow/src/ai/miniforge/workflow/runner_environment.clj`:
 
 - Deleted the deprecated `assert-executor-for-mode!` thrower.
 - Renamed `check-executor-for-mode-anomaly` → `check-executor-for-mode`.
-- Inlined the boundary throw at the single call site in `acquire-execution-environment!`. Preserves the legacy `:anomalies.executor/unavailable` ex-info shape for legacy `try+` callers above this layer.
+- Inlined the boundary throw at the single call site in `acquire-execution-environment!`. Preserves the legacy
+  `:anomalies.executor/unavailable` ex-info shape for legacy `try+` callers above this layer.
 
 `components/workflow/src/ai/miniforge/workflow/runner.clj`:
 
 - Deleted the deprecated private `build-initial-context` thrower.
 - Renamed `build-initial-context-anomaly` → `build-initial-context`.
-- Inlined the boundary throw at the single call site in `run-pipeline`'s let bindings. Preserves the `:anomalies.workflow/no-capsule-executor` ex-info shape that external callers (CLI / MCP / orchestrator) expect on misconfiguration.
+- Inlined the boundary throw at the single call site in `run-pipeline`'s let bindings. Preserves the
+  `:anomalies.workflow/no-capsule-executor` ex-info shape that external callers (CLI / MCP / orchestrator) expect on
+  misconfiguration.
 
 `components/workflow/test/.../anomaly/`:
 
-- `transition_status_test.clj` — references `transition-status` (not `*-anomaly`); deprecated-thrower compat tests replaced with `mark-completed` / `mark-failed` integration tests that exercise the private `transition-status!` boundary helper.
-- `check_executor_for_mode_test.clj` — references `check-executor-for-mode`; `assert-executor-for-mode!` tests replaced with `acquire-execution-environment!` integration tests (with stubbed `dag-executor-fns`) that exercise the inlined boundary throw.
-- `build_initial_context_test.clj` — references `build-initial-context`; deprecated-thrower compat tests removed. Run-pipeline boundary integration test omitted with a documented rationale: `acquire-environment` runs first along that path with its own governed-mode throw, so the integration test would test the wrong escalation site. Coverage for the build-initial-context boundary specifically is delegated to the runner's existing pipeline tests.
+- `transition_status_test.clj` — references `transition-status` (not `*-anomaly`); deprecated-thrower compat tests
+  replaced with `mark-completed` / `mark-failed` integration tests that exercise the private `transition-status!`
+  boundary helper.
+- `check_executor_for_mode_test.clj` — references `check-executor-for-mode`; `assert-executor-for-mode!` tests replaced
+  with `acquire-execution-environment!` integration tests (with stubbed `dag-executor-fns`) that exercise the inlined
+  boundary throw.
+- `build_initial_context_test.clj` — references `build-initial-context`; deprecated-thrower compat tests removed.
+  Run-pipeline boundary integration test omitted with a documented rationale: `acquire-environment` runs first along
+  that path with its own governed-mode throw, so the integration test would test the wrong escalation site. Coverage for
+  the build-initial-context boundary specifically is delegated to the runner's existing pipeline tests.
 
 ## API surface (after this PR)
 
@@ -71,36 +95,53 @@ ai.miniforge.workflow.runner/build-initial-context                    ; was *-an
 ai.miniforge.workflow.state/transition-status!                        ; private
 ```
 
-The deprecated throwers (`transition-status` thrower, `assert-executor-for-mode!`, `build-initial-context` thrower wrapper) are **gone**. Boundary escalation to slingshot ex-info now lives inlined at the call sites that actually need to throw.
+The deprecated throwers (`transition-status` thrower, `assert-executor-for-mode!`, `build-initial-context` thrower
+wrapper) are **gone**. Boundary escalation to slingshot ex-info now lives inlined at the call sites that actually need
+to throw.
 
 ## External caller contracts
 
 Unchanged. External callers above the workflow component see the same slingshot `:anomaly/category` shapes as before:
 
 - `acquire-execution-environment!` still throws `:anomalies.executor/unavailable` for governed-mode-without-capsule.
-- `run-pipeline` still throws `:anomalies.workflow/no-capsule-executor` when build-initial-context returns the no-capsule anomaly.
-- `mark-completed` / `mark-failed` / `transition-to-phase` still throw `:anomalies.workflow/invalid-transition` on FSM rejection (now via private `transition-status!`).
+- `run-pipeline` still throws `:anomalies.workflow/no-capsule-executor` when build-initial-context returns the
+  no-capsule anomaly.
+- `mark-completed` / `mark-failed` / `transition-to-phase` still throw `:anomalies.workflow/invalid-transition` on FSM
+  rejection (now via private `transition-status!`).
 
 ## Strata Affected
 
 - `ai.miniforge.workflow.runner` — `build-initial-context` is now anomaly-returning; boundary throw inlined in `run-pipeline`
-- `ai.miniforge.workflow.runner-environment` — `check-executor-for-mode` is anomaly-returning; boundary throw inlined in `acquire-execution-environment!`
-- `ai.miniforge.workflow.state` — `transition-status` is anomaly-returning; private `transition-status!` boundary helper used by `mark-completed` / `mark-failed` / `transition-to-phase`
+- `ai.miniforge.workflow.runner-environment` — `check-executor-for-mode` is anomaly-returning; boundary throw inlined in
+  `acquire-execution-environment!`
+- `ai.miniforge.workflow.state` — `transition-status` is anomaly-returning; private `transition-status!` boundary helper
+  used by `mark-completed` / `mark-failed` / `transition-to-phase`
 
 ## Testing Plan
 
-- `bb test` — **5003 tests / 22890 passes / 0 failures / 0 errors** (post-cleanup; deprecated-thrower compat tests removed; new boundary integration tests added).
+- `bb test` — **5003 tests / 22890 passes / 0 failures / 0 errors** (post-cleanup; deprecated-thrower compat tests
+  removed; new boundary integration tests added).
 - No deprecation warnings emitted (no deprecated throwers remain).
 
 ## Deployment Plan
 
-No migration required for external callers — these helpers are component-internal (no `interface.clj` exports). External callers continue to see the same slingshot `:anomaly/category` shapes when escalation happens at the component boundaries.
+No migration required for external callers — these helpers are component-internal (no `interface.clj` exports). External
+callers continue to see the same slingshot `:anomaly/category` shapes when escalation happens at the component
+boundaries.
 
 ## Notes / Surprises
 
-- **Policy update.** This PR codifies the kill-the-deprecation pattern for component-scope cleanups. Foundation-tier APIs (>~30 callers; `schema/validate`, `dag-primitives/unwrap`) keep coexistence because hard cuts are genuinely impractical there. Documented in the commit body and reflected in the wave-6 closing summary.
-- **Run-pipeline boundary integration test omitted.** The build-initial-context throw escalation through `run-pipeline` is hard to exercise because `acquire-environment` runs first and has its own throw on the same governed-mode-without-capsule scenario. The boundary escalation pattern is tested via `acquire-execution-environment!` in `check_executor_for_mode_test.clj`. End-to-end coverage of the build-initial-context boundary is the runner's existing pipeline tests.
-- **`:anomalies.workflow/no-capsule-executor` is still not in `response/anomaly/workflow-anomalies` taxonomy.** Pre-existing latent quirk — `throw-anomaly!` doesn't validate against the taxonomy. Preserved at the new inlined boundary throw; flagged for the loader-side cleanup or a separate hygiene pass.
+- **Policy update.** This PR codifies the kill-the-deprecation pattern for component-scope cleanups. Foundation-tier
+  APIs (>~30 callers; `schema/validate`, `dag-primitives/unwrap`) keep coexistence because hard cuts are genuinely
+  impractical there. Documented in the commit body and reflected in the wave-6 closing summary.
+- **Run-pipeline boundary integration test omitted.** The build-initial-context throw escalation through `run-pipeline`
+  is hard to exercise because `acquire-environment` runs first and has its own throw on the same
+  governed-mode-without-capsule scenario. The boundary escalation pattern is tested via `acquire-execution-environment!`
+  in `check_executor_for_mode_test.clj`. End-to-end coverage of the build-initial-context boundary is the runner's
+  existing pipeline tests.
+- **`:anomalies.workflow/no-capsule-executor` is still not in `response/anomaly/workflow-anomalies` taxonomy.**
+  Pre-existing latent quirk — `throw-anomaly!` doesn't validate against the taxonomy. Preserved at the new inlined
+  boundary throw; flagged for the loader-side cleanup or a separate hygiene pass.
 
 ## Related Issues/PRs
 

--- a/docs/pull-requests/2026-05-04-refactor-kill-workflow-runtime-deprecation.md
+++ b/docs/pull-requests/2026-05-04-refactor-kill-workflow-runtime-deprecation.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: kill workflow runtime deprecated throwers (single API)
 
 ## Overview

--- a/docs/pull-requests/2026-05-04-refactor-workflow-loader-cleanup.md
+++ b/docs/pull-requests/2026-05-04-refactor-workflow-loader-cleanup.md
@@ -1,15 +1,25 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of workflow (loader side)
 
 ## Overview
 
-Finishes the `workflow` component's exceptions-as-data cleanup. Migrates every loader-side `:cleanup-needed` throw site (9 of 9 per `work/exception-cleanup-inventory.md`) to a single anomaly-returning API. Boundary throws live only at the call sites that need to escalate to slingshot, inlined per the kill-the-deprecation pattern from PR #777.
+Finishes the `workflow` component's exceptions-as-data cleanup. Migrates every loader-side `:cleanup-needed` throw site
+(9 of 9 per `work/exception-cleanup-inventory.md`) to a single anomaly-returning API. Boundary throws live only at the
+call sites that need to escalate to slingshot, inlined per the kill-the-deprecation pattern from PR #777.
 
-Pairs with the runtime-side cleanup (PR #769 → PR #777). Together they retire the workflow component's full `:cleanup-needed` row in the inventory.
+Pairs with the runtime-side cleanup (PR #769 → PR #777). Together they retire the workflow component's full
+`:cleanup-needed` row in the inventory.
 
 ## Motivation
 
-Per the inventory, `workflow` was the second-highest-density cleanup target after `repo-dag`. The runtime side landed in two PRs (#769 introduced anomaly variants, #777 killed the deprecated throwers). This PR mirrors that final shape directly — anomaly-returning helpers as the canonical API; throws inlined at boundary call sites — and applies it to the loader / registry / schemas surface in one PR rather than two.
+Per the inventory, `workflow` was the second-highest-density cleanup target after `repo-dag`. The runtime side landed in
+two PRs (#769 introduced anomaly variants, #777 killed the deprecated throwers). This PR mirrors that final shape
+directly — anomaly-returning helpers as the canonical API; throws inlined at boundary call sites — and applies it to the
+loader / registry / schemas surface in one PR rather than two.
 
 ## Base Branch
 
@@ -36,7 +46,8 @@ Refactor / per-component cleanup tier. Workflow loader namespaces only; runtime 
 
 - `load-from-resource` returns `nil` | workflow | `:fault` anomaly on parse failure (was: `response/throw-anomaly!` of `:anomalies/fault`)
 - `validate-and-cache-workflow` returns result map | `:invalid-input` anomaly on validator failure (was: throw)
-- `load-workflow` becomes the single boundary site that inlines `response/throw-anomaly!` for source faults, validation failures, and the missing-everywhere not-found case
+- `load-workflow` becomes the single boundary site that inlines `response/throw-anomaly!` for source faults, validation
+  failures, and the missing-everywhere not-found case
 
 `components/workflow/src/ai/miniforge/workflow/chain_loader.clj`:
 
@@ -59,7 +70,10 @@ Refactor / per-component cleanup tier. Workflow loader namespaces only; runtime 
 
 `components/workflow/test/ai/miniforge/workflow/anomaly/`:
 
-- Decomposed coverage, one file per scope: `load-from-resource-test`, `validate-and-cache-workflow-test`, `try-load-chain-test`, `load-workflow-from-resource-test`, `workflow-characteristics-test`, `register-workflow-test`, `validate-checkpoint-data-test`. Each covers anomaly happy / anomaly failure / boundary-escalation through the throwing entry point.
+- Decomposed coverage, one file per scope: `load-from-resource-test`, `validate-and-cache-workflow-test`,
+  `try-load-chain-test`, `load-workflow-from-resource-test`, `workflow-characteristics-test`, `register-workflow-test`,
+  `validate-checkpoint-data-test`. Each covers anomaly happy / anomaly failure / boundary-escalation through the
+  throwing entry point.
 
 ## Per-site classification
 
@@ -96,7 +110,8 @@ ai.miniforge.workflow.registry/register-workflow!           ; throws :anomalies/
 ai.miniforge.workflow.schemas/validate-checkpoint-data!     ; throws ex-info
 ```
 
-No deprecated throwers retained. The boundary helpers preserve the same slingshot `:anomaly/category` shapes external callers above the component depend on (CLI / MCP / orchestrator).
+No deprecated throwers retained. The boundary helpers preserve the same slingshot `:anomaly/category` shapes external
+callers above the component depend on (CLI / MCP / orchestrator).
 
 ## Strata Affected
 
@@ -118,14 +133,23 @@ No deprecated throwers retained. The boundary helpers preserve the same slingsho
 
 ## Deployment Plan
 
-No migration required for external callers. The boundary entry points (`load-workflow`, `load-chain`, `workflow-characteristics`, `register-workflow!`, `validate-checkpoint-data!`) preserve the same thrown ex-info shapes that legacy `try+` callers above the workflow component expect.
+No migration required for external callers. The boundary entry points (`load-workflow`, `load-chain`,
+`workflow-characteristics`, `register-workflow!`, `validate-checkpoint-data!`) preserve the same thrown ex-info shapes
+that legacy `try+` callers above the workflow component expect.
 
-New code can opt into the anomaly-returning helpers directly (e.g. `try-load-chain` for callers that want to branch on `:not-found` as data without try+ machinery). Discovery paths (`discover-workflows-from-resources`) now degrade gracefully: a single broken resource no longer aborts the whole sequence.
+New code can opt into the anomaly-returning helpers directly (e.g. `try-load-chain` for callers that want to branch on
+`:not-found` as data without try+ machinery). Discovery paths (`discover-workflows-from-resources`) now degrade
+gracefully: a single broken resource no longer aborts the whole sequence.
 
 ## Notes / Surprises
 
-- **Discovery resilience improvement.** `discover-workflows-from-resources` previously aborted the entire sequence the moment any single resource failed to read. With `load-workflow-from-resource` now anomaly-returning, the discovery sequence filters anomalies out — one bad EDN no longer hides every other workflow. Behavior change is intentional and consistent with how a registry should behave; flagged here for visibility.
-- **`some` / boolean schema gap.** While migrating, the agent observed a place where a `(some pred coll)` result is fed into a malli schema that expected boolean. This is a pre-existing pattern, not introduced by this PR; flagged as a follow-up hygiene item.
+- **Discovery resilience improvement.** `discover-workflows-from-resources` previously aborted the entire sequence the
+  moment any single resource failed to read. With `load-workflow-from-resource` now anomaly-returning, the discovery
+  sequence filters anomalies out — one bad EDN no longer hides every other workflow. Behavior change is intentional and
+  consistent with how a registry should behave; flagged here for visibility.
+- **`some` / boolean schema gap.** While migrating, the agent observed a place where a `(some pred coll)` result is fed
+  into a malli schema that expected boolean. This is a pre-existing pattern, not introduced by this PR; flagged as a
+  follow-up hygiene item.
 - **Commit-budget gate.** Same friction as PR #758 / #769 / #777. Override path used per established precedent.
 
 ## Related Issues/PRs

--- a/docs/pull-requests/2026-05-04-refactor-workflow-loader-cleanup.md
+++ b/docs/pull-requests/2026-05-04-refactor-workflow-loader-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of workflow (loader side)
 
 ## Overview

--- a/docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md
+++ b/docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Summary
 
 This PR packages the remaining Claude dogfood review-boundary fix from the `behavioral-verification-monitor` run on

--- a/docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md
+++ b/docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Summary
 
 This PR packages the remaining Claude dogfood review-boundary fix from the `behavioral-verification-monitor` run on

--- a/docs/pull-requests/2026-05-06-fix-dogfood-startup-implement-resume.md
+++ b/docs/pull-requests/2026-05-06-fix-dogfood-startup-implement-resume.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Summary
 
 This PR packages the Claude dogfood fixes that are not review-policy specific:

--- a/docs/pull-requests/2026-05-06-fix-dogfood-startup-implement-resume.md
+++ b/docs/pull-requests/2026-05-06-fix-dogfood-startup-implement-resume.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Summary
 
 This PR packages the Claude dogfood fixes that are not review-policy specific:

--- a/docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md
+++ b/docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix(polylith): restore workspace structure gate
 
 ## Summary

--- a/docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md
+++ b/docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix(polylith): restore workspace structure gate
 
 ## Summary

--- a/docs/pull-requests/2026-05-06-refactor-agent-component-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-agent-component-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of agent component
 
 ## Overview

--- a/docs/pull-requests/2026-05-06-refactor-agent-component-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-agent-component-cleanup.md
@@ -1,15 +1,24 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of agent component
 
 ## Overview
 
-Migrates 6 throw sites across `components/agent/` (`prompts.clj`, `planner.clj`, `meta_protocol.clj`, `file_artifacts.clj`) to a single anomaly-returning API per site, with boundary throws inlined where external slingshot callers depend on the legacy taxonomy.
+Migrates 6 throw sites across `components/agent/` (`prompts.clj`, `planner.clj`, `meta_protocol.clj`,
+`file_artifacts.clj`) to a single anomaly-returning API per site, with boundary throws inlined where external slingshot
+callers depend on the legacy taxonomy.
 
 Mirrors the kill-the-deprecation pattern from PR #777.
 
 ## Motivation
 
-Per `work/exception-cleanup-inventory.md`, the `agent` component had 6 `:cleanup-needed` / `:ambiguous` sites distributed across four files. The `prompts.clj` sites were tagged `:ambiguous` (missing prompt resources currently fatal at startup); the inventory left the design pivot ("construct with fallback prompts") for a separate workstream and asked this PR to migrate the throw shape only.
+Per `work/exception-cleanup-inventory.md`, the `agent` component had 6 `:cleanup-needed` / `:ambiguous` sites
+distributed across four files. The `prompts.clj` sites were tagged `:ambiguous` (missing prompt resources currently
+fatal at startup); the inventory left the design pivot ("construct with fallback prompts") for a separate workstream and
+asked this PR to migrate the throw shape only.
 
 ## Base Branch
 
@@ -29,22 +38,31 @@ Refactor / per-component cleanup tier.
 
 - `snapshot-working-dir` git failure now returns a `:fault` anomaly. Two in-component callers handle the new return shape:
   - `collect-written-files` branches on `anomaly?` and returns nil.
-  - `artifact-session/create-session!` (the `:pre-session-snapshot` site) wraps the call in a let, checks for `nil` (legacy thrown-exception path) or anomaly, and coerces to `empty-snapshot` so a fault never flows downstream into diffing / changed-paths logic.
+  - `artifact-session/create-session!` (the `:pre-session-snapshot` site) wraps the call in a let, checks for `nil`
+    (legacy thrown-exception path) or anomaly, and coerces to `empty-snapshot` so a fault never flows downstream into
+    diffing / changed-paths logic.
 
   No external boundary escalation needed — both callers degrade gracefully.
 
 `components/agent/src/.../meta_protocol.clj`:
 
-- `create-meta-config` missing `:id` / `:name` returns `:invalid-input` anomaly. The only caller passes valid input today; no boundary escalation.
+- `create-meta-config` missing `:id` / `:name` returns `:invalid-input` anomaly. The only caller passes valid input
+  today; no boundary escalation.
 
 `components/agent/src/.../planner.clj`:
 
-- Two new anomaly-returning private helpers — `parsed-plan-or-anomaly` and `require-llm-client-or-anomaly` (both `defn-`; tests reach via `#'planner/...`). Boundary throws live at the call sites where `planner_test.clj` (and external slingshot callers) assert the legacy `:anomalies.agent/invoke-failed` and `:anomalies.agent/llm-error` taxonomy.
-- The previously redundant `(if llm-client …)` wrapper was removed — `require-llm-client-or-anomaly` already escalates above it, so the else-branch was unreachable.
+- Two new anomaly-returning private helpers — `parsed-plan-or-anomaly` and `require-llm-client-or-anomaly` (both
+  `defn-`; tests reach via `#'planner/...`). Boundary throws live at the call sites where `planner_test.clj` (and
+  external slingshot callers) assert the legacy `:anomalies.agent/invoke-failed` and `:anomalies.agent/llm-error`
+  taxonomy.
+- The previously redundant `(if llm-client …)` wrapper was removed — `require-llm-client-or-anomaly` already escalates
+  above it, so the else-branch was unreachable.
 
 `components/agent/src/.../prompts.clj` (3 sites):
 
-- Missing prompt resource at startup remains a fail-fast boundary throw, but now uses the canonical `:anomalies/fault` slingshot category instead of the bespoke `:anomalies/not-found` ex-info. Design pivot ("construct with fallback prompts") deferred per the brief.
+- Missing prompt resource at startup remains a fail-fast boundary throw, but now uses the canonical `:anomalies/fault`
+  slingshot category instead of the bespoke `:anomalies/not-found` ex-info. Design pivot ("construct with fallback
+  prompts") deferred per the brief.
 
 `components/agent/test/.../file_artifacts_extended_test.clj`:
 
@@ -79,7 +97,8 @@ Each covers happy path + failure path + boundary-escalation behaviour.
 
 ## Testing Plan
 
-`bb pre-commit` green: **5108 tests / 23274 assertions / 0 failures / 0 errors**. GraalVM compat: 6 tests, 490 assertions, 0 failures.
+`bb pre-commit` green: **5108 tests / 23274 assertions / 0 failures / 0 errors**. GraalVM compat: 6 tests, 490
+assertions, 0 failures.
 
 One transient flake in `workflow.merge-resolution-test/conflict-fixture` (unrelated to agent component); passed on retry.
 
@@ -87,13 +106,20 @@ Required `MINIFORGE_COMMIT_BUDGET_OVERRIDE` since the diff is +408/-57 across 4 
 
 ## Deployment Plan
 
-No migration. External slingshot callers continue to see `:anomalies.agent/invoke-failed` and `:anomalies.agent/llm-error` ex-info shapes via the boundary throws in `planner.clj`. The `prompts.clj` startup fail-fast boundary now uses the canonical `:anomalies/fault` category — only an internal change in classification keyword; the throw still happens at the same code path.
+No migration. External slingshot callers continue to see `:anomalies.agent/invoke-failed` and
+`:anomalies.agent/llm-error` ex-info shapes via the boundary throws in `planner.clj`. The `prompts.clj` startup
+fail-fast boundary now uses the canonical `:anomalies/fault` category — only an internal change in classification
+keyword; the throw still happens at the same code path.
 
 ## Notes / Surprises
 
-- **`planner.clj` `(if llm-client …)` removed.** The `require-llm-client-or-anomaly` boundary throw above already escalates, so the else-branch was unreachable.
-- **`:anomaly/category` (slingshot) and `:anomaly/type` (data) namespaces remain distinct.** Helpers return canonical `:not-found` / `:invalid-input` / `:fault`; boundary throws use the legacy `:anomalies.agent/*` taxonomy that external `try+` callers depend on. Same shape as `loader.clj` post-#787.
-- **Prompts design pivot deferred.** "Construct with fallback prompts and only fail at first invocation" is a future workstream; this PR moves the throw category only.
+- **`planner.clj` `(if llm-client …)` removed.** The `require-llm-client-or-anomaly` boundary throw above already
+  escalates, so the else-branch was unreachable.
+- **`:anomaly/category` (slingshot) and `:anomaly/type` (data) namespaces remain distinct.** Helpers return canonical
+  `:not-found` / `:invalid-input` / `:fault`; boundary throws use the legacy `:anomalies.agent/*` taxonomy that external
+  `try+` callers depend on. Same shape as `loader.clj` post-#787.
+- **Prompts design pivot deferred.** "Construct with fallback prompts and only fail at first invocation" is a future
+  workstream; this PR moves the throw category only.
 
 ## Related Issues/PRs
 

--- a/docs/pull-requests/2026-05-06-refactor-operator-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-operator-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of operator
 
 ## Overview

--- a/docs/pull-requests/2026-05-06-refactor-operator-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-operator-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of operator
 
 ## Overview

--- a/docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md
@@ -1,15 +1,22 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of spec-parser
 
 ## Overview
 
-Migrates every throw site in `components/spec-parser/src/.../core.clj` (7 sites) to anomaly returns. Boundary escalation lives in `parse-spec-file` only — anomalies rethrown as `ex-info` with `:anomaly/type` tagged in `ex-data` so existing slingshot callers (CLI `run`, task-executor pre-flight) stay green.
+Migrates every throw site in `components/spec-parser/src/.../core.clj` (7 sites) to anomaly returns. Boundary escalation
+lives in `parse-spec-file` only — anomalies rethrown as `ex-info` with `:anomaly/type` tagged in `ex-data` so existing
+slingshot callers (CLI `run`, task-executor pre-flight) stay green.
 
 Mirrors the kill-the-deprecation pattern from PR #777. Single API per site.
 
 ## Motivation
 
-Per `work/exception-cleanup-inventory.md`, `spec-parser` had 6 `:cleanup-needed` sites in `core.clj` plus 2 `:fatal-only` markers that got minimal cleanup pass-through (no new throw sites in anomaly-returning paths).
+Per `work/exception-cleanup-inventory.md`, `spec-parser` had 6 `:cleanup-needed` sites in `core.clj` plus 2
+`:fatal-only` markers that got minimal cleanup pass-through (no new throw sites in anomaly-returning paths).
 
 ## Base Branch
 
@@ -27,13 +34,15 @@ Refactor / per-component cleanup tier.
 
 `components/spec-parser/deps.edn`:
 
-- Adds `:local/root` deps on `ai.miniforge/anomaly` (and explicit `ai.miniforge/knowledge` since `core.clj` already required it but the dep was missing from the component's own deps.edn — pre-existing latent gap).
+- Adds `:local/root` deps on `ai.miniforge/anomaly` (and explicit `ai.miniforge/knowledge` since `core.clj` already
+  required it but the dep was missing from the component's own deps.edn — pre-existing latent gap).
 
 `components/spec-parser/src/.../core.clj`:
 
 - Each thrower replaced with anomaly-returning logic.
 - Private helpers introduced: `escalate!`, `file-not-found-anomaly`, `spec-shape-anomaly`, `assemble-normalized-spec`.
-- `parse-spec-file` is the single boundary site that inlines `escalate!` to rethrow anomalies as `ex-info` with `:anomaly/type` tagged.
+- `parse-spec-file` is the single boundary site that inlines `escalate!` to rethrow anomalies as `ex-info` with
+  `:anomaly/type` tagged.
 
 `components/spec-parser/test/.../interface_test.clj`:
 
@@ -41,7 +50,9 @@ Refactor / per-component cleanup tier.
 
 `components/spec-parser/test/.../anomaly/` (new):
 
-- Six new decomposed test files, one per fn: `detect_format_test.clj`, `parse_edn_test.clj`, `parse_json_test.clj`, `normalize_spec_test.clj`, `parse_content_test.clj`, `parse_spec_file_test.clj`. Each covers happy path + failure path + boundary escalation through `parse-spec-file`.
+- Six new decomposed test files, one per fn: `detect_format_test.clj`, `parse_edn_test.clj`, `parse_json_test.clj`,
+  `normalize_spec_test.clj`, `parse_content_test.clj`, `parse_spec_file_test.clj`. Each covers happy path + failure path
+  - boundary escalation through `parse-spec-file`.
 
 ## Per-site classification
 
@@ -64,17 +75,24 @@ Refactor / per-component cleanup tier.
 
 ## Testing Plan
 
-- `bb pre-commit` green: lint:clj clean, fmt:md clean, test **5129 tests / 23341 passes / 0 failures / 0 errors**, GraalVM compat clean.
-- One transient `bb_proc.core_test/test-run!-returns-result-on-zero-exit` flake on a non-final pre-commit run; cleared on the run that landed the commit. Unrelated to spec-parser.
+- `bb pre-commit` green: lint:clj clean, fmt:md clean, test **5129 tests / 23341 passes / 0 failures / 0 errors**,
+  GraalVM compat clean.
+- One transient `bb_proc.core_test/test-run!-returns-result-on-zero-exit` flake on a non-final pre-commit run; cleared
+  on the run that landed the commit. Unrelated to spec-parser.
 
 ## Deployment Plan
 
-No migration. External slingshot callers continue to see the same `ex-info` shape via the `parse-spec-file` boundary; in-component anomaly returns are additive surface for new callers.
+No migration. External slingshot callers continue to see the same `ex-info` shape via the `parse-spec-file` boundary;
+in-component anomaly returns are additive surface for new callers.
 
 ## Notes
 
-- **`spec-parser/deps.edn` was implicitly relying on `ai.miniforge/knowledge`** via the polylith workspace — `core.clj` required it but the dep was missing from the component's own `deps.edn`. Added it explicitly. Pre-existing latent gap, not caused by this refactor.
-- **Commit budget**: tripped at 447 lines (ceiling 200). Override invoked per the precedent set by PRs #758 / #769 / #777 / #787 — cleanup is single-purpose with mandatory paired tests; slicing impl from tests violates the workstream's acceptance criteria.
+- **`spec-parser/deps.edn` was implicitly relying on `ai.miniforge/knowledge`** via the polylith workspace — `core.clj`
+  required it but the dep was missing from the component's own `deps.edn`. Added it explicitly. Pre-existing latent gap,
+  not caused by this refactor.
+- **Commit budget**: tripped at 447 lines (ceiling 200). Override invoked per the precedent set by PRs #758 / #769 /
+  #777 / #787 — cleanup is single-purpose with mandatory paired tests; slicing impl from tests violates the workstream's
+  acceptance criteria.
 
 ## Related Issues/PRs
 

--- a/docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of spec-parser
 
 ## Overview

--- a/docs/pull-requests/2026-05-06-refactor-task-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-task-cleanup.md
@@ -1,13 +1,22 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of task
 
 ## Overview
 
-Migrates the 5 `:cleanup-needed` throw sites in `components/task/src/.../core.clj` to a single anomaly-returning API. Mirrors the FSM-transition cleanup pattern from PR #777 directly: anomaly-returning canonical fns + private `*!` boundary helpers for in-component invariants where rejection is a programmer error.
+Migrates the 5 `:cleanup-needed` throw sites in `components/task/src/.../core.clj` to a single anomaly-returning API.
+Mirrors the FSM-transition cleanup pattern from PR #777 directly: anomaly-returning canonical fns + private `*!`
+boundary helpers for in-component invariants where rejection is a programmer error.
 
 ## Motivation
 
-Per `work/exception-cleanup-inventory.md`, `task` had 5 `:cleanup-needed` sites with the inventory note: "FSM transition + lookup pattern repeated." Same shape the workflow `state.clj` cleanup landed in PR #777 — applied here directly without redesign.
+Per `work/exception-cleanup-inventory.md`, `task` had 5 `:cleanup-needed` sites with the inventory note: "FSM transition
+
++ lookup pattern repeated." Same shape the workflow `state.clj` cleanup landed in PR #777 — applied here directly
+without redesign.
 
 ## Base Branch
 
@@ -15,8 +24,8 @@ Per `work/exception-cleanup-inventory.md`, `task` had 5 `:cleanup-needed` sites 
 
 ## Depends On
 
-- `ai.miniforge.anomaly` (merged) — anomaly type vocabulary
-- `ai.miniforge.response` (merged) — slingshot `throw-anomaly!`
++ `ai.miniforge.anomaly` (merged) — anomaly type vocabulary
++ `ai.miniforge.response` (merged) — slingshot `throw-anomaly!`
 
 ## Layer
 
@@ -26,21 +35,26 @@ Refactor / per-component cleanup tier.
 
 `components/task/deps.edn`:
 
-- Adds `:local/root` deps on `ai.miniforge/anomaly` and `ai.miniforge/response`.
++ Adds `:local/root` deps on `ai.miniforge/anomaly` and `ai.miniforge/response`.
 
 `components/task/src/.../core.clj`:
 
-- New canonical anomaly-returning fns:
-  - `transition-result` — `nil | :invalid-input anomaly` for FSM rejections (replacing `validate-transition`'s throw)
-  - `lookup-task` — `task | :not-found anomaly` (replacing the four lookup-then-throw call sites in `update-task!`, `delete-task!`, `transition-task!`, `decompose-task!`)
-- New private boundary helper:
-  - `lookup-task!` — calls `lookup-task`; on anomaly raises via `response/throw-anomaly!` with `:anomalies/not-found` slingshot category for legacy callers above the component
-- The pre-cleanup throw call sites now consume the anomaly-returning path. Boundary escalation happens at the in-component callers where workflow-definition invariants make rejection a programmer error (mirrors `state.clj`'s `transition-status!`).
++ New canonical anomaly-returning fns:
+  + `transition-result` — `nil | :invalid-input anomaly` for FSM rejections (replacing `validate-transition`'s throw)
+  + `lookup-task` — `task | :not-found anomaly` (replacing the four lookup-then-throw call sites in `update-task!`,
+    `delete-task!`, `transition-task!`, `decompose-task!`)
++ New private boundary helper:
+  + `lookup-task!` — calls `lookup-task`; on anomaly raises via `response/throw-anomaly!` with `:anomalies/not-found`
+    slingshot category for legacy callers above the component
++ The pre-cleanup throw call sites now consume the anomaly-returning path. Boundary escalation happens at the
+  in-component callers where workflow-definition invariants make rejection a programmer error (mirrors `state.clj`'s
+  `transition-status!`).
 
 `components/task/test/.../anomaly/` (new):
 
-- `transition_result_test.clj` — 10 tests / 31 assertions (FSM transition cascade)
-- `lookup_task_test.clj` — 11 tests / 30 assertions, including a regression test verifying `decompose-task!` validates the parent before any side effects.
++ `transition_result_test.clj` — 10 tests / 31 assertions (FSM transition cascade)
++ `lookup_task_test.clj` — 11 tests / 30 assertions, including a regression test verifying `decompose-task!` validates
+  the parent before any side effects.
 
 ## Per-site classification
 
@@ -52,46 +66,56 @@ Refactor / per-component cleanup tier.
 | 244 | `transition-task!` (lookup) | `:not-found` | `:anomalies/not-found` |
 | 350 | `decompose-task!` (parent lookup) | `:not-found` (via `lookup-task` 2-arg) | `:anomalies/not-found` |
 
-Boundary throws use the **general** `:anomalies/conflict` and `:anomalies/not-found` slingshot categories (not a task-specific taxonomy) — adding a `:anomalies.task/*` set would touch the response component, which is out of scope here.
+Boundary throws use the **general** `:anomalies/conflict` and `:anomalies/not-found` slingshot categories (not a
+task-specific taxonomy) — adding a `:anomalies.task/*` set would touch the response component, which is out of scope
+here.
 
 ## Strata Affected
 
-- `ai.miniforge.task.core` — FSM-transition + lookup cleanup
-- New `ai.miniforge.task.anomaly.*` test namespaces
++ `ai.miniforge.task.core` — FSM-transition + lookup cleanup
++ New `ai.miniforge.task.anomaly.*` test namespaces
 
 ## Testing Plan
 
-- `bb test`: **5262 tests / 23699 passes / 0 failures / 1 error** in unrelated `llm/interface-test/stream-parser-recovers-result-only-content-test`. Pre-existing baseline failure: arity mismatch in `llm-client/stream-with-parser`. Reproduces on the unmodified branch baseline (verified via `git stash` — 5205 tests, 0 failures, 1 error before changes). `llm` has no dep on `task`; the failure is unrelated.
-- All `task` tests pass: `task.core-test` (38 assertions), `task.interface-test` (31), `task.queue-test` (30), `task.anomaly.transition-result-test` (31), `task.anomaly.lookup-task-test` (30).
-- Lint: 4 files, 0 errors, 0 warnings.
++ `bb test`: **5262 tests / 23699 passes / 0 failures / 1 error** in unrelated
+  `llm/interface-test/stream-parser-recovers-result-only-content-test`. Pre-existing baseline failure: arity mismatch in
+  `llm-client/stream-with-parser`. Reproduces on the unmodified branch baseline (verified via `git stash` — 5205 tests,
+  0 failures, 1 error before changes). `llm` has no dep on `task`; the failure is unrelated.
++ All `task` tests pass: `task.core-test` (38 assertions), `task.interface-test` (31), `task.queue-test` (30),
+  `task.anomaly.transition-result-test` (31), `task.anomaly.lookup-task-test` (30).
++ Lint: 4 files, 0 errors, 0 warnings.
 
-Hook bypass via `--no-verify` because the pre-commit chain's `test` step exits non-zero on the pre-existing `llm` baseline failure. Lint and format both clean.
+Hook bypass via `--no-verify` because the pre-commit chain's `test` step exits non-zero on the pre-existing `llm`
+baseline failure. Lint and format both clean.
 
-Commit budget tripped at 331 lines (ceiling 200); override invoked per the kill-the-deprecation precedent — atomic refactor, splitting would leave broken intermediate state.
+Commit budget tripped at 331 lines (ceiling 200); override invoked per the kill-the-deprecation precedent — atomic
+refactor, splitting would leave broken intermediate state.
 
 ## Deployment Plan
 
-No migration. External slingshot callers continue to see the same ex-info shapes via the boundary throws (`:anomalies/not-found`, `:anomalies/conflict`).
+No migration. External slingshot callers continue to see the same ex-info shapes via the boundary throws
+(`:anomalies/not-found`, `:anomalies/conflict`).
 
 ## Notes
 
-- **FSM-transition-cleanup shape applies directly.** Same `transition-X` (anomaly-returning, public) + `lookup-task!` (boundary, throwing) split as `state.clj` post-#777. Saves design time and keeps the codebase coherent.
-- **Pre-existing `llm` test baseline failure** noted above; not introduced by this PR.
++ **FSM-transition-cleanup shape applies directly.** Same `transition-X` (anomaly-returning, public) + `lookup-task!`
+  (boundary, throwing) split as `state.clj` post-#777. Saves design time and keeps the codebase coherent.
++ **Pre-existing `llm` test baseline failure** noted above; not introduced by this PR.
 
 ## Related Issues/PRs
 
-- Built on PR #777 (FSM-transition cleanup precedent for the workflow component)
-- Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
-- Companion to Wave 7 cleanup PRs — operator, spec-parser, agent component
++ Built on PR #777 (FSM-transition cleanup precedent for the workflow component)
++ Tracked in PR #691 (`work/exception-cleanup-inventory.md`)
++ Companion to Wave 7 cleanup PRs — operator, spec-parser, agent component
 
 ## Checklist
 
-- [x] All 5 `:cleanup-needed` task sites retired
-- [x] FSM-transition + lookup-cleanup pattern from PR #777 applied
-- [x] Single API per site
-- [x] Boundary throws inlined via `lookup-task!`
-- [x] External caller contracts preserved
-- [x] Decomposed test files (two: `transition_result_test`, `lookup_task_test`)
-- [x] No new throws in anomaly-returning code paths
-- [x] All `task` tests pass; the one unrelated `llm` test failure is pre-existing
-- [x] Apache 2 license headers preserved
++ [x] All 5 `:cleanup-needed` task sites retired
++ [x] FSM-transition + lookup-cleanup pattern from PR #777 applied
++ [x] Single API per site
++ [x] Boundary throws inlined via `lookup-task!`
++ [x] External caller contracts preserved
++ [x] Decomposed test files (two: `transition_result_test`, `lookup_task_test`)
++ [x] No new throws in anomaly-returning code paths
++ [x] All `task` tests pass; the one unrelated `llm` test failure is pre-existing
++ [x] Apache 2 license headers preserved

--- a/docs/pull-requests/2026-05-06-refactor-task-cleanup.md
+++ b/docs/pull-requests/2026-05-06-refactor-task-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of task
 
 ## Overview

--- a/docs/pull-requests/2026-05-09-fix-test-phase-loader-support.md
+++ b/docs/pull-requests/2026-05-09-fix-test-phase-loader-support.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix(test): add explicit phase loader support
 
 ## Summary

--- a/docs/pull-requests/2026-05-09-fix-test-phase-loader-support.md
+++ b/docs/pull-requests/2026-05-09-fix-test-phase-loader-support.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix(test): add explicit phase loader support
 
 ## Summary

--- a/docs/pull-requests/2026-05-09-refactor-cli-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-cli-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of cli base
 
 ## Overview

--- a/docs/pull-requests/2026-05-09-refactor-cli-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-cli-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of cli base
 
 ## Overview
@@ -81,7 +85,7 @@ Refactor / per-component cleanup tier.
 ## Testing Plan
 
 - New `anomaly.*` tests: 7 tests covering both fns' escalation paths
-  + happy-path returns.
+  - happy-path returns.
 - CI to confirm full cli suite still green.
 
 ## Deployment Plan

--- a/docs/pull-requests/2026-05-09-refactor-event-stream-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-event-stream-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of event-stream
 
 ## Overview

--- a/docs/pull-requests/2026-05-09-refactor-event-stream-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-event-stream-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of event-stream
 
 ## Overview

--- a/docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of pr-lifecycle
 
 ## Overview

--- a/docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of pr-lifecycle
 
 ## Overview

--- a/docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup tail bundle (policy-pack + tool-registry)
 
 ## Overview

--- a/docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md
+++ b/docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup tail bundle (policy-pack + tool-registry)
 
 ## Overview

--- a/docs/pull-requests/2026-05-12-refactor-connector-data-sources-cleanup.md
+++ b/docs/pull-requests/2026-05-12-refactor-connector-data-sources-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of data-source connectors
 
 ## Overview

--- a/docs/pull-requests/2026-05-12-refactor-connector-data-sources-cleanup.md
+++ b/docs/pull-requests/2026-05-12-refactor-connector-data-sources-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of data-source connectors
 
 ## Overview

--- a/docs/pull-requests/2026-05-12-refactor-connector-foundation-cleanup.md
+++ b/docs/pull-requests/2026-05-12-refactor-connector-foundation-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of connector foundation + small connectors
 
 ## Overview

--- a/docs/pull-requests/2026-05-12-refactor-connector-foundation-cleanup.md
+++ b/docs/pull-requests/2026-05-12-refactor-connector-foundation-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of connector foundation + small connectors
 
 ## Overview

--- a/docs/pull-requests/2026-05-14-refactor-connector-vcs-cleanup.md
+++ b/docs/pull-requests/2026-05-14-refactor-connector-vcs-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of VCS connectors (github + gitlab + jira)
 
 ## Overview

--- a/docs/pull-requests/2026-05-14-refactor-connector-vcs-cleanup.md
+++ b/docs/pull-requests/2026-05-14-refactor-connector-vcs-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of VCS connectors (github + gitlab + jira)
 
 ## Overview

--- a/docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md
+++ b/docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Dogfood Artifact Provenance
 
 ## Overview

--- a/docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md
+++ b/docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Dogfood Artifact Provenance
 
 ## Overview

--- a/docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md
+++ b/docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Dogfood Resume Checkpoint Repair
 
 ## Overview

--- a/docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md
+++ b/docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Dogfood Resume Checkpoint Repair
 
 ## Overview

--- a/docs/pull-requests/2026-05-15-fix-resume-artifact-base-metadata.md
+++ b/docs/pull-requests/2026-05-15-fix-resume-artifact-base-metadata.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Resume Artifact Base Metadata
 
 ## Overview

--- a/docs/pull-requests/2026-05-15-fix-resume-artifact-base-metadata.md
+++ b/docs/pull-requests/2026-05-15-fix-resume-artifact-base-metadata.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Resume Artifact Base Metadata
 
 ## Overview

--- a/docs/pull-requests/2026-05-15-fix-resume-status-stale-failure.md
+++ b/docs/pull-requests/2026-05-15-fix-resume-status-stale-failure.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix Resume Status Stale Failure
 
 ## Summary

--- a/docs/pull-requests/2026-05-15-fix-resume-status-stale-failure.md
+++ b/docs/pull-requests/2026-05-15-fix-resume-status-stale-failure.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix Resume Status Stale Failure
 
 ## Summary

--- a/docs/pull-requests/2026-05-15-refactor-connector-test-followups.md
+++ b/docs/pull-requests/2026-05-15-refactor-connector-test-followups.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: connector cleanup test coverage follow-ups
 
 ## Overview

--- a/docs/pull-requests/2026-05-15-refactor-connector-test-followups.md
+++ b/docs/pull-requests/2026-05-15-refactor-connector-test-followups.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: connector cleanup test coverage follow-ups
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md
+++ b/docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Overview
 
 Replaces `bb test` (stable-derived sweep) in the `bb pre-commit` chain

--- a/docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md
+++ b/docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Overview
 
 Replaces `bb test` (stable-derived sweep) in the `bb pre-commit` chain

--- a/docs/pull-requests/2026-05-16-fix-dogfood-stale-status.md
+++ b/docs/pull-requests/2026-05-16-fix-dogfood-stale-status.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Dogfood stale status
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-dogfood-stale-status.md
+++ b/docs/pull-requests/2026-05-16-fix-dogfood-stale-status.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Dogfood stale status
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-dogfood-submit-tool-and-display.md
+++ b/docs/pull-requests/2026-05-16-fix-dogfood-submit-tool-and-display.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Submit MCP tool schema (Anthropic 400) + honest phase outcome display
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-dogfood-submit-tool-and-display.md
+++ b/docs/pull-requests/2026-05-16-fix-dogfood-submit-tool-and-display.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Submit MCP tool schema (Anthropic 400) + honest phase outcome display
 
 ## Overview
@@ -22,7 +26,7 @@ on the same theme: the system was lying to the operator.
    `^[a-zA-Z0-9_.-]{1,64}$`, so every implementer invocation that
    loaded the tool produced:
 
-   ```
+   ```text
    API Error: 400 tools.12.custom.input_schema.properties:
    Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'
    ```
@@ -96,7 +100,8 @@ on the same theme: the system was lying to the operator.
 ## Testing Plan
 
 - `bases/mcp-context-server` focused tests:
-  ```
+
+  ```bash
   clojure -A:test:dev -M -e "(require 'clojure.test
     '[ai.miniforge.mcp-context-server.tools-test]
     '[ai.miniforge.mcp-context-server.context-cache-test])
@@ -104,9 +109,11 @@ on the same theme: the system was lying to the operator.
       'ai.miniforge.mcp-context-server.tools-test
       'ai.miniforge.mcp-context-server.context-cache-test)"
   ```
+
   → 27 tests, 69 assertions, 0 failures.
 - `bases/cli` display tests:
-  ```
+
+  ```bash
   clojure -A:test:dev -M -e "(require 'clojure.test
     '[ai.miniforge.cli.workflow-runner.display-output-test]
     '[ai.miniforge.cli.main-test])
@@ -114,6 +121,7 @@ on the same theme: the system was lying to the operator.
       'ai.miniforge.cli.workflow-runner.display-output-test
       'ai.miniforge.cli.main-test)"
   ```
+
   → 51 tests, 130 assertions, 0 failures.
 - `bb pre-commit` — to be run on the committed branch before merge.
 

--- a/docs/pull-requests/2026-05-16-fix-phase-repair-handoff-envelope.md
+++ b/docs/pull-requests/2026-05-16-fix-phase-repair-handoff-envelope.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Phase repair handoff envelope
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-phase-repair-handoff-envelope.md
+++ b/docs/pull-requests/2026-05-16-fix-phase-repair-handoff-envelope.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Phase repair handoff envelope
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-resume-status-handling.md
+++ b/docs/pull-requests/2026-05-16-fix-resume-status-handling.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: workflow resume fails loud on non-terminal status + honest "Resuming from phase" line
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-resume-status-handling.md
+++ b/docs/pull-requests/2026-05-16-fix-resume-status-handling.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: workflow resume fails loud on non-terminal status + honest "Resuming from phase" line
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md
+++ b/docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Resume From Workspace Checkpoints
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md
+++ b/docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Resume From Workspace Checkpoints
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md
+++ b/docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Reviewer issue schema rejected explicit nils, flipping :approved to :rejected silently
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md
+++ b/docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Reviewer issue schema rejected explicit nils, flipping :approved to :rejected silently
 
 ## Overview

--- a/docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md
+++ b/docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix Reviewer Issue Shape Validation
 
 ## Summary

--- a/docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md
+++ b/docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix Reviewer Issue Shape Validation
 
 ## Summary

--- a/docs/pull-requests/2026-05-17-fix-capsule-acquisition-timeout.md
+++ b/docs/pull-requests/2026-05-17-fix-capsule-acquisition-timeout.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: capsule acquire-environment! wall-clock timeout
 
 ## Overview

--- a/docs/pull-requests/2026-05-17-fix-capsule-acquisition-timeout.md
+++ b/docs/pull-requests/2026-05-17-fix-capsule-acquisition-timeout.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: capsule acquire-environment! wall-clock timeout
 
 ## Overview

--- a/docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md
+++ b/docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: exceptions-as-data cleanup of self-healing + progress-detector + workflow
 
 ## Overview

--- a/docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md
+++ b/docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: exceptions-as-data cleanup of self-healing + progress-detector + workflow
 
 ## Overview

--- a/docs/pull-requests/2026-05-26-task-c1b44bd7.md
+++ b/docs/pull-requests/2026-05-26-task-c1b44bd7.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: policy-pack rule lookup for the knowledge component
 
 ## Overview

--- a/docs/pull-requests/2026-05-26-task-c1b44bd7.md
+++ b/docs/pull-requests/2026-05-26-task-c1b44bd7.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: policy-pack rule lookup for the knowledge component
 
 ## Overview

--- a/docs/pull-requests/2026-06-10-feat-supervisory-golden-fixtures.md
+++ b/docs/pull-requests/2026-06-10-feat-supervisory-golden-fixtures.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat-supervisory-golden-fixtures
 
 **Tier:** contract-hardening / consumer-enabler

--- a/docs/pull-requests/2026-06-10-feat-supervisory-golden-fixtures.md
+++ b/docs/pull-requests/2026-06-10-feat-supervisory-golden-fixtures.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat-supervisory-golden-fixtures
 
 **Tier:** contract-hardening / consumer-enabler

--- a/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
+++ b/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: remove resolver hotspots from standards remediation wave 50
 
 ## Overview

--- a/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
+++ b/docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: remove resolver hotspots from standards remediation wave 50
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-phase-act-collapse.md
+++ b/docs/pull-requests/2026-06-19-chris-phase-act-collapse.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: collapse the phase-outcome derivation into one Domain authority
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-phase-act-collapse.md
+++ b/docs/pull-requests/2026-06-19-chris-phase-act-collapse.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: collapse the phase-outcome derivation into one Domain authority
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix CLI Artifact And Policy Command Composition
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix CLI Artifact And Policy Command Composition
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave52.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave52.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix Policy Pack Custom Detector Registration
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave52.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave52.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix Policy Pack Custom Detector Registration
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave53.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave53.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix CLI ETL Repo Direct Analysis
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-standards-remediation-wave53.md
+++ b/docs/pull-requests/2026-06-19-chris-standards-remediation-wave53.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix CLI ETL Repo Direct Analysis
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-typed-phase-acts.md
+++ b/docs/pull-requests/2026-06-19-chris-typed-phase-acts.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: typed handoff acts for phase outputs, meta-loop halts, and PR-monitor decisions
 
 ## Overview

--- a/docs/pull-requests/2026-06-19-chris-typed-phase-acts.md
+++ b/docs/pull-requests/2026-06-19-chris-typed-phase-acts.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: typed handoff acts for phase outputs, meta-loop halts, and PR-monitor decisions
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-function-local-require-audit.md
+++ b/docs/pull-requests/2026-06-20-chris-function-local-require-audit.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # chore: audit function-local require patterns
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-function-local-require-audit.md
+++ b/docs/pull-requests/2026-06-20-chris-function-local-require-audit.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # chore: audit function-local require patterns
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-lsp-mcp-bridge-boundary-audit.md
+++ b/docs/pull-requests/2026-06-20-chris-lsp-mcp-bridge-boundary-audit.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # chore: LSP MCP Bridge Boundary Audit
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-lsp-mcp-bridge-boundary-audit.md
+++ b/docs/pull-requests/2026-06-20-chris-lsp-mcp-bridge-boundary-audit.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # chore: LSP MCP Bridge Boundary Audit
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md
+++ b/docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat(phase): complete the phase-outcome authority — emit :skipped, route leave-handlers, fix resume
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md
+++ b/docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat(phase): complete the phase-outcome authority — emit :skipped, route leave-handlers, fix resume
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-policy-gate-compiler.md
+++ b/docs/pull-requests/2026-06-20-chris-policy-gate-compiler.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: compile policy-pack rules into executable checks
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-policy-gate-compiler.md
+++ b/docs/pull-requests/2026-06-20-chris-policy-gate-compiler.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: compile policy-pack rules into executable checks
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-policy-gate-phase-wiring.md
+++ b/docs/pull-requests/2026-06-20-chris-policy-gate-phase-wiring.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: Policy Gate Phase Wiring
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-policy-gate-phase-wiring.md
+++ b/docs/pull-requests/2026-06-20-chris-policy-gate-phase-wiring.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: Policy Gate Phase Wiring
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md
+++ b/docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: Polylith CI Change Scope
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md
+++ b/docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: Polylith CI Change Scope
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-resolver-hotspots-followup.md
+++ b/docs/pull-requests/2026-06-20-chris-resolver-hotspots-followup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # chore: clarify CLI optional provider registry
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-resolver-hotspots-followup.md
+++ b/docs/pull-requests/2026-06-20-chris-resolver-hotspots-followup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # chore: clarify CLI optional provider registry
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-verify-test-direct-private-vars.md
+++ b/docs/pull-requests/2026-06-20-chris-verify-test-direct-private-vars.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # test: replace verify test dynamic resolves
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-chris-verify-test-direct-private-vars.md
+++ b/docs/pull-requests/2026-06-20-chris-verify-test-direct-private-vars.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # test: replace verify test dynamic resolves
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-feat-config-resource-loader.md
+++ b/docs/pull-requests/2026-06-20-feat-config-resource-loader.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: shared config-resource loader in ai.miniforge.config
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-feat-config-resource-loader.md
+++ b/docs/pull-requests/2026-06-20-feat-config-resource-loader.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: shared config-resource loader in ai.miniforge.config
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-adapter-claude-code-staleness-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-adapter-claude-code-staleness-config.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(adapter-claude-code): externalize session staleness windows to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-adapter-claude-code-staleness-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-adapter-claude-code-staleness-config.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(adapter-claude-code): externalize session staleness windows to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-agent-llm-call-tuning-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-agent-llm-call-tuning-config.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(agent): externalize curator/meta-eval/heartbeat tuning to config
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-agent-llm-call-tuning-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-agent-llm-call-tuning-config.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(agent): externalize curator/meta-eval/heartbeat tuning to config
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(cli): externalize default user config to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(cli): externalize default user config to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-connector-edgar-base-url-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-connector-edgar-base-url-config.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(connector-edgar): make SEC base URLs configurable
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-connector-edgar-base-url-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-connector-edgar-base-url-config.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(connector-edgar): make SEC base URLs configurable
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(llm): externalize backend endpoint/model data to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(llm): externalize backend endpoint/model data to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-lsp-client-timeouts-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-lsp-client-timeouts-config.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Externalize LSP client timeouts to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-lsp-client-timeouts-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-lsp-client-timeouts-config.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Externalize LSP client timeouts to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-lsp-mcp-bridge-timeouts-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-lsp-mcp-bridge-timeouts-config.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Externalize lsp-mcp-bridge LSP client timeouts to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-lsp-mcp-bridge-timeouts-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-lsp-mcp-bridge-timeouts-config.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Externalize lsp-mcp-bridge LSP client timeouts to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-orchestrator-operator-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-orchestrator-operator-config-edn.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(orchestrator,operator): externalize default-config to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-orchestrator-operator-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-orchestrator-operator-config-edn.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(orchestrator,operator): externalize default-config to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-phase-deployment-timeouts-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-phase-deployment-timeouts-config.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Externalize phase-deployment shell timeouts to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-phase-deployment-timeouts-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-phase-deployment-timeouts-config.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Externalize phase-deployment shell timeouts to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-self-healing-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-self-healing-config-edn.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: externalize self-healing backend-failover policy to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-self-healing-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-self-healing-config-edn.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: externalize self-healing backend-failover policy to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-semantic-analyzer-limits-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-semantic-analyzer-limits-config.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(semantic-analyzer): externalize scan limits to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-semantic-analyzer-limits-config.md
+++ b/docs/pull-requests/2026-06-20-refactor-semantic-analyzer-limits-config.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(semantic-analyzer): externalize scan limits to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-task-executor-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-task-executor-config-edn.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(task-executor): externalize runtime/cost config to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-task-executor-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-task-executor-config-edn.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(task-executor): externalize runtime/cost config to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-web-dashboard-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-web-dashboard-config-edn.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor(web-dashboard): externalize deployment/session knobs to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-20-refactor-web-dashboard-config-edn.md
+++ b/docs/pull-requests/2026-06-20-refactor-web-dashboard-config-edn.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor(web-dashboard): externalize deployment/session knobs to EDN
 
 ## Overview

--- a/docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md
+++ b/docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Route config.resource diagnostics through a system-locale catalog
 
 ## Overview

--- a/docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md
+++ b/docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Route config.resource diagnostics through a system-locale catalog
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-bb-data-plane-http-anomalies.md
+++ b/docs/pull-requests/2026-06-25-chris-bb-data-plane-http-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Return data-plane HTTP failures as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-bb-data-plane-http-anomalies.md
+++ b/docs/pull-requests/2026-06-25-chris-bb-data-plane-http-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Return data-plane HTTP failures as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-bb-r2-pull-anomalies.md
+++ b/docs/pull-requests/2026-06-25-chris-bb-r2-pull-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Return R2 pull failures as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-bb-r2-pull-anomalies.md
+++ b/docs/pull-requests/2026-06-25-chris-bb-r2-pull-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Return R2 pull failures as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-control-plane-transition-not-found.md
+++ b/docs/pull-requests/2026-06-25-chris-control-plane-transition-not-found.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Return missing control-plane agent transitions as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-control-plane-transition-not-found.md
+++ b/docs/pull-requests/2026-06-25-chris-control-plane-transition-not-found.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Return missing control-plane agent transitions as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-exceptions-boundary-ns-detection.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-boundary-ns-detection.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Classify MCP and Listener Boundary Namespaces
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-exceptions-boundary-ns-detection.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-boundary-ns-detection.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Classify MCP and Listener Boundary Namespaces
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-exceptions-fallback-loaders.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-fallback-loaders.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor: Consolidate Fail-Open Config Loaders
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-exceptions-fallback-loaders.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-fallback-loaders.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor: Consolidate Fail-Open Config Loaders
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-exceptions-fatal-only-review-filter.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-fatal-only-review-filter.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Separate Fatal-Only Exception Notes from Review Violations
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-exceptions-fatal-only-review-filter.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-fatal-only-review-filter.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Separate Fatal-Only Exception Notes from Review Violations
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-exceptions-required-resource-context.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-required-resource-context.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor: Preserve Context on Required Config Resources
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-exceptions-required-resource-context.md
+++ b/docs/pull-requests/2026-06-25-chris-exceptions-required-resource-context.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor: Preserve Context on Required Config Resources
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-pipeline-config-connector-anomaly.md
+++ b/docs/pull-requests/2026-06-25-chris-pipeline-config-connector-anomaly.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Return connector registry misses as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-chris-pipeline-config-connector-anomaly.md
+++ b/docs/pull-requests/2026-06-25-chris-pipeline-config-connector-anomaly.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Return connector registry misses as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md
+++ b/docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Exceptions Config Loader Consolidation
 
 ## Summary

--- a/docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md
+++ b/docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Exceptions Config Loader Consolidation
 
 ## Summary

--- a/docs/pull-requests/2026-06-25-exceptions-resource-boundary-consolidation.md
+++ b/docs/pull-requests/2026-06-25-exceptions-resource-boundary-consolidation.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Exceptions Resource Boundary Consolidation
 
 ## Summary

--- a/docs/pull-requests/2026-06-25-exceptions-resource-boundary-consolidation.md
+++ b/docs/pull-requests/2026-06-25-exceptions-resource-boundary-consolidation.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Exceptions Resource Boundary Consolidation
 
 ## Summary

--- a/docs/pull-requests/2026-06-25-review-self-healing-resources-classpath.md
+++ b/docs/pull-requests/2026-06-25-review-self-healing-resources-classpath.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Wire self-healing resources into review classpaths
 
 ## Overview

--- a/docs/pull-requests/2026-06-25-review-self-healing-resources-classpath.md
+++ b/docs/pull-requests/2026-06-25-review-self-healing-resources-classpath.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Wire self-healing resources into review classpaths
 
 ## Overview

--- a/docs/pull-requests/2026-06-26-chris-bb-generate-icon-source-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-bb-generate-icon-source-anomaly.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Return icon source misses as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-26-chris-bb-generate-icon-source-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-bb-generate-icon-source-anomaly.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Return icon source misses as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-26-chris-lsp-download-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-lsp-download-anomaly.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Return LSP download failures as data
 
 ## Overview

--- a/docs/pull-requests/2026-06-26-chris-lsp-download-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-lsp-download-anomaly.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Return LSP download failures as data
 
 ## Overview

--- a/docs/pull-requests/2026-06-26-chris-release-files-path-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-release-files-path-anomaly.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Return release file path traversal as data
 
 ## Overview

--- a/docs/pull-requests/2026-06-26-chris-release-files-path-anomaly.md
+++ b/docs/pull-requests/2026-06-26-chris-release-files-path-anomaly.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Return release file path traversal as data
 
 ## Overview

--- a/docs/pull-requests/2026-06-26-chris-workflow-cost-breakdown-anomalies.md
+++ b/docs/pull-requests/2026-06-26-chris-workflow-cost-breakdown-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix: Return cost breakdown validation failures as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-26-chris-workflow-cost-breakdown-anomalies.md
+++ b/docs/pull-requests/2026-06-26-chris-workflow-cost-breakdown-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix: Return cost breakdown validation failures as anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-27-chris-connector-file-extract-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-file-extract-anomaly.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix connector-file extract anomaly
 
 ## Summary

--- a/docs/pull-requests/2026-06-27-chris-connector-file-extract-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-file-extract-anomaly.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix connector-file extract anomaly
 
 ## Summary

--- a/docs/pull-requests/2026-06-27-chris-connector-github-config-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-github-config-anomaly.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix connector-github config anomaly
 
 ## Summary

--- a/docs/pull-requests/2026-06-27-chris-connector-github-config-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-github-config-anomaly.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix connector-github config anomaly
 
 ## Summary

--- a/docs/pull-requests/2026-06-27-chris-connector-gitlab-project-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-gitlab-project-anomaly.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Fix connector-gitlab project anomaly
 
 ## Summary

--- a/docs/pull-requests/2026-06-27-chris-connector-gitlab-project-anomaly.md
+++ b/docs/pull-requests/2026-06-27-chris-connector-gitlab-project-anomaly.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Fix connector-gitlab project anomaly
 
 ## Summary

--- a/docs/pull-requests/2026-06-29-chris-connector-auth-helper-cleanup.md
+++ b/docs/pull-requests/2026-06-29-chris-connector-auth-helper-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: remove connector throwing auth helpers
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-connector-auth-helper-cleanup.md
+++ b/docs/pull-requests/2026-06-29-chris-connector-auth-helper-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: remove connector throwing auth helpers
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-connector-handle-helper-cleanup.md
+++ b/docs/pull-requests/2026-06-29-chris-connector-handle-helper-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: remove connector throwing handle helper
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-connector-handle-helper-cleanup.md
+++ b/docs/pull-requests/2026-06-29-chris-connector-handle-helper-cleanup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: remove connector throwing handle helper
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-edgar-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-edgar-connector-validation-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return EDGAR connector handle anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-edgar-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-edgar-connector-validation-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return EDGAR connector handle anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-excel-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-excel-connector-validation-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return Excel connector handle anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-excel-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-excel-connector-validation-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return Excel connector handle anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-file-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-file-connector-validation-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return File connector handle anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-file-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-file-connector-validation-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return File connector handle anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-github-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-github-connector-validation-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return GitHub connector validation anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-github-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-github-connector-validation-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return GitHub connector validation anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-gitlab-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-gitlab-connector-validation-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return GitLab connector validation anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-gitlab-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-gitlab-connector-validation-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return GitLab connector validation anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-jira-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-jira-connector-validation-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return Jira connector validation anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-jira-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-jira-connector-validation-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return Jira connector validation anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-sarif-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-sarif-connector-validation-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return SARIF connector handle anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-29-chris-sarif-connector-validation-anomalies.md
+++ b/docs/pull-requests/2026-06-29-chris-sarif-connector-validation-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return SARIF connector handle anomalies
 
 ## Overview

--- a/docs/pull-requests/2026-06-30-chris-pr-lifecycle-controller-anomalies.md
+++ b/docs/pull-requests/2026-06-30-chris-pr-lifecycle-controller-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Return PR Lifecycle Controller Anomalies
 
 ## Summary

--- a/docs/pull-requests/2026-06-30-chris-pr-lifecycle-controller-anomalies.md
+++ b/docs/pull-requests/2026-06-30-chris-pr-lifecycle-controller-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Return PR Lifecycle Controller Anomalies
 
 ## Summary

--- a/docs/pull-requests/2026-06-30-chris-repo-dag-query-alias-anomalies.md
+++ b/docs/pull-requests/2026-06-30-chris-repo-dag-query-alias-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Return Repo DAG Query Alias Anomalies
 
 ## Summary

--- a/docs/pull-requests/2026-06-30-chris-repo-dag-query-alias-anomalies.md
+++ b/docs/pull-requests/2026-06-30-chris-repo-dag-query-alias-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Return Repo DAG Query Alias Anomalies
 
 ## Summary

--- a/docs/pull-requests/2026-07-01-chris-agent-planner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-agent-planner-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor: return planner expected anomalies as data
 
 ## Overview

--- a/docs/pull-requests/2026-07-01-chris-agent-planner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-agent-planner-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor: return planner expected anomalies as data
 
 ## Overview

--- a/docs/pull-requests/2026-07-01-chris-bb-test-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-bb-test-runner-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor: return bb test runner parse failures as data
 
 ## Overview

--- a/docs/pull-requests/2026-07-01-chris-bb-test-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-bb-test-runner-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor: return bb test runner parse failures as data
 
 ## Overview

--- a/docs/pull-requests/2026-07-01-chris-exceptions-scanner-fatal-registry.md
+++ b/docs/pull-requests/2026-07-01-chris-exceptions-scanner-fatal-registry.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor: classify registry invariant throws as fatal-only
 
 ## Overview

--- a/docs/pull-requests/2026-07-01-chris-exceptions-scanner-fatal-registry.md
+++ b/docs/pull-requests/2026-07-01-chris-exceptions-scanner-fatal-registry.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor: classify registry invariant throws as fatal-only
 
 ## Overview

--- a/docs/pull-requests/2026-07-01-chris-oci-cli-runtime-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-oci-cli-runtime-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return OCI CLI runtime failures as data
 
 ## Summary

--- a/docs/pull-requests/2026-07-01-chris-oci-cli-runtime-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-oci-cli-runtime-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return OCI CLI runtime failures as data
 
 ## Summary

--- a/docs/pull-requests/2026-07-01-chris-task-executor-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-task-executor-runner-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor: return task executor runner failures as data
 
 ## Overview

--- a/docs/pull-requests/2026-07-01-chris-task-executor-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-task-executor-runner-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor: return task executor runner failures as data
 
 ## Overview

--- a/docs/pull-requests/2026-07-01-chris-workflow-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-workflow-runner-anomalies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: return workflow runner failures as data
 
 ## Summary

--- a/docs/pull-requests/2026-07-01-chris-workflow-runner-anomalies.md
+++ b/docs/pull-requests/2026-07-01-chris-workflow-runner-anomalies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: return workflow runner failures as data
 
 ## Summary

--- a/docs/pull-requests/2026-07-04-fix-clojure-standards-defaults.md
+++ b/docs/pull-requests/2026-07-04-fix-clojure-standards-defaults.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: Clear Clojure standards scanner defaults
 
 ## Overview

--- a/docs/pull-requests/2026-07-04-fix-clojure-standards-defaults.md
+++ b/docs/pull-requests/2026-07-04-fix-clojure-standards-defaults.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: Clear Clojure standards scanner defaults
 
 ## Overview

--- a/docs/pull-requests/2026-07-04-fix-repo-dag-anomaly-api.md
+++ b/docs/pull-requests/2026-07-04-fix-repo-dag-anomaly-api.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # docs: Align repo-DAG anomaly API documentation
 
 ## Overview

--- a/docs/pull-requests/2026-07-04-fix-repo-dag-anomaly-api.md
+++ b/docs/pull-requests/2026-07-04-fix-repo-dag-anomaly-api.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # docs: Align repo-DAG anomaly API documentation
 
 ## Overview

--- a/docs/pull-requests/2026-07-18-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only.md
+++ b/docs/pull-requests/2026-07-18-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only.md
@@ -1,0 +1,158 @@
+# fix: [810] Enforce Miniforge.ai header and copyright on published content — OSS repositories only compliance pass
+
+**Branch:** `fix/compliance-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only`
+**Date:** 2026-07-18
+
+---
+```yaml
+generated-by: miniforge-compliance-scanner
+rule-id: 810
+rule-title: "Enforce Miniforge.ai header and copyright on published content — OSS repositories only"
+fix-type: mechanical
+violations-fixed: 124
+files-changed: 124
+date: 2026-07-18
+```
+---
+
+## Summary
+
+Automated compliance pass applying mechanical fixes for **Enforce Miniforge.ai header and copyright on published content — OSS repositories only** (Dewey 810).
+124 violations fixed across 124 files.
+
+## Files Changed
+
+| File | Line | Current | Suggested |
+|------|------|---------|-----------|
+| `docs/pull-requests/2026-06-10-feat-supervisory-golden-fixtures.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-02-feat-policy-attention-context.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-review-self-healing-resources-classpath.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-gitlab-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md` | 1 | `(missing copyright header)` |
+| `docs/design/automation-edge-correlator.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-chris-resolver-hotspots-followup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-chris-bb-data-plane-http-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-adapter-claude-code-staleness-config.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-16-fix-phase-repair-handoff-envelope.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-web-dashboard-config-edn.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-orchestrator-operator-config-edn.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-01-feat-dependency-attribution-ux.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-19-chris-typed-phase-acts.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-chris-function-local-require-audit.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-github-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/design/supervisory-spec-entity.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-02-feat-direct-workflow-agent-supervisory-projection.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-chris-bb-r2-pull-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-01-refactor-exceptions-as-data-connector-callsite-migration.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-14-refactor-connector-vcs-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-task-executor-config-edn.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-lsp-client-timeouts-config.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-chris-exceptions-boundary-ns-detection.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-07-04-fix-repo-dag-anomaly-api.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-01-feat-dependency-evidence-and-observe.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-15-fix-resume-artifact-base-metadata.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-26-task-c1b44bd7.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-07-01-chris-oci-cli-runtime-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-chris-control-plane-transition-not-found.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-02-fix-claude-dogfood-repair-loop-and-observability.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-16-fix-dogfood-stale-status.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-edgar-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-12-refactor-connector-data-sources-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-chris-exceptions-required-resource-context.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-03-fix-dogfood-backend-preflight-and-stream-supervision.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-06-refactor-operator-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-04-refactor-workflow-loader-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-26-chris-release-files-path-anomaly.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-file-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-03-fix-dogfood-source-root-mcp.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-chris-exceptions-fallback-loaders.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-26-chris-bb-generate-icon-source-anomaly.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-16-fix-dogfood-submit-tool-and-display.md` | 1 | `(missing copyright header)` |
+| `docs/design/event-stream-replay-retention.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-chris-lsp-mcp-bridge-boundary-audit.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-26-chris-lsp-download-anomaly.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-27-chris-connector-github-config-anomaly.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-chris-pipeline-config-connector-anomaly.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-self-healing-config-edn.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-07-01-chris-exceptions-scanner-fatal-registry.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-09-refactor-event-stream-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-excel-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-09-refactor-cli-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-chris-verify-test-direct-private-vars.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-01-fix-210-clojure-polylith-per-file-stratified-design.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-15-fix-resume-status-stale-failure.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-09-fix-test-phase-loader-support.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-01-feat-dependency-events-and-degradation.md` | 1 | `(missing copyright header)` |
+| `specs/informative/I-CLASSIFICATION-RUNTIME.md` | 1 | `(missing copyright header)` |
+| `docs/research/policy-enforcement-gap-analysis.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md` | 1 | `(missing copyright header)` |
+| `docs/design/labeled-pr-actions-plan.md` | 1 | `(missing copyright header)` |
+| `docs/architecture/state-ownership-and-phase-graph.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-feat-config-resource-loader.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-15-refactor-connector-test-followups.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-04-refactor-kill-workflow-runtime-deprecation.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-02-fix-dogfood-review-boundaries.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-04-fix-workflow-taxonomy-no-capsule-executor.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-30-chris-pr-lifecycle-controller-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-connector-handle-helper-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-16-fix-resume-status-handling.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-07-01-chris-agent-planner-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-07-01-chris-bb-test-runner-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-19-chris-standards-remediation-wave52.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-06-refactor-task-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-sarif-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-19-chris-phase-act-collapse.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-lsp-mcp-bridge-timeouts-config.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-27-chris-connector-gitlab-project-anomaly.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-chris-policy-gate-compiler.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-semantic-analyzer-limits-config.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-06-refactor-agent-component-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-connector-edgar-base-url-config.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-19-chris-standards-remediation-wave53.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-07-01-chris-task-executor-runner-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-chris-policy-gate-phase-wiring.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-agent-llm-call-tuning-config.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-06-fix-dogfood-startup-implement-resume.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-chris-exceptions-fatal-only-review-filter.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-connector-auth-helper-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-20-refactor-phase-deployment-timeouts-config.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/standards/strata-violations-baseline.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-26-chris-workflow-cost-breakdown-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-25-exceptions-resource-boundary-consolidation.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-17-fix-capsule-acquisition-timeout.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-27-chris-connector-file-extract-anomaly.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-30-chris-repo-dag-query-alias-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/plan-from-agent-dag-wiring.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-06-29-chris-jira-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-07-04-fix-clojure-standards-defaults.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-07-01-chris-workflow-runner-anomalies.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-05-12-refactor-connector-foundation-cleanup.md` | 1 | `(missing copyright header)` |
+
+## Verification
+
+- Re-run `bb miniforge run docs/compliance/miniforge-scan.md` to confirm zero violations for this rule
+- All fixes are mechanical — no semantic changes
+
+---
+*Auto-generated by the Miniforge compliance scanner.*

--- a/docs/pull-requests/2026-07-18-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only.md
+++ b/docs/pull-requests/2026-07-18-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only.md
@@ -41,4 +41,4 @@ Merge normally. This is published-content metadata and formatting only; it has n
 - [x] Apply all 124 required headers.
 - [x] Preserve document bodies.
 - [x] Pass the focused Dewey 810 scan.
-- [ ] Pass final full standards scan and pre-commit verification.
+- [x] Pass pre-commit and reduce the full scan from 149 findings to the expected 25 deferred findings.

--- a/docs/pull-requests/2026-07-18-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only.md
+++ b/docs/pull-requests/2026-07-18-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only.md
@@ -1,158 +1,44 @@
-# fix: [810] Enforce Miniforge.ai header and copyright on published content — OSS repositories only compliance pass
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Add missing published-content copyright headers
 
-**Branch:** `fix/compliance-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only`
-**Date:** 2026-07-18
+## Overview
 
----
-```yaml
-generated-by: miniforge-compliance-scanner
-rule-id: 810
-rule-title: "Enforce Miniforge.ai header and copyright on published content — OSS repositories only"
-fix-type: mechanical
-violations-fixed: 124
-files-changed: 124
-date: 2026-07-18
-```
----
+Add the required Apache 2.0 copyright header to 124 published Markdown files identified by the compliance scanner.
 
-## Summary
+## Motivation
 
-Automated compliance pass applying mechanical fixes for **Enforce Miniforge.ai header and copyright on published content — OSS repositories only** (Dewey 810).
-124 violations fixed across 124 files.
+The repository's Dewey 810 rule requires the verbatim Miniforge.ai header on published content. The current scan reported
+124 files without it, mostly historical pull-request documentation.
 
-## Files Changed
+## Changes in Detail
 
-| File | Line | Current | Suggested |
-|------|------|---------|-----------|
-| `docs/pull-requests/2026-06-10-feat-supervisory-golden-fixtures.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-02-feat-policy-attention-context.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-16-fix-resume-workspace-checkpoint.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-review-self-healing-resources-classpath.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-gitlab-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-22-config-loader-system-locale-messages.md` | 1 | `(missing copyright header)` |
-| `docs/design/automation-edge-correlator.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-chris-resolver-hotspots-followup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-chris-bb-data-plane-http-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-adapter-claude-code-staleness-config.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-16-fix-phase-repair-handoff-envelope.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-web-dashboard-config-edn.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-orchestrator-operator-config-edn.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-01-feat-dependency-attribution-ux.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-03-refactor-exceptions-as-data-workflow-runtime-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-19-chris-typed-phase-acts.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-chris-function-local-require-audit.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-github-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/design/supervisory-spec-entity.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-02-feat-direct-workflow-agent-supervisory-projection.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-chris-bb-r2-pull-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-llm-backends-edn.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-16-fix-reviewer-issue-schema-nil-tolerance.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-18-chris-standards-remediation-wave50.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-16-chore-pre-commit-smoke-tests.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-01-refactor-exceptions-as-data-connector-callsite-migration.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-14-refactor-connector-vcs-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-task-executor-config-edn.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-lsp-client-timeouts-config.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-chris-exceptions-boundary-ns-detection.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-07-04-fix-repo-dag-anomaly-api.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-01-feat-dependency-evidence-and-observe.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-15-fix-resume-artifact-base-metadata.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-26-task-c1b44bd7.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-07-01-chris-oci-cli-runtime-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-chris-control-plane-transition-not-found.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-15-fix-dogfood-artifact-provenance.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-02-fix-claude-dogfood-repair-loop-and-observability.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-16-fix-dogfood-stale-status.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-edgar-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-12-refactor-connector-data-sources-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-cli-user-defaults-edn.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-chris-exceptions-required-resource-context.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-03-fix-dogfood-backend-preflight-and-stream-supervision.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-06-refactor-operator-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-04-refactor-workflow-loader-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-26-chris-release-files-path-anomaly.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-file-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-03-fix-dogfood-source-root-mcp.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-chris-exceptions-fallback-loaders.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-26-chris-bb-generate-icon-source-anomaly.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-16-fix-dogfood-submit-tool-and-display.md` | 1 | `(missing copyright header)` |
-| `docs/design/event-stream-replay-retention.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-09-refactor-pr-lifecycle-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-chris-lsp-mcp-bridge-boundary-audit.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-26-chris-lsp-download-anomaly.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-27-chris-connector-github-config-anomaly.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-chris-pipeline-config-connector-anomaly.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-self-healing-config-edn.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-07-01-chris-exceptions-scanner-fatal-registry.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-09-refactor-event-stream-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-15-fix-dogfood-resume-checkpoint-repair.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-excel-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-09-refactor-cli-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-chris-verify-test-direct-private-vars.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-01-fix-210-clojure-polylith-per-file-stratified-design.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-15-fix-resume-status-stale-failure.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-09-fix-test-phase-loader-support.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-06-refactor-spec-parser-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-01-feat-dependency-events-and-degradation.md` | 1 | `(missing copyright header)` |
-| `specs/informative/I-CLASSIFICATION-RUNTIME.md` | 1 | `(missing copyright header)` |
-| `docs/research/policy-enforcement-gap-analysis.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-19-chris-standards-remediation-wave51.md` | 1 | `(missing copyright header)` |
-| `docs/design/labeled-pr-actions-plan.md` | 1 | `(missing copyright header)` |
-| `docs/architecture/state-ownership-and-phase-graph.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-feat-config-resource-loader.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-15-refactor-connector-test-followups.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-04-refactor-kill-workflow-runtime-deprecation.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-02-fix-dogfood-review-boundaries.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-16-fix-reviewer-issue-shape-validation.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-04-fix-workflow-taxonomy-no-capsule-executor.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-30-chris-pr-lifecycle-controller-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-connector-handle-helper-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-16-fix-resume-status-handling.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-07-01-chris-agent-planner-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-07-01-chris-bb-test-runner-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-chris-phase-outcome-complete.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-19-chris-standards-remediation-wave52.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-exceptions-config-loader-consolidation.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-06-refactor-task-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-sarif-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-19-chris-phase-act-collapse.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-lsp-mcp-bridge-timeouts-config.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-02-refactor-exceptions-as-data-repo-dag-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-27-chris-connector-gitlab-project-anomaly.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-chris-policy-gate-compiler.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-semantic-analyzer-limits-config.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-06-refactor-agent-component-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-connector-edgar-base-url-config.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-19-chris-standards-remediation-wave53.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-07-01-chris-task-executor-runner-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-04-fix-claude-plan-stream-progress.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-chris-policy-gate-phase-wiring.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-agent-llm-call-tuning-config.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-06-fix-dogfood-startup-implement-resume.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-chris-exceptions-fatal-only-review-filter.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-09-refactor-tail-bundle-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-chris-polylith-ci-change-scope.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-connector-auth-helper-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-20-refactor-phase-deployment-timeouts-config.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-21-refactor-self-healing-progress-workflow-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/standards/strata-violations-baseline.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-26-chris-workflow-cost-breakdown-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-06-fix-dogfood-reviewer-timeout-rejections.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-25-exceptions-resource-boundary-consolidation.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-06-fix-polylith-cleanliness-gate.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-17-fix-capsule-acquisition-timeout.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-27-chris-connector-file-extract-anomaly.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-30-chris-repo-dag-query-alias-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/plan-from-agent-dag-wiring.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-06-29-chris-jira-connector-validation-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-07-04-fix-clojure-standards-defaults.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-07-01-chris-workflow-runner-anomalies.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-05-12-refactor-connector-foundation-cleanup.md` | 1 | `(missing copyright header)` |
+- Add the required multiline header to 124 Markdown files.
+- Preserve the existing document content below each inserted header.
+- Repair Markdown formatting findings exposed when the touched files entered the pre-commit lint scope.
 
-## Verification
+## Testing Plan
 
-- Re-run `bb miniforge run docs/compliance/miniforge-scan.md` to confirm zero violations for this rule
-- All fixes are mechanical — no semantic changes
+- Run the Dewey 810 scanner and confirm zero header findings.
+- Run `bb pre-commit` through the normal commit hook.
+- Run `git diff --check`.
 
----
-*Auto-generated by the Miniforge compliance scanner.*
+## Deployment Plan
+
+Merge normally. This is published-content metadata and formatting only; it has no runtime deployment impact.
+
+## Related Issues/PRs
+
+- Replaces closed PR #1419 after its generated header template used literal `\\n` sequences.
+- Base branch: `main`.
+- Depends on: none.
+
+## Checklist
+
+- [x] Apply all 124 required headers.
+- [x] Preserve document bodies.
+- [x] Pass the focused Dewey 810 scan.
+- [ ] Pass final full standards scan and pre-commit verification.

--- a/docs/pull-requests/plan-from-agent-dag-wiring.md
+++ b/docs/pull-requests/plan-from-agent-dag-wiring.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # plan-from-agent-dag-wiring
 
 **Spec:** `work/plan-from-agent-dag-wiring.spec.edn`

--- a/docs/pull-requests/plan-from-agent-dag-wiring.md
+++ b/docs/pull-requests/plan-from-agent-dag-wiring.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # plan-from-agent-dag-wiring
 
 **Spec:** `work/plan-from-agent-dag-wiring.spec.edn`
@@ -91,7 +95,7 @@ Registered all three DAG events in `event_type_registry.clj`:
 
 ## Tests
 
-```
+```text
 # New tests
 7 tests, 10 assertions — 0 failures, 0 errors
 

--- a/docs/research/policy-enforcement-gap-analysis.md
+++ b/docs/research/policy-enforcement-gap-analysis.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Policy enforcement gap analysis + program
 
 Status: draft 2026-06-18. Drives a multi-wave program. The trust boundary:

--- a/docs/research/policy-enforcement-gap-analysis.md
+++ b/docs/research/policy-enforcement-gap-analysis.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Policy enforcement gap analysis + program
 
 Status: draft 2026-06-18. Drives a multi-wave program. The trust boundary:

--- a/docs/standards/strata-violations-baseline.md
+++ b/docs/standards/strata-violations-baseline.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Stratified-Design Violations — Baseline (2026-05-01, revised)
 
 Audit of `components/**/src` and `bases/**/src` for within-namespace

--- a/docs/standards/strata-violations-baseline.md
+++ b/docs/standards/strata-violations-baseline.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Stratified-Design Violations — Baseline (2026-05-01, revised)
 
 Audit of `components/**/src` and `bases/**/src` for within-namespace

--- a/specs/informative/I-CLASSIFICATION-RUNTIME.md
+++ b/specs/informative/I-CLASSIFICATION-RUNTIME.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Generalized Classification Runtime
 
 > **Status:** informative — architectural design spec. Captures the

--- a/specs/informative/I-CLASSIFICATION-RUNTIME.md
+++ b/specs/informative/I-CLASSIFICATION-RUNTIME.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Generalized Classification Runtime
 
 > **Status:** informative — architectural design spec. Captures the


### PR DESCRIPTION
## Layer

Documentation metadata (mechanical compliance remediation).

## Depends on

- None; based on `main`.

## What this adds

- Adds the verbatim Dewey 810 Apache 2.0 header to all 124 scanner-identified Markdown files.
- Preserves existing document bodies.
- Repairs Markdown lint findings exposed in touched historical documents.
- Replaces the original malformed literal-`\\n` executor output with real multiline HTML comments.

## Verification

- Focused Dewey 810 scan: 0 findings.
- Full standards scan: 25 findings remain, exactly the deferred 21 Clojure cases and 4 DateVer false positives.
- Normal pre-commit hook passed for every corrective batch.
- Smoke tests per batch: 330 tests / 1,235 assertions, zero failures.
- GraalVM compatibility per batch: 6 tests / 522 assertions, zero failures.
- `git diff --check`: clean.

## Test classification

No test changes: published-content metadata and Markdown formatting only; runtime behavior is unchanged.

PR documentation: `docs/pull-requests/2026-07-18-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content-oss-repositories-only.md`