### PR TITLE
fix(phase-software-factory): bounded wait in the orphan-process verify test

### DIFF
--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
@@ -250,20 +250,34 @@
     ;; This is what we observed as PID 31181 still alive 30+ min after
     ;; killing the parent. After the fix the descendant tree is walked
     ;; first, so no PID survives.
-    (let [;; sleep 7200 in the shell so the test fails red if the tree
-          ;; isn't actually killed (CI noticing a 2h orphan process).
-          result (verify/run-tests! "/tmp" :test-cmd "sleep 7200" :timeout-ms 500)]
-      (is (true? (:timed-out? result)))
-      ;; Give the OS a beat to reap.
-      (Thread/sleep 250)
-      ;; Walk the JVM's current process descendants — no `sleep 7200` should remain.
-      (let [orphans (->> (.. (java.lang.ProcessHandle/current) descendants (toArray))
-                         (filter (fn [^java.lang.ProcessHandle ph]
-                                   (some-> ph .info .command .get
-                                           (clojure.string/includes? "sleep")))))]
-        (is (empty? orphans)
-            (str "destroy-process-tree! must reap every descendant sleep process; "
-                 "found " (count orphans) " orphan(s)"))))))
+    (letfn [(descendant-sleeps []
+              ;; Walk the JVM's current process descendants for a surviving
+              ;; `sleep`. `.orElse` (not `.get`) — a just-killed zombie can
+              ;; report an empty command Optional, which must read as "not
+              ;; an orphan", not throw.
+              (->> (.. (java.lang.ProcessHandle/current) descendants (toArray))
+                   (filter (fn [^java.lang.ProcessHandle ph]
+                             (-> ph .info .command (.orElse "")
+                                 (clojure.string/includes? "sleep"))))))]
+      (let [;; sleep 7200 in the shell so the test fails red if the tree
+            ;; isn't actually killed (CI noticing a 2h orphan process).
+            result (verify/run-tests! "/tmp" :test-cmd "sleep 7200" :timeout-ms 500)]
+        (is (true? (:timed-out? result)))
+        ;; Bounded wait, not a fixed beat: the kill lands immediately but a
+        ;; loaded CI runner can take >250ms to clear the process table, which
+        ;; a fixed sleep misread as a leak (flaked on main + PR CI,
+        ;; 2026-07-18/19). The deadline only spends fully when the tree
+        ;; genuinely leaks — the 2h sleep this test exists to catch.
+        (let [deadline (+ (System/currentTimeMillis) 5000)]
+          (loop []
+            (when (and (seq (descendant-sleeps))
+                       (< (System/currentTimeMillis) deadline))
+              (Thread/sleep 100)
+              (recur))))
+        (let [orphans (descendant-sleeps)]
+          (is (empty? orphans)
+              (str "destroy-process-tree! must reap every descendant sleep process; "
+                   "found " (count orphans) " orphan(s)")))))))
 
 (deftest run-tests-in-capsule-passes-timeout-to-execute-fn-test
   (testing "run-tests-in-capsule! threads :timeout-ms into execute-fn opts so capsule executors honour it"

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
@@ -258,7 +258,7 @@
               (->> (.. (java.lang.ProcessHandle/current) descendants (toArray))
                    (filter (fn [^java.lang.ProcessHandle ph]
                              (-> ph .info .command (.orElse "")
-                                 (clojure.string/includes? "sleep"))))))]
+                                 (str/includes? "sleep"))))))]
       (let [;; sleep 7200 in the shell so the test fails red if the tree
             ;; isn't actually killed (CI noticing a 2h orphan process).
             result (verify/run-tests! "/tmp" :test-cmd "sleep 7200" :timeout-ms 500)]

--- a/docs/pull-requests/2026-07-18-fix-verify-orphan-test-race.md
+++ b/docs/pull-requests/2026-07-18-fix-verify-orphan-test-race.md
@@ -1,0 +1,36 @@
+<!--
+  Title: Fix reap-race flake in the verify orphan-process test
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(phase-software-factory): bounded wait in the orphan-process verify test
+
+Branch: `fix/verify-orphan-test-race`
+
+## Summary
+
+`run-tests-kills-child-process-not-just-shell-test` kills a
+`sh -c "sleep 7200"` tree, slept a fixed 250ms, then asserted the JVM's
+descendant table held no `sleep`. On a loaded CI runner the kill lands
+but the process table can take longer than 250ms to clear, so the reap
+race read as a leak — it failed main's CI at `62db3519b` and both runs
+on PR #1420 (2026-07-18/19) while passing locally every time.
+
+Two changes:
+
+- The fixed beat becomes a bounded poll (100ms interval, 5s deadline).
+  The deadline only spends fully when the tree genuinely leaks — the
+  2-hour sleep this test exists to catch — so the regression signal is
+  intact and the timing assumption is gone.
+- The descendant filter reads the command with `.orElse ""` instead of
+  `Optional.get` — a just-killed zombie can report an empty command
+  Optional, which previously would have thrown instead of reading as
+  "not an orphan".
+
+## Test plan
+
+- `clj-kondo` clean; `poly test brick:phase-software-factory` green
+  locally.
+- The real proof is CI on this PR plus subsequent main runs going
+  green where the flake was intermittent.


### PR DESCRIPTION
## Summary

`run-tests-kills-child-process-not-just-shell-test` kills a `sh -c "sleep 7200"` tree, slept a fixed 250ms, then asserted the JVM's descendant table held no `sleep`. On loaded CI runners the kill lands but the process table takes longer than 250ms to clear — the reap race read as a leak. It failed main's own CI at `62db3519b` and both runs on #1420 (2026-07-18/19), while passing locally every time.

- Fixed beat → bounded poll (100ms interval, 5s deadline). The deadline only spends fully when the tree genuinely leaks — the 2-hour sleep this test exists to catch — so the regression signal is intact and the timing assumption is gone.
- Descendant command read via `Optional.orElse ""` instead of `.get`, which can throw on a just-killed zombie handle.

Unblocks the red Test check on #1420 (that PR's diff is unrelated — llm component only).

PR doc: `docs/pull-requests/2026-07-18-fix-verify-orphan-test-race.md`

## Test plan

- clj-kondo clean; `poly test brick:phase-software-factory` green locally.
- Proof is this PR's CI + main runs going green where the flake was intermittent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5JYUg7VUfeBWvxgVEfHP