### PR TITLE
fix(dag-executor): launch containers from the gate's resolved image digest

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
@@ -757,9 +757,14 @@
    (a passing gate may still carry non-blocking :security/warnings — e.g. a
    non-rootless runtime in OSS), or `result/err :security-policy-violation`
    with the findings on a hard-stop. A nil digest fails closed (hard-stop),
-   since a plan with no pinned digest cannot satisfy require-image-digest-pin."
+   since a plan with no pinned digest cannot satisfy require-image-digest-pin.
+
+   A passing result also carries the resolved `:image-digest`;
+   `acquire-environment!` launches the container from that immutable ID rather
+   than the mutable tag, so the image that runs is the image the gate checked."
   [descriptor image env-config digest-fn]
-  (let [plan            {:image-digest (digest-fn descriptor image)
+  (let [digest          (digest-fn descriptor image)
+        plan            {:image-digest digest
                          :mounts       (get env-config :mounts [])}
         security-config {:host-path-allowlist #{(get env-config :workdir default-workdir)}
                          :rootless-action     plan-security/default-rootless-action}
@@ -768,7 +773,7 @@
       (result/err :security-policy-violation
                   (:anomaly/message decision)
                   {:security/findings (:security/findings decision)})
-      (result/ok (:output decision)))))
+      (result/ok (assoc (:output decision) :image-digest digest)))))
 
 ;; ============================================================================
 ;; OciCliExecutor Record
@@ -821,9 +826,11 @@
             (let [container-name (str container-name-prefix
                                       (subs (str task-id) 0 container-name-uuid-slice))
                   workdir (get env-config :workdir default-workdir)
+                  ;; Launch from the gate's resolved digest, not the mutable
+                  ;; tag — the image that runs is the image the gate checked.
                   create-result (create-container descriptor
                                                   container-name
-                                                  image
+                                                  (get-in gate-result [:data :image-digest])
                                                   workdir
                                                   (:env env-config)
                                                   (:resources env-config)

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_security_gate_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_security_gate_test.clj
@@ -22,6 +22,7 @@
    resolver is injected, so these exercise the gate decision (block / warn /
    review / pass) without a container runtime."
   (:require
+   [ai.miniforge.dag-executor.protocols.executor :as proto]
    [ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli :as oci-cli]
    [ai.miniforge.dag-executor.result :as result]
    [clojure.test :refer [deftest is testing]]))
@@ -86,3 +87,29 @@
           r   (oci-cli/security-gate-check rootless-descriptor "img" env good-digest-fn)]
       (is (result/ok? r))
       (is (= :pass (get-in r [:data :security/decision]))))))
+
+(deftest gate-ok-carries-resolved-digest-test
+  (testing "a passing gate returns the resolved digest for the launch to use"
+    (let [r (oci-cli/security-gate-check rootless-descriptor "img" base-env good-digest-fn)]
+      (is (result/ok? r))
+      (is (= valid-digest (get-in r [:data :image-digest]))))))
+
+(deftest acquire-launches-from-resolved-digest-test
+  (testing "acquire-environment! creates the container from the gate's resolved
+            digest, not the mutable tag it was configured with"
+    (let [launched (atom nil)
+          executor (oci-cli/map->OciCliExecutor
+                    {:config     {}
+                     :descriptor {:runtime/kind :docker :runtime/capabilities #{:rootless}}
+                     :image      "task-runner:latest"
+                     :network    nil})]
+      (with-redefs [oci-cli/image-exists?          (fn [_ _] true)
+                    oci-cli/resolve-image-digest!  (fn [_ _] valid-digest)
+                    oci-cli/create-container       (fn [_ container-name image _ & _]
+                                                     (reset! launched image)
+                                                     (result/ok {:container-id "c1"
+                                                                 :container-name container-name}))
+                    oci-cli/container-image-digest (fn [_ _] valid-digest)]
+        (let [r (proto/acquire-environment! executor "abcd1234efgh" {:workdir "/workspace"})]
+          (is (result/ok? r))
+          (is (= valid-digest @launched)))))))


### PR DESCRIPTION
## Summary

The capsule security gate (#1352/#1356) resolves and verifies the image digest before launch, but `create-container` still ran the mutable tag — a re-tag in the inspect-to-create window could swap the image under a passed gate.

- `security-gate-check` now returns the resolved `:image-digest` on the ok path.
- `acquire-environment!` creates the container from that immutable ID instead of the tag, so the image that runs is the image the gate checked.
- Digest form verified against Docker: `docker create sha256:<64hex>` launches by image ID.

## Test plan

- `plan-security-test` + `oci-cli-security-gate-test`: 17 tests / 55 assertions green, including two new tests — gate ok-result carries the digest; `acquire-environment!` passes the digest (not the tag) to `create-container`.
- `oci-cli-test`: 31 tests / 76 assertions green.
- End-to-end against the local Docker daemon: acquired an environment via `create-docker-executor` with `alpine:latest`; the created container's `.Config.Image` is the sha256 digest; release cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)