### PR TITLE
fix(llm): make token defaults nil-explicit

### DIFF
--- a/components/llm/src/ai/miniforge/llm/cost.clj
+++ b/components/llm/src/ai/miniforge/llm/cost.clj
@@ -64,10 +64,13 @@
       (catch Exception _ {}))))
 
 (defn- usage-token-count
-  "Return a usage token count, treating a missing, nil, or false value as zero."
+  "Return a usage token count, treating anything non-numeric — missing,
+   nil, false, or a malformed value — as zero. Numeric-or-zero is the
+   contract the summing callers (and estimate-cost's never-throws
+   promise) rely on."
   [usage token-key]
   (let [tokens (get usage token-key)]
-    (if tokens tokens 0)))
+    (if (number? tokens) tokens 0)))
 
 ;; Public API
 

--- a/components/llm/src/ai/miniforge/llm/cost.clj
+++ b/components/llm/src/ai/miniforge/llm/cost.clj
@@ -63,6 +63,13 @@
           {})
       (catch Exception _ {}))))
 
+(defn- usage-token-count
+  "Return a usage token count, treating a missing or nil value as zero."
+  [usage token-key]
+  (if-some [tokens (get usage token-key)]
+    tokens
+    0))
+
 ;; Public API
 
 (defn pricing-for-model
@@ -94,8 +101,8 @@
    and cost summing see a consistent type."
   [usage model-id]
   (let [{:keys [input-per-1m output-per-1m]} (pricing-for-model model-id)
-        in-tokens  (or (:input-tokens usage) 0)
-        out-tokens (or (:output-tokens usage) 0)]
+        in-tokens  (usage-token-count usage :input-tokens)
+        out-tokens (usage-token-count usage :output-tokens)]
     (if (and input-per-1m output-per-1m)
       (double (+ (* in-tokens  (/ input-per-1m  tokens-per-million))
                  (* out-tokens (/ output-per-1m tokens-per-million))))

--- a/components/llm/src/ai/miniforge/llm/cost.clj
+++ b/components/llm/src/ai/miniforge/llm/cost.clj
@@ -64,10 +64,8 @@
       (catch Exception _ {}))))
 
 (defn- usage-token-count
-  "Return a usage token count, treating anything non-numeric — missing,
-   nil, false, or a malformed value — as zero. Numeric-or-zero is the
-   contract the summing callers (and estimate-cost's never-throws
-   promise) rely on."
+  "Return a numeric usage token count, treating missing or malformed values
+   as zero so cost estimation remains total for upstream payloads."
   [usage token-key]
   (let [tokens (get usage token-key)]
     (if (number? tokens) tokens 0)))

--- a/components/llm/src/ai/miniforge/llm/cost.clj
+++ b/components/llm/src/ai/miniforge/llm/cost.clj
@@ -65,7 +65,7 @@
 
 (defn- usage-token-count
   "Return a numeric usage token count, treating missing or malformed values
-   as zero so cost estimation remains total for upstream payloads."
+   as zero so cost estimation remains numeric for upstream payloads."
   [usage token-key]
   (let [tokens (get usage token-key)]
     (if (number? tokens) tokens 0)))

--- a/components/llm/src/ai/miniforge/llm/cost.clj
+++ b/components/llm/src/ai/miniforge/llm/cost.clj
@@ -64,11 +64,10 @@
       (catch Exception _ {}))))
 
 (defn- usage-token-count
-  "Return a usage token count, treating a missing or nil value as zero."
+  "Return a usage token count, treating a missing, nil, or false value as zero."
   [usage token-key]
-  (if-some [tokens (get usage token-key)]
-    tokens
-    0))
+  (let [tokens (get usage token-key)]
+    (if tokens tokens 0)))
 
 ;; Public API
 

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1573,13 +1573,20 @@
    recover and a retry just re-sends the over-budget prompt). See N12 §4."
   "context_overflow")
 
+(defn- usage-token-count
+  "Return a usage token count, treating a missing or nil value as zero."
+  [usage token-key]
+  (if-some [tokens (get usage token-key)]
+    tokens
+    0))
+
 (defn total-input-tokens
   "prompt + cache-creation + cache-read tokens. Summed because a large
    prompt lands mostly under cache-creation, not :input-tokens. See N12 §2."
   [usage]
-  (+ (or (:input-tokens usage) 0)
-     (or (:cache-creation-input-tokens usage) 0)
-     (or (:cache-read-input-tokens usage) 0)))
+  (+ (usage-token-count usage :input-tokens)
+     (usage-token-count usage :cache-creation-input-tokens)
+     (usage-token-count usage :cache-read-input-tokens)))
 
 (defn context-overflow-by-usage?
   "True when total input tokens >= the model's context window — the

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1574,11 +1574,10 @@
   "context_overflow")
 
 (defn- usage-token-count
-  "Return a usage token count, treating a missing or nil value as zero."
+  "Return a usage token count, treating a missing, nil, or false value as zero."
   [usage token-key]
-  (if-some [tokens (get usage token-key)]
-    tokens
-    0))
+  (let [tokens (get usage token-key)]
+    (if tokens tokens 0)))
 
 (defn total-input-tokens
   "prompt + cache-creation + cache-read tokens. Summed because a large

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1574,10 +1574,13 @@
   "context_overflow")
 
 (defn- usage-token-count
-  "Return a usage token count, treating a missing, nil, or false value as zero."
+  "Return a usage token count, treating anything non-numeric — missing,
+   nil, false, or a malformed value — as zero. Numeric-or-zero is the
+   contract the summing callers (and estimate-cost's never-throws
+   promise) rely on."
   [usage token-key]
   (let [tokens (get usage token-key)]
-    (if tokens tokens 0)))
+    (if (number? tokens) tokens 0)))
 
 (defn total-input-tokens
   "prompt + cache-creation + cache-read tokens. Summed because a large

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -1574,10 +1574,8 @@
   "context_overflow")
 
 (defn- usage-token-count
-  "Return a usage token count, treating anything non-numeric — missing,
-   nil, false, or a malformed value — as zero. Numeric-or-zero is the
-   contract the summing callers (and estimate-cost's never-throws
-   promise) rely on."
+  "Return a numeric usage token count, treating missing or malformed values
+   as zero so context accounting remains numeric for upstream payloads."
   [usage token-key]
   (let [tokens (get usage token-key)]
     (if (number? tokens) tokens 0)))

--- a/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
+++ b/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
@@ -44,7 +44,11 @@
     (is (= 0 (impl/total-input-tokens
               {:input-tokens false
                :cache-creation-input-tokens false
-               :cache-read-input-tokens false})))))
+               :cache-read-input-tokens false})))
+    (is (= 0 (impl/total-input-tokens
+              {:input-tokens "unknown"
+               :cache-creation-input-tokens :unknown
+               :cache-read-input-tokens []})))))
 
 (deftest context-overflow-by-usage?-test
   (testing "true once total input tokens reach the model's context window"

--- a/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
+++ b/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
@@ -36,7 +36,11 @@
                     :cache-creation-input-tokens 204279
                     :cache-read-input-tokens 0})))
     (is (= 0 (impl/total-input-tokens nil)))
-    (is (= 5 (impl/total-input-tokens {:input-tokens 5})))))
+    (is (= 5 (impl/total-input-tokens {:input-tokens 5})))
+    (is (= 0 (impl/total-input-tokens
+              {:input-tokens nil
+               :cache-creation-input-tokens nil
+               :cache-read-input-tokens nil})))))
 
 (deftest context-overflow-by-usage?-test
   (testing "true once total input tokens reach the model's context window"

--- a/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
+++ b/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
@@ -40,7 +40,11 @@
     (is (= 0 (impl/total-input-tokens
               {:input-tokens nil
                :cache-creation-input-tokens nil
-               :cache-read-input-tokens nil})))))
+               :cache-read-input-tokens nil})))
+    (is (= 0 (impl/total-input-tokens
+              {:input-tokens false
+               :cache-creation-input-tokens false
+               :cache-read-input-tokens false})))))
 
 (deftest context-overflow-by-usage?-test
   (testing "true once total input tokens reach the model's context window"

--- a/components/llm/test/ai/miniforge/llm/cost_test.clj
+++ b/components/llm/test/ai/miniforge/llm/cost_test.clj
@@ -84,13 +84,16 @@
                                    :output-tokens 50000}
                                   "free-local-model")))))
 
-(deftest estimate-cost-nil-usage-returns-zero-test
-  (testing "nil, empty, or explicitly nil usage with a priced model still
-            returns 0.0 — zero tokens means zero cost, no surprises."
+(deftest estimate-cost-falsy-usage-returns-zero-test
+  (testing "nil, empty, or explicitly falsy usage with a priced model still
+            returns 0.0 — absent tokens mean zero cost, no surprises."
     (is (= 0.0 (sut/estimate-cost nil "claude-sonnet-4-6")))
     (is (= 0.0 (sut/estimate-cost {} "claude-sonnet-4-6")))
     (is (= 0.0 (sut/estimate-cost {:input-tokens nil
                                    :output-tokens nil}
+                                  "claude-sonnet-4-6")))
+    (is (= 0.0 (sut/estimate-cost {:input-tokens false
+                                   :output-tokens false}
                                   "claude-sonnet-4-6")))))
 
 (deftest estimate-cost-missing-input-or-output-tokens-test

--- a/components/llm/test/ai/miniforge/llm/cost_test.clj
+++ b/components/llm/test/ai/miniforge/llm/cost_test.clj
@@ -94,6 +94,9 @@
                                   "claude-sonnet-4-6")))
     (is (= 0.0 (sut/estimate-cost {:input-tokens false
                                    :output-tokens false}
+                                  "claude-sonnet-4-6")))
+    (is (= 0.0 (sut/estimate-cost {:input-tokens "unknown"
+                                   :output-tokens :unknown}
                                   "claude-sonnet-4-6")))))
 
 (deftest estimate-cost-missing-input-or-output-tokens-test

--- a/components/llm/test/ai/miniforge/llm/cost_test.clj
+++ b/components/llm/test/ai/miniforge/llm/cost_test.clj
@@ -84,9 +84,9 @@
                                    :output-tokens 50000}
                                   "free-local-model")))))
 
-(deftest estimate-cost-falsy-usage-returns-zero-test
-  (testing "nil, empty, or explicitly falsy usage with a priced model still
-            returns 0.0 — absent tokens mean zero cost, no surprises."
+(deftest estimate-cost-missing-or-nonnumeric-token-counts-return-zero-test
+  (testing "Missing usage or non-numeric token counts with a priced model
+            return 0.0 — absent tokens mean zero cost, no surprises."
     (is (= 0.0 (sut/estimate-cost nil "claude-sonnet-4-6")))
     (is (= 0.0 (sut/estimate-cost {} "claude-sonnet-4-6")))
     (is (= 0.0 (sut/estimate-cost {:input-tokens nil

--- a/components/llm/test/ai/miniforge/llm/cost_test.clj
+++ b/components/llm/test/ai/miniforge/llm/cost_test.clj
@@ -85,10 +85,13 @@
                                   "free-local-model")))))
 
 (deftest estimate-cost-nil-usage-returns-zero-test
-  (testing "nil / empty usage with a priced model still returns 0.0 —
-            zero tokens means zero cost, no surprises."
+  (testing "nil, empty, or explicitly nil usage with a priced model still
+            returns 0.0 — zero tokens means zero cost, no surprises."
     (is (= 0.0 (sut/estimate-cost nil "claude-sonnet-4-6")))
-    (is (= 0.0 (sut/estimate-cost {} "claude-sonnet-4-6")))))
+    (is (= 0.0 (sut/estimate-cost {} "claude-sonnet-4-6")))
+    (is (= 0.0 (sut/estimate-cost {:input-tokens nil
+                                   :output-tokens nil}
+                                  "claude-sonnet-4-6")))))
 
 (deftest estimate-cost-missing-input-or-output-tokens-test
   (testing "Partial usage maps (only :input-tokens, only

--- a/docs/pull-requests/2026-07-19-fix-clojure-map-default-semantics-wave1-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-clojure-map-default-semantics-wave1-20260719.md
@@ -19,8 +19,8 @@ rewrite.
 ## Changes in Detail
 
 - Replace five LLM token-count fallback expressions with intent-named helpers that use explicit map lookup.
-- Preserve the established contract that missing, nil, and false token counts mean zero.
-- Add regression coverage for explicit nil and false values in cost estimation and context-window accounting.
+- Treat missing and non-numeric token counts as zero so malformed upstream payloads remain safe.
+- Add regression coverage for nil, false, and truthy non-numeric values in cost estimation and context accounting.
 
 ## Testing Plan
 

--- a/docs/pull-requests/2026-07-19-fix-clojure-map-default-semantics-wave1-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-clojure-map-default-semantics-wave1-20260719.md
@@ -19,8 +19,8 @@ rewrite.
 ## Changes in Detail
 
 - Replace five LLM token-count fallback expressions with intent-named helpers that use explicit map lookup.
-- Preserve the established contract that both missing and explicitly nil token counts mean zero.
-- Add regression coverage for explicit nil values in cost estimation and context-window accounting.
+- Preserve the established contract that missing, nil, and false token counts mean zero.
+- Add regression coverage for explicit nil and false values in cost estimation and context-window accounting.
 
 ## Testing Plan
 

--- a/docs/pull-requests/2026-07-19-fix-clojure-map-default-semantics-wave1-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-clojure-map-default-semantics-wave1-20260719.md
@@ -1,0 +1,46 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Clarify Clojure map-default semantics wave 1
+
+## Overview
+
+Resolve a coherent subset of the remaining Dewey 210 map-default findings after reviewing each call site for explicit
+nil behavior.
+
+## Motivation
+
+The scanner suggests replacing `(or (key-fn m) fallback)` with three-argument `get`, but those forms differ when the
+map contains the key with a nil or false value. Each change therefore needs contract and test review rather than a bulk
+rewrite.
+
+## Changes in Detail
+
+- Replace five LLM token-count fallback expressions with intent-named helpers that use explicit map lookup.
+- Preserve the established contract that both missing and explicitly nil token counts mean zero.
+- Add regression coverage for explicit nil values in cost estimation and context-window accounting.
+
+## Testing Plan
+
+- Run focused component tests for every touched behavior.
+- Run the Dewey 210 scanner and verify only intentionally deferred findings remain.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. This PR must remain independently mergeable and behaviorally explicit.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Follows #1419 and #1425.
+
+## Checklist
+
+- [x] Review nil and false semantics for every selected finding.
+- [x] Add regression coverage for changed behavior.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Clarify Clojure map-default semantics wave 1

## Overview

Resolve a coherent subset of the remaining Dewey 210 map-default findings after reviewing each call site for explicit
nil behavior.

## Motivation

The scanner suggests replacing `(or (key-fn m) fallback)` with three-argument `get`, but those forms differ when the
map contains the key with a nil or false value. Each change therefore needs contract and test review rather than a bulk
rewrite.

## Changes in Detail

- Replace five LLM token-count fallback expressions with intent-named helpers that use explicit map lookup.
- Preserve the established contract that both missing and explicitly nil token counts mean zero.
- Add regression coverage for explicit nil values in cost estimation and context-window accounting.

## Testing Plan

- Run focused component tests for every touched behavior.
- Run the Dewey 210 scanner and verify only intentionally deferred findings remain.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. This PR must remain independently mergeable and behaviorally explicit.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Follows #1419 and #1425.

## Checklist

- [x] Review nil and false semantics for every selected finding.
- [x] Add regression coverage for changed behavior.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
