### PR TITLE
feat(llm): generic OpenAI-compatible backend; thread :num-ctx to Ollama

### DIFF
--- a/components/llm/resources/llm/backends.edn
+++ b/components/llm/resources/llm/backends.edn
@@ -76,6 +76,21 @@
               :api-key-env "OPENAI_API_KEY"
               :probe-endpoint "https://api.openai.com/"}
 
+ ;; Generic OpenAI-compatible server (LM Studio, llama.cpp server,
+ ;; vLLM, and any other /v1/chat/completions endpoint). Local servers
+ ;; are typically credential-free, so no :api-key-env — a client
+ ;; :api-key is honored when supplied but never required. The endpoint
+ ;; is the LM Studio default; override per client with :base-url or
+ ;; via :base-url-env.
+ :openai-compat {:cmd "http"
+                 :streaming? false
+                 :description "Any OpenAI-compatible server (LM Studio, llama.cpp, vLLM, ...)"
+                 :provider "OpenAI-Compatible"
+                 :requires-cli? false
+                 :api-endpoint "http://localhost:1234/v1/chat/completions"
+                 :base-url-env "MINIFORGE_OPENAI_COMPAT_BASE_URL"
+                 :probe-endpoint "http://localhost:1234/v1/models"}
+
  ;; Gemini's REST shape embeds the model in the URL path, so
  ;; :api-endpoint is a format string filled by `request-endpoint`
  ;; (:model-in-url?).

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -935,14 +935,16 @@
       (some-> (:api-key-env backend-config) System/getenv str str/trim not-empty)))
 
 (defn- resolve-base-url
-  "The endpoint for a backend that supports base-url override: a
-   non-blank client-config `:base-url` wins, then the backend's
-   `:base-url-env` environment variable, then the backend's static
-   `:api-endpoint` default."
+  "The endpoint for the request. Only a backend that declares
+   `:base-url-env` supports overrides — there a non-blank client-config
+   `:base-url` wins, then the env variable. Every other backend always
+   uses its static `:api-endpoint`, so a stray client `:base-url` can
+   never redirect a fixed-endpoint provider."
   [backend-config config]
-  (or (some-> (:base-url config) str str/trim not-empty)
-      (some-> (:base-url-env backend-config) System/getenv str str/trim
-              not-empty)
+  (or (when (:base-url-env backend-config)
+        (or (some-> (:base-url config) str str/trim not-empty)
+            (some-> (:base-url-env backend-config) System/getenv str str/trim
+                    not-empty)))
       (:api-endpoint backend-config)))
 
 (defn- request-endpoint

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -912,6 +912,11 @@
                  "anthropic-version" (anthropic-api-version)}
     "OpenAI"    {"Content-Type" "application/json"
                  "Authorization" (str "Bearer " api-key)}
+    ;; Compatible servers are usually credential-free; send auth only
+    ;; when a key was actually supplied (vLLM behind a gateway, etc.).
+    "OpenAI-Compatible" (cond-> {"Content-Type" "application/json"}
+                          (some? api-key)
+                          (assoc "Authorization" (str "Bearer " api-key)))
     "Gemini"    {"Content-Type" "application/json"
                  "x-goog-api-key" api-key}
     {"Content-Type" "application/json"}))
@@ -929,11 +934,22 @@
   (or (some-> (:api-key config) str str/trim not-empty)
       (some-> (:api-key-env backend-config) System/getenv str str/trim not-empty)))
 
+(defn- resolve-base-url
+  "The endpoint for a backend that supports base-url override: a
+   non-blank client-config `:base-url` wins, then the backend's
+   `:base-url-env` environment variable, then the backend's static
+   `:api-endpoint` default."
+  [backend-config config]
+  (or (some-> (:base-url config) str str/trim not-empty)
+      (some-> (:base-url-env backend-config) System/getenv str str/trim
+              not-empty)
+      (:api-endpoint backend-config)))
+
 (defn- request-endpoint
   "Resolve the request URL. Gemini embeds the model in the URL path
    (`:model-in-url?`); the other providers take it in the body."
-  [backend-config request]
-  (let [endpoint (:api-endpoint backend-config)]
+  [backend-config request config]
+  (let [endpoint (resolve-base-url backend-config config)]
     (if (:model-in-url? backend-config)
       (format endpoint (:model request))
       endpoint)))
@@ -1010,6 +1026,10 @@
    "OpenAI"    {:body-fn openai-request-body
                 :parse-fn (partial parse-provider-response extract-openai)
                 :requires-model? true}
+   "OpenAI-Compatible" {:body-fn openai-request-body
+                        :parse-fn (partial parse-provider-response
+                                           extract-openai)
+                        :requires-model? true}
    "Gemini"    {:body-fn gemini-request-body
                 :parse-fn (partial parse-provider-response extract-gemini)
                 :requires-model? true}})
@@ -1048,7 +1068,8 @@
                         {:provider provider}))
 
       :else
-      (parse-fn (http-post-request (request-endpoint backend-config request)
+      (parse-fn (http-post-request (request-endpoint backend-config request
+                                                     config)
                                    (provider-headers provider api-key)
                                    (body-fn request))))))
 

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -704,14 +704,17 @@
 ;------------------------------------------------------------------------------ HTTP Backend Support
 
 (defn ollama-request-body
-  "Build Ollama API request body."
-  [{:keys [prompt messages model streaming?]}]
+  "Build Ollama API request body. `:num-ctx` sets Ollama's context-window
+   option — without it Ollama applies its own small default and silently
+   truncates long prompts."
+  [{:keys [prompt messages model streaming? num-ctx]}]
   (let [model (or model "codellama")
         msg-content (or prompt
                         (build-messages-prompt messages))]
-    {:model model
-     :messages [{:role "user" :content msg-content}]
-     :stream (boolean streaming?)}))
+    (cond-> {:model model
+             :messages [{:role "user" :content msg-content}]
+             :stream (boolean streaming?)}
+      num-ctx (assoc :options {:num_ctx (long num-ctx)}))))
 
 (defn- http-failure-anomaly
   "Build the canonical `:unavailable` anomaly that this brick emits for
@@ -1687,10 +1690,12 @@
 
 (defn complete-impl [client request]
   (let [{:keys [config logger exec-fn]} client
-        {:keys [backend model]} config
+        {:keys [backend model num-ctx]} config
         backend-config (get backends backend)
         {:keys [cmd args-fn]} backend-config
-        request-with-model (cond-> request model (assoc :model model))]
+        request-with-model (cond-> request
+                             model (assoc :model model)
+                             num-ctx (assoc :num-ctx num-ctx))]
     (log-prompt-sent logger backend (build-request-prompt request))
 
     ;; Handle HTTP backends differently from CLI backends
@@ -1930,11 +1935,13 @@
 (defn handle-streaming [client request on-chunk backend-config progress-monitor]
   (let [{:keys [logger config]} client
         stream-fn (or (:stream-exec-fn client) stream-exec-fn)
-        {:keys [backend model]} config
+        {:keys [backend model num-ctx]} config
         {:keys [cmd args-fn stream-parser]} backend-config
         prompt     (build-request-prompt request)
         prompt-via (resolve-prompt-via backend-config)
-        request-with-model (cond-> request model (assoc :model model))
+        request-with-model (cond-> request
+                             model (assoc :model model)
+                             num-ctx (assoc :num-ctx num-ctx))
         args     (args-fn (assoc request-with-model
                                  :prompt prompt
                                  :streaming? true
@@ -2041,7 +2048,7 @@
 
 (defn complete-stream-impl [client request on-chunk]
   (let [{:keys [config]} client
-        {:keys [backend model]} config
+        {:keys [backend model num-ctx]} config
         backend-config (get backends backend)
         {:keys [streaming? cmd]} backend-config
         progress-monitor (or (:progress-monitor request)
@@ -2052,7 +2059,9 @@
     ;; Handle HTTP backends
     (if (= cmd "http")
       (http-stream-complete backend-config
-                            (cond-> request model (assoc :model model))
+                            (cond-> request
+                              model (assoc :model model)
+                              num-ctx (assoc :num-ctx num-ctx))
                             on-chunk
                             config)
 

--- a/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
@@ -53,6 +53,10 @@
    - :num-ctx - Optional context-window size for the Ollama backend;
                 without it Ollama applies its own small default and
                 silently truncates long prompts
+   - :base-url - Optional endpoint override for the :openai-compat
+                backend (LM Studio, llama.cpp server, vLLM, ...);
+                falls back to the backend's :base-url-env variable,
+                then its default endpoint
    - :logger  - Optional logger for request/response logging
    - :exec-fn - Optional execution function override (for testing)
 
@@ -63,7 +67,8 @@
      (create-client {:backend :claude :logger my-logger})
      (create-client {:backend :anthropic-api :model \"claude-opus-4-8\"})"
   ([] (create-client {}))
-  ([{:keys [backend logger exec-fn stream-exec-fn model api-key num-ctx]
+  ([{:keys [backend logger exec-fn stream-exec-fn model api-key num-ctx
+            base-url]
      :or {backend :codex}}]
    (when-not (contains? impl/backends backend)
      (response/throw-anomaly! :anomalies/incorrect
@@ -73,7 +78,8 @@
    (->CLIClient (cond-> {:backend backend}
                   model (assoc :model model)
                   api-key (assoc :api-key api-key)
-                  num-ctx (assoc :num-ctx num-ctx))
+                  num-ctx (assoc :num-ctx num-ctx)
+                  base-url (assoc :base-url base-url))
                 logger
                 ;; Normalize so 1-arity user-supplied exec-fns keep
                 ;; working when the impl invokes 2-arity (the

--- a/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
@@ -50,6 +50,9 @@
    - :model   - Optional model id passed through to the backend
    - :api-key - Optional API key for the direct HTTP providers;
                 falls back to the backend's :api-key-env variable
+   - :num-ctx - Optional context-window size for the Ollama backend;
+                without it Ollama applies its own small default and
+                silently truncates long prompts
    - :logger  - Optional logger for request/response logging
    - :exec-fn - Optional execution function override (for testing)
 
@@ -60,7 +63,8 @@
      (create-client {:backend :claude :logger my-logger})
      (create-client {:backend :anthropic-api :model \"claude-opus-4-8\"})"
   ([] (create-client {}))
-  ([{:keys [backend logger exec-fn stream-exec-fn model api-key] :or {backend :codex}}]
+  ([{:keys [backend logger exec-fn stream-exec-fn model api-key num-ctx]
+     :or {backend :codex}}]
    (when-not (contains? impl/backends backend)
      (response/throw-anomaly! :anomalies/incorrect
                              (str "Unknown backend: " backend)
@@ -68,7 +72,8 @@
                               :available (keys impl/backends)}))
    (->CLIClient (cond-> {:backend backend}
                   model (assoc :model model)
-                  api-key (assoc :api-key api-key))
+                  api-key (assoc :api-key api-key)
+                  num-ctx (assoc :num-ctx num-ctx))
                 logger
                 ;; Normalize so 1-arity user-supplied exec-fns keep
                 ;; working when the impl invokes 2-arity (the

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -209,6 +209,60 @@
       (is (= "answer" (:content result)))
       (is (= {:input-tokens 11 :output-tokens 7} (:usage result))))))
 
+(deftest openai-compat-wiring-test
+  (testing "the generic backend rides the OpenAI wire shape, is
+            credential-free by default (no :api-key-env), and defaults to
+            the LM Studio endpoint"
+    (let [entry (backend-config :openai-compat)]
+      (is (= "http" (:cmd entry)))
+      (is (= "OpenAI-Compatible" (:provider entry)))
+      (is (nil? (:api-key-env entry)) "no env var -> never fails closed on a key")
+      (is (= "http://localhost:1234/v1/chat/completions" (:api-endpoint entry)))
+      (is (= "MINIFORGE_OPENAI_COMPAT_BASE_URL" (:base-url-env entry)))
+      (is (false? (:requires-cli? entry))))))
+
+(deftest openai-compat-keyless-round-trip-test
+  (testing "a keyless local server gets no Authorization header; the OpenAI
+            body/parse shapes are reused"
+    (let [{:keys [result captured]}
+          (capture-http (openai-200 "local answer")
+                        (fn []
+                          (llm/complete (llm/create-client {:backend :openai-compat
+                                                            :model "qwen3-30b-a3b"})
+                                        {:prompt "hi"})))]
+      (is (true? (:success result)))
+      (is (= "local answer" (:content result)))
+      (is (= "http://localhost:1234/v1/chat/completions" (:url captured)))
+      (is (not (contains? (:headers captured) "Authorization")))
+      (is (= "qwen3-30b-a3b" (:model (:body captured)))))))
+
+(deftest openai-compat-key-and-base-url-override-test
+  (testing "a supplied :api-key becomes a bearer header and :base-url wins
+            over the default endpoint"
+    (let [{:keys [captured]}
+          (capture-http (openai-200 "ok")
+                        (fn []
+                          (llm/complete (llm/create-client
+                                         {:backend :openai-compat
+                                          :model "m"
+                                          :api-key test-api-key
+                                          :base-url "http://localhost:8000/v1/chat/completions"})
+                                        {:prompt "hi"})))]
+      (is (= (str "Bearer " test-api-key)
+             (get (:headers captured) "Authorization")))
+      (is (= "http://localhost:8000/v1/chat/completions" (:url captured))))))
+
+(deftest openai-compat-requires-model-test
+  (testing "no model on client or request fails closed before any request"
+    (let [{:keys [result captured]}
+          (capture-http (openai-200 "never")
+                        (fn []
+                          (llm/complete (llm/create-client {:backend :openai-compat})
+                                        {:prompt "hi"})))]
+      (is (false? (:success result)))
+      (is (= "missing_model" (get-in result [:error :type])))
+      (is (nil? captured) "failed closed before the transport"))))
+
 (deftest missing-api-key-test
   (let [result (impl/http-complete {:provider "Anthropic"
                                     :api-key-env missing-key-env

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -111,6 +111,27 @@
               {:role "assistant" :content "b"}]
              (:messages body))))))
 
+(deftest ollama-request-body-num-ctx-test
+  (testing ":num-ctx becomes Ollama's options.num_ctx; absent means no options
+            key at all (Ollama then applies its own default)"
+    (let [body (impl/ollama-request-body {:prompt "hi" :model "m" :num-ctx 32768})]
+      (is (= {:num_ctx 32768} (:options body))))
+    (let [body (impl/ollama-request-body {:prompt "hi" :model "m"})]
+      (is (not (contains? body :options))))))
+
+(deftest ollama-num-ctx-threads-from-client-config-test
+  (testing "a client created with :num-ctx sends it on every Ollama request —
+            the silent-truncation guard for long prompts"
+    (let [{:keys [captured]}
+          (capture-http (http-200 {:message {:content "ok"}
+                                   :prompt_eval_count 1 :eval_count 1})
+                        (fn []
+                          (llm/complete (llm/create-client {:backend :ollama
+                                                            :model "m"
+                                                            :num-ctx 65536})
+                                        {:prompt "long surface"})))]
+      (is (= {:num_ctx 65536} (:options (:body captured)))))))
+
 (deftest openai-request-body-test
   (testing "system becomes the leading system-role message"
     (let [body (impl/openai-request-body {:prompt "hi" :model "gpt-x" :system "s"})]

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -252,6 +252,20 @@
              (get (:headers captured) "Authorization")))
       (is (= "http://localhost:8000/v1/chat/completions" (:url captured))))))
 
+(deftest base-url-override-is-scoped-to-declaring-backends-test
+  (testing "a stray :base-url on a fixed-endpoint provider is ignored —
+            only backends declaring :base-url-env support the override"
+    (let [{:keys [captured]}
+          (capture-http (openai-200 "ok")
+                        (fn []
+                          (llm/complete (llm/create-client
+                                         {:backend :openai-api
+                                          :model "m"
+                                          :api-key test-api-key
+                                          :base-url "http://localhost:9999/hijack"})
+                                        {:prompt "hi"})))]
+      (is (= "https://api.openai.com/v1/chat/completions" (:url captured))))))
+
 (deftest openai-compat-requires-model-test
   (testing "no model on client or request fails closed before any request"
     (let [{:keys [result captured]}

--- a/components/llm/test/ai/miniforge/llm/network_health_test.clj
+++ b/components/llm/test/ai/miniforge/llm/network_health_test.clj
@@ -70,6 +70,8 @@
     (is (= "https://api2.cursor.sh/"    (impl/probe-endpoint-for :cursor)))
     (is (= "http://localhost:11434/api/version"
            (impl/probe-endpoint-for :ollama)))
+    (is (= "http://localhost:1234/v1/models"
+           (impl/probe-endpoint-for :openai-compat)))
     (is (= "https://api.anthropic.com/" (impl/probe-endpoint-for :opencode))
         "OpenCode defaults to Anthropic — the typical provider routing"))
 

--- a/docs/pull-requests/2026-07-19-feat-llm-openai-compat.md
+++ b/docs/pull-requests/2026-07-19-feat-llm-openai-compat.md
@@ -1,0 +1,57 @@
+<!--
+  Title: Generic OpenAI-compatible HTTP backend + Ollama num_ctx threading
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat(llm): generic OpenAI-compatible backend; thread :num-ctx to Ollama
+
+Branch: `feat/llm-openai-compat`
+
+## Summary
+
+The DMG (non-App-Store) distribution of Thesium Career supports "bring
+your own LOCAL model." The local-inference ecosystem converged on the
+OpenAI Chat Completions wire shape: LM Studio, llama.cpp's server,
+vLLM, and newer engines (e.g. colibrì) all expose
+`/v1/chat/completions`. Rather than one backend per engine, this PR
+adds a single generic backend behind the `http-providers` registry
+that #1420 introduced:
+
+| Backend | Wire shape | Endpoint |
+|---|---|---|
+| `:openai-compat` | OpenAI Chat Completions | client `:base-url` → `MINIFORGE_OPENAI_COMPAT_BASE_URL` → LM Studio default (`http://localhost:1234/v1/chat/completions`) |
+
+Second fix in the same component: Ollama silently truncates long
+prompts to its own small default context window because nothing
+threaded `num_ctx`. `create-client` now accepts `:num-ctx`, both
+completion paths carry it beside `:model`, and `ollama-request-body`
+emits it as `options.num_ctx`. Long-surface product reads (a rank
+claim surface is 40–88K tokens) were previously silently truncated on
+local Ollama runs.
+
+## Design
+
+- **Reuse over new shapes.** The provider entry reuses
+  `openai-request-body` / `extract-openai` wholesale — the point of an
+  OpenAI-compatible backend is that nothing wire-level is new. Only
+  endpoint resolution and auth policy differ.
+- **Credential-free by default, key honored when supplied.** Local
+  servers are typically keyless, so the backend declares no
+  `:api-key-env` (which would fail closed per #1420's contract). A
+  client `:api-key` becomes a bearer header when present — vLLM behind
+  a gateway still works.
+- **Base-url resolution mirrors key resolution:** client config wins,
+  env variable next, static default last (`resolve-base-url`;
+  `request-endpoint` now takes the client config).
+- **`:requires-model?` stays true.** Compatible servers accept a model
+  field and several route on it; failing closed on a missing model
+  beats serializing `"model": null`.
+
+## Verification
+
+`clojure -M:poly test` (changed bricks) green, including new coverage:
+backend wiring shape, keyless round-trip (no Authorization header,
+OpenAI body/parse reuse), key + base-url override, missing-model
+fail-closed before transport, probe endpoint, `num_ctx` body emission
+and client-config threading.


### PR DESCRIPTION
## Summary

The DMG (non-App-Store) distribution of Thesium Career supports "bring
your own LOCAL model." The local-inference ecosystem converged on the
OpenAI Chat Completions wire shape: LM Studio, llama.cpp's server,
vLLM, and newer engines (e.g. colibrì) all expose
`/v1/chat/completions`. Rather than one backend per engine, this PR
adds a single generic backend behind the `http-providers` registry
that #1420 introduced:

| Backend | Wire shape | Endpoint |
|---|---|---|
| `:openai-compat` | OpenAI Chat Completions | client `:base-url` → `MINIFORGE_OPENAI_COMPAT_BASE_URL` → LM Studio default (`http://localhost:1234/v1/chat/completions`) |

Second fix in the same component: Ollama silently truncates long
prompts to its own small default context window because nothing
threaded `num_ctx`. `create-client` now accepts `:num-ctx`, both
completion paths carry it beside `:model`, and `ollama-request-body`
emits it as `options.num_ctx`. Long-surface product reads (a rank
claim surface is 40–88K tokens) were previously silently truncated on
local Ollama runs.

## Design

- **Reuse over new shapes.** The provider entry reuses
  `openai-request-body` / `extract-openai` wholesale — the point of an
  OpenAI-compatible backend is that nothing wire-level is new. Only
  endpoint resolution and auth policy differ.
- **Credential-free by default, key honored when supplied.** Local
  servers are typically keyless, so the backend declares no
  `:api-key-env` (which would fail closed per #1420's contract). A
  client `:api-key` becomes a bearer header when present — vLLM behind
  a gateway still works.
- **Base-url resolution mirrors key resolution:** client config wins,
  env variable next, static default last (`resolve-base-url`;
  `request-endpoint` now takes the client config).
- **`:requires-model?` stays true.** Compatible servers accept a model
  field and several route on it; failing closed on a missing model
  beats serializing `"model": null`.

## Verification

`clojure -M:poly test` (changed bricks) green, including new coverage:
backend wiring shape, keyless round-trip (no Authorization header,
OpenAI body/parse reuse), key + base-url override, missing-model
fail-closed before transport, probe endpoint, `num_ctx` body emission
and client-config threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AjtfaqZyuE64GmnMSNgjC