### PR TITLE
fix(llm): return HTTP parse failures as data

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -32,7 +32,7 @@
    [ai.miniforge.llm.network-monitor :as nnm]
    [ai.miniforge.llm.progress-monitor :as pm]
    [ai.miniforge.response.interface :as response]
-   [slingshot.slingshot :refer [throw+ try+]])
+   [slingshot.slingshot :refer [try+]])
   (:import
    [java.io ByteArrayInputStream]
    [java.net HttpURLConnection]
@@ -187,16 +187,18 @@
    identically). The original `:operation` lives under `:anomaly/data`."
   ([category error-type message]
    (llm-error category error-type message nil))
-  ([category error-type message {:keys [exit-code stderr stdout raw-stdout timeout]}]
+  ([category error-type message
+    {:keys [exit-code stderr stdout raw-stdout timeout failure-anomaly]}]
    (cond-> {:success false
             :error (cond-> {:type error-type :message message}
                      stderr  (assoc :stderr stderr)
                      stdout  (assoc :stdout stdout)
                      raw-stdout (assoc :raw-stdout raw-stdout)
                      timeout (assoc :timeout timeout))
-            :anomaly (->canonical-anomaly
-                      category message
-                      {:operation :llm-complete})}
+            :anomaly (or failure-anomaly
+                         (->canonical-anomaly
+                          category message
+                          {:operation :llm-complete}))}
      (some? exit-code) (assoc :exit-code exit-code))))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -779,6 +781,7 @@
    instead of everything collapsing into a generic api_error."
   [status]
   (cond
+    (not (integer? status))                              :anomalies/unavailable
     (or (= status HttpURLConnection/HTTP_UNAUTHORIZED)
         (= status HttpURLConnection/HTTP_FORBIDDEN))  :anomalies/forbidden
     (= status HttpURLConnection/HTTP_NOT_FOUND)       :anomalies/not-found
@@ -786,28 +789,21 @@
     (< status HttpURLConnection/HTTP_INTERNAL_ERROR)  :anomalies/incorrect
     :else                                             :anomalies/unavailable))
 
-(defn- parse-body-or-throw
-  "Parse a response body as JSON. A malformed body on a NON-OK response
-   is not a parse error — the provider signalled failure and the status
-   is the signal — so that case throws the typed provider-http-error
-   instead of surfacing as :anomalies/fault."
+(defn- parse-response-body
+  "Parse a response body as JSON, returning a canonical fault anomaly when
+   the JSON library throws. Callers retain the HTTP status alongside this
+   value so a non-OK response remains a status failure, not a parse failure."
   [{:keys [status body]}]
-  (try
+  (try+
     (json/parse-string body true)
     (catch Exception e
-      (if (= HttpURLConnection/HTTP_OK status)
-        (throw e)
-        (throw+ {:type ::provider-http-error
-                 :status status
-                 :message (ex-message e)})))))
-
-(defn- throw-provider-http-error!
-  "Throw the typed non-OK provider error carrying the status and the
-   provider's own message when it sent one."
-  [{:keys [status]} provider-message]
-  (throw+ {:type ::provider-http-error
-           :status status
-           :message provider-message}))
+      (anomaly/exception-anomaly
+       :fault
+       (msg/t :http-provider.system/parse-failed
+              {:reason (ex-message e)})
+       {:operation :parse-provider-response
+        :status status}
+       e))))
 
 (defn- provider-http-error->llm-error
   "Build the canonical failure for a non-OK provider response: the
@@ -821,6 +817,15 @@
                      :message (or message
                                   (msg/t :http-provider.system/unknown-api-error))})))
 
+(defn- response-parse-error
+  "Wrap a canonical JSON-parse anomaly in the LLM failure shape without
+   discarding its operation, HTTP status, or exception provenance."
+  [parse-anomaly]
+  (llm-error :anomalies/fault
+             "parse_error"
+             (:anomaly/message parse-anomaly)
+             {:failure-anomaly parse-anomaly}))
+
 (defn parse-ollama-response
   "Parse Ollama API response.
 
@@ -833,20 +838,21 @@
   ;; If response is already a canonical anomaly map, re-wrap it as :anomalies/unavailable so downstream classification stays identical
   (if (anomaly/anomaly? response)
     (llm-error :anomalies/unavailable "http_error" (:anomaly/message response))
-    (try+
-      (let [body (parse-body-or-throw response)]
-        (when-not (= HttpURLConnection/HTTP_OK (:status response))
-          (throw-provider-http-error! response
-                                      (get body :error)))
+    (let [body   (parse-response-body response)
+          status (:status response)]
+      (cond
+        (not= HttpURLConnection/HTTP_OK status)
+        (provider-http-error->llm-error
+         {:status status
+          :message (when-not (anomaly/anomaly? body) (get body :error))})
+
+        (anomaly/anomaly? body)
+        (response-parse-error body)
+
+        :else
         (llm-success (get-in body [:message :content] "")
                      {:usage (token-usage (:prompt_eval_count body)
-                                          (:eval_count body))}))
-      (catch [:type ::provider-http-error] e
-        (provider-http-error->llm-error e))
-      (catch Exception e
-        (llm-error :anomalies/fault "parse_error"
-                   (msg/t :http-provider.system/parse-failed
-                          {:reason (.getMessage e)}))))))
+                                          (:eval_count body))})))))
 
 ;------------------------------------------------------------------------------ Direct provider requests
 ;; Request/response shaping for the API-key HTTP backends
@@ -970,22 +976,24 @@
   [extract-fn response]
   (if (anomaly/anomaly? response)
     (llm-error :anomalies/unavailable "http_error" (:anomaly/message response))
-    (try+
-      (let [body (parse-body-or-throw response)]
-        (when-not (= HttpURLConnection/HTTP_OK (:status response))
-          (throw-provider-http-error! response
-                                      (get-in body [:error :message])))
+    (let [body   (parse-response-body response)
+          status (:status response)]
+      (cond
+        (not= HttpURLConnection/HTTP_OK status)
+        (provider-http-error->llm-error
+         {:status status
+          :message (when-not (anomaly/anomaly? body)
+                     (get-in body [:error :message]))})
+
+        (anomaly/anomaly? body)
+        (response-parse-error body)
+
+        :else
         (let [{:keys [content usage]} (extract-fn body)]
           (if (str/blank? content)
             (llm-error :anomalies.agent/llm-error "empty_success_output"
                        (msg/t :http-provider.system/no-generated-text))
-            (llm-success content {:usage usage}))))
-      (catch [:type ::provider-http-error] e
-        (provider-http-error->llm-error e))
-      (catch Exception e
-        (llm-error :anomalies/fault "parse_error"
-                   (msg/t :http-provider.system/parse-failed
-                          {:reason (.getMessage e)}))))))
+            (llm-success content {:usage usage})))))))
 
 (defn- extract-anthropic
   "Text + usage from an Anthropic Messages response: join the `text`

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -333,6 +333,16 @@
                                              {:api-key test-api-key}))]
       (is (= "api_error" (get-in result [:error :type])))
       (is (= :unavailable (get-in result [:anomaly :anomaly/type])))))
+  (testing "a non-JSON body on a 200 returns a parse failure as data"
+    (let [{:keys [result]}
+          (capture-http {:status 200 :body "not-json"}
+                        #(impl/http-complete (backend-config :anthropic-api)
+                                             {:prompt "q" :model "m"}
+                                             {:api-key test-api-key}))]
+      (is (= "parse_error" (get-in result [:error :type])))
+      (is (= :fault (get-in result [:anomaly :anomaly/type])))
+      (is (= :parse-provider-response
+             (get-in result [:anomaly :anomaly/data :operation])))))
   (testing "200 with no generated text fails instead of passing empty content"
     (let [{:keys [result]}
           (capture-http (http-200 {:content [] :usage {}})
@@ -371,6 +381,19 @@
       (is (:success result))
       (is (= {} (:usage result)))
       (is (= 0 (:tokens result))))))
+
+(deftest ollama-response-failures-are-data-test
+  (testing "a non-OK response is classified by status without throwing"
+    (let [result (impl/parse-ollama-response
+                  {:status 503 :body (json/generate-string {:error "overloaded"})})]
+      (is (= "api_error" (get-in result [:error :type])))
+      (is (= :unavailable (get-in result [:anomaly :anomaly/type])))))
+  (testing "malformed JSON on a 200 becomes a parse failure with provenance"
+    (let [result (impl/parse-ollama-response {:status 200 :body "not-json"})]
+      (is (= "parse_error" (get-in result [:error :type])))
+      (is (= :fault (get-in result [:anomaly :anomaly/type])))
+      (is (= :parse-provider-response
+             (get-in result [:anomaly :anomaly/data :operation]))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Client integration: config threading through complete / complete-stream

--- a/docs/pull-requests/2026-07-19-fix-llm-http-exceptions-as-data-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-llm-http-exceptions-as-data-20260719.md
@@ -1,0 +1,46 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Align LLM HTTP failures with Exceptions as Data
+
+## Overview
+
+Resolve the Exceptions-as-Data findings introduced with direct HTTP LLM providers while preserving provider error
+details at the public invocation boundary.
+
+## Motivation
+
+Provider HTTP failures currently cross an internal boundary as thrown values. The repository standard requires expected
+operational failures to remain explicit data so callers can classify and render them without exception control flow.
+
+## Changes in Detail
+
+- Parse JSON into either a body value or a canonical fault anomaly instead of throwing through local control flow.
+- Classify non-success responses by HTTP status even when their bodies are malformed.
+- Preserve parse operation, status, and exception provenance when wrapping anomalies in LLM failure responses.
+- Add regression coverage for direct-provider and Ollama status and parse failures.
+
+## Testing Plan
+
+- Run focused LLM HTTP-provider tests.
+- Run the Exceptions-as-Data scanner and verify these findings are removed.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. No data migration or rollout step is required.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Follow-up to #1420 and #1427.
+
+## Checklist
+
+- [x] Preserve provider error classification and diagnostics.
+- [x] Add regression coverage for expected failure paths.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Align LLM HTTP failures with Exceptions as Data

## Overview

Resolve the Exceptions-as-Data findings introduced with direct HTTP LLM providers while preserving provider error
details at the public invocation boundary.

## Motivation

Provider HTTP failures currently cross an internal boundary as thrown values. The repository standard requires expected
operational failures to remain explicit data so callers can classify and render them without exception control flow.

## Changes in Detail

- Parse JSON into either a body value or a canonical fault anomaly instead of throwing through local control flow.
- Classify non-success responses by HTTP status even when their bodies are malformed.
- Preserve parse operation, status, and exception provenance when wrapping anomalies in LLM failure responses.
- Add regression coverage for direct-provider and Ollama status and parse failures.

## Testing Plan

- Run focused LLM HTTP-provider tests.
- Run the Exceptions-as-Data scanner and verify these findings are removed.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. No data migration or rollout step is required.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Follow-up to #1420 and #1427.

## Checklist

- [x] Preserve provider error classification and diagnostics.
- [x] Add regression coverage for expected failure paths.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
