### PR TITLE
feat(workbench): orchestration adapter projects supervisory state to minibench

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -180,6 +180,15 @@
   ;; Cross-language contract fixtures
   ;; ──────────────────────────────────────────────────────────────────────────
 
+  workbench:orchestration:registry
+  {:doc  "Export the Miniforge orchestration workbench state-variable registry as JSON (args: :out \"<path>\")"
+   :task (let [exit (apply run-clojure-stream!
+                           "-X:dev"
+                           "ai.miniforge.workbench-orchestration-adapter.interface/export-registry!"
+                           *command-line-args*)]
+           (when-not (zero? exit)
+             (System/exit exit)))}
+
   fixtures:supervisory
   {:doc  "Regenerate the supervisory golden fixtures (contracts/supervisory-entities/golden) consumed by miniforge-control. Run after any supervisory entity schema change, commit the diff, re-vendor downstream."
    :task (let [exit (run-clojure-stream!

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
@@ -25,6 +25,7 @@
    (N3 §3.19) for consumers — the Rust control console, native app, and web
    dashboard."
   (:require
+   [ai.miniforge.supervisory-state.accumulator :as accumulator]
    [ai.miniforge.supervisory-state.core :as core]
    [ai.miniforge.supervisory-state.golden-fixtures :as golden-fixtures]
    [ai.miniforge.supervisory-state.schema :as schema]))
@@ -48,6 +49,22 @@
    crate as the cross-language contract test corpus. `clojure -X`
    compatible; see the `fixtures:supervisory` bb task."
   golden-fixtures/write-golden-fixtures!)
+
+(def empty-table
+  "Initial empty EntityTable. Seed value for [[apply-event]] /
+   [[apply-events]] when folding an event sequence without a component."
+  schema/empty-table)
+
+(def apply-event
+  "Pure reducer: apply one event to an EntityTable, returning the (possibly
+   identical) updated table. Unknown event types are ignored at the entity
+   level. Lets consumers (replay tooling, workbench adapters, tests)
+   materialize a table from an event sequence without a live stream."
+  accumulator/apply-event)
+
+(def apply-events
+  "Pure fold of an event sequence into an EntityTable via [[apply-event]]."
+  accumulator/apply-events)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schemas (re-exports)

--- a/components/workbench-orchestration-adapter/deps.edn
+++ b/components/workbench-orchestration-adapter/deps.edn
@@ -1,0 +1,16 @@
+{:paths ["src" "resources"]
+
+ :deps {ai.miniforge/content-hash {:local/root "../content-hash"}
+        ai.miniforge/schema       {:local/root "../schema"}
+        cheshire/cheshire         {:mvn/version "5.13.0"}
+        io.github.miniforge-ai/workbench-contract
+        {:git/url "ssh://git@github.com/miniforge-ai/workbench-contract.git"
+         :git/sha "5212f32ed9bdbfbc982e9ff746352c2f190d8e12"
+         :deps/root "bindings/clojure"}}
+
+ :aliases {:test {:extra-paths ["test"]
+                  ;; Test fixtures fold synthetic event streams through the
+                  ;; REAL supervisory-state accumulator and pass the REAL
+                  ;; workflow phase-transition map — never hand-rolled shapes.
+                  :extra-deps {ai.miniforge/supervisory-state {:local/root "../supervisory-state"}
+                               ai.miniforge/workflow          {:local/root "../workflow"}}}}}

--- a/components/workbench-orchestration-adapter/resources/workbench/miniforge-orchestration-state-vars.edn
+++ b/components/workbench-orchestration-adapter/resources/workbench/miniforge-orchestration-state-vars.edn
@@ -1,0 +1,119 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+{:schema_version "state_var_registry/v1"
+ :registry_id "miniforge-orchestration-state-vars"
+ :version "2026.07.19.1"
+ :product "miniforge"
+ :state_vars
+ [{:id "miniforge.workflow.machine_authoritative"
+   :version "1.0.0"
+   :product "miniforge"
+   :area "workflow"
+   :kind "integrity"
+   :description "The observed phase history is a path through the single authoritative execution machine and the terminal projection is legal (N2 §2.1-§2.3, §3.1)."
+   :value_type "boolean"
+   :thresholds {:pass 1.0 :fail 0.0}
+   :evidence_requirements {:required_refs ["workflow-run" "workflow-phase-history"]
+                           :min_count 1
+                           :must_include_source_role true}
+   :score_components ["legal_transition_rate" "terminal_phase_legal" "observed_transitions"]
+   :gate_effects {:fail "blocks_transition"}
+   :lifecycle "experimental"
+   :owner "miniforge/supervisory-state"}
+
+  {:id "miniforge.workflow.runs_resolved"
+   :version "1.0.0"
+   :product "miniforge"
+   :area "workflow"
+   :kind "sufficiency"
+   :description "The fraction of workflow runs at the snapshot boundary that reached a terminal lifecycle status - completed, failed, or cancelled per N2 §2.2-§2.3. Dangling runs are excluded from snapshots."
+   :value_type "number"
+   :thresholds {:pass 1.0 :warn 0.8}
+   :evidence_requirements {:required_refs ["workflow-run"]
+                           :min_count 1
+                           :must_include_source_role true}
+   :score_components ["resolved_runs" "total_runs" "dangling_runs"]
+   :gate_effects {:warn "marks_low_confidence" :fail "marks_low_confidence"}
+   :lifecycle "experimental"
+   :owner "miniforge/supervisory-state"}
+
+  {:id "miniforge.gate.critical_violations_block"
+   :version "1.0.0"
+   :product "miniforge"
+   :area "gate"
+   :kind "compliance"
+   :description "Every recorded PolicyEvaluation for the run that carries a critical violation has a blocking failed outcome (N4 §3 gate execution contract, §3.3 violation schema)."
+   :value_type "boolean"
+   :thresholds {:pass 1.0 :fail 0.0}
+   :evidence_requirements {:required_refs ["policy-evaluation"]
+                           :min_count 0
+                           :must_include_source_role true}
+   :score_components ["critical_evaluations" "blocking_evaluations" "unblocked_evaluations"]
+   :gate_effects {:fail "blocks_transition"}
+   :lifecycle "experimental"
+   :owner "miniforge/supervisory-state"}
+
+  {:id "miniforge.policy.evaluations_recorded"
+   :version "1.0.0"
+   :product "miniforge"
+   :area "policy"
+   :kind "presence"
+   :description "A run whose observed phase history traversed the verify phase has at least one recorded PolicyEvaluation (N4 §3 gate execution contract; N2 §2.4 lifecycle events)."
+   :value_type "boolean"
+   :thresholds {:pass 1.0 :fail 0.0}
+   :evidence_requirements {:required_refs ["policy-evaluation"]
+                           :min_count 0
+                           :must_include_source_role true}
+   :score_components ["policy_evaluations" "verify_traversed"]
+   :gate_effects {:fail "marks_low_confidence"}
+   :lifecycle "experimental"
+   :owner "miniforge/supervisory-state"}
+
+  {:id "miniforge.attention.items_actioned"
+   :version "1.0.0"
+   :product "miniforge"
+   :area "attention"
+   :kind "quality"
+   :description "The fraction of AttentionItems derived for the run that are resolved at the snapshot boundary (N5-delta-1 §3.1, §5)."
+   :value_type "number"
+   :thresholds {:pass 1.0 :warn 0.8}
+   :evidence_requirements {:required_refs ["attention-item"]
+                           :min_count 0
+                           :must_include_source_role true}
+   :score_components ["actioned_items" "total_items" "open_items"]
+   :gate_effects {:warn "marks_low_confidence" :fail "marks_low_confidence"}
+   :lifecycle "experimental"
+   :owner "miniforge/supervisory-state"}
+
+  {:id "miniforge.decision.queue_drained"
+   :version "1.0.0"
+   :product "miniforge"
+   :area "decision"
+   :kind "sufficiency"
+   :description "DecisionCards and InterventionRequests bound to the run are resolved or settled at the snapshot boundary (N5-delta-3 §2.4; N5-delta-supervisory-control-plane §3.3)."
+   :value_type "number"
+   :thresholds {:pass 1.0 :warn 0.8}
+   :evidence_requirements {:required_refs ["decision-card" "intervention-request"]
+                           :min_count 0
+                           :must_include_source_role true}
+   :score_components ["resolved_decisions" "total_decisions"
+                      "settled_interventions" "total_interventions"]
+   :gate_effects {:warn "marks_low_confidence" :fail "marks_low_confidence"}
+   :lifecycle "experimental"
+   :owner "miniforge/supervisory-state"}]}

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/config.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/config.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workbench-orchestration-adapter.config
+  "Pure resolved-run boundary for orchestration workbench snapshots.
+
+   An orchestration run is RESOLVED when its lifecycle projection reached a
+   terminal status per N2 §2.2-§2.3: `:completed`, `:failed`, or
+   `:cancelled`. Only resolved runs are comparable across minibench
+   variants; unresolved (dangling) runs are excluded from snapshots.
+
+   The supervisory-state EntityTable keeps only `:workflow-run/current-phase`
+   - not the traversed phase sequence - so the observed phase history is
+   derived here as a pure fold over the same N2 §2.4 lifecycle event stream
+   the caller already folded into the table.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Resolved-run boundary
+
+(def resolved-run-schema-version "miniforge_orchestration_resolved_run/v1")
+
+(def terminal-statuses
+  "Terminal `:workflow-run/status` values per N2 §2.2-§2.3. `:done` is the
+   phase machine's terminal node; these are the lifecycle projections a run
+   lands on once the machine can make no further transition."
+  #{:completed :failed :cancelled})
+
+(defn resolved?
+  "True when `run` (a supervisory-state WorkflowRun entity) is at the
+   resolved-run boundary - its lifecycle status is terminal."
+  [run]
+  (contains? terminal-statuses (:workflow-run/status run)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Boundary queries over an EntityTable
+
+(defn resolved-runs
+  "All resolved WorkflowRun entities in `table`, ordered by started-at."
+  [table]
+  (->> (vals (:workflows table))
+       (filter resolved?)
+       (sort-by :workflow-run/started-at)
+       vec))
+
+(defn dangling-run-count
+  "Number of workflow runs in `table` that have not reached the boundary."
+  [table]
+  (count (remove resolved? (vals (:workflows table)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Observed phase history
+
+(defn phase-history
+  "Ordered phases observed for `workflow-id` in `events` - a pure fold over
+   the `:workflow/phase-started` lifecycle events (N2 §2.4) that also fed
+   the supervisory-state accumulator. Returns a (possibly empty) vector."
+  [events workflow-id]
+  (into []
+        (comp (filter #(= :workflow/phase-started (:event/type %)))
+              (filter #(= workflow-id (:workflow/id %)))
+              (keep :workflow/phase))
+        events))

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/core.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/core.clj
@@ -1,0 +1,100 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workbench-orchestration-adapter.core
+  "Pure assembly of a Miniforge orchestration workbench_snapshot/v1 wire map."
+  (:require
+   [ai.miniforge.workbench-orchestration-adapter.config :as config]
+   [ai.miniforge.workbench-orchestration-adapter.evaluation :as evaluation]))
+
+(def registry-id "miniforge-orchestration-state-vars")
+(def registry-version "2026.07.19.1")
+
+(def ^:private product "miniforge")
+(def ^:private snapshot-schema-version "workbench_snapshot/v1")
+(def ^:private signature-stub
+  {:algorithm "sha256"
+   :digest "0000000000000000000000000000000000000000000000000000000000000000"
+   :canonicalization "json-c14n/1"})
+
+(defn- iso-instant
+  "Render an entity timestamp (java.util.Date or java.time.Instant) as an
+   ISO-8601 string. Pure - never reads a clock."
+  [timestamp]
+  (cond
+    (instance? java.util.Date timestamp) (str (.toInstant ^java.util.Date timestamp))
+    (some? timestamp) (str timestamp)
+    :else nil))
+
+(defn- variant [run experiment-id label]
+  {:experiment_id experiment-id
+   :label label
+   :workflow {:id (:workflow-run/workflow-key run)}
+   :method "orchestration"
+   :axes {:workflow_key (:workflow-run/workflow-key run)
+          :terminal_status (name (:workflow-run/status run))}})
+
+(defn- workflow-run-entity [run]
+  (cond-> {:workflow/id (str (:workflow-run/id run))
+           :workflow/status (name (:workflow-run/status run))
+           :workflow/current-phase (name (:workflow-run/current-phase run))
+           :workflow/workflow-key (:workflow-run/workflow-key run)
+           :workflow/started-at (iso-instant (:workflow-run/started-at run))
+           :workflow/updated-at (iso-instant (:workflow-run/updated-at run))
+           :workflow/pr-count (count (:workflow-run/prs run))}
+    (:workflow-run/evidence-bundle-id run)
+    (assoc :workflow/evidence-bundle-id
+           (str (:workflow-run/evidence-bundle-id run)))))
+
+(defn snapshot
+  "Project one resolved workflow run from `table` into a snapshot.
+
+   Pure projection: `generated_at` is caller-supplied via `:generated-at`
+   and defaults to the run's own `:workflow-run/updated-at` - no clock is
+   read here (same purity discipline as the ETL adapter)."
+  [table run {:keys [experiment-id label snapshot-id run-id generated-at
+                     source-hashes transitions phase-history]}]
+  (let [phase-history (vec phase-history)
+        run-id        (or run-id (str (:workflow-run/id run)))
+        snapshot-id   (or snapshot-id (str "wb-" run-id))
+        generated-at  (or generated-at
+                          (iso-instant (:workflow-run/updated-at run)))]
+    (cond->
+     {:schema_version snapshot-schema-version
+      :snapshot_id snapshot-id
+      :generated_at generated-at
+      :product product
+      :run_id run-id
+      :variant (variant run experiment-id label)
+      :registry_ref {:registry_id registry-id :version registry-version}
+      :evaluations (evaluation/evaluations {:run run
+                                            :table table
+                                            :transitions transitions
+                                            :phase-history phase-history
+                                            :evaluated-at generated-at})
+      :entities {:miniforge.workflow_run (workflow-run-entity run)}
+      :metadata
+      {:provenance (evaluation/provenance)
+       :resolved_run {:schema_version config/resolved-run-schema-version
+                      :domain "orchestration"
+                      :terminal_status (name (:workflow-run/status run))
+                      :phase_history (mapv name phase-history)
+                      :observed_transition_count (max 0 (dec (count phase-history)))
+                      :dangling_run_count (config/dangling-run-count table)}}
+      :signature signature-stub}
+      (seq source-hashes) (assoc :source_hashes (vec source-hashes)))))

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/core.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/core.clj
@@ -22,9 +22,6 @@
    [ai.miniforge.workbench-orchestration-adapter.config :as config]
    [ai.miniforge.workbench-orchestration-adapter.evaluation :as evaluation]))
 
-(def registry-id "miniforge-orchestration-state-vars")
-(def registry-version "2026.07.19.1")
-
 (def ^:private product "miniforge")
 (def ^:private snapshot-schema-version "workbench_snapshot/v1")
 (def ^:private signature-stub
@@ -68,7 +65,7 @@
    and defaults to the run's own `:workflow-run/updated-at` - no clock is
    read here (same purity discipline as the ETL adapter)."
   [table run {:keys [experiment-id label snapshot-id run-id generated-at
-                     source-hashes transitions phase-history]}]
+                     source-hashes transitions phase-history registry]}]
   (let [phase-history (vec phase-history)
         run-id        (str (or run-id (:workflow-run/id run)))
         snapshot-id   (str (or snapshot-id (str "wb-" run-id)))
@@ -81,7 +78,10 @@
       :product product
       :run_id run-id
       :variant (variant run experiment-id label)
-      :registry_ref {:registry_id registry-id :version registry-version}
+      ;; Sourced from the loaded registry (validated by the caller), never
+      ;; from constants — snapshots can't drift from the exported registry.
+      :registry_ref {:registry_id (:registry_id registry)
+                     :version (:version registry)}
       :evaluations (evaluation/evaluations {:run run
                                             :table table
                                             :transitions transitions

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/core.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/core.clj
@@ -70,10 +70,10 @@
   [table run {:keys [experiment-id label snapshot-id run-id generated-at
                      source-hashes transitions phase-history]}]
   (let [phase-history (vec phase-history)
-        run-id        (or run-id (str (:workflow-run/id run)))
-        snapshot-id   (or snapshot-id (str "wb-" run-id))
-        generated-at  (or generated-at
-                          (iso-instant (:workflow-run/updated-at run)))]
+        run-id        (str (or run-id (:workflow-run/id run)))
+        snapshot-id   (str (or snapshot-id (str "wb-" run-id)))
+        generated-at  (iso-instant (or generated-at
+                                       (:workflow-run/updated-at run)))]
     (cond->
      {:schema_version snapshot-schema-version
       :snapshot_id snapshot-id

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/evaluation.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/evaluation.clj
@@ -1,0 +1,426 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workbench-orchestration-adapter.evaluation
+  "Pure orchestration state-variable evaluation and evaluator provenance.
+
+   Every evaluator is a deterministic function of the supervisory-state
+   EntityTable plus caller-supplied context (the legal phase-transition map
+   and the observed phase history). No LLM, no clock, no I/O."
+  (:require
+   [ai.miniforge.content-hash.interface :as content-hash]
+   [ai.miniforge.workbench-orchestration-adapter.config :as config]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Evaluation policy
+
+(def ^:private product "miniforge")
+(def ^:private evaluator-version "miniforge-orchestration-workbench-adapter/1.0.0")
+(def ^:private policy-version "miniforge-orchestration-evaluation-policy/1.0.0")
+(def ^:private rate-warn-threshold 0.8)
+
+(def ^:private settled-intervention-states
+  "InterventionRequest lifecycle states that need no further supervisory
+   action per N5-delta-supervisory-control-plane §3.3."
+  #{:rejected :applied :verified :failed})
+
+(def ^:private evaluator-definition
+  {:evaluators
+   [{:id "miniforge.workflow.machine_authoritative" :formula :observed-history-subset-of-legal-transitions}
+    {:id "miniforge.workflow.runs_resolved" :formula :resolved-runs-over-all-runs}
+    {:id "miniforge.gate.critical_violations_block" :formula :critical-evaluations-all-blocked}
+    {:id "miniforge.policy.evaluations_recorded" :formula :verify-traversal-implies-policy-evaluation}
+    {:id "miniforge.attention.items_actioned" :formula :resolved-items-over-all-items}
+    {:id "miniforge.decision.queue_drained" :formula :settled-queue-entries-over-all-entries}]})
+
+(def ^:private policy-definition
+  {:rate-warn-threshold rate-warn-threshold
+   :terminal-statuses config/terminal-statuses
+   :settled-intervention-states settled-intervention-states})
+
+(def ^:private evaluator-hash
+  (str "sha256:" (content-hash/content-hash evaluator-definition)))
+
+(def ^:private policy-hash
+  (str "sha256:" (content-hash/content-hash policy-definition)))
+
+(def ^:private illegal-transition-message
+  "Observed phase history contains a transition outside the authoritative machine")
+(def ^:private terminal-phase-message
+  "Completed run did not end on the machine's terminal phase")
+(def ^:private dangling-runs-message
+  "One or more workflow runs have not reached the resolved-run boundary")
+(def ^:private unblocked-critical-message
+  "One or more critical policy violations did not block progression")
+(def ^:private missing-evaluation-message
+  "Run traversed the verify phase without a recorded policy evaluation")
+(def ^:private open-attention-message
+  "One or more attention items remain unresolved at the boundary")
+(def ^:private pending-queue-message
+  "One or more decisions or interventions remain pending at the boundary")
+
+(defn- ratio [numerator denominator]
+  (if (zero? denominator)
+    1.0
+    (double (/ numerator denominator))))
+
+(defn- status-for-boolean [ok?]
+  (if ok? "pass" "fail"))
+
+(defn- status-for-rate [score]
+  (cond
+    (= 1.0 score) "pass"
+    (>= score rate-warn-threshold) "warn"
+    :else "fail"))
+
+(defn- gate-effect [status failure-effect]
+  (case status
+    "pass" "none"
+    "not_applicable" "none"
+    "warn" "marks_low_confidence"
+    failure-effect))
+
+(defn- finding [severity message]
+  {:severity severity :message message})
+
+(defn- rate-findings [status message]
+  (case status
+    "pass" nil
+    "warn" [(finding "warn" message)]
+    [(finding "error" message)]))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Evidence and evaluation assembly
+
+(defn- evaluation
+  [{:keys [state-var-id status value score confidence components evidence findings
+           gate-effect evaluated-at]}]
+  (cond-> {:state_var_id state-var-id
+           :product product
+           :status status
+           :score score
+           :confidence confidence
+           :evidence_refs (vec evidence)
+           :findings (vec findings)
+           :gate_effect gate-effect
+           :evaluated_at evaluated-at}
+    (some? value)      (assoc :value value)
+    (some? components) (assoc :score_components components)))
+
+(defn- run-evidence [run evaluated-at]
+  [{:id (str "miniforge.workflow.run." (:workflow-run/id run))
+    :source_role "workflow-run"
+    :quote (str (:workflow-run/workflow-key run)
+                " status " (name (:workflow-run/status run)))
+    :created_at evaluated-at}])
+
+(defn- transition-evidence [run pairs evaluated-at]
+  (mapv (fn [index [from to]]
+          {:id (str "miniforge.workflow.transition." (:workflow-run/id run) "." index)
+           :source_role "workflow-phase-history"
+           :quote (str (name from) " -> " (name to))
+           :created_at evaluated-at})
+        (range)
+        pairs))
+
+(defn- table-run-evidence [runs evaluated-at]
+  (mapv (fn [run]
+          {:id (str "miniforge.workflow.run." (:workflow-run/id run))
+           :source_role "workflow-run"
+           :quote (str (:workflow-run/workflow-key run)
+                       " status " (name (:workflow-run/status run)))
+           :created_at evaluated-at})
+        runs))
+
+(defn- policy-eval-evidence [evals evaluated-at]
+  (mapv (fn [policy-eval]
+          {:id (str (:policy-eval/id policy-eval))
+           :source_role "policy-evaluation"
+           :quote (str "gate " (some-> policy-eval :policy-eval/gate-id name)
+                       " passed? " (:policy-eval/passed? policy-eval)
+                       ", violations " (count (:policy-eval/violations policy-eval)))
+           :created_at evaluated-at})
+        evals))
+
+(defn- attention-evidence [items evaluated-at]
+  (mapv (fn [item]
+          {:id (str (:attention/id item))
+           :source_role "attention-item"
+           :quote (str (name (:attention/severity item)) " "
+                       (:attention/summary item)
+                       (if (:attention/resolved? item) " [resolved]" " [open]"))
+           :created_at evaluated-at})
+        items))
+
+(defn- decision-evidence [decisions evaluated-at]
+  (mapv (fn [decision]
+          {:id (str (:decision/id decision))
+           :source_role "decision-card"
+           :quote (str (:decision/summary decision)
+                       " status " (name (:decision/status decision)))
+           :created_at evaluated-at})
+        decisions))
+
+(defn- intervention-evidence [interventions evaluated-at]
+  (mapv (fn [intervention]
+          {:id (str (:intervention/id intervention))
+           :source_role "intervention-request"
+           :quote (str (name (:intervention/type intervention))
+                       " state " (name (:intervention/state intervention)))
+           :created_at evaluated-at})
+        interventions))
+
+(defn- run-policy-evals [table run]
+  (->> (vals (:policy-evals table))
+       (filter #(= (:workflow-run/id run) (:policy-eval/workflow-run-id %)))
+       (sort-by :policy-eval/evaluated-at)
+       vec))
+
+(defn- critical-policy-eval? [policy-eval]
+  (boolean (some #(= :critical (:violation/severity %))
+                 (:policy-eval/violations policy-eval))))
+
+(defn- run-attention-items [table run]
+  (->> (vals (:attention table))
+       (filter #(= (:workflow-run/id run) (:attention/source-id %)))
+       (sort-by :attention/derived-at)
+       vec))
+
+(defn- run-decisions [table run]
+  (->> (vals (:decisions table))
+       (filter #(= (:workflow-run/id run) (:decision/workflow-run-id %)))
+       (sort-by :decision/created-at)
+       vec))
+
+(defn- run-interventions [table run]
+  (->> (vals (:interventions table))
+       (filter #(= (:workflow-run/id run) (:intervention/target-id %)))
+       (sort-by :intervention/requested-at)
+       vec))
+
+;------------------------------------------------------------------------------ Layer 2
+;; State-variable evaluators and public projection helpers
+
+(defn- machine-authoritative
+  "Observed phase history must be a path through the authoritative machine
+   (N2 §2.1, §3.1) and a `:completed` run must end on the machine's
+   terminal `:done` phase. Failed/cancelled runs are lifecycle-terminal
+   from any phase per N2 §2.3."
+  [{:keys [run phase-history transitions evaluated-at]}]
+  (let [observed        (if (seq phase-history)
+                          (vec phase-history)
+                          (vec (remove #{:unknown}
+                                       [(:workflow-run/current-phase run)])))
+        pairs           (vec (partition 2 1 observed))
+        illegal         (vec (remove (fn [[from to]]
+                                       (contains? (get transitions from #{}) to))
+                                     pairs))
+        completed?      (= :completed (:workflow-run/status run))
+        terminal-legal? (or (not completed?)
+                            (= :done (last observed)))
+        ok?             (and (empty? illegal) terminal-legal?)
+        status          (status-for-boolean ok?)]
+    (evaluation
+     {:state-var-id "miniforge.workflow.machine_authoritative"
+      :status status
+      :value ok?
+      :score (if ok? 1.0 0.0)
+      :confidence 1.0
+      :components {:legal_transition_rate (ratio (- (count pairs) (count illegal))
+                                                 (count pairs))
+                   :terminal_phase_legal (if terminal-legal? 1.0 0.0)
+                   :observed_transitions (double (count pairs))}
+      :evidence (into (run-evidence run evaluated-at)
+                      (transition-evidence run pairs evaluated-at))
+      :findings (cond-> []
+                  (seq illegal)         (conj (finding "error" illegal-transition-message))
+                  (not terminal-legal?) (conj (finding "error" terminal-phase-message)))
+      :gate-effect (gate-effect status "blocks_transition")
+      :evaluated-at evaluated-at})))
+
+(defn- runs-resolved
+  "Resolved-run boundary health across the whole table: the fraction of
+   workflow runs whose lifecycle status is terminal (N2 §2.2-§2.3)."
+  [{:keys [table evaluated-at]}]
+  (let [runs     (vec (vals (:workflows table)))
+        resolved (count (filter config/resolved? runs))
+        dangling (- (count runs) resolved)
+        score    (ratio resolved (count runs))
+        status   (status-for-rate score)]
+    (evaluation
+     {:state-var-id "miniforge.workflow.runs_resolved"
+      :status status
+      :value score
+      :score score
+      :confidence 1.0
+      :components {:resolved_runs (double resolved)
+                   :total_runs (double (count runs))
+                   :dangling_runs (double dangling)}
+      :evidence (table-run-evidence runs evaluated-at)
+      :findings (rate-findings status dangling-runs-message)
+      :gate-effect (gate-effect status "marks_low_confidence")
+      :evaluated-at evaluated-at})))
+
+(defn- critical-violations-block
+  "Every run-scoped PolicyEvaluation carrying a critical violation must have
+   a blocking failed outcome (N4 §3, §3.3)."
+  [{:keys [run table evaluated-at]}]
+  (let [evals     (run-policy-evals table run)
+        criticals (filter critical-policy-eval? evals)
+        unblocked (filter :policy-eval/passed? criticals)
+        ok?       (empty? unblocked)
+        status    (status-for-boolean ok?)]
+    (evaluation
+     {:state-var-id "miniforge.gate.critical_violations_block"
+      :status status
+      :value ok?
+      :score (if ok? 1.0 0.0)
+      :confidence 1.0
+      :components {:critical_evaluations (double (count criticals))
+                   :blocking_evaluations (double (- (count criticals)
+                                                    (count unblocked)))
+                   :unblocked_evaluations (double (count unblocked))}
+      :evidence (policy-eval-evidence evals evaluated-at)
+      :findings (when-not ok?
+                  [(finding "error" unblocked-critical-message)])
+      :gate-effect (gate-effect status "blocks_transition")
+      :evaluated-at evaluated-at})))
+
+(defn- policy-evaluations-recorded
+  "A run that traversed `:verify` must have at least one recorded
+   PolicyEvaluation (N4 §3). Runs that never reached verify are out of the
+   variable's scope and read `not_applicable`."
+  [{:keys [run table phase-history evaluated-at]}]
+  (let [verify?    (boolean (some #{:verify} phase-history))
+        evals      (run-policy-evals table run)
+        components {:policy_evaluations (double (count evals))
+                    :verify_traversed (if verify? 1.0 0.0)}]
+    (if-not verify?
+      (evaluation
+       {:state-var-id "miniforge.policy.evaluations_recorded"
+        :status "not_applicable"
+        :score 1.0
+        :confidence 1.0
+        :components components
+        :gate-effect "none"
+        :evaluated-at evaluated-at})
+      (let [ok?    (pos? (count evals))
+            status (status-for-boolean ok?)]
+        (evaluation
+         {:state-var-id "miniforge.policy.evaluations_recorded"
+          :status status
+          :value ok?
+          :score (if ok? 1.0 0.0)
+          :confidence 1.0
+          :components components
+          :evidence (policy-eval-evidence evals evaluated-at)
+          :findings (when-not ok?
+                      [(finding "error" missing-evaluation-message)])
+          :gate-effect (gate-effect status "marks_low_confidence")
+          :evaluated-at evaluated-at})))))
+
+(defn- attention-items-actioned
+  "Fraction of the run's derived AttentionItems that are resolved
+   (N5-delta-1 §3.1, §5). No items at all reads `not_applicable`."
+  [{:keys [run table evaluated-at]}]
+  (let [items    (run-attention-items table run)
+        actioned (count (filter :attention/resolved? items))]
+    (if (empty? items)
+      (evaluation
+       {:state-var-id "miniforge.attention.items_actioned"
+        :status "not_applicable"
+        :score 1.0
+        :confidence 1.0
+        :components {:actioned_items 0.0 :total_items 0.0 :open_items 0.0}
+        :gate-effect "none"
+        :evaluated-at evaluated-at})
+      (let [score  (ratio actioned (count items))
+            status (status-for-rate score)]
+        (evaluation
+         {:state-var-id "miniforge.attention.items_actioned"
+          :status status
+          :value score
+          :score score
+          :confidence 1.0
+          :components {:actioned_items (double actioned)
+                       :total_items (double (count items))
+                       :open_items (double (- (count items) actioned))}
+          :evidence (attention-evidence items evaluated-at)
+          :findings (rate-findings status open-attention-message)
+          :gate-effect (gate-effect status "marks_low_confidence")
+          :evaluated-at evaluated-at})))))
+
+(defn- decision-queue-drained
+  "Fraction of the run's DecisionCards resolved and InterventionRequests
+   settled (N5-delta-3 §2.4; N5-delta §3.3). An empty queue reads
+   `not_applicable`."
+  [{:keys [run table evaluated-at]}]
+  (let [decisions     (run-decisions table run)
+        interventions (run-interventions table run)
+        resolved      (count (filter #(= :resolved (:decision/status %)) decisions))
+        settled       (count (filter (comp settled-intervention-states
+                                           :intervention/state)
+                                     interventions))
+        total         (+ (count decisions) (count interventions))]
+    (if (zero? total)
+      (evaluation
+       {:state-var-id "miniforge.decision.queue_drained"
+        :status "not_applicable"
+        :score 1.0
+        :confidence 1.0
+        :components {:resolved_decisions 0.0 :total_decisions 0.0
+                     :settled_interventions 0.0 :total_interventions 0.0}
+        :gate-effect "none"
+        :evaluated-at evaluated-at})
+      (let [score  (ratio (+ resolved settled) total)
+            status (status-for-rate score)]
+        (evaluation
+         {:state-var-id "miniforge.decision.queue_drained"
+          :status status
+          :value score
+          :score score
+          :confidence 1.0
+          :components {:resolved_decisions (double resolved)
+                       :total_decisions (double (count decisions))
+                       :settled_interventions (double settled)
+                       :total_interventions (double (count interventions))}
+          :evidence (into (decision-evidence decisions evaluated-at)
+                          (intervention-evidence interventions evaluated-at))
+          :findings (rate-findings status pending-queue-message)
+          :gate-effect (gate-effect status "marks_low_confidence")
+          :evaluated-at evaluated-at})))))
+
+(defn provenance
+  "Return stable evaluator and policy provenance for snapshot metadata."
+  []
+  {:policy_hash policy-hash
+   :policy_version policy-version
+   :evaluator_hash evaluator-hash
+   :evaluator_version evaluator-version})
+
+(defn evaluations
+  "Evaluate the six shipped orchestration state variables for one resolved
+   run. `ctx` carries `:run`, `:table`, `:transitions`, `:phase-history`,
+   and `:evaluated-at`."
+  [ctx]
+  [(machine-authoritative ctx)
+   (runs-resolved ctx)
+   (critical-violations-block ctx)
+   (policy-evaluations-recorded ctx)
+   (attention-items-actioned ctx)
+   (decision-queue-drained ctx)])

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/evaluation.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/evaluation.clj
@@ -129,14 +129,46 @@
                 " status " (name (:workflow-run/status run)))
     :created_at evaluated-at}])
 
-(defn- transition-evidence [run pairs evaluated-at]
-  (mapv (fn [index [from to]]
-          {:id (str "miniforge.workflow.transition." (:workflow-run/id run) "." index)
-           :source_role "workflow-phase-history"
-           :quote (str (name from) " -> " (name to))
-           :created_at evaluated-at})
-        (range)
-        pairs))
+(defn- absence-evidence
+  "An honest evidence ref for an observed ABSENCE. A registry
+   `required_refs` role must be represented even when the collection it is
+   derived from is empty - otherwise the evaluation violates its own
+   `evidence_requirements` (the workbench kernel's evidence validator
+   matches `required_refs` against `source_role`). The quote states the
+   absence the evaluator actually judged on; it never asserts a positive
+   fact that was not observed."
+  [{:keys [scope-id source-role quote evaluated-at]}]
+  [{:id (str "miniforge.absent." source-role "." scope-id)
+    :source_role source-role
+    :quote quote
+    :created_at evaluated-at}])
+
+(defn- or-absence
+  "`refs` when non-empty, otherwise a single honest absence ref."
+  [refs absence]
+  (if (seq refs) (vec refs) (absence-evidence absence)))
+
+(defn- phase-history-evidence
+  "One ref per observed transition. A resolved run can legally have fewer
+   than two observed phases - failed/cancelled are lifecycle-terminal from
+   any phase (N2 §2.3) - so with no transition pairs this emits a single
+   honest ref describing the observed history instead of nothing."
+  [run observed pairs evaluated-at]
+  (or-absence
+   (mapv (fn [index [from to]]
+           {:id (str "miniforge.workflow.transition." (:workflow-run/id run) "." index)
+            :source_role "workflow-phase-history"
+            :quote (str (name from) " -> " (name to))
+            :created_at evaluated-at})
+         (range)
+         pairs)
+   {:scope-id (:workflow-run/id run)
+    :source-role "workflow-phase-history"
+    :quote (if (seq observed)
+             (str "single observed phase " (name (first observed))
+                  ", no transitions")
+             "no phase-started events observed")
+    :evaluated-at evaluated-at}))
 
 (defn- table-run-evidence [runs evaluated-at]
   (mapv (fn [run]
@@ -246,7 +278,7 @@
                    :terminal_phase_legal (if terminal-legal? 1.0 0.0)
                    :observed_transitions (double (count pairs))}
       :evidence (into (run-evidence run evaluated-at)
-                      (transition-evidence run pairs evaluated-at))
+                      (phase-history-evidence run observed pairs evaluated-at))
       :findings (cond-> []
                   (seq illegal)         (conj (finding "error" illegal-transition-message))
                   (not terminal-legal?) (conj (finding "error" terminal-phase-message)))
@@ -295,7 +327,11 @@
                    :blocking_evaluations (double (- (count criticals)
                                                     (count unblocked)))
                    :unblocked_evaluations (double (count unblocked))}
-      :evidence (policy-eval-evidence evals evaluated-at)
+      :evidence (or-absence (policy-eval-evidence evals evaluated-at)
+                            {:scope-id (:workflow-run/id run)
+                             :source-role "policy-evaluation"
+                             :quote "no policy evaluations recorded for this run"
+                             :evaluated-at evaluated-at})
       :findings (when-not ok?
                   [(finding "error" unblocked-critical-message)])
       :gate-effect (gate-effect status "blocks_transition")
@@ -317,6 +353,11 @@
         :score 1.0
         :confidence 1.0
         :components components
+        :evidence (absence-evidence
+                   {:scope-id (:workflow-run/id run)
+                    :source-role "policy-evaluation"
+                    :quote "run never traversed :verify; policy evaluation out of scope"
+                    :evaluated-at evaluated-at})
         :gate-effect "none"
         :evaluated-at evaluated-at})
       (let [ok?    (pos? (count evals))
@@ -328,7 +369,11 @@
           :score (if ok? 1.0 0.0)
           :confidence 1.0
           :components components
-          :evidence (policy-eval-evidence evals evaluated-at)
+          :evidence (or-absence (policy-eval-evidence evals evaluated-at)
+                                {:scope-id (:workflow-run/id run)
+                                 :source-role "policy-evaluation"
+                                 :quote "run traversed :verify with no policy evaluation recorded"
+                                 :evaluated-at evaluated-at})
           :findings (when-not ok?
                       [(finding "error" missing-evaluation-message)])
           :gate-effect (gate-effect status "marks_low_confidence")
@@ -347,6 +392,11 @@
         :score 1.0
         :confidence 1.0
         :components {:actioned_items 0.0 :total_items 0.0 :open_items 0.0}
+        :evidence (absence-evidence
+                   {:scope-id (:workflow-run/id run)
+                    :source-role "attention-item"
+                    :quote "no attention items derived for this run"
+                    :evaluated-at evaluated-at})
         :gate-effect "none"
         :evaluated-at evaluated-at})
       (let [score  (ratio actioned (count items))
@@ -385,6 +435,16 @@
         :confidence 1.0
         :components {:resolved_decisions 0.0 :total_decisions 0.0
                      :settled_interventions 0.0 :total_interventions 0.0}
+        :evidence (into (absence-evidence
+                         {:scope-id (:workflow-run/id run)
+                          :source-role "decision-card"
+                          :quote "no decision cards raised for this run"
+                          :evaluated-at evaluated-at})
+                        (absence-evidence
+                         {:scope-id (:workflow-run/id run)
+                          :source-role "intervention-request"
+                          :quote "no intervention requests raised for this run"
+                          :evaluated-at evaluated-at}))
         :gate-effect "none"
         :evaluated-at evaluated-at})
       (let [score  (ratio (+ resolved settled) total)
@@ -399,8 +459,16 @@
                        :total_decisions (double (count decisions))
                        :settled_interventions (double settled)
                        :total_interventions (double (count interventions))}
-          :evidence (into (decision-evidence decisions evaluated-at)
-                          (intervention-evidence interventions evaluated-at))
+          :evidence (into (or-absence (decision-evidence decisions evaluated-at)
+                                      {:scope-id (:workflow-run/id run)
+                                       :source-role "decision-card"
+                                       :quote "no decision cards raised for this run"
+                                       :evaluated-at evaluated-at})
+                          (or-absence (intervention-evidence interventions evaluated-at)
+                                      {:scope-id (:workflow-run/id run)
+                                       :source-role "intervention-request"
+                                       :quote "no intervention requests raised for this run"
+                                       :evaluated-at evaluated-at}))
           :findings (rate-findings status pending-queue-message)
           :gate-effect (gate-effect status "marks_low_confidence")
           :evaluated-at evaluated-at})))))

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
@@ -42,6 +42,9 @@
 (def ^:private missing-transitions-message
   "Orchestration workbench projection requires the legal phase-transition map")
 
+(def ^:private missing-phase-history-message
+  "Orchestration workbench projection requires :phase-history (a sequential of observed phases; may be empty)")
+
 (def ^:private invalid-snapshot-message
   "Orchestration adapter emitted an invalid workbench_snapshot/v1")
 
@@ -96,13 +99,18 @@
   "Project one resolved workflow run from `table` into a validated
    workbench snapshot.
 
-   `opts` requires `:experiment-id`, `:label`, and `:transitions` (the
-   legal phase-transition map from the workflow component's interface).
-   `:phase-history` carries the run's observed phases (see
-   [[phase-history]]); `:generated-at`, `:snapshot-id`, `:run-id`, and
-   `:source-hashes` are optional. Unresolved runs are rejected at the
-   boundary. Returns a standard schema success/failure map."
-  [table workflow-run-id {:keys [experiment-id label transitions] :as opts}]
+   `opts` requires `:experiment-id`, `:label`, `:transitions` (the legal
+   phase-transition map from the workflow component's interface), and
+   `:phase-history` — the run's observed phases (see [[phase-history]]),
+   a sequential that MAY be empty but must be supplied explicitly:
+   evaluations key off it (machine-authoritative transition validation,
+   verify traversal), so a silently-omitted history would produce a
+   contract-valid snapshot with wrong evaluations. `:generated-at`,
+   `:snapshot-id`, `:run-id`, and `:source-hashes` are optional.
+   Unresolved runs are rejected at the boundary. Returns a standard
+   schema success/failure map."
+  [table workflow-run-id {:keys [experiment-id label transitions phase-history]
+                          :as opts}]
   (let [run (get-in table [:workflows workflow-run-id])]
     (cond
       (nil? run)
@@ -119,6 +127,10 @@
 
       (not (map? transitions))
       (schema/failure :snapshot missing-transitions-message)
+
+      (not (sequential? phase-history))
+      (schema/failure :snapshot missing-phase-history-message
+                      {:phase-history phase-history})
 
       :else
       ;; Load the shipped registry ONCE: validate it, then thread the same

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
@@ -48,6 +48,9 @@
 (def ^:private missing-out-message
   "Orchestration registry export requires an :out path")
 
+(def ^:private invalid-registry-message
+  "Orchestration registry export requires a registry conforming to the canonical registry schema")
+
 (def ^:private registry-resource
   "workbench/miniforge-orchestration-state-vars.edn")
 
@@ -125,9 +128,20 @@
 (defn export-registry!
   "Write the shipped registry as pretty-printed JSON to `:out`. Companion
    to the `workbench:orchestration:registry` bb task; the JSON shape
-   matches the minibench workbench-contract fixture registry."
+   matches the minibench workbench-contract fixture registry.
+
+   Fails loudly (ex-info) when the shipped registry is missing from the
+   classpath or does not conform to the canonical registry schema — an
+   invalid fixture is never written. The registry is loaded once; the
+   value validated is the value written."
   [{:keys [out]}]
   (when (or (nil? out) (and (string? out) (str/blank? out)))
     (throw (ex-info missing-out-message {:out out})))
-  (spit (str out) (json/generate-string (state-var-registry) {:pretty true}))
-  (println "Wrote" (str out)))
+  (let [registry (state-var-registry)]
+    (when-not (schema/valid? workbench-schema/StateVarRegistry registry)
+      (throw (ex-info invalid-registry-message
+                      {:registry-resource registry-resource
+                       :errors (schema/explain workbench-schema/StateVarRegistry
+                                               registry)})))
+    (spit (str out) (json/generate-string registry {:pretty true}))
+    (println "Wrote" (str out))))

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
@@ -1,0 +1,127 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workbench-orchestration-adapter.interface
+  "Validated public boundary for the Miniforge orchestration workbench
+   adapter: projects supervisory-state (EntityTable) into a validated
+   `workbench_snapshot/v1` at the resolved-run boundary."
+  (:require
+   [ai.miniforge.schema.interface :as schema]
+   [ai.miniforge.workbench-contract.schema :as workbench-schema]
+   [ai.miniforge.workbench-orchestration-adapter.config :as config]
+   [ai.miniforge.workbench-orchestration-adapter.core :as core]
+   [cheshire.core :as json]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(def ^:private missing-run-message
+  "Orchestration workbench projection requires a known workflow run")
+
+(def ^:private unresolved-run-message
+  "Orchestration workbench projection only admits resolved (terminal) workflow runs")
+
+(def ^:private missing-variant-message
+  "Orchestration workbench projection requires experiment-id and label")
+
+(def ^:private missing-transitions-message
+  "Orchestration workbench projection requires the legal phase-transition map")
+
+(def ^:private invalid-snapshot-message
+  "Orchestration adapter emitted an invalid workbench_snapshot/v1")
+
+(def ^:private registry-resource
+  "workbench/miniforge-orchestration-state-vars.edn")
+
+(defn resolved?
+  "True when `run` (a supervisory-state WorkflowRun entity) has reached the
+   resolved-run boundary - a terminal lifecycle status per N2 §2.2-§2.3."
+  [run]
+  (config/resolved? run))
+
+(defn resolved-runs
+  "All resolved WorkflowRun entities in `table`, ordered by started-at.
+   Unresolved (dangling) runs are excluded from snapshots by default."
+  [table]
+  (config/resolved-runs table))
+
+(defn phase-history
+  "Ordered `:workflow/phase-started` phases observed for `workflow-id` in
+   `events` - the same event stream the caller folded into the table."
+  [events workflow-id]
+  (config/phase-history events workflow-id))
+
+(defn valid-snapshot?
+  "True when `snapshot` conforms to the canonical workbench wire schema."
+  [snapshot]
+  (schema/valid? workbench-schema/WorkbenchSnapshot snapshot))
+
+(defn state-var-registry
+  "Load the product-owned orchestration state-variable registry from the
+   classpath."
+  []
+  (some-> registry-resource io/resource slurp edn/read-string))
+
+(defn valid-registry?
+  "True when the shipped orchestration registry conforms to the canonical
+   registry schema."
+  []
+  (schema/valid? workbench-schema/StateVarRegistry (state-var-registry)))
+
+(defn project
+  "Project one resolved workflow run from `table` into a validated
+   workbench snapshot.
+
+   `opts` requires `:experiment-id`, `:label`, and `:transitions` (the
+   legal phase-transition map from the workflow component's interface).
+   `:phase-history` carries the run's observed phases (see
+   [[phase-history]]); `:generated-at`, `:snapshot-id`, `:run-id`, and
+   `:source-hashes` are optional. Unresolved runs are rejected at the
+   boundary. Returns a standard schema success/failure map."
+  [table workflow-run-id {:keys [experiment-id label transitions] :as opts}]
+  (let [run (get-in table [:workflows workflow-run-id])]
+    (cond
+      (nil? run)
+      (schema/failure :snapshot missing-run-message
+                      {:workflow-run-id workflow-run-id})
+
+      (not (config/resolved? run))
+      (schema/failure :snapshot unresolved-run-message
+                      {:workflow-run-id workflow-run-id
+                       :status (:workflow-run/status run)})
+
+      (or (nil? experiment-id) (nil? label))
+      (schema/failure :snapshot missing-variant-message)
+
+      (not (map? transitions))
+      (schema/failure :snapshot missing-transitions-message)
+
+      :else
+      (let [snapshot (core/snapshot table run opts)]
+        (if (valid-snapshot? snapshot)
+          (schema/success :snapshot snapshot)
+          (schema/failure :snapshot invalid-snapshot-message
+                          {:errors (schema/explain workbench-schema/WorkbenchSnapshot
+                                                   snapshot)}))))))
+
+(defn export-registry!
+  "Write the shipped registry as pretty-printed JSON to `:out`. Companion
+   to the `workbench:orchestration:registry` bb task; the JSON shape
+   matches the minibench workbench-contract fixture registry."
+  [{:keys [out]}]
+  (spit (str out) (json/generate-string (state-var-registry) {:pretty true}))
+  (println "Wrote" (str out)))

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
@@ -51,6 +51,9 @@
 (def ^:private invalid-registry-message
   "Orchestration registry export requires a registry conforming to the canonical registry schema")
 
+(def ^:private invalid-registry-projection-message
+  "Orchestration workbench projection requires a loadable, schema-valid state-variable registry")
+
 (def ^:private registry-resource
   "workbench/miniforge-orchestration-state-vars.edn")
 
@@ -118,12 +121,22 @@
       (schema/failure :snapshot missing-transitions-message)
 
       :else
-      (let [snapshot (core/snapshot table run opts)]
-        (if (valid-snapshot? snapshot)
-          (schema/success :snapshot snapshot)
-          (schema/failure :snapshot invalid-snapshot-message
-                          {:errors (schema/explain workbench-schema/WorkbenchSnapshot
-                                                   snapshot)}))))))
+      ;; Load the shipped registry ONCE: validate it, then thread the same
+      ;; value into the snapshot so :registry_ref is read from — and can
+      ;; never drift from — the registry a minibench comparison will load.
+      ;; A missing/invalid classpath resource fails projection here rather
+      ;; than emitting a snapshot that references an unloadable registry.
+      (let [registry (state-var-registry)]
+        (if-not (schema/valid? workbench-schema/StateVarRegistry registry)
+          (schema/failure :snapshot invalid-registry-projection-message
+                          {:errors (schema/explain workbench-schema/StateVarRegistry
+                                                   registry)})
+          (let [snapshot (core/snapshot table run (assoc opts :registry registry))]
+            (if (valid-snapshot? snapshot)
+              (schema/success :snapshot snapshot)
+              (schema/failure :snapshot invalid-snapshot-message
+                              {:errors (schema/explain workbench-schema/WorkbenchSnapshot
+                                                       snapshot)}))))))))
 
 (defn export-registry!
   "Write the shipped registry as pretty-printed JSON to `:out`. Companion

--- a/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
+++ b/components/workbench-orchestration-adapter/src/ai/miniforge/workbench_orchestration_adapter/interface.clj
@@ -27,7 +27,8 @@
    [ai.miniforge.workbench-orchestration-adapter.core :as core]
    [cheshire.core :as json]
    [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
 
 (def ^:private missing-run-message
   "Orchestration workbench projection requires a known workflow run")
@@ -43,6 +44,9 @@
 
 (def ^:private invalid-snapshot-message
   "Orchestration adapter emitted an invalid workbench_snapshot/v1")
+
+(def ^:private missing-out-message
+  "Orchestration registry export requires an :out path")
 
 (def ^:private registry-resource
   "workbench/miniforge-orchestration-state-vars.edn")
@@ -123,5 +127,7 @@
    to the `workbench:orchestration:registry` bb task; the JSON shape
    matches the minibench workbench-contract fixture registry."
   [{:keys [out]}]
+  (when (or (nil? out) (and (string? out) (str/blank? out)))
+    (throw (ex-info missing-out-message {:out out})))
   (spit (str out) (json/generate-string (state-var-registry) {:pretty true}))
   (println "Wrote" (str out)))

--- a/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
+++ b/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
@@ -1,0 +1,254 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workbench-orchestration-adapter.interface-test
+  "Fixtures are NOT hand-rolled EntityTable shapes: every table is produced
+   by folding a synthetic N2 §2.4 event stream through the real
+   supervisory-state accumulator, and the legal transition map is the real
+   one from the workflow component's interface."
+  (:require
+   [ai.miniforge.schema.interface :as schema]
+   [ai.miniforge.supervisory-state.interface :as supervisory-state]
+   [ai.miniforge.workbench-orchestration-adapter.interface :as sut]
+   [ai.miniforge.workflow.interface :as workflow]
+   [clojure.test :refer [deftest is testing]]))
+
+(def ^:private t0 #inst "2026-07-19T10:00:00Z")
+(def ^:private t-end #inst "2026-07-19T12:00:00Z")
+
+(def ^:private clean-run-id    #uuid "00000000-0000-0000-0000-000000000001")
+(def ^:private illegal-run-id  #uuid "00000000-0000-0000-0000-000000000002")
+(def ^:private dangling-run-id #uuid "00000000-0000-0000-0000-000000000003")
+(def ^:private gate-event-id   #uuid "00000000-0000-0000-0000-000000000010")
+(def ^:private attention-id    #uuid "00000000-0000-0000-0000-000000000020")
+(def ^:private decision-id     #uuid "00000000-0000-0000-0000-000000000030")
+(def ^:private agent-id        #uuid "00000000-0000-0000-0000-000000000031")
+(def ^:private intervention-id #uuid "00000000-0000-0000-0000-000000000040")
+
+(def ^:private legal-phases
+  [:spec :plan :implement :verify :review :release :observe :done])
+
+(defn- started-event [run-id]
+  {:event/type :workflow/started
+   :workflow/id run-id
+   :workflow/intent "fixture intent"
+   :workflow/spec {:workflow/key "canonical-sdlc" :title "Fixture run"}
+   :event/timestamp t0})
+
+(defn- phase-events [run-id phases]
+  (map (fn [phase]
+         {:event/type :workflow/phase-started
+          :workflow/id run-id
+          :workflow/phase phase
+          :event/timestamp t0})
+       phases))
+
+(defn- gate-event [event-type violations]
+  {:event/type event-type
+   :event/id gate-event-id
+   :workflow/id clean-run-id
+   :gate/id :verify-gate
+   :gate/target-type :workflow-output
+   :gate/packs ["core-security"]
+   :gate/violations violations
+   :event/timestamp t0})
+
+(def ^:private critical-violation
+  {:rule-id :no-secrets
+   :severity :critical
+   :category :security
+   :message "secret leaked"
+   :remediable? false})
+
+(def ^:private supervisory-events
+  [{:event/type :supervisory/attention-derived
+    :supervisory/entity {:attention/id attention-id
+                         :attention/severity :warning
+                         :attention/source-type :workflow
+                         :attention/source-id clean-run-id
+                         :attention/summary "verify gate failed once"
+                         :attention/derived-at t0
+                         :attention/resolved? true}}
+   {:event/type :control-plane/decision-created
+    :cp/agent-id agent-id
+    :cp/decision-id decision-id
+    :cp/summary "Approve release"
+    :workflow/id clean-run-id
+    :event/timestamp t0}
+   {:event/type :control-plane/decision-resolved
+    :cp/decision-id decision-id
+    :cp/resolution "approved"
+    :event/timestamp t0}
+   {:event/type :supervisory/intervention-requested
+    :intervention/id intervention-id
+    :intervention/type :pause-workflow
+    :intervention/target-type :workflow-run
+    :intervention/target-id clean-run-id
+    :intervention/requested-by "operator"
+    :intervention/request-source :cli
+    :intervention/state :applied
+    :event/timestamp t0}])
+
+(defn- clean-run-events [gate-outcome-type]
+  (concat [(started-event clean-run-id)]
+          (phase-events clean-run-id legal-phases)
+          [(gate-event gate-outcome-type [critical-violation])]
+          supervisory-events
+          [{:event/type :workflow/completed
+            :workflow/id clean-run-id
+            :event/timestamp t-end}]))
+
+(def ^:private illegal-run-events
+  (concat [(started-event illegal-run-id)]
+          (phase-events illegal-run-id [:spec :implement])
+          [{:event/type :workflow/completed
+            :workflow/id illegal-run-id
+            :event/timestamp t-end}]))
+
+(def ^:private dangling-run-events
+  (concat [(started-event dangling-run-id)]
+          (phase-events dangling-run-id [:spec])))
+
+(defn- table-for [events]
+  (supervisory-state/apply-events supervisory-state/empty-table events))
+
+(defn- opts-for [events run-id]
+  {:experiment-id "miniforge.orchestration.fixture"
+   :label "baseline"
+   :transitions workflow/phase-transitions
+   :phase-history (sut/phase-history events run-id)})
+
+(defn- evaluation-by-id [snapshot state-var-id]
+  (first (filter #(= state-var-id (:state_var_id %)) (:evaluations snapshot))))
+
+;------------------------------------------------------------------------------ Tests
+
+(deftest shipped-registry-is-contract-valid
+  (is (sut/valid-registry?))
+  (is (= 6 (count (:state_vars (sut/state-var-registry))))))
+
+(deftest accumulator-projects-expected-table-shape
+  (let [events (clean-run-events :gate/failed)
+        table  (table-for events)
+        run    (get-in table [:workflows clean-run-id])]
+    (testing "the real accumulator produced the shapes the adapter reads"
+      (is (= :completed (:workflow-run/status run)))
+      (is (= :done (:workflow-run/current-phase run)))
+      (is (= "canonical-sdlc" (:workflow-run/workflow-key run)))
+      (is (false? (get-in table [:policy-evals gate-event-id :policy-eval/passed?])))
+      (is (true? (get-in table [:attention attention-id :attention/resolved?])))
+      (is (= :resolved (get-in table [:decisions decision-id :decision/status])))
+      (is (= :applied (get-in table [:interventions intervention-id :intervention/state])))
+      (is (= legal-phases (sut/phase-history events clean-run-id))))))
+
+(deftest clean-resolved-run-passes-all-six-vars
+  (let [events   (clean-run-events :gate/failed)
+        table    (table-for events)
+        result   (sut/project table clean-run-id (opts-for events clean-run-id))
+        snapshot (:snapshot result)]
+    (is (schema/succeeded? result))
+    (is (sut/valid-snapshot? snapshot))
+    (is (= 6 (count (:evaluations snapshot))))
+    (is (every? #(= "pass" (:status %)) (:evaluations snapshot)))
+    (is (every? #(seq (:evidence_refs %)) (:evaluations snapshot)))
+    (is (= (str "wb-" clean-run-id) (:snapshot_id snapshot)))
+    (is (= "2026-07-19T12:00:00Z" (:generated_at snapshot)))
+    (is (= "miniforge-orchestration-state-vars"
+           (get-in snapshot [:registry_ref :registry_id])))
+    (testing "entities bag matches the contract fixture namespace and keys"
+      (let [entity (get-in snapshot [:entities :miniforge.workflow_run])]
+        (is (= (str clean-run-id) (:workflow/id entity)))
+        (is (= "completed" (:workflow/status entity)))
+        (is (= "done" (:workflow/current-phase entity)))))))
+
+(deftest illegal-transition-fails-machine-authoritative
+  (let [events   illegal-run-events
+        table    (table-for events)
+        result   (sut/project table illegal-run-id (opts-for events illegal-run-id))
+        snapshot (:snapshot result)
+        machine  (evaluation-by-id snapshot "miniforge.workflow.machine_authoritative")]
+    (is (schema/succeeded? result))
+    (is (sut/valid-snapshot? snapshot))
+    (is (= "fail" (:status machine)))
+    (is (false? (:value machine)))
+    (is (= 0.0 (:score machine)))
+    (is (= "blocks_transition" (:gate_effect machine)))
+    (is (= 0.0 (get-in machine [:score_components :legal_transition_rate])))
+    (is (= 0.0 (get-in machine [:score_components :terminal_phase_legal])))))
+
+(deftest unblocked-critical-violation-fails-gate-var
+  (let [events   (clean-run-events :gate/passed)
+        table    (table-for events)
+        snapshot (:snapshot (sut/project table clean-run-id
+                                         (opts-for events clean-run-id)))
+        gate-var (evaluation-by-id snapshot "miniforge.gate.critical_violations_block")]
+    (is (true? (get-in table [:policy-evals gate-event-id :policy-eval/passed?])))
+    (is (= "fail" (:status gate-var)))
+    (is (false? (:value gate-var)))
+    (is (= "blocks_transition" (:gate_effect gate-var)))
+    (is (= 1.0 (get-in gate-var [:score_components :unblocked_evaluations])))))
+
+(deftest unresolved-runs-are-excluded-at-the-boundary
+  (let [events (concat (clean-run-events :gate/failed) dangling-run-events)
+        table  (table-for events)]
+    (testing "a dangling run cannot be projected"
+      (let [result (sut/project table dangling-run-id
+                                (opts-for events dangling-run-id))]
+        (is (schema/failed? result))
+        (is (= :running (:status result)))))
+    (testing "resolved-runs excludes the dangling run"
+      (is (= [clean-run-id]
+             (mapv :workflow-run/id (sut/resolved-runs table)))))
+    (testing "runs_resolved measures the boundary across the table"
+      (let [snapshot (:snapshot (sut/project table clean-run-id
+                                             (opts-for events clean-run-id)))
+            resolved (evaluation-by-id snapshot "miniforge.workflow.runs_resolved")]
+        (is (= "fail" (:status resolved)))
+        (is (= 0.5 (:score resolved)))
+        (is (= "marks_low_confidence" (:gate_effect resolved)))
+        (is (= 1.0 (get-in resolved [:score_components :dangling_runs])))))))
+
+(deftest verify-without-policy-evaluation-fails-and-empty-queues-not-applicable
+  (let [events   (concat [(started-event illegal-run-id)]
+                         (phase-events illegal-run-id legal-phases)
+                         [{:event/type :workflow/completed
+                           :workflow/id illegal-run-id
+                           :event/timestamp t-end}])
+        table    (table-for events)
+        snapshot (:snapshot (sut/project table illegal-run-id
+                                         (opts-for events illegal-run-id)))]
+    (is (sut/valid-snapshot? snapshot))
+    (let [recorded (evaluation-by-id snapshot "miniforge.policy.evaluations_recorded")]
+      (is (= "fail" (:status recorded)))
+      (is (= "marks_low_confidence" (:gate_effect recorded)))
+      (is (= 1.0 (get-in recorded [:score_components :verify_traversed]))))
+    (doseq [state-var-id ["miniforge.attention.items_actioned"
+                          "miniforge.decision.queue_drained"]]
+      (let [evaluation (evaluation-by-id snapshot state-var-id)]
+        (is (= "not_applicable" (:status evaluation)) state-var-id)
+        (is (= "none" (:gate_effect evaluation)) state-var-id)))))
+
+(deftest projection-requires-variant-and-transitions
+  (let [events (clean-run-events :gate/failed)
+        table  (table-for events)
+        opts   (opts-for events clean-run-id)]
+    (is (schema/failed? (sut/project table clean-run-id
+                                     (dissoc opts :experiment-id))))
+    (is (schema/failed? (sut/project table clean-run-id
+                                     (dissoc opts :transitions))))
+    (is (schema/failed? (sut/project table (random-uuid) opts)))))

--- a/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
+++ b/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
@@ -162,6 +162,30 @@
           (is (not (.exists out))
               "no fixture file may be written for an invalid registry"))))))
 
+(deftest project-fails-when-registry-missing-or-invalid
+  (testing "a broken classpath resource fails PROJECTION — no snapshot may
+            reference a registry a minibench comparison cannot load"
+    (doseq [broken [nil {:not "a registry"}]]
+      (with-redefs [sut/state-var-registry (fn [] broken)]
+        (let [events (clean-run-events :gate/failed)
+              table  (table-for events)
+              result (sut/project table clean-run-id
+                                  (opts-for events clean-run-id))]
+          (is (not (schema/succeeded? result)) (pr-str broken)))))))
+
+(deftest registry-ref-reads-from-the-shipped-registry
+  (testing "snapshot :registry_ref is sourced from the loaded registry, so it
+            cannot drift from what export-registry! writes"
+    (let [events   (clean-run-events :gate/failed)
+          table    (table-for events)
+          registry (sut/state-var-registry)
+          snapshot (:snapshot (sut/project table clean-run-id
+                                           (opts-for events clean-run-id)))]
+      (is (= (:registry_id registry)
+             (get-in snapshot [:registry_ref :registry_id])))
+      (is (= (:version registry)
+             (get-in snapshot [:registry_ref :version]))))))
+
 (deftest accumulator-projects-expected-table-shape
   (let [events (clean-run-events :gate/failed)
         table  (table-for events)

--- a/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
+++ b/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
@@ -263,6 +263,77 @@
         (is (= "not_applicable" (:status evaluation)) state-var-id)
         (is (= "none" (:gate_effect evaluation)) state-var-id)))))
 
+(def ^:private failed-at-spec-events
+  "A run that fails at :spec — lifecycle-terminal from any phase per N2
+   §2.3, so it IS resolved and projectable, with a single observed phase
+   and therefore zero transition pairs."
+  (concat [(started-event illegal-run-id)]
+          (phase-events illegal-run-id [:spec])
+          [{:event/type :workflow/failed
+            :workflow/id illegal-run-id
+            :workflow/error "spec rejected"
+            :event/timestamp t-end}]))
+
+(defn- required-roles [state-var-id]
+  (->> (:state_vars (sut/state-var-registry))
+       (filter #(= state-var-id (:id %)))
+       first
+       :evidence_requirements
+       :required_refs
+       set))
+
+(defn- evidence-requirement-violations
+  "Mirror of the workbench kernel's evidence validator: every declared
+   `required_refs` role must be matched by at least one evidence ref's
+   `source_role`, and no evaluation may carry zero refs."
+  [snapshot]
+  (for [evaluation (:evaluations snapshot)
+        :let [roles   (set (map :source_role (:evidence_refs evaluation)))
+              missing (remove roles (required-roles (:state_var_id evaluation)))]
+        :when (or (empty? (:evidence_refs evaluation)) (seq missing))]
+    [(:state_var_id evaluation) (vec missing)]))
+
+(deftest every-evaluation-satisfies-its-registry-evidence-requirements
+  (testing "no evaluation may violate its own evidence_requirements — the
+            adapter must never emit what the kernel's evidence validator
+            would reject, in ANY reachable table shape"
+    (doseq [[label events run-id]
+            [["clean run"          (clean-run-events :gate/failed) clean-run-id]
+             ["passed gate"        (clean-run-events :gate/passed) clean-run-id]
+             ["illegal transition" illegal-run-events              illegal-run-id]
+             ["failed at spec"     failed-at-spec-events           illegal-run-id]
+             ["verify, no policy"  (concat [(started-event illegal-run-id)]
+                                           (phase-events illegal-run-id legal-phases)
+                                           [{:event/type :workflow/completed
+                                             :workflow/id illegal-run-id
+                                             :event/timestamp t-end}])
+              illegal-run-id]]]
+      (let [table    (table-for events)
+            snapshot (:snapshot (sut/project table run-id (opts-for events run-id)))]
+        (is (sut/valid-snapshot? snapshot) label)
+        (is (empty? (evidence-requirement-violations snapshot))
+            (str label ": " (pr-str (evidence-requirement-violations snapshot))))))))
+
+(deftest resolved-run-without-transitions-still-carries-phase-history-evidence
+  (testing "a run that fails at :spec has zero transition pairs, but
+            machine_authoritative declares a workflow-phase-history
+            required_ref — an honest absence ref satisfies it"
+    (let [events   failed-at-spec-events
+          table    (table-for events)
+          run      (get-in table [:workflows illegal-run-id])
+          result   (sut/project table illegal-run-id (opts-for events illegal-run-id))
+          snapshot (:snapshot result)
+          machine  (evaluation-by-id snapshot "miniforge.workflow.machine_authoritative")
+          roles    (set (map :source_role (:evidence_refs machine)))]
+      (is (= :failed (:workflow-run/status run)))
+      (is (sut/resolved? run) "failed is lifecycle-terminal per N2 §2.3")
+      (is (schema/succeeded? result))
+      (is (contains? roles "workflow-phase-history"))
+      (is (contains? roles "workflow-run"))
+      (is (= 0.0 (get-in machine [:score_components :observed_transitions])))
+      (testing "a failed run is not held to the :done terminal projection"
+        (is (= "pass" (:status machine)))))))
+
 (deftest projection-requires-variant-and-transitions
   (let [events (clean-run-events :gate/failed)
         table  (table-for events)

--- a/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
+++ b/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
@@ -142,6 +142,12 @@
   (is (sut/valid-registry?))
   (is (= 6 (count (:state_vars (sut/state-var-registry))))))
 
+(deftest export-registry-rejects-missing-out
+  (testing "a bb task called without :out fails loudly rather than writing to \"\""
+    (is (thrown? clojure.lang.ExceptionInfo (sut/export-registry! {})))
+    (is (thrown? clojure.lang.ExceptionInfo (sut/export-registry! {:out nil})))
+    (is (thrown? clojure.lang.ExceptionInfo (sut/export-registry! {:out "  "})))))
+
 (deftest accumulator-projects-expected-table-shape
   (let [events (clean-run-events :gate/failed)
         table  (table-for events)

--- a/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
+++ b/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
@@ -382,4 +382,12 @@
                                      (dissoc opts :experiment-id))))
     (is (schema/failed? (sut/project table clean-run-id
                                      (dissoc opts :transitions))))
+    (is (schema/failed? (sut/project table clean-run-id
+                                     (dissoc opts :phase-history)))
+        "omitted phase-history must fail loudly — evaluations key off it")
+    (is (schema/failed? (sut/project table clean-run-id
+                                     (assoc opts :phase-history :not-a-seq))))
+    (is (schema/succeeded? (sut/project table clean-run-id
+                                        (assoc opts :phase-history [])))
+        "an EXPLICIT empty history is a deliberate caller statement, allowed")
     (is (schema/failed? (sut/project table (random-uuid) opts)))))

--- a/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
+++ b/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
@@ -148,6 +148,20 @@
     (is (thrown? clojure.lang.ExceptionInfo (sut/export-registry! {:out nil})))
     (is (thrown? clojure.lang.ExceptionInfo (sut/export-registry! {:out "  "})))))
 
+(deftest export-registry-rejects-invalid-registry
+  (testing "a missing or schema-invalid registry fails loudly before any
+            write — a \"null\" or malformed fixture is never produced"
+    (doseq [broken [nil {:not "a registry"}]]
+      (with-redefs [sut/state-var-registry (fn [] broken)]
+        (let [out (java.io.File/createTempFile "registry-export" ".json")]
+          (.deleteOnExit out)
+          (.delete out)
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (sut/export-registry! {:out (.getPath out)}))
+              (pr-str broken))
+          (is (not (.exists out))
+              "no fixture file may be written for an invalid registry"))))))
+
 (deftest accumulator-projects-expected-table-shape
   (let [events (clean-run-events :gate/failed)
         table  (table-for events)

--- a/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
+++ b/components/workbench-orchestration-adapter/test/ai/miniforge/workbench_orchestration_adapter/interface_test.clj
@@ -196,6 +196,22 @@
         (is (= "completed" (:workflow/status entity)))
         (is (= "done" (:workflow/current-phase entity)))))))
 
+(deftest snapshot-normalizes-native-identity-and-timestamp-overrides
+  (let [table       (table-for (clean-run-events :gate/failed))
+        snapshot-id #uuid "00000000-0000-0000-0000-000000000099"
+        generated-at #inst "2026-07-20T01:02:03Z"
+        result      (sut/project table clean-run-id
+                                 (assoc (opts-for (clean-run-events :gate/failed)
+                                                  clean-run-id)
+                                        :run-id clean-run-id
+                                        :snapshot-id snapshot-id
+                                        :generated-at generated-at))
+        snapshot    (:snapshot result)]
+    (is (schema/succeeded? result))
+    (is (= (str clean-run-id) (:run_id snapshot)))
+    (is (= (str snapshot-id) (:snapshot_id snapshot)))
+    (is (= "2026-07-20T01:02:03Z" (:generated_at snapshot)))))
+
 (deftest illegal-transition-fails-machine-authoritative
   (let [events   illegal-run-events
         table    (table-for events)

--- a/deps.edn
+++ b/deps.edn
@@ -87,6 +87,8 @@
                        "components/repo-dag/src"
                        "components/event-stream/src"
                        "components/supervisory-state/src"
+                       "components/workbench-orchestration-adapter/src"
+                       "components/workbench-orchestration-adapter/resources"
                        "components/automation-edge-correlator/src"
                        "components/pr-scoring/src"
                        "components/workflow-resume/src"
@@ -249,6 +251,7 @@
                      ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                      ai.miniforge/event-stream {:local/root "components/event-stream"}
                      ai.miniforge/supervisory-state {:local/root "components/supervisory-state"}
+                     ai.miniforge/workbench-orchestration-adapter {:local/root "components/workbench-orchestration-adapter"}
                      ai.miniforge/automation-edge-correlator {:local/root "components/automation-edge-correlator"}
                      ai.miniforge/pr-scoring {:local/root "components/pr-scoring"}
                      ai.miniforge/workflow-resume {:local/root "components/workflow-resume"}
@@ -373,6 +376,7 @@
                        "components/repo-dag/test"
                        "components/event-stream/test"
                        "components/supervisory-state/test"
+                       "components/workbench-orchestration-adapter/test"
                        "components/automation-edge-correlator/test"
                        "components/pr-scoring/test"
                        "components/workflow-resume/test"
@@ -500,6 +504,7 @@
                       ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                       ai.miniforge/event-stream {:local/root "components/event-stream"}
                       ai.miniforge/supervisory-state {:local/root "components/supervisory-state"}
+                      ai.miniforge/workbench-orchestration-adapter {:local/root "components/workbench-orchestration-adapter"}
                       ai.miniforge/automation-edge-correlator {:local/root "components/automation-edge-correlator"}
                       ai.miniforge/pr-scoring {:local/root "components/pr-scoring"}
                       ai.miniforge/workflow-resume {:local/root "components/workflow-resume"}

--- a/docs/architecture/minibench-orchestration-adapter.md
+++ b/docs/architecture/minibench-orchestration-adapter.md
@@ -1,0 +1,132 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Minibench product adapter: orchestration slice
+
+Status: implemented on 2026-07-19
+
+## Result
+
+The Miniforge-owned orchestration adapter projects supervisory state — the
+EntityTable materialized from the N2 §2.4 lifecycle event stream — into a
+validated `workbench_snapshot/v1`. Minibench remains tenant-agnostic: it
+consumes the snapshot and the product registry, never a Miniforge domain
+namespace. This is the orchestration counterpart to the ETL slice
+(`docs/architecture/minibench-etl-adapter.md`), and it replaces the
+hand-written `fixtures/miniforge/snapshot.json` stand-in the workbench
+contract has round-tripped so far.
+
+## Resolved-run boundary
+
+The ETL slice flagged that orchestration lacked "a single canonical
+resolved-run value … assembled and frozen at the run boundary". This
+adapter defines that boundary for workflow runs:
+
+- A run is **resolved** when its lifecycle projection has reached a
+  terminal status per N2 §2.2–§2.3: `:completed`, `:failed`, or
+  `:cancelled`. The phase machine's own terminal node is `:done` (no
+  outgoing transitions in the authoritative transition map); `:failed`
+  and `:cancelled` are lifecycle-terminal from any phase.
+- **Unresolved (dangling) runs are excluded from snapshots.** `project`
+  rejects them at the boundary, and `resolved-runs` never returns them.
+  The `miniforge.workflow.runs_resolved` state variable measures how much
+  of the table sits at the boundary, so dangling runs stay visible even
+  though they are not projectable.
+- **Snapshot identity**: `run_id` is the workflow run's UUID;
+  `snapshot_id` defaults to `wb-<run_id>`. `generated_at` is supplied by
+  the caller and defaults to the run's own `:workflow-run/updated-at` —
+  the projection is pure and reads no clock, mirroring the ETL adapter's
+  purity discipline.
+- **Observed phase history** is not retained on the EntityTable (only
+  `:workflow-run/current-phase` is), so it is derived as a pure fold over
+  the same `:workflow/phase-started` events the caller already folded
+  into the table (`phase-history`), and passed to `project` alongside the
+  legal transition map from the workflow component's interface.
+
+The full resolved-run *configuration* inventory (workflow, phase, prompt,
+model, runner, and user defaults assembled into one frozen value) remains
+future work; until orchestration assembles that value at run start, the
+ETL factor-inventory/diff primitive cannot count orchestration factors
+defensibly. This slice freezes the *outcome* boundary — which runs are
+comparable at all — and the supervisory evidence behind it.
+
+## Orchestration state variables
+
+The product registry is `miniforge-orchestration-state-vars@2026.07.19.1`
+and defines six deterministic, LLM-free variables, each evaluable from the
+EntityTable plus the observed phase history:
+
+- `miniforge.workflow.machine_authoritative` — observed phase history is a
+  path through the single authoritative execution machine and the terminal
+  projection is legal (N2 §2.1–§2.3, §3.1).
+- `miniforge.workflow.runs_resolved` — fraction of runs at the resolved-run
+  boundary (N2 §2.2–§2.3).
+- `miniforge.gate.critical_violations_block` — every run-scoped
+  PolicyEvaluation carrying a critical violation has a blocking failed
+  outcome (N4 §3, §3.3).
+- `miniforge.policy.evaluations_recorded` — a run that traversed `:verify`
+  has at least one recorded PolicyEvaluation (N4 §3; N2 §2.4).
+- `miniforge.attention.items_actioned` — fraction of the run's
+  AttentionItems resolved at the boundary (N5-delta-1 §3.1, §5).
+- `miniforge.decision.queue_drained` — DecisionCards resolved and
+  InterventionRequests settled at the boundary (N5-delta-3 §2.4;
+  N5-delta-supervisory-control-plane §3.3).
+
+Evidence refs are honest: they carry real supervisory entity/event ids
+(workflow run ids, PolicyEvaluation ids, AttentionItem ids, DecisionCard
+ids, InterventionRequest ids) with `source_role` values matching each
+variable's `evidence_requirements`. Snapshot metadata stamps evaluator and
+policy hash/version plus the resolved-run boundary summary (terminal
+status, phase history, dangling-run count).
+
+## Usage
+
+```clojure
+(require '[ai.miniforge.supervisory-state.interface :as sup]
+         '[ai.miniforge.workflow.interface :as workflow]
+         '[ai.miniforge.workbench-orchestration-adapter.interface :as adapter])
+
+(let [table  (sup/apply-events sup/empty-table events)
+      run-id (:workflow-run/id (first (adapter/resolved-runs table)))]
+  (adapter/project table run-id
+                   {:experiment-id "miniforge.orchestration.example"
+                    :label "baseline"
+                    :transitions workflow/phase-transitions
+                    :phase-history (adapter/phase-history events run-id)}))
+```
+
+Registry export for minibench comparison:
+
+```bash
+bb workbench:orchestration:registry :out '"runs/miniforge-orchestration-registry.json"'
+```
+
+The adapter is deliberately not wired into `bases/cli` yet: PR #1426
+(the ETL slice) already modifies `bases/cli/main.clj`, the ETL command
+file, and the CLI message resources, so CLI exposure is deferred to a
+follow-up after that PR merges. The component interface plus the bb task
+above are the exposure for now.
+
+## Fixture provenance
+
+The adapter tests never hand-roll EntityTable shapes: fixtures fold
+synthetic N2 §2.4 event streams through the real supervisory-state
+accumulator (`sup/apply-events`, newly exposed on its interface as a pure
+pass-through) and assert on the projected table before projecting. The
+transition map under test is the real `workflow/phase-transitions`. A
+follow-up in the minibench/workbench-contract repo should replace the
+hand-written `fixtures/miniforge/{registry,snapshot}.json` pair with this
+adapter's real output.
+
+## Verification
+
+- adapter contract, registry, boundary-exclusion, illegal-transition,
+  unblocked-critical, missing-evaluation, and not-applicable tests;
+- accumulator-shape assertion test (table produced by the real reducer);
+- snapshot and registry validated against the workbench-contract Clojure
+  mirror (`ai.miniforge.workbench-contract.schema`), same as the ETL
+  adapter;
+- Polylith workspace checking and targeted clj-kondo linting.

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -66,6 +66,7 @@
         ;; Event streaming and observability
         ai.miniforge/event-stream {:local/root "../../components/event-stream"}
         ai.miniforge/supervisory-state {:local/root "../../components/supervisory-state"}
+        ai.miniforge/workbench-orchestration-adapter {:local/root "../../components/workbench-orchestration-adapter"}
         ai.miniforge/automation-edge-correlator {:local/root "../../components/automation-edge-correlator"}
         ai.miniforge/workflow-resume {:local/root "../../components/workflow-resume"}
         ;; Self-healing: workaround detection, backend health tracking

--- a/workspace.edn
+++ b/workspace.edn
@@ -49,6 +49,10 @@
                                           "training-capture"
                                           "tui-views"
                                           "web-dashboard"
+                                          ;; Minibench orchestration projection: consumed via the
+                                          ;; component interface + bb task (no CLI wiring yet), so
+                                          ;; static analysis doesn't see the dependency.
+                                          "workbench-orchestration-adapter"
                                           "workflow-chain-deployment"
                                           "workflow-chain-software-factory"
                                           "workflow-compliance-scanner"


### PR DESCRIPTION
## Summary

The orchestration counterpart to the ETL adapter (#1426): `components/workbench-orchestration-adapter` projects the supervisory-state EntityTable into validated `workbench_snapshot/v1` snapshots, with the state-variable registry and the resolved-run boundary #1426 flagged as missing.

- **Resolved-run boundary**: a run is resolved when `:workflow-run/status` ∈ `#{:completed :failed :cancelled}` (N2 §2.2–2.3; `:done` is the only machine-terminal phase, failed/cancelled are lifecycle-terminal from any phase). Unresolved runs are excluded and stay visible via a dedicated state var. Pure projection — `generated_at` caller-supplied, no clock inside; phase history is a pure fold over the same `:workflow/phase-started` events the caller folded into the table, judged against the real `workflow/phase-transitions` map.
- **Registry** `miniforge-orchestration-state-vars@2026.07.19.1`, six vars, each grounded in an N-anchor: `workflow.machine_authoritative` (history ⊆ legal transitions, completed ⇒ `:done`; N2), `workflow.runs_resolved`, `gate.critical_violations_block` (N4), `policy.evaluations_recorded` (N4; not_applicable pre-verify), `attention.items_actioned` (N5-δ1), `decision.queue_drained` (N5-δ3). Thresholds live in the registry and reuse established numbers only. Evidence refs carry real entity/event ids with source_roles matching each var's `evidence_requirements` — no empty stubs (the workbench kernel is gaining an evidence validator, minibench PR #16).
- **supervisory-state interface**: pass-through-only additions (`empty-table`, `apply-event`, `apply-events`) so consumers can fold event sequences without a live stream.
- The old hand-written fixture's `miniforge.evidence.bundle_complete` is deliberately absent — it needs an evidence-bundle-aware evaluator before it can return honestly; left out rather than faked.
- CLI exposure deferred to avoid #1426's files: interface + `bb workbench:orchestration:registry` task only. Shared-file overlap with #1426 is two files, different hunks (root `deps.edn`, `bb.edn`) — clean merges expected either order. Once both land, CI needs #1426's ssh arrangement for the `workbench-contract` git dep.
- `docs/architecture/minibench-orchestration-adapter.md` documents the boundary and the projection, sibling to the ETL doc.

## Testing

- 8 tests / 52 assertions — fixtures built by folding synthetic event streams through the REAL supervisory-state accumulator (no hand-rolled table shapes): clean pass, illegal transition, unblocked critical violation, boundary exclusion, missing policy evaluation + not_applicable, opts validation, registry contract validity. Snapshot + registry validate against `ai.miniforge.workbench-contract.schema` exactly as the ETL adapter does.
- Full supervisory-state suite green (83 tests / 267 assertions); `poly check` clean (pre-existing warning 205 only); clj-kondo 0/0; pre-commit gate passed on every commit.

## Follow-up

Companion minibench fixtures PR (peer of minibench #13): real orchestration snapshot pair from a fixture event stream + registry export, replacing the hand-written miniforge stand-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)