### PR TITLE
fix(event-stream): normalize timeline messages

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -124,6 +124,12 @@
 (defn- event-type [event]
   (:event/type event))
 
+(defn- event-message
+  "Return the renderable event message, or an empty string when absent or malformed."
+  [event]
+  (let [message (get event :message)]
+    (if (string? message) message "")))
+
 (defn- truncate
   "Truncate string `s` to at most `n` characters, appending the
    localized `:timeline/truncation-suffix` if cut."
@@ -213,7 +219,7 @@
                    :workflow/phase-completed (messages/t :timeline/phase-suffix-completed)
                    (name ev-type))
         marker   (messages/t :timeline/phase-marker {:suffix suffix})
-        msg      (or (:message event) "")]
+        msg      (event-message event)]
     (if (seq msg)
       (format "%s  %s  %s  %s" ts phase marker msg)
       (format "%s  %s  %s" ts phase marker))))
@@ -246,7 +252,7 @@
   (let [ts       (format-hms (event-timestamp event))
         phase    (event-phase event)
         ev-type  (or (event-type event) (messages/t :timeline/unknown-event-type))
-        msg      (or (:message event) "")]
+        msg      (event-message event)]
     (format "%s  %s  %s  %s" ts phase (str ev-type) (truncate msg args-preview-length))))
 
 (defn- render-event

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -231,7 +231,7 @@
   (let [ts     (format-hms (event-timestamp event))
         phase  (event-phase event)
         marker (messages/t :timeline/terminated-marker)
-        reason (or (:message event)
+        reason (or (not-empty (event-message event))
                    (when-let [r (:workflow/result event)]
                      (str r))
                    "")]
@@ -243,7 +243,8 @@
   (let [ts     (format-hms (event-timestamp event))
         phase  (event-phase event)
         marker (messages/t :timeline/stall-marker)
-        msg    (or (:message event) (messages/t :timeline/stall-default-msg))]
+        msg    (or (not-empty (event-message event))
+                   (messages/t :timeline/stall-default-msg))]
     (format "%s  %s  %s  %s" ts phase marker msg)))
 
 (defn- render-generic

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -148,8 +148,8 @@
    Prefers `:tool/args-digest :digest/preview`, falls back to `:message`."
   [event]
   (let [preview (get-in event [:tool/args-digest :digest/preview])
-        raw     (or preview (:message event) "")]
-    (truncate (str raw) args-preview-length)))
+        raw     (if (string? preview) preview (event-message event))]
+    (truncate raw args-preview-length)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Duration helpers

--- a/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
@@ -207,14 +207,18 @@
       (is (str/includes? result "something happened")))))
 
 (deftest non-string-event-messages-render-as-empty-test
-  (testing "phase, generic, and tool renderers tolerate a missing message key"
+  (testing "message-bearing renderers tolerate a missing message key"
     (doseq [event-type [:workflow/phase-started
+                        :workflow/completed
+                        :agent/stream-stalled
                         :some/unknown-event
                         :agent/tool-call-started]]
       (is (string? (sut/render-timeline [(mk-event event-type 0)]))
           (str event-type " missing :message"))))
   (testing "non-string messages are omitted rather than stringified"
     (doseq [event-type [:workflow/phase-started
+                        :workflow/completed
+                        :agent/stream-stalled
                         :some/unknown-event
                         :agent/tool-call-started]
             message    [false :not-a-string 42]
@@ -228,7 +232,14 @@
                              :message "safe fallback"
                              :tool/args-digest {:digest/preview 42})])]
       (is (str/includes? result "safe fallback"))
-      (is (not (str/includes? result "42"))))))
+      (is (not (str/includes? result "42")))))
+  (testing "terminal events with malformed messages fall back to the workflow result"
+    (let [result (sut/render-timeline
+                  [(mk-event :workflow/failed 0
+                             :message :not-a-string
+                             :workflow/result :failed)])]
+      (is (str/includes? result ":failed"))
+      (is (not (str/includes? result ":not-a-string"))))))
 
 (deftest events-without-timestamps-handled-gracefully
   (testing "events with nil timestamp render with ?? placeholders but do not throw"

--- a/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
@@ -207,16 +207,28 @@
       (is (str/includes? result "something happened")))))
 
 (deftest non-string-event-messages-render-as-empty-test
-  (testing "phase and generic renderers tolerate missing, nil, false, and malformed messages"
-    (doseq [event-type [:workflow/phase-started :some/unknown-event]
-            message    [nil false :not-a-string 42]
+  (testing "phase, generic, and tool renderers tolerate a missing message key"
+    (doseq [event-type [:workflow/phase-started
+                        :some/unknown-event
+                        :agent/tool-call-started]]
+      (is (string? (sut/render-timeline [(mk-event event-type 0)]))
+          (str event-type " missing :message"))))
+  (testing "non-string messages are omitted rather than stringified"
+    (doseq [event-type [:workflow/phase-started
+                        :some/unknown-event
+                        :agent/tool-call-started]
+            message    [false :not-a-string 42]
             :let       [result (sut/render-timeline
                                 [(mk-event event-type 0 :message message)])]]
-      (is (string? result) (str event-type " " (pr-str message)))))
-  (testing "malformed values are omitted rather than stringified"
+      (is (not (str/includes? result (str message)))
+          (str event-type " did not render " (pr-str message)))))
+  (testing "a malformed args preview falls back to a valid event message"
     (let [result (sut/render-timeline
-                  [(mk-event :some/unknown-event 0 :message :not-a-string)])]
-      (is (not (str/includes? result "not-a-string"))))))
+                  [(mk-event :agent/tool-call-started 0
+                             :message "safe fallback"
+                             :tool/args-digest {:digest/preview 42})])]
+      (is (str/includes? result "safe fallback"))
+      (is (not (str/includes? result "42"))))))
 
 (deftest events-without-timestamps-handled-gracefully
   (testing "events with nil timestamp render with ?? placeholders but do not throw"

--- a/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
@@ -206,6 +206,18 @@
       (is (str/includes? result ":some/unknown-event"))
       (is (str/includes? result "something happened")))))
 
+(deftest non-string-event-messages-render-as-empty-test
+  (testing "phase and generic renderers tolerate missing, nil, false, and malformed messages"
+    (doseq [event-type [:workflow/phase-started :some/unknown-event]
+            message    [nil false :not-a-string 42]
+            :let       [result (sut/render-timeline
+                                [(mk-event event-type 0 :message message)])]]
+      (is (string? result) (str event-type " " (pr-str message)))))
+  (testing "malformed values are omitted rather than stringified"
+    (let [result (sut/render-timeline
+                  [(mk-event :some/unknown-event 0 :message :not-a-string)])]
+      (is (not (str/includes? result "not-a-string"))))))
+
 (deftest events-without-timestamps-handled-gracefully
   (testing "events with nil timestamp render with ?? placeholders but do not throw"
     (let [event  {:event/type     :agent/tool-call-started

--- a/docs/pull-requests/2026-07-19-fix-event-timeline-message-defaults-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-event-timeline-message-defaults-20260719.md
@@ -17,7 +17,7 @@ must remain safe without relying on `or` for map defaults.
 
 ## Changes in Detail
 
-- Normalize timeline messages through one string-only extraction helper.
+- Normalize timeline messages through one string-only extraction helper, including tool-call argument fallback.
 - Preserve empty rendering for missing, nil, and false values while safely omitting malformed values.
 - Add regression coverage across phase-lifecycle and generic renderers.
 

--- a/docs/pull-requests/2026-07-19-fix-event-timeline-message-defaults-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-event-timeline-message-defaults-20260719.md
@@ -1,0 +1,45 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Clarify event timeline message defaults
+
+## Overview
+
+Resolve the two Dewey 210 message-default findings in event timeline rendering with explicit nil and malformed-value
+semantics.
+
+## Motivation
+
+Timeline renderers require strings, while incoming event maps may omit `:message` or carry a nil value. The fallback
+must remain safe without relying on `or` for map defaults.
+
+## Changes in Detail
+
+- Normalize timeline messages through one string-only extraction helper.
+- Preserve empty rendering for missing, nil, and false values while safely omitting malformed values.
+- Add regression coverage across phase-lifecycle and generic renderers.
+
+## Testing Plan
+
+- Run focused event-stream timeline tests.
+- Run the Dewey 210 scanner and verify two findings are removed.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. No data migration is required.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Follows #1427 and #1430.
+
+## Checklist
+
+- [x] Preserve timeline rendering for absent and invalid messages.
+- [x] Add regression coverage for selected findings.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.

--- a/docs/pull-requests/2026-07-19-fix-event-timeline-message-defaults-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-event-timeline-message-defaults-20260719.md
@@ -18,8 +18,8 @@ must remain safe without relying on `or` for map defaults.
 ## Changes in Detail
 
 - Normalize timeline messages through one string-only extraction helper, including tool-call argument fallback.
-- Preserve empty rendering for missing, nil, and false values while safely omitting malformed values.
-- Add regression coverage across phase-lifecycle and generic renderers.
+- Normalize missing, nil, false, and malformed messages to empty text before applying renderer-specific fallbacks.
+- Add regression coverage across phase-lifecycle, terminal, stall, generic, and tool-call renderers.
 
 ## Testing Plan
 


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Clarify event timeline message defaults

## Overview

Resolve the two Dewey 210 message-default findings in event timeline rendering with explicit nil and malformed-value
semantics.

## Motivation

Timeline renderers require strings, while incoming event maps may omit `:message` or carry a nil value. The fallback
must remain safe without relying on `or` for map defaults.

## Changes in Detail

- Normalize timeline messages through one string-only extraction helper.
- Preserve empty rendering for missing, nil, and false values while safely omitting malformed values.
- Add regression coverage across phase-lifecycle and generic renderers.

## Testing Plan

- Run focused event-stream timeline tests.
- Run the Dewey 210 scanner and verify two findings are removed.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. No data migration is required.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Follows #1427 and #1430.

## Checklist

- [x] Preserve timeline rendering for absent and invalid messages.
- [x] Add regression coverage for selected findings.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
