### PR TITLE
fix(tool): normalize searchable metadata

### DIFF
--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -90,6 +90,11 @@
   [tool]
   (messages/t :tool/summary {:name (:tool/name tool) :description (:tool/description tool)}))
 
+(defn- searchable-text
+  "Return string metadata as searchable text; ignore absent or malformed values."
+  [value]
+  (if (string? value) value ""))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Tool protocol and registry
 
@@ -195,8 +200,8 @@
            vals
            (filter (fn [tool]
                      (let [info (tool-info tool)]
-                       (or (str/includes? (str/lower-case (or (:name info) "")) q)
-                           (str/includes? (str/lower-case (or (:description info) "")) q)))))))))
+                       (or (str/includes? (str/lower-case (searchable-text (:name info))) q)
+                           (str/includes? (str/lower-case (searchable-text (:description info))) q)))))))))
 
 (defn create-function-tool
   "Create a function-based tool.

--- a/components/tool/test/ai/miniforge/tool/interface_test.clj
+++ b/components/tool/test/ai/miniforge/tool/interface_test.clj
@@ -144,7 +144,28 @@
 
   (testing "returns empty for no matches"
     (let [registry (tool/create-registry)]
-      (is (empty? (tool/find-tools registry "nonexistent"))))))
+      (is (empty? (tool/find-tools registry "nonexistent")))))
+
+  (testing "ignores non-string names and descriptions"
+    (doseq [value [nil false :malformed-metadata-token 42]
+            :let [registry (tool/create-registry)
+                  malformed-tool (tool/create-tool
+                                  {:id :test/malformed
+                                   :name value
+                                   :description value
+                                   :handler (constantly nil)})]]
+      (tool/register! registry malformed-tool)
+      (is (empty? (tool/find-tools registry "definitely-absent"))
+          (str "search tolerates " (pr-str value))))
+    (let [registry (tool/create-registry)
+          malformed-tool (tool/create-tool
+                          {:id :test/malformed
+                           :name :malformed-metadata-token
+                           :description :malformed-metadata-token
+                           :handler (constantly nil)})]
+      (tool/register! registry malformed-tool)
+      (is (empty? (tool/find-tools registry "malformed-metadata-token"))
+          "malformed metadata is not stringified into searchable text"))))
 
 ;; Execution tests
 

--- a/docs/pull-requests/2026-07-19-fix-tool-search-defaults-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-tool-search-defaults-20260719.md
@@ -1,0 +1,44 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Normalize tool search text
+
+## Overview
+
+Resolve the two Dewey 210 map-default findings in tool-registry search with explicit malformed-value semantics.
+
+## Motivation
+
+Tool names and descriptions are searched case-insensitively, but optional or malformed metadata must not cause
+`clojure.string/lower-case` to fail. Search should use only string metadata and treat every other value as empty text.
+
+## Changes in Detail
+
+- Normalize searchable tool metadata through a string-only helper.
+- Preserve matching for valid names and descriptions while ignoring missing, nil, false, keyword, and numeric values.
+- Add regression coverage for malformed metadata in both searchable fields.
+
+## Testing Plan
+
+- Run focused tool component tests.
+- Run the Dewey 210 scanner and verify two findings are removed from this branch.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. No data migration is required.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Continues the standards-remediation series after #1433.
+
+## Checklist
+
+- [x] Preserve valid tool search behavior.
+- [x] Add malformed-metadata regression coverage.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Normalize tool search text

## Overview

Resolve the two Dewey 210 map-default findings in tool-registry search with explicit malformed-value semantics.

## Motivation

Tool names and descriptions are searched case-insensitively, but optional or malformed metadata must not cause
`clojure.string/lower-case` to fail. Search should use only string metadata and treat every other value as empty text.

## Changes in Detail

- Normalize searchable tool metadata through a string-only helper.
- Preserve matching for valid names and descriptions while ignoring missing, nil, false, keyword, and numeric values.
- Add regression coverage for malformed metadata in both searchable fields.

## Testing Plan

- Run focused tool component tests.
- Run the Dewey 210 scanner and verify two findings are removed from this branch.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. No data migration is required.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Continues the standards-remediation series after #1433.

## Checklist

- [x] Preserve valid tool search behavior.
- [x] Add malformed-metadata regression coverage.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
