### PR TITLE
fix(dag-executor): validate worktree Git output

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -174,6 +174,12 @@
   [path]
   (.mkdirs (File. ^String path)))
 
+(defn- command-output
+  "Return command stdout when it is a string; otherwise return empty text."
+  [result]
+  (let [output (get result :out)]
+    (if (string? output) output "")))
+
 ;; ============================================================================
 ;; Git Operations
 ;; ============================================================================
@@ -218,7 +224,7 @@
   [repo-path branch]
   (let [r (run-git "-C" repo-path "rev-parse" branch)]
     (when (zero? (:exit r))
-      (let [sha (str/trim (or (:out r) ""))]
+      (let [sha (str/trim (command-output r))]
         (when (seq sha) sha)))))
 
 (defn create-worktree
@@ -689,18 +695,22 @@
   [worktree-path]
   (let [r (run-git "-C" worktree-path "rev-parse" "--git-common-dir")]
     (if (zero? (:exit r))
-      (let [git-common-str  (str/trim (or (:out r) ""))
-            ;; --git-common-dir may return a relative path; resolve against
-            ;; the worktree's CWD so we get the correct absolute path even
-            ;; when the worktree lives far from the parent repo.
-            git-common-file (let [f (File. ^String git-common-str)]
-                              (if (.isAbsolute f)
-                                f
-                                (File. ^String worktree-path ^String git-common-str)))
-            abs-git-common  (.getAbsolutePath git-common-file)
-            parent-repo     (.getAbsolutePath
-                             (.getParentFile (File. ^String abs-git-common)))]
-        (result/ok {:parent-repo-path parent-repo}))
+      (let [git-common-str (str/trim (command-output r))]
+        (if (seq git-common-str)
+          (let [;; --git-common-dir may return a relative path; resolve against
+                ;; the worktree's CWD so we get the correct absolute path even
+                ;; when the worktree lives far from the parent repo.
+                git-common-file (let [f (File. ^String git-common-str)]
+                                  (if (.isAbsolute f)
+                                    f
+                                    (File. ^String worktree-path ^String git-common-str)))
+                abs-git-common  (.getAbsolutePath git-common-file)
+                parent-repo     (.getAbsolutePath
+                                 (.getParentFile (File. ^String abs-git-common)))]
+            (result/ok {:parent-repo-path parent-repo}))
+          (result/err :derive-parent-repo-failed
+                      "git rev-parse --git-common-dir returned no usable path"
+                      {:worktree-path worktree-path})))
       (result/err :derive-parent-repo-failed
                   (str "git rev-parse --git-common-dir failed: " (:err r))
                   {:worktree-path worktree-path

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_lifecycle_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_lifecycle_test.clj
@@ -172,6 +172,16 @@
         (is (result/err? r))
         (is (= :derive-parent-repo-failed (get-in r [:error :code])))))))
 
+(deftest derive-parent-repo-path-rejects-unusable-output-test
+  (testing "successful git execution without a usable common-dir returns an error"
+    (doseq [output [nil false :not-a-path 42 " \n"]]
+      (with-redefs [worktree/run-git
+                    (fn [& _]
+                      {:exit 0 :out output :err ""})]
+        (let [r (worktree/derive-parent-repo-path "/tmp/my-repo")]
+          (is (result/err? r) (str "rejected " (pr-str output)))
+          (is (= :derive-parent-repo-failed (get-in r [:error :code]))))))))
+
 ;;------------------------------------------------------------------------------ notify-file-written! tests
 
 (deftest notify-file-written!-calls-scratch-commit-with-parent-repo-test

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -29,6 +29,13 @@
 ;; create-worktree: lock and fallback strategy
 ;; ============================================================================
 
+(deftest resolve-branch-sha-rejects-unusable-output-test
+  (testing "successful rev-parse with absent, blank, or malformed stdout remains unresolved"
+    (doseq [output [nil false :not-a-sha 42 " \n"]]
+      (with-redefs [worktree/run-git (fn [& _] {:exit 0 :out output :err ""})]
+        (is (nil? (#'worktree/resolve-branch-sha "/tmp/repo" "main"))
+            (str "ignored " (pr-str output)))))))
+
 (deftest create-worktree-succeeds-on-first-attempt-test
   (testing "returns ok with worktree-path when git worktree add -b succeeds immediately"
     (with-redefs [worktree/run-git     (fn [& _] {:exit 0 :out "" :err ""})

--- a/docs/pull-requests/2026-07-19-fix-worktree-output-defaults-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-worktree-output-defaults-20260719.md
@@ -1,0 +1,46 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Validate worktree Git output
+
+## Overview
+
+Resolve the two Dewey 210 map-default findings in the worktree executor with explicit command-output semantics.
+
+## Motivation
+
+Git command stdout is expected to be a string, but missing, nil, or malformed values must not reach string functions.
+Branch resolution can safely decline an unusable SHA, while parent-repository derivation must return an error rather
+than fabricate a path from empty output.
+
+## Changes in Detail
+
+- Normalize Git stdout through a string-only helper.
+- Treat absent, blank, and malformed branch-resolution output as unresolved.
+- Return a canonical error when successful `--git-common-dir` execution yields unusable output.
+- Add regression coverage for both call sites.
+
+## Testing Plan
+
+- Run focused dag-executor tests.
+- Run the Dewey 210 scanner and verify two findings are removed from this branch.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. No data migration is required.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Continues the standards-remediation series after #1434.
+
+## Checklist
+
+- [x] Preserve valid Git output handling.
+- [x] Add unusable-output regression coverage.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Validate worktree Git output

## Overview

Resolve the two Dewey 210 map-default findings in the worktree executor with explicit command-output semantics.

## Motivation

Git command stdout is expected to be a string, but missing, nil, or malformed values must not reach string functions.
Branch resolution can safely decline an unusable SHA, while parent-repository derivation must return an error rather
than fabricate a path from empty output.

## Changes in Detail

- Normalize Git stdout through a string-only helper.
- Treat absent, blank, and malformed branch-resolution output as unresolved.
- Return a canonical error when successful `--git-common-dir` execution yields unusable output.
- Add regression coverage for both call sites.

## Testing Plan

- Run focused dag-executor tests.
- Run the Dewey 210 scanner and verify two findings are removed from this branch.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. No data migration is required.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Continues the standards-remediation series after #1434.

## Checklist

- [x] Preserve valid Git output handling.
- [x] Add unusable-output regression coverage.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
