### PR TITLE
fix(compliance-scanner): normalize text defaults

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
@@ -52,6 +52,12 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Payload construction
 
+(defn- rationale-text
+  "Return a violation rationale when it is a string; otherwise return empty text."
+  [violation]
+  (let [rationale (get violation :rationale)]
+    (if (string? rationale) rationale "")))
+
 (defn violation->payload
   "Build the :comment/payload map for a single classified Violation.
 
@@ -73,7 +79,7 @@
    :violation/severity       (infer-severity violation)
    :violation/auto-fixable?  (boolean (:auto-fixable? violation))
    :violation/suggested-fix  (:suggested violation)
-   :violation/rationale      (or (:rationale violation) "")
+   :violation/rationale      (rationale-text violation)
    :violation/pack-id        (:pack/id pack-info)
    :violation/pack-version   (:pack/version pack-info)})
 

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
@@ -62,7 +62,7 @@
   "Build the :comment/payload map for a single classified Violation.
 
    Arguments:
-   - violation    - classified Violation (must have :auto-fixable? and :rationale)
+   - violation    - classified Violation (must have :auto-fixable?; :rationale is optional)
    - pack-info    - {:pack/id <string> :pack/version <string>}
 
    Returns the inner payload map shape per N13 §2.3:
@@ -112,7 +112,8 @@
   [violation payload]
   (str "**" (or (:rule/title violation) (name (:rule/id violation))) "**\n"
        "\n"
-       (when-let [r (:rationale violation)] (str r "\n\n"))
+       (when-let [r (not-empty (:violation/rationale payload))]
+         (str r "\n\n"))
        (when-let [s (:suggested violation)]
          (str "Suggested fix:\n```\n" s "\n```\n\n"))
        "```edn\n"

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -289,12 +289,13 @@
 (defn- local-boundary-wrapper?
   "True when the enclosing defn is a documented local compatibility boundary.
 
-   Whole boundary namespaces are exempt earlier. This narrower classifier
-   covers the post-cleanup shape used inside ordinary component namespaces:
-   a canonical anomaly-returning function plus a retained thrower that bridges
-   old exception callers. Undocumented throwers remain `:cleanup-needed`."
+  Whole boundary namespaces are exempt earlier. This narrower classifier
+  covers the post-cleanup shape used inside ordinary component namespaces:
+  a canonical anomaly-returning function plus a retained thrower that bridges
+  old exception callers. Undocumented throwers remain `:cleanup-needed`."
   [context]
-  (let [doc-text  (str/lower-case (or (:defn-doc context) ""))
+  (let [doc-value (get context :defn-doc)
+        doc-text  (str/lower-case (if (string? doc-value) doc-value ""))
         meta-text (str/lower-case (str/join " " (collect-text (:defn-meta context))))
         evidence  (str doc-text " " meta-text)]
     (boolean

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
@@ -58,6 +58,16 @@
       (is (= "1.4.0" (:violation/pack-version p)))
       (is (#{:error :warning :info} (:violation/severity p))))))
 
+(deftest payload-rationale-is-always-text
+  (testing "absent and malformed rationales become empty strings"
+    (doseq [violation [(dissoc auto-fixable-violation :rationale)
+                       (assoc auto-fixable-violation :rationale nil)
+                       (assoc auto-fixable-violation :rationale false)
+                       (assoc auto-fixable-violation :rationale :not-text)
+                       (assoc auto-fixable-violation :rationale 42)]]
+      (is (= "" (:violation/rationale
+                 (comments/violation->payload violation base-pack-info)))))))
+
 (deftest payload-severity-inference
   (testing "auto-fixable + non-critical → :warning"
     (is (= :warning

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
@@ -68,6 +68,16 @@
       (is (= "" (:violation/rationale
                  (comments/violation->payload violation base-pack-info)))))))
 
+(deftest comment-body-uses-normalized-rationale
+  (testing "absent and malformed rationales are omitted from the human-readable body"
+    (doseq [rationale [nil false :not-text 987654321]
+            :let [violation (assoc auto-fixable-violation :rationale rationale)
+                  comment (comments/violation->comment violation base-pack-info)
+                  body (:comment/body comment)]]
+      (is (= "" (get-in comment [:comment/payload :violation/rationale])))
+      (is (not (str/includes? body (pr-str rationale)))
+          (str "did not render " (pr-str rationale))))))
+
 (deftest payload-severity-inference
   (testing "auto-fixable + non-critical → :warning"
     (is (= :warning

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_test.clj
@@ -45,6 +45,16 @@
       (is (= 1 (count violations)))
       (is (= :local-boundary (:classification (first violations)))))))
 
+(deftest malformed-documentation-is-not-boundary-evidence
+  (testing "absent and malformed function documentation is treated as empty text"
+    (doseq [context [{}
+                     {:defn-doc nil}
+                     {:defn-doc false}
+                     {:defn-doc :not-text}
+                     {:defn-doc 42}]]
+      (is (false? (#'exc/local-boundary-wrapper? context))
+          (str "ignored " (pr-str (:defn-doc context)))))))
+
 (deftest throwing-boundary-with-data-equivalent-is-local-boundary
   (testing "response/throw-anomaly! bridges with anomaly-returning equivalents are local boundaries"
     (let [src "(ns ai.miniforge.foo.core

--- a/docs/pull-requests/2026-07-19-fix-compliance-text-defaults-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-compliance-text-defaults-20260719.md
@@ -1,0 +1,44 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Normalize compliance scanner text
+
+## Overview
+
+Resolve two Dewey 210 map-default findings where compliance-scanner logic requires string values.
+
+## Motivation
+
+Review-comment payloads require string rationales, and exception-boundary classification applies string operations to
+function documentation. Missing, nil, false, or malformed values must consistently behave as empty text.
+
+## Changes in Detail
+
+- Normalize violation rationales to string-only payload text.
+- Normalize parsed function documentation before boundary classification.
+- Add regression coverage for absent and malformed values at both call sites.
+
+## Testing Plan
+
+- Run focused compliance-scanner tests.
+- Run the Dewey 210 scanner and verify two findings are removed from this branch.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. No data migration is required.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Continues the standards-remediation series after #1435.
+
+## Checklist
+
+- [x] Preserve valid rationale and boundary-classification behavior.
+- [x] Add malformed-value regression coverage.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Normalize compliance scanner text

## Overview

Resolve two Dewey 210 map-default findings where compliance-scanner logic requires string values.

## Motivation

Review-comment payloads require string rationales, and exception-boundary classification applies string operations to
function documentation. Missing, nil, false, or malformed values must consistently behave as empty text.

## Changes in Detail

- Normalize violation rationales to string-only payload text.
- Normalize parsed function documentation before boundary classification.
- Add regression coverage for absent and malformed values at both call sites.

## Testing Plan

- Run focused compliance-scanner tests.
- Run the Dewey 210 scanner and verify two findings are removed from this branch.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. No data migration is required.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Continues the standards-remediation series after #1435.

## Checklist

- [x] Preserve valid rationale and boundary-classification behavior.
- [x] Add malformed-value regression coverage.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
