### PR TITLE
fix(agent): normalize typed defaults

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -802,6 +802,12 @@
               (:derived-artifact recovered))
       recovered)))
 
+(defn- normalized-artifact-source
+  "Return a keyword artifact source for telemetry, defaulting malformed values to :none."
+  [normalized]
+  (let [source (get normalized :artifact-source)]
+    (if (keyword? source) source :none)))
+
 (defn- invoke-with-llm
   "Invoke the implementer via the LLM backend."
   [llm-client user-prompt effective-system-prompt config context on-chunk logger
@@ -837,7 +843,7 @@
               {:data (cond-> {:success (llm/success? response)
                               :tokens (:tokens normalized)
                               :streaming? (boolean on-chunk)
-                              :artifact-source (or (:artifact-source normalized) :none)
+                              :artifact-source (normalized-artifact-source normalized)
                               ;; Dir the agent wrote to / collection scanned —
                               ;; surfaces the worktree-path-vs-CWD resolution so
                               ;; a write/scan dir mismatch is diagnosable.

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -256,6 +256,12 @@
   [review]
   (str "```clojure\n" (pr-str review) "\n```"))
 
+(defn- normalized-response
+  "Return the failed session response when it is a map; otherwise return an empty map."
+  [failed]
+  (let [response (get failed :response)]
+    (if (map? response) response {})))
+
 (defn- combine-normalized-review-results
   "Combine split reviewer calls into one normalized result. Any split session
    that fails to parse or times out keeps the combined result failed; only an
@@ -271,7 +277,7 @@
              :content joined-content
              :tokens tokens
              :cost-usd cost-usd
-             :response (cond-> (assoc (or (:response failed) {})
+             :response (cond-> (assoc (normalized-response failed)
                                       :tokens tokens)
                          cost-usd (assoc :cost-usd cost-usd)))
       (let [review (combine-parsed-reviews (mapv :parsed-content normalized-results))

--- a/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
+++ b/components/agent/src/ai/miniforge/agent/supervisory_bridge.clj
@@ -90,7 +90,8 @@
 
 (defn- direct-agent-role
   [agent]
-  (or (:role agent) :agent))
+  (let [role (get agent :role)]
+    (if (keyword? role) role :agent)))
 
 (defn- workflow-phase
   [task context]

--- a/components/agent/test/ai/miniforge/agent/implementer_extended_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_extended_test.clj
@@ -210,6 +210,17 @@
       (is (= :mcp
              (get-in result [:error :data :artifact-source]))))))
 
+(deftest normalized-artifact-source-is-always-a-keyword-test
+  (testing "valid artifact sources are preserved"
+    (is (= :mcp (#'impl/normalized-artifact-source {:artifact-source :mcp}))))
+  (testing "absent and malformed artifact sources become :none"
+    (doseq [normalized [{}
+                        {:artifact-source nil}
+                        {:artifact-source false}
+                        {:artifact-source "mcp"}
+                        {:artifact-source 42}]]
+      (is (= :none (#'impl/normalized-artifact-source normalized))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; extract-language tests
 

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -132,6 +132,25 @@
     :warnings []
     :duration-ms duration-ms}))
 
+(deftest split-review-failure-normalizes-response-map-test
+  (testing "aggregate tokens are added to a valid failed response map"
+    (let [combined (#'reviewer/combine-normalized-review-results
+                    [{:parsed-content nil
+                      :content "failed"
+                      :tokens 3
+                      :response {:success false :error :timeout}}])]
+      (is (= {:success false :error :timeout :tokens 3}
+             (:response combined)))))
+  (testing "absent and malformed failed responses become maps"
+    (doseq [response [nil false :not-a-map 42 []]
+            :let [combined (#'reviewer/combine-normalized-review-results
+                            [{:parsed-content nil
+                              :content "failed"
+                              :tokens 3
+                              :response response}])]]
+      (is (= {:tokens 3} (:response combined))
+          (str "normalized " (pr-str response))))))
+
 (defn- adaptive-timeout-message
   [elapsed-ms]
   (str "Adaptive timeout: Stagnation timeout: no progress for "

--- a/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
+++ b/components/agent/test/ai/miniforge/agent/runtime_supervisory_projection_test.clj
@@ -95,6 +95,17 @@
     (validate [_ _ _] {:valid? true})
     (repair [_ output _ _] output)))
 
+(deftest direct-agent-role-is-always-a-keyword-test
+  (testing "valid roles are preserved"
+    (is (= :reviewer (#'supervisory-bridge/direct-agent-role {:role :reviewer}))))
+  (testing "absent and malformed roles become :agent"
+    (doseq [agent-value [{}
+                         {:role nil}
+                         {:role false}
+                         {:role "reviewer"}
+                         {:role 42}]]
+      (is (= :agent (#'supervisory-bridge/direct-agent-role agent-value))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Projection coverage
 

--- a/docs/pull-requests/2026-07-19-fix-agent-typed-defaults-20260719.md
+++ b/docs/pull-requests/2026-07-19-fix-agent-typed-defaults-20260719.md
@@ -1,0 +1,45 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Normalize agent typed defaults
+
+## Overview
+
+Resolve three Dewey 210 map-default findings in the agent component with explicit type-aware semantics.
+
+## Motivation
+
+Agent telemetry and split-review aggregation consume typed values: artifact sources and roles are keywords, while an
+LLM response is a map. Missing, nil, false, or malformed values must fall back to the documented type-safe defaults.
+
+## Changes in Detail
+
+- Normalize implementer artifact-source telemetry to a keyword or `:none`.
+- Normalize failed split-review responses to a map before adding aggregate token and cost data.
+- Normalize supervisory direct-agent roles to a keyword or `:agent`.
+- Add regression coverage for malformed values at all three call sites.
+
+## Testing Plan
+
+- Run focused agent component tests.
+- Run the Dewey 210 scanner and verify three findings are removed from this branch.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. No data migration is required.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Continues the standards-remediation series after #1436.
+
+## Checklist
+
+- [x] Preserve valid artifact, response, and role values.
+- [x] Add malformed-value regression coverage.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Normalize agent typed defaults

## Overview

Resolve three Dewey 210 map-default findings in the agent component with explicit type-aware semantics.

## Motivation

Agent telemetry and split-review aggregation consume typed values: artifact sources and roles are keywords, while an
LLM response is a map. Missing, nil, false, or malformed values must fall back to the documented type-safe defaults.

## Changes in Detail

- Normalize implementer artifact-source telemetry to a keyword or `:none`.
- Normalize failed split-review responses to a map before adding aggregate token and cost data.
- Normalize supervisory direct-agent roles to a keyword or `:agent`.
- Add regression coverage for malformed values at all three call sites.

## Testing Plan

- Run focused agent component tests.
- Run the Dewey 210 scanner and verify three findings are removed from this branch.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. No data migration is required.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Continues the standards-remediation series after #1436.

## Checklist

- [x] Preserve valid artifact, response, and role values.
- [x] Add malformed-value regression coverage.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
