### PR TITLE
fix(cli): normalize typed defaults

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_policy_respond.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_policy_respond.clj
@@ -51,6 +51,12 @@
     :checkout-failed (messages/t :pr/policy-respond-checkout-failed {:n (:n error)})
     :fetch-failed    (messages/t :pr/policy-respond-fetch-failed    {:n (:n error)})))
 
+(defn- commit-sha-text
+  "Return a commit SHA when it is a string; otherwise return the display sentinel."
+  [data]
+  (let [commit-sha (get data :commit-sha)]
+    (if (string? commit-sha) commit-sha "—")))
+
 (defn- print-summary!
   [pr-number r]
   (let [d (:data r)
@@ -65,7 +71,7 @@
                   :failed   failed
                   :escalated escalated
                   :skipped  skipped
-                  :commit   (or (:commit-sha d) "—")}))
+                  :commit   (commit-sha-text d)}))
     (doseq [e (:escalated d)]
       (display/print-info
        (messages/t :pr/policy-respond-escalated

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -404,8 +404,9 @@
 
 (defn- response-output
   [response]
-  (merge (select-keys response [:content :exit-code :version])
-         (or (:output response) {})))
+  (let [output (get response :output)]
+    (merge (select-keys response [:content :exit-code :version])
+           (if (map? output) output {}))))
 
 (defn- response-succeeded?
   [response]

--- a/bases/cli/test/ai/miniforge/cli/typed_defaults_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/typed_defaults_test.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.typed-defaults-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.main.commands.pr-policy-respond :as pr-policy]
+   [ai.miniforge.cli.workflow-runner :as workflow-runner]))
+
+(deftest commit-sha-text-is-always-a-string-test
+  (testing "valid commit SHAs are preserved"
+    (is (= "abc123" (#'pr-policy/commit-sha-text {:commit-sha "abc123"}))))
+  (testing "absent and malformed commit SHAs use the display sentinel"
+    (doseq [data [{}
+                  {:commit-sha nil}
+                  {:commit-sha false}
+                  {:commit-sha :abc123}
+                  {:commit-sha 42}]]
+      (is (= "—" (#'pr-policy/commit-sha-text data))))))
+
+(deftest response-output-is-always-a-map-test
+  (testing "valid response output is merged into top-level projection fields"
+    (is (= {:content "outer" :exit-code 0 :detail :ok}
+           (#'workflow-runner/response-output
+            {:content "outer" :exit-code 0 :output {:detail :ok}}))))
+  (testing "absent and malformed output preserves only top-level projection fields"
+    (doseq [output [nil false :not-a-map 42 []]]
+      (is (= {:content "outer"}
+             (#'workflow-runner/response-output
+              {:content "outer" :output output}))))))

--- a/bases/cli/test/ai/miniforge/cli/typed_defaults_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/typed_defaults_test.clj
@@ -39,6 +39,8 @@
            (#'workflow-runner/response-output
             {:content "outer" :exit-code 0 :output {:detail :ok}}))))
   (testing "absent and malformed output preserves only top-level projection fields"
+    (is (= {:content "outer"}
+           (#'workflow-runner/response-output {:content "outer"})))
     (doseq [output [nil false :not-a-map 42 []]]
       (is (= {:content "outer"}
              (#'workflow-runner/response-output

--- a/docs/pull-requests/2026-07-20-fix-cli-typed-defaults-20260720.md
+++ b/docs/pull-requests/2026-07-20-fix-cli-typed-defaults-20260720.md
@@ -1,0 +1,45 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Normalize CLI typed defaults
+
+## Overview
+
+Resolve the final two Dewey 210 findings in the CLI base with explicit type-aware defaults.
+
+## Motivation
+
+PR policy summaries render commit SHAs as text, while workflow response projection merges output maps. Missing, nil,
+false, or malformed values must fall back to the display sentinel and empty map without stringifying or merging invalid
+data.
+
+## Changes in Detail
+
+- Normalize policy-response commit SHAs to strings or the em-dash sentinel.
+- Normalize workflow response output to a map before projection.
+- Add regression coverage for valid, absent, and malformed values.
+
+## Testing Plan
+
+- Run focused CLI tests.
+- Run the Dewey 210 scanner and verify two findings are removed from this branch.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. No data migration is required.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Continues the standards-remediation series after the agent typed-default wave.
+
+## Checklist
+
+- [x] Preserve valid commit and response output values.
+- [x] Add malformed-value regression coverage.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Normalize CLI typed defaults

## Overview

Resolve the final two Dewey 210 findings in the CLI base with explicit type-aware defaults.

## Motivation

PR policy summaries render commit SHAs as text, while workflow response projection merges output maps. Missing, nil,
false, or malformed values must fall back to the display sentinel and empty map without stringifying or merging invalid
data.

## Changes in Detail

- Normalize policy-response commit SHAs to strings or the em-dash sentinel.
- Normalize workflow response output to a map before projection.
- Add regression coverage for valid, absent, and malformed values.

## Testing Plan

- Run focused CLI tests.
- Run the Dewey 210 scanner and verify two findings are removed from this branch.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. No data migration is required.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Continues the standards-remediation series after the agent typed-default wave.

## Checklist

- [x] Preserve valid commit and response output values.
- [x] Add malformed-value regression coverage.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
