### PR TITLE
fix(core): normalize remaining typed defaults

### DIFF
--- a/components/dag-primitives/src/ai/miniforge/dag_primitives/result.clj
+++ b/components/dag-primitives/src/ai/miniforge/dag_primitives/result.clj
@@ -41,6 +41,12 @@
 ;;------------------------------------------------------------------------------ Layer 1
 ;; Extraction
 
+(defn- unwrap-error-message
+  "Return an error message when it is a string; otherwise return the canonical fallback."
+  [error]
+  (let [message (get error :message)]
+    (if (string? message) message "Unwrap called on error result")))
+
 (defn unwrap-anomaly
   "Extract data from a result. On ok, return the wrapped data; on err,
    return a canonical `:fault` anomaly carrying the error code, message,
@@ -54,7 +60,7 @@
     (:data result)
     (let [error (:error result)]
       (anomaly/anomaly :fault
-                       (or (:message error) "Unwrap called on error result")
+                       (unwrap-error-message error)
                        (cond-> {}
                          (:code error) (assoc :code (:code error))
                          (:data error) (assoc :error-data (:data error)))))))

--- a/components/dag-primitives/test/ai/miniforge/dag_primitives/unwrap_anomaly_failure_test.clj
+++ b/components/dag-primitives/test/ai/miniforge/dag_primitives/unwrap_anomaly_failure_test.clj
@@ -58,3 +58,11 @@
       (is (anomaly/anomaly? result))
       (is (string? (:anomaly/message result)))
       (is (seq (:anomaly/message result))))))
+
+(deftest unwrap-anomaly-normalizes-malformed-messages
+  (testing "nil, false, and non-string messages use the canonical fallback"
+    (doseq [message [nil false :not-text 42 []]
+            :let [result (dp/unwrap-anomaly
+                          {:ok? false :error {:code :unknown :message message}})]]
+      (is (= "Unwrap called on error result" (:anomaly/message result))
+          (str "normalized " (pr-str message))))))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/views/workflows.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/views/workflows.clj
@@ -192,7 +192,8 @@
    (when-let [dependency-issues (seq (:dependency-issues wf))]
      (c/badge (msg/t :workflow/dependency-issue-count
                      {:count (count dependency-issues)})
-              {:variant (or (:dependency-severity wf) :warning)}))
+              {:variant (let [severity (get wf :dependency-severity)]
+                          (if (keyword? severity) severity :warning))}))
    [:span.wf-phase (or (some-> (:phase wf) name) (msg/t :time/none))]
    [:div.wf-progress-inline
     [:div.wf-progress-track

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/views/workflows_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/views/workflows_test.clj
@@ -74,6 +74,12 @@
           result (render-str (sut/workflow-list-fragment [workflow]))]
       (is (str/includes? result "badge-error"))))
   (testing "absent and malformed severities use the warning badge"
+    (let [workflow {:id "wf-severity"
+                    :name "Severity"
+                    :status :running
+                    :dependency-issues [{}]}
+          result (render-str (sut/workflow-list-fragment [workflow]))]
+      (is (str/includes? result "badge-warning")))
     (doseq [severity [nil false "error" 42 []]
             :let [workflow {:id "wf-severity"
                             :name "Severity"

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/views/workflows_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/views/workflows_test.clj
@@ -63,3 +63,23 @@
                                            :dependency/status :degraded}]}]
           result (render-str (sut/workflow-list-fragment workflows))]
       (is (str/includes? result "1 dependency issue(s)")))))
+
+(deftest workflow-list-fragment-normalizes-dependency-severity
+  (testing "valid keyword severities are preserved"
+    (let [workflow {:id "wf-severity"
+                    :name "Severity"
+                    :status :running
+                    :dependency-severity :error
+                    :dependency-issues [{}]}
+          result (render-str (sut/workflow-list-fragment [workflow]))]
+      (is (str/includes? result "badge-error"))))
+  (testing "absent and malformed severities use the warning badge"
+    (doseq [severity [nil false "error" 42 []]
+            :let [workflow {:id "wf-severity"
+                            :name "Severity"
+                            :status :running
+                            :dependency-severity severity
+                            :dependency-issues [{}]}
+                  result (render-str (sut/workflow-list-fragment [workflow]))]]
+      (is (str/includes? result "badge-warning")
+          (str "normalized " (pr-str severity))))))

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -106,6 +106,12 @@
         (when (zero? exit) (str/trim out)))
       (catch Exception _ nil))))
 
+(defn- normalized-environment-metadata
+  "Return acquired environment metadata when it is a map; otherwise return an empty map."
+  [env]
+  (let [metadata (get env :metadata)]
+    (if (map? metadata) metadata {})))
+
 (defn build-env-record
   "Acquire environment from executor and build the result map.
 
@@ -121,7 +127,7 @@
       (let [env       (result-unwrap env-result)
             workdir   (:workdir env)
             base-sha  (read-head-sha workdir)
-            metadata  (cond-> (or (:metadata env) {})
+            metadata  (cond-> (normalized-environment-metadata env)
                         base-sha (assoc :base-sha base-sha))]
         {:executor             executor
          :environment-id       (:environment-id env)

--- a/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
@@ -88,6 +88,20 @@
           (is (= "main" (get-in record [:environment-metadata :base-branch]))
               "pre-existing metadata fields must survive the merge"))))))
 
+(deftest normalized-environment-metadata-is-always-a-map-test
+  (testing "valid metadata maps are preserved"
+    (is (= {:base-branch "main"}
+           (#'env/normalized-environment-metadata
+            {:metadata {:base-branch "main"}}))))
+  (testing "absent and malformed metadata becomes an empty map"
+    (doseq [env-value [{}
+                       {:metadata nil}
+                       {:metadata false}
+                       {:metadata :not-a-map}
+                       {:metadata 42}
+                       {:metadata []}]]
+      (is (= {} (#'env/normalized-environment-metadata env-value))))))
+
 (deftest build-env-record-omits-base-sha-when-no-git-test
   (testing "non-git worktree → :base-sha absent, no crash"
     (let [non-git-dir (str (System/getProperty "java.io.tmpdir") "/m1-no-git-"

--- a/docs/pull-requests/2026-07-20-fix-remaining-component-defaults-20260720.md
+++ b/docs/pull-requests/2026-07-20-fix-remaining-component-defaults-20260720.md
@@ -1,0 +1,45 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: Normalize remaining component defaults
+
+## Overview
+
+Resolve the final three component-layer Dewey 210 findings with explicit type-aware defaults.
+
+## Motivation
+
+Anomaly messages require strings, dashboard badge variants require keywords, and environment metadata requires a map.
+Missing, nil, false, or malformed values must consistently use the documented fallback for each contract.
+
+## Changes in Detail
+
+- Normalize DAG error messages to strings or the canonical unwrap fallback.
+- Normalize workflow dependency badge severity to a keyword or `:warning`.
+- Normalize acquired environment metadata to a map before adding the base SHA.
+- Add regression coverage for valid, absent, and malformed values.
+
+## Testing Plan
+
+- Run focused tests for dag-primitives, web-dashboard, and workflow.
+- Run the Dewey 210 scanner and verify three findings are removed from this branch.
+- Run `bb pre-commit`.
+
+## Deployment Plan
+
+Merge normally after CI and review. No data migration is required.
+
+## Related Issues/PRs
+
+- Base branch: `main`.
+- Depends on: none.
+- Final component-layer wave in the current standards-remediation series.
+
+## Checklist
+
+- [x] Preserve valid message, severity, and metadata values.
+- [x] Add malformed-value regression coverage.
+- [x] Pass focused scans and tests.
+- [ ] Pass CI and resolve review comments.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: Normalize remaining component defaults

## Overview

Resolve the final three component-layer Dewey 210 findings with explicit type-aware defaults.

## Motivation

Anomaly messages require strings, dashboard badge variants require keywords, and environment metadata requires a map.
Missing, nil, false, or malformed values must consistently use the documented fallback for each contract.

## Changes in Detail

- Normalize DAG error messages to strings or the canonical unwrap fallback.
- Normalize workflow dependency badge severity to a keyword or `:warning`.
- Normalize acquired environment metadata to a map before adding the base SHA.
- Add regression coverage for valid, absent, and malformed values.

## Testing Plan

- Run focused tests for dag-primitives, web-dashboard, and workflow.
- Run the Dewey 210 scanner and verify three findings are removed from this branch.
- Run `bb pre-commit`.

## Deployment Plan

Merge normally after CI and review. No data migration is required.

## Related Issues/PRs

- Base branch: `main`.
- Depends on: none.
- Final component-layer wave in the current standards-remediation series.

## Checklist

- [x] Preserve valid message, severity, and metadata values.
- [x] Add malformed-value regression coverage.
- [x] Pass focused scans and tests.
- [ ] Pass CI and resolve review comments.
