### PR TITLE
feat(llm): openai-compat honors an optional API key (OpenRouter et al.)

### DIFF
--- a/components/llm/resources/llm/backends.edn
+++ b/components/llm/resources/llm/backends.edn
@@ -82,13 +82,23 @@
  ;; :api-key is honored when supplied but never required. The endpoint
  ;; is the LM Studio default; override per client with :base-url or
  ;; via :base-url-env.
+ ;; Any OpenAI-compatible /v1/chat/completions endpoint: local keyless
+ ;; servers (LM Studio, llama.cpp, vLLM) AND keyed aggregators
+ ;; (OpenRouter, an OpenAI/Together key). :optional-api-key? true means a
+ ;; key is SENT when resolved (client :api-key, else the env var) but is
+ ;; NOT required — so a local keyless server and a keyed OpenRouter host
+ ;; both work through this one backend. For OpenRouter, set
+ ;; MINIFORGE_OPENAI_COMPAT_BASE_URL=https://openrouter.ai/api/v1/chat/completions
+ ;; and MINIFORGE_OPENAI_COMPAT_API_KEY=<key>.
  :openai-compat {:cmd "http"
                  :streaming? false
-                 :description "Any OpenAI-compatible server (LM Studio, llama.cpp, vLLM, ...)"
+                 :description "Any OpenAI-compatible server (LM Studio, llama.cpp, vLLM, OpenRouter, ...)"
                  :provider "OpenAI-Compatible"
                  :requires-cli? false
                  :api-endpoint "http://localhost:1234/v1/chat/completions"
                  :base-url-env "MINIFORGE_OPENAI_COMPAT_BASE_URL"
+                 :api-key-env "MINIFORGE_OPENAI_COMPAT_API_KEY"
+                 :optional-api-key? true
                  :probe-endpoint "http://localhost:1234/v1/models"}
 
  ;; Gemini's REST shape embeds the model in the URL path, so

--- a/components/llm/resources/llm/backends.edn
+++ b/components/llm/resources/llm/backends.edn
@@ -76,18 +76,14 @@
               :api-key-env "OPENAI_API_KEY"
               :probe-endpoint "https://api.openai.com/"}
 
- ;; Generic OpenAI-compatible server (LM Studio, llama.cpp server,
- ;; vLLM, and any other /v1/chat/completions endpoint). Local servers
- ;; are typically credential-free, so no :api-key-env — a client
- ;; :api-key is honored when supplied but never required. The endpoint
- ;; is the LM Studio default; override per client with :base-url or
- ;; via :base-url-env.
  ;; Any OpenAI-compatible /v1/chat/completions endpoint: local keyless
  ;; servers (LM Studio, llama.cpp, vLLM) AND keyed aggregators
- ;; (OpenRouter, an OpenAI/Together key). :optional-api-key? true means a
- ;; key is SENT when resolved (client :api-key, else the env var) but is
- ;; NOT required — so a local keyless server and a keyed OpenRouter host
- ;; both work through this one backend. For OpenRouter, set
+ ;; (OpenRouter, a hosted OpenAI/Together key). :optional-api-key? true
+ ;; means a key is SENT when resolved (client :api-key, else the env var)
+ ;; but is NOT required — so a local keyless server and a keyed OpenRouter
+ ;; host both work through this one backend, and the endpoint (LM Studio
+ ;; default) is overridable per client via :base-url or :base-url-env.
+ ;; For OpenRouter, set
  ;; MINIFORGE_OPENAI_COMPAT_BASE_URL=https://openrouter.ai/api/v1/chat/completions
  ;; and MINIFORGE_OPENAI_COMPAT_API_KEY=<key>.
  :openai-compat {:cmd "http"

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -927,9 +927,10 @@
                  "x-goog-api-key" api-key}
     {"Content-Type" "application/json"}))
 
-(defn- getenv-value
+(defn getenv-value
   "Indirection over `System/getenv` so env-dependent backend resolution
-   (api-key, base-url) is testable via `with-redefs`."
+   (api-key, base-url) is testable via `with-redefs` (kept public like
+   `http-post-request` for exactly that reason)."
   [k]
   (System/getenv k))
 

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -927,6 +927,12 @@
                  "x-goog-api-key" api-key}
     {"Content-Type" "application/json"}))
 
+(defn- getenv-value
+  "Indirection over `System/getenv` so env-dependent backend resolution
+   (api-key, base-url) is testable via `with-redefs`."
+  [k]
+  (System/getenv k))
+
 (defn- resolve-api-key
   "Resolve the API key for a direct provider backend: a non-blank
    `:api-key` in the client config wins; otherwise the backend's
@@ -938,7 +944,7 @@
    ever touching disk."
   [backend-config config]
   (or (some-> (:api-key config) str str/trim not-empty)
-      (some-> (:api-key-env backend-config) System/getenv str str/trim not-empty)))
+      (some-> (:api-key-env backend-config) getenv-value str str/trim not-empty)))
 
 (defn- resolve-base-url
   "The endpoint for the request. Only a backend that declares
@@ -949,7 +955,7 @@
   [backend-config config]
   (or (when (:base-url-env backend-config)
         (or (some-> (:base-url config) str str/trim not-empty)
-            (some-> (:base-url-env backend-config) System/getenv str str/trim
+            (some-> (:base-url-env backend-config) getenv-value str str/trim
                     not-empty)))
       (:api-endpoint backend-config)))
 
@@ -1065,7 +1071,9 @@
                  (msg/t :http-provider.system/unsupported-backend
                         {:provider provider}))
 
-      (and api-key-env (str/blank? (str api-key)))
+      (and api-key-env
+           (not (:optional-api-key? backend-config))
+           (str/blank? (str api-key)))
       (llm-error :anomalies/incorrect "missing_api_key"
                  (msg/t :http-provider.system/missing-api-key
                         {:provider provider :env-var api-key-env}))

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -277,6 +277,35 @@
       (is (= "missing_model" (get-in result [:error :type])))
       (is (nil? captured) "failed closed before the transport"))))
 
+(deftest openai-compat-api-key-is-optional-not-fail-closed-test
+  (testing "openai-compat declares :api-key-env but :optional-api-key? true, so
+            a missing key does NOT fail closed (a local keyless server works) —
+            unlike the cloud providers which do fail closed"
+    (let [{:keys [result captured]}
+          (capture-http (openai-200 "keyless ok")
+                        (fn []
+                          (llm/complete (llm/create-client {:backend :openai-compat
+                                                            :model "m"})
+                                        {:prompt "hi"})))]
+      (is (true? (:success result)) "no key -> still succeeds (keyless)")
+      (is (not (contains? (:headers captured) "Authorization"))
+          "no Authorization header when no key is resolved"))))
+
+(deftest openai-compat-resolves-api-key-from-env-test
+  (testing "with no client :api-key, the key resolves from the backend's
+            :api-key-env (the OpenRouter path) and becomes a bearer header"
+    (let [env-var (get (backend-config :openai-compat) :api-key-env)
+          {:keys [captured]}
+          (capture-http (openai-200 "keyed ok")
+                        (fn []
+                          (with-redefs [impl/getenv-value
+                                        (fn [k] (when (= k env-var) test-api-key))]
+                            (llm/complete (llm/create-client {:backend :openai-compat
+                                                              :model "m"})
+                                          {:prompt "hi"}))))]
+      (is (= (str "Bearer " test-api-key)
+             (get (:headers captured) "Authorization"))))))
+
 (deftest missing-api-key-test
   (let [result (impl/http-complete {:provider "Anthropic"
                                     :api-key-env missing-key-env

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -210,13 +210,16 @@
       (is (= {:input-tokens 11 :output-tokens 7} (:usage result))))))
 
 (deftest openai-compat-wiring-test
-  (testing "the generic backend rides the OpenAI wire shape, is
-            credential-free by default (no :api-key-env), and defaults to
+  (testing "the generic backend rides the OpenAI wire shape, carries an
+            OPTIONAL api key (so a key is sent when present but never
+            required — keyless local servers still work), and defaults to
             the LM Studio endpoint"
     (let [entry (backend-config :openai-compat)]
       (is (= "http" (:cmd entry)))
       (is (= "OpenAI-Compatible" (:provider entry)))
-      (is (nil? (:api-key-env entry)) "no env var -> never fails closed on a key")
+      (is (= "MINIFORGE_OPENAI_COMPAT_API_KEY" (:api-key-env entry)))
+      (is (true? (:optional-api-key? entry))
+          "optional -> declaring api-key-env must not fail closed on a missing key")
       (is (= "http://localhost:1234/v1/chat/completions" (:api-endpoint entry)))
       (is (= "MINIFORGE_OPENAI_COMPAT_BASE_URL" (:base-url-env entry)))
       (is (false? (:requires-cli? entry))))))

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -284,9 +284,10 @@
     (let [{:keys [result captured]}
           (capture-http (openai-200 "keyless ok")
                         (fn []
-                          (llm/complete (llm/create-client {:backend :openai-compat
-                                                            :model "m"})
-                                        {:prompt "hi"})))]
+                          (with-redefs [impl/getenv-value (constantly nil)]
+                            (llm/complete (llm/create-client {:backend :openai-compat
+                                                              :model "m"})
+                                          {:prompt "hi"}))))]
       (is (true? (:success result)) "no key -> still succeeds (keyless)")
       (is (not (contains? (:headers captured) "Authorization"))
           "no Authorization header when no key is resolved"))))

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -230,9 +230,10 @@
     (let [{:keys [result captured]}
           (capture-http (openai-200 "local answer")
                         (fn []
-                          (llm/complete (llm/create-client {:backend :openai-compat
-                                                            :model "qwen3-30b-a3b"})
-                                        {:prompt "hi"})))]
+                          (with-redefs [impl/getenv-value (constantly nil)]
+                            (llm/complete (llm/create-client {:backend :openai-compat
+                                                              :model "qwen3-30b-a3b"})
+                                          {:prompt "hi"}))))]
       (is (true? (:success result)))
       (is (= "local answer" (:content result)))
       (is (= "http://localhost:1234/v1/chat/completions" (:url captured)))


### PR DESCRIPTION
The `:openai-compat` backend served only keyless local servers (LM Studio, llama.cpp, vLLM). This adds optional API-key support so the same backend reaches keyed OpenAI-compatible aggregators — notably OpenRouter — without breaking keyless use.

Change:
- `:openai-compat` declares `:api-key-env MINIFORGE_OPENAI_COMPAT_API_KEY` + `:optional-api-key? true`.
- The http-complete fail-closed gate now keys off `:optional-api-key?` rather than `api-key-env` presence, so a resolved key (client `:api-key`, else the env var) is sent as a bearer header, while a missing key still succeeds for a local keyless server. Cloud providers (anthropic/openai/gemini-api) are unchanged — they still fail closed.
- Adds a `getenv-value` indirection so env-dependent resolution (api-key, base-url) is testable via `with-redefs`.

Why: agentic CLI wrappers (`codex exec`, `opencode run`) turn a structured completion prompt into a coding-agent task (workspace reads, todos) and can't produce a clean JSON classification — so they're unsuitable for the growth/structured reads. The direct `:openai-compat` completion path is the correct way to call an open or OpenAI-compatible model for those reads; this unblocks it for OpenRouter. Validated out-of-band: deepseek-v3.2 via OpenRouter `/v1/chat/completions` returns a clean, calibrated judgment payload.

Tests: openai-compat keyless (no fail-closed, no auth header), key-from-env (bearer header), plus the existing client-key/base-url/requires-model coverage. Full `clojure -M:poly test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AjtfaqZyuE64GmnMSNgjC