### PR TITLE
fix(workflow): one run, one identity — adopt the caller's run id

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -218,13 +218,31 @@
 
 ;------------------------------------------------------------------------------ Context operations
 
+(defn- opts-run-id
+  "Adopt the caller's run identity when opts carry one. The CLI announces a
+   run id and publishes lifecycle events under it BEFORE the pipeline
+   starts; minting a second UUID here forks the run's identity — in the
+   2026-07-21 dogfood the phase/agent events landed under the pipeline's
+   id, the lifecycle events under the CLI's, and the staleness watchdog
+   false-fired on the half without heartbeats. Accepts a uuid or a
+   uuid-shaped string; anything else returns nil (fresh uuid fallback), so
+   non-uuid session labels never break event routing."
+  [opts]
+  (let [wid (:workflow-id opts)]
+    (cond
+      (uuid? wid)   wid
+      (string? wid) (parse-uuid wid)
+      :else         nil)))
+
 (defn create-context
   "Create initial execution context.
 
    Arguments:
    - workflow: Workflow configuration
    - input: Input data for the workflow
-   - opts: Execution options (including :llm-backend, :artifact-store, callbacks)
+   - opts: Execution options (including :llm-backend, :artifact-store,
+           callbacks, and optionally :workflow-id — the caller's run id,
+           adopted as :execution/id so one run has one identity)
 
    Returns execution context map with FSM state initialized."
   [workflow input opts]
@@ -234,7 +252,7 @@
         checkpoint-root (checkpoint-store/resolve-checkpoint-root opts)]
     (sync-machine-projections
      (merge
-      {:execution/id (random-uuid)
+      {:execution/id (or (opts-run-id opts) (random-uuid))
        :execution/workflow workflow
        :execution/workflow-id (:workflow/id workflow)
        :execution/workflow-version (:workflow/version workflow)

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -277,6 +277,22 @@
    :workflow/pipeline [{:phase runner-test-plan}
                        {:phase runner-test-done}]})
 
+(deftest create-context-adopts-caller-run-id-test
+  (testing "one run, one identity: a :workflow-id in opts becomes
+            :execution/id (uuid or uuid-shaped string), so lifecycle events
+            published by the caller and phase/agent events published by the
+            pipeline land under the same id"
+    (let [wid (random-uuid)]
+      (is (= wid (:execution/id (ctx/create-context minimal-rollup-test-workflow
+                                                    {:task "T"} {:workflow-id wid}))))
+      (is (= wid (:execution/id (ctx/create-context minimal-rollup-test-workflow
+                                                    {:task "T"} {:workflow-id (str wid)}))))))
+  (testing "a non-uuid session label never breaks event routing — fresh uuid"
+    (let [adopted (:execution/id (ctx/create-context minimal-rollup-test-workflow
+                                                     {:task "T"}
+                                                     {:workflow-id "session-label"}))]
+      (is (uuid? adopted)))))
+
 (deftest apply-dag-success-rolls-dag-metrics-into-execution-test
   (testing "DAG sub-workflow tokens/cost/duration roll into :execution/metrics on success"
     ;; `apply-phase-transition` ignores its `pipeline` arg (see _pipeline in


### PR DESCRIPTION
## Summary

Found by the 2026-07-21 dogfood run (`phase-stream-idle` spec). One run produced events under TWO workflow ids: the CLI's announced id carried only 4 lifecycle events (`current-phase :unknown`), while the pipeline's self-minted `:execution/id` carried the 35 phase/agent/heartbeat events — and the staleness watchdog false-fired 31 attention warnings on the id without heartbeats. The console starves because the run's identity is forked at `create-context`, which ignored the `:workflow-id` the CLI already threads through opts.

`create-context` now adopts opts `:workflow-id` (uuid or uuid-shaped string) as `:execution/id`. Non-uuid session labels fall back to a fresh uuid so event routing never breaks. Side effect worth noting: checkpoints become keyed by the announced run id, which is what `resume <workflow-id>` looks up.

## Test plan

- New `create-context-adopts-caller-run-id-test`: uuid adopted, uuid-string parsed and adopted, non-uuid label falls back to a fresh uuid.
- `runner-extended-test` + `build-initial-context-test`: 41 tests / 79 assertions green.
- E2E validation comes from the dogfood re-run tracked in the session (single event directory expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)