### PR TITLE
fix(agent): inline-utilization cap — shed bodies well before window fit

### DIFF
--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -41,6 +41,14 @@
  ;; <200k so the shed didn't fire, but actual input hit 215k and overflowed.
  :prompt/context-window-reserve-tokens 50000
 
+ ;; Ceiling on eagerly-inlined file bodies as a fraction of the effective
+ ;; window. Window-FIT is not enough: 2026-07-21 dogfood sent a 148,803-token
+ ;; planner prompt that "fit" a 150k effective window by 0.8% — the turn could
+ ;; not finish inside the 600s phase timeout and the phase was killed mid-turn.
+ ;; Above this fraction the bodies shed to a manifest (still reachable via
+ ;; context_read), keeping prompts small enough to complete a turn.
+ :prompt/max-inline-window-fraction 0.5
+
  ;; Submission-retry runs after the main planner turn already produced
  ;; useful prose but failed to land the plan as `.miniforge/plan.edn`.
  ;; Caps and turn budget are tight on purpose: the only legitimate work

--- a/components/agent/src/ai/miniforge/agent/context_budget.clj
+++ b/components/agent/src/ai/miniforge/agent/context_budget.clj
@@ -79,10 +79,13 @@
         ;; treated as 0 — never crash prompt assembly, and never let a
         ;; negative value INFLATE the effective window above the real one
         ;; (which would wave genuinely overflowing prompts through).
+        ;; Extreme-but-numeric values (BigInt > Long/MAX) saturate at a
+        ;; ceiling far above any window instead of throwing on the cast;
+        ;; the window/2 clamp below governs the actual effect either way.
         sane-reserve (if (and (number? reserve)
                               (Double/isFinite (double reserve))
                               (not (neg? (double reserve))))
-                       (long reserve)
+                       (long (min (double reserve) 1e15))
                        0)
         eff-reserve (when window (min sane-reserve (quot window 2)))
         clamped?    (boolean (and window (> sane-reserve eff-reserve)))

--- a/components/agent/src/ai/miniforge/agent/context_budget.clj
+++ b/components/agent/src/ai/miniforge/agent/context_budget.clj
@@ -78,7 +78,8 @@
         eff-reserve (when window (min reserve (quot window 2)))
         clamped?    (boolean (and window (> reserve eff-reserve)))
         effective   (when window (- window eff-reserve))
-        inline-cap  (when effective (long (* effective max-inline-fraction)))
+        inline-fraction (-> max-inline-fraction (max 0.0) (min 1.0))
+        inline-cap  (when effective (long (* effective inline-fraction)))
         est         (fn [user] (:estimated-input-tokens
                                 (llm/prompt-size-telemetry effective-system user)))
         full        (build-full)

--- a/components/agent/src/ai/miniforge/agent/context_budget.clj
+++ b/components/agent/src/ai/miniforge/agent/context_budget.clj
@@ -78,7 +78,10 @@
         eff-reserve (when window (min reserve (quot window 2)))
         clamped?    (boolean (and window (> reserve eff-reserve)))
         effective   (when window (- window eff-reserve))
-        inline-fraction (-> max-inline-fraction (max 0.0) (min 1.0))
+        inline-fraction (if (and (number? max-inline-fraction)
+                                 (Double/isFinite (double max-inline-fraction)))
+                          (-> (double max-inline-fraction) (max 0.0) (min 1.0))
+                          1.0)
         inline-cap  (when effective (long (* effective inline-fraction)))
         est         (fn [user] (:estimated-input-tokens
                                 (llm/prompt-size-telemetry effective-system user)))

--- a/components/agent/src/ai/miniforge/agent/context_budget.clj
+++ b/components/agent/src/ai/miniforge/agent/context_budget.clj
@@ -59,28 +59,40 @@
    - `:shed-count` — number of sheddable units (e.g. inlined file bodies).
      Zero means nothing to shed, so an over-budget prompt is irreducibly
      over.
+   - `:max-inline-fraction` — ceiling on the eagerly-inlined form as a
+     fraction of the effective window (default 1.0 = shed only on window
+     overflow). Window-FIT alone is a trap: the 2026-07-21 dogfood sent a
+     planner prompt at 99.2% of the effective window — it fit, and the turn
+     could not complete inside the phase timeout. Roles that inline large
+     bodies should cap well below 1.0; the shed keeps the bodies reachable
+     via `context_read`, so shedding early costs a fetch, not information.
 
    Returns {:user-prompt :shed? :over-after-shed? :window :reserve
-            :effective-window :reserve-clamped? :est-full :est-final
-            :file-count}; `:over-after-shed?` marks an irreducible overflow."
-  [{:keys [effective-system model reserve build-full build-shed shed-count]}]
+            :effective-window :reserve-clamped? :inline-cap :est-full
+            :est-final :file-count}; `:over-after-shed?` marks an
+   irreducible overflow of the WINDOW (not of the inline cap)."
+  [{:keys [effective-system model reserve build-full build-shed shed-count
+           max-inline-fraction]
+    :or   {max-inline-fraction 1.0}}]
   (let [window      (llm/context-window-for-model-id model)
         eff-reserve (when window (min reserve (quot window 2)))
         clamped?    (boolean (and window (> reserve eff-reserve)))
         effective   (when window (- window eff-reserve))
+        inline-cap  (when effective (long (* effective max-inline-fraction)))
         est         (fn [user] (:estimated-input-tokens
                                 (llm/prompt-size-telemetry effective-system user)))
         full        (build-full)
         est-full    (est full)
         base        {:window window :reserve reserve :effective-window effective
-                     :reserve-clamped? clamped?
+                     :reserve-clamped? clamped? :inline-cap inline-cap
                      :est-full est-full :file-count shed-count}]
     (cond
-      (or (nil? effective) (< est-full effective))
+      (or (nil? effective) (< est-full inline-cap))
       (merge base {:user-prompt full :shed? false :over-after-shed? false :est-final est-full})
 
-      (zero? shed-count)                 ; nothing left to shed — irreducibly over
-      (merge base {:user-prompt full :shed? false :over-after-shed? true :est-final est-full})
+      (zero? shed-count)                 ; nothing to shed — over only if past the window
+      (merge base {:user-prompt full :shed? false
+                   :over-after-shed? (>= est-full effective) :est-final est-full})
 
       :else
       (let [shed     (build-shed)

--- a/components/agent/src/ai/miniforge/agent/context_budget.clj
+++ b/components/agent/src/ai/miniforge/agent/context_budget.clj
@@ -75,8 +75,17 @@
            max-inline-fraction]
     :or   {max-inline-fraction 1.0}}]
   (let [window      (llm/context-window-for-model-id model)
-        eff-reserve (when window (min reserve (quot window 2)))
-        clamped?    (boolean (and window (> reserve eff-reserve)))
+        ;; A misconfigured reserve (nil, non-numeric, NaN/Inf, negative) is
+        ;; treated as 0 — never crash prompt assembly, and never let a
+        ;; negative value INFLATE the effective window above the real one
+        ;; (which would wave genuinely overflowing prompts through).
+        sane-reserve (if (and (number? reserve)
+                              (Double/isFinite (double reserve))
+                              (not (neg? (double reserve))))
+                       (long reserve)
+                       0)
+        eff-reserve (when window (min sane-reserve (quot window 2)))
+        clamped?    (boolean (and window (> sane-reserve eff-reserve)))
         effective   (when window (- window eff-reserve))
         inline-fraction (if (and (number? max-inline-fraction)
                                  (Double/isFinite (double max-inline-fraction)))
@@ -87,7 +96,7 @@
                                 (llm/prompt-size-telemetry effective-system user)))
         full        (build-full)
         est-full    (est full)
-        base        {:window window :reserve reserve :effective-window effective
+        base        {:window window :reserve sane-reserve :effective-window effective
                      :reserve-clamped? clamped? :inline-cap inline-cap
                      :est-full est-full :file-count shed-count}]
     (cond

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -203,13 +203,18 @@
    make every prompt look over-budget; `:reserve-clamped?` flags that.
 
    Thin role wrapper over `context-budget/assemble-within-budget`: supplies
-   the planner's full/shed prompt builders and its sheddable-unit count
-   (the eagerly-inlined existing files)."
+   the planner's full/shed prompt builders, its sheddable-unit count
+   (the eagerly-inlined existing files), and the planner's inline cap
+   (`:prompt/max-inline-window-fraction`) — bodies shed to a manifest well
+   before window fit, so a barely-fitting prompt can't stall a turn past
+   the phase timeout."
   [spec-text existing-files effective-system model reserve]
   (context-budget/assemble-within-budget
    {:effective-system effective-system
     :model            model
     :reserve          reserve
+    :max-inline-fraction (get @planner-prompt-data
+                              :prompt/max-inline-window-fraction 0.5)
     :build-full       #(build-user-prompt spec-text existing-files)
     :build-shed       #(build-user-prompt spec-text existing-files
                                           format-existing-files-manifest)
@@ -235,6 +240,7 @@
                     :prompt/reserve (:reserve budget)
                     :prompt/reserve-clamped? (:reserve-clamped? budget)
                     :prompt/effective-window (:effective-window budget)
+                    :prompt/inline-cap (:inline-cap budget)
                     :prompt/shed? (:shed? budget)
                     :prompt/estimated-after-shed (:est-final budget)
                     :prompt/file-count (:file-count budget))))

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -185,14 +185,16 @@
 
 (defn- assemble-within-budget
   "Assemble the planner user-prompt within the model's context window
-   (N12 §5). If the prompt would overflow, shed the eagerly-inlined file
-   bodies down to a manifest (paths only) — the bodies stay reachable via
-   the context MCP cache (seeded separately in invoke-planner-session), so
-   the agent keeps a query surface, and the section's already-satisfied
-   evidence-bundle instructions are preserved. Returns
+   (N12 §5). If the prompt reaches the configured inline cap or overflows
+   the window, shed the eagerly-inlined file bodies down to a manifest
+   (paths only) — the bodies stay reachable via the context MCP cache
+   (seeded separately in invoke-planner-session), so the agent keeps a query
+   surface, and the section's already-satisfied evidence-bundle instructions
+   are preserved. Returns
    {:user-prompt :shed? :over-after-shed? :window :reserve :effective-window
-    :est-full :est-final :file-count}; :over-after-shed? marks an
-    irreducible overflow.
+    :reserve-clamped? :inline-cap :est-full :est-final :file-count};
+   :over-after-shed? marks an irreducible WINDOW overflow, not merely an
+   inline-cap crossing.
 
    `reserve` is headroom kept below the real window: the estimate covers
    only miniforge's assembled prompt, while the agent CLI adds its own
@@ -214,7 +216,7 @@
     :model            model
     :reserve          reserve
     :max-inline-fraction (get @planner-prompt-data
-                              :prompt/max-inline-window-fraction 0.5)
+                              :prompt/max-inline-window-fraction 1.0)
     :build-full       #(build-user-prompt spec-text existing-files)
     :build-shed       #(build-user-prompt spec-text existing-files
                                           format-existing-files-manifest)

--- a/components/agent/test/ai/miniforge/agent/context_budget_test.clj
+++ b/components/agent/test/ai/miniforge/agent/context_budget_test.clj
@@ -156,5 +156,15 @@
       (is (false? (:shed? r)) "a trivial prompt still fits")
       (is (false? (:over-after-shed? r)))))
 
+  (testing "an invalid reserve (nil, non-numeric, NaN/Inf, negative) is
+            treated as 0 — no crash, and a negative value can never INFLATE
+            the effective window above the real one"
+    (doseq [invalid [nil "50000" ##NaN ##Inf ##-Inf -5000]]
+      (let [r (assemble {:model "codellama-34b" :reserve invalid})]
+        (is (= (:window r) (:effective-window r)) (pr-str invalid))
+        (is (= 0 (:reserve r)) (pr-str invalid))
+        (is (false? (:reserve-clamped? r)) (pr-str invalid))
+        (is (false? (:shed? r)) (pr-str invalid)))))
+
   (testing ":file-count echoes the supplied shed-count"
     (is (= 7 (:file-count (assemble {:model "codellama-34b" :shed-count 7}))))))

--- a/components/agent/test/ai/miniforge/agent/context_budget_test.clj
+++ b/components/agent/test/ai/miniforge/agent/context_budget_test.clj
@@ -82,16 +82,25 @@
   (testing "max-inline-fraction sheds a prompt that FITS the window but exceeds
             the cap — window fit alone stalls turns past the phase timeout
             (2026-07-21 dogfood: 99.2%-of-window prompt, killed at 600s)"
-    ;; window 16384, reserve 0 → cap 0.5 ⇒ inline-cap 8192.
-    ;; ~40000 chars ≈ 10000 est tokens: under the window, over the cap.
+    ;; ~40000 chars ≈ 10000 est tokens: under the window, over its 0.5 cap.
     (let [mid (apply str (repeat 40000 \x))
           r (assemble {:model "codellama-34b"
                        :max-inline-fraction 0.5
                        :build-full (constantly mid)
                        :build-shed (constantly "manifest")})]
-      (is (= 8192 (:inline-cap r)))
+      (is (= (long (* 0.5 (:effective-window r))) (:inline-cap r)))
       (is (true? (:shed? r)))
       (is (false? (:over-after-shed? r)) "under the window — not an overflow")
+      (is (= "manifest" (:user-prompt r)))))
+
+  (testing "max-inline-fraction is clamped so bad config cannot exceed the window"
+    (let [big (apply str (repeat 300000 \x))
+          r (assemble {:model "codellama-34b"
+                       :max-inline-fraction 2.0
+                       :build-full (constantly big)
+                       :build-shed (constantly "manifest")})]
+      (is (= (:effective-window r) (:inline-cap r)))
+      (is (true? (:shed? r)))
       (is (= "manifest" (:user-prompt r)))))
 
   (testing "a prompt under the cap stays fully inlined"

--- a/components/agent/test/ai/miniforge/agent/context_budget_test.clj
+++ b/components/agent/test/ai/miniforge/agent/context_budget_test.clj
@@ -79,6 +79,40 @@
       (is (true? (:shed? r)))
       (is (true? (:over-after-shed? r)))))
 
+  (testing "max-inline-fraction sheds a prompt that FITS the window but exceeds
+            the cap — window fit alone stalls turns past the phase timeout
+            (2026-07-21 dogfood: 99.2%-of-window prompt, killed at 600s)"
+    ;; window 16384, reserve 0 → cap 0.5 ⇒ inline-cap 8192.
+    ;; ~40000 chars ≈ 10000 est tokens: under the window, over the cap.
+    (let [mid (apply str (repeat 40000 \x))
+          r (assemble {:model "codellama-34b"
+                       :max-inline-fraction 0.5
+                       :build-full (constantly mid)
+                       :build-shed (constantly "manifest")})]
+      (is (= 8192 (:inline-cap r)))
+      (is (true? (:shed? r)))
+      (is (false? (:over-after-shed? r)) "under the window — not an overflow")
+      (is (= "manifest" (:user-prompt r)))))
+
+  (testing "a prompt under the cap stays fully inlined"
+    (let [small (apply str (repeat 20000 \x))    ; ≈5000 est tokens < 8192 cap
+          r (assemble {:model "codellama-34b"
+                       :max-inline-fraction 0.5
+                       :build-full (constantly small)})]
+      (is (false? (:shed? r)))
+      (is (= small (:user-prompt r)))))
+
+  (testing "over the cap with nothing to shed is sent as-is and is NOT an
+            irreducible overflow — that word is reserved for the window"
+    (let [mid (apply str (repeat 40000 \x))
+          r (assemble {:model "codellama-34b"
+                       :max-inline-fraction 0.5
+                       :build-full (constantly mid)
+                       :shed-count 0})]
+      (is (false? (:shed? r)))
+      (is (false? (:over-after-shed? r)))
+      (is (= mid (:user-prompt r)))))
+
   (testing "the reserve drops the effective window and fires the shed earlier"
     (let [content    (apply str (repeat 50000 \x))
           no-reserve (assemble {:model "codellama-34b"

--- a/components/agent/test/ai/miniforge/agent/context_budget_test.clj
+++ b/components/agent/test/ai/miniforge/agent/context_budget_test.clj
@@ -166,5 +166,13 @@
         (is (false? (:reserve-clamped? r)) (pr-str invalid))
         (is (false? (:shed? r)) (pr-str invalid)))))
 
+  (testing "an extreme-but-numeric reserve (BigInt > Long/MAX) saturates
+            instead of throwing on the long cast; the window/2 clamp governs"
+    (let [r (assemble {:model "codellama-34b"
+                       :reserve (*' 2 Long/MAX_VALUE)})]
+      (is (true? (:reserve-clamped? r)))
+      (is (pos? (:effective-window r)))
+      (is (false? (:shed? r)))))
+
   (testing ":file-count echoes the supplied shed-count"
     (is (= 7 (:file-count (assemble {:model "codellama-34b" :shed-count 7}))))))

--- a/components/agent/test/ai/miniforge/agent/context_budget_test.clj
+++ b/components/agent/test/ai/miniforge/agent/context_budget_test.clj
@@ -103,6 +103,13 @@
       (is (true? (:shed? r)))
       (is (= "manifest" (:user-prompt r)))))
 
+  (testing "invalid inline fractions fall back to the full effective window"
+    (doseq [invalid ["half" ##NaN ##Inf ##-Inf]]
+      (let [r (assemble {:model "codellama-34b"
+                         :max-inline-fraction invalid})]
+        (is (= (:effective-window r) (:inline-cap r)) (pr-str invalid))
+        (is (false? (:shed? r)) (pr-str invalid)))))
+
   (testing "a prompt under the cap stays fully inlined"
     (let [small (apply str (repeat 20000 \x))    ; ≈5000 est tokens < 8192 cap
           r (assemble {:model "codellama-34b"

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -720,6 +720,17 @@
       (is (false? (:shed? r)))
       (is (str/includes? (:user-prompt r) "big.clj"))))
 
+  (testing "an older prompt resource without an inline cap preserves window-fit behavior"
+    (let [prompt-data @(var-get #'planner/planner-prompt-data)]
+      (with-redefs-fn
+        {#'planner/planner-prompt-data
+         (delay (dissoc prompt-data :prompt/max-inline-window-fraction))}
+        #(let [r (assemble-within-budget "do the thing" [(big-file 40000)]
+                                         "system" "codellama-34b" 0)]
+           (is (< (:est-full r) (:effective-window r)))
+           (is (= (:effective-window r) (:inline-cap r)))
+           (is (false? (:shed? r)))))))
+
   (testing "files that blow the window shed to a manifest: bodies drop, the
             path + context_read hint stay, and the prompt now fits"
     ;; ~300k chars of file content >> 16384 tokens; spec+system alone fits

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -737,21 +737,23 @@
       ;; ...and keeps the already-satisfied evidence-bundle instructions
       (is (str/includes? (:user-prompt r) ":already-satisfied"))))
 
-  (testing "the reserve fires the shed earlier: a prompt that fits the full
-            window sheds once the reserve drops the effective window below it"
-    ;; This is the 2026-06-07 fix — reserve headroom for the unmeasured CLI
-    ;; baseline. Derive the reserve from the actual estimate so the test
-    ;; doesn't hard-code window/template sizes.
-    (let [files      [(big-file 50000)]
+  (testing "the reserve fires the shed earlier: a prompt under the inline cap
+            sheds once the reserve shrinks the effective window (and with it
+            the cap) below the estimate"
+    ;; 2026-06-07 fix — reserve headroom for the unmeasured CLI baseline.
+    ;; Sizes derive from the returned window/estimate so the test doesn't
+    ;; hard-code template sizes. The planner's 0.5 inline cap applies, so
+    ;; the shed threshold is half the effective window.
+    (let [files      [(big-file 20000)]
           no-reserve (assemble-within-budget "do it" files "system" "codellama-34b" 0)
           window     (:window no-reserve)
           est        (:est-full no-reserve)
-          ;; a reserve that drops the effective window just below the estimate
-          ;; (kept under window/2 so it isn't clamped)
-          reserve    (+ (- window est) 1000)
+          ;; drop the effective window until the cap (0.5 × effective) sits
+          ;; just below the estimate, kept under window/2 so it isn't clamped
+          reserve    (+ (- window (* 2 est)) 1000)
           reserved   (assemble-within-budget "do it" files "system" "codellama-34b" reserve)]
-      (is (false? (:shed? no-reserve)) "fits the full window with no reserve")
-      (is (true? (:shed? reserved)) "reserve pushes it past the effective window")
+      (is (false? (:shed? no-reserve)) "under the inline cap with no reserve")
+      (is (true? (:shed? reserved)) "reserve shrinks the cap below the estimate")
       (is (false? (:reserve-clamped? reserved)))
       (is (= (- window reserve) (:effective-window reserved)))))
 


### PR DESCRIPTION
## Summary

Found by the 2026-07-21 dogfood run. The planner sent a 148,803-token prompt (25 fully-inlined in-scope files) against a 150,000-token effective window: it "fit" by 0.8%, the turn could not complete inside the 600s phase timeout, and the phase was killed mid-turn — no artifact, gate fail, workflow dead, the whole thing misclassified as `:unknown-failure` at $0.00 attributed cost. The framework's own `:agent/prompt-size` event recorded `shed? false` at 99.2% utilization.

Window-fit is the wrong shed threshold. `assemble-within-budget` gains `:max-inline-fraction` (default 1.0 = existing behavior): above that fraction of the effective window, inlined bodies shed to the manifest — which stays reachable via `context_read`, so shedding early costs a fetch, not information. The planner wires 0.5 from `:prompt/max-inline-window-fraction`; `:prompt/inline-cap` joins the prompt-size telemetry. A capped prompt with nothing to shed is sent as-is; `:over-after-shed?` still means window overflow only.

Reviewer keeps the 1.0 default for now — shedding the artifact-under-review changes review semantics and deserves its own evidence (the 2026-06-06 reviewer stream-idle-on-big-prompts finding points the same direction).

## Test plan

- New context-budget tests: over-cap-under-window sheds (not an overflow), under-cap stays inlined, over-cap with nothing to shed sends as-is without the irreducible-overflow flag.
- Planner reserve test updated for cap semantics (thresholds derived, not hard-coded).
- 20 tests / 147 assertions green across context-budget and planner namespaces.
- E2E validation from the dogfood re-run tracked in the session (expected: shed to manifest, plan completes inside the phase budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)