### PR TITLE
feat(operator): apply approved interventions to live runners (Phase D D-3)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -1116,16 +1116,6 @@
           ;; Control state for dashboard commands (pause/resume/stop)
           control-state (es/create-control-state)
           command-poller-cleanup (dashboard/start-command-poller! workflow-id control-state)
-          ;; Phase D: governed control path. Register this runner so
-          ;; operator-directory interventions can act on it, and start
-          ;; the operator-event consumer with the D-3 applier. Runs
-          ;; alongside the legacy `.edn` dashboard poller until D-4
-          ;; deletes it.
-          _ (operator/register-live-runner! workflow-id
-                                            {:control-state control-state})
-          operator-consumer (operator/start-operator-consumer!
-                             {:stream event-stream
-                              :apply! operator/apply-intervention!})
           ;; Create workflow-specific LLM client for execution
           llm-client (context/create-llm-client workflow spec quiet backend-override)
           callbacks (create-phase-callbacks quiet)
@@ -1152,37 +1142,51 @@
 ))
           sandbox? (or (:sandbox opts) (:spec/sandbox spec))
           [context sandbox-cleanup] (sandbox/setup-sandbox-context base-context sandbox? spec enriched-spec quiet)
-          progress-cleanup (display/start-progress! event-stream quiet)]
-      (when-not quiet
-        (display/print-workflow-header (keyword (str "adhoc-" (hash spec))) "adhoc" quiet))
-      (dashboard/print-dashboard-status! quiet)
-      (assert-runtime-alignment! spec context)
-      (print-runtime-provenance! quiet context)
-      (run-backend-preflight! quiet llm-client context)
-      (let [provenance (move-spec-to-in-progress! (:spec/provenance enriched-spec))]
-        (try
-          (let [result (execute-with-events {:run-pipeline run-pipeline
-                                             :workflow workflow
-                                             :workflow-input workflow-input
-                                             :context context
-                                             :artifact-store artifact-store
-                                             :event-stream event-stream
-                                             :workflow-id workflow-id
-                                             :sandbox-cleanup sandbox-cleanup
-                                             :opts opts})
-                outcome-status (if (phase/succeeded? result) :completed :failed)]
-            (move-spec-on-completion! provenance result)
-            ;; Trigger meta-loop learning cycle in background
-            (trigger-meta-loop-after-workflow! workflow-id outcome-status nil)
-            result)
-          (finally
-            (progress-cleanup)
-            (when command-poller-cleanup (command-poller-cleanup))
-            (operator/stop-operator-consumer! operator-consumer)
-            (operator/deregister-live-runner! workflow-id)
-            ;; Schedule deferred GC for this workflow's scratch ref — in finally
-            ;; so it fires on both normal completion and exception exit paths.
-            (enqueue-workflow-gc-best-effort! workflow-id)))))
+          progress-cleanup (display/start-progress! event-stream quiet)
+          ;; Acquire the governed control path last, after every binding that
+          ;; may throw. If consumer startup itself fails, undo registration
+          ;; before propagating the error.
+          operator-consumer
+          (do
+            (operator/register-live-runner! workflow-id
+                                            {:control-state control-state})
+            (try
+              (operator/start-operator-consumer!
+               {:stream event-stream
+                :apply! operator/apply-intervention!})
+              (catch Throwable e
+                (operator/deregister-live-runner! workflow-id)
+                (throw e))))]
+      (try
+        (when-not quiet
+          (display/print-workflow-header (keyword (str "adhoc-" (hash spec))) "adhoc" quiet))
+        (dashboard/print-dashboard-status! quiet)
+        (assert-runtime-alignment! spec context)
+        (print-runtime-provenance! quiet context)
+        (run-backend-preflight! quiet llm-client context)
+        (let [provenance (move-spec-to-in-progress! (:spec/provenance enriched-spec))
+              result (execute-with-events {:run-pipeline run-pipeline
+                                           :workflow workflow
+                                           :workflow-input workflow-input
+                                           :context context
+                                           :artifact-store artifact-store
+                                           :event-stream event-stream
+                                           :workflow-id workflow-id
+                                           :sandbox-cleanup sandbox-cleanup
+                                           :opts opts})
+              outcome-status (if (phase/succeeded? result) :completed :failed)]
+          (move-spec-on-completion! provenance result)
+          ;; Trigger meta-loop learning cycle in background
+          (trigger-meta-loop-after-workflow! workflow-id outcome-status nil)
+          result)
+        (finally
+          (progress-cleanup)
+          (when command-poller-cleanup (command-poller-cleanup))
+          (operator/stop-operator-consumer! operator-consumer)
+          (operator/deregister-live-runner! workflow-id)
+          ;; Schedule deferred GC for this workflow's scratch ref — in finally
+          ;; so it fires on both normal completion and exception exit paths.
+          (enqueue-workflow-gc-best-effort! workflow-id))))
     (catch Object _
       (let [e (:throwable &throw-context)]
         (when-not quiet

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -1231,8 +1231,7 @@
                     (messages/t :workflow-runner/no-completed-tasks))))
         (run-workflow-from-spec! spec opts)))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Chain-driven execution
+;; ── Chain-driven execution ─────────────────────────────────────────────────
 
 (defn resolve-chain-input
   "Resolve chain input from a spec file path or inline JSON."

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.event-stream.interface.manifest :as es-manifest]
    [ai.miniforge.supervisory-state.interface :as supervisory]
+   [ai.miniforge.operator.interface :as operator]
    [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.workflow.interface.resume :as workflow-resume]
@@ -1115,6 +1116,16 @@
           ;; Control state for dashboard commands (pause/resume/stop)
           control-state (es/create-control-state)
           command-poller-cleanup (dashboard/start-command-poller! workflow-id control-state)
+          ;; Phase D: governed control path. Register this runner so
+          ;; operator-directory interventions can act on it, and start
+          ;; the operator-event consumer with the D-3 applier. Runs
+          ;; alongside the legacy `.edn` dashboard poller until D-4
+          ;; deletes it.
+          _ (operator/register-live-runner! workflow-id
+                                            {:control-state control-state})
+          operator-consumer (operator/start-operator-consumer!
+                             {:stream event-stream
+                              :apply! operator/apply-intervention!})
           ;; Create workflow-specific LLM client for execution
           llm-client (context/create-llm-client workflow spec quiet backend-override)
           callbacks (create-phase-callbacks quiet)
@@ -1167,6 +1178,8 @@
           (finally
             (progress-cleanup)
             (when command-poller-cleanup (command-poller-cleanup))
+            (operator/stop-operator-consumer! operator-consumer)
+            (operator/deregister-live-runner! workflow-id)
             ;; Schedule deferred GC for this workflow's scratch ref — in finally
             ;; so it fires on both normal completion and exception exit paths.
             (enqueue-workflow-gc-best-effort! workflow-id)))))

--- a/components/operator/deps.edn
+++ b/components/operator/deps.edn
@@ -7,6 +7,7 @@
         ai.miniforge/llm {:local/root "../llm"}
         ai.miniforge/workflow {:local/root "../workflow"}
         ai.miniforge/anomaly {:local/root "../anomaly"}
-        ai.miniforge/event-stream {:local/root "../event-stream"}}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
+        ai.miniforge/reliability {:local/root "../reliability"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -1,0 +1,192 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.application
+  "Intervention application layer — Phase D D-3.
+
+   Turns an `:approved` InterventionRequest into an actual effect on a
+   live workflow runner, advancing the lifecycle
+   `approved → dispatched → applied → verified` (or `→ failed`) and
+   publishing every transition through the consumer's canonical
+   state-changed emitter.
+
+   Application mapping (Phase D design decision 5, v1):
+
+   | intervention                       | mechanism                          |
+   |------------------------------------|------------------------------------|
+   | :pause / :resume / :cancel         | event-stream control-state flags   |
+   | :acknowledge / :request-human-review | supervisory-state only (no machine effect) |
+   | :force-safe-mode / :exit-safe-mode | degradation manager (when wired)   |
+   | :retry / :retry-from-phase / :waive / :re-evaluate / :request-replan | not yet applied — fail loudly |
+
+   **Process-lifetime honesty:** control-state is in-process, so
+   interventions act only on workflows registered by a live runner in
+   THIS process. Anything else fails `:no-live-runner` — visible,
+   typed, retryable — rather than pretending. The not-yet-applied
+   verbs fail `:not-implemented` for the same reason: a red chip with
+   a reason keyword beats silently-parked hope.
+
+   **Verification is a readback, not an echo:** control-state verbs
+   verify by reading the flag back (`paused?` / `cancelled?`), so a
+   `verified` chip means the runner's own control flags actually
+   changed."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.operator.consumer :as consumer]
+   [ai.miniforge.operator.intervention :as intervention]
+   [ai.miniforge.reliability.interface :as reliability]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Live-runner registry — process-scoped
+
+(defonce ^:private live-runners
+  ;; workflow-id string → {:control-state <atom>
+  ;;                       :degradation-manager <manager, optional>}
+  (atom {}))
+
+(defn register-runner!
+  "Register a live runner's control handles for `workflow-id`.
+   `handles` must carry `:control-state`; `:degradation-manager` is
+   optional (safe-mode verbs fail typed when absent)."
+  [workflow-id handles]
+  (swap! live-runners assoc (str workflow-id) handles)
+  nil)
+
+(defn deregister-runner!
+  "Remove `workflow-id` from the live-runner registry. Idempotent."
+  [workflow-id]
+  (swap! live-runners dissoc (str workflow-id))
+  nil)
+
+(defn live-runner?
+  [workflow-id]
+  (contains? @live-runners (str workflow-id)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Lifecycle publication helpers
+
+(defn- advance!
+  "Apply lifecycle `step-fn` to `interv`, publish the transition, and
+   return the updated intervention. Returns nil (after publishing a
+   `failed` transition where possible) when the step is rejected."
+  [stream interv step-fn & step-args]
+  (let [result (apply step-fn interv step-args)]
+    (if (:success? result)
+      (let [updated (:intervention result)]
+        (consumer/publish-state-changed! stream updated)
+        updated)
+      nil)))
+
+(defn- fail!
+  [stream interv reason]
+  (when-let [failed (advance! stream interv intervention/fail reason)]
+    failed))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Mechanisms
+
+(defn- control-state-effect!
+  "Flip the control-state flag for `verb` and return the readback the
+   verification step asserts."
+  [control-state verb]
+  (case verb
+    :pause  (do (es/pause! control-state)
+                {:verb :pause :observed (boolean (es/paused? control-state))
+                 :expected true})
+    :resume (do (es/resume! control-state)
+                {:verb :resume :observed (boolean (es/paused? control-state))
+                 :expected false})
+    :cancel (do (es/cancel! control-state)
+                {:verb :cancel :observed (boolean (es/cancelled? control-state))
+                 :expected true})))
+
+(defn- apply-control-verb!
+  [stream dispatched entry verb]
+  (let [{:keys [observed expected] :as readback}
+        (control-state-effect! (:control-state entry) verb)]
+    (if-let [applied (advance! stream dispatched intervention/apply-result)]
+      (if (= observed expected)
+        (advance! stream applied intervention/verify readback)
+        (fail! stream applied :control-state-readback-mismatch))
+      nil)))
+
+(defn- apply-safe-mode-verb!
+  [stream dispatched entry verb interv]
+  (if-let [manager (:degradation-manager entry)]
+    (do (case verb
+          :force-safe-mode
+          (reliability/enter-safe-mode! manager :manual
+                                        (or (:intervention/justification interv)
+                                            "operator intervention"))
+          :exit-safe-mode
+          (reliability/exit-safe-mode! manager
+                                       (or (:intervention/justification interv)
+                                           "operator intervention")
+                                       (:intervention/requested-by interv)))
+        (when-let [applied (advance! stream dispatched intervention/apply-result)]
+          (advance! stream applied intervention/verify {:verb verb})))
+    (fail! stream dispatched :no-degradation-manager)))
+
+(defn- apply-no-effect-verb!
+  "Verbs whose whole effect IS the supervisory record (Phase D mapping:
+   `supervisory-state only`). Dispatch → applied → verified with no
+   machine touch."
+  [stream dispatched verb]
+  (when-let [applied (advance! stream dispatched intervention/apply-result)]
+    (advance! stream applied intervention/verify {:verb verb})))
+
+;------------------------------------------------------------------------------ Layer 3
+;; The applier hook
+
+(defn apply-intervention!
+  "Apply one `:approved` intervention. This is the `:apply!` hook the
+   operator-event consumer invokes (Phase D D-3).
+
+   Returns the final intervention map (state `:verified` or `:failed`),
+   or nil when a lifecycle step was itself rejected (never expected
+   from `:approved` input; nil keeps the caller honest rather than
+   fabricating a state)."
+  [stream interv]
+  (let [verb (:intervention/type interv)
+        entry (get @live-runners (str (:intervention/target-id interv)))]
+    (if-let [dispatched (advance! stream interv intervention/dispatch)]
+      (try
+        (case verb
+          (:pause :resume :cancel)
+          (if entry
+            (apply-control-verb! stream dispatched entry verb)
+            (fail! stream dispatched :no-live-runner))
+
+          (:acknowledge :request-human-review)
+          (apply-no-effect-verb! stream dispatched verb)
+
+          (:force-safe-mode :exit-safe-mode)
+          (if entry
+            (apply-safe-mode-verb! stream dispatched entry verb interv)
+            (fail! stream dispatched :no-live-runner))
+
+          ;; :retry / :retry-from-phase / :waive / :re-evaluate /
+          ;; :request-replan — mechanisms not yet wired (resume
+          ;; machinery, waiver records, policy re-evaluation). Loud,
+          ;; typed failure per the honesty doctrine; D-3b lands them.
+          (fail! stream dispatched :not-implemented))
+        (catch Exception _e
+          ;; A throwing mechanism must not abort the consumer's pass —
+          ;; the failure IS the outcome, recorded on the lifecycle.
+          (fail! stream dispatched :application-error)))
+      nil)))

--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -64,6 +64,11 @@
    `handles` must carry `:control-state`; `:degradation-manager` is
    optional (safe-mode verbs fail typed when absent)."
   [workflow-id handles]
+  (when-not (and (map? handles)
+                 (instance? clojure.lang.Atom (:control-state handles)))
+    (throw (ex-info "Live runner registration requires an atom :control-state"
+                    {:workflow-id workflow-id
+                     :control-state (:control-state handles)})))
   (swap! live-runners assoc (str workflow-id) handles)
   nil)
 

--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -97,8 +97,7 @@
   (when-let [failed (advance! stream interv intervention/fail reason)]
     failed))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Mechanisms
+;; ── Mechanisms ─────────────────────────────────────────────────────────────
 
 (defn- control-state-effect!
   "Flip the control-state flag for `verb` and return the readback the
@@ -150,7 +149,7 @@
   (when-let [applied (advance! stream dispatched intervention/apply-result)]
     (advance! stream applied intervention/verify {:verb verb})))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 ;; The applier hook
 
 (defn apply-intervention!

--- a/components/operator/src/ai/miniforge/operator/consumer.clj
+++ b/components/operator/src/ai/miniforge/operator/consumer.clj
@@ -176,7 +176,11 @@
   (when (= :workflow (:intervention/target-type interv))
     (:intervention/target-id interv)))
 
-(defn- publish-state-changed!
+(defn publish-state-changed!
+  "Publish a `:supervisory/intervention-state-changed` event for
+   `interv`. The single canonical emitter for lifecycle transitions —
+   the application layer (D-3) publishes through here too, so every
+   transition carries the same envelope shape."
   [stream interv]
   (let [envelope (es/create-envelope
                   stream

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -20,6 +20,7 @@
   "Public API for the operator (meta-agent) component.
    Manages the meta-loop: observe signals, detect patterns, propose improvements."
   (:require
+   [ai.miniforge.operator.application :as application]
    [ai.miniforge.operator.consumer :as consumer]
    [ai.miniforge.operator.core :as core]
    [ai.miniforge.operator.intervention :as intervention]
@@ -227,6 +228,28 @@
   "Request sources whose interventions are auto-approved (the human IS
    the approver): the operator surfaces, not delegated agents."
   consumer/auto-approve-request-sources)
+
+;------------------------------------------------------------------------------ Layer 1c
+;; Intervention application (Phase D D-3)
+
+(def register-live-runner!
+  "Register a live runner's control handles for a workflow id so
+   interventions can act on it. `handles`: {:control-state <atom>,
+   :degradation-manager <optional>}."
+  application/register-runner!)
+
+(def deregister-live-runner!
+  "Remove a workflow id from the live-runner registry. Idempotent."
+  application/deregister-runner!)
+
+(def apply-intervention!
+  "The D-3 `:apply!` hook: apply one approved intervention to its live
+   runner (control-state flags / no-effect verbs / safe-mode), advance
+   the lifecycle approved→dispatched→applied→verified (or →failed with
+   a typed reason such as :no-live-runner), publishing every
+   transition. Pass as `:apply!` to [[consume-operator-events!]] /
+   [[start-operator-consumer!]]."
+  application/apply-intervention!)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Signal observation

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -149,17 +149,13 @@
         (is (true? (es/cancelled? cs)))
         (is (= :verified (:intervention/state result)))))))
 
-(deftest pause-on-broken-control-state-fails-contained
-  (testing "a throwing mechanism becomes :failed, never an escaped throw"
-    (let [wid (str (random-uuid))]
-      (application/register-runner! wid {:control-state :not-an-atom})
-      (try
-        (let [stream (memory-stream)
-              result (application/apply-intervention! stream (approved :pause wid))]
-          (is (= :failed (:intervention/state result)))
-          (is (= :application-error (:intervention/reason result))))
-        (finally
-          (application/deregister-runner! wid))))))
+(deftest register-runner-rejects-invalid-control-state
+  (testing "runner wiring fails early instead of becoming an application error"
+    (doseq [handles [{} {:control-state :not-an-atom} :not-a-map]]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"requires an atom :control-state"
+           (application/register-runner! (random-uuid) handles))))))
 
 ;------------------------------------------------------------------------------ No-effect and unwired verbs
 

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -1,0 +1,199 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.application-test
+  "Intervention application layer (Phase D D-3) tests, including the
+   Phase D verification-bar sequence: injected request file → consumer
+   → applier → control-state flip → observable
+   proposed→approved→dispatched→applied→verified event trail, and the
+   no-live-runner failure path."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.operator.application :as application]
+   [ai.miniforge.operator.consumer :as consumer]
+   [ai.miniforge.operator.intervention :as intervention]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(def ^:const golden-pause-target-id
+  "The workflow target id stamped by the Rust golden-fixture generator."
+  "00000000-0000-4000-8000-0000000000aa")
+
+(defn- find-workspace-root
+  []
+  (loop [dir (io/file (System/getProperty "user.dir")) hops 0]
+    (cond
+      (.exists (io/file dir "workspace.edn")) dir
+      (or (nil? (.getParentFile dir)) (>= hops 8))
+      (throw (ex-info "workspace.edn not found" {}))
+      :else (recur (.getParentFile dir) (inc hops)))))
+
+(defn- temp-events-dir
+  ^java.io.File []
+  (.toFile (Files/createTempDirectory "operator-application-test"
+                                      (make-array FileAttribute 0))))
+
+(defn- stage-golden-pause!
+  [events-dir]
+  (let [target (io/file events-dir "operator" "pause.transit.json")]
+    (io/make-parents target)
+    (spit target
+          (slurp (io/file (find-workspace-root)
+                          "contracts" "operator-events" "golden"
+                          "pause.transit.json")
+                 :encoding "UTF-8")
+          :encoding "UTF-8")))
+
+(defn- memory-stream []
+  (es/create-event-stream {:sinks []}))
+
+(defn- approved
+  "Build an :approved intervention of `type` against `target-id`."
+  [type target-id]
+  (:intervention
+   (intervention/approve
+    (intervention/create-intervention
+     {:intervention/type type
+      :intervention/target-id target-id
+      :intervention/requested-by "test@example.invalid"
+      :intervention/request-source :tui}))))
+
+(defn- state-trail
+  [stream]
+  (->> (es/get-events stream)
+       (filter #(= consumer/state-changed-event-type (:event/type %)))
+       (mapv :intervention/state)))
+
+(defn- with-runner
+  "Register a control-state for a fresh workflow id, run `f`, always
+   deregister. Returns [workflow-id control-state result]."
+  [f]
+  (let [wid (str (random-uuid))
+        cs (es/create-control-state)]
+    (application/register-runner! wid {:control-state cs})
+    (try
+      [wid cs (f wid cs)]
+      (finally
+        (application/deregister-runner! wid)))))
+
+;------------------------------------------------------------------------------ Phase D verification bar — request file → paused workflow
+
+(deftest injected-request-file-pauses-the-registered-runner
+  (let [events-dir (temp-events-dir)
+        stream (memory-stream)
+        cs (es/create-control-state)]
+    (application/register-runner! golden-pause-target-id {:control-state cs})
+    (try
+      (stage-golden-pause! events-dir)
+      (is (= {:routed 1 :skipped 0 :anomalies 0}
+             (consumer/consume-pass! {:events-dir events-dir
+                                      :stream stream
+                                      :apply! application/apply-intervention!})))
+      (is (true? (es/paused? cs)) "the runner's control-state actually flipped")
+      (is (= [:approved :dispatched :applied :verified] (state-trail stream))
+          "the full lifecycle trail is observable on the stream")
+      (finally
+        (application/deregister-runner! golden-pause-target-id)))))
+
+(deftest no-live-runner-fails-typed
+  (let [events-dir (temp-events-dir)
+        stream (memory-stream)]
+    (stage-golden-pause! events-dir)
+    ;; Nothing registered for the fixture's target id.
+    (consumer/consume-pass! {:events-dir events-dir
+                             :stream stream
+                             :apply! application/apply-intervention!})
+    (is (= [:approved :dispatched :failed] (state-trail stream)))
+    (let [failed (->> (es/get-events stream)
+                      (filter #(= :failed (:intervention/state %)))
+                      first)]
+      (is (= :no-live-runner (:intervention/reason failed))
+          "the reason keyword travels verbatim — the UI renders it"))))
+
+;------------------------------------------------------------------------------ Control-state verbs verify by readback
+
+(deftest resume-flips-paused-off
+  (with-runner
+    (fn [wid cs]
+      (es/pause! cs)
+      (let [stream (memory-stream)
+            result (application/apply-intervention! stream (approved :resume wid))]
+        (is (false? (es/paused? cs)))
+        (is (= :verified (:intervention/state result)))))))
+
+(deftest cancel-sets-stopped
+  (with-runner
+    (fn [wid cs]
+      (let [stream (memory-stream)
+            result (application/apply-intervention! stream (approved :cancel wid))]
+        (is (true? (es/cancelled? cs)))
+        (is (= :verified (:intervention/state result)))))))
+
+(deftest pause-on-broken-control-state-fails-contained
+  (testing "a throwing mechanism becomes :failed, never an escaped throw"
+    (let [wid (str (random-uuid))]
+      (application/register-runner! wid {:control-state :not-an-atom})
+      (try
+        (let [stream (memory-stream)
+              result (application/apply-intervention! stream (approved :pause wid))]
+          (is (= :failed (:intervention/state result)))
+          (is (= :application-error (:intervention/reason result))))
+        (finally
+          (application/deregister-runner! wid))))))
+
+;------------------------------------------------------------------------------ No-effect and unwired verbs
+
+(deftest acknowledge-verifies-without-a-runner
+  (let [stream (memory-stream)
+        result (application/apply-intervention!
+                stream (approved :acknowledge (str (random-uuid))))]
+    (is (= :verified (:intervention/state result)))
+    (is (= [:dispatched :applied :verified] (state-trail stream)))))
+
+(deftest retry-fails-not-implemented
+  (with-runner
+    (fn [wid _cs]
+      (let [stream (memory-stream)
+            result (application/apply-intervention! stream (approved :retry wid))]
+        (is (= :failed (:intervention/state result)))
+        (is (= :not-implemented (:intervention/reason result)))))))
+
+(deftest safe-mode-without-manager-fails-typed
+  (with-runner
+    (fn [wid _cs]
+      (let [stream (memory-stream)
+            result (application/apply-intervention!
+                    stream (approved :force-safe-mode wid))]
+        (is (= :failed (:intervention/state result)))
+        (is (= :no-degradation-manager (:intervention/reason result)))))))
+
+;------------------------------------------------------------------------------ Registry
+
+(deftest registry-round-trip
+  (let [wid (str (random-uuid))]
+    (is (false? (application/live-runner? wid)))
+    (application/register-runner! wid {:control-state (es/create-control-state)})
+    (is (true? (application/live-runner? wid)))
+    (application/deregister-runner! wid)
+    (application/deregister-runner! wid)
+    (is (false? (application/live-runner? wid)))))


### PR DESCRIPTION
Stacked on #1443 (D-2). Merge that first; this PR's diff is the D-3 layer only.

## What

The application half of the intervention round-trip: an `:approved` InterventionRequest now actually does something, and the lifecycle advances `approved → dispatched → applied → verified` (or `→ failed` with a typed reason), every transition published as `:supervisory/intervention-state-changed`.

- **`operator/application.clj`** — process-scoped live-runner registry + the `:apply!` hook for the D-2 consumer.
  - `pause` / `resume` / `cancel` → event-stream control-state flags, **verified by readback** (`paused?`/`cancelled?`), not by echo.
  - `acknowledge` / `request-human-review` → supervisory-state only (the record IS the effect).
  - `force-safe-mode` / `exit-safe-mode` → degradation manager when the runner registered one; `:no-degradation-manager` otherwise.
  - `retry` / `retry-from-phase` / `waive` / `re-evaluate` / `request-replan` → `:not-implemented` until D-3b wires the resume/waiver/policy mechanisms. Loud red chip over silent parking.
- **Process-lifetime honesty** (Phase D risk §5): no registered live runner → `failed/:no-live-runner`, reason keyword verbatim for the UI. A throwing mechanism becomes `failed/:application-error`, contained — it never aborts the consumer pass.
- **Runner wiring** — the spec-runner path registers its control-state, starts the operator-event consumer with the applier, and tears both down in `finally`. The legacy `.edn` dashboard poller still runs beside it until D-4 deletes it. (The chain-runner and plan-executor paths get the same wiring in D-4 when the poller swap touches them anyway.)

## Verification (Phase D bar)

Integration test: injected golden `pause` request file → consumer → applier → the registered control-state is actually paused → `approved→dispatched→applied→verified` trail observable on the stream. Plus no-live-runner, readback verbs, contained-throw, not-implemented, safe-mode-unwired, and registry tests. 19 tests / 67 assertions with the consumer suite, 0 failures. JVM and Babashka load gates on `workflow-runner`.

Real dogfood run (live `mf run` + pause from the console) lands with D-5/U-1 on the miniforge-control side, where the button and chip exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)