### PR TITLE
fix(pr-train): emit governed PR events supervisory-state can materialize

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -76,6 +76,7 @@
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.mcp-context-server.interface :as mcp-context-server]
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.repo-dag.interface :as repo-dag]
@@ -111,9 +112,12 @@
     (str caught)))
 
 (defn- create-pr-train-manager
-  []
+  "Build the PR-train manager bound to `event-stream` so train
+   mutations (add-pr, complete-merge) publish governed events that
+   supervisory-state materializes for the consoles."
+  [event-stream]
   (try+
-    (pr-train/create-manager)
+    (pr-train/create-manager {:event-stream event-stream})
     (catch Object e
       (println (messages/t :web/pr-train-warning
                            {:error (caught-message e (:throwable &throw-context))}))
@@ -136,7 +140,8 @@
                      'start!)]
     (fn [{:keys [port]}]
       (let [event-stream (es/create-event-stream)
-            pr-train-manager (create-pr-train-manager)
+            _ (supervisory/ensure-attached! event-stream)
+            pr-train-manager (create-pr-train-manager event-stream)
             repo-dag-manager (create-repo-dag-manager)]
         (start! {:port port
                  :event-stream event-stream

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -118,13 +118,17 @@
   "Build the PR-train manager bound to `event-stream` so train
    mutations (add-pr, complete-merge) publish governed events that
    supervisory-state materializes for the consoles."
-  [event-stream]
-  (try+
-    (pr-train/create-manager {:event-stream event-stream})
-    (catch Object e
-      (println (messages/t :web/pr-train-warning
-                           {:error (caught-message e (:throwable &throw-context))}))
-      nil)))
+  ([]
+   (create-pr-train-manager nil))
+  ([event-stream]
+   (try+
+     (if event-stream
+       (pr-train/create-manager {:event-stream event-stream})
+       (pr-train/create-manager))
+     (catch Object e
+       (println (messages/t :web/pr-train-warning
+                            {:error (caught-message e (:throwable &throw-context))}))
+       nil))))
 
 (defn- create-repo-dag-manager
   []

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -85,6 +85,9 @@
    [ai.miniforge.lsp-mcp-bridge.tasks :as lsp-tasks]
    [slingshot.slingshot :refer [try+]]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Composition seams (optional web/TUI providers) and pure helpers
+
 (defn- optional-composition-var
   "Resolve a provider whose entire component is optional for this CLI product.
    This is the CLI's only late-binding boundary: miniforge-core loads this
@@ -179,8 +182,7 @@
    'ai.miniforge.tui-views.interface/start-fleet-tui!
    start-fleet-tui!))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Constants and pure helpers
+;; ── Constants and pure helpers ──────────────────────────────────────────────
 
 (def version-info
   {:name (app-config/binary-name)

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -347,9 +347,9 @@
 (def PRCreated
   "Schema for pr/created event.
 
-   Emitted when a workflow creates a PR that should appear in the
-   supervisory PR fleet. `:workflow/id` is the owning workflow run, which
-   lets downstream consumers correlate the PR back to the run/spec dossier."
+   Emitted when a workflow or operator-owned PR train creates a PR that
+   should appear in the supervisory PR fleet. `:workflow/id` is the owning
+   workflow run when one exists, and nil for operator-scoped train entries."
   (with-identity
    [:map
       [:event/type [:= :pr/created]]
@@ -357,7 +357,7 @@
     [:event/timestamp inst?]
     [:event/version string?]
     [:event/sequence-number int?]
-    [:workflow/id uuid?]
+    [:workflow/id [:maybe uuid?]]
     [:pr/repo string?]
     [:pr/number int?]
     [:pr/url string?]

--- a/components/event-stream/test/ai/miniforge/event_stream/new_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/new_events_test.clj
@@ -50,6 +50,15 @@
 (def ^:private zero-heartbeat-gap-ms 0)
 (def ^:private zero-heartbeat-event-count 0)
 
+(deftest operator-scoped-pr-created-allows-nil-workflow
+  (let [event (assoc (es/create-envelope (stream) :pr/created nil "PR joined train")
+                     :pr/repo "acme/repo"
+                     :pr/number 7
+                     :pr/url "https://example.test/pull/7"
+                     :pr/branch "feature")]
+    (is (nil? (:workflow/id event)))
+    (is (m/validate schema/PRCreated event))))
+
 ;------------------------------------------------------------------------------ :agent/tool-call-started
 
 (deftest agent-tool-call-started-event-type

--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -155,6 +155,23 @@
                         (update :train/prs conj pr)
                         state/recompute-train-state)]
         (swap! trains assoc train-id updated)
+        ;; Announce the PR on the governed stream so supervisory-state
+        ;; materializes an entity BEFORE any merge/close event needs to
+        ;; update it — the consoles' Train surface renders from these.
+        (when event-stream
+          (try
+            (es/publish! event-stream
+                         (assoc (es/create-envelope
+                                 event-stream :pr/created nil
+                                 (str "PR #" pr-number " joined train"))
+                                :pr/repo repo
+                                :pr/number pr-number
+                                :pr/url url
+                                :pr/branch branch
+                                :pr/title title
+                                :pr/merge-order merge-order
+                                :train/id train-id))
+            (catch Exception _ nil)))
         updated)))
 
   (remove-pr [_this train-id pr-number]
@@ -252,15 +269,22 @@
       (when-let [updated (state/transition-pr-status train pr-number :merged)]
         (let [final (-> updated
                         state/recompute-train-state
-                        state/auto-transition-train)]
+                        state/auto-transition-train)
+              pr (state/find-pr train pr-number)]
           (swap! trains assoc train-id final)
+          ;; Enveloped (event id + sequence + timestamp) and keyed with
+          ;; :pr/repo — supervisory-state's pr-key needs repo+number, so
+          ;; the previous bare {:event/type :pr/merged :pr/number n} map
+          ;; could never update an entity.
           (when event-stream
             (try
               (es/publish! event-stream
-                           {:event/type :pr/merged
-                            :pr/number pr-number
-                            :train/id train-id
-                            :timestamp (java.util.Date.)})
+                           (assoc (es/create-envelope
+                                   event-stream :pr/merged nil
+                                   (str "PR #" pr-number " merged"))
+                                  :pr/repo (:pr/repo pr)
+                                  :pr/number pr-number
+                                  :train/id train-id))
               (catch Exception _ nil)))
           final))))
 

--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -409,8 +409,7 @@
   ([opts]
    (->InMemoryPRTrainManager (atom {}) (atom {}) (:event-stream opts))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Utility functions for working with trains
+;; ── Utility functions for working with trains ───────────────────────────────
 
 (defn list-trains
   "List all trains in a manager.

--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -158,20 +158,21 @@
         ;; Announce the PR on the governed stream so supervisory-state
         ;; materializes an entity BEFORE any merge/close event needs to
         ;; update it — the consoles' Train surface renders from these.
+        ;; No try/catch: the stream already isolates sink/subscriber
+        ;; failures internally; swallowing here would make emission
+        ;; failures silent.
         (when event-stream
-          (try
-            (es/publish! event-stream
-                         (assoc (es/create-envelope
-                                 event-stream :pr/created nil
-                                 (str "PR #" pr-number " joined train"))
-                                :pr/repo repo
-                                :pr/number pr-number
-                                :pr/url url
-                                :pr/branch branch
-                                :pr/title title
-                                :pr/merge-order merge-order
-                                :train/id train-id))
-            (catch Exception _ nil)))
+          (es/publish! event-stream
+                       (assoc (es/create-envelope
+                               event-stream :pr/created nil
+                               (str "PR #" pr-number " joined train"))
+                              :pr/repo repo
+                              :pr/number pr-number
+                              :pr/url url
+                              :pr/branch branch
+                              :pr/title title
+                              :pr/merge-order merge-order
+                              :train/id train-id)))
         updated)))
 
   (remove-pr [_this train-id pr-number]
@@ -275,17 +276,17 @@
           ;; Enveloped (event id + sequence + timestamp) and keyed with
           ;; :pr/repo — supervisory-state's pr-key needs repo+number, so
           ;; the previous bare {:event/type :pr/merged :pr/number n} map
-          ;; could never update an entity.
+          ;; could never update an entity. No try/catch: the stream
+          ;; isolates sink/subscriber failures internally; swallowing
+          ;; here would make a failed :pr/merged emission silent.
           (when event-stream
-            (try
-              (es/publish! event-stream
-                           (assoc (es/create-envelope
-                                   event-stream :pr/merged nil
-                                   (str "PR #" pr-number " merged"))
-                                  :pr/repo (:pr/repo pr)
-                                  :pr/number pr-number
-                                  :train/id train-id))
-              (catch Exception _ nil)))
+            (es/publish! event-stream
+                         (assoc (es/create-envelope
+                                 event-stream :pr/merged nil
+                                 (str "PR #" pr-number " merged"))
+                                :pr/repo (:pr/repo pr)
+                                :pr/number pr-number
+                                :train/id train-id)))
           final))))
 
   (fail-merge [_this train-id pr-number _reason]

--- a/components/pr-train/test/ai/miniforge/pr_train/event_stream_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/event_stream_test.clj
@@ -25,7 +25,10 @@
 
 (deftest complete-merge-emits-pr-merged-event
   (testing "complete-merge publishes :pr/merged event to event-stream"
-    ;; Use a real event-stream (no with-redefs — safe under pmap)
+    ;; Real event-stream (no with-redefs — safe under pmap), sinkless:
+    ;; the default file sink writes into the operator's REAL
+    ;; ~/.miniforge/events directory, which polluted it with test
+    ;; events every suite run.
     (let [stream (es/create-event-stream {:sinks []})
           captured (atom [])
           mgr (train/create-manager {:event-stream stream})]
@@ -56,13 +59,36 @@
           (is (some? result) "complete-merge should return updated train")
           (is (= :merged (:pr/status (train/get-pr-from-train mgr train-id 42))))
 
-          ;; Verify event was published
+          ;; Verify event was published, enveloped, and keyed: the
+          ;; supervisory accumulator's pr-key needs repo+number, and a
+          ;; proper envelope gives the event identity + timestamp.
           (is (= 1 (count @captured)) "exactly one :pr/merged event should be published")
           (let [event (first @captured)]
             (is (= :pr/merged (:event/type event)))
+            (is (= "acme/repo" (:pr/repo event)))
             (is (= 42 (:pr/number event)))
             (is (= train-id (:train/id event)))
-            (is (inst? (:timestamp event)))))))))
+            (is (uuid? (:event/id event)))
+            (is (inst? (:event/timestamp event)))))))))
+
+(deftest add-pr-emits-pr-created-event
+  (testing "add-pr announces the PR so an entity exists before merge"
+    (let [stream (es/create-event-stream {:sinks []})
+          captured (atom [])
+          mgr (train/create-manager {:event-stream stream})]
+      (es/subscribe! stream :test-subscriber
+                     (fn [event] (swap! captured conj event))
+                     (fn [event] (= :pr/created (:event/type event))))
+      (let [train-id (train/create-train mgr "Created Test" (random-uuid) nil)]
+        (train/add-pr mgr train-id "acme/repo" 7 "url" "branch" "PR 7")
+        (is (= 1 (count @captured)))
+        (let [event (first @captured)]
+          (is (= "acme/repo" (:pr/repo event)))
+          (is (= 7 (:pr/number event)))
+          (is (= "PR 7" (:pr/title event)))
+          (is (= 1 (:pr/merge-order event)))
+          (is (= train-id (:train/id event)))
+          (is (uuid? (:event/id event))))))))
 
 (deftest complete-merge-without-event-stream
   (testing "complete-merge works normally when no event-stream is configured"

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -255,7 +255,9 @@
       spec-id (assoc-in [:specs spec-id] entity))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; WorkflowRun handlers
+;; Entity handlers — one section per family
+
+;; ── WorkflowRun handlers ───────────────────────────────────────────────────
 
 (defn workflow-started
   [table {:workflow/keys [id] :as event}]
@@ -399,8 +401,7 @@
       (-> (ensure-workflow workflow-id ts)
           (assoc-in [:workflows workflow-id :workflow-run/updated-at] ts)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; AgentSession handlers
+;; ── AgentSession handlers ──────────────────────────────────────────────────
 
 (defn cp-agent-registered
   [table {:cp/keys [agent-id vendor agent-name external-id capabilities] :as event}]
@@ -452,8 +453,7 @@
                  {:agent/status         (coarse-agent-status type)
                   :agent/last-heartbeat ts}))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; PrFleetEntry handlers
+;; ── PrFleetEntry handlers ──────────────────────────────────────────────────
 
 (defn- pr-key
   [event]
@@ -567,8 +567,7 @@
                    (assoc :pr/workflow-run-id workflow-id))]
     (assoc-in table [:prs k] scored)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; TaskNode handlers (N5-δ3 §2.3, §3.3)
+;; ── TaskNode handlers (N5-δ3 §2.3, §3.3) ───────────────────────────────────
 
 (def task-kanban-mapping-resource
   "Classpath location of the EDN mapping from :task/status to the closed
@@ -651,8 +650,7 @@
     (cond-> table
       task-id (assoc-in [:tasks task-id] merged))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; PolicyEvaluation handlers
+;; ── PolicyEvaluation handlers ──────────────────────────────────────────────
 
 (defn- normalize-violation
   [v]
@@ -690,8 +688,7 @@
   (let [eval (policy-evaluation event false)]
     (assoc-in table [:policy-evals (:policy-eval/id eval)] eval)))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Snapshot-event handlers — applied during startup replay.
+;; ── Snapshot-event handlers — applied during startup replay ────────────────
 ;; A `:supervisory/*-upserted` event carries the canonical entity in
 ;; :supervisory/entity; we trust it as the baseline state.
 
@@ -737,8 +734,7 @@
     (cond-> table
       entity (assoc-in [:tasks (:task/id entity)] entity))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; DecisionCard handlers (N5-δ3 §2.4, §3.4)
+;; ── DecisionCard handlers (N5-δ3 §2.4, §3.4) ───────────────────────────────
 
 (defn cp-decision-created
   "Handler for `:control-plane/decision-created` — creates a pending
@@ -800,8 +796,7 @@
     (cond-> table
       entity (assoc-in [:decisions (:decision/id entity)] entity))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; InterventionRequest handlers
+;; ── InterventionRequest handlers ───────────────────────────────────────────
 
 (defn- intervention-stub
   [event]
@@ -960,7 +955,7 @@
     (cond-> table
       updated (assoc-in [:dependencies dependency-id] updated))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 ;; Dispatch table — events not listed are no-ops at the entity-state level
 
 (def handlers

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -477,16 +477,35 @@
               (cond-> pr-state
                 workflow-id (assoc :pr/workflow-run-id workflow-id)))))
 
+(defn- pr-stub
+  "Minimal schema-complete PR entity, used when a lifecycle event is
+   observed before `:pr/created` (same rationale as [[pr-scored]]'s
+   stub: never lose an observed status because the create event was
+   missed — a later create/upsert fills the richer fields via merge)."
+  [{:pr/keys [repo number]}]
+  {:pr/repo       (or repo "")
+   :pr/number     (or number 0)
+   :pr/url        ""
+   :pr/branch     ""
+   :pr/title      ""
+   :pr/status     :open
+   :pr/merge-order 0
+   :pr/depends-on []
+   :pr/blocks     []
+   :pr/ci-status  :pending})
+
 (defn pr-merged
   [table event]
   (let [k (pr-key event)
         ts (event-instant event)
         workflow-id (:workflow/id event)]
     (cond-> table
-      (get-in table [:prs k])
+      ;; Both key halves must be present: a repo-less event (the
+      ;; pre-envelope bare-map shape) must not mint a [nil n] entity.
+      (and (:pr/repo event) (:pr/number event))
       (update-in [:prs k]
                  (fn [pr]
-                   (cond-> (merge pr
+                   (cond-> (merge (or pr (pr-stub event))
                                   {:pr/status :merged
                                    :pr/merged-at ts})
                      (and workflow-id (nil? (:pr/workflow-run-id pr)))
@@ -497,10 +516,10 @@
   (let [k (pr-key event)
         workflow-id (:workflow/id event)]
     (cond-> table
-      (get-in table [:prs k])
+      (and (:pr/repo event) (:pr/number event))
       (update-in [:prs k]
                  (fn [pr]
-                   (cond-> (assoc pr :pr/status :closed)
+                   (cond-> (assoc (or pr (pr-stub event)) :pr/status :closed)
                      (and workflow-id (nil? (:pr/workflow-run-id pr)))
                      (assoc :pr/workflow-run-id workflow-id)))))))
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -483,8 +483,8 @@
    stub: never lose an observed status because the create event was
    missed — a later create/upsert fills the richer fields via merge)."
   [{:pr/keys [repo number]}]
-  {:pr/repo       (or repo "")
-   :pr/number     (or number 0)
+  {:pr/repo       repo
+   :pr/number     number
    :pr/url        ""
    :pr/branch     ""
    :pr/title      ""

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -494,15 +494,25 @@
    :pr/blocks     []
    :pr/ci-status  :pending})
 
+(defn- pr-lifecycle-keyable?
+  "True when the event carries a usable [repo number] entity key: a
+   NON-BLANK repo (the entity schema requires min length 1; a blank
+   string would mint a [\"\" n] entity) and a present number."
+  [event]
+  (and (string? (:pr/repo event))
+       (not (str/blank? (:pr/repo event)))
+       (some? (:pr/number event))))
+
 (defn pr-merged
   [table event]
   (let [k (pr-key event)
         ts (event-instant event)
         workflow-id (:workflow/id event)]
     (cond-> table
-      ;; Both key halves must be present: a repo-less event (the
-      ;; pre-envelope bare-map shape) must not mint a [nil n] entity.
-      (and (:pr/repo event) (:pr/number event))
+      ;; A usable key requires a non-blank repo and a number: repo-less
+      ;; or blank-repo events (the pre-envelope bare-map shape) must
+      ;; not mint [nil n] / ["" n] entities.
+      (pr-lifecycle-keyable? event)
       (update-in [:prs k]
                  (fn [pr]
                    (cond-> (merge (or pr (pr-stub event))
@@ -516,7 +526,7 @@
   (let [k (pr-key event)
         workflow-id (:workflow/id event)]
     (cond-> table
-      (and (:pr/repo event) (:pr/number event))
+      (pr-lifecycle-keyable? event)
       (update-in [:prs k]
                  (fn [pr]
                    (cond-> (assoc (or pr (pr-stub event)) :pr/status :closed)

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -443,6 +443,36 @@
     (is (some? (:pr/merged-at pr)))
     (is (= wf-id (:pr/workflow-run-id pr)))))
 
+(deftest pr-merged-before-created-stubs-minimal-entry
+  ;; Same rationale as the :pr/scored stub: an observed status must not
+  ;; be lost because the create event was missed (e.g. the console
+  ;; attached mid-stream, or the producer only announces merges).
+  (let [table (acc/apply-event schema/empty-table
+                               (ev :pr/merged
+                                   {:pr/repo "acme/widget"
+                                    :pr/number 43}))
+        pr    (get-in table [:prs ["acme/widget" 43]])]
+    (is (some? pr))
+    (is (= :merged (:pr/status pr)))
+    (is (some? (:pr/merged-at pr)))))
+
+(deftest pr-closed-before-created-stubs-minimal-entry
+  (let [table (acc/apply-event schema/empty-table
+                               (ev :pr/closed
+                                   {:pr/repo "acme/widget"
+                                    :pr/number 44}))
+        pr    (get-in table [:prs ["acme/widget" 44]])]
+    (is (some? pr))
+    (is (= :closed (:pr/status pr)))))
+
+(deftest repo-less-pr-lifecycle-events-mint-nothing
+  ;; The pre-envelope bare-map shape ({:event/type :pr/merged
+  ;; :pr/number n} with no repo) must not create a [nil n] entity.
+  (let [table (-> schema/empty-table
+                  (acc/apply-event (ev :pr/merged {:pr/number 45}))
+                  (acc/apply-event (ev :pr/closed {:pr/number 45})))]
+    (is (empty? (:prs table)))))
+
 ;------------------------------------------------------------------------------ :pr/scored
 
 (def ^:private sample-readiness

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -467,10 +467,15 @@
 
 (deftest repo-less-pr-lifecycle-events-mint-nothing
   ;; The pre-envelope bare-map shape ({:event/type :pr/merged
-  ;; :pr/number n} with no repo) must not create a [nil n] entity.
+  ;; :pr/number n} with no repo) must not create a [nil n] entity;
+  ;; a BLANK repo violates the entity schema (min length 1) and must
+  ;; not mint ["" n] either.
   (let [table (-> schema/empty-table
                   (acc/apply-event (ev :pr/merged {:pr/number 45}))
-                  (acc/apply-event (ev :pr/closed {:pr/number 45})))]
+                  (acc/apply-event (ev :pr/closed {:pr/number 45}))
+                  (acc/apply-event (ev :pr/merged {:pr/repo "" :pr/number 45}))
+                  (acc/apply-event (ev :pr/closed {:pr/repo "  " :pr/number 45}))
+                  (acc/apply-event (ev :pr/merged {:pr/repo "acme/widget"})))]
     (is (empty? (:prs table)))))
 
 ;------------------------------------------------------------------------------ :pr/scored

--- a/components/tui-views/deps.edn
+++ b/components/tui-views/deps.edn
@@ -1,6 +1,8 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/coerce {:local/root "../coerce"}
         ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
+        ai.miniforge/supervisory-state {:local/root "../supervisory-state"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/pr-train {:local/root "../pr-train"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -531,8 +531,9 @@
         ;; supervisory materialized view attached, idempotently) so
         ;; train mutations publish governed events instead of nothing.
         _ (when event-stream (supervisory/ensure-attached! event-stream))
-        train-mgr (pr-train/create-manager
-                   (when event-stream {:event-stream event-stream}))
+        train-mgr (if event-stream
+                    (pr-train/create-manager {:event-stream event-stream})
+                    (pr-train/create-manager))
         app (tui/create-app
              {:init   (fn []
                         (persistence-pr/load-all-into-model
@@ -619,7 +620,6 @@
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Start TUI with event stream
-  (require '[ai.miniforge.event-stream.interface :as es])
   (def stream (es/create-event-stream))
   (def app (future (start-tui! stream)))
 

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -26,6 +26,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.coerce.interface :as coerce]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.tui-engine.interface :as tui]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.effect :as effect]
@@ -525,7 +527,12 @@
    The TUI blocks the calling thread until the user quits (q key)."
   [event-stream & [{:keys [throttle-ms screen load-limit]
                     :or {throttle-ms 1000 load-limit 100}}]]
-  (let [train-mgr (pr-train/create-manager)
+  (let [;; Bind the train manager to the caller's stream (with the
+        ;; supervisory materialized view attached, idempotently) so
+        ;; train mutations publish governed events instead of nothing.
+        _ (when event-stream (supervisory/ensure-attached! event-stream))
+        train-mgr (pr-train/create-manager
+                   (when event-stream {:event-stream event-stream}))
         app (tui/create-app
              {:init   (fn []
                         (persistence-pr/load-all-into-model
@@ -572,7 +579,13 @@
   [& [opts]]
   (when (:debug opts)
     (tui/set-log-level! :debug))
-  (let [train-mgr (pr-train/create-manager)
+  (let [;; Standalone mode has no caller stream: create a governed one
+        ;; (default file sink → ~/.miniforge/events) with supervisory
+        ;; attached, so TUI-driven train merges become durable events
+        ;; the operator console ingests.
+        train-stream (doto (es/create-event-stream)
+                       (supervisory/ensure-attached!))
+        train-mgr (pr-train/create-manager {:event-stream train-stream})
         app (tui/create-app
              {:init   (fn []
                         (-> (model/init-model)


### PR DESCRIPTION
## Problem

The operator console's PR fleet is permanently empty. Tracing the produce side found the PR event path broken at three layers:

1. **pr-train** published `:pr/merged` as a bare map — no envelope, no `:pr/repo`. supervisory-state keys PR entities by `[repo number]`, so this event could never update anything; with no `:workflow/id`, the file sink dropped it into `operator/` as an orphan (the 144-byte `pr/merged` files in the real events dir).
2. **The TUI entry points and the CLI web launcher** constructed the train manager with no event stream at all — TUI-driven merges published nothing anywhere.
3. **The accumulator's** `pr-merged`/`pr-closed` handlers only updated existing entities — a merge observed without a prior `:pr/created` vanished.

## Fixes

- `complete-merge` publishes an enveloped `:pr/merged` carrying `:pr/repo`; `add-pr` announces `:pr/created` (repo/number/url/branch/title/merge-order) so an entity exists before any merge updates it.
- `start-tui!` binds the manager to the caller's stream with `supervisory/ensure-attached!` (idempotent); standalone mode creates a governed file-sinked stream so TUI merges become durable events the console ingests. Same for `cli main`'s web launcher.
- `pr-merged`/`pr-closed` stub a minimal schema-complete entity when observed before `:pr/created` (the `pr-scored` precedent, same rationale); repo-less legacy-shaped events mint nothing (no `[nil n]` entities).
- Test hygiene: the pr-train event test used a **default-sinked stream**, writing test events into the operator's real `~/.miniforge/events` on every suite run — the source of the orphan `pr/merged` files observed on the dogfood machine. Now sinkless. (Other suites have the same pollution pattern — follow-up sweep flagged separately.)

## Verification

pr-train + supervisory-state accumulator suites: 79 tests / 276 assertions, 0 failures. JVM and Babashka load gates on `tui-views.interface` and `cli.main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)