### PR TITLE
feat: gate commits on stratum-lint

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -55,6 +55,11 @@
    :requires ([lint])
    :task (lint/clj-all)}
 
+  lint:stratum
+  {:doc  "Stratified-design lint (stratum-lint) over staged Clojure files"
+   :requires ([lint])
+   :task (lint/stratum-staged)}
+
   fmt:md
   {:doc  "Format staged Markdown files (lint --fix)"
    :requires ([fmt])
@@ -195,7 +200,7 @@
 
   pre-commit
   {:doc     "Run pre-commit checks (commit budget, structure, lint, format, smoke tests, graalvm). Full test suite runs in CI."
-   :depends [commit-budget poly:check lint:clj fmt:md test:precommit test:graalvm]
+   :depends [commit-budget poly:check lint:clj lint:stratum fmt:md test:precommit test:graalvm]
    :task    (println "\n✅ ALL PRE-COMMIT CHECKS PASSED\n")}
 
   ;; ──────────────────────────────────────────────────────────────────────────

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -64,3 +64,36 @@
     (when-not (zero? exit)
       (println "❌ Linting failed with exit code:" exit)
       (System/exit exit))))
+
+(def ^:private stratum-lint-deps
+  "Sha-pinned git coordinate for the stratum-lint Clojure component
+   (bb-native; the linter for the `;---- Layer N` stratified-design
+   headings, miniforge-standards rule 210). Resolved lazily in a
+   subprocess via `bb -Sdeps` so plain `bb <task>` invocations — CI
+   included — never fetch the sibling repo; only the pre-commit gate
+   pays the one-time clone."
+  (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
+                  {:git/sha "7ca43db35c7547fe919069e9d69ef8c5d2810042"
+                   :deps/root "clojure"}}}))
+
+(defn stratum-staged []
+  (let [files (->> (concat (staged-by-ext ".clj")
+                           (staged-by-ext ".cljc"))
+                   (remove (fn [f] (str/starts-with? f ".clj-kondo/"))))]
+    (if (seq files)
+      (do
+        (println "🔍 Stratum-linting" (count files) "Clojure file(s)...")
+        ;; Exit contract per stratum-lint: 0 clean, 1 findings, 2 usage
+        ;; error. Files without Layer headings are ignored by the
+        ;; linter, so unannotated legacy namespaces pass untouched —
+        ;; enforcement tightens file-by-file as headings appear.
+        (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
+                                            "bb" "-Sdeps" stratum-lint-deps
+                                            "-m" "stratum-lint.interface"
+                                            files)]
+          (when-not (str/blank? out) (println out))
+          (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+          (when-not (zero? exit)
+            (println "❌ Stratified-design lint failed")
+            (System/exit 1))))
+      (println "✓ No Clojure files to stratum-lint"))))

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -67,8 +67,8 @@
 
 (def ^:private stratum-lint-deps
   "Sha-pinned git coordinate for the stratum-lint Clojure component
-   (bb-native; the linter for the `;---- Layer N` stratified-design
-   headings, miniforge-standards rule 210). Resolved lazily in a
+   (bb-native; the linter for stratified-design separator comments whose
+   heading ends in `Layer N`, miniforge-standards rule 210). Resolved lazily in a
    subprocess via `bb -Sdeps` so plain `bb <task>` invocations — CI
    included — never fetch the sibling repo; only the pre-commit gate
    pays the one-time clone."
@@ -94,6 +94,6 @@
           (when-not (str/blank? out) (println out))
           (when-not (str/blank? err) (binding [*out* *err*] (println err)))
           (when-not (zero? exit)
-            (println "❌ Stratified-design lint failed")
-            (System/exit 1))))
+            (println "❌ Stratified-design lint failed with exit code:" exit)
+            (System/exit exit))))
       (println "✓ No Clojure files to stratum-lint"))))


### PR DESCRIPTION
## What

Wires the stratified-design linter ([stratum-lint](https://github.com/miniforge-ai/stratum-lint), Clojure component) into the pre-commit chain. Layering has been reviewer-enforced only; drift (repeated `Layer N` headings, over-budget strata) accumulated silently until the manual cleanup on the Phase D branches (#1443/#1444/#1445).

- **`lint:stratum`** — stratum-lint over staged `.clj`/`.cljc` files; added to `pre-commit :depends` next to `lint:clj`.
- **Lazy, contained resolution** — the linter resolves in a subprocess via `bb -Sdeps`, sha-pinned (`7ca43db`, `:deps/root "clojure"`). Plain `bb <task>` invocations — CI included — never fetch the sibling repo; only the pre-commit gate pays the one-time clone.
- **Incremental adoption** — the linter ignores files without Layer headings, so unannotated legacy namespaces pass untouched; enforcement tightens file-by-file as headings appear.

Note: the pin is the tip of stratum-lint's `feat/clojure-linter` branch (three review commits ahead of its main). Worth merging that branch and re-pinning to a main sha as a follow-up.

## Verification

- Staged violating file → `SL002` finding line + exit 1, commit blocked.
- Clean staged file → exit 0.
- No staged Clojure → skip message.
- Full `bb pre-commit` chain (commit budget, poly:check, kondo, stratum, fmt, smoke, graalvm) passes with the gate in place — this commit itself went through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)