### PR TITLE
feat: :phase/timeout terminal verdict — stream-idle is infra, not rejection

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -32,6 +32,7 @@
    [ai.miniforge.agent.interface.specialized :as specialized]
    [ai.miniforge.agent.interface.supervision :as supervision]
    [ai.miniforge.agent.interface.watchdog :as watchdog]
+   [ai.miniforge.agent.result-boundary :as result-boundary]
    [ai.miniforge.agent.tool-supervisor :as tool-supervisor]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -718,3 +719,55 @@
   "Return the captured session ID string, or nil if not yet captured.
    See `ai.miniforge.agent.stream-watchdog/get-session-id`."
   watchdog/get-session-id)
+
+;------------------------------------------------------------------------------ Layer 6
+;; Phase-result-level timeout predicates
+;;
+;; `stream-idle-error?` / `network-drop-error?` / `backend-timeout-error?` read
+;; the NORMALIZED boundary (output of `normalize-llm-result`). The predicates
+;; below read PHASE RESULT MAPS — the fully-assembled results returned by a
+;; role's invoke-fn (e.g. what `timeout-only-error-result` and
+;; `build-review-result` return). Phase-software-factory holds the phase result,
+;; not the intermediate normalized map; these predicates let it branch on
+;; infra-timeout results without reaching into role internals.
+;;
+;; Design note — why two levels?
+;; The 2026-06-05 dogfood (adhoc-944448986) showed that predicting timeout from
+;; the PARSED review (`timeout-only-review?`) misses the nil-parse path: when
+;; the LLM errors before producing content there is nothing to parse, so the
+;; parsed-review predicate silently returns false and the framework synthesizes
+;; a false `:rejected`. The phase-result predicates here catch that path at the
+;; role boundary BEFORE any parse attempt, routing infra timeouts to
+;; `timeout-only-error-result` (infra exit) instead of a synthesized rejection.
+
+(def stream-idle-in-result?
+  "True when a phase result map (output of a role's invoke-fn, NOT a
+   normalized boundary) carries a stream-idle indicator.
+
+   Uses a three-path cascade (most-to-least specific):
+   1. `[:error :data :timeout :type]` — primary: standard production shape
+      for any role that calls `error-response` / `timeout-only-error-result`.
+   2. `[:timeout :type]` — secondary: direct on the result map for alternate
+      error shapes that skip the `:error/:data` wrapper.
+   3. Message-channel string markers on `[:error :type]` / `[:type]`
+      containing 'stream-idle' — covers JSON/transit round-trips where
+      keywords serialise to strings.
+
+   Use when the consumer holds the fully-assembled phase result (e.g.
+   phase-software-factory inspecting a reviewer or implementer result for
+   infra-timeout routing). Distinct from `stream-idle-error?`, which reads
+   the normalized boundary (result of `normalize-llm-result`).
+
+   Symmetric twin of `network-drop-in-result?`."
+  result-boundary/stream-idle-in-result?)
+
+(def network-drop-in-result?
+  "True when a phase result map (output of a role's invoke-fn, NOT a
+   normalized boundary) carries a network-drop indicator.
+
+   Same three-path cascade as `stream-idle-in-result?`, checking for
+   `:network-drop` type. Route to the auto-resumer (PR-C) rather than
+   the backend-timeout retry path when this fires.
+
+   Symmetric twin of `stream-idle-in-result?`."
+  result-boundary/network-drop-in-result?)

--- a/components/agent/src/ai/miniforge/agent/result_boundary.clj
+++ b/components/agent/src/ai/miniforge/agent/result_boundary.clj
@@ -75,7 +75,7 @@
   [{:keys [structured-artifact parsed-content derived-artifact]}]
   (or structured-artifact parsed-content derived-artifact))
 
-;------------------------------------------------------------------------------ LLM-timeout classification
+;------------------------------------------------------------------------------ LLM-timeout classification (normalized boundary)
 ;;
 ;; `llm-client/timeout-result` packs an adaptive-timeout reason into the
 ;; LLM-error's `:timeout` field. The `:type` keyword inside that field is
@@ -149,6 +149,88 @@
    `stream-idle-error?`, which catches only one of the three types."
   [normalized]
   (boolean (adaptive-timeout-types (llm-timeout-type normalized))))
+
+;------------------------------------------------------------------------------ Phase-result-level timeout classification
+;;
+;; `stream-idle-error?` / `network-drop-error?` / `backend-timeout-error?` read
+;; the NORMALIZED BOUNDARY (output of `normalize-llm-result`). The predicates
+;; below read PHASE RESULT MAPS — the fully-assembled result returned by a role's
+;; invoke-fn (e.g. what `timeout-only-error-result` and `build-review-result`
+;; return). Phase-software-factory holds the phase result, not the intermediate
+;; normalized map; it needs these predicates to branch on infra-timeout results
+;; without reaching into role internals.
+;;
+;; Lesson from the 2026-06-05 dogfood shape mismatch: `timeout-only-review?`
+;; read the PARSED review map, which was nil when the LLM call itself errored —
+;; so it never fired on the most common stream-idle path. The same shape drift
+;; is prevented here by reading the phase result's structured error paths, not
+;; any parsed payload.
+
+(defn- result-timeout-type
+  "Extract the canonical timeout-type keyword from a phase result map using
+   a three-path cascade (most-to-least specific):
+
+   1. `[:error :data :timeout :type]` — primary path: `result-boundary/error-response`
+      merges the LLM-client's llm-error (including its `:timeout` envelope) into
+      `[:error :data]`; this is the standard production shape for any role that
+      calls `error-response` / `timeout-only-error-result`.
+   2. `[:timeout :type]` — secondary: direct on the result map for alternate error
+      shapes that skip the `:error/:data` wrapper.
+   3. Message-channel type marker: the same `:timeout/:type` paths as strings (from
+      JSON/transit round-trips where keywords serialise to strings), followed by
+      the top-level `:error :type` / `:type` field, each checked for known
+      timeout-taxonomy substrings.
+
+   Returns the canonical keyword (`:stream-idle`, `:network-drop`, `:stagnation`,
+   `:hard-limit`) or nil when no marker is present."
+  [result]
+  (let [kw-if   (fn [v] (when (keyword? v) v))
+        str->kw (fn [v]
+                  (when (string? v)
+                    (cond
+                      (str/includes? v "stream-idle")  :stream-idle
+                      (str/includes? v "network-drop") :network-drop
+                      (str/includes? v "stagnation")   :stagnation
+                      (str/includes? v "hard-limit")   :hard-limit)))
+        path1 (get-in result [:error :data :timeout :type])
+        path2 (get-in result [:timeout :type])]
+    (or (kw-if path1)
+        (kw-if path2)
+        (str->kw path1)
+        (str->kw path2)
+        (str->kw (get-in result [:error :type]))
+        (str->kw (get-in result [:type])))))
+
+(defn stream-idle-in-result?
+  "True when a phase result map (output of a role's invoke-fn, NOT a normalized
+   boundary) carries a stream-idle indicator.
+
+   Uses the three-path cascade in `result-timeout-type`:
+   `[:error :data :timeout :type]` → `[:timeout :type]` → message-channel
+   string marker containing 'stream-idle'.
+
+   Distinct from `stream-idle-error?`, which reads the normalized boundary
+   (result of `normalize-llm-result`). Use this predicate when the consumer
+   holds the fully-assembled phase result — e.g. phase-software-factory
+   inspecting a reviewer or implementer result for infra-timeout routing —
+   not the intermediate normalized map.
+
+   Symmetric twin of `network-drop-in-result?`. Both predicates use the same
+   three-path cascade to prevent the shape drift that caused the 2026-06-05
+   `timeout-only-review?` mis-classification."
+  [result]
+  (= :stream-idle (result-timeout-type result)))
+
+(defn network-drop-in-result?
+  "True when a phase result map carries a network-drop indicator.
+
+   Symmetric twin of `stream-idle-in-result?` — same three-path cascade,
+   checks for `:network-drop` type. Callers should route to the auto-resumer
+   (PR-C) rather than the backend-timeout retry path."
+  [result]
+  (= :network-drop (result-timeout-type result)))
+
+;------------------------------------------------------------------------------ Error / usability helpers
 
 (defn error-response
   "Build a failure response that preserves the backend error shape plus

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -557,31 +557,22 @@
                     gate-result (gates/make-review-decision gate-feedbacks config)
                     counts (gates/calculate-gate-counts gate-feedbacks)
                     timeout-failure-message (llm-response/backend-failure-message response llm-review)
-                    timeout-only-review? (llm-response/timeout-only-review? llm-review gate-result)
-                    ;; `timeout-only-review?` only fires when the LLM
-                    ;; parsed a `:rejected` whose `:review/blocking-
-                    ;; issues` are all timeout-shaped — it cannot fire
-                    ;; when the LLM call itself errored, because
-                    ;; `llm-review` is nil and every condition in the
-                    ;; predicate reads from it. The 2026-06-05 dogfood
-                    ;; (workflow adhoc-944448986) reviewer stream-idle'd
-                    ;; at 360s with no parsed response; the framework
-                    ;; promoted the timeout text into `:review/blocking-
-                    ;; issues` via the parse-failed branch and synthesized
-                    ;; a false `:rejected`. The boundary-level check below
-                    ;; covers that path so a real infra timeout takes the
-                    ;; `timeout-only-error-result` exit instead of
-                    ;; masquerading as a code-review rejection.
-                    ;;
-                    ;; ANY adaptive LLM timeout (stream-idle / stagnation /
-                    ;; hard-limit) means the reviewer produced no verdict — route
-                    ;; to the backend-timeout (infra) path, not a synthesized
-                    ;; :rejected. The 2026-06-05 fix only covered :stream-idle; a
-                    ;; 2026-06-14 dogfood (rn-03) stagnation-timed-out and was
-                    ;; promoted into a false :rejected via the parse-failed
-                    ;; branch, redirecting implement to "fix" a non-rejection.
+                    ;; Two timeout paths, checked at their own layers:
+                    ;; (a) boundary — the LLM call errored/stream-idled before
+                    ;;     producing parseable content (nil llm-review, the
+                    ;;     2026-06-05 dogfood pathology): `backend-timeout-error?`
+                    ;;     on the normalized result.
+                    ;; (b) review-shaped — a parsed :rejected whose blocking
+                    ;;     issues are ALL timeout text: 2-arg
+                    ;;     `timeout-only-review?`.
+                    ;; Either way the reviewer produced no real verdict — route
+                    ;; to the backend-timeout (infra) path, not a synthesised
+                    ;; :rejected. `backend-adaptive-timeout?` stays a separate
+                    ;; log field so operators can tell the layers apart.
                     backend-adaptive-timeout? (result-boundary/backend-timeout-error? normalized)
-                    backend-timeout? (or timeout-only-review? backend-adaptive-timeout?)
+                    timeout-only-review? (or backend-adaptive-timeout?
+                                             (llm-response/timeout-only-review? llm-review gate-result))
+                    backend-timeout? timeout-only-review?
                     ;; "initial" = the first-call decision/issues fed into the
                     ;; enumeration validator. Named to contrast with
                     ;; `recovered-review` below; these are already normalized,

--- a/components/agent/src/ai/miniforge/agent/reviewer/llm_response.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/llm_response.clj
@@ -30,7 +30,15 @@
      (`review-failure-message`, `backend-failure-message`)
    - Backend-timeout detection (`backend-timeout-issue?`,
      `timeout-only-review?`) — distinguishes a real `:rejected` verdict
-     from the reviewer LLM hitting its own progress-monitor timeout
+     from the reviewer LLM hitting its own progress-monitor timeout.
+     `timeout-only-review?` reads the parsed review map and gate result;
+     the nil-parse path (LLM errored before producing content) is handled
+     by the CALLER (artifact.clj) using `result-boundary/stream-idle-in-result?`
+     or `result-boundary/backend-timeout-error?` on the phase result
+     BEFORE invoking this predicate — splitting the two levels prevents
+     the 2026-06-05 dogfood shape drift (adhoc-944448986) where nil
+     `llm-review` caused `timeout-only-review?` to silently return false
+     and synthesize a false `:rejected`.
    - Enumeration-retry validator + recovery (`enumeration-retry?`,
      `well-formed-recovery?`, `recover-review-enumeration`) — re-runs
      the LLM once when a rejection lands without inline blockers"
@@ -112,22 +120,37 @@
                  message))))
 
 (defn timeout-only-review?
-  "True when a parsed review artifact is just reflecting the reviewer
-   backend's own timeout rather than providing actionable code-review
-   findings.
+  "True when the reviewer's outcome reflects the reviewer backend's own
+   timeout rather than actionable code-review findings.
 
-   Conditions (all must hold):
+   Reads the PARSED review map directly; all conditions must hold:
    - LLM decision is a rejection-class verdict
      (`:rejected` / `:changes-requested`)
    - Deterministic gates are otherwise approved
    - `:review/blocking-issues` is present (the LLM enumerated something)
    - `:review/recommendations` and `:review/issues` are both empty
    - Every entry in `:review/blocking-issues` is a timeout-shaped string
-     per `backend-timeout-issue?`"
+     per `backend-timeout-issue?`
+
+   Scope boundary — nil-parse path NOT handled here:
+   When the LLM errors before producing any parseable content, `llm-review`
+   is nil and the checks below silently return false. That path is the
+   exact 2026-06-05 dogfood (adhoc-944448986) pathology where stream-idle
+   text got promoted into `:review/blocking-issues` from the parse-failed
+   branch, synthesising a false `:rejected`. The caller (artifact.clj)
+   MUST check `result-boundary/stream-idle-in-result?` or
+   `result-boundary/backend-timeout-error?` on the phase result BEFORE
+   calling this predicate so nil-parse timeouts route to
+   `timeout-only-error-result` (infra exit), not here.
+
+   Args:
+   - `llm-review`  — parsed review map (nil when LLM errored; caller
+                     guards the nil-parse path at the phase-result level).
+   - `gate-result` — deterministic gate decision map."
   [llm-review gate-result]
-  (let [blocking-issues (vec (:review/blocking-issues llm-review))
-        recommendations (vec (:review/recommendations llm-review))
-        issue-vec (vec (:review/issues llm-review))
+  (let [blocking-issues    (vec (:review/blocking-issues llm-review))
+        recommendations    (vec (:review/recommendations llm-review))
+        issue-vec          (vec (:review/issues llm-review))
         negative-decision? (contains? issues/rejection-decisions
                                       (:review/decision llm-review))]
     (and negative-decision?

--- a/components/agent/src/ai/miniforge/agent/reviewer/llm_response.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/llm_response.clj
@@ -33,12 +33,12 @@
      from the reviewer LLM hitting its own progress-monitor timeout.
      `timeout-only-review?` reads the parsed review map and gate result;
      the nil-parse path (LLM errored before producing content) is handled
-     by the CALLER (artifact.clj) using `result-boundary/stream-idle-in-result?`
-     or `result-boundary/backend-timeout-error?` on the phase result
-     BEFORE invoking this predicate — splitting the two levels prevents
-     the 2026-06-05 dogfood shape drift (adhoc-944448986) where nil
-     `llm-review` caused `timeout-only-review?` to silently return false
-     and synthesize a false `:rejected`.
+     by the CALLER (reviewer.clj) ORing this predicate with
+     `result-boundary/backend-timeout-error?` on the NORMALIZED boundary
+     — splitting the two levels prevents the 2026-06-05 dogfood shape
+     drift (adhoc-944448986) where nil `llm-review` caused
+     `timeout-only-review?` to silently return false and synthesize a
+     false `:rejected`.
    - Enumeration-retry validator + recovery (`enumeration-retry?`,
      `well-formed-recovery?`, `recover-review-enumeration`) — re-runs
      the LLM once when a rejection lands without inline blockers"
@@ -137,15 +137,15 @@
    is nil and the checks below silently return false. That path is the
    exact 2026-06-05 dogfood (adhoc-944448986) pathology where stream-idle
    text got promoted into `:review/blocking-issues` from the parse-failed
-   branch, synthesising a false `:rejected`. The caller (artifact.clj)
-   MUST check `result-boundary/stream-idle-in-result?` or
-   `result-boundary/backend-timeout-error?` on the phase result BEFORE
-   calling this predicate so nil-parse timeouts route to
-   `timeout-only-error-result` (infra exit), not here.
+   branch, synthesising a false `:rejected`. This predicate covers only
+   the review-SHAPED case (a parsed rejection whose blockers are all
+   timeout text); the caller (reviewer.clj) ORs it with
+   `result-boundary/backend-timeout-error?` on the NORMALIZED boundary so
+   nil-parse timeouts route to the backend-timeout (infra) exit, not here.
 
    Args:
-   - `llm-review`  — parsed review map (nil when LLM errored; caller
-                     guards the nil-parse path at the phase-result level).
+   - `llm-review`  — parsed review map (nil when LLM errored; the caller's
+                     boundary check covers that path).
    - `gate-result` — deterministic gate decision map."
   [llm-review gate-result]
   (let [blocking-issues    (vec (:review/blocking-issues llm-review))

--- a/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
+++ b/components/agent/test/ai/miniforge/agent/result_boundary_test.clj
@@ -183,3 +183,53 @@
       (is (= :timeout (get-in result [:error :data :stop-reason])))
       (is (= 3 (get-in result [:error :data :num-turns])))
       (is (= 17 (get-in result [:metrics :tokens]))))))
+
+;; -------------------------------------------------------------------------- phase-result timeout predicates
+;;
+;; `stream-idle-in-result?` / `network-drop-in-result?` read fully-assembled
+;; phase result maps (NOT normalized boundaries) through a three-path
+;; cascade. Pin every supported shape so routing regressions — the
+;; 2026-06-05 `timeout-only-review?` mis-classification was exactly this
+;; kind of shape drift — flip a test instead of a dogfood run.
+
+(deftest in-result-predicates-cover-the-three-path-cascade
+  (testing "path 1 — [:error :data :timeout :type] keyword (production
+            error-response shape)"
+    (is (sut/stream-idle-in-result?
+         {:error {:data {:timeout {:type :stream-idle}}}}))
+    (is (sut/network-drop-in-result?
+         {:error {:data {:timeout {:type :network-drop}}}})))
+
+  (testing "path 2 — [:timeout :type] keyword (unwrapped error shapes)"
+    (is (sut/stream-idle-in-result? {:timeout {:type :stream-idle}}))
+    (is (sut/network-drop-in-result? {:timeout {:type :network-drop}})))
+
+  (testing "path 3 — string markers after JSON/transit round-trips, on the
+            timeout paths and the top-level type fields"
+    (is (sut/stream-idle-in-result?
+         {:error {:data {:timeout {:type "stream-idle"}}}}))
+    (is (sut/stream-idle-in-result? {:timeout {:type "stream-idle-timeout"}}))
+    (is (sut/stream-idle-in-result? {:error {:type "adaptive stream-idle limit"}}))
+    (is (sut/stream-idle-in-result? {:type "stream-idle"}))
+    (is (sut/network-drop-in-result? {:error {:type "network-drop detected"}})))
+
+  (testing "keyword markers outrank string markers when both are present"
+    (is (sut/stream-idle-in-result?
+         {:error {:data {:timeout {:type "network-drop"}}}
+          :timeout {:type :stream-idle}})
+        "a keyword on the secondary path beats a string on the primary"))
+
+  (testing "the twins never both fire on one result"
+    (let [r {:error {:data {:timeout {:type :stream-idle}}}}]
+      (is (sut/stream-idle-in-result? r))
+      (is (not (sut/network-drop-in-result? r)))))
+
+  (testing "negatives — no marker, unrelated markers, non-string/keyword types"
+    (doseq [r [{}
+               {:error {:data {}}}
+               {:timeout {:type :hard-limit}}
+               {:error {:type "rate-limit"}}
+               {:timeout {:type 42}}
+               {:status :failed}]]
+      (is (not (sut/stream-idle-in-result? r)) (pr-str r))
+      (is (not (sut/network-drop-in-result? r)) (pr-str r)))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj
@@ -59,10 +59,20 @@
   ([result watchdog-state]
    (let [error-code    (get-in result [:error :data :code])
          error-type    (get-in result [:error :data :type])
+         ;; The standard adaptive-timeout taxonomy rides the timeout
+         ;; envelope: [:error :data :timeout :type] (result-boundary
+         ;; error-response shape) or [:timeout :type] (unwrapped). Read
+         ;; both keyword paths directly — the full string-tolerant cascade
+         ;; lives in agent result-boundary, but this ns is Layer-0
+         ;; dependency-free and the in-process result maps here carry
+         ;; keywords. :error-code stays as a compat arm.
+         timeout-type  (or (get-in result [:error :data :timeout :type])
+                           (get-in result [:timeout :type]))
          gap-ms        (get watchdog-state :stall/gap-duration-ms)
          stalled?      (or (boolean (:stalled? watchdog-state))
                            (and (number? gap-ms) (pos? gap-ms)))
          stream-idle?  (or (boolean (:stream-idle? watchdog-state))
+                           (= :stream-idle timeout-type)
                            (= :stream-idle error-code))
          rate-limited? (boolean (:rate-limited? watchdog-state))]
      (cond

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/phase_terminal.clj
@@ -29,10 +29,11 @@
   "Derive the :phase/termination-reason for a phase-completed event.
 
    Checks in priority order:
-     1. Watchdog stall    → :agent-stalled  (+ :stall/gap-duration-ms when present)
-     2. Curator rejection → :curator-rejected
-     3. Tool / infra error → :tool-error
-     4. Default           → :normal
+     1. Watchdog stall     → :agent-stalled  (+ :stall/gap-duration-ms when present)
+     2. Stream-idle        → :stream-idle-timeout  (+ :phase/stream-idle-detected true)
+     3. Curator rejection  → :curator-rejected
+     4. Tool / infra error → :tool-error
+     5. Default            → :normal
 
    Arguments:
      result         — phase result map (from [:phase :result] in context).
@@ -40,6 +41,8 @@
                       phase-local detection; may contain:
                         :stalled?              truthy when supervisor detected a hang
                         :stall/gap-duration-ms gap in ms since the last agent event
+                        :stream-idle?          truthy when the LLM output stream went
+                                               quiet before the phase wall-clock cap
                         :rate-limited?         truthy to force :tool-error classification
 
    Returns a map suitable for merging into a phase-completed event payload:
@@ -47,6 +50,8 @@
      {:phase/termination-reason :normal}
      {:phase/termination-reason :agent-stalled
       :stall/gap-duration-ms    <ms>}
+     {:phase/termination-reason :stream-idle-timeout
+      :phase/stream-idle-detected true}
      {:phase/termination-reason :curator-rejected}
      {:phase/termination-reason :tool-error}"
   ([result]
@@ -57,12 +62,22 @@
          gap-ms        (get watchdog-state :stall/gap-duration-ms)
          stalled?      (or (boolean (:stalled? watchdog-state))
                            (and (number? gap-ms) (pos? gap-ms)))
+         stream-idle?  (or (boolean (:stream-idle? watchdog-state))
+                           (= :stream-idle error-code))
          rate-limited? (boolean (:rate-limited? watchdog-state))]
      (cond
        ;; Watchdog stall takes precedence — explicit signal from the supervisor
        stalled?
        (cond-> {:phase/termination-reason :agent-stalled}
          gap-ms (assoc :stall/gap-duration-ms gap-ms))
+
+       ;; Stream-idle: the LLM output stream went quiet before the phase cap.
+       ;; Separate from :agent-stalled (no response at all) — here the stream
+       ;; started but then went idle. Emits :phase/stream-idle-detected true as
+       ;; a telemetry tag so consumers can route / alert on idle events.
+       stream-idle?
+       {:phase/termination-reason   :stream-idle-timeout
+        :phase/stream-idle-detected true}
 
        ;; Curator or release executor found nothing to commit/ship
        (or (= :curator/no-files-written error-code)

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj
@@ -109,18 +109,30 @@
     (let [result {:status :error}]
       (is (= :normal (reason result {:stream-idle? nil}))))))
 
-(deftest stream-idle-by-error-code
-  (testing ":stream-idle error code in result produces :stream-idle-timeout"
+(deftest stream-idle-by-result-marker
+  (testing "the PRODUCTION shape — [:error :data :timeout :type] :stream-idle
+            (result-boundary error-response envelope) — produces
+            :stream-idle-timeout"
     (let [result {:status :error
-                  :error  {:data {:code :stream-idle}
-                            :message "LLM output stream idle"}}
+                  :error  {:data {:timeout {:type :stream-idle}}
+                           :message "LLM output stream idle"}}
           out    (sut/derive-termination-reason result)]
       (is (= :stream-idle-timeout (:phase/termination-reason out)))
       (is (true? (:phase/stream-idle-detected out)))))
 
-  (testing ":stream-idle error code triggers even with no watchdog state"
+  (testing "the unwrapped envelope — [:timeout :type] :stream-idle"
+    (let [result {:status :error :timeout {:type :stream-idle}}]
+      (is (= :stream-idle-timeout (reason result)))))
+
+  (testing "the legacy :code marker stays supported (compat arm)"
     (let [result {:status :error :error {:data {:code :stream-idle}}}]
-      (is (= :stream-idle-timeout (reason result))))))
+      (is (= :stream-idle-timeout (reason result)))))
+
+  (testing "a non-stream-idle timeout type does NOT classify as stream-idle"
+    (let [result {:status :error
+                  :error  {:data {:timeout {:type :network-drop}}}}]
+      (is (not= :stream-idle-timeout (:phase/termination-reason
+                                      (sut/derive-termination-reason result)))))))
 
 (deftest stream-idle-priority
   (testing "stall takes precedence over stream-idle"

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/phase_terminal_test.clj
@@ -92,6 +92,55 @@
       (is (= 12000 (:stall/gap-duration-ms out))))))
 
 ;; ---------------------------------------------------------------------------
+;; Stream-idle → :stream-idle-timeout
+
+(deftest stream-idle-by-watchdog-flag
+  (testing ":stream-idle? true in watchdog produces :stream-idle-timeout"
+    (let [result {:status :error :error {:message "stream went quiet"}}
+          out    (sut/derive-termination-reason result {:stream-idle? true})]
+      (is (= :stream-idle-timeout (:phase/termination-reason out)))
+      (is (true? (:phase/stream-idle-detected out)))))
+
+  (testing ":stream-idle? false with no error code is not stream-idle"
+    (let [result {:status :error}]
+      (is (= :normal (reason result {:stream-idle? false})))))
+
+  (testing "nil :stream-idle? is not stream-idle"
+    (let [result {:status :error}]
+      (is (= :normal (reason result {:stream-idle? nil}))))))
+
+(deftest stream-idle-by-error-code
+  (testing ":stream-idle error code in result produces :stream-idle-timeout"
+    (let [result {:status :error
+                  :error  {:data {:code :stream-idle}
+                            :message "LLM output stream idle"}}
+          out    (sut/derive-termination-reason result)]
+      (is (= :stream-idle-timeout (:phase/termination-reason out)))
+      (is (true? (:phase/stream-idle-detected out)))))
+
+  (testing ":stream-idle error code triggers even with no watchdog state"
+    (let [result {:status :error :error {:data {:code :stream-idle}}}]
+      (is (= :stream-idle-timeout (reason result))))))
+
+(deftest stream-idle-priority
+  (testing "stall takes precedence over stream-idle"
+    ;; :stalled? wins — agent-stalled is higher priority than stream-idle
+    (let [result {:status :error :error {:data {:code :stream-idle}}}
+          out    (sut/derive-termination-reason result {:stalled? true})]
+      (is (= :agent-stalled (:phase/termination-reason out)))))
+
+  (testing "stream-idle takes precedence over curator-rejected"
+    (let [result {:status :error
+                  :error  {:data {:code :curator/no-files-written}}}
+          out    (sut/derive-termination-reason result {:stream-idle? true})]
+      (is (= :stream-idle-timeout (:phase/termination-reason out)))))
+
+  (testing "stream-idle takes precedence over tool-error"
+    (let [result {:status :error :error {:data {:code :tool-error}}}
+          out    (sut/derive-termination-reason result {:stream-idle? true})]
+      (is (= :stream-idle-timeout (:phase/termination-reason out))))))
+
+;; ---------------------------------------------------------------------------
 ;; Curator rejection → :curator-rejected
 
 (deftest curator-rejected-no-files-written

--- a/components/workflow/resources/config/workflow/runner/defaults.edn
+++ b/components/workflow/resources/config/workflow/runner/defaults.edn
@@ -16,7 +16,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-;; Malli schema for :runner/defaults (validated at load time in runner_defaults.clj):
+;; Documented shape for :runner/defaults (not currently validated at load time):
 ;;
 ;;   [:map {:closed false}
 ;;    [:max-phases                     {:optional true} :int]

--- a/components/workflow/resources/config/workflow/runner/defaults.edn
+++ b/components/workflow/resources/config/workflow/runner/defaults.edn
@@ -15,11 +15,31 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
+;;
+;; Malli schema for :runner/defaults (validated at load time in runner_defaults.clj):
+;;
+;;   [:map {:closed false}
+;;    [:max-phases                     {:optional true} :int]
+;;    [:max-redirects                  {:optional true} :int]
+;;    [:max-infra-retries              {:optional true} :int]
+;;    [:max-consecutive-phase-retries  {:optional true} :int]
+;;    [:max-backoff-ms                 {:optional true} :int]
+;;    [:backoff-base-ms                {:optional true} :int]
+;;    [:pause-poll-interval-ms         {:optional true} :int]
+;;    [:default-workdir                {:optional true} :string]
+;;    [:task-branch-prefix             {:optional true} :string]
+;;    [:default-docker-image           {:optional true} :string]]
 
 {:runner/defaults
  {;; Pipeline execution limits
   :max-phases             50
   :max-redirects          5
+  ;; Infra-retry budget: transient infrastructure verdicts (:phase/timeout,
+  ;; :verify/timeout, rate-limits, backend-died) retry the same phase up to
+  ;; this many times before falling through to terminal. Default 1 retry per
+  ;; phase-LLM call — enough to survive a single flaky provider response
+  ;; without burning more work budget on a genuine failure.
+  :max-infra-retries      1
   :max-consecutive-phase-retries 3
   :max-backoff-ms         30000
   :backoff-base-ms        1000

--- a/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
@@ -18,7 +18,21 @@
 
 (ns ai.miniforge.workflow.runner-defaults
   "Configuration-as-data for the workflow runner.
-   All constants live in config/workflow/runner/defaults.edn."
+   All constants live in config/workflow/runner/defaults.edn.
+
+   Malli schema for :runner/defaults (documented in the EDN file header):
+
+     [:map {:closed false}
+      [:max-phases                     {:optional true} :int]
+      [:max-redirects                  {:optional true} :int]
+      [:max-infra-retries              {:optional true} :int]
+      [:max-consecutive-phase-retries  {:optional true} :int]
+      [:max-backoff-ms                 {:optional true} :int]
+      [:backoff-base-ms                {:optional true} :int]
+      [:pause-poll-interval-ms         {:optional true} :int]
+      [:default-workdir                {:optional true} :string]
+      [:task-branch-prefix             {:optional true} :string]
+      [:default-docker-image           {:optional true} :string]]"
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]))
 
@@ -34,7 +48,8 @@
 ;; Infra-retry budget (Fable §2.4): transient infrastructure verdicts
 ;; (timeout/rate-limit/backend-died) retry the SAME phase up to this many
 ;; times — a budget DISTINCT from max-redirects, so a flaky provider can't
-;; burn the work/redirect budget.
+;; burn the work/redirect budget. EDN value is 1 (one retry per phase-LLM
+;; call). Fallback of 3 is a safety net when the EDN resource is absent.
 (defn max-infra-retries    [] (get @defaults :max-infra-retries 3))
 (defn max-consecutive-phase-retries
   "Cap on how many times the SAME phase may run in immediately consecutive

--- a/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
+++ b/components/workflow/src/ai/miniforge/workflow/standard_guards_and_actions.clj
@@ -61,13 +61,18 @@
    backend/stream death, or dropped network. A retry after backoff CAN clear
    these; they are not evidence the work is wrong. Today still terminal (kept
    in `terminal-verdicts`); PR-B routes them to retry-same-phase against a
-   dedicated infra-retry budget instead of the redirect/work budget."
+   dedicated infra-retry budget instead of the redirect/work budget.
+
+   :phase/timeout is included here: it covers FSM-level phase timeouts
+   (stream-idle, wall-clock cap) — transient in the same sense as a
+   backend-timeout, so the infra-retry machinery applies."
   #{:verify/timeout
     :verify/rate-limited
     :implement/rate-limited
     :implement/network-dropped
     :implement/backend-timeout
-    :review/backend-timeout})
+    :review/backend-timeout
+    :phase/timeout})
 
 (def no-op-verdicts
   "EVIDENCE-OF-ABSENCE failures — the work produced nothing actionable, so a
@@ -139,7 +144,10 @@
    dedicated infra budget — not the redirect/work budget. Once the budget is
    spent this returns false and the verdict falls through to
    `verdict-terminal?` → `:failed` (infra verdicts are still in
-   `terminal-verdicts`). Fable §2.4."
+   `terminal-verdicts`). Fable §2.4.
+
+   :phase/timeout verdicts are covered — they land in `infrastructure-verdicts`
+   and thus participate in infra-retry before falling through to terminal."
   [state event]
   (and (contains? infrastructure-verdicts (:phase/verdict event))
        (< (get (fsm/context state) :infra-retry-count 0)

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -253,9 +253,10 @@
                                              {:type :phase/fail
                                               :phase/verdict :implement/rate-limited}))
           retried (reduce (fn [s _] (fail-infra s)) state (range budget))]
-      (is (pos? budget) "a zero budget would make the retry arm dead code")
-      (is (= phase (:_state retried)) "same phase while infra budget remains")
-      (is (= budget (:infra-retry-count retried)) "the infra counter bumps each retry")
+      (is (not (neg? budget)) "the infra-retry budget must be non-negative")
+      (is (= phase (:_state retried)) "same phase until the infra budget is spent")
+      (is (= budget (get retried :infra-retry-count 0))
+          "the infra counter matches the retries consumed (0 when the budget is 0)")
       (is (= 0 (get retried :redirect-count 0)) "redirect/work budget is untouched")
       (let [spent (fail-infra retried)]
         (is (= :failed (:_state spent))

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -33,6 +33,7 @@
    [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.workflow.execution :as exec]
    [ai.miniforge.workflow.fsm :as workflow-fsm]
+   [ai.miniforge.workflow.runner-defaults :as runner-defaults]
    ;; loaded for its eager guard/action registration (infra-retry guards)
    [ai.miniforge.workflow.standard-guards-and-actions]))
 
@@ -242,20 +243,22 @@
 (deftest infra-verdict-retries-same-phase-then-terminates
   (testing "infra verdict retries the same phase up to the infra budget, then
             terminates — and never touches the redirect/work budget"
+    ;; The budget is EDN-owned (:max-infra-retries) — derive the loop from
+    ;; the live value instead of pinning it, so a config change moves the
+    ;; test with it rather than driving the machine past :failed.
     (let [{:keys [machine state]} (guarded-phase-machine)
-          phase (:_state state)
+          phase  (:_state state)
+          budget (runner-defaults/max-infra-retries)
           fail-infra (fn [s] (fsm/transition machine s
                                              {:type :phase/fail
                                               :phase/verdict :implement/rate-limited}))
-          s1 (fail-infra state)
-          s2 (fail-infra s1)
-          s3 (fail-infra s2)]
-      (is (= phase (:_state s1)) "1st infra fail retries the same phase, not :failed")
-      (is (= phase (:_state s3)) "still at the phase while infra budget remains")
-      (is (= 3 (:infra-retry-count s3)) "the infra counter bumps each retry")
-      (is (= 0 (get s3 :redirect-count 0)) "redirect/work budget is untouched")
-      (let [s4 (fail-infra s3)]
-        (is (= :failed (:_state s4))
+          retried (reduce (fn [s _] (fail-infra s)) state (range budget))]
+      (is (pos? budget) "a zero budget would make the retry arm dead code")
+      (is (= phase (:_state retried)) "same phase while infra budget remains")
+      (is (= budget (:infra-retry-count retried)) "the infra counter bumps each retry")
+      (is (= 0 (get retried :redirect-count 0)) "redirect/work budget is untouched")
+      (let [spent (fail-infra retried)]
+        (is (= :failed (:_state spent))
             "infra budget exhausted (>= max-infra-retries) → terminal :failed")))))
 
 (deftest non-infra-verdict-does-not-consume-infra-budget

--- a/components/workflow/test/ai/miniforge/workflow/standard_guards_and_actions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/standard_guards_and_actions_test.clj
@@ -36,7 +36,8 @@
              :verify/timeout :verify/rate-limited :release/zero-files
              :implement/rate-limited :implement/empty-diff
              :implement/already-implemented-invalid :implement/network-dropped
-             :review/backend-timeout :implement/backend-timeout}
+             :review/backend-timeout :implement/backend-timeout
+             :phase/timeout}
            sut/terminal-verdicts)
         "pins the exact terminal set so any future change is deliberate")))
 
@@ -50,6 +51,7 @@
   (testing "each terminal verdict classifies into its class"
     (is (= :infrastructure (sut/verdict-class :verify/timeout)))
     (is (= :infrastructure (sut/verdict-class :review/backend-timeout)))
+    (is (= :infrastructure (sut/verdict-class :phase/timeout)))
     (is (= :no-op (sut/verdict-class :implement/empty-diff)))
     (is (= :no-op (sut/verdict-class :release/zero-files)))
     (is (= :work-terminal (sut/verdict-class :stagnated)))
@@ -63,20 +65,32 @@
   (testing "guard still fires for every terminal verdict, not for :work ones"
     (is (true? (sut/verdict-terminal? {} {:phase/verdict :stagnated})))
     (is (true? (sut/verdict-terminal? {} {:phase/verdict :verify/timeout})))
+    (is (true? (sut/verdict-terminal? {} {:phase/verdict :phase/timeout})))
     (is (false? (sut/verdict-terminal? {} {:phase/verdict :repair-requested})))
     (is (false? (sut/verdict-terminal? {} {:phase/verdict nil})))))
+
 (deftest verdict-infra-retriable?-test
   (testing "infra verdict + infra budget left → retriable (retry same phase)"
+    ;; max-infra-retries is 1 (from EDN). count 0 < 1 → retriable.
     (is (true? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 0}
                                              {:phase/verdict :verify/timeout})))
-    (is (true? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 2}
+    (is (true? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 0}
                                              {:phase/verdict :implement/rate-limited})))
     (is (true? (sut/verdict-infra-retriable? {:_state :p}
                                              {:phase/verdict :review/backend-timeout}))
-        "absent counter treated as 0"))
-  (testing "infra verdict + budget spent (>= max 3) → not retriable → falls to terminal"
+        "absent counter treated as 0")
+    (is (true? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 0}
+                                             {:phase/verdict :phase/timeout}))
+        "phase/timeout is an infra verdict — retriable when budget allows"))
+  (testing "infra verdict + budget spent (>= max) → not retriable → falls to terminal"
+    ;; max-infra-retries is 1 from EDN; fallback is 3 if EDN absent.
+    ;; count 1 >= 1 (EDN) or count 3 >= 3 (fallback) — both spent.
     (is (false? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 3}
-                                              {:phase/verdict :verify/timeout}))))
+                                              {:phase/verdict :verify/timeout}))
+        "count 3 is >= max in both EDN (1) and fallback (3) configurations")
+    (is (false? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 3}
+                                              {:phase/verdict :phase/timeout}))
+        "phase/timeout also falls to terminal once budget is spent"))
   (testing "non-infra verdict is never infra-retriable, regardless of budget"
     (is (false? (sut/verdict-infra-retriable? {:_state :p :infra-retry-count 0}
                                               {:phase/verdict :stagnated})))


### PR DESCRIPTION
## Summary

Implements `work/phase-stream-idle-as-terminal-timeout.spec.edn` (blocker tier, dogfood-resilience theme). **Produced by the miniforge dogfood run `715fc67b`** — planned, implemented, gate-checked, and twice repair-iterated by the framework itself; salvaged to this branch after the run was externally stopped mid re-verify and `resume` hit the FSM unknown-event bug (production repro filed on the `workflow-resume-fsm-advance-investigation` spec).

- `:phase/timeout` joins `infrastructure-verdicts`: terminal via the union, retried by `verdict-infra-retriable?` with `infra-inc-count`, budget EDN-owned (`:max-infra-retries 1`).
- `phase_terminal.clj` detects stream-idle (watchdog state or `:stream-idle` error code) → `:phase/termination-reason :stream-idle-timeout` + `:phase/stream-idle-detected true` telemetry.
- Reviewer: boundary-level `backend-timeout-error?` OR review-shaped 2-arg `timeout-only-review?` — a reviewer stream-idle classifies as infra before shape parsing can mislabel it a rejection (the 2026-06-05 `adhoc-944448986` pathology). `stream-idle-in-result?` / `network-drop-in-result?` exported on the agent interface.

Meta-review notes (defects I caught and fixed while salvaging, worth reviewer attention): the dogfood's second repair reverted `timeout-only-review?` to 2 args but left the 3-arg call site in `reviewer.clj` — 18 ArityExceptions visible only to the full smoke suite, not change-scoped selection; and the `phase-transitions` infra-retry test hard-coded the old budget of 3 — now derived from the live EDN value.

## Test plan

- 61 tests / 317 assertions green across reviewer, llm-response, artifact, result-boundary.
- 15 / 36 green on phase-transitions (budget-derived loop).
- Guards + phase-terminal suites green; full pre-commit smoke suite green on both commits.
- The spec's retry-composition acceptance criterion (checkpoint resume on `:phase/timeout`) rides the existing `verdict-infra-retriable?` machinery, covered by the FSM tests; a live stream-idle E2E needs a provider timeout to occur and remains observational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)