### PR TITLE
fix: resolve tui-views.subscription-test namespace collision

### DIFF
--- a/projects/miniforge/test/ai/miniforge/tui_views/subscription_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/tui_views/subscription_integration_test.clj
@@ -16,7 +16,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(ns ai.miniforge.tui-views.subscription-test
+(ns ai.miniforge.tui-views.subscription-integration-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.tui-views.subscription :as sub]

--- a/tasks/test_runner.clj
+++ b/tasks/test_runner.clj
@@ -60,7 +60,7 @@
                          "ai.miniforge.phase.handoff-test"
                          "ai.miniforge.tool-registry.integration-test"
                          "ai.miniforge.self-healing.backend-health-test"
-                         "ai.miniforge.tui-views.subscription-test"
+                         "ai.miniforge.tui-views.subscription-integration-test"
                          "ai.miniforge.tui-engine.core-test"
                          "ai.miniforge.web-dashboard.interface-test"
                          "ai.miniforge.tui-views.pr-views-test"


### PR DESCRIPTION
## Summary
- Two test files defined the same namespace `ai.miniforge.tui-views.subscription-test`: `components/tui-views/test/ai/miniforge/tui_views/subscription_test.clj` (translate-event unit tests) and `projects/miniforge/test/ai/miniforge/tui_views/subscription_test.clj` (stream-integration tests using `es/create-event-stream`). Whichever loaded last on a shared classpath silently shadowed the other.
- Renamed the project-level file/namespace to `ai.miniforge.tui-views.subscription-integration-test` and updated its reference in `tasks/test_runner.clj`.

## Test plan
- [x] `poly test brick:tui-views` — `ai.miniforge.tui-views.subscription-test` runs its 20 translate-event tests / 50 assertions, no shadowing.
- [x] Ran `ai.miniforge.tui-views.subscription-integration-test` directly from `projects/miniforge` — 6 tests / 14 assertions pass.
- [x] `poly check` — no new warnings.
- [x] `bb pre-commit` — commit-budget, poly check, lint, pre-commit smoke (331 tests), GraalVM compat all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)