### PR TITLE
fix(operator): atomically guard apply/reject transitions against non-:proposed state

### DIFF
--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -347,7 +347,7 @@
                       (:improvement/rationale applied)
                       (:improvement/rationale applied)
                       :rule
-                      :tags #{:auto-generated :operator}
+                      :tags [:auto-generated :operator]
                       :source {:type :operator
                                :proposal-id proposal-id})]
             (knowledge/put-zettel knowledge-store rule)))

--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -328,44 +328,52 @@
            (sort-by :improvement/created-at >))))
 
   (apply-improvement [_this proposal-id]
-    (when-let [proposal (get @proposals proposal-id)]
-      (let [applied-proposal (assoc proposal
-                                    :improvement/status :applied
-                                    :improvement/applied-at (System/currentTimeMillis))]
-        (swap! proposals assoc proposal-id applied-proposal)
-
-        ;; If it's a rule addition, add to knowledge base
-        (when (and (= :rule-addition (:improvement/type proposal))
+    (let [result (atom nil)]
+      (swap! proposals
+             (fn [state]
+               (let [proposal (get state proposal-id)]
+                 (if (= :proposed (:improvement/status proposal))
+                   (let [applied (assoc proposal
+                                        :improvement/status :applied
+                                        :improvement/applied-at (System/currentTimeMillis))]
+                     (reset! result applied)
+                     (assoc state proposal-id applied))
+                   (do (reset! result nil) state)))))
+      (when-let [applied @result]
+        (when (and (= :rule-addition (:improvement/type applied))
                    knowledge-store)
           (let [rule (knowledge/create-zettel
                       (str "auto-rule-" (subs (str proposal-id) 0 8))
-                      (:improvement/rationale proposal)
+                      (:improvement/rationale applied)
                       :rule
                       {:tags #{:auto-generated :operator}
                        :source {:type :operator
                                 :proposal-id proposal-id}})]
             (knowledge/put-zettel knowledge-store rule)))
-
         (log/info logger :operator :operator/improvement-applied
                   {:data {:improvement-id proposal-id
-                          :improvement-type (:improvement/type proposal)}})
-
+                          :improvement-type (:improvement/type applied)}})
         {:success? true
-         :applied applied-proposal})))
+         :applied applied})))
 
   (reject-improvement [_this proposal-id reason]
-    (when-let [proposal (get @proposals proposal-id)]
-      (let [rejected-proposal (assoc proposal
-                                     :improvement/status :rejected
-                                     :improvement/rejected-at (System/currentTimeMillis)
-                                     :improvement/rejection-reason reason)]
-        (swap! proposals assoc proposal-id rejected-proposal)
-
+    (let [result (atom nil)]
+      (swap! proposals
+             (fn [state]
+               (let [proposal (get state proposal-id)]
+                 (if (= :proposed (:improvement/status proposal))
+                   (let [rejected (assoc proposal
+                                         :improvement/status :rejected
+                                         :improvement/rejected-at (System/currentTimeMillis)
+                                         :improvement/rejection-reason reason)]
+                     (reset! result rejected)
+                     (assoc state proposal-id rejected))
+                   (do (reset! result nil) state)))))
+      (when-let [rejected @result]
         (log/info logger :operator :operator/improvement-rejected
                   {:data {:improvement-id proposal-id
                           :reason reason}})
-
-        rejected-proposal))))
+        rejected))))
 
 ;; Implement WorkflowObserver to receive workflow events
 (extend-type SimpleOperator

--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -345,10 +345,11 @@
           (let [rule (knowledge/create-zettel
                       (str "auto-rule-" (subs (str proposal-id) 0 8))
                       (:improvement/rationale applied)
+                      (:improvement/rationale applied)
                       :rule
-                      {:tags #{:auto-generated :operator}
-                       :source {:type :operator
-                                :proposal-id proposal-id}})]
+                      :tags #{:auto-generated :operator}
+                      :source {:type :operator
+                               :proposal-id proposal-id})]
             (knowledge/put-zettel knowledge-store rule)))
         (log/info logger :operator :operator/improvement-applied
                   {:data {:improvement-id proposal-id

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -315,14 +315,18 @@
 (defn apply-improvement
   "Apply an approved improvement.
 
-   Returns {:success? bool :applied improvement-map}"
+   Returns {:success? bool :applied improvement-map} when the proposal is in
+   :proposed state, or nil if the proposal has already been applied or rejected
+   (idempotent no-op — callers must nil-check before destructuring)."
   [operator proposal-id]
   (proto/apply-improvement operator proposal-id))
 
 (defn reject-improvement
   "Reject an improvement proposal.
 
-   Returns updated proposal with rejection reason."
+   Returns the updated proposal map (with :improvement/rejection-reason) when
+   the proposal is in :proposed state, or nil if the proposal is already
+   :rejected (idempotent no-op — callers must nil-check)."
   [operator proposal-id reason]
   (proto/reject-improvement operator proposal-id reason))
 

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -316,8 +316,9 @@
   "Apply an approved improvement.
 
    Returns {:success? bool :applied improvement-map} when the proposal is in
-   :proposed state, or nil if the proposal has already been applied or rejected
-   (idempotent no-op — callers must nil-check before destructuring)."
+   :proposed state, or nil if the proposal is not in :proposed state (already
+   :applied, :rejected, or missing) — callers must nil-check before
+   destructuring."
   [operator proposal-id]
   (proto/apply-improvement operator proposal-id))
 

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -325,8 +325,9 @@
   "Reject an improvement proposal.
 
    Returns the updated proposal map (with :improvement/rejection-reason) when
-   the proposal is in :proposed state, or nil if the proposal is already
-   :rejected (idempotent no-op — callers must nil-check)."
+   the proposal is in :proposed state, or nil if the proposal is not in
+   :proposed state (already :applied, :rejected, or missing) — callers must
+   nil-check."
   [operator proposal-id reason]
   (proto/reject-improvement operator proposal-id reason))
 

--- a/components/operator/src/ai/miniforge/operator/protocol.clj
+++ b/components/operator/src/ai/miniforge/operator/protocol.clj
@@ -76,11 +76,16 @@
 
   (apply-improvement [this proposal-id]
     "Apply an approved improvement.
-     Returns {:success? bool :applied improvement-map}")
+     Returns {:success? bool :applied improvement-map} when the proposal is in
+     :proposed state, or nil if the proposal is not in :proposed state
+     (already :applied, :rejected, or missing) — callers must nil-check.")
 
   (reject-improvement [this proposal-id reason]
     "Reject an improvement proposal.
-     Returns updated proposal."))
+     Returns the updated proposal map (with :improvement/rejection-reason) when
+     the proposal is in :proposed state, or nil if the proposal is not in
+     :proposed state (already :applied, :rejected, or missing) — callers must
+     nil-check."))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Pattern detector protocol

--- a/components/operator/test/ai/miniforge/operator/interface_test.clj
+++ b/components/operator/test/ai/miniforge/operator/interface_test.clj
@@ -20,6 +20,7 @@
   "Tests for the operator (meta-agent) component."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.operator.interface :as op]
    [ai.miniforge.operator.protocol :as proto]))
 
@@ -256,3 +257,24 @@
     (is (contains? op/improvement-types :prompt-change))
     (is (contains? op/improvement-types :rule-addition))
     (is (contains? op/improvement-types :workflow-modification))))
+
+;; ============================================================================
+;; Knowledge store integration tests
+;; ============================================================================
+
+(deftest apply-improvement-writes-rule-exactly-once-test
+  (testing "apply-improvement writes exactly one rule to the knowledge store"
+    (let [k-store  (knowledge/create-store)
+          operator (op/create-operator {:knowledge-store k-store})
+          {:keys [proposal-id]} (op/propose-improvement operator
+                                                         {:type      :rule-addition
+                                                          :target    :knowledge-base
+                                                          :rationale "Prevent syntax errors"})]
+
+      (testing "first apply writes one zettel"
+        (is (:success? (op/apply-improvement operator proposal-id)))
+        (is (= 1 (count (knowledge/list-zettels k-store)))))
+
+      (testing "second apply is a no-op — knowledge store still has exactly one zettel"
+        (is (nil? (op/apply-improvement operator proposal-id)))
+        (is (= 1 (count (knowledge/list-zettels k-store))))))))

--- a/components/operator/test/ai/miniforge/operator/interface_test.clj
+++ b/components/operator/test/ai/miniforge/operator/interface_test.clj
@@ -155,6 +155,33 @@
       (is (:success? result))
       (is (= :applied (get-in result [:applied :improvement/status]))))))
 
+(deftest apply-improvement-idempotency-test
+  (testing "apply-improvement returns nil when proposal is not in :proposed state"
+    (let [operator (op/create-operator)
+          {:keys [proposal-id]} (op/propose-improvement operator
+                                                         {:type :rule-addition
+                                                          :target :test
+                                                          :rationale "Test"})]
+      (testing "first apply succeeds"
+        (is (:success? (op/apply-improvement operator proposal-id))))
+      (testing "second apply on already-:applied proposal returns nil"
+        (is (nil? (op/apply-improvement operator proposal-id))))
+      (testing "state is still :applied after the no-op second call"
+        (let [proposals (op/get-proposals operator {:status :applied})]
+          (is (= 1 (count proposals))))))))
+
+(deftest apply-improvement-guards-rejected-test
+  (testing "apply-improvement cannot override a human rejection"
+    (let [operator (op/create-operator)
+          {:keys [proposal-id]} (op/propose-improvement operator
+                                                         {:type :rule-addition
+                                                          :target :test
+                                                          :rationale "Test"})]
+      (op/reject-improvement operator proposal-id "Not needed")
+      (is (nil? (op/apply-improvement operator proposal-id)))
+      (let [proposals (op/get-proposals operator {:status :rejected})]
+        (is (= 1 (count proposals)))))))
+
 (deftest reject-improvement-test
   (testing "reject-improvement updates proposal with reason"
     (let [operator (op/create-operator)
@@ -165,6 +192,18 @@
           rejected (op/reject-improvement operator proposal-id "Not applicable")]
       (is (= :rejected (:improvement/status rejected)))
       (is (= "Not applicable" (:improvement/rejection-reason rejected))))))
+
+(deftest reject-improvement-idempotency-test
+  (testing "reject-improvement returns nil when proposal is already :rejected"
+    (let [operator (op/create-operator)
+          {:keys [proposal-id]} (op/propose-improvement operator
+                                                         {:type :rule-addition
+                                                          :target :test
+                                                          :rationale "Test"})]
+      (op/reject-improvement operator proposal-id "First reason")
+      (is (nil? (op/reject-improvement operator proposal-id "Second reason")))
+      (let [proposals (op/get-proposals operator {:status :rejected})]
+        (is (= "First reason" (:improvement/rejection-reason (first proposals))))))))
 
 ;; ============================================================================
 ;; Governance tests


### PR DESCRIPTION
## What

`apply-improvement` and `reject-improvement` used a TOCTOU pattern: read the proposal from `@proposals` outside `swap!`, check `when-let`, then write with a separate `swap!`. Two concurrent callers could both pass the guard while the proposal is still `:proposed`, both enter `swap!`, and both fire `knowledge/put-zettel` — writing two zettel records with the same `:zettel/uid` into the `FileBackedStore` index. Separately, a human-rejected proposal could be silently re-applied because no `:proposed` status check existed before the transition write.

This is directly relevant to in-flight PR #1443 (`feat/d2-operator-event-consumer`), which wires an event-driven consumer that will call `apply-improvement` at higher throughput with retries — raising the probability of the concurrent-apply race.

## Fix

Both methods now follow the `decision_queue.clj` result-capture pattern (lines 178-189): the existence check and the `:proposed` status guard live _inside_ the `swap!` body, making the check-and-write a single atomic operation. A `result` atom captures the outcome; side effects (`knowledge/put-zettel`, `log/info`) happen outside `swap!` only when the capture atom was set.

```clojure
;; Before — two separate operations, TOCTOU window
(when-let [proposal (get @proposals proposal-id)]   ; read outside
  ...
  (swap! proposals assoc proposal-id applied)        ; write separately
  (knowledge/put-zettel ...))

;; After — atomic: check + write in one swap! body
(let [result (atom nil)]
  (swap! proposals
         (fn [state]
           (let [proposal (get state proposal-id)]
             (if (= :proposed (:improvement/status proposal))
               (do (reset! result applied) (assoc state proposal-id applied))
               (do (reset! result nil) state)))))
  (when-let [applied @result]
    (knowledge/put-zettel ...)
    {:success? true :applied applied}))
```

## Tests added (`interface_test.clj`)

| Test | Guards |
|------|--------|
| `apply-improvement-idempotency-test` | Second apply on `:applied` proposal returns `nil`; count stays 1 |
| `apply-improvement-guards-rejected-test` | Cannot re-apply a human-rejected proposal |
| `reject-improvement-idempotency-test` | Second reject is no-op; original reason preserved |

> **Note:** `bb` / Clojure toolchain not available in this remote environment; tests verified by structural review against the `decision_queue.clj` reference pattern. CI will run the full suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBzu1xMm5RtkyqKmLFSZB7)_