### PR TITLE
feat(operator): implement retry and re-evaluate intervention mechanisms (Phase D D-3b)

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -116,6 +116,14 @@
    ~/.miniforge/events; (base-dir workflow-id)."
   sinks/workflow-dir)
 
+(def default-events-dir
+  "The default events root (`~/.miniforge/events`) as a java.io.File —
+   the base every other path fn in this family defaults to. Exposed so
+   callers that must resolve the root themselves (the operator
+   application layer reconstructing a resume context) read the same
+   convention the file sink writes under instead of rebuilding it."
+  sinks/default-events-dir)
+
 (def operator-dir
   "The cross-workflow operator events directory (`{base-dir}/operator/`).
    Writer side: [[operator-event-file-path]] via the file sink; read

--- a/components/operator/deps.edn
+++ b/components/operator/deps.edn
@@ -9,6 +9,7 @@
         ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/reliability {:local/root "../reliability"}
+        ai.miniforge/supervisory-state {:local/root "../supervisory-state"}
         ai.miniforge/workflow-resume {:local/root "../workflow-resume"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/operator/deps.edn
+++ b/components/operator/deps.edn
@@ -8,6 +8,7 @@
         ai.miniforge/workflow {:local/root "../workflow"}
         ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/event-stream {:local/root "../event-stream"}
-        ai.miniforge/reliability {:local/root "../reliability"}}
+        ai.miniforge/reliability {:local/root "../reliability"}
+        ai.miniforge/workflow-resume {:local/root "../workflow-resume"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/operator/resources/config/operator/messages/en-US.edn
+++ b/components/operator/resources/config/operator/messages/en-US.edn
@@ -53,6 +53,9 @@
   :application/invalid-control-state
   "Live runner registration requires an atom :control-state"
 
+  :application/invalid-policy-evaluator
+  "Policy evaluator registration requires a function"
+
   :application/invalid-resume-launcher
   "Resume launcher registration requires a :launch! function"
 
@@ -65,6 +68,9 @@
   :application/no-live-runner
   "No live runner owns the intervention target"
 
+  :application/no-policy-evaluator
+  "No process policy evaluator is available"
+
   :application/no-resume-context
   "The target workflow has no reconstructable resume context"
 
@@ -73,6 +79,12 @@
 
   :application/not-implemented
   "The intervention mechanism is not implemented"
+
+  :application/policy-evaluation-readback-mismatch
+  "No new policy evaluation was recorded for the target"
+
+  :application/policy-re-evaluated
+  "Policy re-evaluated for {target}: {result}"
 
   :application/resume-not-dispatched
   "The resume launcher reported no resumed run"

--- a/components/operator/resources/config/operator/messages/en-US.edn
+++ b/components/operator/resources/config/operator/messages/en-US.edn
@@ -71,6 +71,9 @@
   :application/no-policy-evaluator
   "No process policy evaluator is available"
 
+  :application/invalid-policy-evaluation
+  "Policy evaluator returned no usable verdict"
+
   :application/no-resume-context
   "The target workflow has no reconstructable resume context"
 

--- a/components/operator/resources/config/operator/messages/en-US.edn
+++ b/components/operator/resources/config/operator/messages/en-US.edn
@@ -53,17 +53,41 @@
   :application/invalid-control-state
   "Live runner registration requires an atom :control-state"
 
+  :application/invalid-resume-launcher
+  "Resume launcher registration requires a :launch! function"
+
+  :application/missing-phase
+  "The retry-from-phase request carries no target phase"
+
   :application/no-degradation-manager
   "No process degradation manager is available"
 
   :application/no-live-runner
   "No live runner owns the intervention target"
 
+  :application/no-resume-context
+  "The target workflow has no reconstructable resume context"
+
+  :application/no-resume-launcher
+  "No process resume launcher is available"
+
   :application/not-implemented
   "The intervention mechanism is not implemented"
+
+  :application/resume-not-dispatched
+  "The resume launcher reported no resumed run"
+
+  :application/resume-readback-mismatch
+  "The resumed run is not observable in the event history"
 
   :application/safe-mode-readback-mismatch
   "Degradation-mode readback did not match the requested state"
 
   :application/unknown-failure
-  "Intervention application failed for an unknown reason"}}
+  "Intervention application failed for an unknown reason"
+
+  :application/unknown-phase
+  "The requested phase is not in the target workflow's phase history"
+
+  :application/unresolved-workflow-type
+  "No loadable workflow type could be resolved for the retry"}}

--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.application
   "Intervention application layer — Phase D D-3.
 
@@ -67,18 +66,18 @@
    [ai.miniforge.reliability.interface :as reliability]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Live-runner registry — process-scoped
 
-(defonce ^:private live-runners
+;; Live-runner registry — process-scoped
+(defonce ^{:stratum 0} ^:private live-runners
   ;; workflow-id string → {:control-state <atom>}
   (atom {}))
 
-(defonce ^:private process-degradation-manager
+(defonce ^{:stratum 0} ^:private process-degradation-manager
   ;; Safe mode is a process-level `:degradation` target, not a workflow
   ;; target. Its canonical target id therefore is not a runner id.
   (atom nil))
 
-(defonce ^:private process-resume-launcher
+(defonce ^{:stratum 0} ^:private process-resume-launcher
   ;; {:launch! (fn [plan] -> {:resume/run-id …}), :events-dir <dir-or-nil>}
   ;; A retry restarts a run whose runner is gone by definition, so it
   ;; cannot go through the live-runner registry. Starting a pipeline is
@@ -86,7 +85,7 @@
   ;; registers the handle — the same shape as the degradation manager.
   (atom nil))
 
-(defonce ^:private process-policy-evaluator
+(defonce ^{:stratum 0} ^:private process-policy-evaluator
   ;; (fn [request] -> {:evaluation/passed? … :evaluation/violations […]
   ;;                   :evaluation/packs-applied […]})
   ;; The return shape is `policy-pack/evaluate-external-pr`'s, so the
@@ -94,7 +93,7 @@
   ;; a PR fetcher — both adapter-owned.
   (atom nil))
 
-(def ^:private failure-message-key-by-code
+(def ^{:stratum 0} ^:private failure-message-key-by-code
   {:application-error :application/application-error
    :control-state-readback-mismatch :application/control-state-readback-mismatch
    :missing-phase :application/missing-phase
@@ -112,163 +111,22 @@
    :unknown-phase :application/unknown-phase
    :unresolved-workflow-type :application/unresolved-workflow-type})
 
-(def ^:private expected-degradation-mode-by-verb
+(def ^{:stratum 0} ^:private expected-degradation-mode-by-verb
   {:force-safe-mode :safe-mode
    :exit-safe-mode :nominal})
 
-(defn register-runner!
-  "Register a live runner's control handles for `workflow-id`.
-   `handles` must carry `:control-state`; `:event-stream` enables the
-   process consumer to publish lifecycle events through this workflow's
-   sequence counter."
-  [workflow-id handles]
-  (when-not (and (map? handles)
-                 (instance? clojure.lang.Atom (:control-state handles)))
-    (throw (ex-info (messages/t :application/invalid-control-state)
-                    {:workflow-id workflow-id
-                     :control-state (:control-state handles)})))
-  (swap! live-runners assoc (str workflow-id) handles)
-  nil)
-
-(defn register-degradation-manager!
-  "Register the process-scoped degradation manager used by safe-mode
-   interventions."
-  [manager]
-  (reset! process-degradation-manager manager)
-  nil)
-
-(defn register-resume-launcher!
-  "Register the process-scoped resume launcher used by `:retry` /
-   `:retry-from-phase`.
-
-   `handles` must carry `:launch!` — `(fn [plan] → {:resume/run-id …})`
-   — which starts a run from the resume plan
-   [[ai.miniforge.operator.mechanism/resume-plan]] builds and reports
-   the run id it started. `:events-dir` optionally overrides the event
-   root the resume context is reconstructed from (default:
-   `~/.miniforge/events`).
-
-   Pass nil to clear. Without a registered launcher, retries fail
-   `:no-resume-launcher` rather than parking."
-  [handles]
-  (when-not (or (nil? handles)
-                (and (map? handles) (ifn? (:launch! handles))))
-    (throw (ex-info (messages/t :application/invalid-resume-launcher)
-                    {:launch! (:launch! handles)})))
-  (reset! process-resume-launcher handles)
-  nil)
-
-(defn register-policy-evaluator!
-  "Register the process-scoped PR policy evaluator used by
-   `:re-evaluate`.
-
-   `evaluate` is `(fn [request] → evaluation)` where `request` is
-   [[ai.miniforge.operator.mechanism/evaluation-request]] and
-   `evaluation` is the `policy-pack/evaluate-external-pr` result shape
-   (`:evaluation/passed?`, `:evaluation/violations`,
-   `:evaluation/packs-applied`). Pass nil to clear.
-
-   Without a registered evaluator, `:re-evaluate` fails
-   `:no-policy-evaluator`. It never publishes a verdict it did not
-   receive — a fabricated pass is worse than a visible failure."
-  [evaluate]
-  (when-not (or (nil? evaluate) (ifn? evaluate))
-    (throw (ex-info (messages/t :application/invalid-policy-evaluator)
-                    {:evaluator evaluate})))
-  (reset! process-policy-evaluator evaluate)
-  nil)
-
-(defn deregister-runner!
-  "Remove `workflow-id` from the live-runner registry. Idempotent."
-  [workflow-id]
-  (swap! live-runners dissoc (str workflow-id))
-  nil)
-
-(defn live-runner?
-  [workflow-id]
-  (contains? @live-runners (str workflow-id)))
-
-(defn live-intervention-target?
-  "True when this process may claim `event` for application. Workflow
-   targets must belong to a registered live runner; process-global
-   intervention targets may be claimed by whichever serialized consumer
-   sees them first."
-  [event]
-  (if-not (intervention/valid-type? (:intervention/type event))
-    true
-    (let [canonical-target-type
-          (intervention/intervention-target-type (:intervention/type event))
-          declared-target-type (:intervention/target-type event)]
-      (or (and declared-target-type
-               (not= canonical-target-type declared-target-type))
-          (not= :workflow canonical-target-type)
-          (live-runner? (:intervention/target-id event))))))
-
-(defn live-intervention-stream
-  "Return the registered event stream for a workflow-targeted
-   intervention, or nil for process-global and unowned targets."
-  [event]
-  (when (= :workflow
-           (intervention/intervention-target-type
-            (:intervention/type event)))
-    (:event-stream
-     (get @live-runners (str (:intervention/target-id event))))))
-
-(defn- failure-message
-  [reason-code]
-  (messages/t (get failure-message-key-by-code
-                   reason-code
-                   :application/unknown-failure)))
-
-(defn- intervention-justification
+(defn- ^{:stratum 0} intervention-justification
   [interv]
   (if-some [justification (:intervention/justification interv)]
     justification
     (messages/t :application/default-justification)))
 
-(defn- transition-succeeded?
+(defn- ^{:stratum 0} transition-succeeded?
   [result]
   (true? (:success? result)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Lifecycle publication helpers
-
-(defn- advance!
-  "Apply lifecycle `step-fn` to `interv`, publish the transition, and
-   return the updated intervention. Returns nil when the lifecycle step
-   itself is rejected."
-  [stream interv step-fn & step-args]
-  (let [result (apply step-fn interv step-args)]
-    (if (transition-succeeded? result)
-      (let [updated (:intervention result)]
-        (consumer/publish-state-changed! stream updated)
-        updated)
-      nil)))
-
-(defn- fail!
-  [stream interv reason-code]
-  (let [with-failure-code (assoc-in interv
-                                    [:intervention/details :failure/code]
-                                    reason-code)]
-    (when-let [failed (advance! stream
-                                with-failure-code
-                                intervention/fail
-                                (failure-message reason-code))]
-      failed)))
-
-(defn- verify-readback!
-  "Shared tail for every readback-verified mechanism: verify `applied`
-   when the mechanism's observable matches what the verb asked for, else
-   fail with `mismatch-code`. Returns nil when the lifecycle step is
-   itself rejected."
-  [stream applied readback mismatch-code]
-  (if (= (:observed readback) (:expected readback))
-    (advance! stream applied intervention/verify readback)
-    (fail! stream applied mismatch-code)))
-
 ;; ── Mechanisms ─────────────────────────────────────────────────────────────
-
-(defn- control-state-effect!
+(defn- ^{:stratum 0} control-state-effect!
   "Flip the control-state flag for `verb` and return the readback the
    verification step asserts."
   [control-state verb]
@@ -283,14 +141,121 @@
                 {:verb :cancel :observed (boolean (es/cancelled? control-state))
                  :expected true})))
 
-(defn- apply-control-verb!
-  [stream dispatched entry verb]
-  (let [readback (control-state-effect! (:control-state entry) verb)]
-    (when-let [applied (advance! stream dispatched intervention/apply-result)]
-      (verify-readback! stream applied readback
-                        :control-state-readback-mismatch))))
+(defn- ^{:stratum 0} resume-events-dir
+  [launcher]
+  (or (:events-dir launcher) (es/default-events-dir)))
 
-(defn- safe-mode-effect!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} register-runner!
+  "Register a live runner's control handles for `workflow-id`.
+   `handles` must carry `:control-state`; `:event-stream` enables the
+   process consumer to publish lifecycle events through this workflow's
+   sequence counter."
+  [workflow-id handles]
+  (when-not (and (map? handles)
+                 (instance? clojure.lang.Atom (:control-state handles)))
+    (throw (ex-info (messages/t :application/invalid-control-state)
+                    {:workflow-id workflow-id
+                     :control-state (:control-state handles)})))
+  (swap! live-runners assoc (str workflow-id) handles)
+  nil)
+
+(defn ^{:stratum 1} register-degradation-manager!
+  "Register the process-scoped degradation manager used by safe-mode
+   interventions."
+  [manager]
+  (reset! process-degradation-manager manager)
+  nil)
+
+(defn ^{:stratum 1} register-resume-launcher!
+  "Register the process-scoped resume launcher used by `:retry` /
+   `:retry-from-phase`.
+
+   `handles` must carry `:launch!` — `(fn [plan] → {:resume/run-id …})`
+   — which starts a run from the resume plan
+   [[ai.miniforge.operator.mechanism/resume-plan]] builds and reports
+   the run id it started. `:events-dir` optionally overrides the event
+   root the resume context is reconstructed from (default:
+   `~/.miniforge/events`).
+
+   Pass nil to clear. Without a registered launcher, retries fail
+   `:no-resume-launcher` rather than parking."
+  [handles]
+  ;; `fn?`, not `ifn?`: a launcher must be an actual function. `ifn?`
+  ;; also admits keywords / maps / sets, which would register silently
+  ;; and only surface later as `:resume-not-dispatched` — reject the
+  ;; misconfiguration here, where the message names it.
+  (when-not (or (nil? handles)
+                (and (map? handles) (fn? (:launch! handles))))
+    (throw (ex-info (messages/t :application/invalid-resume-launcher)
+                    {:launch! (:launch! handles)})))
+  (reset! process-resume-launcher handles)
+  nil)
+
+(defn ^{:stratum 1} register-policy-evaluator!
+  "Register the process-scoped PR policy evaluator used by
+   `:re-evaluate`.
+
+   `evaluate` is `(fn [request] → evaluation)` where `request` is
+   [[ai.miniforge.operator.mechanism/evaluation-request]] and
+   `evaluation` is the `policy-pack/evaluate-external-pr` result shape
+   (`:evaluation/passed?`, `:evaluation/violations`,
+   `:evaluation/packs-applied`). Pass nil to clear.
+
+   Without a registered evaluator, `:re-evaluate` fails
+   `:no-policy-evaluator`. It never publishes a verdict it did not
+   receive — a fabricated pass is worse than a visible failure."
+  [evaluate]
+  ;; `fn?`, not `ifn?` — see register-resume-launcher!. A keyword or map
+  ;; is not an evaluator; reject it at registration, not as a confusing
+  ;; `:invalid-policy-evaluation` on the first re-evaluate.
+  (when-not (or (nil? evaluate) (fn? evaluate))
+    (throw (ex-info (messages/t :application/invalid-policy-evaluator)
+                    {:evaluator evaluate})))
+  (reset! process-policy-evaluator evaluate)
+  nil)
+
+(defn ^{:stratum 1} deregister-runner!
+  "Remove `workflow-id` from the live-runner registry. Idempotent."
+  [workflow-id]
+  (swap! live-runners dissoc (str workflow-id))
+  nil)
+
+(defn ^{:stratum 1} live-runner?
+  [workflow-id]
+  (contains? @live-runners (str workflow-id)))
+
+(defn ^{:stratum 1} live-intervention-stream
+  "Return the registered event stream for a workflow-targeted
+   intervention, or nil for process-global and unowned targets."
+  [event]
+  (when (= :workflow
+           (intervention/intervention-target-type
+            (:intervention/type event)))
+    (:event-stream
+     (get @live-runners (str (:intervention/target-id event))))))
+
+(defn- ^{:stratum 1} failure-message
+  [reason-code]
+  (messages/t (get failure-message-key-by-code
+                   reason-code
+                   :application/unknown-failure)))
+
+;; Lifecycle publication helpers
+(defn- ^{:stratum 1} advance!
+  "Apply lifecycle `step-fn` to `interv`, publish the transition, and
+   return the updated intervention. Returns nil when the lifecycle step
+   itself is rejected."
+  [stream interv step-fn & step-args]
+  (let [result (apply step-fn interv step-args)]
+    (if (transition-succeeded? result)
+      (let [updated (:intervention result)]
+        (consumer/publish-state-changed! stream updated)
+        updated)
+      nil)))
+
+(defn- ^{:stratum 1} safe-mode-effect!
   "Move the degradation manager for `verb` and return the readback the
    verification step asserts."
   [manager verb interv]
@@ -306,7 +271,65 @@
      :observed (reliability/degradation-mode manager)
      :expected (get expected-degradation-mode-by-verb verb)}))
 
-(defn- apply-safe-mode-verb!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} live-intervention-target?
+  "True when this process may claim `event` for application. Workflow
+   targets must belong to a registered live runner; process-global
+   intervention targets may be claimed by whichever serialized consumer
+   sees them first."
+  [event]
+  (if-not (intervention/valid-type? (:intervention/type event))
+    true
+    (let [canonical-target-type
+          (intervention/intervention-target-type (:intervention/type event))
+          declared-target-type (:intervention/target-type event)]
+      (or (and declared-target-type
+               (not= canonical-target-type declared-target-type))
+          (not= :workflow canonical-target-type)
+          (live-runner? (:intervention/target-id event))))))
+
+(defn- ^{:stratum 2} fail!
+  [stream interv reason-code]
+  (let [with-failure-code (assoc-in interv
+                                    [:intervention/details :failure/code]
+                                    reason-code)]
+    (when-let [failed (advance! stream
+                                with-failure-code
+                                intervention/fail
+                                (failure-message reason-code))]
+      failed)))
+
+(defn- ^{:stratum 2} apply-no-effect-verb!
+  "Verbs whose whole effect IS the supervisory record (Phase D mapping:
+   `supervisory-state only`). Dispatch → applied → verified with no
+   machine touch."
+  [stream dispatched verb]
+  (when-let [applied (advance! stream dispatched intervention/apply-result)]
+    (advance! stream applied intervention/verify {:verb verb})))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} verify-readback!
+  "Shared tail for every readback-verified mechanism: verify `applied`
+   when the mechanism's observable matches what the verb asked for, else
+   fail with `mismatch-code`. Returns nil when the lifecycle step is
+   itself rejected."
+  [stream applied readback mismatch-code]
+  (if (= (:observed readback) (:expected readback))
+    (advance! stream applied intervention/verify readback)
+    (fail! stream applied mismatch-code)))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} apply-control-verb!
+  [stream dispatched entry verb]
+  (let [readback (control-state-effect! (:control-state entry) verb)]
+    (when-let [applied (advance! stream dispatched intervention/apply-result)]
+      (verify-readback! stream applied readback
+                        :control-state-readback-mismatch))))
+
+(defn- ^{:stratum 4} apply-safe-mode-verb!
   [stream dispatched manager verb interv]
   (if manager
     (let [readback (safe-mode-effect! manager verb interv)]
@@ -315,19 +338,7 @@
                           :safe-mode-readback-mismatch)))
     (fail! stream dispatched :no-degradation-manager)))
 
-(defn- apply-no-effect-verb!
-  "Verbs whose whole effect IS the supervisory record (Phase D mapping:
-   `supervisory-state only`). Dispatch → applied → verified with no
-   machine touch."
-  [stream dispatched verb]
-  (when-let [applied (advance! stream dispatched intervention/apply-result)]
-    (advance! stream applied intervention/verify {:verb verb})))
-
-(defn- resume-events-dir
-  [launcher]
-  (or (:events-dir launcher) (es/default-events-dir)))
-
-(defn- dispatch-resume!
+(defn- ^{:stratum 4} dispatch-resume!
   "Hand `plan` to the launcher, then read the run it reports back
    through the resume machinery itself. The readback is deliberately
    the resume component's view rather than the launcher's return value:
@@ -347,23 +358,7 @@
           (verify-readback! stream applied readback
                             :resume-readback-mismatch))))))
 
-(defn- apply-resume-verb!
-  "Rebuild resume state for a retry, then dispatch it.
-
-   Every rejection is typed and lands before the launcher runs — a
-   request naming a phase the run never reached must not be guessed
-   into a plan and started."
-  [stream dispatched launcher verb interv]
-  (if-not launcher
-    (fail! stream dispatched :no-resume-launcher)
-    (let [events-dir (resume-events-dir launcher)
-          prepared (mechanism/prepare-resume events-dir interv verb)]
-      (if-let [failure-code (:failure/code prepared)]
-        (fail! stream dispatched failure-code)
-        (dispatch-resume! stream dispatched launcher events-dir verb
-                          (:resume/plan prepared))))))
-
-(defn- apply-re-evaluate-verb!
+(defn- ^{:stratum 4} apply-re-evaluate-verb!
   "Run the registered evaluator, publish its verdict as a gate event,
    and read the materialized entity table back.
 
@@ -385,10 +380,28 @@
             (verify-readback! stream applied readback
                               :policy-evaluation-readback-mismatch)))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; The applier hook
+;------------------------------------------------------------------------------ Layer 5
 
-(defn apply-intervention!
+(defn- ^{:stratum 5} apply-resume-verb!
+  "Rebuild resume state for a retry, then dispatch it.
+
+   Every rejection is typed and lands before the launcher runs — a
+   request naming a phase the run never reached must not be guessed
+   into a plan and started."
+  [stream dispatched launcher verb interv]
+  (if-not launcher
+    (fail! stream dispatched :no-resume-launcher)
+    (let [events-dir (resume-events-dir launcher)
+          prepared (mechanism/prepare-resume events-dir interv verb)]
+      (if-let [failure-code (:failure/code prepared)]
+        (fail! stream dispatched failure-code)
+        (dispatch-resume! stream dispatched launcher events-dir verb
+                          (:resume/plan prepared))))))
+
+;------------------------------------------------------------------------------ Layer 6
+
+;; The applier hook
+(defn ^{:stratum 6} apply-intervention!
   "Apply one `:approved` intervention. This is the `:apply!` hook the
    operator-event consumer invokes (Phase D D-3, mechanisms extended in
    D-3b).

--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -99,6 +99,7 @@
    :control-state-readback-mismatch :application/control-state-readback-mismatch
    :missing-phase :application/missing-phase
    :no-degradation-manager :application/no-degradation-manager
+   :invalid-policy-evaluation :application/invalid-policy-evaluation
    :no-live-runner :application/no-live-runner
    :no-policy-evaluator :application/no-policy-evaluator
    :no-resume-context :application/no-resume-context
@@ -372,12 +373,17 @@
   [stream dispatched evaluate interv]
   (if-not evaluate
     (fail! stream dispatched :no-policy-evaluator)
-    (let [evaluation (evaluate (mechanism/evaluation-request interv))
-          readback (mechanism/record-policy-evaluation! stream interv evaluation)]
-      (when-let [applied (advance! stream dispatched
-                                   intervention/apply-result readback)]
-        (verify-readback! stream applied readback
-                          :policy-evaluation-readback-mismatch)))))
+    (let [evaluation (evaluate (mechanism/evaluation-request interv))]
+      ;; Validate BEFORE publishing: a nil/garbage result would otherwise
+      ;; coerce to `passed? false`, mint a bogus :gate/failed record, and
+      ;; verify — a verdict we never received. Fail typed, publish nothing.
+      (if-not (mechanism/valid-evaluation? evaluation)
+        (fail! stream dispatched :invalid-policy-evaluation)
+        (let [readback (mechanism/record-policy-evaluation! stream interv evaluation)]
+          (when-let [applied (advance! stream dispatched
+                                       intervention/apply-result readback)]
+            (verify-readback! stream applied readback
+                              :policy-evaluation-readback-mismatch)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; The applier hook

--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -32,7 +32,8 @@
    | :pause / :resume / :cancel         | event-stream control-state flags   |
    | :acknowledge / :request-human-review | supervisory-state only (no machine effect) |
    | :force-safe-mode / :exit-safe-mode | degradation manager (when wired)   |
-   | :retry / :retry-from-phase / :waive / :re-evaluate / :request-replan | not yet applied — fail loudly |
+   | :retry / :retry-from-phase         | workflow-resume + the resume launcher |
+   | :waive / :re-evaluate / :request-replan | not yet applied — fail loudly |
 
    **Process-lifetime honesty:** control-state is in-process, so
    interventions act only on workflows registered by a live runner in
@@ -44,11 +45,14 @@
    **Verification is a readback, not an echo:** control-state verbs
    verify by reading the flag back (`paused?` / `cancelled?`), so a
    `verified` chip means the runner's own control flags actually
-   changed."
+   changed. A retry holds the same bar: it verifies by reconstructing
+   the launched run from its own event history, so a launcher naming a
+   run it never started does not buy a `verified` chip."
   (:require
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.operator.consumer :as consumer]
    [ai.miniforge.operator.intervention :as intervention]
+   [ai.miniforge.operator.mechanism :as mechanism]
    [ai.miniforge.operator.messages :as messages]
    [ai.miniforge.reliability.interface :as reliability]))
 
@@ -64,13 +68,28 @@
   ;; target. Its canonical target id therefore is not a runner id.
   (atom nil))
 
+(defonce ^:private process-resume-launcher
+  ;; {:launch! (fn [plan] -> {:resume/run-id …}), :events-dir <dir-or-nil>}
+  ;; A retry restarts a run whose runner is gone by definition, so it
+  ;; cannot go through the live-runner registry. Starting a pipeline is
+  ;; adapter work (workflow loader + LLM client), so the process owner
+  ;; registers the handle — the same shape as the degradation manager.
+  (atom nil))
+
 (def ^:private failure-message-key-by-code
   {:application-error :application/application-error
    :control-state-readback-mismatch :application/control-state-readback-mismatch
+   :missing-phase :application/missing-phase
    :no-degradation-manager :application/no-degradation-manager
    :no-live-runner :application/no-live-runner
+   :no-resume-context :application/no-resume-context
+   :no-resume-launcher :application/no-resume-launcher
    :not-implemented :application/not-implemented
-   :safe-mode-readback-mismatch :application/safe-mode-readback-mismatch})
+   :resume-not-dispatched :application/resume-not-dispatched
+   :resume-readback-mismatch :application/resume-readback-mismatch
+   :safe-mode-readback-mismatch :application/safe-mode-readback-mismatch
+   :unknown-phase :application/unknown-phase
+   :unresolved-workflow-type :application/unresolved-workflow-type})
 
 (def ^:private expected-degradation-mode-by-verb
   {:force-safe-mode :safe-mode
@@ -95,6 +114,27 @@
    interventions."
   [manager]
   (reset! process-degradation-manager manager)
+  nil)
+
+(defn register-resume-launcher!
+  "Register the process-scoped resume launcher used by `:retry` /
+   `:retry-from-phase`.
+
+   `handles` must carry `:launch!` — `(fn [plan] → {:resume/run-id …})`
+   — which starts a run from the resume plan
+   [[ai.miniforge.operator.mechanism/resume-plan]] builds and reports
+   the run id it started. `:events-dir` optionally overrides the event
+   root the resume context is reconstructed from (default:
+   `~/.miniforge/events`).
+
+   Pass nil to clear. Without a registered launcher, retries fail
+   `:no-resume-launcher` rather than parking."
+  [handles]
+  (when-not (or (nil? handles)
+                (and (map? handles) (ifn? (:launch! handles))))
+    (throw (ex-info (messages/t :application/invalid-resume-launcher)
+                    {:launch! (:launch! handles)})))
+  (reset! process-resume-launcher handles)
   nil)
 
 (defn deregister-runner!
@@ -242,12 +282,53 @@
   (when-let [applied (advance! stream dispatched intervention/apply-result)]
     (advance! stream applied intervention/verify {:verb verb})))
 
+(defn- resume-events-dir
+  [launcher]
+  (or (:events-dir launcher) (es/default-events-dir)))
+
+(defn- dispatch-resume!
+  "Hand `plan` to the launcher, then read the run it reports back
+   through the resume machinery itself. The readback is deliberately
+   the resume component's view rather than the launcher's return value:
+   a launcher naming a run it never started must not buy a `verified`
+   chip."
+  [stream dispatched launcher events-dir verb plan]
+  (let [run-id (mechanism/launched-run-id ((:launch! launcher) plan))]
+    (if-not run-id
+      (fail! stream dispatched :resume-not-dispatched)
+      (let [readback {:verb verb
+                      :resume/run-id run-id
+                      :resume/from-phase (:resume/from-phase plan)
+                      :observed (mechanism/resume-observable? events-dir run-id)
+                      :expected true}]
+        (when-let [applied (advance! stream dispatched
+                                     intervention/apply-result readback)]
+          (verify-readback! stream applied readback
+                            :resume-readback-mismatch))))))
+
+(defn- apply-resume-verb!
+  "Rebuild resume state for a retry, then dispatch it.
+
+   Every rejection is typed and lands before the launcher runs — a
+   request naming a phase the run never reached must not be guessed
+   into a plan and started."
+  [stream dispatched launcher verb interv]
+  (if-not launcher
+    (fail! stream dispatched :no-resume-launcher)
+    (let [events-dir (resume-events-dir launcher)
+          prepared (mechanism/prepare-resume events-dir interv verb)]
+      (if-let [failure-code (:failure/code prepared)]
+        (fail! stream dispatched failure-code)
+        (dispatch-resume! stream dispatched launcher events-dir verb
+                          (:resume/plan prepared))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; The applier hook
 
 (defn apply-intervention!
   "Apply one `:approved` intervention. This is the `:apply!` hook the
-   operator-event consumer invokes (Phase D D-3).
+   operator-event consumer invokes (Phase D D-3, mechanisms extended in
+   D-3b).
 
    Returns the final intervention map (state `:verified` or `:failed`),
    or nil when a lifecycle step was itself rejected (never expected
@@ -274,10 +355,17 @@
                                  verb
                                  interv)
 
-          ;; :retry / :retry-from-phase / :waive / :re-evaluate /
-          ;; :request-replan — mechanisms not yet wired (resume
-          ;; machinery, waiver records, policy re-evaluation). Loud,
-          ;; typed failure per the honesty doctrine; D-3b lands them.
+          (:retry :retry-from-phase)
+          (apply-resume-verb! stream
+                              dispatched
+                              @process-resume-launcher
+                              verb
+                              interv)
+
+          ;; :waive / :re-evaluate — mechanisms not yet wired (waiver
+          ;; records, policy re-evaluation). :request-replan — deferred
+          ;; to D-7 (phase-redirect semantics). Loud, typed failure per
+          ;; the honesty doctrine.
           (fail! stream dispatched :not-implemented))
         (catch Exception _e
           ;; A throwing mechanism must not abort the consumer's pass —

--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -33,7 +33,8 @@
    | :acknowledge / :request-human-review | supervisory-state only (no machine effect) |
    | :force-safe-mode / :exit-safe-mode | degradation manager (when wired)   |
    | :retry / :retry-from-phase         | workflow-resume + the resume launcher |
-   | :waive / :re-evaluate / :request-replan | not yet applied — fail loudly |
+   | :re-evaluate                       | policy evaluator → new PolicyEvaluation |
+   | :waive / :request-replan           | not yet applied — fail loudly      |
 
    **Process-lifetime honesty:** control-state is in-process, so
    interventions act only on workflows registered by a live runner in
@@ -42,12 +43,21 @@
    not-yet-applied verbs fail the same way: a red chip with a stable
    code beats silently-parked hope.
 
+   `:waive` stays unapplied on purpose. N5-delta-1 §6 Waiver records
+   have a schema (`schema/Waiver`) and a TUI surface that derives
+   `:waived` from them, but no store: no event type produces one, no
+   accumulator table holds one, no emitter publishes one. Applying the
+   verb would mean inventing that store here, off to one side of the
+   supervisory entity families — so it fails `:not-implemented` until
+   the store lands where the other entities live.
+
    **Verification is a readback, not an echo:** control-state verbs
    verify by reading the flag back (`paused?` / `cancelled?`), so a
    `verified` chip means the runner's own control flags actually
-   changed. A retry holds the same bar: it verifies by reconstructing
-   the launched run from its own event history, so a launcher naming a
-   run it never started does not buy a `verified` chip."
+   changed. The D-3b mechanisms hold the same bar: a resume verifies by
+   reconstructing the launched run from its event history, a
+   re-evaluation by finding a PolicyEvaluation in the materialized
+   entity table that was not there before the publish."
   (:require
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.operator.consumer :as consumer]
@@ -76,15 +86,25 @@
   ;; registers the handle — the same shape as the degradation manager.
   (atom nil))
 
+(defonce ^:private process-policy-evaluator
+  ;; (fn [request] -> {:evaluation/passed? … :evaluation/violations […]
+  ;;                   :evaluation/packs-applied […]})
+  ;; The return shape is `policy-pack/evaluate-external-pr`'s, so the
+  ;; canonical implementer is a partial of it bound to a pack loader and
+  ;; a PR fetcher — both adapter-owned.
+  (atom nil))
+
 (def ^:private failure-message-key-by-code
   {:application-error :application/application-error
    :control-state-readback-mismatch :application/control-state-readback-mismatch
    :missing-phase :application/missing-phase
    :no-degradation-manager :application/no-degradation-manager
    :no-live-runner :application/no-live-runner
+   :no-policy-evaluator :application/no-policy-evaluator
    :no-resume-context :application/no-resume-context
    :no-resume-launcher :application/no-resume-launcher
    :not-implemented :application/not-implemented
+   :policy-evaluation-readback-mismatch :application/policy-evaluation-readback-mismatch
    :resume-not-dispatched :application/resume-not-dispatched
    :resume-readback-mismatch :application/resume-readback-mismatch
    :safe-mode-readback-mismatch :application/safe-mode-readback-mismatch
@@ -135,6 +155,26 @@
     (throw (ex-info (messages/t :application/invalid-resume-launcher)
                     {:launch! (:launch! handles)})))
   (reset! process-resume-launcher handles)
+  nil)
+
+(defn register-policy-evaluator!
+  "Register the process-scoped PR policy evaluator used by
+   `:re-evaluate`.
+
+   `evaluate` is `(fn [request] → evaluation)` where `request` is
+   [[ai.miniforge.operator.mechanism/evaluation-request]] and
+   `evaluation` is the `policy-pack/evaluate-external-pr` result shape
+   (`:evaluation/passed?`, `:evaluation/violations`,
+   `:evaluation/packs-applied`). Pass nil to clear.
+
+   Without a registered evaluator, `:re-evaluate` fails
+   `:no-policy-evaluator`. It never publishes a verdict it did not
+   receive — a fabricated pass is worse than a visible failure."
+  [evaluate]
+  (when-not (or (nil? evaluate) (ifn? evaluate))
+    (throw (ex-info (messages/t :application/invalid-policy-evaluator)
+                    {:evaluator evaluate})))
+  (reset! process-policy-evaluator evaluate)
   nil)
 
 (defn deregister-runner!
@@ -322,6 +362,23 @@
         (dispatch-resume! stream dispatched launcher events-dir verb
                           (:resume/plan prepared))))))
 
+(defn- apply-re-evaluate-verb!
+  "Run the registered evaluator, publish its verdict as a gate event,
+   and read the materialized entity table back.
+
+   `verified` means a PolicyEvaluation that did not exist before the
+   publish exists after it — a new immutable record per N5-delta-1
+   §12.2, not a mutation of the evaluation being re-run."
+  [stream dispatched evaluate interv]
+  (if-not evaluate
+    (fail! stream dispatched :no-policy-evaluator)
+    (let [evaluation (evaluate (mechanism/evaluation-request interv))
+          readback (mechanism/record-policy-evaluation! stream interv evaluation)]
+      (when-let [applied (advance! stream dispatched
+                                   intervention/apply-result readback)]
+        (verify-readback! stream applied readback
+                          :policy-evaluation-readback-mismatch)))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; The applier hook
 
@@ -362,10 +419,17 @@
                               verb
                               interv)
 
-          ;; :waive / :re-evaluate — mechanisms not yet wired (waiver
-          ;; records, policy re-evaluation). :request-replan — deferred
-          ;; to D-7 (phase-redirect semantics). Loud, typed failure per
-          ;; the honesty doctrine.
+          :re-evaluate
+          (apply-re-evaluate-verb! stream
+                                   dispatched
+                                   @process-policy-evaluator
+                                   interv)
+
+          ;; :waive — N5-delta-1 §6 Waiver records have a schema and a
+          ;; TUI surface but no store: no event, no entity table, no
+          ;; emitter. :request-replan — deferred to D-7 (phase-redirect
+          ;; semantics). Loud, typed failure per the honesty doctrine
+          ;; rather than a mechanism invented here.
           (fail! stream dispatched :not-implemented))
         (catch Exception _e
           ;; A throwing mechanism must not abort the consumer's pass —

--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -175,6 +175,16 @@
                                 (failure-message reason-code))]
       failed)))
 
+(defn- verify-readback!
+  "Shared tail for every readback-verified mechanism: verify `applied`
+   when the mechanism's observable matches what the verb asked for, else
+   fail with `mismatch-code`. Returns nil when the lifecycle step is
+   itself rejected."
+  [stream applied readback mismatch-code]
+  (if (= (:observed readback) (:expected readback))
+    (advance! stream applied intervention/verify readback)
+    (fail! stream applied mismatch-code)))
+
 ;; ── Mechanisms ─────────────────────────────────────────────────────────────
 
 (defn- control-state-effect!
@@ -194,33 +204,34 @@
 
 (defn- apply-control-verb!
   [stream dispatched entry verb]
-  (let [{:keys [observed expected] :as readback}
-        (control-state-effect! (:control-state entry) verb)]
-    (if-let [applied (advance! stream dispatched intervention/apply-result)]
-      (if (= observed expected)
-        (advance! stream applied intervention/verify readback)
-        (fail! stream applied :control-state-readback-mismatch))
-      nil)))
+  (let [readback (control-state-effect! (:control-state entry) verb)]
+    (when-let [applied (advance! stream dispatched intervention/apply-result)]
+      (verify-readback! stream applied readback
+                        :control-state-readback-mismatch))))
+
+(defn- safe-mode-effect!
+  "Move the degradation manager for `verb` and return the readback the
+   verification step asserts."
+  [manager verb interv]
+  (let [justification (intervention-justification interv)]
+    (case verb
+      :force-safe-mode
+      (reliability/enter-safe-mode! manager :manual justification)
+      :exit-safe-mode
+      (reliability/exit-safe-mode! manager
+                                   justification
+                                   (:intervention/requested-by interv)))
+    {:verb verb
+     :observed (reliability/degradation-mode manager)
+     :expected (get expected-degradation-mode-by-verb verb)}))
 
 (defn- apply-safe-mode-verb!
   [stream dispatched manager verb interv]
   (if manager
-    (let [justification (intervention-justification interv)
-          _ (case verb
-              :force-safe-mode
-              (reliability/enter-safe-mode! manager :manual justification)
-              :exit-safe-mode
-              (reliability/exit-safe-mode! manager
-                                           justification
-                                           (:intervention/requested-by interv)))
-          observed (reliability/degradation-mode manager)
-          expected (get expected-degradation-mode-by-verb verb)
-          readback {:verb verb :observed observed :expected expected}]
-      (if-let [applied (advance! stream dispatched intervention/apply-result)]
-        (if (= observed expected)
-          (advance! stream applied intervention/verify readback)
-          (fail! stream applied :safe-mode-readback-mismatch))
-        nil))
+    (let [readback (safe-mode-effect! manager verb interv)]
+      (when-let [applied (advance! stream dispatched intervention/apply-result)]
+        (verify-readback! stream applied readback
+                          :safe-mode-readback-mismatch)))
     (fail! stream dispatched :no-degradation-manager)))
 
 (defn- apply-no-effect-verb!

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -254,6 +254,15 @@
    retries fail `:no-resume-launcher`."
   application/register-resume-launcher!)
 
+(def register-policy-evaluator!
+  "Register the process-scoped PR policy evaluator used by
+   `:re-evaluate` (Phase D D-3b). Takes `(fn [request] → evaluation)`
+   returning the `policy-pack/evaluate-external-pr` result shape. Pass
+   nil to clear. Unregistered, `:re-evaluate` fails
+   `:no-policy-evaluator` — it never publishes a verdict it did not
+   receive."
+  application/register-policy-evaluator!)
+
 (def deregister-live-runner!
   "Remove a workflow id from the live-runner registry. Idempotent."
   application/deregister-runner!)
@@ -270,11 +279,14 @@
   application/live-intervention-stream)
 
 (def apply-intervention!
-  "The D-3 `:apply!` hook: apply one approved intervention to its live
-   runner (control-state flags / no-effect verbs / safe-mode), advance
-   the lifecycle approved→dispatched→applied→verified (or →failed with
-   a localized reason and typed `[:intervention/details :failure/code]`),
-   publishing every transition. Pass as `:apply!` to [[consume-operator-events!]] /
+  "The D-3 `:apply!` hook: apply one approved intervention to its
+   mechanism — control-state flags on a live runner, no-effect verbs,
+   safe-mode, and (D-3b) the resume launcher for `:retry` /
+   `:retry-from-phase` and the policy evaluator for `:re-evaluate`.
+   Advances the lifecycle approved→dispatched→applied→verified (or
+   →failed with a localized reason and typed
+   `[:intervention/details :failure/code]`), publishing every
+   transition. Pass as `:apply!` to [[consume-operator-events!]] /
    [[start-operator-consumer!]]."
   application/apply-intervention!)
 

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -246,6 +246,14 @@
    interventions."
   application/register-degradation-manager!)
 
+(def register-resume-launcher!
+  "Register the process-scoped resume launcher used by `:retry` /
+   `:retry-from-phase` (Phase D D-3b). Takes a handles map carrying
+   `:launch!` — `(fn [resume-plan] → {:resume/run-id …})` — and an
+   optional `:events-dir` override. Pass nil to clear. Unregistered,
+   retries fail `:no-resume-launcher`."
+  application/register-resume-launcher!)
+
 (def deregister-live-runner!
   "Remove a workflow id from the live-runner registry. Idempotent."
   application/deregister-runner!)

--- a/components/operator/src/ai/miniforge/operator/mechanism.clj
+++ b/components/operator/src/ai/miniforge/operator/mechanism.clj
@@ -18,19 +18,37 @@
 
 (ns ai.miniforge.operator.mechanism
   "Intervention mechanisms that reach past the runner's control-state —
-   Phase D D-3b. `application` owns the lifecycle; this namespace owns
-   the mechanisms whose effect lives in another component.
+   Phase D D-3b.
 
-   `:retry` / `:retry-from-phase` map to `workflow-resume`. The domain
-   half runs here — rebuilding the run's resume state and validating a
-   requested phase against its real phase history — and the runtime
-   half, starting a pipeline, is a handle the process owner registers
-   with `application`. A component cannot reach into a base to load a
-   workflow and drive a run, so the honest split is: do the real work
-   here, fail loudly when the handle is missing."
+   `application` owns the lifecycle; this namespace owns the two
+   mechanisms whose effect lives in another component:
+
+   | verb                        | mechanism                              |
+   |-----------------------------|----------------------------------------|
+   | :retry / :retry-from-phase  | `workflow-resume` reconstruction, then |
+   |                             | the registered resume launcher         |
+   | :re-evaluate                | a gate event that materializes a NEW   |
+   |                             | PolicyEvaluation in `supervisory-state`|
+
+   Both are split the same way: the *domain* half runs here (rebuilding
+   resume state, validating the requested phase against the run's real
+   phase history, turning an evaluation verdict into the gate event the
+   accumulator materializes), and the *runtime* half — starting a
+   pipeline, fetching a PR diff, loading policy packs — is a handle the
+   process owner registers with `application`. A component cannot reach
+   into a base for either, so the honest split is: do the real work
+   here, fail loudly when the handle is missing.
+
+   Nothing here fabricates a verdict. `re-evaluate` publishes only what
+   the registered evaluator computed; without an evaluator the verb
+   fails rather than inventing a pass."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.operator.messages :as messages]
+   [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.workflow-resume.interface :as wr]
+   [clojure.set :as set]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -168,3 +186,82 @@
   (boolean
    (and run-id
         (not (anomaly/anomaly? (wr/reconstruct-context events-dir (str run-id)))))))
+
+;; ── Policy re-evaluation ───────────────────────────────────────────────────
+
+(def ^:const re-evaluation-gate-id
+  "Gate id stamped on the gate event a `:re-evaluate` intervention
+   publishes, so the resulting PolicyEvaluation is attributable to an
+   operator re-run rather than to a workflow gate."
+  :supervisory/re-evaluate)
+
+(defn evaluation-request
+  "The payload handed to the registered policy evaluator. Carries the
+   target and the requester identity the audit record needs; details
+   pass through verbatim so a client can scope the re-run (packs,
+   rule ids) without this layer growing an opinion about them."
+  [interv]
+  {:policy/target-type (:intervention/target-type interv)
+   :policy/target-id (str (:intervention/target-id interv))
+   :policy/requested-by (:intervention/requested-by interv)
+   :policy/details (:intervention/details interv)
+   :policy/intervention-id (:intervention/id interv)})
+
+(defn- materialized-policy-eval-ids
+  "PolicyEvaluation ids currently materialized from `stream`'s events,
+   folded through the canonical supervisory accumulator. Reading the
+   entity table — not the raw event log — is what makes the post-publish
+   comparison a readback of the record rather than of our own write."
+  [stream]
+  (set (keys (:policy-evals
+              (supervisory/apply-events supervisory/empty-table
+                                        (es/get-events stream))))))
+
+(defn- pack-ids
+  "Pack identifiers as the strings `:policy-eval/packs-applied` requires;
+   evaluators name packs with keywords or strings interchangeably."
+  [packs]
+  (mapv #(if (string? %) % (str (symbol %))) (or packs [])))
+
+(defn evaluation-gate-event
+  "The `:gate/passed` / `:gate/failed` event that materializes a new
+   PolicyEvaluation for `interv`'s target.
+
+   Going through a gate event rather than writing a
+   `:supervisory/policy-evaluated` snapshot keeps the producer/
+   materializer direction intact: producers emit gate outcomes,
+   `supervisory-state` derives the record. Its `:policy-eval/id` is this
+   event's `:event/id`, so every re-evaluation is a fresh, immutable
+   record per N5-delta-1 §12.2 — never a mutation of a prior one."
+  [stream interv evaluation]
+  (let [passed? (true? (:evaluation/passed? evaluation))
+        target-id (str (:intervention/target-id interv))]
+    (-> (es/create-envelope stream
+                            (if passed? :gate/passed :gate/failed)
+                            nil
+                            (messages/t :application/policy-re-evaluated
+                                        {:target target-id
+                                         :result (if passed? "pass" "fail")}))
+        (assoc :gate/id re-evaluation-gate-id
+               :gate/target-type :pr
+               :gate/target-id target-id
+               :gate/packs (pack-ids (:evaluation/packs-applied evaluation))
+               :gate/violations (vec (:evaluation/violations evaluation))))))
+
+(defn record-policy-evaluation!
+  "Publish the evaluator's verdict and read the entity table back.
+
+   Returns the readback the verification step asserts:
+   `{:verb :re-evaluate :policy-eval/id <id> :observed <bool>
+     :expected true}` — `:observed` is true only when a PolicyEvaluation
+   that did not exist before the publish exists after it."
+  [stream interv evaluation]
+  (let [before (materialized-policy-eval-ids stream)
+        event (evaluation-gate-event stream interv evaluation)
+        _ (es/publish! stream event)
+        added (set/difference (materialized-policy-eval-ids stream) before)]
+    {:verb :re-evaluate
+     :policy-eval/id (:event/id event)
+     :policy-eval/passed? (true? (:evaluation/passed? evaluation))
+     :observed (contains? added (:event/id event))
+     :expected true}))

--- a/components/operator/src/ai/miniforge/operator/mechanism.clj
+++ b/components/operator/src/ai/miniforge/operator/mechanism.clj
@@ -1,0 +1,170 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.mechanism
+  "Intervention mechanisms that reach past the runner's control-state —
+   Phase D D-3b. `application` owns the lifecycle; this namespace owns
+   the mechanisms whose effect lives in another component.
+
+   `:retry` / `:retry-from-phase` map to `workflow-resume`. The domain
+   half runs here — rebuilding the run's resume state and validating a
+   requested phase against its real phase history — and the runtime
+   half, starting a pipeline, is a handle the process owner registers
+   with `application`. A component cannot reach into a base to load a
+   workflow and drive a run, so the honest split is: do the real work
+   here, fail loudly when the handle is missing."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.workflow-resume.interface :as wr]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Request-detail reading
+
+(def phase-detail-keys
+  "Keys `:retry-from-phase` accepts for its target phase, in priority
+   order. The wire form is the string `\"phase\"`: transit-JSON map keys
+   inside `:intervention/details` arrive untagged, so the reader leaves
+   them as plain strings (see the golden fixture
+   `contracts/operator-events/golden/retry-from-phase.transit.json`).
+   The keyword form is what in-process callers write."
+  ["phase" :phase])
+
+(defn- phase-keyword
+  "Coerce a details value to a phase keyword, or nil when it carries no
+   usable phase. Blank strings are nil rather than `:` — an empty
+   request must fail as a missing phase, not resolve to a phantom one."
+  [v]
+  (cond
+    (keyword? v) v
+    (and (string? v) (not (str/blank? v))) (keyword v)
+    :else nil))
+
+(defn requested-phase
+  "The phase an intervention's `:intervention/details` targets, as a
+   keyword, or nil when the request carries none."
+  [interv]
+  (let [details (:intervention/details interv)]
+    (some #(phase-keyword (get details %)) phase-detail-keys)))
+
+;; ── Phase history — the resume mechanism's own record of what ran ──────────
+
+(defn known-phases
+  "Every phase the target run actually recorded, drawn from the
+   reconstructed resume context: phases it completed, phases it produced
+   a result for (a failed phase has a result but is not completed), and
+   the phase its FSM snapshot parked on. A `:retry-from-phase` request
+   naming anything outside this set is rejected rather than guessed at."
+  [context]
+  (let [current-phase (get-in context [:machine-snapshot :execution/current-phase])]
+    (cond-> (into (set (:completed-phases context))
+                  (keys (:phase-results context)))
+      current-phase (conj current-phase))))
+
+(defn phases-before
+  "The completed-phase prefix strictly preceding `phase`. Rewinding to
+   `phase` means everything from `phase` onward must run again, so the
+   resume's completed set is truncated there."
+  [completed-phases phase]
+  (vec (take-while #(not= phase %) completed-phases)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Resume plan
+
+(defn resume-plan
+  "The launcher payload for a retry.
+
+   Deliberately shaped as the options a resume run needs — the same set
+   `mf resume` threads into `run-pipeline` — so a launcher is a thin
+   adapter rather than a translation layer.
+
+   `from-phase` nil (plain `:retry`) keeps the FSM machine snapshot: the
+   mapping table's \"resume path with FSM snapshot dispatch\". A
+   `:retry-from-phase` rewind drops it, because restoring a snapshot
+   parked *after* the requested phase would silently ignore the rewind."
+  [interv context workflow-identity from-phase]
+  (cond-> {:resume/workflow-id (str (:intervention/target-id interv))
+           :resume/workflow-type (:workflow-type workflow-identity)
+           :resume/workflow-version (:workflow-version workflow-identity)
+           :resume/completed-phases (if from-phase
+                                      (phases-before (:completed-phases context)
+                                                     from-phase)
+                                      (vec (:completed-phases context)))
+           :resume/phase-results (:phase-results context)
+           :resume/machine-snapshot (when-not from-phase
+                                      (:machine-snapshot context))
+           :resume/workspace (:workspace-checkpoint context)
+           :resume/completed-dag-tasks (:completed-dag-tasks context)
+           :resume/completed-artifacts (:completed-dag-artifacts context)
+           :resume/requested-by (:intervention/requested-by interv)
+           :resume/intervention-id (:intervention/id interv)}
+    from-phase (assoc :resume/from-phase from-phase)))
+
+(defn- resume-failure
+  [code]
+  {:failure/code code})
+
+(defn prepare-resume
+  "Rebuild resume state for a `:retry` / `:retry-from-phase`
+   intervention against `events-dir`.
+
+   Returns `{:resume/plan <plan>}`, or `{:failure/code <keyword>}` when
+   the request cannot be honoured:
+
+   - `:missing-phase`            — `:retry-from-phase` with no `phase` detail
+   - `:no-resume-context`        — the target has no reconstructable history
+   - `:unknown-phase`            — the requested phase never ran
+   - `:unresolved-workflow-type` — no loadable workflow type in the history"
+  [events-dir interv verb]
+  (let [from-phase (when (= :retry-from-phase verb) (requested-phase interv))]
+    (if (and (= :retry-from-phase verb) (nil? from-phase))
+      (resume-failure :missing-phase)
+      (let [context (wr/reconstruct-context events-dir
+                                            (str (:intervention/target-id interv)))]
+        (cond
+          (anomaly/anomaly? context)
+          (resume-failure :no-resume-context)
+
+          (and from-phase (not (contains? (known-phases context) from-phase)))
+          (resume-failure :unknown-phase)
+
+          :else
+          (let [workflow-identity (wr/resolve-workflow-identity context
+                                                                (constantly nil))]
+            (if (anomaly/anomaly? workflow-identity)
+              (resume-failure :unresolved-workflow-type)
+              {:resume/plan (resume-plan interv context workflow-identity
+                                         from-phase)})))))))
+
+(defn launched-run-id
+  "The run id a launcher reported, or nil when it reported none. A
+   launcher that returns an anomaly, nil, or a map without a run id has
+   not dispatched anything the lifecycle can verify."
+  [launch-result]
+  (when (and (map? launch-result) (not (anomaly/anomaly? launch-result)))
+    (:resume/run-id launch-result)))
+
+(defn resume-observable?
+  "Readback for a dispatched resume: true when the launched run has
+   become observable in the event history the resume machinery itself
+   reads. Asserts the mechanism's own record — a run that never started
+   reconstructs to a `:not-found` anomaly and reads back false."
+  [events-dir run-id]
+  (boolean
+   (and run-id
+        (not (anomaly/anomaly? (wr/reconstruct-context events-dir (str run-id)))))))

--- a/components/operator/src/ai/miniforge/operator/mechanism.clj
+++ b/components/operator/src/ai/miniforge/operator/mechanism.clj
@@ -65,11 +65,20 @@
 (defn- ^{:stratum 0} phase-keyword
   "Coerce a details value to a phase keyword, or nil when it carries no
    usable phase. Blank strings are nil rather than `:` — an empty
-   request must fail as a missing phase, not resolve to a phantom one."
+   request must fail as a missing phase, not resolve to a phantom one.
+
+   The string is trimmed first: a wire detail of `\"plan \"` should
+   resolve to `:plan` and match a real phase, not become `:plan `
+   (trailing space) and get spuriously rejected as `:unknown-phase`.
+   (`keyword` does not throw on odd strings — it just interns them
+   verbatim — so trimming is about resolving to the intended phase, not
+   about avoiding an exception.)"
   [v]
   (cond
     (keyword? v) v
-    (and (string? v) (not (str/blank? v))) (keyword v)
+    (string? v) (let [trimmed (str/trim v)]
+                  (when-not (str/blank? trimmed)
+                    (keyword trimmed)))
     :else nil))
 
 ;; ── Phase history — the resume mechanism's own record of what ran ──────────

--- a/components/operator/src/ai/miniforge/operator/mechanism.clj
+++ b/components/operator/src/ai/miniforge/operator/mechanism.clj
@@ -105,11 +105,19 @@
 ;; Resume plan
 
 (defn resume-plan
-  "The launcher payload for a retry.
+  "The launcher payload for a retry: the resume inputs a run needs, under
+   stable `:resume/*` keys.
 
-   Deliberately shaped around the same *semantic inputs* a resume run needs
-   (phase results, workspace checkpoint, optional FSM snapshot, DAG state),
-   so a launcher can be a thin adapter rather than a large translation layer.
+   It carries the same *semantic inputs* a resume run needs — phase
+   results, workspace checkpoint, optional FSM snapshot, DAG state — but
+   NOT under the option keys the resume path ultimately threads into
+   `run-pipeline`. Those are non-namespaced
+   (`:resume-machine-snapshot`, `:resume-phase-results`,
+   `:resume-workspace`, `:pre-completed-dag-tasks`, … — see
+   `cli/main/commands/resume.clj`). The registered launcher maps this
+   namespaced payload onto them: a thin adapter, one job. Keeping the
+   contract a stable `:resume/*` shape is what lets the CLI's internal
+   option names change without touching this layer.
 
    `from-phase` nil (plain `:retry`) keeps the FSM machine snapshot: the
    mapping table's \"resume path with FSM snapshot dispatch\". A
@@ -248,8 +256,22 @@
                :gate/packs (pack-ids (:evaluation/packs-applied evaluation))
                :gate/violations (vec (:evaluation/violations evaluation))))))
 
+(defn valid-evaluation?
+  "A usable evaluator result: a map carrying a boolean
+   `:evaluation/passed?`. Anything else — nil, a non-map, or a map
+   whose verdict is missing or non-boolean — is NOT an evaluation and
+   must never be published as one. Without this check a nil/garbage
+   result coerces to `passed? false` and mints a bogus `:gate/failed`
+   PolicyEvaluation, breaking the \"never publishes a verdict it did
+   not receive\" guarantee."
+  [evaluation]
+  (and (map? evaluation)
+       (boolean? (:evaluation/passed? evaluation))))
+
 (defn record-policy-evaluation!
   "Publish the evaluator's verdict and read the entity table back.
+   Caller MUST gate on [[valid-evaluation?]] first — this fn assumes a
+   well-formed evaluation and does not re-check.
 
    Returns the readback the verification step asserts:
    `{:verb :re-evaluate :policy-eval/id <id> :observed <bool>

--- a/components/operator/src/ai/miniforge/operator/mechanism.clj
+++ b/components/operator/src/ai/miniforge/operator/mechanism.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.mechanism
   "Intervention mechanisms that reach past the runner's control-state —
    Phase D D-3b.
@@ -52,9 +51,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Request-detail reading
 
-(def phase-detail-keys
+;; Request-detail reading
+(def ^{:stratum 0} phase-detail-keys
   "Keys `:retry-from-phase` accepts for its target phase, in priority
    order. The wire form is the string `\"phase\"`: transit-JSON map keys
    inside `:intervention/details` arrive untagged, so the reader leaves
@@ -63,7 +62,7 @@
    The keyword form is what in-process callers write."
   ["phase" :phase])
 
-(defn- phase-keyword
+(defn- ^{:stratum 0} phase-keyword
   "Coerce a details value to a phase keyword, or nil when it carries no
    usable phase. Blank strings are nil rather than `:` — an empty
    request must fail as a missing phase, not resolve to a phantom one."
@@ -73,16 +72,8 @@
     (and (string? v) (not (str/blank? v))) (keyword v)
     :else nil))
 
-(defn requested-phase
-  "The phase an intervention's `:intervention/details` targets, as a
-   keyword, or nil when the request carries none."
-  [interv]
-  (let [details (:intervention/details interv)]
-    (some #(phase-keyword (get details %)) phase-detail-keys)))
-
 ;; ── Phase history — the resume mechanism's own record of what ran ──────────
-
-(defn known-phases
+(defn ^{:stratum 0} known-phases
   "Every phase the target run actually recorded, drawn from the
    reconstructed resume context: phases it completed, phases it produced
    a result for (a failed phase has a result but is not completed), and
@@ -94,17 +85,104 @@
                   (keys (:phase-results context)))
       current-phase (conj current-phase))))
 
-(defn phases-before
+(defn ^{:stratum 0} phases-before
   "The completed-phase prefix strictly preceding `phase`. Rewinding to
    `phase` means everything from `phase` onward must run again, so the
    resume's completed set is truncated there."
   [completed-phases phase]
   (vec (take-while #(not= phase %) completed-phases)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Resume plan
+(defn- ^{:stratum 0} resume-failure
+  [code]
+  {:failure/code code})
 
-(defn resume-plan
+(defn ^{:stratum 0} launched-run-id
+  "The run id a launcher reported, or nil when it reported none. A
+   launcher that returns an anomaly, nil, or a map without a run id has
+   not dispatched anything the lifecycle can verify."
+  [launch-result]
+  (when (and (map? launch-result) (not (anomaly/anomaly? launch-result)))
+    (:resume/run-id launch-result)))
+
+(defn ^{:stratum 0} resume-observable?
+  "Readback for a dispatched resume: true when the launched run has
+   become observable in the event history the resume machinery itself
+   reads. Asserts the mechanism's own record — a run that never started
+   reconstructs to a `:not-found` anomaly and reads back false."
+  [events-dir run-id]
+  (boolean
+   (and run-id
+        (not (anomaly/anomaly? (wr/reconstruct-context events-dir (str run-id)))))))
+
+;; ── Policy re-evaluation ───────────────────────────────────────────────────
+(def ^{:stratum 0} ^:const re-evaluation-gate-id
+  "Gate id stamped on the gate event a `:re-evaluate` intervention
+   publishes, so the resulting PolicyEvaluation is attributable to an
+   operator re-run rather than to a workflow gate."
+  :supervisory/re-evaluate)
+
+(defn ^{:stratum 0} evaluation-request
+  "The payload handed to the registered policy evaluator. Carries the
+   target and the requester identity the audit record needs; details
+   pass through verbatim so a client can scope the re-run (packs,
+   rule ids) without this layer growing an opinion about them."
+  [interv]
+  {:policy/target-type (:intervention/target-type interv)
+   :policy/target-id (str (:intervention/target-id interv))
+   :policy/requested-by (:intervention/requested-by interv)
+   :policy/details (:intervention/details interv)
+   :policy/intervention-id (:intervention/id interv)})
+
+(defn- ^{:stratum 0} materialized-policy-eval-ids
+  "PolicyEvaluation ids currently materialized from `stream`'s events,
+   folded through the canonical supervisory accumulator. Reading the
+   entity table — not the raw event log — is what makes the post-publish
+   comparison a readback of the record rather than of our own write."
+  [stream]
+  (set (keys (:policy-evals
+              (supervisory/apply-events supervisory/empty-table
+                                        (es/get-events stream))))))
+
+(defn- ^{:stratum 0} pack-id
+  "One pack identifier as the string `:policy-eval/packs-applied`
+   requires. Evaluators name packs as strings, keywords, or symbols
+   interchangeably; coerce each explicitly, preserving any namespace
+   (`:my/pack` → `\"my/pack\"`), with a `str` fallback for anything else.
+
+   The prior `(str (symbol %))` leaned on `symbol` accepting a keyword —
+   which it happens to on Clojure 1.12, but that is not `symbol`'s
+   contract and it throws outright on a non-ident (e.g. a numeric id).
+   Explicit coercion removes the dependency."
+  [pack]
+  (cond
+    (string? pack) pack
+    (or (keyword? pack) (symbol? pack))
+    (if-let [ns (namespace pack)] (str ns "/" (name pack)) (name pack))
+    :else (str pack)))
+
+(defn ^{:stratum 0} valid-evaluation?
+  "A usable evaluator result: a map carrying a boolean
+   `:evaluation/passed?`. Anything else — nil, a non-map, or a map
+   whose verdict is missing or non-boolean — is NOT an evaluation and
+   must never be published as one. Without this check a nil/garbage
+   result coerces to `passed? false` and mints a bogus `:gate/failed`
+   PolicyEvaluation, breaking the \"never publishes a verdict it did
+   not receive\" guarantee."
+  [evaluation]
+  (and (map? evaluation)
+       (boolean? (:evaluation/passed? evaluation))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} requested-phase
+  "The phase an intervention's `:intervention/details` targets, as a
+   keyword, or nil when the request carries none."
+  [interv]
+  (let [details (:intervention/details interv)]
+    (some #(phase-keyword (get details %)) phase-detail-keys)))
+
+;; Resume plan
+(defn ^{:stratum 1} resume-plan
   "The launcher payload for a retry: the resume inputs a run needs, under
    stable `:resume/*` keys.
 
@@ -141,11 +219,13 @@
            :resume/intervention-id (:intervention/id interv)}
     from-phase (assoc :resume/from-phase from-phase)))
 
-(defn- resume-failure
-  [code]
-  {:failure/code code})
+(defn- ^{:stratum 1} pack-ids
+  [packs]
+  (mapv pack-id (or packs [])))
 
-(defn prepare-resume
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} prepare-resume
   "Rebuild resume state for a `:retry` / `:retry-from-phase`
    intervention against `events-dir`.
 
@@ -177,61 +257,7 @@
               {:resume/plan (resume-plan interv context workflow-identity
                                          from-phase)})))))))
 
-(defn launched-run-id
-  "The run id a launcher reported, or nil when it reported none. A
-   launcher that returns an anomaly, nil, or a map without a run id has
-   not dispatched anything the lifecycle can verify."
-  [launch-result]
-  (when (and (map? launch-result) (not (anomaly/anomaly? launch-result)))
-    (:resume/run-id launch-result)))
-
-(defn resume-observable?
-  "Readback for a dispatched resume: true when the launched run has
-   become observable in the event history the resume machinery itself
-   reads. Asserts the mechanism's own record — a run that never started
-   reconstructs to a `:not-found` anomaly and reads back false."
-  [events-dir run-id]
-  (boolean
-   (and run-id
-        (not (anomaly/anomaly? (wr/reconstruct-context events-dir (str run-id)))))))
-
-;; ── Policy re-evaluation ───────────────────────────────────────────────────
-
-(def ^:const re-evaluation-gate-id
-  "Gate id stamped on the gate event a `:re-evaluate` intervention
-   publishes, so the resulting PolicyEvaluation is attributable to an
-   operator re-run rather than to a workflow gate."
-  :supervisory/re-evaluate)
-
-(defn evaluation-request
-  "The payload handed to the registered policy evaluator. Carries the
-   target and the requester identity the audit record needs; details
-   pass through verbatim so a client can scope the re-run (packs,
-   rule ids) without this layer growing an opinion about them."
-  [interv]
-  {:policy/target-type (:intervention/target-type interv)
-   :policy/target-id (str (:intervention/target-id interv))
-   :policy/requested-by (:intervention/requested-by interv)
-   :policy/details (:intervention/details interv)
-   :policy/intervention-id (:intervention/id interv)})
-
-(defn- materialized-policy-eval-ids
-  "PolicyEvaluation ids currently materialized from `stream`'s events,
-   folded through the canonical supervisory accumulator. Reading the
-   entity table — not the raw event log — is what makes the post-publish
-   comparison a readback of the record rather than of our own write."
-  [stream]
-  (set (keys (:policy-evals
-              (supervisory/apply-events supervisory/empty-table
-                                        (es/get-events stream))))))
-
-(defn- pack-ids
-  "Pack identifiers as the strings `:policy-eval/packs-applied` requires;
-   evaluators name packs with keywords or strings interchangeably."
-  [packs]
-  (mapv #(if (string? %) % (str (symbol %))) (or packs [])))
-
-(defn evaluation-gate-event
+(defn ^{:stratum 2} evaluation-gate-event
   "The `:gate/passed` / `:gate/failed` event that materializes a new
    PolicyEvaluation for `interv`'s target.
 
@@ -256,19 +282,9 @@
                :gate/packs (pack-ids (:evaluation/packs-applied evaluation))
                :gate/violations (vec (:evaluation/violations evaluation))))))
 
-(defn valid-evaluation?
-  "A usable evaluator result: a map carrying a boolean
-   `:evaluation/passed?`. Anything else — nil, a non-map, or a map
-   whose verdict is missing or non-boolean — is NOT an evaluation and
-   must never be published as one. Without this check a nil/garbage
-   result coerces to `passed? false` and mints a bogus `:gate/failed`
-   PolicyEvaluation, breaking the \"never publishes a verdict it did
-   not receive\" guarantee."
-  [evaluation]
-  (and (map? evaluation)
-       (boolean? (:evaluation/passed? evaluation))))
+;------------------------------------------------------------------------------ Layer 3
 
-(defn record-policy-evaluation!
+(defn ^{:stratum 3} record-policy-evaluation!
   "Publish the evaluator's verdict and read the entity table back.
    Caller MUST gate on [[valid-evaluation?]] first — this fn assumes a
    well-formed evaluation and does not re-check.

--- a/components/operator/src/ai/miniforge/operator/mechanism.clj
+++ b/components/operator/src/ai/miniforge/operator/mechanism.clj
@@ -107,9 +107,9 @@
 (defn resume-plan
   "The launcher payload for a retry.
 
-   Deliberately shaped as the options a resume run needs — the same set
-   `mf resume` threads into `run-pipeline` — so a launcher is a thin
-   adapter rather than a translation layer.
+   Deliberately shaped around the same *semantic inputs* a resume run needs
+   (phase results, workspace checkpoint, optional FSM snapshot, DAG state),
+   so a launcher can be a thin adapter rather than a large translation layer.
 
    `from-phase` nil (plain `:retry`) keeps the FSM machine snapshot: the
    mapping table's \"resume path with FSM snapshot dispatch\". A

--- a/components/operator/src/ai/miniforge/operator/mechanism.clj
+++ b/components/operator/src/ai/miniforge/operator/mechanism.clj
@@ -107,11 +107,20 @@
 
 (defn ^{:stratum 0} launched-run-id
   "The run id a launcher reported, or nil when it reported none. A
-   launcher that returns an anomaly, nil, or a map without a run id has
-   not dispatched anything the lifecycle can verify."
+   launcher that returns an anomaly, nil, a map without a run id, or a
+   run id that is not a scalar identifier has not dispatched anything
+   the lifecycle can verify.
+
+   Only `string?` / `uuid?` run ids are accepted: a map or collection
+   under `:resume/run-id` is a misbehaving launcher, and letting it
+   through would `(str …)` into a directory name that matches nothing
+   and surface as the misleading `:resume-readback-mismatch` instead of
+   the accurate `:resume-not-dispatched`."
   [launch-result]
   (when (and (map? launch-result) (not (anomaly/anomaly? launch-result)))
-    (:resume/run-id launch-result)))
+    (let [run-id (:resume/run-id launch-result)]
+      (when (or (string? run-id) (uuid? run-id))
+        run-id))))
 
 (defn ^{:stratum 0} resume-observable?
   "Readback for a dispatched resume: true when the launched run has

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -23,15 +23,19 @@
    proposed→approved→dispatched→applied→verified event trail, and the
    no-live-runner failure path.
 
-   D-3b adds the resume launcher behind `:retry` / `:retry-from-phase`,
-   verified by reconstructing the launched run from its own event
-   history rather than by trusting what the launcher reported."
+   D-3b adds the two mechanisms that reach past control-state: the
+   resume launcher behind `:retry` / `:retry-from-phase` and the policy
+   evaluator behind `:re-evaluate`. Both are verified by readback —
+   reconstructing the launched run from its own event history, and
+   finding a PolicyEvaluation in the materialized entity table that was
+   not there before the publish."
   (:require
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.operator.application :as application]
    [ai.miniforge.operator.consumer :as consumer]
    [ai.miniforge.operator.intervention :as intervention]
    [ai.miniforge.reliability.interface :as reliability]
+   [ai.miniforge.supervisory-state.interface :as supervisory]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]])
   (:import
@@ -119,17 +123,25 @@
       (finally
         (reset! manager-state original)))))
 
-(defn- with-resume-launcher
-  "Bind the process-scoped resume launcher for the duration of `f`,
-   restoring whatever was there before."
-  [launcher f]
-  (let [launcher-state (var-get #'application/process-resume-launcher)
-        original @launcher-state]
-    (reset! launcher-state launcher)
+(defn- with-mechanism-handle
+  "Bind one of the process-scoped mechanism handles for the duration of
+   `f`, restoring whatever was there before."
+  [handle-var handle f]
+  (let [handle-state (var-get handle-var)
+        original @handle-state]
+    (reset! handle-state handle)
     (try
       (f)
       (finally
-        (reset! launcher-state original)))))
+        (reset! handle-state original)))))
+
+(defn- with-resume-launcher
+  [launcher f]
+  (with-mechanism-handle #'application/process-resume-launcher launcher f))
+
+(defn- with-policy-evaluator
+  [evaluate f]
+  (with-mechanism-handle #'application/process-policy-evaluator evaluate f))
 
 ;; -- Staged workflow history -- what a resume reconstructs from ------------
 
@@ -174,6 +186,13 @@
    `run-id` as the run it started."
   [captured run-id]
   {:launch! (fn [plan] (reset! captured plan) {:resume/run-id run-id})})
+
+(defn- policy-evals
+  "PolicyEvaluation entities materialized from `stream`'s events through
+   the canonical supervisory accumulator."
+  [stream]
+  (vals (:policy-evals (supervisory/apply-events supervisory/empty-table
+                                                 (es/get-events stream)))))
 
 ;------------------------------------------------------------------------------ Phase D verification bar — request file → paused workflow
 
@@ -248,9 +267,8 @@
     (is (= [:dispatched :applied :verified] (state-trail stream)))))
 
 (deftest verbs-without-a-mechanism-fail-not-implemented
-  (testing "waive and re-evaluate have no mechanism yet; request-replan is D-7"
+  (testing "waive has no Waiver store to write to; request-replan is D-7"
     (doseq [[verb target-id] [[:waive (str (random-uuid))]
-                              [:re-evaluate "golden/synthetic#1"]
                               [:request-replan (str (random-uuid))]]]
       (let [stream (memory-stream)
             result (application/apply-intervention! stream
@@ -489,6 +507,83 @@
            clojure.lang.ExceptionInfo
            #"requires a :launch! function"
            (application/register-resume-launcher! handles))))))
+
+(def ^:const golden-pr-target-id
+  "PR target the re-evaluation tests score."
+  "golden/synthetic#1")
+
+(defn- failing-evaluation []
+  {:evaluation/passed? false
+   :evaluation/packs-applied [:golden-pack]
+   :evaluation/violations [{:rule-id :golden/rule-001
+                            :severity :medium
+                            :category :process
+                            :message "Golden synthetic violation"}]})
+
+(deftest re-evaluate-without-an-evaluator-fails-typed
+  (with-policy-evaluator
+    nil
+    (fn []
+      (let [stream (memory-stream)
+            result (application/apply-intervention!
+                    stream (approved :re-evaluate golden-pr-target-id))]
+        (is (= :failed (:intervention/state result)))
+        (is (= :no-policy-evaluator (failure-code result))
+            "no verdict is invented when nothing can compute one")
+        (is (empty? (events-of-type stream :gate/failed))
+            "and nothing is published on the target's behalf")))))
+
+(deftest re-evaluate-writes-a-new-policy-evaluation
+  (let [captured (atom nil)]
+    (with-policy-evaluator
+      (fn [request] (reset! captured request) (failing-evaluation))
+      (fn []
+        (let [stream (memory-stream)
+              result (application/apply-intervention!
+                      stream (approved :re-evaluate golden-pr-target-id))
+              evals (policy-evals stream)]
+          (is (= :verified (:intervention/state result)))
+          (is (= [:dispatched :applied :verified] (state-trail stream)))
+          (is (= golden-pr-target-id (:policy/target-id @captured))
+              "the evaluator is asked about the intervention's target")
+          (is (= 1 (count evals)) "exactly one PolicyEvaluation materialized")
+          (is (= (get-in result [:intervention/outcome :policy-eval/id])
+                 (:policy-eval/id (first evals)))
+              "the verified outcome names the record that was written"))))))
+
+(deftest re-evaluation-adds-a-record-rather-than-mutating-one
+  (testing "N5-delta-1 §12.2: completed evaluations are immutable"
+    (with-policy-evaluator
+      (fn [_request] (failing-evaluation))
+      (fn []
+        (let [stream (memory-stream)
+              first-result (application/apply-intervention!
+                            stream (approved :re-evaluate golden-pr-target-id))
+              second-result (application/apply-intervention!
+                             stream (approved :re-evaluate golden-pr-target-id))
+              eval-ids (mapv :policy-eval/id (policy-evals stream))]
+          (is (= :verified (:intervention/state first-result)))
+          (is (= :verified (:intervention/state second-result)))
+          (is (= 2 (count (set eval-ids)))
+              "the second re-evaluation is a second record with a fresh id"))))))
+
+(deftest a-throwing-evaluator-becomes-a-failed-intervention
+  (with-policy-evaluator
+    (fn [_request] (throw (ex-info "evaluator exploded" {})))
+    (fn []
+      (let [stream (memory-stream)
+            result (application/apply-intervention!
+                    stream (approved :re-evaluate golden-pr-target-id))]
+        (is (= :failed (:intervention/state result)))
+        (is (= :application-error (failure-code result)))
+        (is (empty? (policy-evals stream))
+            "a throwing evaluator writes no PolicyEvaluation")))))
+
+(deftest policy-evaluator-registration-rejects-a-non-function
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"requires a function"
+       (application/register-policy-evaluator! "not-a-fn"))))
 
 ;------------------------------------------------------------------------------ Registry
 

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -349,6 +349,147 @@
         (is (= [:approved :dispatched :applied :verified]
                (state-trail stream)))))))
 
+(deftest retry-keeps-the-fsm-snapshot-and-the-full-completed-set
+  (let [events-dir (temp-events-dir)
+        workflow-id (random-uuid)
+        captured (atom nil)]
+    (stage-two-phase-run! events-dir workflow-id)
+    (with-resume-launcher
+      (assoc (recording-launcher captured workflow-id) :events-dir events-dir)
+      (fn []
+        (let [stream (memory-stream)
+              result (application/apply-intervention!
+                      stream (approved :retry (str workflow-id)))]
+          (is (= :verified (:intervention/state result)))
+          (is (nil? (:resume/from-phase @captured)))
+          (is (= [:explore :plan] (:resume/completed-phases @captured))))))))
+
+(deftest retry-without-reconstructable-history-fails-typed
+  (let [events-dir (temp-events-dir)]
+    (with-resume-launcher
+      {:launch! (fn [_plan] {:resume/run-id (random-uuid)})
+       :events-dir events-dir}
+      (fn []
+        (let [stream (memory-stream)
+              result (application/apply-intervention!
+                      stream (approved :retry (str (random-uuid))))]
+          (is (= :failed (:intervention/state result)))
+          (is (= :no-resume-context (failure-code result))
+              "a target with no events must not be guessed into a plan"))))))
+
+(deftest retry-from-phase-without-a-phase-detail-fails-typed
+  (let [events-dir (temp-events-dir)
+        workflow-id (random-uuid)]
+    (stage-two-phase-run! events-dir workflow-id)
+    (with-resume-launcher
+      {:launch! (fn [_plan] {:resume/run-id (random-uuid)})
+       :events-dir events-dir}
+      (fn []
+        (let [stream (memory-stream)
+              result (application/apply-intervention!
+                      stream (approved :retry-from-phase (str workflow-id)))]
+          (is (= :failed (:intervention/state result)))
+          (is (= :missing-phase (failure-code result))))))))
+
+(deftest retry-from-phase-rejects-a-phase-the-run-never-reached
+  (let [events-dir (temp-events-dir)
+        workflow-id (random-uuid)
+        launched (atom false)]
+    (stage-two-phase-run! events-dir workflow-id)
+    (with-resume-launcher
+      {:launch! (fn [_plan] (reset! launched true) {:resume/run-id (random-uuid)})
+       :events-dir events-dir}
+      (fn []
+        (let [stream (memory-stream)
+              interv (assoc (approved :retry-from-phase (str workflow-id))
+                            :intervention/details {"phase" "implement"})
+              result (application/apply-intervention! stream interv)]
+          (is (= :failed (:intervention/state result)))
+          (is (= :unknown-phase (failure-code result)))
+          (is (false? @launched)
+              "an unvalidated phase must never reach the launcher"))))))
+
+(deftest retry-launcher-reporting-no-run-fails-typed
+  (let [events-dir (temp-events-dir)
+        workflow-id (random-uuid)]
+    (stage-two-phase-run! events-dir workflow-id)
+    (with-resume-launcher
+      {:launch! (fn [_plan] nil) :events-dir events-dir}
+      (fn []
+        (let [stream (memory-stream)
+              result (application/apply-intervention!
+                      stream (approved :retry (str workflow-id)))]
+          (is (= :failed (:intervention/state result)))
+          (is (= :resume-not-dispatched (failure-code result))))))))
+
+(deftest retry-verification-is-a-readback-not-the-launchers-word
+  (testing "a launcher reporting a run that never started fails the readback"
+    (let [events-dir (temp-events-dir)
+          workflow-id (random-uuid)]
+      (stage-two-phase-run! events-dir workflow-id)
+      (with-resume-launcher
+        {:launch! (fn [_plan] {:resume/run-id (random-uuid)})
+         :events-dir events-dir}
+        (fn []
+          (let [stream (memory-stream)
+                result (application/apply-intervention!
+                        stream (approved :retry (str workflow-id)))]
+            (is (= :failed (:intervention/state result)))
+            (is (= :resume-readback-mismatch (failure-code result)))
+            (is (= [:dispatched :applied :failed] (state-trail stream))
+                "the failure lands after :applied — the dispatch did happen")))))))
+
+(deftest a-throwing-launcher-becomes-a-failed-intervention
+  (testing "a mechanism that blows up must not abort the consumer's pass"
+    (let [events-dir (temp-events-dir)
+          workflow-id (random-uuid)]
+      (stage-two-phase-run! events-dir workflow-id)
+      (with-resume-launcher
+        {:launch! (fn [_plan] (throw (ex-info "launcher exploded" {})))
+         :events-dir events-dir}
+        (fn []
+          (let [stream (memory-stream)
+                result (application/apply-intervention!
+                        stream (approved :retry (str workflow-id)))]
+            (is (= :failed (:intervention/state result)))
+            (is (= :application-error (failure-code result)))))))))
+
+(deftest injected-retry-from-phase-file-drives-the-resume-launcher
+  (testing "the Rust-produced golden fixture reaches the resume mechanism"
+    (let [events-dir (temp-events-dir)
+          stream (memory-stream)
+          resumed-id (random-uuid)
+          captured (atom nil)]
+      (stage-golden! events-dir "retry-from-phase.transit.json")
+      (stage-workflow-history!
+       events-dir golden-pause-target-id
+       [(workflow-event (parse-uuid golden-pause-target-id) :workflow/started
+                        {:workflow/spec {:workflow-type :canonical-sdlc}})
+        (workflow-event (parse-uuid golden-pause-target-id) :workflow/phase-completed
+                        {:workflow/phase :explore :phase/outcome :success})
+        (workflow-event (parse-uuid golden-pause-target-id) :workflow/phase-completed
+                        {:workflow/phase :implement :phase/outcome :failure})])
+      (stage-two-phase-run! events-dir resumed-id)
+      (with-resume-launcher
+        (assoc (recording-launcher captured resumed-id) :events-dir events-dir)
+        (fn []
+          (is (= {:routed 1 :skipped 0 :anomalies 0}
+                 (consumer/consume-pass! {:events-dir events-dir
+                                          :stream stream
+                                          :apply! application/apply-intervention!})))
+          (is (= :implement (:resume/from-phase @captured))
+              "the fixture's `phase` detail survives the wire round-trip")
+          (is (= [:approved :dispatched :applied :verified]
+                 (state-trail stream))))))))
+
+(deftest resume-launcher-registration-rejects-unusable-handles
+  (testing "wiring fails early instead of becoming an application error"
+    (doseq [handles [{} {:launch! "not-a-fn"} :not-a-map]]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"requires a :launch! function"
+           (application/register-resume-launcher! handles))))))
+
 ;------------------------------------------------------------------------------ Registry
 
 (deftest registry-round-trip

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -21,7 +21,11 @@
    Phase D verification-bar sequence: injected request file → consumer
    → applier → control-state flip → observable
    proposed→approved→dispatched→applied→verified event trail, and the
-   no-live-runner failure path."
+   no-live-runner failure path.
+
+   D-3b adds the resume launcher behind `:retry` / `:retry-from-phase`,
+   verified by reconstructing the launched run from its own event
+   history rather than by trusting what the launcher reported."
   (:require
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.operator.application :as application]
@@ -115,6 +119,62 @@
       (finally
         (reset! manager-state original)))))
 
+(defn- with-resume-launcher
+  "Bind the process-scoped resume launcher for the duration of `f`,
+   restoring whatever was there before."
+  [launcher f]
+  (let [launcher-state (var-get #'application/process-resume-launcher)
+        original @launcher-state]
+    (reset! launcher-state launcher)
+    (try
+      (f)
+      (finally
+        (reset! launcher-state original)))))
+
+;; -- Staged workflow history -- what a resume reconstructs from ------------
+
+(defn- workflow-event
+  [workflow-id event-type attrs]
+  (merge {:event/id (random-uuid)
+          :event/type event-type
+          :event/timestamp (java.util.Date.)
+          :event/sequence-number 0
+          :workflow/id workflow-id}
+         attrs))
+
+(defn- stage-workflow-history!
+  "Write `events` into the live layout `read-workflow-events-by-id`
+   probes, through the production transit encoder. Returns workflow-id."
+  [events-dir workflow-id events]
+  (let [dir (io/file events-dir "live" (str workflow-id))]
+    (.mkdirs dir)
+    (doseq [[i event] (map-indexed vector events)]
+      (spit (io/file dir (format "%03d-event.json" i))
+            (es/serialize-event event)
+            :encoding "UTF-8"))
+    workflow-id))
+
+(defn- stage-two-phase-run!
+  "A run that completed `:explore` then `:plan` and stopped. Its phase
+   history is exactly #{:explore :plan} — anything else a
+   `retry-from-phase` names must be rejected."
+  [events-dir workflow-id]
+  (stage-workflow-history!
+   events-dir workflow-id
+   [(workflow-event workflow-id :workflow/started
+                    {:workflow/spec {:workflow-type :canonical-sdlc
+                                     :version "1.0.0"}})
+    (workflow-event workflow-id :workflow/phase-completed
+                    {:workflow/phase :explore :phase/outcome :success})
+    (workflow-event workflow-id :workflow/phase-completed
+                    {:workflow/phase :plan :phase/outcome :success})]))
+
+(defn- recording-launcher
+  "A resume launcher that records the plan it was handed and reports
+   `run-id` as the run it started."
+  [captured run-id]
+  {:launch! (fn [plan] (reset! captured plan) {:resume/run-id run-id})})
+
 ;------------------------------------------------------------------------------ Phase D verification bar — request file → paused workflow
 
 (deftest injected-request-file-pauses-the-registered-runner
@@ -187,13 +247,56 @@
     (is (= :verified (:intervention/state result)))
     (is (= [:dispatched :applied :verified] (state-trail stream)))))
 
-(deftest retry-fails-not-implemented
-  (with-runner
-    (fn [wid _cs]
+(deftest verbs-without-a-mechanism-fail-not-implemented
+  (testing "waive and re-evaluate have no mechanism yet; request-replan is D-7"
+    (doseq [[verb target-id] [[:waive (str (random-uuid))]
+                              [:re-evaluate "golden/synthetic#1"]
+                              [:request-replan (str (random-uuid))]]]
       (let [stream (memory-stream)
-            result (application/apply-intervention! stream (approved :retry wid))]
-        (is (= :failed (:intervention/state result)))
+            result (application/apply-intervention! stream
+                                                    (approved verb target-id))]
+        (is (= :failed (:intervention/state result))
+            (str verb " must fail rather than park"))
         (is (= :not-implemented (failure-code result)))))))
+
+;------------------------------------------------------------------------------ Retry — resume machinery (D-3b)
+
+(deftest retry-without-a-launcher-fails-typed
+  (with-resume-launcher
+    nil
+    (fn []
+      (let [stream (memory-stream)
+            result (application/apply-intervention!
+                    stream (approved :retry (str (random-uuid))))]
+        (is (= :failed (:intervention/state result)))
+        (is (= :no-resume-launcher (failure-code result)))))))
+
+(deftest retry-from-phase-rewinds-and-verifies-by-readback
+  (let [events-dir (temp-events-dir)
+        workflow-id (random-uuid)
+        resumed-id (random-uuid)
+        captured (atom nil)]
+    (stage-two-phase-run! events-dir workflow-id)
+    ;; The launcher's run is observable in the event history the resume
+    ;; machinery itself reads — that is what `verified` asserts.
+    (stage-two-phase-run! events-dir resumed-id)
+    (with-resume-launcher
+      (assoc (recording-launcher captured resumed-id) :events-dir events-dir)
+      (fn []
+        (let [stream (memory-stream)
+              interv (assoc (approved :retry-from-phase (str workflow-id))
+                            :intervention/details {"phase" "plan"})
+              result (application/apply-intervention! stream interv)]
+          (is (= :verified (:intervention/state result)))
+          (is (= [:dispatched :applied :verified] (state-trail stream)))
+          (is (= :plan (:resume/from-phase @captured))
+              "the wire's string-keyed `phase` detail resolves to a phase keyword")
+          (is (= [:explore] (:resume/completed-phases @captured))
+              "rewinding to :plan re-runs :plan and everything after it")
+          (is (nil? (:resume/machine-snapshot @captured))
+              "a rewind must not restore an FSM snapshot parked past the target")
+          (is (= :canonical-sdlc (:resume/workflow-type @captured))))))))
+
 
 (deftest safe-mode-without-manager-fails-typed
   (with-degradation-manager

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -551,6 +551,28 @@
                  (:policy-eval/id (first evals)))
               "the verified outcome names the record that was written"))))))
 
+(deftest re-evaluate-with-an-invalid-verdict-fails-and-publishes-nothing
+  (testing "a nil / non-map / verdict-less evaluator result is not a verdict"
+    (doseq [bad [nil
+                 "not-a-map"
+                 {}                                  ; missing :evaluation/passed?
+                 {:evaluation/passed? "true"}        ; non-boolean verdict
+                 {:evaluation/violations []}]]       ; violations but no verdict
+      (with-policy-evaluator
+        (fn [_request] bad)
+        (fn []
+          (let [stream (memory-stream)
+                result (application/apply-intervention!
+                        stream (approved :re-evaluate golden-pr-target-id))]
+            (is (= :failed (:intervention/state result))
+                (str "invalid evaluator result must fail the intervention: "
+                     (pr-str bad)))
+            (is (= :invalid-policy-evaluation (failure-code result)))
+            (is (empty? (events-of-type stream :gate/failed))
+                "no bogus :gate/failed record is minted")
+            (is (empty? (policy-evals stream))
+                "no PolicyEvaluation is materialized from a non-verdict")))))))
+
 (deftest re-evaluation-adds-a-record-rather-than-mutating-one
   (testing "N5-delta-1 §12.2: completed evaluations are immutable"
     (with-policy-evaluator

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -169,7 +169,10 @@
 
 (deftest ^{:stratum 0} resume-launcher-registration-rejects-unusable-handles
   (testing "wiring fails early instead of becoming an application error"
-    (doseq [handles [{} {:launch! "not-a-fn"} :not-a-map]]
+    ;; `:launch! :kw` / a map are `ifn?` but not `fn?` — the old check
+    ;; let them register and fail later; they must be rejected here.
+    (doseq [handles [{} {:launch! "not-a-fn"} :not-a-map
+                     {:launch! :a-keyword} {:launch! {:not "a fn"}}]]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"requires a :launch! function"
@@ -188,10 +191,14 @@
                             :message "Golden synthetic violation"}]})
 
 (deftest ^{:stratum 0} policy-evaluator-registration-rejects-a-non-function
-  (is (thrown-with-msg?
-       clojure.lang.ExceptionInfo
-       #"requires a function"
-       (application/register-policy-evaluator! "not-a-fn"))))
+  ;; string, keyword, and map are all NOT `fn?` (keyword/map are `ifn?`,
+  ;; which the old check wrongly accepted).
+  (doseq [bad ["not-a-fn" :a-keyword {:not "a fn"}]]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"requires a function"
+         (application/register-policy-evaluator! bad))
+        (str "bad evaluator " (pr-str bad)))))
 
 (deftest ^{:stratum 0} ownership-filter-does-not-hide-invalid-request-types
   (is (true? (application/live-intervention-target?

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.application-test
   "Intervention application layer (Phase D D-3) tests, including the
    Phase D verification-bar sequence: injected request file → consumer
@@ -42,13 +41,14 @@
    [java.nio.file Files]
    [java.nio.file.attribute FileAttribute]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:const golden-pause-target-id
+;------------------------------------------------------------------------------ Helpers
+(def ^{:stratum 0} ^:const golden-pause-target-id
   "The workflow target id stamped by the Rust golden-fixture generator."
   "00000000-0000-4000-8000-0000000000aa")
 
-(defn- find-workspace-root
+(defn- ^{:stratum 0} find-workspace-root
   []
   (loop [dir (io/file (System/getProperty "user.dir")) hops 0]
     (cond
@@ -57,26 +57,15 @@
       (throw (ex-info "workspace.edn not found" {}))
       :else (recur (.getParentFile dir) (inc hops)))))
 
-(defn- temp-events-dir
+(defn- ^{:stratum 0} temp-events-dir
   ^java.io.File []
   (.toFile (Files/createTempDirectory "operator-application-test"
                                       (make-array FileAttribute 0))))
 
-(defn- stage-golden!
-  [events-dir fixture-name]
-  (let [target (io/file events-dir "operator" fixture-name)]
-    (io/make-parents target)
-    (spit target
-          (slurp (io/file (find-workspace-root)
-                          "contracts" "operator-events" "golden"
-                          fixture-name)
-                 :encoding "UTF-8")
-          :encoding "UTF-8")))
-
-(defn- memory-stream []
+(defn- ^{:stratum 0} memory-stream []
   (es/create-event-stream {:sinks []}))
 
-(defn- approved
+(defn- ^{:stratum 0} approved
   "Build an :approved intervention of `type` against `target-id`."
   [type target-id]
   (:intervention
@@ -87,21 +76,21 @@
       :intervention/requested-by "test@example.invalid"
       :intervention/request-source :tui}))))
 
-(defn- state-trail
+(defn- ^{:stratum 0} state-trail
   [stream]
   (->> (es/get-events stream)
        (filter #(= consumer/state-changed-event-type (:event/type %)))
        (mapv :intervention/state)))
 
-(defn- events-of-type
+(defn- ^{:stratum 0} events-of-type
   [stream event-type]
   (filterv #(= event-type (:event/type %)) (es/get-events stream)))
 
-(defn- failure-code
+(defn- ^{:stratum 0} failure-code
   [interv]
   (get-in interv [:intervention/details :failure/code]))
 
-(defn- with-runner
+(defn- ^{:stratum 0} with-runner
   "Register a control-state for a fresh workflow id, run `f`, always
    deregister. Returns [workflow-id control-state result]."
   [f]
@@ -113,7 +102,7 @@
       (finally
         (application/deregister-runner! wid)))))
 
-(defn- with-degradation-manager
+(defn- ^{:stratum 0} with-degradation-manager
   [manager f]
   (let [manager-state (var-get #'application/process-degradation-manager)
         original @manager-state]
@@ -123,7 +112,7 @@
       (finally
         (reset! manager-state original)))))
 
-(defn- with-mechanism-handle
+(defn- ^{:stratum 0} with-mechanism-handle
   "Bind one of the process-scoped mechanism handles for the duration of
    `f`, restoring whatever was there before."
   [handle-var handle f]
@@ -135,17 +124,8 @@
       (finally
         (reset! handle-state original)))))
 
-(defn- with-resume-launcher
-  [launcher f]
-  (with-mechanism-handle #'application/process-resume-launcher launcher f))
-
-(defn- with-policy-evaluator
-  [evaluate f]
-  (with-mechanism-handle #'application/process-policy-evaluator evaluate f))
-
 ;; -- Staged workflow history -- what a resume reconstructs from ------------
-
-(defn- workflow-event
+(defn- ^{:stratum 0} workflow-event
   [workflow-id event-type attrs]
   (merge {:event/id (random-uuid)
           :event/type event-type
@@ -154,7 +134,7 @@
           :workflow/id workflow-id}
          attrs))
 
-(defn- stage-workflow-history!
+(defn- ^{:stratum 0} stage-workflow-history!
   "Write `events` into the live layout `read-workflow-events-by-id`
    probes, through the production transit encoder. Returns workflow-id."
   [events-dir workflow-id events]
@@ -166,7 +146,87 @@
             :encoding "UTF-8"))
     workflow-id))
 
-(defn- stage-two-phase-run!
+(defn- ^{:stratum 0} recording-launcher
+  "A resume launcher that records the plan it was handed and reports
+   `run-id` as the run it started."
+  [captured run-id]
+  {:launch! (fn [plan] (reset! captured plan) {:resume/run-id run-id})})
+
+(defn- ^{:stratum 0} policy-evals
+  "PolicyEvaluation entities materialized from `stream`'s events through
+   the canonical supervisory accumulator."
+  [stream]
+  (vals (:policy-evals (supervisory/apply-events supervisory/empty-table
+                                                 (es/get-events stream)))))
+
+(deftest ^{:stratum 0} register-runner-rejects-invalid-control-state
+  (testing "runner wiring fails early instead of becoming an application error"
+    (doseq [handles [{} {:control-state :not-an-atom} :not-a-map]]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"requires an atom :control-state"
+           (application/register-runner! (random-uuid) handles))))))
+
+(deftest ^{:stratum 0} resume-launcher-registration-rejects-unusable-handles
+  (testing "wiring fails early instead of becoming an application error"
+    (doseq [handles [{} {:launch! "not-a-fn"} :not-a-map]]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"requires a :launch! function"
+           (application/register-resume-launcher! handles))))))
+
+(def ^{:stratum 0} ^:const golden-pr-target-id
+  "PR target the re-evaluation tests score."
+  "golden/synthetic#1")
+
+(defn- ^{:stratum 0} failing-evaluation []
+  {:evaluation/passed? false
+   :evaluation/packs-applied [:golden-pack]
+   :evaluation/violations [{:rule-id :golden/rule-001
+                            :severity :medium
+                            :category :process
+                            :message "Golden synthetic violation"}]})
+
+(deftest ^{:stratum 0} policy-evaluator-registration-rejects-a-non-function
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"requires a function"
+       (application/register-policy-evaluator! "not-a-fn"))))
+
+(deftest ^{:stratum 0} ownership-filter-does-not-hide-invalid-request-types
+  (is (true? (application/live-intervention-target?
+              {:intervention/type :not-in-the-bounded-vocabulary
+               :intervention/target-type :workflow
+               :intervention/target-id (random-uuid)}))
+      "unknown types must reach lifecycle validation and emit an anomaly")
+  (is (true? (application/live-intervention-target?
+              {:intervention/type :force-safe-mode
+               :intervention/target-type :workflow
+               :intervention/target-id (random-uuid)}))
+      "mismatched known targets must not be deferred as unowned"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} stage-golden!
+  [events-dir fixture-name]
+  (let [target (io/file events-dir "operator" fixture-name)]
+    (io/make-parents target)
+    (spit target
+          (slurp (io/file (find-workspace-root)
+                          "contracts" "operator-events" "golden"
+                          fixture-name)
+                 :encoding "UTF-8")
+          :encoding "UTF-8")))
+
+(defn- ^{:stratum 1} with-resume-launcher
+  [launcher f]
+  (with-mechanism-handle #'application/process-resume-launcher launcher f))
+
+(defn- ^{:stratum 1} with-policy-evaluator
+  [evaluate f]
+  (with-mechanism-handle #'application/process-policy-evaluator evaluate f))
+
+(defn- ^{:stratum 1} stage-two-phase-run!
   "A run that completed `:explore` then `:plan` and stopped. Its phase
    history is exactly #{:explore :plan} — anything else a
    `retry-from-phase` names must be rejected."
@@ -181,22 +241,95 @@
     (workflow-event workflow-id :workflow/phase-completed
                     {:workflow/phase :plan :phase/outcome :success})]))
 
-(defn- recording-launcher
-  "A resume launcher that records the plan it was handed and reports
-   `run-id` as the run it started."
-  [captured run-id]
-  {:launch! (fn [plan] (reset! captured plan) {:resume/run-id run-id})})
+;------------------------------------------------------------------------------ Control-state verbs verify by readback
+(deftest ^{:stratum 1} resume-flips-paused-off
+  (with-runner
+    (fn [wid cs]
+      (es/pause! cs)
+      (let [stream (memory-stream)
+            result (application/apply-intervention! stream (approved :resume wid))]
+        (is (false? (es/paused? cs)))
+        (is (= :verified (:intervention/state result)))))))
 
-(defn- policy-evals
-  "PolicyEvaluation entities materialized from `stream`'s events through
-   the canonical supervisory accumulator."
-  [stream]
-  (vals (:policy-evals (supervisory/apply-events supervisory/empty-table
-                                                 (es/get-events stream)))))
+(deftest ^{:stratum 1} cancel-sets-stopped
+  (with-runner
+    (fn [wid cs]
+      (let [stream (memory-stream)
+            result (application/apply-intervention! stream (approved :cancel wid))]
+        (is (true? (es/cancelled? cs)))
+        (is (= :verified (:intervention/state result)))))))
+
+;------------------------------------------------------------------------------ No-effect and unwired verbs
+(deftest ^{:stratum 1} acknowledge-verifies-without-a-runner
+  (let [stream (memory-stream)
+        result (application/apply-intervention!
+                stream (approved :acknowledge (str (random-uuid))))]
+    (is (= :verified (:intervention/state result)))
+    (is (= [:dispatched :applied :verified] (state-trail stream)))))
+
+(deftest ^{:stratum 1} verbs-without-a-mechanism-fail-not-implemented
+  (testing "waive has no Waiver store to write to; request-replan is D-7"
+    (doseq [[verb target-id] [[:waive (str (random-uuid))]
+                              [:request-replan (str (random-uuid))]]]
+      (let [stream (memory-stream)
+            result (application/apply-intervention! stream
+                                                    (approved verb target-id))]
+        (is (= :failed (:intervention/state result))
+            (str verb " must fail rather than park"))
+        (is (= :not-implemented (failure-code result)))))))
+
+(deftest ^{:stratum 1} safe-mode-without-manager-fails-typed
+  (with-degradation-manager
+    nil
+    (fn []
+      (let [stream (memory-stream)
+            result (application/apply-intervention!
+                    stream (approved :force-safe-mode "degradation"))]
+        (is (= :failed (:intervention/state result)))
+        (is (= :no-degradation-manager (failure-code result)))))))
+
+(deftest ^{:stratum 1} safe-mode-verifies-manual-entry-and-exit-by-readback
+  (let [stream (memory-stream)
+        manager (reliability/create-degradation-manager stream)
+        target-id "degradation"]
+    (with-degradation-manager
+      manager
+      (fn []
+        (let [entered (application/apply-intervention!
+                       stream (approved :force-safe-mode target-id))
+              safe-mode-events (events-of-type stream :safe-mode/entered)]
+          (is (= :verified (:intervention/state entered)))
+          (is (= :safe-mode (reliability/degradation-mode manager)))
+          (is (= :manual (:safe-mode/trigger (first safe-mode-events))))
+          (let [exited (application/apply-intervention!
+                        stream (approved :exit-safe-mode target-id))]
+            (is (= :verified (:intervention/state exited)))
+            (is (= :nominal (reliability/degradation-mode manager)))
+            (is (= {:verb :exit-safe-mode
+                    :observed :nominal
+                    :expected :nominal}
+                   (:intervention/outcome exited)))))))))
+
+;------------------------------------------------------------------------------ Registry
+(deftest ^{:stratum 1} registry-round-trip
+  (let [wid (str (random-uuid))
+        stream (memory-stream)]
+    (is (false? (application/live-runner? wid)))
+    (application/register-runner! wid {:control-state (es/create-control-state)
+                                       :event-stream stream})
+    (is (true? (application/live-runner? wid)))
+    (is (identical? stream
+                    (application/live-intervention-stream
+                     {:intervention/type :pause
+                      :intervention/target-id wid})))
+    (application/deregister-runner! wid)
+    (application/deregister-runner! wid)
+    (is (false? (application/live-runner? wid)))))
+
+;------------------------------------------------------------------------------ Layer 2
 
 ;------------------------------------------------------------------------------ Phase D verification bar — request file → paused workflow
-
-(deftest injected-request-file-pauses-the-registered-runner
+(deftest ^{:stratum 2} injected-request-file-pauses-the-registered-runner
   (let [events-dir (temp-events-dir)
         stream (memory-stream)
         cs (es/create-control-state)]
@@ -213,7 +346,7 @@
       (finally
         (application/deregister-runner! golden-pause-target-id)))))
 
-(deftest no-live-runner-fails-typed
+(deftest ^{:stratum 2} no-live-runner-fails-typed
   (let [events-dir (temp-events-dir)
         stream (memory-stream)]
     (stage-golden! events-dir "pause.transit.json")
@@ -230,56 +363,8 @@
       (is (= :no-live-runner (failure-code failed))
           "the machine-readable failure code remains typed"))))
 
-;------------------------------------------------------------------------------ Control-state verbs verify by readback
-
-(deftest resume-flips-paused-off
-  (with-runner
-    (fn [wid cs]
-      (es/pause! cs)
-      (let [stream (memory-stream)
-            result (application/apply-intervention! stream (approved :resume wid))]
-        (is (false? (es/paused? cs)))
-        (is (= :verified (:intervention/state result)))))))
-
-(deftest cancel-sets-stopped
-  (with-runner
-    (fn [wid cs]
-      (let [stream (memory-stream)
-            result (application/apply-intervention! stream (approved :cancel wid))]
-        (is (true? (es/cancelled? cs)))
-        (is (= :verified (:intervention/state result)))))))
-
-(deftest register-runner-rejects-invalid-control-state
-  (testing "runner wiring fails early instead of becoming an application error"
-    (doseq [handles [{} {:control-state :not-an-atom} :not-a-map]]
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"requires an atom :control-state"
-           (application/register-runner! (random-uuid) handles))))))
-
-;------------------------------------------------------------------------------ No-effect and unwired verbs
-
-(deftest acknowledge-verifies-without-a-runner
-  (let [stream (memory-stream)
-        result (application/apply-intervention!
-                stream (approved :acknowledge (str (random-uuid))))]
-    (is (= :verified (:intervention/state result)))
-    (is (= [:dispatched :applied :verified] (state-trail stream)))))
-
-(deftest verbs-without-a-mechanism-fail-not-implemented
-  (testing "waive has no Waiver store to write to; request-replan is D-7"
-    (doseq [[verb target-id] [[:waive (str (random-uuid))]
-                              [:request-replan (str (random-uuid))]]]
-      (let [stream (memory-stream)
-            result (application/apply-intervention! stream
-                                                    (approved verb target-id))]
-        (is (= :failed (:intervention/state result))
-            (str verb " must fail rather than park"))
-        (is (= :not-implemented (failure-code result)))))))
-
 ;------------------------------------------------------------------------------ Retry — resume machinery (D-3b)
-
-(deftest retry-without-a-launcher-fails-typed
+(deftest ^{:stratum 2} retry-without-a-launcher-fails-typed
   (with-resume-launcher
     nil
     (fn []
@@ -289,7 +374,7 @@
         (is (= :failed (:intervention/state result)))
         (is (= :no-resume-launcher (failure-code result)))))))
 
-(deftest retry-from-phase-rewinds-and-verifies-by-readback
+(deftest ^{:stratum 2} retry-from-phase-rewinds-and-verifies-by-readback
   (let [events-dir (temp-events-dir)
         workflow-id (random-uuid)
         resumed-id (random-uuid)
@@ -315,40 +400,7 @@
               "a rewind must not restore an FSM snapshot parked past the target")
           (is (= :canonical-sdlc (:resume/workflow-type @captured))))))))
 
-
-(deftest safe-mode-without-manager-fails-typed
-  (with-degradation-manager
-    nil
-    (fn []
-      (let [stream (memory-stream)
-            result (application/apply-intervention!
-                    stream (approved :force-safe-mode "degradation"))]
-        (is (= :failed (:intervention/state result)))
-        (is (= :no-degradation-manager (failure-code result)))))))
-
-(deftest safe-mode-verifies-manual-entry-and-exit-by-readback
-  (let [stream (memory-stream)
-        manager (reliability/create-degradation-manager stream)
-        target-id "degradation"]
-    (with-degradation-manager
-      manager
-      (fn []
-        (let [entered (application/apply-intervention!
-                       stream (approved :force-safe-mode target-id))
-              safe-mode-events (events-of-type stream :safe-mode/entered)]
-          (is (= :verified (:intervention/state entered)))
-          (is (= :safe-mode (reliability/degradation-mode manager)))
-          (is (= :manual (:safe-mode/trigger (first safe-mode-events))))
-          (let [exited (application/apply-intervention!
-                        stream (approved :exit-safe-mode target-id))]
-            (is (= :verified (:intervention/state exited)))
-            (is (= :nominal (reliability/degradation-mode manager)))
-            (is (= {:verb :exit-safe-mode
-                    :observed :nominal
-                    :expected :nominal}
-                   (:intervention/outcome exited)))))))))
-
-(deftest injected-safe-mode-file-uses-the-process-degradation-manager
+(deftest ^{:stratum 2} injected-safe-mode-file-uses-the-process-degradation-manager
   (let [events-dir (temp-events-dir)
         stream (memory-stream)
         manager (reliability/create-degradation-manager stream)]
@@ -367,7 +419,7 @@
         (is (= [:approved :dispatched :applied :verified]
                (state-trail stream)))))))
 
-(deftest retry-keeps-the-fsm-snapshot-and-the-full-completed-set
+(deftest ^{:stratum 2} retry-keeps-the-fsm-snapshot-and-the-full-completed-set
   (let [events-dir (temp-events-dir)
         workflow-id (random-uuid)
         captured (atom nil)]
@@ -382,7 +434,7 @@
           (is (nil? (:resume/from-phase @captured)))
           (is (= [:explore :plan] (:resume/completed-phases @captured))))))))
 
-(deftest retry-without-reconstructable-history-fails-typed
+(deftest ^{:stratum 2} retry-without-reconstructable-history-fails-typed
   (let [events-dir (temp-events-dir)]
     (with-resume-launcher
       {:launch! (fn [_plan] {:resume/run-id (random-uuid)})
@@ -395,7 +447,7 @@
           (is (= :no-resume-context (failure-code result))
               "a target with no events must not be guessed into a plan"))))))
 
-(deftest retry-from-phase-without-a-phase-detail-fails-typed
+(deftest ^{:stratum 2} retry-from-phase-without-a-phase-detail-fails-typed
   (let [events-dir (temp-events-dir)
         workflow-id (random-uuid)]
     (stage-two-phase-run! events-dir workflow-id)
@@ -409,7 +461,7 @@
           (is (= :failed (:intervention/state result)))
           (is (= :missing-phase (failure-code result))))))))
 
-(deftest retry-from-phase-rejects-a-phase-the-run-never-reached
+(deftest ^{:stratum 2} retry-from-phase-rejects-a-phase-the-run-never-reached
   (let [events-dir (temp-events-dir)
         workflow-id (random-uuid)
         launched (atom false)]
@@ -427,7 +479,7 @@
           (is (false? @launched)
               "an unvalidated phase must never reach the launcher"))))))
 
-(deftest retry-launcher-reporting-no-run-fails-typed
+(deftest ^{:stratum 2} retry-launcher-reporting-no-run-fails-typed
   (let [events-dir (temp-events-dir)
         workflow-id (random-uuid)]
     (stage-two-phase-run! events-dir workflow-id)
@@ -440,7 +492,7 @@
           (is (= :failed (:intervention/state result)))
           (is (= :resume-not-dispatched (failure-code result))))))))
 
-(deftest retry-verification-is-a-readback-not-the-launchers-word
+(deftest ^{:stratum 2} retry-verification-is-a-readback-not-the-launchers-word
   (testing "a launcher reporting a run that never started fails the readback"
     (let [events-dir (temp-events-dir)
           workflow-id (random-uuid)]
@@ -457,7 +509,7 @@
             (is (= [:dispatched :applied :failed] (state-trail stream))
                 "the failure lands after :applied — the dispatch did happen")))))))
 
-(deftest a-throwing-launcher-becomes-a-failed-intervention
+(deftest ^{:stratum 2} a-throwing-launcher-becomes-a-failed-intervention
   (testing "a mechanism that blows up must not abort the consumer's pass"
     (let [events-dir (temp-events-dir)
           workflow-id (random-uuid)]
@@ -472,7 +524,7 @@
             (is (= :failed (:intervention/state result)))
             (is (= :application-error (failure-code result)))))))))
 
-(deftest injected-retry-from-phase-file-drives-the-resume-launcher
+(deftest ^{:stratum 2} injected-retry-from-phase-file-drives-the-resume-launcher
   (testing "the Rust-produced golden fixture reaches the resume mechanism"
     (let [events-dir (temp-events-dir)
           stream (memory-stream)
@@ -500,27 +552,7 @@
           (is (= [:approved :dispatched :applied :verified]
                  (state-trail stream))))))))
 
-(deftest resume-launcher-registration-rejects-unusable-handles
-  (testing "wiring fails early instead of becoming an application error"
-    (doseq [handles [{} {:launch! "not-a-fn"} :not-a-map]]
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"requires a :launch! function"
-           (application/register-resume-launcher! handles))))))
-
-(def ^:const golden-pr-target-id
-  "PR target the re-evaluation tests score."
-  "golden/synthetic#1")
-
-(defn- failing-evaluation []
-  {:evaluation/passed? false
-   :evaluation/packs-applied [:golden-pack]
-   :evaluation/violations [{:rule-id :golden/rule-001
-                            :severity :medium
-                            :category :process
-                            :message "Golden synthetic violation"}]})
-
-(deftest re-evaluate-without-an-evaluator-fails-typed
+(deftest ^{:stratum 2} re-evaluate-without-an-evaluator-fails-typed
   (with-policy-evaluator
     nil
     (fn []
@@ -533,7 +565,7 @@
         (is (empty? (events-of-type stream :gate/failed))
             "and nothing is published on the target's behalf")))))
 
-(deftest re-evaluate-writes-a-new-policy-evaluation
+(deftest ^{:stratum 2} re-evaluate-writes-a-new-policy-evaluation
   (let [captured (atom nil)]
     (with-policy-evaluator
       (fn [request] (reset! captured request) (failing-evaluation))
@@ -549,9 +581,26 @@
           (is (= 1 (count evals)) "exactly one PolicyEvaluation materialized")
           (is (= (get-in result [:intervention/outcome :policy-eval/id])
                  (:policy-eval/id (first evals)))
-              "the verified outcome names the record that was written"))))))
+              "the verified outcome names the record that was written")
+          (is (= ["golden-pack"] (:policy-eval/packs-applied (first evals)))
+              "keyword pack ids coerce to plain strings on the record"))))))
 
-(deftest re-evaluate-with-an-invalid-verdict-fails-and-publishes-nothing
+(deftest ^{:stratum 2} re-evaluate-coerces-mixed-pack-id-forms-to-strings
+  (testing "packs arrive as string / keyword / namespaced-keyword / symbol"
+    (with-policy-evaluator
+      (fn [_request]
+        {:evaluation/passed? true
+         :evaluation/packs-applied ["core" :security :org/house 'legacy]
+         :evaluation/violations []})
+      (fn []
+        (let [stream (memory-stream)
+              _ (application/apply-intervention!
+                 stream (approved :re-evaluate golden-pr-target-id))
+              packs (:policy-eval/packs-applied (first (policy-evals stream)))]
+          (is (= ["core" "security" "org/house" "legacy"] packs)
+              "every form becomes its plain string, namespace preserved"))))))
+
+(deftest ^{:stratum 2} re-evaluate-with-an-invalid-verdict-fails-and-publishes-nothing
   (testing "a nil / non-map / verdict-less evaluator result is not a verdict"
     (doseq [bad [nil
                  "not-a-map"
@@ -573,7 +622,7 @@
             (is (empty? (policy-evals stream))
                 "no PolicyEvaluation is materialized from a non-verdict")))))))
 
-(deftest re-evaluation-adds-a-record-rather-than-mutating-one
+(deftest ^{:stratum 2} re-evaluation-adds-a-record-rather-than-mutating-one
   (testing "N5-delta-1 §12.2: completed evaluations are immutable"
     (with-policy-evaluator
       (fn [_request] (failing-evaluation))
@@ -589,7 +638,7 @@
           (is (= 2 (count (set eval-ids)))
               "the second re-evaluation is a second record with a fresh id"))))))
 
-(deftest a-throwing-evaluator-becomes-a-failed-intervention
+(deftest ^{:stratum 2} a-throwing-evaluator-becomes-a-failed-intervention
   (with-policy-evaluator
     (fn [_request] (throw (ex-info "evaluator exploded" {})))
     (fn []
@@ -600,38 +649,3 @@
         (is (= :application-error (failure-code result)))
         (is (empty? (policy-evals stream))
             "a throwing evaluator writes no PolicyEvaluation")))))
-
-(deftest policy-evaluator-registration-rejects-a-non-function
-  (is (thrown-with-msg?
-       clojure.lang.ExceptionInfo
-       #"requires a function"
-       (application/register-policy-evaluator! "not-a-fn"))))
-
-;------------------------------------------------------------------------------ Registry
-
-(deftest registry-round-trip
-  (let [wid (str (random-uuid))
-        stream (memory-stream)]
-    (is (false? (application/live-runner? wid)))
-    (application/register-runner! wid {:control-state (es/create-control-state)
-                                       :event-stream stream})
-    (is (true? (application/live-runner? wid)))
-    (is (identical? stream
-                    (application/live-intervention-stream
-                     {:intervention/type :pause
-                      :intervention/target-id wid})))
-    (application/deregister-runner! wid)
-    (application/deregister-runner! wid)
-    (is (false? (application/live-runner? wid)))))
-
-(deftest ownership-filter-does-not-hide-invalid-request-types
-  (is (true? (application/live-intervention-target?
-              {:intervention/type :not-in-the-bounded-vocabulary
-               :intervention/target-type :workflow
-               :intervention/target-id (random-uuid)}))
-      "unknown types must reach lifecycle validation and emit an anomaly")
-  (is (true? (application/live-intervention-target?
-              {:intervention/type :force-safe-mode
-               :intervention/target-type :workflow
-               :intervention/target-id (random-uuid)}))
-      "mismatched known targets must not be deferred as unowned"))

--- a/components/operator/test/ai/miniforge/operator/mechanism_test.clj
+++ b/components/operator/test/ai/miniforge/operator/mechanism_test.clj
@@ -1,0 +1,105 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.mechanism-test
+  "Unit coverage for the pure halves of the D-3b mechanisms: reading the
+   requested phase off the wire, deriving a run's real phase history,
+   and shaping the resume plan. The lifecycle wiring these feed is
+   covered in `application-test`."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.operator.mechanism :as mechanism]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Requested phase
+
+(deftest requested-phase-reads-both-detail-shapes
+  (testing "the wire's string key (transit leaves details keys untagged)"
+    (is (= :implement
+           (mechanism/requested-phase
+            {:intervention/details {"phase" "implement"}}))))
+
+  (testing "the in-process keyword shape"
+    (is (= :implement
+           (mechanism/requested-phase
+            {:intervention/details {:phase :implement}}))))
+
+  (testing "absent, blank, and unusable values yield nil, not a phantom phase"
+    (doseq [details [nil {} {"phase" ""} {"phase" "   "} {"phase" 7}]]
+      (is (nil? (mechanism/requested-phase {:intervention/details details}))
+          (str "details " (pr-str details))))))
+
+;------------------------------------------------------------------------------ Phase history
+
+(deftest known-phases-covers-completed-attempted-and-current
+  (let [context {:completed-phases [:explore :plan]
+                 :phase-results {:explore {} :plan {} :implement {}}
+                 :machine-snapshot {:execution/current-phase :verify}}]
+    (is (= #{:explore :plan :implement :verify}
+           (mechanism/known-phases context))
+        "a failed phase has a result without being completed — it still ran")))
+
+(deftest known-phases-tolerates-a-bare-context
+  (is (= #{} (mechanism/known-phases {}))))
+
+(deftest phases-before-truncates-at-the-target
+  (is (= [:explore] (mechanism/phases-before [:explore :plan :implement] :plan)))
+  (is (= [] (mechanism/phases-before [:explore :plan] :explore)))
+  (is (= [:explore :plan] (mechanism/phases-before [:explore :plan] :nowhere))
+      "a phase outside the list truncates nothing — the caller validates first"))
+
+;------------------------------------------------------------------------------ Resume plan
+
+(def ^:private context
+  {:completed-phases [:explore :plan]
+   :phase-results {:explore {:outcome :success}}
+   :machine-snapshot {:execution/current-phase :implement}
+   :workspace-checkpoint {:branch "feat/x"}
+   :completed-dag-tasks #{"task-1"}
+   :completed-dag-artifacts [{:path "a.clj"}]})
+
+(def ^:private workflow-identity
+  {:workflow-type :canonical-sdlc :workflow-version "1.0.0"})
+
+(deftest plain-retry-keeps-the-fsm-snapshot
+  (let [plan (mechanism/resume-plan {:intervention/target-id "wf-1"
+                                     :intervention/requested-by "op@example.invalid"}
+                                    context workflow-identity nil)]
+    (is (= [:explore :plan] (:resume/completed-phases plan)))
+    (is (= {:execution/current-phase :implement} (:resume/machine-snapshot plan)))
+    (is (not (contains? plan :resume/from-phase)))
+    (is (= "wf-1" (:resume/workflow-id plan)))
+    (is (= :canonical-sdlc (:resume/workflow-type plan)))
+    (is (= #{"task-1"} (:resume/completed-dag-tasks plan)))))
+
+(deftest retry-from-phase-rewinds-and-drops-the-snapshot
+  (let [plan (mechanism/resume-plan {:intervention/target-id "wf-1"} context
+                                    workflow-identity :plan)]
+    (is (= :plan (:resume/from-phase plan)))
+    (is (= [:explore] (:resume/completed-phases plan)))
+    (is (nil? (:resume/machine-snapshot plan))
+        "restoring a snapshot parked past the target would ignore the rewind")))
+
+;------------------------------------------------------------------------------ Launcher result
+
+(deftest launched-run-id-accepts-only-a-reported-run
+  (is (= "run-1" (mechanism/launched-run-id {:resume/run-id "run-1"})))
+  (doseq [result [nil {} "run-1"
+                  (anomaly/anomaly :fault "launcher blew up" {})]]
+    (is (nil? (mechanism/launched-run-id result))
+        (str "result " (pr-str result)))))

--- a/components/operator/test/ai/miniforge/operator/mechanism_test.clj
+++ b/components/operator/test/ai/miniforge/operator/mechanism_test.clj
@@ -19,11 +19,14 @@
 (ns ai.miniforge.operator.mechanism-test
   "Unit coverage for the pure halves of the D-3b mechanisms: reading the
    requested phase off the wire, deriving a run's real phase history,
-   and shaping the resume plan. The lifecycle wiring these feed is
-   covered in `application-test`."
+   shaping the resume plan, and turning an evaluation verdict into the
+   gate event `supervisory-state` materializes. The lifecycle wiring
+   these feed is covered in `application-test`."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.operator.mechanism :as mechanism]
+   [ai.miniforge.supervisory-state.interface :as supervisory]
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Requested phase
@@ -103,3 +106,65 @@
                   (anomaly/anomaly :fault "launcher blew up" {})]]
     (is (nil? (mechanism/launched-run-id result))
         (str "result " (pr-str result)))))
+
+;------------------------------------------------------------------------------ Policy re-evaluation
+
+(def ^:private re-evaluate-intervention
+  {:intervention/id (random-uuid)
+   :intervention/type :re-evaluate
+   :intervention/target-type :pr
+   :intervention/target-id "golden/synthetic#1"
+   :intervention/requested-by "op@example.invalid"
+   :intervention/details {"packs" ["golden-pack"]}})
+
+(defn- memory-stream [] (es/create-event-stream {:sinks []}))
+
+(defn- materialized-evals
+  [stream]
+  (vals (:policy-evals (supervisory/apply-events supervisory/empty-table
+                                                 (es/get-events stream)))))
+
+(deftest evaluation-request-carries-target-and-requester
+  (let [request (mechanism/evaluation-request re-evaluate-intervention)]
+    (is (= "golden/synthetic#1" (:policy/target-id request)))
+    (is (= :pr (:policy/target-type request)))
+    (is (= "op@example.invalid" (:policy/requested-by request)))
+    (is (= {"packs" ["golden-pack"]} (:policy/details request))
+        "scoping details pass through verbatim")))
+
+(deftest gate-event-type-follows-the-verdict
+  (let [stream (memory-stream)
+        passed (mechanism/evaluation-gate-event stream re-evaluate-intervention
+                                                {:evaluation/passed? true})
+        failed (mechanism/evaluation-gate-event stream re-evaluate-intervention
+                                                {:evaluation/passed? false})]
+    (is (= :gate/passed (:event/type passed)))
+    (is (= :gate/failed (:event/type failed)))
+    (is (= :pr (:gate/target-type passed)))
+    (is (= "golden/synthetic#1" (:gate/target-id passed)))
+    (is (= mechanism/re-evaluation-gate-id (:gate/id passed)))))
+
+(deftest gate-event-coerces-pack-ids-to-strings
+  (let [event (mechanism/evaluation-gate-event
+               (memory-stream) re-evaluate-intervention
+               {:evaluation/passed? true
+                :evaluation/packs-applied [:golden-pack "literal-pack"]})]
+    (is (= ["golden-pack" "literal-pack"] (:gate/packs event))
+        "PolicyEvaluation requires string pack ids; evaluators use either")))
+
+(deftest recording-an-evaluation-reads-the-new-record-back
+  (let [stream (memory-stream)
+        readback (mechanism/record-policy-evaluation!
+                  stream re-evaluate-intervention
+                  {:evaluation/passed? false
+                   :evaluation/packs-applied ["golden-pack"]
+                   :evaluation/violations [{:rule-id :golden/rule-001
+                                            :severity :medium
+                                            :message "synthetic"}]})
+        evals (materialized-evals stream)]
+    (is (true? (:observed readback)))
+    (is (= (:expected readback) (:observed readback)))
+    (is (= 1 (count evals)))
+    (is (= (:policy-eval/id readback) (:policy-eval/id (first evals)))
+        "the readback names the record the accumulator materialized")
+    (is (false? (:policy-eval/passed? (first evals))))))

--- a/components/operator/test/ai/miniforge/operator/mechanism_test.clj
+++ b/components/operator/test/ai/miniforge/operator/mechanism_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.mechanism-test
   "Unit coverage for the pure halves of the D-3b mechanisms: reading the
    requested phase off the wire, deriving a run's real phase history,
@@ -27,11 +26,13 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.operator.mechanism :as mechanism]
    [ai.miniforge.supervisory-state.interface :as supervisory]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]))
 
-;------------------------------------------------------------------------------ Requested phase
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest requested-phase-reads-both-detail-shapes
+;------------------------------------------------------------------------------ Requested phase
+(deftest ^{:stratum 0} requested-phase-reads-both-detail-shapes
   (testing "the wire's string key (transit leaves details keys untagged)"
     (is (= :implement
            (mechanism/requested-phase
@@ -45,11 +46,19 @@
   (testing "absent, blank, and unusable values yield nil, not a phantom phase"
     (doseq [details [nil {} {"phase" ""} {"phase" "   "} {"phase" 7}]]
       (is (nil? (mechanism/requested-phase {:intervention/details details}))
-          (str "details " (pr-str details))))))
+          (str "details " (pr-str details)))))
+
+  (testing "surrounding whitespace is trimmed so it resolves to the real phase"
+    (doseq [padded ["implement " " implement" "  implement  "]]
+      (let [resolved (mechanism/requested-phase
+                      {:intervention/details {"phase" padded}})]
+        (is (= :implement resolved)
+            (str "padded " (pr-str padded)))
+        (is (not (str/includes? (name resolved) " "))
+            "the resolved phase keyword carries no stray whitespace")))))
 
 ;------------------------------------------------------------------------------ Phase history
-
-(deftest known-phases-covers-completed-attempted-and-current
+(deftest ^{:stratum 0} known-phases-covers-completed-attempted-and-current
   (let [context {:completed-phases [:explore :plan]
                  :phase-results {:explore {} :plan {} :implement {}}
                  :machine-snapshot {:execution/current-phase :verify}}]
@@ -57,18 +66,17 @@
            (mechanism/known-phases context))
         "a failed phase has a result without being completed — it still ran")))
 
-(deftest known-phases-tolerates-a-bare-context
+(deftest ^{:stratum 0} known-phases-tolerates-a-bare-context
   (is (= #{} (mechanism/known-phases {}))))
 
-(deftest phases-before-truncates-at-the-target
+(deftest ^{:stratum 0} phases-before-truncates-at-the-target
   (is (= [:explore] (mechanism/phases-before [:explore :plan :implement] :plan)))
   (is (= [] (mechanism/phases-before [:explore :plan] :explore)))
   (is (= [:explore :plan] (mechanism/phases-before [:explore :plan] :nowhere))
       "a phase outside the list truncates nothing — the caller validates first"))
 
 ;------------------------------------------------------------------------------ Resume plan
-
-(def ^:private context
+(def ^{:stratum 0} ^:private context
   {:completed-phases [:explore :plan]
    :phase-results {:explore {:outcome :success}}
    :machine-snapshot {:execution/current-phase :implement}
@@ -76,10 +84,36 @@
    :completed-dag-tasks #{"task-1"}
    :completed-dag-artifacts [{:path "a.clj"}]})
 
-(def ^:private workflow-identity
+(def ^{:stratum 0} ^:private workflow-identity
   {:workflow-type :canonical-sdlc :workflow-version "1.0.0"})
 
-(deftest plain-retry-keeps-the-fsm-snapshot
+;------------------------------------------------------------------------------ Launcher result
+(deftest ^{:stratum 0} launched-run-id-accepts-only-a-reported-run
+  (is (= "run-1" (mechanism/launched-run-id {:resume/run-id "run-1"})))
+  (doseq [result [nil {} "run-1"
+                  (anomaly/anomaly :fault "launcher blew up" {})]]
+    (is (nil? (mechanism/launched-run-id result))
+        (str "result " (pr-str result)))))
+
+;------------------------------------------------------------------------------ Policy re-evaluation
+(def ^{:stratum 0} ^:private re-evaluate-intervention
+  {:intervention/id (random-uuid)
+   :intervention/type :re-evaluate
+   :intervention/target-type :pr
+   :intervention/target-id "golden/synthetic#1"
+   :intervention/requested-by "op@example.invalid"
+   :intervention/details {"packs" ["golden-pack"]}})
+
+(defn- ^{:stratum 0} memory-stream [] (es/create-event-stream {:sinks []}))
+
+(defn- ^{:stratum 0} materialized-evals
+  [stream]
+  (vals (:policy-evals (supervisory/apply-events supervisory/empty-table
+                                                 (es/get-events stream)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} plain-retry-keeps-the-fsm-snapshot
   (let [plan (mechanism/resume-plan {:intervention/target-id "wf-1"
                                      :intervention/requested-by "op@example.invalid"}
                                     context workflow-identity nil)]
@@ -90,7 +124,7 @@
     (is (= :canonical-sdlc (:resume/workflow-type plan)))
     (is (= #{"task-1"} (:resume/completed-dag-tasks plan)))))
 
-(deftest retry-from-phase-rewinds-and-drops-the-snapshot
+(deftest ^{:stratum 1} retry-from-phase-rewinds-and-drops-the-snapshot
   (let [plan (mechanism/resume-plan {:intervention/target-id "wf-1"} context
                                     workflow-identity :plan)]
     (is (= :plan (:resume/from-phase plan)))
@@ -98,33 +132,7 @@
     (is (nil? (:resume/machine-snapshot plan))
         "restoring a snapshot parked past the target would ignore the rewind")))
 
-;------------------------------------------------------------------------------ Launcher result
-
-(deftest launched-run-id-accepts-only-a-reported-run
-  (is (= "run-1" (mechanism/launched-run-id {:resume/run-id "run-1"})))
-  (doseq [result [nil {} "run-1"
-                  (anomaly/anomaly :fault "launcher blew up" {})]]
-    (is (nil? (mechanism/launched-run-id result))
-        (str "result " (pr-str result)))))
-
-;------------------------------------------------------------------------------ Policy re-evaluation
-
-(def ^:private re-evaluate-intervention
-  {:intervention/id (random-uuid)
-   :intervention/type :re-evaluate
-   :intervention/target-type :pr
-   :intervention/target-id "golden/synthetic#1"
-   :intervention/requested-by "op@example.invalid"
-   :intervention/details {"packs" ["golden-pack"]}})
-
-(defn- memory-stream [] (es/create-event-stream {:sinks []}))
-
-(defn- materialized-evals
-  [stream]
-  (vals (:policy-evals (supervisory/apply-events supervisory/empty-table
-                                                 (es/get-events stream)))))
-
-(deftest evaluation-request-carries-target-and-requester
+(deftest ^{:stratum 1} evaluation-request-carries-target-and-requester
   (let [request (mechanism/evaluation-request re-evaluate-intervention)]
     (is (= "golden/synthetic#1" (:policy/target-id request)))
     (is (= :pr (:policy/target-type request)))
@@ -132,7 +140,7 @@
     (is (= {"packs" ["golden-pack"]} (:policy/details request))
         "scoping details pass through verbatim")))
 
-(deftest gate-event-type-follows-the-verdict
+(deftest ^{:stratum 1} gate-event-type-follows-the-verdict
   (let [stream (memory-stream)
         passed (mechanism/evaluation-gate-event stream re-evaluate-intervention
                                                 {:evaluation/passed? true})
@@ -144,7 +152,7 @@
     (is (= "golden/synthetic#1" (:gate/target-id passed)))
     (is (= mechanism/re-evaluation-gate-id (:gate/id passed)))))
 
-(deftest gate-event-coerces-pack-ids-to-strings
+(deftest ^{:stratum 1} gate-event-coerces-pack-ids-to-strings
   (let [event (mechanism/evaluation-gate-event
                (memory-stream) re-evaluate-intervention
                {:evaluation/passed? true
@@ -152,7 +160,7 @@
     (is (= ["golden-pack" "literal-pack"] (:gate/packs event))
         "PolicyEvaluation requires string pack ids; evaluators use either")))
 
-(deftest recording-an-evaluation-reads-the-new-record-back
+(deftest ^{:stratum 1} recording-an-evaluation-reads-the-new-record-back
   (let [stream (memory-stream)
         readback (mechanism/record-policy-evaluation!
                   stream re-evaluate-intervention

--- a/components/operator/test/ai/miniforge/operator/mechanism_test.clj
+++ b/components/operator/test/ai/miniforge/operator/mechanism_test.clj
@@ -89,11 +89,18 @@
 
 ;------------------------------------------------------------------------------ Launcher result
 (deftest ^{:stratum 0} launched-run-id-accepts-only-a-reported-run
-  (is (= "run-1" (mechanism/launched-run-id {:resume/run-id "run-1"})))
-  (doseq [result [nil {} "run-1"
-                  (anomaly/anomaly :fault "launcher blew up" {})]]
-    (is (nil? (mechanism/launched-run-id result))
-        (str "result " (pr-str result)))))
+  (testing "a scalar run id (string or uuid) is the report the lifecycle verifies"
+    (is (= "run-1" (mechanism/launched-run-id {:resume/run-id "run-1"})))
+    (let [u (random-uuid)]
+      (is (= u (mechanism/launched-run-id {:resume/run-id u})))))
+  (testing "no report, an anomaly, or a non-scalar run id all read as nil"
+    (doseq [result [nil {} "run-1"
+                    (anomaly/anomaly :fault "launcher blew up" {})
+                    {:resume/run-id {:nested "map"}}
+                    {:resume/run-id [:a :collection]}
+                    {:resume/run-id 42}]]
+      (is (nil? (mechanism/launched-run-id result))
+          (str "result " (pr-str result))))))
 
 ;------------------------------------------------------------------------------ Policy re-evaluation
 (def ^{:stratum 0} ^:private re-evaluate-intervention

--- a/tests/graalvm_compatibility_test.clj
+++ b/tests/graalvm_compatibility_test.clj
@@ -267,6 +267,58 @@
         (is (some? (resolve 'ai.miniforge.workflow.interface/run-pipeline))
             "Should resolve run-pipeline")))))
 
+(deftest test-operator-intervention-application-executes
+  (testing "Phase D intervention mechanisms run under Babashka, not just load"
+    ;; A loading namespace is not a working one: SCI refuses some interop
+    ;; at call time, so the control path is exercised here rather than
+    ;; merely required. Resolved dynamically so a classpath without the
+    ;; operator brick reports a plain load failure instead of a compile
+    ;; error in this file.
+    (let [[loaded? error-msg] (require-namespace 'ai.miniforge.operator.interface)]
+      (is loaded? (str "Operator interface should load: " error-msg))
+      (when loaded?
+        (let [[es-loaded?] (require-namespace 'ai.miniforge.event-stream.interface)
+              create-stream (resolve 'ai.miniforge.event-stream.interface/create-event-stream)
+              create-interv (resolve 'ai.miniforge.operator.interface/create-intervention)
+              approve (resolve 'ai.miniforge.operator.interface/approve-intervention)
+              apply-interv! (resolve 'ai.miniforge.operator.interface/apply-intervention!)
+              register-evaluator! (resolve 'ai.miniforge.operator.interface/register-policy-evaluator!)]
+          (is es-loaded? "event-stream interface should load")
+          (is (every? some? [create-stream create-interv approve apply-interv!
+                             register-evaluator!])
+              "Phase D application entry points should resolve")
+          (when (every? some? [create-stream create-interv approve apply-interv!
+                               register-evaluator!])
+            (let [stream (create-stream {:sinks []})
+                  approved (fn [type target-id]
+                             (:intervention
+                              (approve (create-interv
+                                        {:intervention/type type
+                                         :intervention/target-id target-id
+                                         :intervention/requested-by "graalvm-test"
+                                         :intervention/request-source :tui}))))
+                  failure-code #(get-in % [:intervention/details :failure/code])]
+              ;; Unwired mechanisms must fail typed rather than throw.
+              (is (= :no-resume-launcher
+                     (failure-code (apply-interv! stream (approved :retry (str (random-uuid))))))
+                  "retry without a launcher fails typed under Babashka")
+              (is (= :not-implemented
+                     (failure-code (apply-interv! stream (approved :waive (str (random-uuid))))))
+                  "waive fails typed under Babashka")
+              ;; The re-evaluate mechanism actually runs: evaluator →
+              ;; gate event → materialized PolicyEvaluation readback.
+              (register-evaluator! (fn [_request]
+                                     {:evaluation/passed? true
+                                      :evaluation/packs-applied []
+                                      :evaluation/violations []}))
+              (try
+                (is (= :verified
+                       (:intervention/state
+                        (apply-interv! stream (approved :re-evaluate "graalvm/synthetic#1"))))
+                    "re-evaluate materializes and verifies a PolicyEvaluation under Babashka")
+                (finally
+                  (register-evaluator! nil))))))))))
+
 ;; ============================================================================
 ;; miniforge-project BB-safety gate — no JVM-only bricks on the CLI classpath
 ;; ============================================================================


### PR DESCRIPTION
Phase D step D-3b — the intervention verbs that were failing `:not-implemented`. Two are now implemented and readback-verified; one is honestly still unimplemented, with the reason recorded in code rather than left as a TODO.

## `retry` / `retry-from-phase` — implemented, verified by readback

New `operator/mechanism.clj` rebuilds resume state through `workflow-resume` (`reconstruct-context` → `resolve-workflow-identity` → the plan shape `mf resume` threads into `run-pipeline`).

`retry-from-phase` reads its phase from `:intervention/details` under **both** the wire's string key and the keyword form — transit leaves details keys untagged, confirmed against `contracts/operator-events/golden/retry-from-phase.transit.json` — then validates it against the run's real phase history: completed phases, phases carrying a result (a failed phase has one without being completed), and the FSM snapshot's current phase. Typed rejections all land **before** the launcher is called: `:missing-phase`, `:no-resume-context`, `:unknown-phase`, `:unresolved-workflow-type`. A plain retry keeps the FSM snapshot; a rewind drops it and truncates the completed set at the target.

**Verification re-reads the resume machinery's own view** — `reconstruct-context` on the run id the launcher reported. A launcher naming a run that never started leaves no history → `:resume-readback-mismatch` after `:applied`. A launcher reporting no run at all → `:resume-not-dispatched`.

## `re-evaluate` — implemented, verified by readback

The registered evaluator computes the verdict; `record-policy-evaluation!` publishes it as a `:gate/passed`/`:gate/failed` event carrying `:gate/target-type :pr`, `:gate/target-id`, `:gate/packs`, `:gate/violations`. That is the existing policy-evaluation path — supervisory-state's accumulator materializes gate events into PolicyEvaluation entities keyed by the event id, so each re-evaluation is a **new immutable record** per §12.2 rule 3, never a mutation.

**Verification** folds the stream through `supervisory/apply-events` before and after the publish and asserts a PolicyEvaluation id exists that did not before. With no evaluator registered → `:no-policy-evaluator`, and **nothing is published**: the verb never emits a verdict it did not receive.

## `waive` — deliberately left `:not-implemented`

There is no waiver store to write to. Present: `schema/Waiver` + `valid-waiver?`, a duplicate schema in tui-views, and a TUI derivation reading `(get model :waivers [])` that is permanently empty. Missing: no event type produces a Waiver, no accumulator table holds one (`empty-table` has no `:waivers` key, the dispatch table no handler), no emitter family publishes one, no interface accessor reads one, no Rust entity.

Building it is a **supervisory-entity-family addition, not an operator change**: event constructor in event-stream, `:waivers` table + handler + schema entry in supervisory-state, a `waiver-upserted` emitter family wired into `diff-and-emit!`, an interface accessor, plus tui-views model wiring. Faking it here would have meant a verb that reports `verified` while writing nowhere.

## Runtime handles — the thing to weigh

Both implemented verbs depend on a process-scoped handle with **no producer yet**: `register-resume-launcher!` and `register-policy-evaluator!`, registered exactly like the existing degradation manager. Starting a pipeline needs a workflow loader and an LLM client — base-level, unreachable from a component.

Until a runner registers them, both verbs fail typed (`:no-resume-launcher` / `:no-policy-evaluator`) rather than `:not-implemented`. More precise, same practical state. The follow-up is wiring those registrations where `register-live-runner!` already happens.

## Gates

- Operator namespaces: **57 tests / 207 assertions, 0 failures** (re-verified independently).
- `bb test:graalvm`: **7 tests / 536 assertions, 0 failures** — includes a new **execution** gate for the mechanisms, because the load-only suite cannot catch an SCI call-time refusal (the class of bug in #1453).
- Touched mechanism components (event-stream, supervisory-state, workflow-resume): 459 tests / 2094 assertions, 0 failures.
- All 8 commits passed the full pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
